### PR TITLE
fix(ui): remove prop override to allow Graph + Single Stat to use line positioning option

### DIFF
--- a/ui/src/shared/components/ViewSwitcher.tsx
+++ b/ui/src/shared/components/ViewSwitcher.tsx
@@ -101,7 +101,6 @@ const ViewSwitcher: FunctionComponent<Props> = ({
         colors: properties.colors.filter(c => c.type === 'scale'),
         type: 'xy' as 'xy',
         geom: 'line' as 'line',
-        position: 'overlaid' as 'overlaid',
       } as XYViewProperties
 
       const singleStatProperties = {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16143 as part of https://github.com/influxdata/influxdb/issues/15836

