### PR TITLE
fix(ui): regression fix, notes are now deletable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [16105](https://github.com/influxdata/influxdb/pull/16105): Fix crash when loading queries built using Query Builder
 1. [16112](https://github.com/influxdata/influxdb/pull/16112): Create cell view properties on dashboard creation
 1. [16172](https://github.com/influxdata/influxdb/pull/16172): Fixed table ui threshold colorization issue where setting thresholds would not change table UI
+1. [16175](https://github.com/influxdata/influxdb/pull/16175): Added delete functionality to note cells so that they can be deleted
 
 ### UI Improvements
 

--- a/ui/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
+++ b/ui/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
@@ -20,10 +20,10 @@ interface RowsProps {
 const Rows: SFC<RowsProps> = ({tags, onDeleteTag, onChange}) => {
   return (
     <div className="input-tag-list">
-      {tags.map((item, index) => {
+      {tags.map(item => {
         return (
           <Row
-            index={index}
+            index={tags.indexOf(item)}
             key={uuid.v4()}
             item={item}
             onDelete={onDeleteTag}

--- a/ui/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
+++ b/ui/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
@@ -20,10 +20,10 @@ interface RowsProps {
 const Rows: SFC<RowsProps> = ({tags, onDeleteTag, onChange}) => {
   return (
     <div className="input-tag-list">
-      {tags.map(item => {
+      {tags.map((item, index) => {
         return (
           <Row
-            index={tags.indexOf(item)}
+            index={index}
             key={uuid.v4()}
             item={item}
             onDelete={onDeleteTag}

--- a/ui/src/shared/components/cells/CellContext.tsx
+++ b/ui/src/shared/components/cells/CellContext.tsx
@@ -69,6 +69,13 @@ const CellContext: FunctionComponent<Props> = ({
             onHide={onHide}
             testID="cell-context--note"
           />
+          <CellContextDangerItem
+            label="Delete"
+            onClick={handleDeleteCell}
+            icon={IconFont.Trash}
+            onHide={onHide}
+            testID="cell-context--delete"
+          />
         </div>
       )
     }


### PR DESCRIPTION
Closes #16170

### Problem

No option was given for deleting note cells

### Solution

Added the existing delete cell functionality to the dropdown

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)