### PR TITLE
feat(ui): cloning monaco editor for use with toml

### DIFF
--- a/ui/src/external/monaco.tomlSyntax.ts
+++ b/ui/src/external/monaco.tomlSyntax.ts
@@ -1,0 +1,26 @@
+import {loadWASM} from 'onigasm' // peer dependency of 'monaco-textmate'
+import {Registry} from 'monaco-textmate' // peer dependency
+import {wireTmGrammars} from 'monaco-editor-textmate'
+
+export async function addSyntax(monaco) {
+  await loadWASM(require(`onigasm/lib/onigasm.wasm`))
+
+  monaco.languages.register({id: 'toml'})
+
+  const registry = new Registry({
+    getGrammarDefinition: async () => ({
+      format: 'json',
+      content: await import(/* webpackPrefetch: 0 */ 'src/external/toml.tmLanguage.json').then(
+        data => {
+          return JSON.stringify(data)
+        }
+      ),
+    }),
+  })
+
+  // map of monaco "language id's" to TextMate scopeNames
+  const grammars = new Map()
+  grammars.set('toml', 'toml')
+
+  await wireTmGrammars(monaco, registry, grammars)
+}

--- a/ui/src/external/monaco.tomlTheme.ts
+++ b/ui/src/external/monaco.tomlTheme.ts
@@ -1,0 +1,52 @@
+export const THEME_NAME = 'tomlTheme'
+export default function(monaco) {
+  monaco.editor.defineTheme(THEME_NAME, {
+    base: 'vs-dark',
+    inherit: false,
+    rules: [
+      {
+        token: 'punctuation.definition.comment.toml',
+        foreground: '#676978',
+      },
+      {
+        token: 'comment.line.number-sign.toml',
+        foreground: '#676978',
+      },
+      {
+        token: 'constant.numeric.integer.toml',
+        foreground: '#7CE490',
+      },
+      {
+        token: 'constant.numeric.float.toml',
+        foreground: '#7CE490',
+      },
+      {
+        token: 'string.quoted.double.toml',
+        foreground: '#7CE490',
+      },
+      {
+        token: 'constant.language.boolean.toml',
+        foreground: '#32B08C',
+      },
+      {
+        token: 'entity.name.section.toml',
+        foreground: '#ff4d96',
+      },
+      {
+        token: '',
+        foreground: '#f8f8f8',
+        background: '#202028',
+      },
+    ],
+    colors: {
+      'editor.foreground': '#F8F8F8',
+      'editor.background': '#202028',
+      'editorGutter.background': '#25252e',
+      'editor.selectionBackground': '#353640',
+      'editorLineNumber.foreground': '#666978',
+      'editor.lineHighlightBackground': '#353640',
+      'editorCursor.foreground': '#ffffff',
+      'editorActiveLineNumber.foreground': '#bec2cc',
+    },
+  })
+}

