### PR TITLE
fix(http/bucket): lift bucket name validation to http layer

### DIFF
--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/influxdata/httprouter"
@@ -327,6 +328,12 @@ func (h *BucketHandler) handlePostBucket(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// names starting with an underscore are reserved for system buckets
+	if err := validBucketName(bucket); err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
 	if err := h.BucketService.CreateBucket(ctx, bucket); err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
@@ -637,6 +644,19 @@ func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
+	}
+
+	if req.Update.Name != nil {
+		b, err := h.BucketService.FindBucketByID(ctx, req.BucketID)
+		if err != nil {
+			h.HandleHTTPError(ctx, err, w)
+			return
+		}
+		b.Name = *req.Update.Name
+		if err := validBucketName(b); err != nil {
+			h.HandleHTTPError(ctx, err, w)
+			return
+		}
 	}
 
 	b, err := h.BucketService.UpdateBucket(ctx, req.BucketID, req.Update)
@@ -987,4 +1007,17 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id influxdb.ID) error 
 	defer resp.Body.Close()
 
 	return CheckError(resp)
+}
+
+// validBucketName reports any errors with bucket names
+func validBucketName(bucket *influxdb.Bucket) error {
+	// names starting with an underscore are reserved for system buckets
+	if strings.HasPrefix(bucket.Name, "_") && bucket.Type != influxdb.BucketTypeSystem {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Op:   "http/bucket",
+			Msg:  fmt.Sprintf("bucket name %s is invalid. Buckets may not start with underscore", bucket.Name),
+		}
+	}
+	return nil
 }

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/influxdata/influxdb"
@@ -648,11 +647,6 @@ func (s *Service) validBucketName(ctx context.Context, tx Tx, b *influxdb.Bucket
 		return BucketAlreadyExistsError(b)
 	}
 
-	// names starting with an underscore are reserved for system buckets
-	if strings.HasPrefix(b.Name, "_") && b.Type != influxdb.BucketTypeSystem {
-		return ReservedBucketNameError(b)
-	}
-
 	return err
 }
 
@@ -909,15 +903,5 @@ func BucketAlreadyExistsError(b *influxdb.Bucket) error {
 		Code: influxdb.EConflict,
 		Op:   "kv/bucket",
 		Msg:  fmt.Sprintf("bucket with name %s already exists", b.Name),
-	}
-}
-
-// ReservedBucketNameError is used when creating a bucket with a name that
-// starts with an underscore.
-func ReservedBucketNameError(b *influxdb.Bucket) error {
-	return &influxdb.Error{
-		Code: influxdb.EInvalid,
-		Op:   "kv/bucket",
-		Msg:  fmt.Sprintf("bucket name %s is invalid. Buckets may not start with underscore", b.Name),
 	}
 }


### PR DESCRIPTION
This removes the bucket name validation from the KV BucketService,
and moves it to the http implementation of the service.
The effect is that API user requests still get validated but direct KV access does not
