### PR TITLE
feat(pkger): add support for exporting telegraf

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -54,6 +54,7 @@ type cmdPkgBuilder struct {
 		buckets      string
 		dashboards   string
 		labels       string
+		telegrafs    string
 		variables    string
 	}
 }
@@ -218,6 +219,7 @@ func (b *cmdPkgBuilder) cmdPkgExport() *cobra.Command {
 	cmd.Flags().StringVar(&b.exportOpts.buckets, "buckets", "", "List of bucket ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.dashboards, "dashboards", "", "List of dashboard ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.labels, "labels", "", "List of label ids comma separated")
+	cmd.Flags().StringVar(&b.exportOpts.telegrafs, "telegraf-configs", "", "List of telegraf config ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.variables, "variables", "", "List of variable ids comma separated")
 
 	cmd.RunE = b.pkgExportRunEFn()
@@ -241,6 +243,7 @@ func (b *cmdPkgBuilder) pkgExportRunEFn() func(*cobra.Command, []string) error {
 			{kind: pkger.KindBucket, idStrs: strings.Split(b.exportOpts.buckets, ",")},
 			{kind: pkger.KindDashboard, idStrs: strings.Split(b.exportOpts.dashboards, ",")},
 			{kind: pkger.KindLabel, idStrs: strings.Split(b.exportOpts.labels, ",")},
+			{kind: pkger.KindTelegraf, idStrs: strings.Split(b.exportOpts.telegrafs, ",")},
 			{kind: pkger.KindVariable, idStrs: strings.Split(b.exportOpts.variables, ",")},
 		}
 		for _, rt := range resTypes {

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -178,6 +178,7 @@ func Test_Pkg(t *testing.T) {
 			bucketIDs    []influxdb.ID
 			dashIDs      []influxdb.ID
 			labelIDs     []influxdb.ID
+			telegrafIDs  []influxdb.ID
 			varIDs       []influxdb.ID
 			expectedMeta pkger.Metadata
 		}{
@@ -189,7 +190,6 @@ func Test_Pkg(t *testing.T) {
 					flags: []flagArg{
 						{name: "name", val: "new name"},
 						{name: "description", val: "new desc"},
-						{name: "version", val: "new version"},
 						{name: "version", val: "new version"},
 					},
 				},
@@ -209,7 +209,6 @@ func Test_Pkg(t *testing.T) {
 						{name: "name", val: "new name"},
 						{name: "description", val: "new desc"},
 						{name: "version", val: "new version"},
-						{name: "version", val: "new version"},
 					},
 				},
 				dashIDs: []influxdb.ID{1, 2},
@@ -227,7 +226,6 @@ func Test_Pkg(t *testing.T) {
 					flags: []flagArg{
 						{name: "name", val: "new name"},
 						{name: "description", val: "new desc"},
-						{name: "version", val: "new version"},
 						{name: "version", val: "new version"},
 					},
 				},
@@ -247,10 +245,27 @@ func Test_Pkg(t *testing.T) {
 						{name: "name", val: "new name"},
 						{name: "description", val: "new desc"},
 						{name: "version", val: "new version"},
-						{name: "version", val: "new version"},
 					},
 				},
 				varIDs: []influxdb.ID{1, 2},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "telegrafs",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+					},
+				},
+				telegrafIDs: []influxdb.ID{1, 2},
 				expectedMeta: pkger.Metadata{
 					Name:        "new name",
 					Description: "new desc",
@@ -266,13 +281,13 @@ func Test_Pkg(t *testing.T) {
 						{name: "name", val: "new name"},
 						{name: "description", val: "new desc"},
 						{name: "version", val: "new version"},
-						{name: "version", val: "new version"},
 					},
 				},
-				bucketIDs: []influxdb.ID{1, 2},
-				dashIDs:   []influxdb.ID{3, 4},
-				labelIDs:  []influxdb.ID{5, 6},
-				varIDs:    []influxdb.ID{7, 8},
+				bucketIDs:   []influxdb.ID{1, 2},
+				dashIDs:     []influxdb.ID{3, 4},
+				labelIDs:    []influxdb.ID{5, 6},
+				varIDs:      []influxdb.ID{7, 8},
+				telegrafIDs: []influxdb.ID{9, 10},
 				expectedMeta: pkger.Metadata{
 					Name:        "new name",
 					Description: "new desc",

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -252,6 +252,10 @@ func TestLauncher_Pkger(t *testing.T) {
 					Kind: pkger.KindLabel,
 					ID:   labels[0].ID,
 				},
+				{
+					Kind: pkger.KindTelegraf,
+					ID:   teles[0].ID,
+				},
 			}
 
 			resWithNewName := []pkger.ResourceToClone{
@@ -295,6 +299,10 @@ func TestLauncher_Pkger(t *testing.T) {
 			assert.Equal(t, "dash_1", dashs[0].Name)
 			assert.Equal(t, "desc1", dashs[0].Description)
 			hasLabelAssociations(t, dashs[0].LabelAssociations, 1, "label_1")
+
+			require.Len(t, newSum.TelegrafConfigs, 1)
+			assert.Equal(t, teles[0].Name, newSum.TelegrafConfigs[0].Name)
+			assert.Equal(t, teles[0].Description, newSum.TelegrafConfigs[0].Description)
 
 			vars := newSum.Variables
 			require.Len(t, vars, 1)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7239,6 +7239,17 @@ components:
                     type: string
                   labelID:
                     type: string
+            telegrafConfigs:
+              type: array
+              items:
+                allOf:
+                  - $ref: "#/components/schemas/TelegrafRequest"
+                  - type: object
+                    properties:
+                      labelAssociations:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Label"
             variables:
               type: array
               items:
@@ -7329,6 +7340,10 @@ components:
                     type: string
                   labelName:
                     type: string
+            telegrafConfigs:
+              type: array
+              items:
+                $ref: "#/components/schemas/TelegrafRequest"
             variables:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -52,7 +52,7 @@ func (k Kind) String() string {
 
 // OK validates the kind is valid.
 func (k Kind) OK() error {
-	newKind := Kind(strings.ToLower(string(k)))
+	newKind := NewKind(string(k))
 	if newKind == KindUnknown {
 		return errors.New("invalid kind")
 	}


### PR DESCRIPTION
Closes #16074 

Adds ability to export telegraf configs to an influx package/template

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)