### PR TITLE
chore(ui): move changelog entries that were added to the previous release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
 ## v2.0.0-alpha.21 [unreleased]
 
 ### Features
+
 1. [15836](https://github.com/influxdata/influxdb/pull/16077): Add stacked line layer option to graphs
 
 ### Bug Fixes
-1. [16101](https://github.com/influxdata/influxdb/pull/16101): Gracefully handle invalid user-supplied JSON
+
+1. [15655](https://github.com/influxdata/influxdb/pull/15655): Allow table columns to be draggable in table settings
+1. [15757](https://github.com/influxdata/influxdb/pull/15757): Light up the home page icon when active
+1. [15797](https://github.com/influxdata/influxdb/pull/15797): Make numeric inputs first class citizens
+1. [15853](https://github.com/influxdata/influxdb/pull/15853): Prompt users to make a dashboard when dashboards are empty
+1. [15884](https://github.com/influxdata/influxdb/pull/15884): Remove name editing from query definition during threshold check creation
+1. [15975](https://github.com/influxdata/influxdb/pull/15975): Wait until user stops dragging and releases marker before zooming in after threshold changes
 1. [16057](https://github.com/influxdata/influxdb/pull/16057): Adds `properties` to each cell on GET /dashboards/{dashboardID}
+1. [16101](https://github.com/influxdata/influxdb/pull/16101): Gracefully handle invalid user-supplied JSON
 1. [16105](https://github.com/influxdata/influxdb/pull/16105): Fix crash when loading queries built using Query Builder
 1. [16112](https://github.com/influxdata/influxdb/pull/16112): Create cell view properties on dashboard creation
 
 ### UI Improvements
+
 
 ## v2.0.0-alpha.20 [2019-11-20]
 
@@ -21,7 +30,6 @@
 1. [15749](https://github.com/influxdata/influxdb/pull/15749): Expose bundle analysis tools for frontend resources
 1. [15674](https://github.com/influxdata/influxdb/pull/15674): Allow users to view just the output section of a telegraf config
 1. [15923](https://github.com/influxdata/influxdb/pull/15923): Allow the users to see string data in the single stat graph type
-1. [15314](https://github.com/influxdata/influxdb/issues/15314): Allow the users to see string data in the single stat graph type
 
 ### Bug Fixes
 
@@ -34,13 +42,7 @@
 1. [15944](https://github.com/influxdata/influxdb/pull/15944): Refactor table state logic on the frontend
 1. [15920](https://github.com/influxdata/influxdb/pull/15920): Arrows in tables now show data in ascending and descening order
 1. [15728](https://github.com/influxdata/influxdb/pull/15728): Sort by retention rules now sorts by seconds
-1. [15628](https://github.com/influxdata/influxdb/pull/15628): Horizontall scrollbar no longer covering data
-1. [15655](https://github.com/influxdata/influxdb/pull/15655): Allow table columns to be draggable in table settings
-1. [15757](https://github.com/influxdata/influxdb/pull/15757): Light up the home page icon when active
-1. [15797](https://github.com/influxdata/influxdb/pull/15797): Make numeric inputs first class citizens
-1. [15853](https://github.com/influxdata/influxdb/pull/15853): Prompt users to make a dashboard when dashboards are empty
-1. [15884](https://github.com/influxdata/influxdb/pull/15884): Remove name editing from query definition during threshold check creation
-1. [15975](https://github.com/influxdata/influxdb/pull/15975): Wait until user stops dragging and releases marker before zooming in after threshold changes
+1. [15628](https://github.com/influxdata/influxdb/pull/15628): Horizontal scrollbar no longer covering data
 
 ### UI Improvements
 1. [15809](https://github.com/influxdata/influxdb/pull/15809): Redesign cards and animations on getting started page


### PR DESCRIPTION
Closes #16116

Moves changelog changes into proper place.

Method I used to figure out what to moved (I'm pretty proud of this git foo):

1. Find the [commit hash](https://github.com/influxdata/influxdb/commit/e52705d2b1f3f2949d46ad8aad48c159ef54ff32) from yesterday where I added the new unreleased changes.
  1. If you don't know how to do that, go to [influxdb on github](https://github.com/influxdata/influxdb) and click [commits](https://github.com/influxdata/influxdb/commits/master) and search through them.
    <img width="1046" alt="Screen Shot 2019-12-04 at 10 05 22 AM" src="https://user-images.githubusercontent.com/146112/70168474-ccbec980-167d-11ea-9525-5569de9bfab0.png">
1. Since we last released on Nov 20 (the date on the last release on the changelog) look for the commit on that day that represents the last commit in the old changelog: https://github.com/influxdata/influxdb/commit/1177ba3cfd91e72be64ca3a5dfd2b2e09119dd02
1. Now that we have the commit range of incorrect changelog changes, we can find all changes to changelog between this commit range:
    ```sh
    git log 1177ba3..e52705d -p CHANGELOG.md
    ```
1. After that, take the changes produced by [that diff](https://gist.github.com/hoorayimhelping/47aacc446f2111d763723ff44dcbc396) and add them to the new release.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass