### PR TITLE
fix(ui): updated useEffect to account for times when an organization isn't returned

### DIFF
--- a/ui/src/shared/containers/SetOrg.tsx
+++ b/ui/src/shared/containers/SetOrg.tsx
@@ -51,7 +51,11 @@ const SetOrg: FunctionComponent<Props> = ({
     }
 
     // else default to first org
-    router.push(`/orgs/${orgs[0].id}`)
+    if (orgs && orgs.length > 0) {
+      router.push(`/orgs/${orgs[0].id}`)
+    }
+    // if no orgs exist are returned, create one
+    router.push(`/orgs/new`)
   }, [orgID])
 
   return (

--- a/ui/src/shared/containers/SetOrg.tsx
+++ b/ui/src/shared/containers/SetOrg.tsx
@@ -53,9 +53,10 @@ const SetOrg: FunctionComponent<Props> = ({
     // else default to first org
     if (orgs && orgs.length > 0) {
       router.push(`/orgs/${orgs[0].id}`)
+    } else {
+      // if no orgs exist are returned, create one
+      router.push(`/orgs/new`)
     }
-    // if no orgs exist are returned, create one
-    router.push(`/orgs/new`)
   }, [orgID])
 
   return (


### PR DESCRIPTION
Closes https://github.com/influxdata/honeybadger-errors/issues/9

### Problem

If the `getOrgs` api fails to return an organization / errors, `orgs[0]` will be undefined. 

### Solution

Added checks to see if `orgs[0]` exist and added a default route to create a new org if no `orgs` have been returned.
