### PR TITLE
fix(pkger): fix flaky test in pkger service tests

### DIFF
--- a/mock/bucket_service.go
+++ b/mock/bucket_service.go
@@ -15,13 +15,20 @@ type BucketService struct {
 	CloseFn func() error
 
 	// Methods for an platform.BucketService
-	FindBucketByIDFn   func(context.Context, platform.ID) (*platform.Bucket, error)
-	FindBucketByNameFn func(context.Context, platform.ID, string) (*platform.Bucket, error)
-	FindBucketFn       func(context.Context, platform.BucketFilter) (*platform.Bucket, error)
-	FindBucketsFn      func(context.Context, platform.BucketFilter, ...platform.FindOptions) ([]*platform.Bucket, int, error)
-	CreateBucketFn     func(context.Context, *platform.Bucket) error
-	UpdateBucketFn     func(context.Context, platform.ID, platform.BucketUpdate) (*platform.Bucket, error)
-	DeleteBucketFn     func(context.Context, platform.ID) error
+	FindBucketByIDFn      func(context.Context, platform.ID) (*platform.Bucket, error)
+	FindBucketByIDCalls   SafeCount
+	FindBucketByNameFn    func(context.Context, platform.ID, string) (*platform.Bucket, error)
+	FindBucketByNameCalls SafeCount
+	FindBucketFn          func(context.Context, platform.BucketFilter) (*platform.Bucket, error)
+	FindBucketCalls       SafeCount
+	FindBucketsFn         func(context.Context, platform.BucketFilter, ...platform.FindOptions) ([]*platform.Bucket, int, error)
+	FindBucketsCalls      SafeCount
+	CreateBucketFn        func(context.Context, *platform.Bucket) error
+	CreateBucketCalls     SafeCount
+	UpdateBucketFn        func(context.Context, platform.ID, platform.BucketUpdate) (*platform.Bucket, error)
+	UpdateBucketCalls     SafeCount
+	DeleteBucketFn        func(context.Context, platform.ID) error
+	DeleteBucketCalls     SafeCount
 }
 
 // NewBucketService returns a mock BucketService where its methods will return
@@ -58,35 +65,42 @@ func (s *BucketService) Close() error { return s.CloseFn() }
 
 // FindBucketByID returns a single bucket by ID.
 func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
+	defer s.FindBucketByIDCalls.IncrFn()()
 	return s.FindBucketByIDFn(ctx, id)
 }
 
 // FindBucketByName returns a single bucket by name.
 func (s *BucketService) FindBucketByName(ctx context.Context, orgID platform.ID, name string) (*platform.Bucket, error) {
+	defer s.FindBucketByNameCalls.IncrFn()()
 	return s.FindBucketByNameFn(ctx, orgID, name)
 }
 
 // FindBucket returns the first bucket that matches filter.
 func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
+	defer s.FindBucketCalls.IncrFn()()
 	return s.FindBucketFn(ctx, filter)
 }
 
 // FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
 func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opts ...platform.FindOptions) ([]*platform.Bucket, int, error) {
+	defer s.FindBucketsCalls.IncrFn()()
 	return s.FindBucketsFn(ctx, filter, opts...)
 }
 
 // CreateBucket creates a new bucket and sets b.ID with the new identifier.
 func (s *BucketService) CreateBucket(ctx context.Context, bucket *platform.Bucket) error {
+	defer s.CreateBucketCalls.IncrFn()()
 	return s.CreateBucketFn(ctx, bucket)
 }
 
 // UpdateBucket updates a single bucket with changeset.
 func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd platform.BucketUpdate) (*platform.Bucket, error) {
+	defer s.UpdateBucketCalls.IncrFn()()
 	return s.UpdateBucketFn(ctx, id, upd)
 }
 
 // DeleteBucket removes a bucket by ID.
 func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error {
+	defer s.DeleteBucketCalls.IncrFn()()
 	return s.DeleteBucketFn(ctx, id)
 }

