### PR TITLE
feat(query): annotate logger with trace id and record query errors in trace log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [15836](https://github.com/influxdata/influxdb/pull/16077): Add stacked line layer option to graphs
+1. [16094](https://github.com/influxdata/influxdb/pull/16094): Annotate log messages with trace ID, if available
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ $ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx setup
 Welcome to InfluxDB 2.0!
 Please type your primary username: user
 
-Please type your password: hunter2
+Please type your password: my-password
 
-Please type your password again: hunter2
+Please type your password again: my-password
 
 Please type your primary organization name.: my-org
 
@@ -128,7 +128,7 @@ Your token has been stored in /Users/you/.influxdbv2/credentials
 You may get into a development loop where `influx setup` becomes tedious.
 Some added flags can help:
 ```
-$ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx setup --username user --password hunter2 --org my-org --bucket my-bucket --retention 168 --token my-token --force
+$ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx setup --username user --password my-password --org my-org --bucket my-bucket --retention 168 --token my-token --force
 ```
 
 `~/.influxdbv2/credentials` contains your auth token.

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/influxdata/influxdb/http/metric"
 	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/kit/tracing"
+	influxlogger "github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/query"
 	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -104,6 +105,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	defer span.Finish()
 
 	ctx := r.Context()
+	log := h.log.With(influxlogger.Trace(ctx)...)
 
 	// TODO(desa): I really don't like how we're recording the usage metrics here
 	// Ideally this will be moved when we solve https://github.com/influxdata/influxdb/issues/13403
@@ -169,7 +171,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 			h.HandleHTTPError(ctx, err, w)
 			return
 		}
-		h.log.Info("Error writing response to client",
+		log.Info("Error writing response to client",
 			zap.String("handler", "flux"),
 			zap.Error(err),
 		)

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -171,6 +171,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 			h.HandleHTTPError(ctx, err, w)
 			return
 		}
+		_ = tracing.LogError(span, err)
 		log.Info("Error writing response to client",
 			zap.String("handler", "flux"),
 			zap.Error(err),

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -105,7 +105,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	defer span.Finish()
 
 	ctx := r.Context()
-	log := h.log.With(influxlogger.Trace(ctx)...)
+	log := h.log.With(influxlogger.TraceFields(ctx)...)
 
 	// TODO(desa): I really don't like how we're recording the usage metrics here
 	// Ideally this will be moved when we solve https://github.com/influxdata/influxdb/issues/13403

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -87,6 +87,7 @@ func Shard(id uint64) zapcore.Field {
 	return zap.Uint64(DBShardIDKey, id)
 }
 
+<<<<<<< HEAD
 // TraceInfo returns the traceID and if it was sampled from the Jaeger span
 // found in the given context. It returns if a span associated to the context has been found.
 func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
@@ -100,7 +101,7 @@ func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
 	return "", false, false
 }
 
-// OTTraceID returns a fields "ot_trace_id" and "ot_trace_sampled", values pulled from the (Jaeger) trace ID
+// Trace returns a fields "ot_trace_id" and "ot_trace_sampled", values pulled from the (Jaeger) trace ID
 // found in the given context. Returns zap.Skip() if the context doesn't have a trace ID.
 func Trace(ctx context.Context) []zap.Field {
 	if span := opentracing.SpanFromContext(ctx); span != nil {

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -100,6 +100,20 @@ func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
 	return "", false, false
 }
 
+// OTTraceID returns a fields "ot_trace_id" and "ot_trace_sampled", values pulled from the (Jaeger) trace ID
+// found in the given context. Returns zap.Skip() if the context doesn't have a trace ID.
+func Trace(ctx context.Context) []zap.Field {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		if spanContext, ok := span.Context().(jaeger.SpanContext); ok {
+			return []zap.Field{
+				zap.String("ot_trace_id", spanContext.TraceID().String()),
+				zap.Bool("ot_trace_sampled", spanContext.IsSampled()),
+			}
+		}
+	}
+	return []zap.Field{zap.Skip()}
+}
+
 // TraceID returns a field "trace_id", value pulled from the (Jaeger) trace ID found in the given context.
 // Returns zap.Skip() if the context doesn't have a trace ID.
 func TraceID(ctx context.Context) zap.Field {

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -33,6 +33,12 @@ const (
 
 	// DBShardIDKey is the logging context key used for identifying name of the relevant shard number.
 	DBShardIDKey = "db_shard_id"
+
+	// TraceIDKey is the logging context key used for identifying the current trace.
+	TraceIDKey = "ot_trace_id"
+
+	// TraceSampledKey is the logging context key used for determining whether the current trace will be sampled.
+	TraceSampledKey = "ot_trace_sampled"
 )
 const (
 	eventStart = "start"
@@ -87,9 +93,8 @@ func Shard(id uint64) zapcore.Field {
 	return zap.Uint64(DBShardIDKey, id)
 }
 
-<<<<<<< HEAD
 // TraceInfo returns the traceID and if it was sampled from the Jaeger span
-// found in the given context. It returns if a span associated to the context has been found.
+// found in the given context. It returns whether a span associated to the context has been found.
 func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		if spanContext, ok := span.Context().(jaeger.SpanContext); ok {
@@ -101,18 +106,14 @@ func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
 	return "", false, false
 }
 
-// Trace returns a fields "ot_trace_id" and "ot_trace_sampled", values pulled from the (Jaeger) trace ID
-// found in the given context. Returns zap.Skip() if the context doesn't have a trace ID.
-func Trace(ctx context.Context) []zap.Field {
-	if span := opentracing.SpanFromContext(ctx); span != nil {
-		if spanContext, ok := span.Context().(jaeger.SpanContext); ok {
-			return []zap.Field{
-				zap.String("ot_trace_id", spanContext.TraceID().String()),
-				zap.Bool("ot_trace_sampled", spanContext.IsSampled()),
-			}
-		}
+// TraceFields returns a fields "ot_trace_id" and "ot_trace_sampled", values pulled from the (Jaeger) trace ID
+// found in the given context. Returns nil if the context doesn't have a trace ID.
+func TraceFields(ctx context.Context) []zap.Field {
+	id, sampled, found := TraceInfo(ctx)
+	if !found {
+		return nil
 	}
-	return []zap.Field{zap.Skip()}
+	return []zap.Field{zap.String(TraceIDKey, id), zap.Bool(TraceSampledKey, sampled)}
 }
 
 // TraceID returns a field "trace_id", value pulled from the (Jaeger) trace ID found in the given context.

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/influxdata/influxdb/kit/errors"
 	"github.com/influxdata/influxdb/kit/prom"
 	"github.com/influxdata/influxdb/kit/tracing"
+	influxlogger "github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/query"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -313,6 +314,8 @@ func (c *Controller) countQueryRequest(q *Query, result requestsLabel) {
 }
 
 func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) (err error) {
+	log := c.log.With(influxlogger.Trace(q.parentCtx)...)
+
 	defer func() {
 		if e := recover(); e != nil {
 			var ok bool
@@ -320,7 +323,7 @@ func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) (err error) 
 			if !ok {
 				err = fmt.Errorf("panic: %v", e)
 			}
-			if entry := c.log.Check(zapcore.InfoLevel, "panic during compile"); entry != nil {
+			if entry := log.Check(zapcore.InfoLevel, "panic during compile"); entry != nil {
 				entry.Stack = string(debug.Stack())
 				entry.Write(zap.Error(err))
 			}
@@ -344,7 +347,7 @@ func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) (err error) 
 	}
 
 	if p, ok := prog.(lang.LoggingProgram); ok {
-		p.SetLogger(c.log)
+		p.SetLogger(log)
 	}
 
 	q.program = prog
@@ -384,6 +387,7 @@ func (c *Controller) processQueryQueue() {
 
 // executeQuery will execute a compiled program and wait for its completion.
 func (c *Controller) executeQuery(q *Query) {
+
 	defer c.waitForQuery(q)
 	defer func() {
 		if e := recover(); e != nil {
@@ -393,7 +397,8 @@ func (c *Controller) executeQuery(q *Query) {
 				err = fmt.Errorf("panic: %v", e)
 			}
 			q.setErr(err)
-			if entry := c.log.Check(zapcore.InfoLevel, "panic during program start"); entry != nil {
+			if entry := c.log.With(influxlogger.Trace(q.parentCtx)...).
+				Check(zapcore.InfoLevel, "panic during program start"); entry != nil {
 				entry.Stack = string(debug.Stack())
 				entry.Write(zap.Error(err))
 			}

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -314,7 +314,7 @@ func (c *Controller) countQueryRequest(q *Query, result requestsLabel) {
 }
 
 func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) (err error) {
-	log := c.log.With(influxlogger.Trace(q.parentCtx)...)
+	log := c.log.With(influxlogger.TraceFields(q.parentCtx)...)
 
 	defer func() {
 		if e := recover(); e != nil {
@@ -397,7 +397,7 @@ func (c *Controller) executeQuery(q *Query) {
 				err = fmt.Errorf("panic: %v", e)
 			}
 			q.setErr(err)
-			if entry := c.log.With(influxlogger.Trace(q.parentCtx)...).
+			if entry := c.log.With(influxlogger.TraceFields(q.parentCtx)...).
 				Check(zapcore.InfoLevel, "panic during program start"); entry != nil {
 				entry.Stack = string(debug.Stack())
 				entry.Write(zap.Error(err))


### PR DESCRIPTION
This PR connects logged errors to their corresponding trace by annotating the logger with the request's trace ID. Additionally, errors bubbling up to the query handler are captured in the trace logs. 

A small, unrelated README update is also included.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Use @affo's `TraceInfo` method once its merged
