### PR TITLE
fix(ui): updated telegrafs reducer to set correctly set props

### DIFF
--- a/ui/src/telegrafs/reducers/index.ts
+++ b/ui/src/telegrafs/reducers/index.ts
@@ -77,7 +77,7 @@ export const telegrafsReducer = (
         if (item) {
           draftState.currentConfig.item = item
         } else {
-          draftState.currentConfig.item = null
+          draftState.currentConfig.item = ''
         }
 
         return


### PR DESCRIPTION
Closes https://github.com/influxdata/honeybadger-errors/issues/4

### Problem

codemirror was expecting the `value` passed in to be a `string`, but the value was being set to `null` in particular default situations

### Solution

Updated the reducer to default setting the `telegrafConfig` to an empty string rather than `null`