--- a/mock/dashboard_service.go
+++ b/mock/dashboard_service.go
@@ -9,19 +9,31 @@ import (
 var _ platform.DashboardService = &DashboardService{}
 
 type DashboardService struct {
-	CreateDashboardF   func(context.Context, *platform.Dashboard) error
-	FindDashboardByIDF func(context.Context, platform.ID) (*platform.Dashboard, error)
-	FindDashboardsF    func(context.Context, platform.DashboardFilter, platform.FindOptions) ([]*platform.Dashboard, int, error)
-	UpdateDashboardF   func(context.Context, platform.ID, platform.DashboardUpdate) (*platform.Dashboard, error)
-	DeleteDashboardF   func(context.Context, platform.ID) error
+	CreateDashboardF       func(context.Context, *platform.Dashboard) error
+	CreateDashboardCalls   SafeCount
+	FindDashboardByIDF     func(context.Context, platform.ID) (*platform.Dashboard, error)
+	FindDashboardByIDCalls SafeCount
+	FindDashboardsF        func(context.Context, platform.DashboardFilter, platform.FindOptions) ([]*platform.Dashboard, int, error)
+	FindDashboardsCalls    SafeCount
+	UpdateDashboardF       func(context.Context, platform.ID, platform.DashboardUpdate) (*platform.Dashboard, error)
+	UpdateDashboardCalls   SafeCount
+	DeleteDashboardF       func(context.Context, platform.ID) error
+	DeleteDashboardCalls   SafeCount
 
-	AddDashboardCellF        func(ctx context.Context, id platform.ID, c *platform.Cell, opts platform.AddDashboardCellOptions) error
-	RemoveDashboardCellF     func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) error
-	GetDashboardCellViewF    func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) (*platform.View, error)
-	UpdateDashboardCellViewF func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error)
-	UpdateDashboardCellF     func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error)
-	CopyDashboardCellF       func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID) (*platform.Cell, error)
-	ReplaceDashboardCellsF   func(ctx context.Context, id platform.ID, cs []*platform.Cell) error
+	AddDashboardCellF            func(ctx context.Context, id platform.ID, c *platform.Cell, opts platform.AddDashboardCellOptions) error
+	AddDashboardCellCalls        SafeCount
+	RemoveDashboardCellF         func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) error
+	RemoveDashboardCellCalls     SafeCount
+	GetDashboardCellViewF        func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) (*platform.View, error)
+	GetDashboardCellViewCalls    SafeCount
+	UpdateDashboardCellViewF     func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error)
+	UpdateDashboardCellViewCalls SafeCount
+	UpdateDashboardCellF         func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error)
+	UpdateDashboardCellCalls     SafeCount
+	CopyDashboardCellF           func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID) (*platform.Cell, error)
+	CopyDashboardCellCalls       SafeCount
+	ReplaceDashboardCellsF       func(ctx context.Context, id platform.ID, cs []*platform.Cell) error
+	ReplaceDashboardCellsCalls   SafeCount
 }
 
 // NewDashboardService returns a mock of DashboardService where its methods will return zero values.
@@ -58,49 +70,61 @@ func NewDashboardService() *DashboardService {
 }
 
 func (s *DashboardService) FindDashboardByID(ctx context.Context, id platform.ID) (*platform.Dashboard, error) {
+	defer s.FindDashboardByIDCalls.IncrFn()()
 	return s.FindDashboardByIDF(ctx, id)
 }
 
 func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
