### PR TITLE
fix(ui): properly map over queryBuilder tags and set default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.0.0-alpha.21 [unreleased]
+
+### Features
+
+### Bug Fixes
+1. [16101](https://github.com/influxdata/influxdb/pull/16101): Gracefully handle invalid user-supplied JSON
+1. [16105](https://github.com/influxdata/influxdb/pull/16105): Fix crash when loading queries built using Query Builder
+
+### UI Improvements
+
 ## v2.0.0-alpha.20 [2019-11-20]
 
 ### Features
@@ -28,7 +38,6 @@
 1. [15853](https://github.com/influxdata/influxdb/pull/15853): Prompt users to make a dashboard when dashboards are empty
 1. [15884](https://github.com/influxdata/influxdb/pull/15884): Remove name editing from query definition during threshold check creation
 1. [15975](https://github.com/influxdata/influxdb/pull/15975): Wait until user stops dragging and releases marker before zooming in after threshold changes
-1. [16101](https://github.com/influxdata/influxdb/pull/16101): Gracefully handle invalid user-supplied JSON
 
 ### UI Improvements
 1. [15809](https://github.com/influxdata/influxdb/pull/15809): Redesign cards and animations on getting started page

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -1103,7 +1103,10 @@ const initialQueryBuilderState = (
     bucketsStatus: RemoteDataState.NotStarted,
     functions: [],
     aggregateWindow: {period: 'auto'},
-    tags: initialStateHelper().queryBuilder.tags,
+    tags: builderConfig.tags.map(() => {
+      const [defaultTag] = initialStateHelper().queryBuilder.tags
+      return defaultTag
+    }),
   }
 }
 


### PR DESCRIPTION
Closes [HoneyBadger #12](https://github.com/influxdata/honeybadger-errors/issues/12)

For the purposes of expediency and fixing a terrible prod bug, this bypasses good hygiene like tests. I [added an issue to follow up on that.](https://github.com/influxdata/influxdb/issues/16106)

Error was introduced [here.](https://github.com/influxdata/influxdb/commit/a90899ebf2e7908d154887bb05b20a22d5281945#diff-afb81e9ccfb919d0134e48bd7176aa6bR1096)

I initially noticed a lot of duplication of the initial state of tags, so I added the notion of an initial tag. Tags in query builder parlance map to the boxes at the bottom of the query builder. So each query that was built with the builder has an array of tags associated with it. On load, these tags are nulled out to an initial state. Here is a kinda psuedocode explanation of what that looks like:

```ts
const initialStateHelperTags = [{
  aggregateFunctionType: 'filter',
  keys: [],
  keysSearchTerm: '',
  keysStatus: RemoteDataState.NotStarted,
  values: [],
  valuesSearchTerm: '',
  valuesStatus: RemoteDataState.NotStarted,
}]

queryBuilder: {
  tags: [
    initialStateHelperTags[0],
    initialStateHelperTags[0],
    initialStateHelperTags[0]
  ]
}
```
When the query builder loads, it _should_ loop over all the tag groups in the query builder and set them to default values.

What my buggy code did was this:
```ts
queryBuilder.tags = initialStateHelperTags
```
See the differences? It set the array of tags, which maps to each filtered section of a query, to an array with with a single item, the default tag.

big oof.

## Testing Instructions:

**On master:**
1. Create a query with the query builder.
1. Load that query
1. 💥 

**Checkout this branch:**
1. `git checkout bs_fix_undefined_tags`
1. Load the query you saved before
1. 🎉 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
