### PR TITLE
chore(http): refactor bucket|dashboard|label|umr|var http clients to use reusable HTTP client

### DIFF
--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -51,10 +51,14 @@ func newBucketService(f Flags) (platform.BucketService, error) {
 	if f.local {
 		return newLocalKVService()
 	}
+
+	client, err := newHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return &http.BucketService{
-		Addr:               f.host,
-		Token:              f.token,
-		InsecureSkipVerify: f.skipVerify,
+		Client: client,
 	}, nil
 }
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -28,6 +28,24 @@ func main() {
 	}
 }
 
+var (
+	httpClient *http.HTTPClient
+)
+
+func newHTTPClient() (*http.HTTPClient, error) {
+	if httpClient != nil {
+		return httpClient, nil
+	}
+
+	c, err := http.NewHTTPClient(flags.host, flags.token, flags.skipVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient = c
+	return httpClient, nil
+}
+
 type httpClientOpts struct {
 	token, addr string
 	skipVerify  bool

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -486,34 +486,18 @@ func createPkgBuf(pkg *pkger.Pkg, outPath string) (*bytes.Buffer, error) {
 }
 
 func newPkgerSVC(cliReqOpts httpClientOpts, opts ...pkger.ServiceSetterFn) (pkger.SVC, error) {
-	teleSVC, err := ihttp.NewTelegrafService(cliReqOpts.addr, cliReqOpts.token, cliReqOpts.skipVerify)
+	httpClient, err := newHTTPClient()
 	if err != nil {
 		return nil, err
 	}
 
 	return pkger.NewService(
 		append(opts,
-			pkger.WithBucketSVC(&ihttp.BucketService{
-				Addr:               cliReqOpts.addr,
-				Token:              cliReqOpts.token,
-				InsecureSkipVerify: cliReqOpts.skipVerify,
-			}),
-			pkger.WithDashboardSVC(&ihttp.DashboardService{
-				Addr:               cliReqOpts.addr,
-				Token:              cliReqOpts.token,
-				InsecureSkipVerify: cliReqOpts.skipVerify,
-			}),
-			pkger.WithLabelSVC(&ihttp.LabelService{
-				Addr:               cliReqOpts.addr,
-				Token:              cliReqOpts.token,
-				InsecureSkipVerify: cliReqOpts.skipVerify,
-			}),
-			pkger.WithTelegrafSVC(teleSVC),
-			pkger.WithVariableSVC(&ihttp.VariableService{
-				Addr:               cliReqOpts.addr,
-				Token:              cliReqOpts.token,
-				InsecureSkipVerify: cliReqOpts.skipVerify,
-			}),
+			pkger.WithBucketSVC(&ihttp.BucketService{Client: httpClient}),
+			pkger.WithDashboardSVC(&ihttp.DashboardService{Client: httpClient}),
+			pkger.WithLabelSVC(&ihttp.LabelService{Client: httpClient}),
+			pkger.WithTelegrafSVC(ihttp.NewTelegrafService(httpClient)),
+			pkger.WithVariableSVC(&ihttp.VariableService{Client: httpClient}),
 		)...,
 	), nil
 }

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -63,10 +63,14 @@ func newUserResourceMappingService() (platform.UserResourceMappingService, error
 	if flags.local {
 		return newLocalKVService()
 	}
+
+	c, err := newHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return &http.UserResourceMappingService{
-		Addr:               flags.host,
-		Token:              flags.token,
-		InsecureSkipVerify: flags.skipVerify,
+		Client: c,
 	}, nil
 }
 
@@ -172,10 +176,13 @@ func userCreateF(cmd *cobra.Command, args []string) error {
 		return errors.New("an invalid org ID provided: " + orgIDStr)
 	}
 
+	c, err := newHTTPClient()
+	if err != nil {
+		return err
+	}
+
 	userResMapSVC := &http.UserResourceMappingService{
-		Addr:               flags.host,
-		Token:              flags.token,
-		InsecureSkipVerify: flags.skipVerify,
+		Client: c,
 	}
 
 	err = userResMapSVC.CreateUserResourceMapping(context.Background(), &platform.UserResourceMapping{

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -83,15 +83,16 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid precision")
 	}
 
-	bs := &http.BucketService{
-		Addr:               flags.host,
-		Token:              flags.token,
-		InsecureSkipVerify: flags.skipVerify,
+	httpClient, err := newHTTPClient()
+	if err != nil {
+		return err
 	}
 
-	var err error
-	filter := platform.BucketFilter{}
+	bs := &http.BucketService{
+		Client: httpClient,
+	}
 
+	var filter platform.BucketFilter
 	if writeFlags.BucketID != "" {
 		filter.ID, err = platform.IDFromString(writeFlags.BucketID)
 		if err != nil {

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -37,6 +37,8 @@ type TestLauncher struct {
 	Bucket *platform.Bucket
 	Auth   *platform.Authorization
 
+	httpClient *http.HTTPClient
+
 	// Standard in/out/err buffers.
 	Stdin  bytes.Buffer
 	Stdout bytes.Buffer
@@ -66,6 +68,7 @@ func NewTestLauncher() *TestLauncher {
 func RunTestLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *TestLauncher {
 	tb.Helper()
 	l := NewTestLauncher()
+
 	if err := l.Run(ctx, args...); err != nil {
 		tb.Fatal(err)
 	}
@@ -325,29 +328,29 @@ func (tl *TestLauncher) FluxQueryService() *http.FluxQueryService {
 	return &http.FluxQueryService{Addr: tl.URL(), Token: tl.Auth.Token}
 }
 
-func (tl *TestLauncher) BucketService() *http.BucketService {
-	return &http.BucketService{Addr: tl.URL(), Token: tl.Auth.Token, OpPrefix: kv.OpPrefix}
+func (tl *TestLauncher) BucketService(tb testing.TB) *http.BucketService {
+	tb.Helper()
+	return &http.BucketService{Client: tl.HTTPClient(tb), OpPrefix: kv.OpPrefix}
 }
 
-func (tl *TestLauncher) DashboardService() *http.DashboardService {
-	return &http.DashboardService{Addr: tl.URL(), Token: tl.Auth.Token}
+func (tl *TestLauncher) DashboardService(tb testing.TB) *http.DashboardService {
+	tb.Helper()
+	return &http.DashboardService{Client: tl.HTTPClient(tb)}
 }
 
-func (tl *TestLauncher) LabelService() *http.LabelService {
-	return &http.LabelService{Addr: tl.URL(), Token: tl.Auth.Token}
+func (tl *TestLauncher) LabelService(tb testing.TB) *http.LabelService {
+	tb.Helper()
+	return &http.LabelService{Client: tl.HTTPClient(tb)}
 }
 
-func (tl *TestLauncher) TelegrafService(t *testing.T) *http.TelegrafService {
-	t.Helper()
-	teleSVC, err := http.NewTelegrafService(tl.URL(), tl.Auth.Token, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return teleSVC
+func (tl *TestLauncher) TelegrafService(tb testing.TB) *http.TelegrafService {
+	tb.Helper()
+	return http.NewTelegrafService(tl.HTTPClient(tb))
 }
 
-func (tl *TestLauncher) VariableService() *http.VariableService {
-	return &http.VariableService{Addr: tl.URL(), Token: tl.Auth.Token}
+func (tl *TestLauncher) VariableService(tb testing.TB) *http.VariableService {
+	tb.Helper()
+	return &http.VariableService{Client: tl.HTTPClient(tb)}
 }
 
 func (tl *TestLauncher) AuthorizationService() *http.AuthorizationService {
@@ -356,6 +359,19 @@ func (tl *TestLauncher) AuthorizationService() *http.AuthorizationService {
 
 func (tl *TestLauncher) TaskService() *http.TaskService {
 	return &http.TaskService{Addr: tl.URL(), Token: tl.Auth.Token}
+}
+
+func (tl *TestLauncher) HTTPClient(tb testing.TB) *http.HTTPClient {
+	tb.Helper()
+
+	if tl.httpClient == nil {
+		client, err := http.NewHTTPClient(tl.URL(), tl.Auth.Token, false)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		tl.httpClient = client
+	}
+	return tl.httpClient
 }
 
 // QueryResult wraps a single flux.Result with some helper methods.

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -21,11 +21,11 @@ func TestLauncher_Pkger(t *testing.T) {
 	defer l.ShutdownOrFail(t, ctx)
 
 	svc := pkger.NewService(
-		pkger.WithBucketSVC(l.BucketService()),
-		pkger.WithDashboardSVC(l.DashboardService()),
-		pkger.WithLabelSVC(l.LabelService()),
+		pkger.WithBucketSVC(l.BucketService(t)),
+		pkger.WithDashboardSVC(l.DashboardService(t)),
+		pkger.WithLabelSVC(l.LabelService(t)),
 		pkger.WithTelegrafSVC(l.TelegrafService(t)),
-		pkger.WithVariableSVC(l.VariableService()),
+		pkger.WithVariableSVC(l.VariableService(t)),
 	)
 
 	t.Run("create a new package", func(t *testing.T) {
@@ -45,20 +45,20 @@ func TestLauncher_Pkger(t *testing.T) {
 
 	t.Run("errors incurred during application of package rolls back to state before package", func(t *testing.T) {
 		svc := pkger.NewService(
-			pkger.WithBucketSVC(l.BucketService()),
-			pkger.WithDashboardSVC(l.DashboardService()),
+			pkger.WithBucketSVC(l.BucketService(t)),
+			pkger.WithDashboardSVC(l.DashboardService(t)),
 			pkger.WithLabelSVC(&fakeLabelSVC{
-				LabelService: l.LabelService(),
+				LabelService: l.LabelService(t),
 				killCount:    2, // hits error on 3rd attempt at creating a mapping
 			}),
 			pkger.WithTelegrafSVC(l.TelegrafService(t)),
-			pkger.WithVariableSVC(l.VariableService()),
+			pkger.WithVariableSVC(l.VariableService(t)),
 		)
 
 		_, err := svc.Apply(ctx, l.Org.ID, newPkg(t))
 		require.Error(t, err)
 
-		bkts, _, err := l.BucketService().FindBuckets(ctx, influxdb.BucketFilter{OrganizationID: &l.Org.ID})
+		bkts, _, err := l.BucketService(t).FindBuckets(ctx, influxdb.BucketFilter{OrganizationID: &l.Org.ID})
 		require.NoError(t, err)
 		for _, b := range bkts {
 			if influxdb.BucketTypeSystem == b.Type {
@@ -68,17 +68,17 @@ func TestLauncher_Pkger(t *testing.T) {
 			assert.Equal(t, l.Bucket.Name, b.Name)
 		}
 
-		labels, err := l.LabelService().FindLabels(ctx, influxdb.LabelFilter{OrgID: &l.Org.ID})
+		labels, err := l.LabelService(t).FindLabels(ctx, influxdb.LabelFilter{OrgID: &l.Org.ID})
 		require.NoError(t, err)
 		assert.Empty(t, labels)
 
-		dashs, _, err := l.DashboardService().FindDashboards(ctx, influxdb.DashboardFilter{
+		dashs, _, err := l.DashboardService(t).FindDashboards(ctx, influxdb.DashboardFilter{
 			OrganizationID: &l.Org.ID,
 		}, influxdb.DefaultDashboardFindOptions)
 		require.NoError(t, err)
 		assert.Empty(t, dashs)
 
-		vars, err := l.VariableService().FindVariables(ctx, influxdb.VariableFilter{OrganizationID: &l.Org.ID})
+		vars, err := l.VariableService(t).FindVariables(ctx, influxdb.VariableFilter{OrganizationID: &l.Org.ID})
 		require.NoError(t, err)
 		assert.Empty(t, vars)
 	})
@@ -323,28 +323,28 @@ func TestLauncher_Pkger(t *testing.T) {
 
 			svc := pkger.NewService(
 				pkger.WithBucketSVC(&fakeBucketSVC{
-					BucketService: l.BucketService(),
+					BucketService: l.BucketService(t),
 					killCount:     0, // kill on first update for bucket
 				}),
-				pkger.WithDashboardSVC(l.DashboardService()),
-				pkger.WithLabelSVC(l.LabelService()),
+				pkger.WithDashboardSVC(l.DashboardService(t)),
+				pkger.WithLabelSVC(l.LabelService(t)),
 				pkger.WithTelegrafSVC(l.TelegrafService(t)),
-				pkger.WithVariableSVC(l.VariableService()),
+				pkger.WithVariableSVC(l.VariableService(t)),
 			)
 
 			_, err = svc.Apply(ctx, l.Org.ID, updatePkg)
 			require.Error(t, err)
 
-			bkt, err := l.BucketService().FindBucketByID(ctx, bkts[0].ID)
+			bkt, err := l.BucketService(t).FindBucketByID(ctx, bkts[0].ID)
 			require.NoError(t, err)
 			// make sure the desc change is not applied and is rolled back to prev desc
 			assert.Equal(t, bkt.Description, bkts[0].Description)
 
-			label, err := l.LabelService().FindLabelByID(ctx, labels[0].ID)
+			label, err := l.LabelService(t).FindLabelByID(ctx, labels[0].ID)
 			require.NoError(t, err)
 			assert.Equal(t, label.Properties["description"], labels[0].Properties["description"])
 
-			v, err := l.VariableService().FindVariableByID(ctx, vars[0].ID)
+			v, err := l.VariableService(t).FindVariableByID(ctx, vars[0].ID)
 			require.NoError(t, err)
 			assert.Equal(t, v.Description, vars[0].Description)
 		})

--- a/cmd/influxd/launcher/tasks_test.go
+++ b/cmd/influxd/launcher/tasks_test.go
@@ -28,11 +28,11 @@ func TestLauncher_Task(t *testing.T) {
 	org := be.Org
 
 	bIn := &influxdb.Bucket{OrgID: org.ID, Name: "my_bucket_in"}
-	if err := be.BucketService().CreateBucket(context.Background(), bIn); err != nil {
+	if err := be.BucketService(t).CreateBucket(context.Background(), bIn); err != nil {
 		t.Fatal(err)
 	}
 	bOut := &influxdb.Bucket{OrgID: org.ID, Name: "my_bucket_out"}
-	if err := be.BucketService().CreateBucket(context.Background(), bOut); err != nil {
+	if err := be.BucketService(t).CreateBucket(context.Background(), bOut); err != nil {
 		t.Fatal(err)
 	}
 	u := be.User

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -434,7 +433,7 @@ type getBucketRequest struct {
 }
 
 func bucketIDPath(id influxdb.ID) string {
-	return path.Join(bucketPath, id.String())
+	return path.Join(bucketsPath, id.String())
 }
 
 // hanldeGetBucketLog retrieves a bucket log by the buckets ID.
@@ -720,15 +719,9 @@ func decodePatchBucketRequest(ctx context.Context, r *http.Request) (*patchBucke
 	}, nil
 }
 
-const (
-	bucketPath = "/api/v2/buckets"
-)
-
 // BucketService connects to Influx via HTTP using tokens to manage buckets
 type BucketService struct {
-	Addr               string
-	Token              string
-	InsecureSkipVerify bool
+	Client *HTTPClient
 	// OpPrefix is an additional property for error
 	// find bucket service, when finds nothing.
 	OpPrefix string
@@ -767,33 +760,15 @@ func (s *BucketService) FindBucketByName(ctx context.Context, orgID influxdb.ID,
 
 // FindBucketByID returns a single bucket by ID.
 func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+	// TODO(@jsteenb2): are tracing
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	u, err := NewURL(s.Addr, bucketIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var br bucketResponse
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+	err := s.Client.get(bucketIDPath(id)).
+		DecodeJSON(&br).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return br.toInfluxDB()
@@ -832,54 +807,34 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	u, err := NewURL(s.Addr, bucketPath)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	query := u.Query()
+	var queryPairs [][2]string
 	if filter.OrganizationID != nil {
-		query.Add("orgID", filter.OrganizationID.String())
+		queryPairs = append(queryPairs, [2]string{"orgID", filter.OrganizationID.String()})
 	}
 	if filter.Org != nil {
-		query.Add("org", *filter.Org)
+		queryPairs = append(queryPairs, [2]string{"org", *filter.Org})
 	}
 	if filter.ID != nil {
-		query.Add("id", filter.ID.String())
+		queryPairs = append(queryPairs, [2]string{"id", filter.ID.String()})
 	}
 	if filter.Name != nil {
-		query.Add("name", *filter.Name)
+		queryPairs = append(queryPairs, [2]string{"name", (*filter.Name)})
 	}
 
-	if len(opt) > 0 {
-		for k, vs := range opt[0].QueryParams() {
+	for _, findOption := range opt {
+		for k, vs := range findOption.QueryParams() {
 			for _, v := range vs {
-				query.Add(k, v)
+				queryPairs = append(queryPairs, [2]string{k, v})
 			}
 		}
 	}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	req.URL.RawQuery = query.Encode()
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, 0, err
-	}
-
 	var bs bucketsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&bs); err != nil {
+	err := s.Client.get(bucketsPath).
+		Queries(queryPairs...).
+		DecodeJSON(&bs).
+		Do(ctx)
+	if err != nil {
 		return nil, 0, err
 	}
 
@@ -901,39 +856,11 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) er
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	u, err := NewURL(s.Addr, bucketPath)
-	if err != nil {
-		return err
-	}
-
-	octets, err := json.Marshal(newBucket(b))
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// TODO(jsternberg): Should this check for a 201 explicitly?
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
 	var br bucketResponse
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+	err := s.Client.post(bucketsPath, bodyJSON(newBucket(b))).
+		DecodeJSON(&br).
+		Do(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -948,39 +875,11 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) er
 // UpdateBucket updates a single bucket with changeset.
 // Returns the new bucket state after update.
 func (s *BucketService) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
-	u, err := NewURL(s.Addr, bucketIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	bu := newBucketUpdate(&upd)
-	octets, err := json.Marshal(bu)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var br bucketResponse
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+	err := s.Client.patch(bucketIDPath(id), bodyJSON(newBucketUpdate(&upd))).
+		DecodeJSON(&br).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return br.toInfluxDB()
@@ -988,25 +887,7 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id influxdb.ID, upd in
 
 // DeleteBucket removes a bucket by ID.
 func (s *BucketService) DeleteBucket(ctx context.Context, id influxdb.ID) error {
-	u, err := NewURL(s.Addr, bucketIDPath(id))
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("DELETE", u.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
+	return s.Client.delete(bucketIDPath(id)).Do(ctx)
 }
 
 // validBucketName reports any errors with bucket names

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -1203,7 +1203,7 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (platform.B
 	handler := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)
 	server := httptest.NewServer(handler)
 	client := BucketService{
-		Addr:     server.URL,
+		Client:   mustNewHTTPClient(t, server.URL, ""),
 		OpPrefix: inmem.OpPrefix,
 	}
 	done := server.Close
@@ -1213,4 +1213,14 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (platform.B
 
 func TestBucketService(t *testing.T) {
 	platformtesting.BucketService(initBucketService, t)
+}
+
+func mustNewHTTPClient(t *testing.T, addr, token string) *HTTPClient {
+	t.Helper()
+
+	httpClient, err := NewHTTPClient(addr, token, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httpClient
 }

--- a/http/client.go
+++ b/http/client.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/url"
 	"path"
 
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 )
 
@@ -19,16 +21,22 @@ type Service struct {
 	InsecureSkipVerify bool
 
 	*AuthorizationService
+	*BucketService
+	*DashboardService
 	*OrganizationService
 	*UserService
-	*BucketService
 	*VariableService
-	*DashboardService
+	*WriteService
 }
 
 // NewService returns a service that is an HTTP
 // client to a remote
-func NewService(addr, token string) *Service {
+func NewService(addr, token string) (*Service, error) {
+	httpClient, err := NewHTTPClient(addr, token, false)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Service{
 		Addr:  addr,
 		Token: token,
@@ -36,6 +44,8 @@ func NewService(addr, token string) *Service {
 			Addr:  addr,
 			Token: token,
 		},
+		BucketService:    &BucketService{Client: httpClient},
+		DashboardService: &DashboardService{Client: httpClient},
 		OrganizationService: &OrganizationService{
 			Addr:  addr,
 			Token: token,
@@ -44,19 +54,12 @@ func NewService(addr, token string) *Service {
 			Addr:  addr,
 			Token: token,
 		},
-		BucketService: &BucketService{
+		VariableService: &VariableService{Client: httpClient},
+		WriteService: &WriteService{
 			Addr:  addr,
 			Token: token,
 		},
-		DashboardService: &DashboardService{
-			Addr:  addr,
-			Token: token,
-		},
-		VariableService: &VariableService{
-			Addr:  addr,
-			Token: token,
-		},
-	}
+	}, nil
 }
 
 // NewURL concats addr and path.
@@ -122,18 +125,51 @@ func NewHTTPClient(addr, token string, insecureSkipVerify bool) (*HTTPClient, er
 }
 
 func (c *HTTPClient) delete(urlPath string) *cReq {
-	return c.newClientReq(http.MethodDelete, urlPath, nil)
+	return c.newClientReq(http.MethodDelete, urlPath, bodyEmpty())
 }
 
 func (c *HTTPClient) get(urlPath string) *cReq {
-	return c.newClientReq(http.MethodGet, urlPath, nil)
+	return c.newClientReq(http.MethodGet, urlPath, bodyEmpty())
 }
 
-func (c *HTTPClient) post(urlPath string, body io.Reader) *cReq {
-	return c.newClientReq(http.MethodPost, urlPath, body)
+func (c *HTTPClient) patch(urlPath string, bFn bodyFn) *cReq {
+	return c.newClientReq(http.MethodPatch, urlPath, bFn)
 }
 
-func (c *HTTPClient) newClientReq(method, urlPath string, body io.Reader) *cReq {
+func (c *HTTPClient) post(urlPath string, bFn bodyFn) *cReq {
+	return c.newClientReq(http.MethodPost, urlPath, bFn)
+}
+
+func (c *HTTPClient) put(urlPath string, bFn bodyFn) *cReq {
+	return c.newClientReq(http.MethodPut, urlPath, bFn)
+}
+
+type bodyFn func() (io.Reader, error)
+
+func bodyEmpty() bodyFn {
+	return func() (io.Reader, error) {
+		return nil, nil
+	}
+}
+
+// TODO(@jsteenb2): discussion add a inspection for an OK() or Valid() method, then enforce
+//  that across all consumers?
+func bodyJSON(v interface{}) bodyFn {
+	return func() (io.Reader, error) {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(v); err != nil {
+			return nil, err
+		}
+		return &buf, nil
+	}
+}
+
+func (c *HTTPClient) newClientReq(method, urlPath string, bFn bodyFn) *cReq {
+	body, err := bFn()
+	if err != nil {
+		return &cReq{err: err}
+	}
+
 	u := c.addr
 	u.Path = path.Join(u.Path, urlPath)
 	req, err := http.NewRequest(method, u.String(), body)
@@ -145,9 +181,9 @@ func (c *HTTPClient) newClientReq(method, urlPath string, body io.Reader) *cReq 
 	}
 
 	cr := &cReq{
-		client: c.client,
-		req:    req,
-		respFn: CheckError,
+		client:   c.client,
+		req:      req,
+		statusFn: CheckError,
 	}
 	return cr.ContentType("application/json")
 }
@@ -156,8 +192,10 @@ type cReq struct {
 	client interface {
 		Do(*http.Request) (*http.Response, error)
 	}
-	req    *http.Request
-	respFn func(*http.Response) error
+	req      *http.Request
+	decodeFn func(*http.Response) error
+	respFn   func(*http.Response) error
+	statusFn func(*http.Response) error
 
 	err error
 }
@@ -170,17 +208,13 @@ func (r *cReq) Header(k, v string) *cReq {
 	return r
 }
 
-type queryPair struct {
-	k, v string
-}
-
-func (r *cReq) Queries(pairs ...queryPair) *cReq {
+func (r *cReq) Queries(pairs ...[2]string) *cReq {
 	if r.err != nil || len(pairs) == 0 {
 		return r
 	}
 	params := r.req.URL.Query()
 	for _, p := range pairs {
-		params.Add(p.k, p.v)
+		params.Add(p[0], p[1])
 	}
 	r.req.URL.RawQuery = params.Encode()
 	return r
@@ -191,13 +225,25 @@ func (r *cReq) ContentType(ct string) *cReq {
 }
 
 func (r *cReq) DecodeJSON(v interface{}) *cReq {
-	return r.RespFn(func(resp *http.Response) error {
-		return json.NewDecoder(resp.Body).Decode(v)
-	})
+	r.decodeFn = func(resp *http.Response) error {
+		if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+			return &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Err:  err,
+			}
+		}
+		return nil
+	}
+	return r
 }
 
 func (r *cReq) RespFn(fn func(*http.Response) error) *cReq {
 	r.respFn = fn
+	return r
+}
+
+func (r *cReq) StatusFn(fn func(*http.Response) error) *cReq {
+	r.statusFn = fn
 	return r
 }
 
@@ -216,5 +262,17 @@ func (r *cReq) Do(ctx context.Context) error {
 		resp.Body.Close()
 	}()
 
-	return r.respFn(resp)
+	responseFns := []func(*http.Response) error{
+		r.statusFn,
+		r.decodeFn,
+		r.respFn,
+	}
+	for _, fn := range responseFns {
+		if fn != nil {
+			if err := fn(resp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1081,183 +1080,74 @@ func (h *DashboardHandler) handlePatchDashboardCell(w http.ResponseWriter, r *ht
 
 // DashboardService is a dashboard service over HTTP to the influxdb server.
 type DashboardService struct {
-	Addr               string
-	Token              string
-	InsecureSkipVerify bool
-	// OpPrefix is the op prefix for certain errors op.
-	OpPrefix string
+	Client *HTTPClient
 }
 
 // FindDashboardByID returns a single dashboard by ID.
 func (s *DashboardService) FindDashboardByID(ctx context.Context, id platform.ID) (*platform.Dashboard, error) {
-	path := dashboardIDPath(id)
-	url, err := NewURL(s.Addr, path)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	urlQuery := req.URL.Query()
-	urlQuery.Add("include", "properties")
-	req.URL.RawQuery = urlQuery.Encode()
-
-	SetToken(s.Token, req)
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var dr dashboardResponse
-	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+	err := s.Client.get(dashboardIDPath(id)).
+		Queries([2]string{"include", "properties"}).
+		DecodeJSON(&dr).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
-
-	dashboard := dr.toPlatform()
-	return dashboard, nil
+	return dr.toPlatform(), nil
 }
 
 // FindDashboards returns a list of dashboards that match filter and the total count of matching dashboards.
 // Additional options provide pagination & sorting.
 func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
-	dashboards := []*platform.Dashboard{}
-	url, err := NewURL(s.Addr, dashboardsPath)
-
-	if err != nil {
-		return dashboards, 0, err
-	}
-
-	qp := url.Query()
+	var queryPairs [][2]string
 	for _, id := range filter.IDs {
-		qp.Add("id", id.String())
+		queryPairs = append(queryPairs, [2]string{"id", id.String()})
 	}
 	if filter.OrganizationID != nil {
-		qp.Add("orgID", filter.OrganizationID.String())
+		queryPairs = append(queryPairs, [2]string{"orgID", filter.OrganizationID.String()})
 	}
 	if filter.Organization != nil {
-		qp.Add("org", *filter.Organization)
+		queryPairs = append(queryPairs, [2]string{"org", *filter.Organization})
 	}
 	for k, vs := range opts.QueryParams() {
 		for _, v := range vs {
-			qp.Add(k, v)
+			queryPairs = append(queryPairs, [2]string{k, v})
 		}
-	}
-	url.RawQuery = qp.Encode()
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return dashboards, 0, err
-	}
-
-	SetToken(s.Token, req)
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return dashboards, 0, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return dashboards, 0, err
 	}
 
 	var dr getDashboardsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
-		return dashboards, 0, err
+	err := s.Client.get(dashboardsPath).
+		Queries(queryPairs...).
+		DecodeJSON(&dr).
+		Do(ctx)
+	if err != nil {
+		return nil, 0, err
 	}
 
-	dashboards = dr.toPlatform()
+	dashboards := dr.toPlatform()
 	return dashboards, len(dashboards), nil
 }
 
 // CreateDashboard creates a new dashboard and sets b.ID with the new identifier.
 func (s *DashboardService) CreateDashboard(ctx context.Context, d *platform.Dashboard) error {
-	url, err := NewURL(s.Addr, dashboardsPath)
-	if err != nil {
-		return err
-	}
-
-	b, err := json.Marshal(d)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(d); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Client.post(dashboardsPath, bodyJSON(d)).
+		DecodeJSON(d).
+		Do(ctx)
 }
 
 // UpdateDashboard updates a single dashboard with changeset.
 // Returns the new dashboard state after update.
 func (s *DashboardService) UpdateDashboard(ctx context.Context, id platform.ID, upd platform.DashboardUpdate) (*platform.Dashboard, error) {
-	u, err := NewURL(s.Addr, dashboardIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(upd); err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var d platform.Dashboard
-	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+	err := s.Client.patch(dashboardIDPath(id), bodyJSON(upd)).
+		DecodeJSON(&d).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
+
 	if len(d.Cells) == 0 {
+		// TODO(@jsteenb2): decipher why this is doing this?
 		d.Cells = nil
 	}
 
@@ -1266,128 +1156,34 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, id platform.ID, 
 
 // DeleteDashboard removes a dashboard by ID.
 func (s *DashboardService) DeleteDashboard(ctx context.Context, id platform.ID) error {
-	u, err := NewURL(s.Addr, dashboardIDPath(id))
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("DELETE", u.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
+	return s.Client.delete(dashboardIDPath(id)).Do(ctx)
 }
 
 // AddDashboardCell adds a cell to a dashboard.
 func (s *DashboardService) AddDashboardCell(ctx context.Context, id platform.ID, c *platform.Cell, opts platform.AddDashboardCellOptions) error {
-	url, err := NewURL(s.Addr, cellPath(id))
-	if err != nil {
-		return err
-	}
-
-	// fixme > in case c does not contain a valid ID this errors out
-	b, err := json.Marshal(c)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	// TODO (goller): deal with the dashboard cell options
-	return json.NewDecoder(resp.Body).Decode(c)
+	return s.Client.post(cellPath(id), bodyJSON(c)).
+		DecodeJSON(c).
+		Do(ctx)
 }
 
 // RemoveDashboardCell removes a dashboard.
 func (s *DashboardService) RemoveDashboardCell(ctx context.Context, dashboardID, cellID platform.ID) error {
-	u, err := NewURL(s.Addr, dashboardCellIDPath(dashboardID, cellID))
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("DELETE", u.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
+	return s.Client.delete(dashboardCellIDPath(dashboardID, cellID)).Do(ctx)
 }
 
 // UpdateDashboardCell replaces the dashboard cell with the provided ID.
 func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
-	op := s.OpPrefix + platform.OpUpdateDashboardCell
 	if err := upd.Valid(); err != nil {
 		return nil, &platform.Error{
-			Op:  op,
 			Err: err,
 		}
 	}
 
-	u, err := NewURL(s.Addr, dashboardCellIDPath(dashboardID, cellID))
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := json.Marshal(upd)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var c platform.Cell
-	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
+	err := s.Client.patch(dashboardCellIDPath(dashboardID, cellID), bodyJSON(upd)).
+		DecodeJSON(&c).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1396,118 +1192,36 @@ func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID,
 
 // GetDashboardCellView retrieves the view for a dashboard cell.
 func (s *DashboardService) GetDashboardCellView(ctx context.Context, dashboardID, cellID platform.ID) (*platform.View, error) {
-	u, err := NewURL(s.Addr, cellViewPath(dashboardID, cellID))
+	var dcv dashboardCellViewResponse
+	err := s.Client.get(cellViewPath(dashboardID, cellID)).
+		DecodeJSON(&dcv).
+		Do(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
-	res := dashboardCellViewResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return nil, err
-	}
-
-	return &res.View, nil
+	return &dcv.View, nil
 }
 
 // UpdateDashboardCellView updates the view for a dashboard cell.
 func (s *DashboardService) UpdateDashboardCellView(ctx context.Context, dashboardID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error) {
-	u, err := NewURL(s.Addr, cellViewPath(dashboardID, cellID))
+	var dcv dashboardCellViewResponse
+	err := s.Client.patch(cellViewPath(dashboardID, cellID), bodyJSON(upd)).
+		DecodeJSON(&dcv).
+		Do(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	b, err := json.Marshal(upd)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
-	res := dashboardCellViewResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return nil, err
-	}
-
-	return &res.View, nil
+	return &dcv.View, nil
 }
 
 // ReplaceDashboardCells replaces all cells in a dashboard
 func (s *DashboardService) ReplaceDashboardCells(ctx context.Context, id platform.ID, cs []*platform.Cell) error {
-	u, err := NewURL(s.Addr, cellPath(id))
-	if err != nil {
-		return err
-	}
-
-	// TODO(goller): I think this should be {"cells":[]}
-	b, err := json.Marshal(cs)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	cells := dashboardCellsResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(&cells); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Client.put(cellPath(id), bodyJSON(cs)).
+		// TODO: previous implementation did not do anything with the response except validate it is valid json.
+		//  seems likely we should have to overwrite (:sadpanda:) the incoming cs...
+		DecodeJSON(&dashboardCellsResponse{}).
+		Do(ctx)
 }
 
 func dashboardIDPath(id platform.ID) string {

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -1770,10 +1770,8 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 	dashboardBackend.DashboardService = svc
 	h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 	server := httptest.NewServer(h)
-	client := DashboardService{
-		Addr:     server.URL,
-		OpPrefix: inmem.OpPrefix,
-	}
+
+	client := DashboardService{Client: mustNewHTTPClient(t, server.URL, "")}
 	done := server.Close
 
 	return &client, inmem.OpPrefix, done

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -290,15 +289,6 @@ func decodePatchLabelRequest(ctx context.Context, r *http.Request) (*patchLabelR
 	}, nil
 }
 
-// LabelService connects to Influx via HTTP using tokens to manage labels
-type LabelService struct {
-	Addr               string
-	Token              string
-	InsecureSkipVerify bool
-	BasePath           string
-	OpPrefix           string
-}
-
 type labelResponse struct {
 	Links map[string]string `json:"links"`
 	Label influxdb.Label    `json:"label"`
@@ -530,32 +520,19 @@ func labelIDPath(id influxdb.ID) string {
 	return path.Join(labelsPath, id.String())
 }
 
+// LabelService connects to Influx via HTTP using tokens to manage labels
+type LabelService struct {
+	Client   *HTTPClient
+	OpPrefix string
+}
+
 // FindLabelByID returns a single label by ID.
 func (s *LabelService) FindLabelByID(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
-	u, err := NewURL(s.Addr, labelIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var lr labelResponse
-	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+	err := s.Client.get(labelIDPath(id)).
+		DecodeJSON(&lr).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return &lr.Label, nil
@@ -563,42 +540,22 @@ func (s *LabelService) FindLabelByID(ctx context.Context, id influxdb.ID) (*infl
 
 // FindLabels is a client for the find labels response from the server.
 func (s *LabelService) FindLabels(ctx context.Context, filter influxdb.LabelFilter, opt ...influxdb.FindOptions) ([]*influxdb.Label, error) {
-	u, err := NewURL(s.Addr, labelsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	q := req.URL.Query()
+	var queryPairs [][2]string
 	if filter.OrgID != nil {
-		q.Add("orgID", filter.OrgID.String())
+		queryPairs = append(queryPairs, [2]string{"orgID", filter.OrgID.String()})
 	}
 	if filter.Name != "" {
-		q.Add("name", filter.Name)
-	}
-	req.URL.RawQuery = q.Encode()
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
+		queryPairs = append(queryPairs, [2]string{"name", filter.Name})
 	}
 
 	var lr labelsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+	err := s.Client.get(labelsPath).
+		Queries(queryPairs...).
+		DecodeJSON(&lr).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
-
 	return lr.Labels, nil
 }
 
@@ -607,73 +564,24 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 	if err := filter.Valid(); err != nil {
 		return nil, err
 	}
-	url, err := NewURL(s.Addr, resourceIDPath(filter.ResourceType, filter.ResourceID, "labels"))
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
 
 	var r labelsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+	err := s.Client.get(resourceIDPath(filter.ResourceType, filter.ResourceID, "labels")).
+		DecodeJSON(&r).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
-
 	return r.Labels, nil
 }
 
 // CreateLabel creates a new label.
 func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error {
-	u, err := NewURL(s.Addr, labelsPath)
-	if err != nil {
-		return err
-	}
-
-	octets, err := json.Marshal(l)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// TODO(jsternberg): Should this check for a 201 explicitly?
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
 	var lr labelResponse
-	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+	err := s.Client.post(labelsPath, bodyJSON(l)).
+		DecodeJSON(&lr).
+		Do(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -682,83 +590,13 @@ func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error
 	return nil
 }
 
-// CreateLabelMapping will create a labbel mapping
-func (s *LabelService) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	if err := m.Validate(); err != nil {
-		return err
-	}
-
-	url, err := NewURL(s.Addr, resourceIDPath(m.ResourceType, m.ResourceID, "labels"))
-	if err != nil {
-		return err
-	}
-
-	octets, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(octets))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(m); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // UpdateLabel updates a label and returns the updated label.
 func (s *LabelService) UpdateLabel(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
-	u, err := NewURL(s.Addr, labelIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	octets, err := json.Marshal(upd)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var lr labelResponse
-	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+	err := s.Client.patch(labelIDPath(id), bodyJSON(upd)).
+		DecodeJSON(&lr).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return &lr.Label, nil
@@ -766,49 +604,25 @@ func (s *LabelService) UpdateLabel(ctx context.Context, id influxdb.ID, upd infl
 
 // DeleteLabel removes a label by ID.
 func (s *LabelService) DeleteLabel(ctx context.Context, id influxdb.ID) error {
-	u, err := NewURL(s.Addr, labelIDPath(id))
-	if err != nil {
+	return s.Client.delete(labelIDPath(id)).Do(ctx)
+}
+
+// CreateLabelMapping will create a labbel mapping
+func (s *LabelService) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
+	if err := m.Validate(); err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("DELETE", u.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
+	urlPath := resourceIDPath(m.ResourceType, m.ResourceID, "labels")
+	return s.Client.post(urlPath, bodyJSON(m)).
+		DecodeJSON(m).
+		Do(ctx)
 }
 
 func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	url, err := NewURL(s.Addr, labelNamePath(s.BasePath, m.ResourceID, m.LabelID))
-	if err != nil {
+	if err := m.Validate(); err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("DELETE", url.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
-}
-
-func labelNamePath(basePath string, resourceID influxdb.ID, labelID influxdb.ID) string {
-	return path.Join(basePath, resourceID.String(), "labels", labelID.String())
+	return s.Client.delete(resourceIDPath(m.ResourceType, m.ResourceID, "labels")).Do(ctx)
 }

--- a/http/variable_service.go
+++ b/http/variable_service.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -242,7 +241,7 @@ func newVariableResponse(m *platform.Variable, labels []*platform.Label) variabl
 
 func (h *VariableHandler) handlePostVariable(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	req, err := decodePostVariableRequest(ctx, r)
+	req, err := decodePostVariableRequest(r)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
@@ -268,7 +267,7 @@ func (r *postVariableRequest) Valid() error {
 	return r.variable.Valid()
 }
 
-func decodePostVariableRequest(ctx context.Context, r *http.Request) (*postVariableRequest, error) {
+func decodePostVariableRequest(r *http.Request) (*postVariableRequest, error) {
 	m := &platform.Variable{}
 
 	err := json.NewDecoder(r.Body).Decode(m)
@@ -439,92 +438,46 @@ func (h *VariableHandler) handleDeleteVariable(w http.ResponseWriter, r *http.Re
 
 // VariableService is a variable service over HTTP to the influxdb server
 type VariableService struct {
-	Addr               string
-	Token              string
-	InsecureSkipVerify bool
+	Client *HTTPClient
 }
 
 // FindVariableByID finds a single variable from the store by its ID
 func (s *VariableService) FindVariableByID(ctx context.Context, id platform.ID) (*platform.Variable, error) {
-	path := variableIDPath(id)
-	url, err := NewURL(s.Addr, path)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	SetToken(s.Token, req)
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var mr variableResponse
-	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+	err := s.Client.get(variableIDPath(id)).
+		DecodeJSON(&mr).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 
-	variable := mr.Variable
-	return variable, nil
+	return mr.Variable, nil
 }
 
 // FindVariables returns a list of variables that match filter.
-//
 // Additional options provide pagination & sorting.
 func (s *VariableService) FindVariables(ctx context.Context, filter platform.VariableFilter, opts ...platform.FindOptions) ([]*platform.Variable, error) {
-	url, err := NewURL(s.Addr, variablePath)
-	if err != nil {
-		return nil, err
-	}
-
-	query := url.Query()
+	var queryPairs [][2]string
 	if filter.OrganizationID != nil {
-		query.Add("orgID", filter.OrganizationID.String())
+		queryPairs = append(queryPairs, [2]string{"orgID", filter.OrganizationID.String()})
 	}
 	if filter.Organization != nil {
-		query.Add("org", *filter.Organization)
+		queryPairs = append(queryPairs, [2]string{"org", *filter.Organization})
 	}
 	if filter.ID != nil {
-		query.Add("id", filter.ID.String())
-	}
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.URL.RawQuery = query.Encode()
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
+		queryPairs = append(queryPairs, [2]string{"id", filter.ID.String()})
 	}
 
 	var ms getVariablesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&ms); err != nil {
+	err := s.Client.get(variablePath).
+		Queries(queryPairs...).
+		DecodeJSON(&ms).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 
-	variables := ms.ToPlatform()
-	return variables, nil
+	return ms.ToPlatform(), nil
 }
 
 // CreateVariable creates a new variable and assigns it an platform.ID
@@ -536,73 +489,18 @@ func (s *VariableService) CreateVariable(ctx context.Context, m *platform.Variab
 		}
 	}
 
-	url, err := NewURL(s.Addr, variablePath)
-	if err != nil {
-		return err
-	}
-
-	octets, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(octets))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	return json.NewDecoder(resp.Body).Decode(m)
+	return s.Client.post(variablePath, bodyJSON(m)).
+		DecodeJSON(m).
+		Do(ctx)
 }
 
 // UpdateVariable updates a single variable with a changeset
 func (s *VariableService) UpdateVariable(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error) {
-	u, err := NewURL(s.Addr, variableIDPath(id))
-	if err != nil {
-		return nil, err
-	}
-
-	octets, err := json.Marshal(update)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return nil, err
-	}
-
 	var m platform.Variable
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+	err := s.Client.patch(variableIDPath(id), bodyJSON(update)).
+		DecodeJSON(&m).
+		Do(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -611,64 +509,14 @@ func (s *VariableService) UpdateVariable(ctx context.Context, id platform.ID, up
 
 // ReplaceVariable replaces a single variable
 func (s *VariableService) ReplaceVariable(ctx context.Context, variable *platform.Variable) error {
-	u, err := NewURL(s.Addr, variableIDPath(variable.ID))
-	if err != nil {
-		return err
-	}
-
-	octets, err := json.Marshal(variable)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(octets))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := CheckError(resp); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&variable); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Client.put(variableIDPath(variable.ID), bodyJSON(variable)).
+		DecodeJSON(variable).
+		Do(ctx)
 }
 
 // DeleteVariable removes a variable from the store
 func (s *VariableService) DeleteVariable(ctx context.Context, id platform.ID) error {
-	u, err := NewURL(s.Addr, variableIDPath(id))
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("DELETE", u.String(), nil)
-	if err != nil {
-		return err
-	}
-	SetToken(s.Token, req)
-
-	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return CheckError(resp)
+	return s.Client.delete(variableIDPath(id)).Do(ctx)
 }
 
 func variableIDPath(id platform.ID) string {

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -130,7 +130,7 @@ func testFlux(t testing.TB, l *launcher.TestLauncher, file *ast.File) {
 		RetentionPeriod: 0,
 	}
 
-	s := l.BucketService()
+	s := l.BucketService(t)
 	if err := s.CreateBucket(context.Background(), b); err != nil {
 		t.Fatal(err)
 	}

--- a/source/bucket.go
+++ b/source/bucket.go
@@ -17,15 +17,13 @@ func NewBucketService(s *platform.Source) (platform.BucketService, error) {
 		// how services are instantiated
 		return nil, fmt.Errorf("self source type not implemented")
 	case platform.V2SourceType:
-		return &http.BucketService{
-			Addr:               s.URL,
-			InsecureSkipVerify: s.InsecureSkipVerify,
-			Token:              s.Token,
-		}, nil
+		httpClient, err := http.NewHTTPClient(s.URL, s.Token, s.InsecureSkipVerify)
+		if err != nil {
+			return nil, err
+		}
+		return &http.BucketService{Client: httpClient}, nil
 	case platform.V1SourceType:
-		return &influxdb.BucketService{
-			Source: s,
-		}, nil
+		return &influxdb.BucketService{Source: s}, nil
 	}
 	return nil, fmt.Errorf("unsupported source type %s", s.Type)
 }

--- a/testing/variable.go
+++ b/testing/variable.go
@@ -359,7 +359,7 @@ func CreateVariable(init func(VariableFields, *testing.T) (platform.VariableServ
 					Name:           "existing-variable",
 					Selected:       []string{"a"},
 					Arguments: &platform.VariableArguments{
-						Type:   "query",
+						Type:   "constant",
 						Values: platform.VariableConstantValues{"a"},
 					},
 					CRUDLog: platform.CRUDLog{


### PR DESCRIPTION
want to take advantage of pooling connections and reducing GC for requests. And reduce 
the amount of boilerplate to get things wrong. Also fill in some holes in testing.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

Notes:
- [x] prepare upstream with fixes (compilation is failing)