+	defer s.FindDashboardsCalls.IncrFn()()
 	return s.FindDashboardsF(ctx, filter, opts)
 }
 
 func (s *DashboardService) CreateDashboard(ctx context.Context, b *platform.Dashboard) error {
+	defer s.CreateDashboardCalls.IncrFn()()
 	return s.CreateDashboardF(ctx, b)
 }
 
 func (s *DashboardService) UpdateDashboard(ctx context.Context, id platform.ID, upd platform.DashboardUpdate) (*platform.Dashboard, error) {
+	defer s.UpdateDashboardCalls.IncrFn()()
 	return s.UpdateDashboardF(ctx, id, upd)
 }
 
 func (s *DashboardService) DeleteDashboard(ctx context.Context, id platform.ID) error {
+	defer s.DeleteDashboardCalls.IncrFn()()
 	return s.DeleteDashboardF(ctx, id)
 }
 
 func (s *DashboardService) GetDashboardCellView(ctx context.Context, dashboardID, cellID platform.ID) (*platform.View, error) {
+	defer s.GetDashboardCellViewCalls.IncrFn()()
 	return s.GetDashboardCellViewF(ctx, dashboardID, cellID)
 }
 
 func (s *DashboardService) UpdateDashboardCellView(ctx context.Context, dashboardID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error) {
+	defer s.UpdateDashboardCellViewCalls.IncrFn()()
 	return s.UpdateDashboardCellViewF(ctx, dashboardID, cellID, upd)
 }
 
 func (s *DashboardService) AddDashboardCell(ctx context.Context, id platform.ID, c *platform.Cell, opts platform.AddDashboardCellOptions) error {
+	defer s.AddDashboardCellCalls.IncrFn()()
 	return s.AddDashboardCellF(ctx, id, c, opts)
 }
 
 func (s *DashboardService) ReplaceDashboardCells(ctx context.Context, id platform.ID, cs []*platform.Cell) error {
+	defer s.ReplaceDashboardCellsCalls.IncrFn()()
 	return s.ReplaceDashboardCellsF(ctx, id, cs)
 }
 
 func (s *DashboardService) RemoveDashboardCell(ctx context.Context, dashboardID platform.ID, cellID platform.ID) error {
+	defer s.RemoveDashboardCellCalls.IncrFn()()
 	return s.RemoveDashboardCellF(ctx, dashboardID, cellID)
 }
 
 func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
+	defer s.UpdateDashboardCellCalls.IncrFn()()
 	return s.UpdateDashboardCellF(ctx, dashboardID, cellID, upd)
 }
 
 func (s *DashboardService) CopyDashboardCell(ctx context.Context, dashboardID platform.ID, cellID platform.ID) (*platform.Cell, error) {
+	defer s.CopyDashboardCellCalls.IncrFn()()
 	return s.CopyDashboardCellF(ctx, dashboardID, cellID)
 }

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -10,14 +10,22 @@ var _ platform.LabelService = &LabelService{}
 
 // LabelService is a mock implementation of platform.LabelService
 type LabelService struct {
-	FindLabelByIDFn      func(ctx context.Context, id platform.ID) (*platform.Label, error)
-	FindLabelsFn         func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
-	FindResourceLabelsFn func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
-	CreateLabelFn        func(context.Context, *platform.Label) error
-	CreateLabelMappingFn func(context.Context, *platform.LabelMapping) error
-	UpdateLabelFn        func(context.Context, platform.ID, platform.LabelUpdate) (*platform.Label, error)
-	DeleteLabelFn        func(context.Context, platform.ID) error
-	DeleteLabelMappingFn func(context.Context, *platform.LabelMapping) error
+	CreateLabelFn           func(context.Context, *platform.Label) error
+	CreateLabelCalls        SafeCount
+	DeleteLabelFn           func(context.Context, platform.ID) error
+	DeleteLabelCalls        SafeCount
+	FindLabelByIDFn         func(ctx context.Context, id platform.ID) (*platform.Label, error)
+	FindLabelByIDCalls      SafeCount
+	FindLabelsFn            func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
+	FindLabelsCalls         SafeCount
+	FindResourceLabelsFn    func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
+	FindResourceLabelsCalls SafeCount
+	UpdateLabelFn           func(context.Context, platform.ID, platform.LabelUpdate) (*platform.Label, error)
+	UpdateLabelCalls        SafeCount
+	CreateLabelMappingFn    func(context.Context, *platform.LabelMapping) error
+	CreateLabelMappingCalls SafeCount
+	DeleteLabelMappingFn    func(context.Context, *platform.LabelMapping) error
+	DeleteLabelMappingCalls SafeCount
 }
 
 // NewLabelService returns a mock of LabelService
