### PR TITLE
fix(honeybadger): updated getTableProps to return empty fieldOptions whenever the files are undefined

### DIFF
--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -139,6 +139,9 @@ export const initialState = (): TimeMachinesState => ({
 })
 
 const getTableProperties = (view, files) => {
+  if (!files || !files[0]) {
+    return {...view.properties, fieldOptions: []}
+  }
   const csv = files[0]
   let pointer = 0,
     ni


### PR DESCRIPTION
Closes https://github.com/influxdata/honeybadger-errors/issues/15

### Problem

Previous implementation assumed that files / files[0] would be defined

### Solution

Added checks for when the files are undefined / empty
