### PR TITLE
chore(ui): telegraf redux

### DIFF
--- a/ui/src/dataLoaders/actions/telegrafEditor.ts
+++ b/ui/src/dataLoaders/actions/telegrafEditor.ts
@@ -1,25 +1,21 @@
-import {
-  Bucket
-} from 'src/types'
+import {Bucket} from 'src/types'
 import {
   TelegrafEditorPluginState,
-  TelegrafEditorActivePluginState
+  TelegrafEditorActivePluginState,
 } from 'src/dataLoaders/reducers/telegrafEditor'
 
-export type PluginAction =
-  | ReturnType<typeof setPlugins>
+export type PluginAction = ReturnType<typeof setPlugins>
 
 const setPlugins = (plugins: TelegrafEditorPluginState) => ({
   type: 'SET_TELEGRAF_EDITOR_PLUGINS' as 'SET_TELEGRAF_EDITOR_PLUGINS',
-  payload: plugins
+  payload: plugins,
 })
 
-export type ActivePluginAction =
-  | ReturnType<typeof setActivePlugins>
+export type ActivePluginAction = ReturnType<typeof setActivePlugins>
 
 const setActivePlugins = (plugins: TelegrafEditorActivePluginState) => ({
   type: 'SET_TELEGRAF_EDITOR_ACTIVE_PLUGINS' as 'SET_TELEGRAF_EDITOR_ACTIVE_PLUGINS',
-  payload: plugins
+  payload: plugins,
 })
 
 export type EditorAction =
@@ -31,24 +27,24 @@ export type EditorAction =
 
 export const setMode = (mode: 'adding' | 'indexing') => ({
   type: 'SET_TELEGRAF_EDITOR_MODE' as 'SET_TELEGRAF_EDITOR_MODE',
-  payload: mode
+  payload: mode,
 })
 