@@ -43,40 +51,48 @@ func NewLabelService() *LabelService {
 
 // FindLabelByID finds mappings by their ID
 func (s *LabelService) FindLabelByID(ctx context.Context, id platform.ID) (*platform.Label, error) {
+	defer s.FindLabelByIDCalls.IncrFn()()
 	return s.FindLabelByIDFn(ctx, id)
 }
 
 // FindLabels finds mappings that match a given filter.
 func (s *LabelService) FindLabels(ctx context.Context, filter platform.LabelFilter, opt ...platform.FindOptions) ([]*platform.Label, error) {
+	defer s.FindLabelsCalls.IncrFn()()
 	return s.FindLabelsFn(ctx, filter)
 }
 
 // FindResourceLabels finds mappings that match a given filter.
 func (s *LabelService) FindResourceLabels(ctx context.Context, filter platform.LabelMappingFilter) ([]*platform.Label, error) {
+	defer s.FindResourceLabelsCalls.IncrFn()()
 	return s.FindResourceLabelsFn(ctx, filter)
 }
 
 // CreateLabel creates a new Label.
 func (s *LabelService) CreateLabel(ctx context.Context, l *platform.Label) error {
+	defer s.CreateLabelCalls.IncrFn()()
 	return s.CreateLabelFn(ctx, l)
 }
 
 // CreateLabelMapping creates a new Label mapping.
 func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	defer s.CreateLabelMappingCalls.IncrFn()()
 	return s.CreateLabelMappingFn(ctx, m)
 }
 
 // UpdateLabel updates a label.
 func (s *LabelService) UpdateLabel(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
+	defer s.UpdateLabelCalls.IncrFn()()
 	return s.UpdateLabelFn(ctx, id, upd)
 }
 
 // DeleteLabel removes a Label.
 func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
+	defer s.DeleteLabelCalls.IncrFn()()
 	return s.DeleteLabelFn(ctx, id)
 }
 
 // DeleteLabelMapping removes a Label mapping.
 func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	defer s.DeleteLabelMappingCalls.IncrFn()()
 	return s.DeleteLabelMappingFn(ctx, m)
 }

--- a/mock/safe_count.go
+++ b/mock/safe_count.go
@@ -1,0 +1,36 @@
+package mock
+
+import (
+	"sync"
+)
+
+// SafeCount provides a safe counter, useful for call counts to maintain
+// thread safety. Removes burden of having to introduce serialization when
+// concurrency is brought in.
+type SafeCount struct {
+	mu sync.Mutex
+	i  int
+}
+
+// IncrFn increments the safe counter by 1.
+func (s *SafeCount) IncrFn() func() {
+	s.mu.Lock()
+	return func() {
+		s.i++
+		s.mu.Unlock()
+	}
+}
+
+// Count returns the current count.
+func (s *SafeCount) Count() int {
+	return s.i
+}
+
+// Reset will reset the count to 0.
+func (s *SafeCount) Reset() {
+	s.mu.Lock()
+	{
+		s.i = 0
+	}
+	s.mu.Unlock()
+}

--- a/mock/telegraf_service.go
+++ b/mock/telegraf_service.go
@@ -6,17 +6,21 @@ import (
 	platform "github.com/influxdata/influxdb"
 )
 
