### PR TITLE
fix(ui): updated getEndTime to account for now() selections as the upper bound of the query

### DIFF
--- a/ui/src/timeMachine/selectors/index.test.ts
+++ b/ui/src/timeMachine/selectors/index.test.ts
@@ -104,16 +104,17 @@ describe('TimeMachine.Selectors.Index', () => {
   })
   it(`getEndTime should return ${newYears} when lower is ${date}`, () => {
     const timeRange = {
-      lower: 'now() - 30d',
+      lower: date,
       upper: date,
     }
     expect(getEndTime(timeRange)).toEqual(newYears)
   })
-  it(`getEndTime should return null when upper is null`, () => {
+  const now = moment().valueOf()
+  it(`getEndTime should return ${now} when upper is null and lower includes now()`, () => {
     const timeRange = {
       lower: 'now() - 30d',
       upper: null,
     }
-    expect(getEndTime(timeRange)).toEqual(null)
+    expect(getEndTime(timeRange)).toBeGreaterThanOrEqual(now)
   })
 })

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -302,11 +302,12 @@ export const getEndTime = (timeRange: TimeRange): number => {
   if (!timeRange) {
     return null
   }
-  const {upper} = timeRange
-  switch (upper) {
-    case null:
-      return null
-    default:
-      return moment(upper).valueOf()
+  const {lower, upper} = timeRange
+  if (lower.includes('now()')) {
+    return moment().valueOf()
   }
+  if (upper) {
+    return moment(upper).valueOf()
+  }
+  return null
 }

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -303,11 +303,11 @@ export const getEndTime = (timeRange: TimeRange): number => {
     return null
   }
   const {lower, upper} = timeRange
-  if (lower.includes('now()')) {
-    return moment().valueOf()
-  }
   if (upper) {
     return moment(upper).valueOf()
+  }
+  if (lower.includes('now()')) {
+    return moment().valueOf()
   }
   return null
 }


### PR DESCRIPTION
Closes #15908 

### Problem

The previous solution failed to account for query boundaries where `now()` was being set as the upper bound in the `lower` property of the timeRange, and `upper` was being set to `null`

### Solution

Updated `getEndTime` to check to see if `lower` includes `now()` and sets returns a moment reference to `now` 