### PR TITLE
fix: remove bucket sort for telegrafs

### DIFF
--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -176,7 +176,7 @@ describe('Collectors', () => {
         cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
       })
       // filter by name
-      it('can filter telegraf configs and sort by bucket and name', () => {
+      it('can filter telegraf configs and sort by name', () => {
         // fixes https://github.com/influxdata/influxdb/issues/15246
         cy.getByTestID('search-widget').type(firstTelegraf)
         cy.getByTestID('resource-card').should('have.length', 1)
@@ -210,37 +210,6 @@ describe('Collectors', () => {
 
         // sort by buckets test here
         cy.reload() // clear out filtering state from the previous test
-        cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
-
-        cy.getByTestID('bucket-sorter')
-          .click()
-          .then(() => {
-            // NOTE: this then is just here to let me scope this variable (alex)
-            const testBucket = bucketz.slice(0).sort()
-            cy.getByTestID('bucket-name')
-              .should('have.length', 3)
-              .each((val, index) => {
-                const text = val.text()
-                expect(text).to.include(testBucket[index])
-              })
-          })
-
-        cy.getByTestID('bucket-sorter')
-          .click()
-          .then(() => {
-            // NOTE: this then is just here to let me scope this variable (alex)
-            const testBucket = bucketz
-              .slice(0)
-              .sort()
-              .reverse()
-            cy.getByTestID('bucket-name').each((val, index) => {
-              const text = val.text()
-              expect(text).to.include(testBucket[index])
-            })
-          })
-
-        // sort by name test here
-        cy.reload() // clear out sorting state from previous test
         cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
 
         cy.getByTestID('collector-card--name').should('have.length', 3)

--- a/ui/src/telegrafs/components/CollectorList.tsx
+++ b/ui/src/telegrafs/components/CollectorList.tsx
@@ -48,13 +48,6 @@ export default class CollectorList extends PureComponent<Props> {
               onClick={onClickColumn}
               testID="name-sorter"
             />
-            <ResourceList.Sorter
-              name="Bucket"
-              sortKey={this.headerKeys[1]}
-              sort={sortKey === this.headerKeys[1] ? sortDirection : Sort.None}
-              onClick={onClickColumn}
-              testID="bucket-sorter"
-            />
           </ResourceList.Header>
           <ResourceList.Body emptyState={emptyState}>
             {this.collectorsList}


### PR DESCRIPTION
During the work for influxdata/idpe#5399, we discovered that there doesn't exist a 1:1 relationship between buckets and telegraf configs, as there can be more than one output plugin per config file. This makes the sort... weird. If the filter is used to select a bucket that contains the string "alpha" and a reverse bucket sort is applied, is the expected behaviour that the config that ALSO references the "zed" bucket is at the top?