### PR TITLE
feat(pkger): add support for notification endpoints to parser

### DIFF
--- a/pkger/models.go
+++ b/pkger/models.go
@@ -3,32 +3,40 @@ package pkger
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/notification/endpoint"
 )
 
 // Package kinds.
 const (
-	KindUnknown   Kind = ""
-	KindBucket    Kind = "bucket"
-	KindDashboard Kind = "dashboard"
-	KindLabel     Kind = "label"
-	KindPackage   Kind = "package"
-	KindTelegraf  Kind = "telegraf"
-	KindVariable  Kind = "variable"
+	KindUnknown                       Kind = ""
+	KindBucket                        Kind = "bucket"
+	KindDashboard                     Kind = "dashboard"
+	KindLabel                         Kind = "label"
+	KindNotificationEndpointPagerDuty Kind = "notificationendpointpagerduty"
+	KindNotificationEndpointHTTP      Kind = "notificationendpointhttp"
+	KindNotificationEndpointSlack     Kind = "notificationendpointslack"
+	KindPackage                       Kind = "package"
+	KindTelegraf                      Kind = "telegraf"
+	KindVariable                      Kind = "variable"
 )
 
 var kinds = map[Kind]bool{
-	KindBucket:    true,
-	KindDashboard: true,
-	KindLabel:     true,
-	KindPackage:   true,
-	KindTelegraf:  true,
-	KindVariable:  true,
+	KindBucket:                        true,
+	KindDashboard:                     true,
+	KindLabel:                         true,
+	KindNotificationEndpointHTTP:      true,
+	KindNotificationEndpointPagerDuty: true,
+	KindNotificationEndpointSlack:     true,
+	KindPackage:                       true,
+	KindTelegraf:                      true,
+	KindVariable:                      true,
 }
 
 // Kind is a resource kind.
