### PR TITLE
fix(http): update swagger for easily use in clients

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6309,9 +6309,11 @@ components:
         start:
           description: RFC3339Nano
           type: string
+          format: date-time
         stop:
           description: RFC3339Nano
           type: string
+          format: date-time
         predicate:
           description: InfluxQL-like delete statement
           example: tag1="value1" and (tag2="value2" and tag3!="value3")
@@ -6849,22 +6851,7 @@ components:
         rp:
           type: string
         retentionRules:
-          type: array
-          description: Rules to expire or retain data.  No rules means data never expires.
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                default: expire
-                enum:
-                  - expire
-              everySeconds:
-                type: integer
-                description: Duration in seconds for how long data will be kept in the database.
-                example: 86400
-                minimum: 1
-            required: [type, everySeconds]
+          $ref: "#/components/schemas/RetentionRules"
       required: [name, retentionRules]
     Bucket:
       properties:
@@ -6929,22 +6916,6 @@ components:
           readOnly: true
         retentionRules:
           $ref: "#/components/schemas/RetentionRules"
-          type: array
-          description: Rules to expire or retain data.  No rules means data never expires.
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                default: expire
-                enum:
-                  - expire
-              everySeconds:
-                type: integer
-                description: Duration in seconds for how long data will be kept in the database.
-                example: 86400
-                minimum: 1
-            required: [type, everySeconds]
         labels:
           $ref: "#/components/schemas/Labels"
       required: [name, retentionRules]
@@ -6962,19 +6933,21 @@ components:
       type: array
       description: Rules to expire or retain data.  No rules means data never expires.
       items:
-        type: object
-        properties:
-          type:
-            type: string
-            default: expire
-            enum:
-              - expire
-          everySeconds:
-            type: integer
-            description: Duration in seconds for how long data will be kept in the database.
-            example: 86400
-            minimum: 1
-        required: [type, everySeconds]
+        $ref: "#/components/schemas/RetentionRule"
+    RetentionRule:
+      type: object
+      properties:
+        type:
+          type: string
+          default: expire
+          enum:
+            - expire
+        everySeconds:
+          type: integer
+          description: Duration in seconds for how long data will be kept in the database.
+          example: 86400
+          minimum: 1
+      required: [type, everySeconds]
     Link:
       type: string
       format: uri
@@ -7361,7 +7334,7 @@ components:
         width:
           type: integer
         properties: # field name is properties
-          ref: "#/components/schemas/ViewProperties"
+          $ref: "#/components/schemas/ViewProperties"
     Runs:
       type: object
       properties:
@@ -9811,25 +9784,9 @@ components:
     Check:
       allOf:
         - $ref: "#/components/schemas/CheckDiscriminator"
-        - type: object
-          properties:
-            labels:
-              $ref: "#/components/schemas/Labels"
     PostCheck:
       allOf:
         - $ref: "#/components/schemas/CheckDiscriminator"
-        - type: object
-          properties:
-            status:
-              type: string
-              enum:
-                - active
-                - inactive
-            labels:
-              type: array
-              description: List of label ids to associate with check
-              items:
-                type: string
     Checks:
       properties:
         checks:
@@ -9886,6 +9843,8 @@ components:
         statusMessageTemplate:
           description: The template used to generate and write a status message.
           type: string
+        labels:
+          $ref: "#/components/schemas/Labels"
         links:
           type: object
           readOnly: true
@@ -9907,6 +9866,9 @@ components:
               $ref: "#/components/schemas/Link"
             owners:
               description: URL to retrieve owners for this check
+              $ref: "#/components/schemas/Link"
+            query:
+              description: URL to retrieve flux script for this check
               $ref: "#/components/schemas/Link"
       required: [name, type, orgID, query]
     ThresholdCheck:
@@ -10035,25 +9997,9 @@ components:
     NotificationRule:
       allOf:
         - $ref: "#/components/schemas/NotificationRuleDiscriminator"
-        - type: object
-          properties:
-            labels:
-              $ref: "#/components/schemas/Labels"
     PostNotificationRule:
       allOf:
         - $ref: "#/components/schemas/NotificationRuleDiscriminator"
-        - type: object
-          properties:
-            status:
-              type: string
-              enum:
-                - active
-                - inactive
-            labels:
-              type: array
-              description: List of label IDs to associate with notification rule.
-              items:
-                type: string
     NotificationRules:
       properties:
         notificationRules:
@@ -10128,6 +10074,8 @@ components:
           minItems: 1
           items:
             $ref: "#/components/schemas/StatusRule"
+        labels:
+          $ref: "#/components/schemas/Labels"
         links:
           type: object
           readOnly: true
@@ -10149,6 +10097,9 @@ components:
               $ref: "#/components/schemas/Link"
             owners:
               description: URL to retrieve owners for this notification rule.
+              $ref: "#/components/schemas/Link"
+            query:
+              description: URL to retrieve flux script for this notification rule.
               $ref: "#/components/schemas/Link"
     TagRule:
       type: object
@@ -10173,7 +10124,7 @@ components:
           type: string
     HTTPNotificationRuleBase:
       type: object
-      required: [type, url]
+      required: [type]
       properties:
         type:
           type: string
@@ -10255,25 +10206,9 @@ components:
     NotificationEndpoint:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointDiscrimator"
-        - type: object
-          properties:
-            labels:
-              $ref: "#/components/schemas/Labels"
     PostNotificationEndpoint:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointDiscrimator"
-        - type: object
-          properties:
-            status:
-              type: string
-              enum:
-                - active
-                - inactive
-            labels:
-              type: array
-              description: List of label IDs to associate with check.
-              items:
-                type: string
     NotificationEndpoints:
       properties:
         notificationEndpoints:
@@ -10310,6 +10245,8 @@ components:
           default: active
           type: string
           enum: ["active", "inactive"]
+        labels:
+          $ref: "#/components/schemas/Labels"
         links:
           type: object
           readOnly: true


### PR DESCRIPTION
* added date-time format for start and stop DeletePredicateRequest
* fixed malformed reference to ViewProperties in PkgChart model
* define separate model for RetentionRule as is in Organizations, Buckets, Labels
* "labels" property from Check and PostCheck should be part of CheckBase (it is ancestor for all Check types)
* "labels" property from NotificationRule and PostNotificationRule should be part of NotificationRuleBase (it is ancestor for all NotificationRule and types)
* "labels" property from NotificationEndpoint and PostNotificationEndpoint should be part of NotificationEndpointBase (it is ancestor for all NotificationEndpoint and types)
* The url property of HTTPNotificationRuleBase should not be required
* Added query link for CheckBase and NotificationRuleBase

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