-var _ platform.TelegrafConfigStore = &TelegrafConfigStore{}
+var _ platform.TelegrafConfigStore = (*TelegrafConfigStore)(nil)
 
 // TelegrafConfigStore represents a service for managing telegraf config data.
 type TelegrafConfigStore struct {
 	*UserResourceMappingService
-	FindTelegrafConfigByIDF func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error)
-	FindTelegrafConfigF     func(ctx context.Context, filter platform.TelegrafConfigFilter) (*platform.TelegrafConfig, error)
-	FindTelegrafConfigsF    func(ctx context.Context, filter platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error)
-	CreateTelegrafConfigF   func(ctx context.Context, tc *platform.TelegrafConfig, userID platform.ID) error
-	UpdateTelegrafConfigF   func(ctx context.Context, id platform.ID, tc *platform.TelegrafConfig, userID platform.ID) (*platform.TelegrafConfig, error)
-	DeleteTelegrafConfigF   func(ctx context.Context, id platform.ID) error
+	FindTelegrafConfigByIDF     func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error)
+	FindTelegrafConfigByIDCalls SafeCount
+	FindTelegrafConfigsF        func(ctx context.Context, filter platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error)
+	FindTelegrafConfigsCalls    SafeCount
+	CreateTelegrafConfigF       func(ctx context.Context, tc *platform.TelegrafConfig, userID platform.ID) error
+	CreateTelegrafConfigCalls   SafeCount
+	UpdateTelegrafConfigF       func(ctx context.Context, id platform.ID, tc *platform.TelegrafConfig, userID platform.ID) (*platform.TelegrafConfig, error)
+	UpdateTelegrafConfigCalls   SafeCount
+	DeleteTelegrafConfigF       func(ctx context.Context, id platform.ID) error
+	DeleteTelegrafConfigCalls   SafeCount
 }
 
 // NewTelegrafConfigStore constructs a new fake TelegrafConfigStore.
