### PR TITLE
feat(pkger): speed up application of pkg with a touch of concurrency

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -92,7 +92,7 @@ func (b *cmdPkgBuilder) cmdPkgApply() *cobra.Command {
 	cmd.Flags().StringVarP(&b.file, "file", "f", "", "Path to package file")
 	cmd.MarkFlagFilename("file", "yaml", "yml", "json")
 	cmd.Flags().BoolVarP(&b.quiet, "quiet", "q", false, "disable output printing")
-	cmd.Flags().IntVarP(&b.applyReqLimit, "req-limit", "r", 0, "TTY input, if package will have destructive changes, proceed if set true.")
+	cmd.Flags().IntVarP(&b.applyReqLimit, "req-limit", "r", 0, "Request limit for applying a pkg, defaults to 5(recommended for OSS).")
 	cmd.Flags().StringVar(&b.applyOpts.force, "force", "", `TTY input, if package will have destructive changes, proceed if set "true".`)
 
 	cmd.Flags().StringVarP(&b.orgID, "org-id", "o", "", "The ID of the organization that owns the bucket")

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -21,7 +21,7 @@ import (
 
 func Test_Pkg(t *testing.T) {
 	fakeSVCFn := func(svc pkger.SVC) pkgSVCFn {
-		return func(opts httpClientOpts) (pkger.SVC, error) {
+		return func(opts httpClientOpts, _ ...pkger.ServiceSetterFn) (pkger.SVC, error) {
 			return svc, nil
 		}
 	}

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -337,8 +337,13 @@ func (tl *TestLauncher) LabelService() *http.LabelService {
 	return &http.LabelService{Addr: tl.URL(), Token: tl.Auth.Token}
 }
 
-func (tl *TestLauncher) TelegrafService() *http.TelegrafService {
-	return http.NewTelegrafService(tl.URL(), tl.Auth.Token, false)
+func (tl *TestLauncher) TelegrafService(t *testing.T) *http.TelegrafService {
+	t.Helper()
+	teleSVC, err := http.NewTelegrafService(tl.URL(), tl.Auth.Token, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return teleSVC
 }
 
 func (tl *TestLauncher) VariableService() *http.VariableService {

--- a/http/client.go
+++ b/http/client.go
@@ -1,8 +1,13 @@
 package http
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/influxdata/influxdb/kit/tracing"
 )
@@ -89,4 +94,127 @@ func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
 	defer span.Finish()
 	tracing.InjectToHTTPRequest(span, r)
 	return c.Client.Do(r)
+}
+
+// HTTPClient is a basic http client that can make cReqs with out having to juggle
+// the token and so forth. It provides sane defaults for checking response
+// statuses, sets auth token when provided, and sets the content type to
+// application/json for each request. The token, response checker, and
+// content type can be overidden on the cReq as well.
+type HTTPClient struct {
+	addr   url.URL
+	token  string
+	client *traceClient
+}
+
+// NewHTTPClient creates a new HTTPClient(client).
+func NewHTTPClient(addr, token string, insecureSkipVerify bool) (*HTTPClient, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HTTPClient{
+		addr:   *u,
+		token:  token,
+		client: NewClient(u.Scheme, insecureSkipVerify),
+	}, nil
+}
+
+func (c *HTTPClient) delete(urlPath string) *cReq {
+	return c.newClientReq(http.MethodDelete, urlPath, nil)
+}
+
+func (c *HTTPClient) get(urlPath string) *cReq {
+	return c.newClientReq(http.MethodGet, urlPath, nil)
+}
+
+func (c *HTTPClient) post(urlPath string, body io.Reader) *cReq {
+	return c.newClientReq(http.MethodPost, urlPath, body)
+}
+
+func (c *HTTPClient) newClientReq(method, urlPath string, body io.Reader) *cReq {
+	u := c.addr
+	u.Path = path.Join(u.Path, urlPath)
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return &cReq{err: err}
+	}
+	if c.token != "" {
+		SetToken(c.token, req)
+	}
+
+	cr := &cReq{
+		client: c.client,
+		req:    req,
+		respFn: CheckError,
+	}
+	return cr.ContentType("application/json")
+}
+
+type cReq struct {
+	client interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+	req    *http.Request
+	respFn func(*http.Response) error
+
+	err error
+}
+
+func (r *cReq) Header(k, v string) *cReq {
+	if r.err != nil {
+		return r
+	}
+	r.req.Header.Add(k, v)
+	return r
+}
+
+type queryPair struct {
+	k, v string
+}
+
+func (r *cReq) Queries(pairs ...queryPair) *cReq {
+	if r.err != nil || len(pairs) == 0 {
+		return r
+	}
+	params := r.req.URL.Query()
+	for _, p := range pairs {
+		params.Add(p.k, p.v)
+	}
+	r.req.URL.RawQuery = params.Encode()
+	return r
+}
+
+func (r *cReq) ContentType(ct string) *cReq {
+	return r.Header("Content-Type", ct)
+}
+
+func (r *cReq) DecodeJSON(v interface{}) *cReq {
+	return r.RespFn(func(resp *http.Response) error {
+		return json.NewDecoder(resp.Body).Decode(v)
+	})
+}
+
+func (r *cReq) RespFn(fn func(*http.Response) error) *cReq {
+	r.respFn = fn
+	return r
+}
+
+func (r *cReq) Do(ctx context.Context) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.req = r.req.WithContext(ctx)
+
+	resp, err := r.client.Do(r.req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body) // drain body completely
+		resp.Body.Close()
+	}()
+
+	return r.respFn(resp)
 }

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3142,14 +3142,14 @@ spec:
 
 				// validates we support all known variable types
 				varEquals(t,
-					"var_const",
+					"var_const_3",
 					"constant",
 					influxdb.VariableConstantValues([]string{"first val"}),
 					sum.Variables[0],
 				)
 
 				varEquals(t,
-					"var_map",
+					"var_map_4",
 					"map",
 					influxdb.VariableMapValues{"k1": "v1"},
 					sum.Variables[1],

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -1412,12 +1412,6 @@ func (r *rollbackCoordinator) rollback(l *zap.Logger, err *error) {
 	}
 }
 
-func (r *rollbackCoordinator) close() {
-	if r.sem != nil {
-		close(r.sem)
-	}
-}
-
 type errMsg struct {
 	resource string
 	err      applyErrBody

--- a/pkger/testdata/variables.json
+++ b/pkger/testdata/variables.json
@@ -26,15 +26,15 @@
       },
       {
         "kind": "Variable",
-        "name": "var_const",
-        "description": "var_const desc",
+        "name": "var_const_3",
+        "description": "var_const_3 desc",
         "type": "constant",
         "values": ["first val"]
       },
       {
         "kind": "Variable",
-        "name": "var_map",
-        "description": "var_map desc",
+        "name": "var_map_4",
+        "description": "var_map_4 desc",
         "type": "map",
         "values": {
           "k1": "v1"

--- a/pkger/testdata/variables.yml
+++ b/pkger/testdata/variables.yml
@@ -20,14 +20,14 @@ spec:
       query: an influxql query of sorts
       language: influxql
     - kind: Variable
-      name: var_const
-      description: var_const desc
+      name: var_const_3
+      description: var_const_3 desc
       type: constant
       values:
         - first val
     - kind: Variable
-      name: var_map
-      description: var_map desc
+      name: var_map_4
+      description: var_map_4 desc
       type: map
       values:
         k1: v1


### PR DESCRIPTION
governs the concurrency with a simple semaphore. Defaults to 5
concurrent reqs, anything greater, puts a lot of pressure
on the system as a whole (especially OSS/bolt store).

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass