### PR TITLE
feat(ui): added more time formats for table dropdown

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -129,7 +129,7 @@
   "dependencies": {
     "@influxdata/clockface": "1.0.6",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.16.8",
+    "@influxdata/giraffe": "0.16.9",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -33,8 +33,11 @@ export const DEFAULT_TABLE_OPTIONS = {
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
   {text: DEFAULT_TIME_FORMAT},
+  {text: 'DD/MM/YYYY HH:mm:ss.sss'},
   {text: 'MM/DD/YYYY HH:mm:ss.sss'},
   {text: 'YYYY/MM/DD HH:mm:ss'},
+  {text: 'HH:mm a'},
+  {text: 'HH:mm'},
   {text: 'HH:mm:ss'},
   {text: 'HH:mm:ss ZZ'},
   {text: 'HH:mm:ss.sss'},


### PR DESCRIPTION
Closes #15905 

### Solution

Most of the requested additions were as simple as updating the selections dropdown menu. However, including the `a` flag on formats (indicating that we should include an am/pm) was not compatible with giraffe. Updating the way giraffe handled 24h locales and `a` flags were required in order to complete this functionality.