### PR TITLE
fix(ui): DWP should default bucket name to selected bucket

### DIFF
--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -110,7 +110,7 @@ describe('Buckets', () => {
   })
 
   // skipping until feature flag feature is removed for deleteWithPredicate
-  describe.skip('should alphabetize buckets in dropdown', () => {
+  describe.skip('should default the bucket to the selected bucket', () => {
     beforeEach(() => {
       cy.get<Organization>('@org').then(({id, name}) => {
         cy.createBucket(id, name, 'Funky Town').then(() => {
@@ -119,6 +119,24 @@ describe('Buckets', () => {
           })
         })
       })
+    })
+
+    it('should set the default bucket in the dropdown to the selected bucket', () => {
+      cy.getByTestID('bucket-delete-task')
+        .first()
+        .click()
+        .then(() => {
+          cy.getByTestID('dropdown--button').contains('ABC')
+          cy.get('.cf-overlay--dismiss').click()
+        })
+        .then(() => {
+          cy.getByTestID('bucket-delete-task')
+            .last()
+            .click()
+            .then(() => {
+              cy.getByTestID('dropdown--button').contains('Jimmy Mack')
+            })
+        })
     })
 
     it('alphabetizes buckets', () => {

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -615,6 +615,34 @@ describe('DataExplorer', () => {
         .click()
     })
 
+    it('should set the default bucket in the dropdown to the selected bucket', () => {
+      cy.get('.cf-overlay--dismiss').click()
+      cy.getByTestID('selector-list defbuck').click()
+      cy.getByTestID('delete-data-predicate')
+        .click()
+        .then(() => {
+          cy.getByTestID('dropdown--button').contains('defbuck')
+          cy.get('.cf-overlay--dismiss').click()
+        })
+        .then(() => {
+          cy.getByTestID('selector-list _monitoring').click()
+          cy.getByTestID('delete-data-predicate')
+            .click()
+            .then(() => {
+              cy.getByTestID('dropdown--button').contains('_monitoring')
+              cy.get('.cf-overlay--dismiss').click()
+            })
+        })
+        .then(() => {
+          cy.getByTestID('selector-list _tasks').click()
+          cy.getByTestID('delete-data-predicate')
+            .click()
+            .then(() => {
+              cy.getByTestID('dropdown--button').contains('_tasks')
+            })
+        })
+    })
+
     it('closes the overlay upon a successful delete with predicate submission', () => {
       cy.getByTestID('delete-checkbox').check({force: true})
       cy.getByTestID('confirm-delete-btn').click()

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -15,6 +15,9 @@ import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, TimeRange} from 'src/types'
 
+// Actions
+import {resetPredicateState} from 'src/shared/actions/predicates'
+
 const resolveTimeRange = (timeRange: TimeRange): [number, number] | null => {
   const [lower, upper] = [
     Date.parse(timeRange.lower),
@@ -33,13 +36,23 @@ interface StateProps {
   selectedTimeRange?: [number, number]
 }
 
-const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
+interface DispatchProps {
+  resetPredicateState: () => void
+}
+
+type Props = StateProps & WithRouterProps & DispatchProps
+
+const DeleteDataOverlay: FunctionComponent<Props> = ({
   router,
   params: {orgID},
   selectedBucketName,
   selectedTimeRange,
+  resetPredicateState,
 }) => {
-  const handleDismiss = () => router.push(`/orgs/${orgID}/data-explorer`)
+  const handleDismiss = () => {
+    resetPredicateState()
+    router.push(`/orgs/${orgID}/data-explorer`)
+  }
 
   return (
     <Overlay visible={true}>
@@ -73,6 +86,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default connect<StateProps>(mstp)(
-  withRouter<StateProps>(DeleteDataOverlay)
-)
+const mdtp: DispatchProps = {
+  resetPredicateState,
+}
+
+export default connect<StateProps, DispatchProps>(
+  mstp,
+  mdtp
+)(withRouter<Props>(DeleteDataOverlay))


### PR DESCRIPTION
Closes #16011

### Problem

Selecting to delete with predicate from an active bucket was not updating the selected bucket once an initial bucket was set

### Solution

The solution to this problem was to separate some of the logic from where the initial bucket name was being received, and also making sure to reset the deleteWithPredicate reducer component to its default state when the overlay is closed.

Buckets:
![buckets-dwp](https://user-images.githubusercontent.com/19984220/69741628-3ffd9400-10f0-11ea-960f-d668c13485f2.gif)

Data Explorer:
![de-dwp](https://user-images.githubusercontent.com/19984220/69741648-4855cf00-10f0-11ea-975a-0a0c928858e3.gif)


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)