--- a/ui/src/external/toml.tmLanguage.json
+++ b/ui/src/external/toml.tmLanguage.json
@@ -1,0 +1,428 @@
+{
+  "fileTypes": [
+    "toml"
+  ],
+  "keyEquivalent": "^~T",
+  "name": "TOML",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#groups"
+    },
+    {
+      "include": "#key_pair"
+    },
+    {
+      "include": "#invalid"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "begin": "(^[ \\t]+)?(?=#)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.toml"
+        }
+      },
+      "end": "(?!\\G)",
+      "patterns": [
+        {
+          "begin": "#",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.comment.toml"
+            }
+          ],
+          "end": "\\n",
+          "name": "comment.line.number-sign.toml"
+        }
+      ]
+    },
+    "groups": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.section.begin.toml"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "[^\\s.]+",
+                  "name": "entity.name.section.toml"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.section.begin.toml"
+            }
+          },
+          "match": "^\\s*(\\[)([^\\[\\]]*)(\\])",
+          "name": "meta.group.toml"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.section.begin.toml"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "[^\\s.]+",
+                  "name": "entity.name.section.toml"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.section.begin.toml"
+            }
+          },
+          "match": "^\\s*(\\[\\[)([^\\[\\]]*)(\\]\\])",
+          "name": "meta.group.double.toml"
+        }
+      ]
+    },
+    "invalid": {
+      "match": "\\S+(\\s*(?=\\S))?",
+      "name": "invalid.illegal.not-allowed-here.toml"
+    },
+    "key_pair": {
+      "patterns": [
+        {
+          "begin": "([A-Za-z0-9_-]+)\\s*(=)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.key.toml"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.toml"
+            }
+          },
+          "end": "(?<=\\S)(?<!=)|$",
+          "patterns": [
+            {
+              "include": "#primatives"
+            }
+          ]
+        },
+        {
+          "begin": "((\")(.*)(\"))\\s*(=)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.key.toml"
+            },
+            "2": {
+              "name": "punctuation.definition.variable.begin.toml"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "match": "\\\\([btnfr\"\\\\]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+                  "name": "constant.character.escape.toml"
+                },
+                {
+                  "match": "\\\\[^btnfr\"\\\\]",
+                  "name": "invalid.illegal.escape.toml"
+                },
+                {
+                  "match": "\"",
+                  "name": "invalid.illegal.not-allowed-here.toml"
+                }
+              ]
+            },
+            "4": {
+              "name": "punctuation.definition.variable.end.toml"
+            },
+            "5": {
+              "name": "punctuation.separator.key-value.toml"
+            }
+          },
+          "end": "(?<=\\S)(?<!=)|$",
+          "patterns": [
+            {
+              "include": "#primatives"
+            }
+          ]
+        },
+        {
+          "begin": "((')([^']*)('))\\s*(=)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.key.toml"
+            },
+            "2": {
+              "name": "punctuation.definition.variable.begin.toml"
+            },
+            "4": {
+              "name": "punctuation.definition.variable.end.toml"
+            },
+            "5": {
+              "name": "punctuation.separator.key-value.toml"
+            }
+          },
+          "end": "(?<=\\S)(?<!=)|$",
+          "patterns": [
+            {
+              "include": "#primatives"
+            }
+          ]
+        },
+        {
+          "begin": "(?x)\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t(?:\n\t\t\t\t\t\t\t\t\t[A-Za-z0-9_-]+\t\t\t\t# Bare key\n\t\t\t\t\t\t\t\t  | \"  (?:[^\"\\\\]|\\\\.)* \"\t\t# Double quoted key\n\t\t\t\t\t\t\t\t  | ' [^']*          '\t\t# Sindle quoted key\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t(?:\n\t\t\t\t\t\t\t\t\t\\s* \\. \\s*\t\t\t\t\t# Dot\n\t\t\t\t\t\t\t\t  | (?= \\s* =)\t\t\t\t\t#   or look-ahead for equals\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t){2,}\t\t\t\t\t\t\t\t# Ensure at least one dot\n\t\t\t\t\t\t)\n\t\t\t\t\t\t\\s*(=)\\s*\n\t\t\t\t\t",
+          "captures": {
+            "1": {
+              "name": "variable.other.key.toml",
+              "patterns": [
+                {
+                  "match": "\\.",
+                  "name": "punctuation.separator.variable.toml"
+                },
+                {
+                  "captures": {
+                    "1": {
+                      "name": "punctuation.definition.variable.begin.toml"
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "match": "\\\\([btnfr\"\\\\]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+                          "name": "constant.character.escape.toml"
+                        },
+                        {
+                          "match": "\\\\[^btnfr\"\\\\]",
+                          "name": "invalid.illegal.escape.toml"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.definition.variable.end.toml"
+                    }
+                  },
+                  "match": "(\")((?:[^\"\\\\]|\\\\.)*)(\")"
+                },
+                {
+                  "captures": {
+                    "1": {
+                      "name": "punctuation.definition.variable.begin.toml"
+                    },
+                    "2": {
+                      "name": "punctuation.definition.variable.end.toml"
+                    }
+                  },
+                  "match": "(')[^']*(')"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.separator.key-value.toml"
+            }
+          },
+          "comment": "Dotted key",
+          "end": "(?<=\\S)(?<!=)|$",
+          "patterns": [
+            {
+              "include": "#primatives"
+            }
+          ]
+        }
+      ]
+    },
+    "primatives": {
+      "patterns": [
+        {
+          "begin": "\\G\"\"\"",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.string.begin.toml"
+            }
+          ],
+          "end": "\"\"\"",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.string.end.toml"
+            }
+          ],
+          "name": "string.quoted.triple.double.toml",
+          "patterns": [
+            {
+              "match": "\\\\([btnfr\"\\\\]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr\"\\\\\\n]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "begin": "\\G\"",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.string.begin.toml"
+            }
+          ],
+          "end": "\"",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.string.end.toml"
+            }
+          ],
+          "name": "string.quoted.double.toml",
+          "patterns": [
+            {
+              "match": "\\\\([btnfr\"\\\\]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+              "name": "constant.character.escape.toml"
+            },
+            {
+              "match": "\\\\[^btnfr\"\\\\]",
+              "name": "invalid.illegal.escape.toml"
+            }
+          ]
+        },
+        {
+          "begin": "\\G'''",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.string.begin.toml"
+            }
+          ],
+          "end": "'''",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.string.end.toml"
+            }
+          ],
+          "name": "string.quoted.triple.single.toml"
+        },
+        {
+          "begin": "\\G'",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.string.begin.toml"
+            }
+          ],
+          "end": "'",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.string.end.toml"
+            }
+          ],
+          "name": "string.quoted.single.toml"
+        },
+        {
+          "match": "\\G(?x)\n\t\t\t\t\t\t[0-9]{4}\n\t\t\t\t\t\t-\n\t\t\t\t\t\t(0[1-9]|1[012])\n\t\t\t\t\t\t-\n\t\t\t\t\t\t(?!00|3[2-9])[0-3][0-9]\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\t[Tt]\n\t\t\t\t\t\t\t(?!2[5-9])[0-2][0-9]\n\t\t\t\t\t\t\t:\n\t\t\t\t\t\t\t[0-5][0-9]\n\t\t\t\t\t\t\t:\n\t\t\t\t\t\t\t(?!6[1-9])[0-6][0-9]\n\t\t\t\t\t\t\t(\\.[0-9]+)?\n\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\tZ\n\t\t\t\t\t\t\t  | [+-](?!2[5-9])[0-2][0-9]:[0-5][0-9]\n\t\t\t\t\t\t\t)?\n\t\t\t\t\t\t)?\n\t\t\t\t\t",
+          "name": "constant.other.date.toml"
+        },
+        {
+          "match": "\\G(true|false)",
+          "name": "constant.language.boolean.toml"
+        },
+        {
+          "match": "\\G0x\\h(\\h|_\\h)*",
+          "name": "constant.numeric.hex.toml"
+        },
+        {
+          "match": "\\G0o[0-7]([0-7]|_[0-7])*",
+          "name": "constant.numeric.octal.toml"
+        },
+        {
+          "match": "\\G0b[01]([01]|_[01])*",
+          "name": "constant.numeric.binary.toml"
+        },
+        {
+          "match": "\\G[+-]?(inf|nan)",
+          "name": "constant.numeric.toml"
+        },
+        {
+          "match": "(?x)\n\t\t\t\t\t\t\\G\n\t\t\t\t\t\t(\n\t\t\t\t\t\t    [+-]?\n\t\t\t\t\t\t    (\n\t\t\t\t\t\t\t\t0\n\t\t\t\t\t\t\t  | ([1-9](([0-9]|_[0-9])+)?)\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t)\n\t\t\t\t\t\t(?=[.eE])\n\t\t\t\t\t\t(\n\t\t\t\t\t\t    \\.\n\t\t\t\t\t\t    ([0-9](([0-9]|_[0-9])+)?)\n\t\t\t\t\t\t)?\n\t\t\t\t\t\t(\n\t\t\t\t\t\t    [eE]\n\t\t\t\t\t\t    ([+-]?(0|([1-9](([0-9]|_[0-9])+)?)))\n\t\t\t\t\t\t)?\n\t\t\t\t\t",
+          "name": "constant.numeric.float.toml"
+        },
+        {
+          "match": "(?x)\n\t\t\t\t\t\t\\G\n\t\t\t\t\t\t(\n\t\t\t\t\t\t    [+-]?\n\t\t\t\t\t\t    (\n\t\t\t\t\t\t\t\t0\n\t\t\t\t\t\t\t  | ([1-9](([0-9]|_[0-9])+)?)\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t)\n\t\t\t\t\t",
+          "name": "constant.numeric.integer.toml"
+        },
+        {
+          "begin": "\\G\\[",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.array.begin.toml"
+            }
+          ],
+          "end": "\\]",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.array.end.toml"
+            }
+          ],
+          "name": "meta.array.toml",
+          "patterns": [
+            {
+              "begin": "(?=[\"'']|[+-]?[0-9]|[+-]?(inf|nan)|true|false|\\[|\\{)",
+              "end": ",|(?=])",
+              "endCaptures": [
+                {
+                  "name": "punctuation.separator.array.toml"
+                }
+              ],
+              "patterns": [
+                {
+                  "include": "#primatives"
+                },
+                {
+                  "include": "#comments"
+                },
+                {
+                  "include": "#invalid"
+                }
+              ]
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#invalid"
+            }
+          ]
+        },
+        {
+          "begin": "\\G\\{",
+          "beginCaptures": [
+            {
+              "name": "punctuation.definition.inline-table.begin.toml"
+            }
+          ],
+          "end": "\\}",
+          "endCaptures": [
+            {
+              "name": "punctuation.definition.inline-table.end.toml"
+            }
+          ],
+          "name": "meta.inline-table.toml",
+          "patterns": [
+            {
+              "begin": "(?=\\S)",
+              "end": ",|(?=})",
+              "endCaptures": [
+                {
+                  "name": "punctuation.separator.inline-table.toml"
+                }
+              ],
+              "patterns": [
+                {
+                  "include": "#key_pair"
+                }
+              ]
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "source.toml",
+  "uuid": "7DEF2EDB-5BB7-4DD2-9E78-3541A26B7923"
+}

--- a/ui/src/shared/components/TomlMonacoEditor.tsx
+++ b/ui/src/shared/components/TomlMonacoEditor.tsx
@@ -52,7 +52,7 @@ const TomlEditorMonaco: FC<Props> = props => {
   const {script, onChangeScript} = props
 
   return (
-    <div className="time-machine-editor" data-testid="toml-editor">
+    <div className="time-machine-editor--embedded" data-testid="toml-editor">
       <MonacoEditor
         language="toml"
         theme={THEME_NAME}

--- a/ui/src/shared/components/TomlMonacoEditor.tsx
+++ b/ui/src/shared/components/TomlMonacoEditor.tsx
@@ -1,0 +1,81 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import MonacoEditor from 'react-monaco-editor'
+import addTomlTheme, {THEME_NAME} from 'src/external/monaco.tomlTheme'
+import {addSyntax} from 'src/external/monaco.tomlSyntax'
+import {OnChangeScript} from 'src/types/flux'
+import './FluxMonacoEditor.scss'
+
+interface Position {
+  line: number
+  ch: number
+}
+
+interface Props {
+  script: string
+  onChangeScript: OnChangeScript
+  onSubmitScript?: () => void
+  onCursorChange?: (position: Position) => void
+}
+
+const TomlEditorMonaco: FC<Props> = props => {
+  const editorWillMount = monaco => {
+    addTomlTheme(monaco)
+    addSyntax(monaco)
+  }
+  const editorDidMount = editor => {
+    editor.onDidChangeCursorPosition(evt => {
+      const {position} = evt
+      const {onCursorChange} = props
+      const pos = {
+        line: position.lineNumber,
+        ch: position.column,
+      }
+
+      if (onCursorChange) {
+        onCursorChange(pos)
+      }
+    })
+
+    editor.onKeyUp(evt => {
+      const {ctrlKey, code} = evt
+      const {onSubmitScript} = props
+      if (ctrlKey && code === 'Enter') {
+        if (onSubmitScript) {
+          onSubmitScript()
+        }
+      }
+    })
+  }
+  const {script, onChangeScript} = props
+
+  return (
+    <div className="time-machine-editor" data-testid="toml-editor">
+      <MonacoEditor
+        language="toml"
+        theme={THEME_NAME}
+        value={script}
+        onChange={onChangeScript}
+        options={{
+          fontSize: 13,
+          fontFamily: '"RobotoMono", monospace',
+          cursorWidth: 2,
+          lineNumbersMinChars: 4,
+          lineDecorationsWidth: 0,
+          minimap: {
+            enabled: false,
+            renderCharacters: false,
+          },
+          overviewRulerBorder: false,
+          automaticLayout: true,
+        }}
+        editorWillMount={editorWillMount}
+        editorDidMount={editorDidMount}
+      />
+    </div>
+  )
+}
+
+export default TomlEditorMonaco

--- a/ui/src/shared/components/TomlMonacoEditor.tsx
+++ b/ui/src/shared/components/TomlMonacoEditor.tsx
@@ -70,6 +70,7 @@ const TomlEditorMonaco: FC<Props> = props => {
           },
           overviewRulerBorder: false,
           automaticLayout: true,
+          readOnly: true,
         }}
         editorWillMount={editorWillMount}
         editorDidMount={editorDidMount}

--- a/ui/src/shared/components/TomlMonacoEditor.tsx
+++ b/ui/src/shared/components/TomlMonacoEditor.tsx
@@ -15,7 +15,7 @@ interface Position {
 
 interface Props {
   script: string
-  onChangeScript: OnChangeScript
+  onChangeScript?: OnChangeScript
   onSubmitScript?: () => void
   onCursorChange?: (position: Position) => void
 }

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -67,19 +67,23 @@ export const FeatureFlag: FunctionComponent<{
 const list = () => {
   console.log('Currently Available Feature Flags')
   if (CLOUD) {
-    console.table(Object.keys(CLOUD_FLAGS)
-    .map((k) => ([k, isFlagEnabled(k)]))
-    .reduce((prev, curr) => {
-      prev[curr[0]] = curr[1]
-      return prev
-    }, {}))
+    console.table(
+      Object.keys(CLOUD_FLAGS)
+        .map(k => [k, isFlagEnabled(k)])
+        .reduce((prev, curr) => {
+          prev[curr[0]] = curr[1]
+          return prev
+        }, {})
+    )
   } else {
-    console.table(Object.keys(CLOUD_FLAGS)
-    .map((k) => ([k, isFlagEnabled(k)]))
-    .reduce((prev, curr) => {
-      prev[curr[0]] = curr[1]
-      return prev
-    }, {}))
+    console.table(
+      Object.keys(CLOUD_FLAGS)
+        .map(k => [k, isFlagEnabled(k)])
+        .reduce((prev, curr) => {
+          prev[curr[0]] = curr[1]
+          return prev
+        }, {})
+    )
   }
 }
 /* eslint-enable no-console */

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -67,9 +67,19 @@ export const FeatureFlag: FunctionComponent<{
 const list = () => {
   console.log('Currently Available Feature Flags')
   if (CLOUD) {
-    console.table(CLOUD_FLAGS)
+    console.table(Object.keys(CLOUD_FLAGS)
+    .map((k) => ([k, isFlagEnabled(k)]))
+    .reduce((prev, curr) => {
+      prev[curr[0]] = curr[1]
+      return prev
+    }, {}))
   } else {
-    console.table(OSS_FLAGS)
+    console.table(Object.keys(CLOUD_FLAGS)
+    .map((k) => ([k, isFlagEnabled(k)]))
+    .reduce((prev, curr) => {
+      prev[curr[0]] = curr[1]
+      return prev
+    }, {}))
   }
 }
 /* eslint-enable no-console */
@@ -87,10 +97,10 @@ const reset = () => {
     })
   } else {
     Object.keys(featureFlags).forEach(k => {
-      if (!CLOUD_FLAGS.hasOwnProperty(k)) {
+      if (!OSS_FLAGS.hasOwnProperty(k)) {
         delete featureFlags[k]
       } else {
-        featureFlags[k] = CLOUD_FLAGS[k]
+        featureFlags[k] = OSS_FLAGS[k]
       }
     })
   }
@@ -121,4 +131,4 @@ export const toggleLocalStorageFlag = (flagName: string) => {
 // Expose utility in dev tools console for convenience
 const w: any = window
 
-w.influx = {toggleFeature: toggleLocalStorageFlag, list, reset}
+w.influx = {toggleFeature: toggleLocalStorageFlag, list, reset, set}

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -71,15 +71,23 @@ const list = () => {
       Object.keys(CLOUD_FLAGS)
         .map(k => [k, isFlagEnabled(k)])
         .reduce((prev, curr) => {
+          if (typeof curr[0] === 'boolean') {
+            return prev
+          }
+
           prev[curr[0]] = curr[1]
           return prev
         }, {})
     )
   } else {
     console.table(
-      Object.keys(CLOUD_FLAGS)
+      Object.keys(OSS_FLAGS)
         .map(k => [k, isFlagEnabled(k)])
         .reduce((prev, curr) => {
+          if (typeof curr[0] === 'boolean') {
+            return prev
+          }
+
           prev[curr[0]] = curr[1]
           return prev
         }, {})

--- a/ui/src/telegrafs/components/TelegrafConfig.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfig.tsx
@@ -13,14 +13,13 @@ import {RemoteDataState} from '@influxdata/clockface'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
-import {getTelegrafConfigToml, editTelegraf} from 'src/telegrafs/actions'
+import {getTelegrafConfigToml} from 'src/telegrafs/actions'
 
 // Types
 import {AppState} from 'src/types'
 
 interface DispatchProps {
   getTelegrafConfigToml: typeof getTelegrafConfigToml
-  editTelegraf: typeof editTelegraf
 }
 
 interface StateProps {
@@ -48,9 +47,6 @@ export class TelegrafConfig extends PureComponent<Props & WithRouterProps> {
 
   private onBeforeChange = () => {}
   private onTouchStart = () => {}
-  private onChange = (text) => {
-    console.log('whoa', text)
-  }
 
   private get overlayBody(): JSX.Element {
     const options = {
@@ -68,7 +64,6 @@ export class TelegrafConfig extends PureComponent<Props & WithRouterProps> {
         <FeatureFlag name="monacoEditor">
           <MonacoEditor
             script={telegrafConfig}
-            onChangeScript={this.onChange}
           />
         </FeatureFlag>
         <FeatureFlag name="monacoEditor" equals={false}>
@@ -101,7 +96,6 @@ const mstp = (state: AppState): StateProps => ({
 
 const mdtp: DispatchProps = {
   getTelegrafConfigToml: getTelegrafConfigToml,
-  editTelegraf: editTelegraf,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/telegrafs/components/TelegrafConfig.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfig.tsx
@@ -51,15 +51,6 @@ export class TelegrafConfig extends PureComponent<Props & WithRouterProps> {
   private onTouchStart = () => {}
 
   private get overlayBody(): JSX.Element {
-    const options = {
-      tabIndex: 1,
-      mode: 'toml',
-      readonly: true,
-      lineNumbers: true,
-      autoRefresh: true,
-      theme: 'time-machine',
-      completeSingle: false,
-    }
     const {telegrafConfig} = this.props
     return (
       <Suspense fallback={spinner}>
@@ -72,13 +63,11 @@ export class TelegrafConfig extends PureComponent<Props & WithRouterProps> {
             autoCursor={true}
             value={telegrafConfig}
             options={{
-              tabIndex: 1,
+              tabindex: 1,
               mode: 'toml',
-              readonly: true,
+              readOnly: true,
               lineNumbers: true,
-              autoRefresh: true,
               theme: 'time-machine',
-              completeSingle: false,
             }}
             onBeforeChange={this.onBeforeChange}
             onTouchStart={this.onTouchStart}

--- a/ui/src/telegrafs/components/TelegrafConfig.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfig.tsx
@@ -5,7 +5,9 @@ import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-const Editor = React.lazy(() => import('react-codemirror2').then(module => ({ default: module.Controlled })))
+const Editor = React.lazy(() =>
+  import('react-codemirror2').then(module => ({default: module.Controlled}))
+)
 const MonacoEditor = React.lazy(() =>
   import('src/shared/components/TomlMonacoEditor')
 )
@@ -62,9 +64,7 @@ export class TelegrafConfig extends PureComponent<Props & WithRouterProps> {
     return (
       <Suspense fallback={spinner}>
         <FeatureFlag name="monacoEditor">
-          <MonacoEditor
-            script={telegrafConfig}
-          />
+          <MonacoEditor script={telegrafConfig} />
         </FeatureFlag>
         <FeatureFlag name="monacoEditor" equals={false}>
           <Editor

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
@@ -26,6 +26,14 @@
   height: 100%;
 }
 
+.time-machine-editor--embedded {
+  @extend .time-machine-editor;
+
+  border-radius: 4px;
+  border: 2px solid $g5-pepper;
+  overflow: hidden;
+}
+
 .time-machine-editor--loading {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
upgrading the toml editor to monaco allows us go from zero
<img width="1171" alt="Screen Shot 2019-12-02 at 12 51 58 PM" src="https://user-images.githubusercontent.com/1434802/69994445-c22bf500-1502-11ea-8758-a5f84a3309fb.png">
to hero
<img width="1286" alt="Screen Shot 2019-12-02 at 2 19 11 PM" src="https://user-images.githubusercontent.com/1434802/69999965-bfcf9800-150e-11ea-995f-d5849b6ce696.png">