@@ -24,9 +28,6 @@ func NewTelegrafConfigStore() *TelegrafConfigStore {
 	return &TelegrafConfigStore{
 		UserResourceMappingService: NewUserResourceMappingService(),
 		FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
-			return nil, nil
-		},
-		FindTelegrafConfigF: func(_ context.Context, f platform.TelegrafConfigFilter) (*platform.TelegrafConfig, error) {
 			return nil, nil
 		},
 		FindTelegrafConfigsF: func(_ context.Context, f platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error) {
@@ -46,27 +47,32 @@ func NewTelegrafConfigStore() *TelegrafConfigStore {
 
 // FindTelegrafConfigByID returns a single telegraf config by ID.
 func (s *TelegrafConfigStore) FindTelegrafConfigByID(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
+	defer s.FindTelegrafConfigByIDCalls.IncrFn()()
 	return s.FindTelegrafConfigByIDF(ctx, id)
 }
 
 // FindTelegrafConfigs returns a list of telegraf configs that match filter and the total count of matching telegraf configs.
 // Additional options provide pagination & sorting.
 func (s *TelegrafConfigStore) FindTelegrafConfigs(ctx context.Context, filter platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error) {
+	defer s.FindTelegrafConfigsCalls.IncrFn()()
 	return s.FindTelegrafConfigsF(ctx, filter, opt...)
 }
 
 // CreateTelegrafConfig creates a new telegraf config and sets b.ID with the new identifier.
 func (s *TelegrafConfigStore) CreateTelegrafConfig(ctx context.Context, tc *platform.TelegrafConfig, userID platform.ID) error {
+	defer s.CreateTelegrafConfigCalls.IncrFn()()
 	return s.CreateTelegrafConfigF(ctx, tc, userID)
 }
 
 // UpdateTelegrafConfig updates a single telegraf config.
 // Returns the new telegraf config after update.
 func (s *TelegrafConfigStore) UpdateTelegrafConfig(ctx context.Context, id platform.ID, tc *platform.TelegrafConfig, userID platform.ID) (*platform.TelegrafConfig, error) {
+	defer s.UpdateTelegrafConfigCalls.IncrFn()()
 	return s.UpdateTelegrafConfigF(ctx, id, tc, userID)
 }
 
 // DeleteTelegrafConfig removes a telegraf config by ID.
 func (s *TelegrafConfigStore) DeleteTelegrafConfig(ctx context.Context, id platform.ID) error {
+	defer s.DeleteTelegrafConfigCalls.IncrFn()()
 	return s.DeleteTelegrafConfigF(ctx, id)
 }

--- a/mock/variable_service.go
+++ b/mock/variable_service.go
@@ -9,50 +9,62 @@ import (
 var _ platform.VariableService = &VariableService{}
 
 type VariableService struct {
-	FindVariablesF    func(context.Context, platform.VariableFilter, ...platform.FindOptions) ([]*platform.Variable, error)
-	FindVariableByIDF func(context.Context, platform.ID) (*platform.Variable, error)
-	CreateVariableF   func(context.Context, *platform.Variable) error
-	UpdateVariableF   func(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error)
-	ReplaceVariableF  func(context.Context, *platform.Variable) error
-	DeleteVariableF   func(context.Context, platform.ID) error
+	CreateVariableF       func(context.Context, *platform.Variable) error
+	CreateVariableCalls   SafeCount
+	DeleteVariableF       func(context.Context, platform.ID) error
+	DeleteVariableCalls   SafeCount
+	FindVariableByIDF     func(context.Context, platform.ID) (*platform.Variable, error)
+	FindVariableByIDCalls SafeCount
+	FindVariablesF        func(context.Context, platform.VariableFilter, ...platform.FindOptions) ([]*platform.Variable, error)
+	FindVariablesCalls    SafeCount
+	ReplaceVariableF      func(context.Context, *platform.Variable) error
+	ReplaceVariableCalls  SafeCount
+	UpdateVariableF       func(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error)
+	UpdateVariableCalls   SafeCount
 }
 
 // NewVariableService returns a mock of VariableService where its methods will return zero values.
 func NewVariableService() *VariableService {
 	return &VariableService{
+		CreateVariableF:   func(context.Context, *platform.Variable) error { return nil },
+		DeleteVariableF:   func(context.Context, platform.ID) error { return nil },
+		FindVariableByIDF: func(context.Context, platform.ID) (*platform.Variable, error) { return nil, nil },
 		FindVariablesF: func(context.Context, platform.VariableFilter, ...platform.FindOptions) ([]*platform.Variable, error) {
 			return nil, nil
 		},
-		FindVariableByIDF: func(context.Context, platform.ID) (*platform.Variable, error) { return nil, nil },
-		CreateVariableF:   func(context.Context, *platform.Variable) error { return nil },
+		ReplaceVariableF: func(context.Context, *platform.Variable) error { return nil },
 		UpdateVariableF: func(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error) {
 			return nil, nil
 		},
-		ReplaceVariableF: func(context.Context, *platform.Variable) error { return nil },
-		DeleteVariableF:  func(context.Context, platform.ID) error { return nil },
 	}
 }
 
 func (s *VariableService) CreateVariable(ctx context.Context, variable *platform.Variable) error {
+	defer s.CreateVariableCalls.IncrFn()()
 	return s.CreateVariableF(ctx, variable)
 }
 
 func (s *VariableService) ReplaceVariable(ctx context.Context, variable *platform.Variable) error {
+	defer s.ReplaceVariableCalls.IncrFn()()
 	return s.ReplaceVariableF(ctx, variable)
 }
 
 func (s *VariableService) FindVariables(ctx context.Context, filter platform.VariableFilter, opts ...platform.FindOptions) ([]*platform.Variable, error) {
+	defer s.FindVariablesCalls.IncrFn()()
 	return s.FindVariablesF(ctx, filter, opts...)
 }
 
 func (s *VariableService) FindVariableByID(ctx context.Context, id platform.ID) (*platform.Variable, error) {
+	defer s.FindVariableByIDCalls.IncrFn()()
 	return s.FindVariableByIDF(ctx, id)
 }
 
 func (s *VariableService) DeleteVariable(ctx context.Context, id platform.ID) error {
+	defer s.DeleteVariableCalls.IncrFn()()
 	return s.DeleteVariableF(ctx, id)
 }
 
 func (s *VariableService) UpdateVariable(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error) {
+	defer s.UpdateVariableCalls.IncrFn()()
 	return s.UpdateVariableF(ctx, id, update)
 }


### PR DESCRIPTION
tests failing from a data race caused in the tests setup. an incrementing
const needs something to serialize it (atomic in this case) to remove that
data race. This touches that up and provides some reuable thread safe
count mechanism within the mock package. Is pretty brittle to tack these
counters on, and then remember to go back in when things are thrown into
concurrent workflows. This lets us take advantage of describing behavior and
it be safe for concurrent access.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass