### PR TITLE
fix: broken tests in dashboard http tests

### DIFF
--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -457,6 +457,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 		"colors": null,
 		"geom": "",
 		"legend": {},
+		"position": "",
 		"note": "",
 		"queries": null,
 		"shadeBelow": false,


### PR DESCRIPTION
makes master whole again. was created when https://github.com/influxdata/influxdb/pull/16077 merged right after another PR that had changes to the dashboard model.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass