### PR TITLE
feat(query): add trace response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [15836](https://github.com/influxdata/influxdb/pull/16077): Add stacked line layer option to graphs
 1. [16094](https://github.com/influxdata/influxdb/pull/16094): Annotate log messages with trace ID, if available
 1. [16187](https://github.com/influxdata/influxdb/pull/16187): Bucket create to accept an org name flag
+1. [16158](https://github.com/influxdata/influxdb/pull/16158): Add trace ID response header to query endpoint
 
 ### Bug Fixes
 

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/influxdata/influxdb/http/metric"
 	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/influxdata/influxdb/logger"
 	influxlogger "github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/query"
 	"github.com/pkg/errors"
@@ -32,7 +33,8 @@ import (
 )
 
 const (
-	fluxPath = "/api/v2/query"
+	fluxPath      = "/api/v2/query"
+	traceIDHeader = "Trace-Id"
 )
 
 // FluxBackend is all services and associated parameters required to construct
@@ -106,6 +108,9 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	log := h.log.With(influxlogger.TraceFields(ctx)...)
+	if id, _, found := logger.TraceInfo(ctx); found {
+		w.Header().Set(traceIDHeader, id)
+	}
 
 	// TODO(desa): I really don't like how we're recording the usage metrics here
 	// Ideally this will be moved when we solve https://github.com/influxdata/influxdb/issues/13403

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3208,6 +3208,11 @@ paths:
                     enum:
                     - gzip
                     - identity
+              Trace-Id:
+                description: The Trace-Id header reports the request's trace ID, if one was generated.
+                schema:
+                  type: string
+                  description: Specifies the request's trace ID.
             content:
               text/csv:
                 schema:


### PR DESCRIPTION
Adds `Trace-Id` response header to query endpoint.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)