@@ -71,6 +79,10 @@ func (k Kind) ResourceType() influxdb.ResourceType {
 		return influxdb.DashboardsResourceType
 	case KindLabel:
 		return influxdb.LabelsResourceType
+	case KindNotificationEndpointHTTP,
+		KindNotificationEndpointPagerDuty,
+		KindNotificationEndpointSlack:
+		return influxdb.NotificationEndpointResourceType
 	case KindTelegraf:
 		return influxdb.TelegrafsResourceType
 	case KindVariable:
@@ -335,12 +347,13 @@ func (d DiffVariable) hasConflict() bool {
 // Summary is a definition of all the resources that have or
 // will be created from a pkg.
 type Summary struct {
-	Buckets         []SummaryBucket       `json:"buckets"`
-	Dashboards      []SummaryDashboard    `json:"dashboards"`
-	Labels          []SummaryLabel        `json:"labels"`
-	LabelMappings   []SummaryLabelMapping `json:"labelMappings"`
-	TelegrafConfigs []SummaryTelegraf     `json:"telegrafConfigs"`
-	Variables       []SummaryVariable     `json:"variables"`
+	Buckets               []SummaryBucket               `json:"buckets"`
+	Dashboards            []SummaryDashboard            `json:"dashboards"`
+	NotificationEndpoints []SummaryNotificationEndpoint `json:"notificationEndpoints"`
+	Labels                []SummaryLabel                `json:"labels"`
+	LabelMappings         []SummaryLabelMapping         `json:"labelMappings"`
+	TelegrafConfigs       []SummaryTelegraf             `json:"telegrafConfigs"`
+	Variables             []SummaryVariable             `json:"variables"`
 }
 
 // SummaryBucket provides a summary of a pkg bucket.
@@ -404,6 +417,12 @@ type SummaryChart struct {
 	Width     int `json:"width"`
 }
 
+// SummaryNotificationEndpoint provides a summary of a pkg endpoint rule.
+type SummaryNotificationEndpoint struct {
+	influxdb.NotificationEndpoint
+	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+}
+
 // SummaryLabel provides a summary of a pkg label.
 type SummaryLabel struct {
 	influxdb.Label
@@ -438,6 +457,7 @@ const (
 	fieldPrefix       = "prefix"
 	fieldQuery        = "query"
 	fieldSuffix       = "suffix"
+	fieldStatus       = "status"
 	fieldType         = "type"
 	fieldValue        = "value"
 	fieldValues       = "values"
@@ -719,6 +739,156 @@ func (s sortedLabels) Less(i, j int) bool {
 
 func (s sortedLabels) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+type notificationKind int
+
+const (
+	notificationKindHTTP notificationKind = iota + 1
+	notificationKindPagerDuty
+	notificationKindSlack
+)
+
+const (
+	notificationHTTPAuthTypeBasic  = "basic"
+	notificationHTTPAuthTypeBearer = "bearer"
+	notificationHTTPAuthTypeNone   = "none"
+)
+
+const (
+	fieldNotificationEndpointPassword   = "password"
+	fieldNotificationEndpointRoutingKey = "routingKey"
+	fieldNotificationEndpointToken      = "token"
+	fieldNotificationEndpointURL        = "url"
+	fieldNotificationEndpointUsername   = "username"
+)
+
+type notificationEndpoint struct {
+	kind        notificationKind
+	name        string
+	description string
+	password    string
+	routingKey  string
+	status      string
+	token       string
+	httpType    string
+	url         string
+	username    string
+
+	labels sortedLabels
+}
+
+func (n *notificationEndpoint) Name() string {
+	return n.name
+}
+
+func (n *notificationEndpoint) ResourceType() influxdb.ResourceType {
+	return KindNotificationEndpointSlack.ResourceType()
+}
+
+func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
+	base := endpoint.Base{
+		Name:        n.Name(),
+		Description: n.description,
+		Status:      influxdb.TaskStatusActive,
+	}
+	if n.status != "" {
+		base.Status = influxdb.Status(n.status)
+	}
+	sum := SummaryNotificationEndpoint{
+		LabelAssociations: toInfluxLabels(n.labels...),
+	}
+	switch n.kind {
+	case notificationKindHTTP:
+		e := &endpoint.HTTP{
+			Base:   base,
+			URL:    n.url,
+			Method: "POST",
+		}
+		switch {
+		case n.password == "" && n.username == "" && n.token == "":
+			e.AuthMethod = notificationHTTPAuthTypeNone
+		case n.token != "":
+			e.AuthMethod = notificationHTTPAuthTypeBearer
+		default:
+			e.AuthMethod = notificationHTTPAuthTypeBasic
+		}
+		sum.NotificationEndpoint = e
+	case notificationKindPagerDuty:
+		sum.NotificationEndpoint = &endpoint.PagerDuty{
+			Base:      base,
+			ClientURL: n.url,
+		}
+	case notificationKindSlack:
+		sum.NotificationEndpoint = &endpoint.Slack{
+			Base: base,
+			URL:  n.url,
+		}
+	}
+	return sum
+}
+
+func (n *notificationEndpoint) valid() []validationErr {
+	var failures []validationErr
+	if _, err := url.Parse(n.url); err != nil || n.url == "" {
+		failures = append(failures, validationErr{
+			Field: fieldNotificationEndpointURL,
+			Msg:   "must be valid url",
+		})
+	}
+
+	if n.status != "" && influxdb.TaskStatusInactive != n.status && influxdb.TaskStatusActive != n.status {
+		failures = append(failures, validationErr{
+			Field: fieldStatus,
+			Msg:   "not a valid status; valid statues are one of [active, inactive]",
+		})
+	}
+
+	switch n.kind {
+	case notificationKindPagerDuty:
+		if n.routingKey == "" {
+			failures = append(failures, validationErr{
+				Field: fieldNotificationEndpointRoutingKey,
+				Msg:   "must provide non empty string",
+			})
+		}
+	case notificationKindHTTP:
+		switch n.httpType {
+		case notificationHTTPAuthTypeBasic:
+			if n.password == "" {
+				failures = append(failures, validationErr{
+					Field: fieldNotificationEndpointPassword,
+					Msg:   "must provide non empty string",
+				})
+			}
+			if n.username == "" {
+				failures = append(failures, validationErr{
+					Field: fieldNotificationEndpointUsername,
+					Msg:   "must provide non empty string",
+				})
+			}
+		case notificationHTTPAuthTypeBearer:
+			if n.token == "" {
+				failures = append(failures, validationErr{
+					Field: fieldNotificationEndpointToken,
+					Msg:   "must provide non empty string",
+				})
+			}
+		case notificationHTTPAuthTypeNone:
+		default:
+			failures = append(failures, validationErr{
+				Field: fieldType,
+				Msg: fmt.Sprintf(
+					"invalid type provided %q; valid type is 1 in [%s, %s, %s]",
+					n.httpType,
+					notificationHTTPAuthTypeBasic,
+					notificationHTTPAuthTypeBearer,
+					notificationHTTPAuthTypeNone,
+				),
+			})
+		}
+	}
+	return failures
 }
 
 const (

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/notification/endpoint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,7 +133,7 @@ spec:
 				{
 					name:           "missing name",
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldName},
 					pkgStr: `apiVersion: 0.1.0
 kind: Package
 meta:
@@ -147,7 +148,7 @@ spec:
 				{
 					name:           "mixed valid and missing name",
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldName},
 					pkgStr: `apiVersion: 0.1.0
 kind: Package
 meta:
@@ -166,7 +167,7 @@ spec:
 					name:           "mixed valid and multiple bad names",
 					resourceErrs:   2,
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldName},
 					pkgStr: `apiVersion: 0.1.0
 kind: Package
 meta:
@@ -187,7 +188,7 @@ spec:
 					name:           "duplicate bucket names",
 					resourceErrs:   1,
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldName},
 					pkgStr: `apiVersion: 0.1.0
 kind: Package
 meta:
@@ -2699,6 +2700,373 @@ spec:
 
 			for _, tt := range tests {
 				testPkgErrors(t, KindDashboard, tt)
+			}
+		})
+	})
+
+	t.Run("pkg with notification endpoints and labels associated", func(t *testing.T) {
+		testfileRunner(t, "testdata/notification_endpoint", func(t *testing.T, pkg *Pkg) {
+			expectedEndpoints := []SummaryNotificationEndpoint{
+				{
+					NotificationEndpoint: &endpoint.HTTP{
+						Base: endpoint.Base{
+							Name:        "http_basic_auth_notification_endpoint",
+							Description: "http basic auth desc",
+							Status:      influxdb.TaskStatusInactive,
+						},
+						URL:        "https://www.example.com/endpoint/basicauth",
+						AuthMethod: "basic",
+						Method:     "POST",
+					},
+				},
+				{
+					NotificationEndpoint: &endpoint.HTTP{
+						Base: endpoint.Base{
+							Name:        "http_bearer_auth_notification_endpoint",
+							Description: "http bearer auth desc",
+							Status:      influxdb.TaskStatusActive,
+						},
+						URL:        "https://www.example.com/endpoint/bearerauth",
+						AuthMethod: "bearer",
+						Method:     "POST",
+					},
+				},
+				{
+					NotificationEndpoint: &endpoint.HTTP{
+						Base: endpoint.Base{
+							Name:        "http_none_auth_notification_endpoint",
+							Description: "http none auth desc",
+							Status:      influxdb.TaskStatusActive,
+						},
+						URL:        "https://www.example.com/endpoint/noneauth",
+						AuthMethod: "none",
+						Method:     "POST",
+					},
+				},
+				{
+					NotificationEndpoint: &endpoint.PagerDuty{
+						Base: endpoint.Base{
+							Name:        "pager_duty_notification_endpoint",
+							Description: "pager duty desc",
+							Status:      influxdb.TaskStatusActive,
+						},
+						ClientURL: "http://localhost:8080/orgs/7167eb6719fa34e5/alert-history",
+					},
+				},
+				{
+					NotificationEndpoint: &endpoint.Slack{
+						Base: endpoint.Base{
+							Name:        "slack_notification_endpoint",
+							Description: "slack desc",
+							Status:      influxdb.TaskStatusActive,
+						},
+						URL: "https://hooks.slack.com/services/bip/piddy/boppidy",
+					},
+				},
+			}
+
+			sum := pkg.Summary()
+			endpoints := sum.NotificationEndpoints
+			require.Len(t, endpoints, len(expectedEndpoints))
+
+			for i := range expectedEndpoints {
+				expected, actual := expectedEndpoints[i], endpoints[i]
+				assert.Equalf(t, expected.NotificationEndpoint, actual.NotificationEndpoint, "index=%d", i)
+				require.Len(t, actual.LabelAssociations, 1)
+				assert.Equal(t, "label_1", actual.LabelAssociations[0].Name)
+
+				require.Len(t, sum.LabelMappings, len(expectedEndpoints))
+				expectedMapping := SummaryLabelMapping{
+					ResourceName: expected.GetName(),
+					LabelName:    "label_1",
+					LabelMapping: influxdb.LabelMapping{
+						ResourceType: influxdb.NotificationEndpointResourceType,
+					},
+				}
+				assert.Contains(t, sum.LabelMappings, expectedMapping)
+			}
+		})
+
+		t.Run("handles bad config", func(t *testing.T) {
+			tests := []struct {
+				kind   Kind
+				resErr testPkgResourceError
+			}{
+				{
+					kind: KindNotificationEndpointSlack,
+					resErr: testPkgResourceError{
+						name:           "missing slack url",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointURL},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointSlack
+      name: name1
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointPagerDuty,
+					resErr: testPkgResourceError{
+						name:           "missing pager duty url",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointURL},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointPagerDuty
+      name: name1
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "missing http url",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointURL},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "bad url",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointURL},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: none
+      url: d_____-_8**(*https://www.examples.coms
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "bad url",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointURL},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: none
+      url: d_____-_8**(*https://www.examples.coms
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "missing basic username",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointUsername},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: basic
+      url: example.com
+      password: password
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "missing basic password",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointPassword},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: basic
+      url: example.com
+      username: user
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "missing basic password and username",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointPassword, fieldNotificationEndpointUsername},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: basic
+      url: example.com
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "missing bearer token",
+						validationErrs: 1,
+						valFields:      []string{fieldNotificationEndpointToken},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: bearer
+      url: example.com
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "invalid http type",
+						validationErrs: 1,
+						valFields:      []string{fieldType},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: threeve
+      url: example.com
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointHTTP,
+					resErr: testPkgResourceError{
+						name:           "invalid http type",
+						validationErrs: 1,
+						valFields:      []string{fieldType},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointHTTP
+      name: name1
+      type: threeve
+      url: example.com
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointSlack,
+					resErr: testPkgResourceError{
+						name:           "duplicate ",
+						validationErrs: 1,
+						valFields:      []string{fieldName},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointSlack
+      name: dupe
+      url: example.com
+    - kind: NotificationEndpointSlack
+      name: dupe
+      url: example.com
+`,
+					},
+				},
+				{
+					kind: KindNotificationEndpointSlack,
+					resErr: testPkgResourceError{
+						name:           "invalid status",
+						validationErrs: 1,
+						valFields:      []string{fieldStatus},
+						pkgStr: `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointSlack
+      name: dupe
+      url: example.com
+      status: rando bad status
+`,
+					},
+				},
+			}
+
+			for _, tt := range tests {
+				testPkgErrors(t, tt.kind, tt.resErr)
 			}
 		})
 	})

--- a/pkger/testdata/notification_endpoint.json
+++ b/pkger/testdata/notification_endpoint.json
@@ -1,0 +1,91 @@
+{
+  "apiVersion": "0.1.0",
+  "kind": "Package",
+  "meta": {
+    "pkgName": "pkg_name",
+    "pkgVersion": "1",
+    "description": "pack description"
+  },
+  "spec": {
+    "resources": [
+      {
+        "kind": "Label",
+        "name": "label_1"
+      },
+      {
+        "kind": "NotificationEndpointSlack",
+        "name": "slack_notification_endpoint",
+        "description": "slack desc",
+        "url": "https://hooks.slack.com/services/bip/piddy/boppidy",
+        "token": "tokenval",
+        "status": "active",
+        "associations": [
+          {
+            "kind": "Label",
+            "name": "label_1"
+          }
+        ]
+      },
+      {
+        "kind": "NotificationEndpointHTTP",
+        "name": "http_none_auth_notification_endpoint",
+        "description": "http none auth desc",
+        "type": "none",
+        "url": "https://www.example.com/endpoint/noneauth",
+        "status": "active",
+        "associations": [
+          {
+            "kind": "Label",
+            "name": "label_1"
+          }
+        ]
+      },
+      {
+        "kind": "NotificationEndpointHTTP",
+        "name": "http_basic_auth_notification_endpoint",
+        "description": "http basic auth desc",
+        "type": "basic",
+        "url": "https://www.example.com/endpoint/basicauth",
+        "username": "secret username",
+        "password": "secret password",
+        "status": "inactive",
+        "associations": [
+          {
+            "kind": "Label",
+            "name": "label_1"
+          }
+        ]
+      },
+      {
+        "kind": "NotificationEndpointHTTP",
+        "name": "http_bearer_auth_notification_endpoint",
+        "description": "http bearer auth desc",
+        "type": "bearer",
+        "url": "https://www.example.com/endpoint/bearerauth",
+        "token": "secret token",
+        "associations": [
+          {
+            "kind": "Label",
+            "name": "label_1"
+          }
+        ]
+      },
+      {
+        "kind": "NotificationEndpointPagerDuty",
+        "name": "pager_duty_notification_endpoint",
+        "description": "pager duty desc",
+        "url": "http://localhost:8080/orgs/7167eb6719fa34e5/alert-history",
+        "routingKey": "secret routing-key",
+        "status": "active",
+        "associations": [
+          {
+            "kind": "Label",
+            "name": "label_1"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+

--- a/pkger/testdata/notification_endpoint.yml
+++ b/pkger/testdata/notification_endpoint.yml
@@ -1,0 +1,58 @@
+apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: Label
+      name: label_1
+    - kind: NotificationEndpointSlack
+      name: slack_notification_endpoint
+      description: slack desc
+      url: https://hooks.slack.com/services/bip/piddy/boppidy
+      status: active
+      token: tokenval
+      associations:
+        - kind: Label
+          name: label_1
+    - kind: NotificationEndpointHTTP
+      name: http_none_auth_notification_endpoint
+      type: none
+      description: http none auth desc
+      url:  https://www.example.com/endpoint/noneauth
+      status: active
+      associations:
+        - kind: Label
+          name: label_1
+    - kind: NotificationEndpointHTTP
+      name: http_basic_auth_notification_endpoint
+      description: http basic auth desc
+      type: basic
+      url:  https://www.example.com/endpoint/basicauth
+      username: "secret username"
+      password: "secret password"
+      status: inactive
+      associations:
+        - kind: Label
+          name: label_1
+    - kind: NotificationEndpointHTTP
+      name: http_bearer_auth_notification_endpoint
+      description: http bearer auth desc
+      type: bearer
+      url:  https://www.example.com/endpoint/bearerauth
+      token: "secret token"
+      associations:
+        - kind: Label
+          name: label_1
+    - kind: NotificationEndpointPagerDuty
+      name: pager_duty_notification_endpoint
+      description: pager duty desc
+      url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
+      routingKey: "secret routing-key"
+      status: active
+      associations:
+        - kind: Label
+          name: label_1
+


### PR DESCRIPTION
Add support for notification endpoints to the pkger parser.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass