### PR TITLE
feat(http): add cell properties to dashboard response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [15749](https://github.com/influxdata/influxdb/pull/15749): Expose bundle analysis tools for frontend resources
 1. [15674](https://github.com/influxdata/influxdb/pull/15674): Allow users to view just the output section of a telegraf config
 1. [15314](https://github.com/influxdata/influxdb/issues/15314): Allow the users to see string data in the single stat graph type
+1. [16057] https://github.com/influxdata/influxdb/pull/16057: Adds `properties` to each cell on GET /dashboards/{dashboardID}
 
 ### Bug Fixes
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -124,6 +124,28 @@ func SortDashboards(opts FindOptions, ds []*Dashboard) {
 type Cell struct {
 	ID ID `json:"id,omitempty"`
 	CellProperty
+	View *View `json:"-"`
+}
+
+// Marshals the cell
+func (cell *Cell) MarshalJSON() ([]byte, error) {
+	type resp struct {
+		ID ID `json:"id,omitempty"`
+		CellProperty
+		ViewProperties ViewProperties `json:"properties,omitempty"`
+		Name           string         `json:"name,omitempty"`
+	}
+
+	response := resp{
+		ID:           cell.ID,
+		CellProperty: cell.CellProperty,
+	}
+
+	if cell.View != nil {
+		response.ViewProperties = cell.View.Properties
+		response.Name = cell.View.Name
+	}
+	return json.Marshal(response)
 }
 
 // CellProperty contains the properties of a cell.
@@ -550,8 +572,8 @@ func MarshalViewPropertiesJSON(v ViewProperties) ([]byte, error) {
 }
 
 // MarshalJSON encodes a view to JSON bytes.
-func (c View) MarshalJSON() ([]byte, error) {
-	vis, err := MarshalViewPropertiesJSON(c.Properties)
+func (v View) MarshalJSON() ([]byte, error) {
+	viewProperties, err := MarshalViewPropertiesJSON(v.Properties)
 	if err != nil {
 		return nil, err
 	}
@@ -560,8 +582,8 @@ func (c View) MarshalJSON() ([]byte, error) {
 		ViewContents
 		ViewProperties json.RawMessage `json:"properties"`
 	}{
-		ViewContents:   c.ViewContents,
-		ViewProperties: vis,
+		ViewContents:   v.ViewContents,
+		ViewProperties: viewProperties,
 	})
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2217,6 +2217,12 @@ paths:
               type: string
             required: true
             description: The ID of the dashboard to update.
+          - in: query
+            name: include
+            required: false
+            schema:
+              type: string
+            description: Includes the cell view properties in the response if set to `properties`
       responses:
           '200':
             description: Get a single dashboard

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2222,6 +2222,7 @@ paths:
             required: false
             schema:
               type: string
+              enum: [properties]
             description: Includes the cell view properties in the response if set to `properties`
       responses:
           '200':

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2222,7 +2222,8 @@ paths:
             required: false
             schema:
               type: string
-              enum: [properties]
+              enum:
+                - properties
             description: Includes the cell view properties in the response if set to `properties`
       responses:
           '200':
@@ -2230,7 +2231,9 @@ paths:
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Dashboard"
+                  oneOf:
+                    - $ref: "#/components/schemas/Dashboard"
+                    - $ref: "#/components/schemas/DashboardWithViewProperties"
           '404':
             description: Dashboard not found
             content:
@@ -7376,12 +7379,11 @@ components:
         width:
           type: integer
         properties: # field name is properties
-          ref: "#/components/schemas/ViewProperties"
+          $ref: "#/components/schemas/ViewProperties"
     Runs:
       type: object
       properties:
         links:
-          readOnly: true
           $ref: "#/components/schemas/Links"
         runs:
           type: array
@@ -8722,6 +8724,16 @@ components:
                 type: integer
               message:
                 type: string
+    CellWithViewProperties:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Cell"
+        - type: object
+          properties:
+            name:
+              type: string
+            properties:
+              $ref: "#/components/schemas/ViewProperties"
     Cell:
       type: object
       properties:
@@ -8749,6 +8761,10 @@ components:
         viewID:
           type: string
           description: The reference to a view from the views API.
+    CellsWithViewProperties:
+      type: array
+      items:
+        $ref: "#/components/schemas/CellWithViewProperties"
     Cells:
       type: array
       items:
@@ -8792,6 +8808,53 @@ components:
       required:
         - orgID
         - name
+    DashboardWithViewProperties:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/CreateDashboardRequest"
+        - type: object
+          properties:
+            links:
+              type: object
+              example:
+                self: "/api/v2/dashboards/1"
+                cells: "/api/v2/dashboards/1/cells"
+                owners: "/api/v2/dashboards/1/owners"
+                members: "/api/v2/dashboards/1/members"
+                logs: "/api/v2/dashboards/1/logs"
+                labels: "/api/v2/dashboards/1/labels"
+                org: "/api/v2/labels/1"
+              properties:
+                self:
+                  $ref: "#/components/schemas/Link"
+                cells:
+                  $ref: "#/components/schemas/Link"
+                members:
+                  $ref: "#/components/schemas/Link"
+                owners:
+                  $ref: "#/components/schemas/Link"
+                logs:
+                  $ref: "#/components/schemas/Link"
+                labels:
+                  $ref: "#/components/schemas/Link"
+                org:
+                  $ref: "#/components/schemas/Link"
+            id:
+              readOnly: true
+              type: string
+            meta:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  format: date-time
+                updatedAt:
+                  type: string
+                  format: date-time
+            cells:
+              $ref: "#/components/schemas/CellsWithViewProperties"
+            labels:
+              $ref: "#/components/schemas/Labels"
     Dashboard:
       type: object
       allOf:


### PR DESCRIPTION
Closes #16052

Describe your proposed changes here.
Adds an optional `?include=properties` query string to `GET /dashboards/:dashboardID` that returns each cells properties


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
