### PR TITLE
fix(ui): polyfill for IntersectionObserver

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -147,6 +147,7 @@
     "history": "^3.2",
     "honeybadger-js": "^1.0.2",
     "immer": "^1.9.3",
+    "intersection-observer": "^0.7.0",
     "lodash": "^4.3.0",
     "memoize-one": "^4.0.2",
     "moment": "^2.13.0",

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -18,6 +18,7 @@ import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import 'intersection-observer'
 
 // Constants
 import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6071,6 +6071,11 @@ interpret@1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
+intersection-observer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
+  integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
+
 invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
Closes influxdata/honeybadger-errors#5

this error looks like we just need a polyfill, so I added one according to MDN's instructions, which is a mirror from the w3c, found here: https://github.com/w3c/IntersectionObserver/tree/master/polyfill