### PR TITLE
feat(query): add trace_id and sampled to the query log

### DIFF
--- a/logger/fields.go
+++ b/logger/fields.go
@@ -87,6 +87,19 @@ func Shard(id uint64) zapcore.Field {
 	return zap.Uint64(DBShardIDKey, id)
 }
 
+// TraceInfo returns the traceID and if it was sampled from the Jaeger span
+// found in the given context. It returns if a span associated to the context has been found.
+func TraceInfo(ctx context.Context) (traceID string, sampled bool, found bool) {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		if spanContext, ok := span.Context().(jaeger.SpanContext); ok {
+			traceID = spanContext.TraceID().String()
+			sampled = spanContext.IsSampled()
+			return traceID, sampled, true
+		}
+	}
+	return "", false, false
+}
+
 // TraceID returns a field "trace_id", value pulled from the (Jaeger) trace ID found in the given context.
 // Returns zap.Skip() if the context doesn't have a trace ID.
 func TraceID(ctx context.Context) zap.Field {

--- a/query/logger.go
+++ b/query/logger.go
@@ -18,6 +18,11 @@ type Log struct {
 	Time time.Time
 	// OrganizationID is the ID of the organization that requested the query
 	OrganizationID platform.ID
+	// TraceID is the ID of the trace related to this query
+	TraceID string
+	// Sampled specifies whether the trace for TraceID was chosen for permanent storage
+	// by the sampling mechanism of the tracer
+	Sampled bool
 	// Error is any error encountered by the query
 	Error error
 

--- a/query/logging.go
+++ b/query/logging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/influxdata/influxdb/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -50,8 +51,11 @@ func (s *LoggingProxyQueryService) Query(ctx context.Context, w io.Writer, req *
 				entry.Write(zap.Error(err))
 			}
 		}
+		traceID, sampled, _ := logger.TraceInfo(ctx)
 		log := Log{
 			OrganizationID: req.Request.OrganizationID,
+			TraceID:        traceID,
+			Sampled:        sampled,
 			ProxyRequest:   req,
 			ResponseSize:   n,
 			Time:           s.nowFunction(),


### PR DESCRIPTION
This adds the trace_id to the query log.