-export const setText = (text: string) =>  ({
+export const setText = (text: string) => ({
   type: 'SET_TELEGRAF_EDITOR_TEXT' as 'SET_TELEGRAF_EDITOR_TEXT',
-  payload: text
+  payload: text,
 })
 
 export const setBucket = (bucket: Bucket) => ({
   type: 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET' as 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET',
-  payload: bucket
+  payload: bucket,
 })
 
 export const setFilter = (filter: string) => ({
   type: 'SET_TELEGRAF_EDITOR_FILTER' as 'SET_TELEGRAF_EDITOR_FILTER',
-  payload: filter
+  payload: filter,
 })
 
 export const reset = () => ({
-  type: 'RESET_TELEGRAF_EDITOR' as 'RESET_TELEGRAF_EDITOR'
+  type: 'RESET_TELEGRAF_EDITOR' as 'RESET_TELEGRAF_EDITOR',
 })

--- a/ui/src/dataLoaders/actions/telegrafEditor.ts
+++ b/ui/src/dataLoaders/actions/telegrafEditor.ts
@@ -1,0 +1,54 @@
+import {
+  Bucket
+} from 'src/types'
+import {
+  TelegrafEditorPluginState,
+  TelegrafEditorActivePluginState
+} from 'src/dataLoaders/reducers/telegrafEditor'
+
+export type PluginAction =
+  | ReturnType<typeof setPlugins>
+
+const setPlugins = (plugins: TelegrafEditorPluginState) => ({
+  type: 'SET_TELEGRAF_EDITOR_PLUGINS' as 'SET_TELEGRAF_EDITOR_PLUGINS',
+  payload: plugins
+})
+
+export type ActivePluginAction =
+  | ReturnType<typeof setActivePlugins>
+
+const setActivePlugins = (plugins: TelegrafEditorActivePluginState) => ({
+  type: 'SET_TELEGRAF_EDITOR_ACTIVE_PLUGINS' as 'SET_TELEGRAF_EDITOR_ACTIVE_PLUGINS',
+  payload: plugins
+})
+
+export type EditorAction =
+  | ReturnType<typeof setMode>
+  | ReturnType<typeof setText>
+  | ReturnType<typeof setBucket>
+  | ReturnType<typeof setFilter>
+  | ReturnType<typeof reset>
+
+export const setMode = (mode: 'adding' | 'indexing') => ({
+  type: 'SET_TELEGRAF_EDITOR_MODE' as 'SET_TELEGRAF_EDITOR_MODE',
+  payload: mode
+})
+
+export const setText = (text: string) =>  ({
+  type: 'SET_TELEGRAF_EDITOR_TEXT' as 'SET_TELEGRAF_EDITOR_TEXT',
+  payload: text
+})
+
+export const setBucket = (bucket: Bucket) => ({
+  type: 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET' as 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET',
+  payload: bucket
+})
+
+export const setFilter = (filter: string) => ({
+  type: 'SET_TELEGRAF_EDITOR_FILTER' as 'SET_TELEGRAF_EDITOR_FILTER',
+  payload: filter
+})
+
+export const reset = () => ({
+  type: 'RESET_TELEGRAF_EDITOR' as 'RESET_TELEGRAF_EDITOR'
+})

--- a/ui/src/dataLoaders/reducers/telegrafEditor.ts
+++ b/ui/src/dataLoaders/reducers/telegrafEditor.ts
@@ -1,0 +1,245 @@
+import {
+  Bucket
+} from 'src/types'
+import {
+  PluginAction,
+  ActivePluginAction,
+  EditorAction
+} from 'src/dataLoaders/actions/telegrafEditor'
+type TelegrafEditorPluginType = 'system' | 'bundle' | 'input' | 'output' | 'processor' | 'aggregator' | 'display'
+type TelegrafEditorPluginName = string
+
+interface TelegrafEditorBasicPlugin {
+  name: TelegrafEditorPluginName
+  description: string
+  code: string
+  type: TelegrafEditorPluginType
+}
+
+interface TelegrafEditorBundlePlugin {
+  name: TelegrafEditorPluginName
+  description: string
+  type: string
+  include: Array<TelegrafEditorPluginName>
+}
+export type TelegrafEditorPluginState = Array<TelegrafEditorBasicPlugin | TelegrafEditorBundlePlugin>
+
+interface TelegrafEditorActivePlugin {
+  name: string
+  type: TelegrafEditorPluginType
+  line: number
+}
+
+export type TelegrafEditorActivePluginState = Array<TelegrafEditorActivePlugin>
+
+type TelegrafEditorMode = 'adding' | 'indexing'
+interface TelegrafEditorState {
+  mode: TelegrafEditorMode
+  bucket: Bucket | null
+  text: string
+  filter: string
+}
+
+const INITIAL_PLUGINS:TelegrafEditorPluginState = [{
+  name: 'cpu',
+  type: 'input',
+  description: 'watch your cpu yo',
+  code: `[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## If true, collect raw CPU time metrics.
+  collect_cpu_time = false
+  ## If true, compute and report the sum of all non-idle CPU states.
+  report_active = false
+  `
+}, {
+  name: 'disk',
+  type: 'input',
+  description: 'watch your disks yo',
+  code: `[[inputs.disk]]
+## By default stats will be gathered for all mount points.
+## Set mount_points will restrict the stats to only the specified mount points.
+# mount_points = ["/"]
+## Ignore mount points by filesystem type.
+ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
+`
+}, {
+  name: 'diskio',
+  type: 'input',
+  description: 'watch your diskio yo',
+  code: `[[inputs.diskio]]
+`
+}, {
+  name: 'memory',
+  type: 'input',
+  description: 'watch your memory yo',
+  code: `[[inputs.mem]]
+`
+}, {
+  name: 'network',
+  type: 'input',
+  description: 'watch your network yo',
+  code: `[[inputs.net]]
+`
+}, {
+  name: 'system',
+  type: 'bundle',
+  description: 'collect all the basic local metrics',
+  include: [
+    'cpu',
+    'disk',
+    'diskio',
+    'memory',
+    'network'
+  ],
+}, {
+  name: 'kubernetes',
+  type: 'input',
+  description: 'watch your cluster yo',
+  code: `[[inputs.kubernetes]]
+## URL for the kubelet
+## exp: http://1.1.1.1:10255
+url = "http://url"
+`
+}, {
+  name: 'agent',
+  type: 'system',
+  description: 'describe the agent',
+  code: `# Configuration for telegraf agent
+[agent]
+## Default data collection interval for all inputs
+interval = "10s"
+## Rounds collection interval to 'interval'
+## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+round_interval = true
+
+## Telegraf will send metrics to outputs in batches of at most
+## metric_batch_size metrics.
+## This controls the size of writes that Telegraf sends to output plugins.
+metric_batch_size = 1000
+
+## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+## output, and will flush this buffer on a successful write. Oldest metrics
+## are dropped first when this buffer fills.
+## This buffer only fills when writes fail to output plugin(s).
+metric_buffer_limit = 10000
+
+## Collection jitter is used to jitter the collection by a random amount.
+## Each plugin will sleep for a random time within jitter before collecting.
+## This can be used to avoid many plugins querying things like sysfs at the
+## same time, which can have a measurable effect on the system.
+collection_jitter = "0s"
+
+## Default flushing interval for all outputs. Maximum flush_interval will be
+## flush_interval + flush_jitter
+flush_interval = "10s"
+## Jitter the flush interval by a random amount. This is primarily to avoid
+## large write spikes for users running a large number of telegraf instances.
+## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+flush_jitter = "0s"
+
+## By default or when set to "0s", precision will be set to the same
+## timestamp order as the collection interval, with the maximum being 1s.
+##   ie, when interval = "10s", precision will be "1s"
+##       when interval = "250ms", precision will be "1ms"
+## Precision will NOT be used for service inputs. It is up to each individual
+## service input to set the timestamp at the appropriate precision.
+## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+precision = ""
+
+## Logging configuration:
+## Run telegraf with debug log messages.
+debug = false
+## Run telegraf in quiet mode (error log messages only).
+quiet = false
+## Specify the log file name. The empty string means to log to stderr.
+logfile = ""
+
+## Override default hostname, if empty use os.Hostname()
+hostname = ""
+## If set to true, do no set the "host" tag in the telegraf agent.
+omit_hostname = false
+`
+}, {
+  name: 'influxdb_v2',
+  type: 'output',
+  description: 'output to the cloud',
+  code: `[[outputs.influxdb_v2]]
+## The URLs of the InfluxDB cluster nodes.
+##
+## Multiple URLs can be specified for a single cluster, only ONE of the
+## urls will be written to each interval.
+## urls exp: http://127.0.0.1:9999
+urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+
+## Token for authentication.
+token = "$INFLUX_TOKEN"
+
+## Organization is the name of the organization you wish to write to; must exist.
+organization = "aboatwright@influxdata.com"
+
+## Destination bucket to write into.
+bucket = "aboatwright's Bucket"
+`
+}, {
+  name: '__default__',
+  type: 'bundle',
+  description: 'default data for a blank telegraf',
+  include: [
+    'agent',
+    'influxdb_v2',
+  ]
+}]
+
+const INITIAL_EDITOR:TelegrafEditorState = {
+  mode: 'adding',
+  bucket: null,
+  text: '',
+  filter: ''
+}
+
+export function pluginsReducer(
+  state = INITIAL_PLUGINS,
+  action: PluginAction
+): TelegrafEditorPluginState {
+  switch (action.type) {
+    case 'SET_TELEGRAF_EDITOR_PLUGINS':
+      return action.payload.slice(0)
+    default:
+      return state
+  }
+}
+
+export function activePluginsReducer(
+  state = [],
+  action: ActivePluginAction
+): TelegrafEditorActivePluginState {
+  switch (action.type) {
+    case 'SET_TELEGRAF_EDITOR_ACTIVE_PLUGINS':
+      return action.payload.slice(0)
+    default:
+      return state
+  }
+}
+
+export function editorReducer(
+  state = INITIAL_EDITOR,
+  action: EditorAction
+): TelegrafEditorState {
+  switch (action.type) {
+    case 'SET_TELEGRAF_EDITOR_MODE':
+      return { ...state, mode: action.payload }
+    case 'SET_TELEGRAF_EDITOR_TEXT':
+      return { ...state, text: action.payload }
+    case 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET':
+      return { ...state, bucket: action.payload }
+    case 'SET_TELEGRAF_EDITOR_FILTER':
+      return { ...state, filter: action.payload }
+    case 'RESET_TELEGRAF_EDITOR':
+      return { ...INITIAL_EDITOR }
+    default:
+      return state
+  }
+}

--- a/ui/src/dataLoaders/reducers/telegrafEditor.ts
+++ b/ui/src/dataLoaders/reducers/telegrafEditor.ts
@@ -1,12 +1,17 @@
-import {
-  Bucket
-} from 'src/types'
+import {Bucket} from 'src/types'
 import {
   PluginAction,
   ActivePluginAction,
-  EditorAction
+  EditorAction,
 } from 'src/dataLoaders/actions/telegrafEditor'
-type TelegrafEditorPluginType = 'system' | 'bundle' | 'input' | 'output' | 'processor' | 'aggregator' | 'display'
+type TelegrafEditorPluginType =
+  | 'system'
+  | 'bundle'
+  | 'input'
+  | 'output'
+  | 'processor'
+  | 'aggregator'
+  | 'display'
 type TelegrafEditorPluginName = string
 
 interface TelegrafEditorBasicPlugin {
@@ -22,7 +27,9 @@ interface TelegrafEditorBundlePlugin {
   type: string
   include: Array<TelegrafEditorPluginName>
 }
-export type TelegrafEditorPluginState = Array<TelegrafEditorBasicPlugin | TelegrafEditorBundlePlugin>
+export type TelegrafEditorPluginState = Array<
+  TelegrafEditorBasicPlugin | TelegrafEditorBundlePlugin
+>
 
 interface TelegrafEditorActivePlugin {
   name: string
@@ -40,11 +47,12 @@ interface TelegrafEditorState {
   filter: string
 }
 
-const INITIAL_PLUGINS:TelegrafEditorPluginState = [{
-  name: 'cpu',
-  type: 'input',
-  description: 'watch your cpu yo',
-  code: `[[inputs.cpu]]
+const INITIAL_PLUGINS: TelegrafEditorPluginState = [
+  {
+    name: 'cpu',
+    type: 'input',
+    description: 'watch your cpu yo',
+    code: `[[inputs.cpu]]
   ## Whether to report per-cpu stats or not
   percpu = true
   ## Whether to report total system cpu stats or not
@@ -53,61 +61,62 @@ const INITIAL_PLUGINS:TelegrafEditorPluginState = [{
   collect_cpu_time = false
   ## If true, compute and report the sum of all non-idle CPU states.
   report_active = false
-  `
-}, {
-  name: 'disk',
-  type: 'input',
-  description: 'watch your disks yo',
-  code: `[[inputs.disk]]
+  `,
+  },
+  {
+    name: 'disk',
+    type: 'input',
+    description: 'watch your disks yo',
+    code: `[[inputs.disk]]
 ## By default stats will be gathered for all mount points.
 ## Set mount_points will restrict the stats to only the specified mount points.
 # mount_points = ["/"]
 ## Ignore mount points by filesystem type.
 ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
-`
-}, {
-  name: 'diskio',
-  type: 'input',
-  description: 'watch your diskio yo',
-  code: `[[inputs.diskio]]
-`
-}, {
-  name: 'memory',
-  type: 'input',
-  description: 'watch your memory yo',
-  code: `[[inputs.mem]]
-`
-}, {
-  name: 'network',
-  type: 'input',
-  description: 'watch your network yo',
-  code: `[[inputs.net]]
-`
-}, {
-  name: 'system',
-  type: 'bundle',
-  description: 'collect all the basic local metrics',
-  include: [
-    'cpu',
-    'disk',
-    'diskio',
-    'memory',
-    'network'
-  ],
-}, {
-  name: 'kubernetes',
-  type: 'input',
-  description: 'watch your cluster yo',
-  code: `[[inputs.kubernetes]]
+`,
+  },
+  {
+    name: 'diskio',
+    type: 'input',
+    description: 'watch your diskio yo',
+    code: `[[inputs.diskio]]
+`,
+  },
+  {
+    name: 'memory',
+    type: 'input',
+    description: 'watch your memory yo',
+    code: `[[inputs.mem]]
+`,
+  },
+  {
+    name: 'network',
+    type: 'input',
+    description: 'watch your network yo',
+    code: `[[inputs.net]]
+`,
+  },
+  {
+    name: 'system',
+    type: 'bundle',
+    description: 'collect all the basic local metrics',
+    include: ['cpu', 'disk', 'diskio', 'memory', 'network'],
+  },
+  {
+    name: 'kubernetes',
+    type: 'input',
+    description: 'watch your cluster yo',
+    code: `[[inputs.kubernetes]]
 ## URL for the kubelet
 ## exp: http://1.1.1.1:10255
 url = "http://url"
-`
-}, {
-  name: 'agent',
-  type: 'system',
-  description: 'describe the agent',
-  code: `# Configuration for telegraf agent
+`,
+  },
+  {
+    name: 'agent',
+    type: 'system',
+    description: 'describe the agent',
+    code: `# Configuration for telegraf agent
 [agent]
 ## Default data collection interval for all inputs
 interval = "10s"
@@ -161,12 +170,13 @@ logfile = ""
 hostname = ""
 ## If set to true, do no set the "host" tag in the telegraf agent.
 omit_hostname = false
-`
-}, {
-  name: 'influxdb_v2',
-  type: 'output',
-  description: 'output to the cloud',
-  code: `[[outputs.influxdb_v2]]
+`,
+  },
+  {
+    name: 'influxdb_v2',
+    type: 'output',
+    description: 'output to the cloud',
+    code: `[[outputs.influxdb_v2]]
 ## The URLs of the InfluxDB cluster nodes.
 ##
 ## Multiple URLs can be specified for a single cluster, only ONE of the
@@ -182,22 +192,21 @@ organization = "aboatwright@influxdata.com"
 
 ## Destination bucket to write into.
 bucket = "aboatwright's Bucket"
-`
-}, {
-  name: '__default__',
-  type: 'bundle',
-  description: 'default data for a blank telegraf',
-  include: [
-    'agent',
-    'influxdb_v2',
-  ]
-}]
+`,
+  },
+  {
+    name: '__default__',
+    type: 'bundle',
+    description: 'default data for a blank telegraf',
+    include: ['agent', 'influxdb_v2'],
+  },
+]
 
-const INITIAL_EDITOR:TelegrafEditorState = {
+const INITIAL_EDITOR: TelegrafEditorState = {
   mode: 'adding',
   bucket: null,
   text: '',
-  filter: ''
+  filter: '',
 }
 
 export function pluginsReducer(
@@ -230,15 +239,15 @@ export function editorReducer(
 ): TelegrafEditorState {
   switch (action.type) {
     case 'SET_TELEGRAF_EDITOR_MODE':
-      return { ...state, mode: action.payload }
+      return {...state, mode: action.payload}
     case 'SET_TELEGRAF_EDITOR_TEXT':
-      return { ...state, text: action.payload }
+      return {...state, text: action.payload}
     case 'SET_TELEGRAF_EDITOR_ACTIVE_BUCKET':
-      return { ...state, bucket: action.payload }
+      return {...state, bucket: action.payload}
     case 'SET_TELEGRAF_EDITOR_FILTER':
-      return { ...state, filter: action.payload }
+      return {...state, filter: action.payload}
     case 'RESET_TELEGRAF_EDITOR':
-      return { ...INITIAL_EDITOR }
+      return {...INITIAL_EDITOR}
     default:
       return state
   }

--- a/ui/src/store/configureStore.ts
+++ b/ui/src/store/configureStore.ts
@@ -35,6 +35,10 @@ import {limitsReducer, LimitsState} from 'src/cloud/reducers/limits'
 import checksReducer from 'src/alerting/reducers/checks'
 import rulesReducer from 'src/alerting/reducers/notifications/rules'
 import endpointsReducer from 'src/alerting/reducers/notifications/endpoints'
+import {
+  pluginsReducer,
+  activePluginsReducer,
+} from 'src/dataLoaders/reducers/telegrafEditor'
 
 // Types
 import {LocalStorage} from 'src/types/localStorage'
@@ -61,6 +65,8 @@ export const rootReducer = combineReducers<ReducerState>({
   variableEditor: variableEditorReducer,
   labels: labelsReducer,
   buckets: bucketsReducer,
+  telegrafEditorPlugins: pluginsReducer,
+  telegrafEditorActivePlugins: activePluginsReducer,
   telegrafs: telegrafsReducer,
   tokens: authorizationsReducer,
   scrapers: scrapersReducer,

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -13,6 +13,10 @@ import {PredicatesState} from 'src/types'
 import {VariablesState, VariableEditorState} from 'src/variables/reducers'
 import {LabelsState} from 'src/labels/reducers'
 import {BucketsState} from 'src/buckets/reducers'
+import {
+  TelegrafEditorPluginState,
+  TelegrafEditorActivePluginState,
+} from 'src/dataLoaders/reducers/telegrafEditor'
 import {TelegrafsState} from 'src/telegrafs/reducers'
 import {TemplatesState} from 'src/templates/reducers'
 import {AuthorizationsState} from 'src/authorizations/reducers'
@@ -54,6 +58,8 @@ export interface AppState {
   rules: NotificationRulesState
   scrapers: ScrapersState
   tasks: TasksState
+  telegrafEditorPlugins: TelegrafEditorPluginState,
+  telegrafEditorActivePlugins: TelegrafEditorActivePluginState,
   telegrafs: TelegrafsState
   templates: TemplatesState
   timeMachines: TimeMachinesState

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -58,8 +58,8 @@ export interface AppState {
   rules: NotificationRulesState
   scrapers: ScrapersState
   tasks: TasksState
-  telegrafEditorPlugins: TelegrafEditorPluginState,
-  telegrafEditorActivePlugins: TelegrafEditorActivePluginState,
+  telegrafEditorPlugins: TelegrafEditorPluginState
+  telegrafEditorActivePlugins: TelegrafEditorActivePluginState
   telegrafs: TelegrafsState
   templates: TemplatesState
   timeMachines: TimeMachinesState


### PR DESCRIPTION
I'm trying to figure out a way to break down the large amount of work going on for influxdata/idpe#5399 into readable pull requests. This one carves out a little portion of the redux store for the telegraf editor feature. there should be a place to put all plugins, the ones currently being used, and some odds and ends connected to the display state of the editor. The default plugin list is only there for testing routing of the data while we deploy the endpoint to populate it. i expect more changes here as the product functionality is fleshed out, but might as well get the swath of it done.