### PR TITLE
fix(ui): updated telegraf description to be more explicit

### DIFF
--- a/ui/src/buckets/components/BucketExplainer.tsx
+++ b/ui/src/buckets/components/BucketExplainer.tsx
@@ -4,8 +4,8 @@ import React, {FunctionComponent} from 'react'
 // Components
 import {Panel, InfluxColors} from '@influxdata/clockface'
 
-const TelegrafExplainer: FunctionComponent = () => (
-  <Panel backgroundColor={InfluxColors.Onyx} style={{marginTop: '32px'}}>
+const BucketExplainer: FunctionComponent = () => (
+  <Panel backgroundColor={InfluxColors.Smoke} style={{marginTop: '32px'}}>
     <Panel.Header>
       <Panel.Title>What is a Bucket?</Panel.Title>
     </Panel.Header>
@@ -29,4 +29,4 @@ const TelegrafExplainer: FunctionComponent = () => (
   </Panel>
 )
 
-export default TelegrafExplainer
+export default BucketExplainer

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -89,10 +89,14 @@ class Collectors extends PureComponent<Props, State> {
     }
   }
 
+  public static defaultProps = {
+    collectors: [],
+  }
+
   public render() {
     const {collectors} = this.props
     const {searchTerm, sortKey, sortDirection, sortType} = this.state
-
+    const hasTelegrafs = collectors && collectors.length > 0
     return (
       <>
         <NoBucketsWarning
@@ -123,8 +127,8 @@ class Collectors extends PureComponent<Props, State> {
           <Grid.Row>
             <Grid.Column
               widthXS={Columns.Twelve}
-              widthSM={collectors.length ? Columns.Eight : Columns.Twelve}
-              widthMD={collectors.length ? Columns.Ten : Columns.Twelve}
+              widthSM={hasTelegrafs ? Columns.Eight : Columns.Twelve}
+              widthMD={hasTelegrafs ? Columns.Ten : Columns.Twelve}
             >
               <GetResources resources={[ResourceType.Labels]}>
                 <FilterList<Telegraf>
@@ -152,7 +156,7 @@ class Collectors extends PureComponent<Props, State> {
                 </FilterList>
               </GetResources>
             </Grid.Column>
-            {collectors.length > 0 && (
+            {hasTelegrafs && (
               <Grid.Column
                 widthXS={Columns.Twelve}
                 widthSM={Columns.Four}

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -247,9 +247,9 @@ class Collectors extends PureComponent<Props, State> {
           <br />
           <br />
           <TelegrafExplainer
+            hasNoTelegrafs={true}
             textAlign="center"
             bodySize={ComponentSize.Medium}
-            titleSize={ComponentSize.Large}
           />
         </EmptyState>
       )

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -5,7 +5,17 @@ import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
-import {Button, EmptyState, Grid, Sort} from '@influxdata/clockface'
+import {
+  Button,
+  EmptyState,
+  Grid,
+  Sort,
+  Columns,
+  IconFont,
+  ComponentSize,
+  ComponentColor,
+  ComponentStatus,
+} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
 import CollectorList from 'src/telegrafs/components/CollectorList'
@@ -23,13 +33,6 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
 import {ITelegraf as Telegraf} from '@influxdata/influx'
-import {
-  Columns,
-  IconFont,
-  ComponentSize,
-  ComponentColor,
-  ComponentStatus,
-} from '@influxdata/clockface'
 import {OverlayState, AppState, Bucket} from 'src/types'
 import {
   setDataLoadersType,
@@ -120,8 +123,8 @@ class Collectors extends PureComponent<Props, State> {
           <Grid.Row>
             <Grid.Column
               widthXS={Columns.Twelve}
-              widthSM={Columns.Eight}
-              widthMD={Columns.Ten}
+              widthSM={collectors.length ? Columns.Eight : Columns.Twelve}
+              widthMD={collectors.length ? Columns.Ten : Columns.Twelve}
             >
               <GetResources resources={[ResourceType.Labels]}>
                 <FilterList<Telegraf>
@@ -149,13 +152,15 @@ class Collectors extends PureComponent<Props, State> {
                 </FilterList>
               </GetResources>
             </Grid.Column>
-            <Grid.Column
-              widthXS={Columns.Twelve}
-              widthSM={Columns.Four}
-              widthMD={Columns.Two}
-            >
-              <TelegrafExplainer />
-            </Grid.Column>
+            {collectors.length > 0 && (
+              <Grid.Column
+                widthXS={Columns.Twelve}
+                widthSM={Columns.Four}
+                widthMD={Columns.Two}
+              >
+                <TelegrafExplainer />
+              </Grid.Column>
+            )}
           </Grid.Row>
         </Grid>
       </>
@@ -239,6 +244,13 @@ class Collectors extends PureComponent<Props, State> {
             not create one?
           </EmptyState.Text>
           {this.createButton}
+          <br />
+          <br />
+          <TelegrafExplainer
+            textAlign="center"
+            bodySize={ComponentSize.Medium}
+            titleSize={ComponentSize.Large}
+          />
         </EmptyState>
       )
     }

--- a/ui/src/telegrafs/components/TelegrafExplainer.tsx
+++ b/ui/src/telegrafs/components/TelegrafExplainer.tsx
@@ -2,27 +2,39 @@
 import React, {FunctionComponent} from 'react'
 
 // Components
-import {Panel, InfluxColors, ComponentSize} from '@influxdata/clockface'
+import {
+  Panel,
+  EmptyState,
+  InfluxColors,
+  ComponentSize,
+} from '@influxdata/clockface'
 import {TextAlignProperty} from 'csstype'
 
 interface Props {
+  hasNoTelegrafs?: boolean
   textAlign?: TextAlignProperty
-  titleSize?: ComponentSize
   bodySize?: ComponentSize
 }
 
 const TelegrafExplainer: FunctionComponent<Props> = ({
+  hasNoTelegrafs = false,
   textAlign = 'inherit',
-  titleSize,
   bodySize,
 }) => (
   <Panel
     backgroundColor={InfluxColors.Smoke}
-    style={{textAlign, marginTop: '32px'}}
+    style={{textAlign, marginTop: 32}}
   >
-    <Panel.Header>
-      <Panel.Title size={titleSize}>What is Telegraf?</Panel.Title>
-    </Panel.Header>
+    {hasNoTelegrafs && (
+      <EmptyState.Text style={{color: InfluxColors.Platinum, marginTop: 16}}>
+        What is Telegraf?
+      </EmptyState.Text>
+    )}
+    {!hasNoTelegrafs && (
+      <Panel.Header>
+        <Panel.Title>What is Telegraf?</Panel.Title>
+      </Panel.Header>
+    )}
     <Panel.Body size={bodySize}>
       Telegraf is an agent written in Go for collecting metrics and writing them
       into <strong>InfluxDB</strong> or other possible outputs.

--- a/ui/src/telegrafs/components/TelegrafExplainer.tsx
+++ b/ui/src/telegrafs/components/TelegrafExplainer.tsx
@@ -2,27 +2,39 @@
 import React, {FunctionComponent} from 'react'
 
 // Components
-import {Panel, InfluxColors} from '@influxdata/clockface'
+import {Panel, InfluxColors, ComponentSize} from '@influxdata/clockface'
+import {TextAlignProperty} from 'csstype'
 
-const TelegrafExplainer: FunctionComponent = () => (
-  <Panel backgroundColor={InfluxColors.Onyx} style={{marginTop: '32px'}}>
+interface Props {
+  textAlign?: TextAlignProperty
+  titleSize?: ComponentSize
+  bodySize?: ComponentSize
+}
+
+const TelegrafExplainer: FunctionComponent<Props> = ({
+  textAlign = 'inherit',
+  titleSize,
+  bodySize,
+}) => (
+  <Panel
+    backgroundColor={InfluxColors.Smoke}
+    style={{textAlign, marginTop: '32px'}}
+  >
     <Panel.Header>
-      <Panel.Title>What is Telegraf?</Panel.Title>
+      <Panel.Title size={titleSize}>What is Telegraf?</Panel.Title>
     </Panel.Header>
-    <Panel.Body>
-      <p>
-        Telegraf is an agent written in Go for collecting metrics and writing
-        them into <strong>InfluxDB</strong> or other possible outputs.
-        <br />
-        <br />
-        Here's a handy guide for{' '}
-        <a
-          href="https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/"
-          target="_blank"
-        >
-          Getting Started with Telegraf
-        </a>
-      </p>
+    <Panel.Body size={bodySize}>
+      Telegraf is an agent written in Go for collecting metrics and writing them
+      into <strong>InfluxDB</strong> or other possible outputs.
+      <br />
+      <br />
+      Here's a handy guide for{' '}
+      <a
+        href="https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/"
+        target="_blank"
+      >
+        Getting Started with Telegraf
+      </a>
     </Panel.Body>
   </Panel>
 )


### PR DESCRIPTION
Closes #15990

### Problem

Due to its position on the page and the lack of context, it was unclear to users what Telegraf was

### Solution

Added a conditionally rendered textbox with larger text to indicate to the user what Telegraf is. Also updated the background color for the existing bucket and telegraf explainer text to make it stand out more

![explainer-update](https://user-images.githubusercontent.com/19984220/69764118-19f1e700-1124-11ea-9f42-7a53e62d25f9.gif)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
