### PR TITLE
feat(http): create cell view properties on dashboard creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Bug Fixes
 1. [16101](https://github.com/influxdata/influxdb/pull/16101): Gracefully handle invalid user-supplied JSON
+1. [16057](https://github.com/influxdata/influxdb/pull/16057): Adds `properties` to each cell on GET /dashboards/{dashboardID}
 1. [16105](https://github.com/influxdata/influxdb/pull/16105): Fix crash when loading queries built using Query Builder
+1. [16112](https://github.com/influxdata/influxdb/pull/16112): Create cell view properties on dashboard creation
 
 ### UI Improvements
 
@@ -19,8 +21,6 @@
 1. [15674](https://github.com/influxdata/influxdb/pull/15674): Allow users to view just the output section of a telegraf config
 1. [15923](https://github.com/influxdata/influxdb/pull/15923): Allow the users to see string data in the single stat graph type
 1. [15314](https://github.com/influxdata/influxdb/issues/15314): Allow the users to see string data in the single stat graph type
-1. [16057] (https://github.com/influxdata/influxdb/pull/16057): Adds `properties` to each cell on GET /dashboards/{dashboardID}
-1. [16112] (https://github.com/influxdata/influxdb/pull/16112): Create cell view properties on dashboard creation
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
 1. [15749](https://github.com/influxdata/influxdb/pull/15749): Expose bundle analysis tools for frontend resources
 1. [15674](https://github.com/influxdata/influxdb/pull/15674): Allow users to view just the output section of a telegraf config
 1. [15923](https://github.com/influxdata/influxdb/pull/15923): Allow the users to see string data in the single stat graph type
-1. [16057](https://github.com/influxdata/influxdb/pull/16057): Adds `properties` to each cell on GET /dashboards/{dashboardID}
+1. [15314](https://github.com/influxdata/influxdb/issues/15314): Allow the users to see string data in the single stat graph type
+1. [16057] (https://github.com/influxdata/influxdb/pull/16057): Adds `properties` to each cell on GET /dashboards/{dashboardID}
+1. [16112] (https://github.com/influxdata/influxdb/pull/16112): Create cell view properties on dashboard creation
 
 ### Bug Fixes
 

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -464,23 +464,96 @@ func (h *DashboardHandler) handlePostDashboard(w http.ResponseWriter, r *http.Re
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	if err := h.DashboardService.CreateDashboard(ctx, req.Dashboard); err != nil {
+
+	pd := req.Dashboard.toPlatform()
+	if err := h.DashboardService.CreateDashboard(ctx, pd); err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
-	if err := encodeResponse(ctx, w, http.StatusCreated, newDashboardResponse(req.Dashboard, []*platform.Label{})); err != nil {
+	if err := encodeResponse(ctx, w, http.StatusCreated, newDashboardResponse(pd, []*platform.Label{})); err != nil {
 		logEncodingError(h.Logger, r, err)
 		return
 	}
 }
 
+func (d *dashboard) toPlatform() *platform.Dashboard {
+	pd := &platform.Dashboard{
+		ID:             d.ID,
+		OrganizationID: d.OrganizationID,
+		Name:           d.Name,
+		Description:    d.Description,
+		Meta:           d.Meta,
+	}
+
+	for _, cell := range d.Cells {
+		pd.Cells = append(pd.Cells, cell.toPlatform())
+	}
+
+	return pd
+}
+
+func (c *cell) toPlatform() *platform.Cell {
+	view := &platform.View{
+		ViewContents: platform.ViewContents{Name: c.Name, ID: c.ID},
+	}
+
+	if c.ViewProperties != nil {
+		view.Properties = *c.ViewProperties
+	}
+
+	return &platform.Cell{
+		ID:           c.ID,
+		CellProperty: c.CellProperty,
+		View:         view,
+	}
+}
+
+type cell struct {
+	platform.Cell
+	ViewProperties *platform.ViewProperties `json:"properties,omitempty"`
+	Name           string                   `json:"name"`
+}
+
+type name struct {
+	Name string `json:"name"`
+}
+
+func (c *cell) UnmarshalJSON(b []byte) error {
+	platformCell := platform.Cell{}
+	if err := json.Unmarshal(b, &platformCell); err != nil {
+		return err
+	}
+
+	v, err := platform.UnmarshalViewPropertiesJSON(b)
+	if err != nil {
+		return err
+	}
+
+	n := name{}
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+
+	if v.GetType() != "" {
+		c.ViewProperties = &v
+	}
+	c.Name = n.Name
+	c.Cell = platformCell
+	return nil
+}
+
+type dashboard struct {
+	platform.Dashboard
+	Cells []*cell `json:"cells"`
+}
+
 type postDashboardRequest struct {
-	Dashboard *platform.Dashboard
+	Dashboard *dashboard
 }
 
 func decodePostDashboardRequest(ctx context.Context, r *http.Request) (*postDashboardRequest, error) {
-	c := &platform.Dashboard{}
+	c := &dashboard{}
 	if err := json.NewDecoder(r.Body).Decode(c); err != nil {
 		return nil, err
 	}

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -977,6 +977,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 								"geom": "",
 								"legend": {},
 								"note": "note",
+								"position": "",
 								"queries": null,
 								"shadeBelow": false,
 								"showNoteWhenEmpty": false,

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -846,40 +846,161 @@ func TestService_handlePostDashboard(t *testing.T) {
 				statusCode:  http.StatusCreated,
 				contentType: "application/json; charset=utf-8",
 				body: `
-{
-  "id": "020f755c3c082000",
-  "orgID": "0000000000000001",
-  "name": "hello",
-  "description": "howdy there",
-  "labels": [],
-  "meta": {
-    "createdAt": "2012-11-10T23:00:00Z",
-    "updatedAt": "2012-11-11T00:00:00Z"
-  },
-  "cells": [
-    {
-      "id": "da7aba5e5d81e550",
-      "x": 1,
-      "y": 2,
-      "w": 3,
-      "h": 4,
-      "links": {
-        "self": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550",
-        "view": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550/view"
-      }
-    }
-  ],
-  "links": {
-    "self": "/api/v2/dashboards/020f755c3c082000",
-    "org": "/api/v2/orgs/0000000000000001",
-    "members": "/api/v2/dashboards/020f755c3c082000/members",
-    "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
-    "cells": "/api/v2/dashboards/020f755c3c082000/cells",
-    "labels": "/api/v2/dashboards/020f755c3c082000/labels"
-  }
-}
-`,
+						{
+						"id": "020f755c3c082000",
+						"orgID": "0000000000000001",
+						"name": "hello",
+						"description": "howdy there",
+						"labels": [],
+						"meta": {
+							"createdAt": "2012-11-10T23:00:00Z",
+							"updatedAt": "2012-11-11T00:00:00Z"
+						},
+						"cells": [
+							{
+								"id": "da7aba5e5d81e550",
+								"x": 1,
+								"y": 2,
+								"w": 3,
+								"h": 4,
+								"links": {
+									"self": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550",
+									"view": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550/view"
+								}
+							}
+						],
+						"links": {
+							"self": "/api/v2/dashboards/020f755c3c082000",
+							"org": "/api/v2/orgs/0000000000000001",
+							"members": "/api/v2/dashboards/020f755c3c082000/members",
+							"owners": "/api/v2/dashboards/020f755c3c082000/owners",
+							"logs": "/api/v2/dashboards/020f755c3c082000/logs",
+							"cells": "/api/v2/dashboards/020f755c3c082000/cells",
+							"labels": "/api/v2/dashboards/020f755c3c082000/labels"
+						}
+						}`,
+			},
+		},
+		{
+			name: "create a new dashboard with cell view properties",
+			fields: fields{
+				&mock.DashboardService{
+					CreateDashboardF: func(ctx context.Context, c *platform.Dashboard) error {
+						c.ID = platformtesting.MustIDBase16("020f755c3c082000")
+						c.Meta = platform.DashboardMeta{
+							CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
+							UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
+						}
+						c.Cells = []*platform.Cell{
+							{
+								ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
+								CellProperty: platform.CellProperty{
+									X: 1,
+									Y: 2,
+									W: 3,
+									H: 4,
+								},
+								View: &platform.View{
+									ViewContents: platform.ViewContents{
+										Name: "hello a view",
+									},
+									Properties: platform.XYViewProperties{
+										Type: platform.ViewPropertyTypeXY,
+										Note: "note",
+									},
+								},
+							},
+						}
+						return nil
+					},
+				},
+			},
+			args: args{
+				dashboard: &platform.Dashboard{
+					ID:             platformtesting.MustIDBase16("020f755c3c082000"),
+					OrganizationID: 1,
+					Name:           "hello",
+					Description:    "howdy there",
+					Cells: []*platform.Cell{
+						{
+							ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
+							CellProperty: platform.CellProperty{
+								X: 1,
+								Y: 2,
+								W: 3,
+								H: 4,
+							},
+							View: &platform.View{
+								ViewContents: platform.ViewContents{
+									Name: "hello a view",
+								},
+								Properties: struct {
+									platform.XYViewProperties
+									Shape string
+								}{
+									XYViewProperties: platform.XYViewProperties{
+										Note: "note",
+										Type: platform.ViewPropertyTypeXY,
+									},
+									Shape: "chronograf-v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			wants: wants{
+				statusCode:  http.StatusCreated,
+				contentType: "application/json; charset=utf-8",
+				body: `
+				{
+					"id": "020f755c3c082000",
+					"orgID": "0000000000000001",
+					"name": "hello",
+					"description": "howdy there",
+					"labels": [],
+					"meta": {
+						"createdAt": "2012-11-10T23:00:00Z",
+						"updatedAt": "2012-11-11T00:00:00Z"
+					},
+					"cells": [
+						{
+							"id": "da7aba5e5d81e550",
+							"x": 1,
+							"y": 2,
+							"w": 3,
+							"h": 4,
+							"name": "hello a view",
+							"properties": {
+								"axes": null,
+								"colors": null,
+								"geom": "",
+								"legend": {},
+								"note": "note",
+								"queries": null,
+								"shadeBelow": false,
+								"showNoteWhenEmpty": false,
+								"type": "",
+								"xColumn": "",
+								"yColumn": "",
+								"type": "xy"
+							},
+							"links": {
+								"self": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550",
+								"view": "/api/v2/dashboards/020f755c3c082000/cells/da7aba5e5d81e550/view"
+							}
+						}
+					],
+					"links": {
+						"self": "/api/v2/dashboards/020f755c3c082000",
+						"org": "/api/v2/orgs/0000000000000001",
+						"members": "/api/v2/dashboards/020f755c3c082000/members",
+						"owners": "/api/v2/dashboards/020f755c3c082000/owners",
+						"logs": "/api/v2/dashboards/020f755c3c082000/logs",
+						"cells": "/api/v2/dashboards/020f755c3c082000/cells",
+						"labels": "/api/v2/dashboards/020f755c3c082000/labels"
+					}
+				}`,
 			},
 		},
 	}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2145,7 +2145,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                oneOf:
+                  - $ref: "#/components/schemas/Dashboard"
+                  - $ref: "#/components/schemas/DashboardWithViewProperties"
         default:
           description: Unexpected error
           content:

--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -287,7 +287,7 @@ func (s *Service) CreateDashboard(ctx context.Context, d *influxdb.Dashboard) er
 		for _, cell := range d.Cells {
 			cell.ID = s.IDGenerator.ID()
 
-			if err := s.createCellView(ctx, tx, d.ID, cell.ID, nil); err != nil {
+			if err := s.createCellView(ctx, tx, d.ID, cell.ID, cell.View); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Closes #16112

Describe your proposed changes here.
An API user should be able to pass an optional param when creating a dashboard to create all nested data with one request.

**_POST_ /dashboards** now optionally accepts a `properties` object nested within each cell.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)