### PR TITLE
fix: remove racy, redundant initialisation

### DIFF
--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -29,10 +29,7 @@ func NewKVStore() *KVStore {
 func (s *KVStore) View(ctx context.Context, fn func(kv.Tx) error) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.buckets == nil {
-		s.buckets = map[string]*Bucket{}
-		s.ro = map[string]*bucket{}
-	}
+
 	return fn(&Tx{
 		kv:       s,
 		writable: false,
@@ -44,10 +41,6 @@ func (s *KVStore) View(ctx context.Context, fn func(kv.Tx) error) error {
 func (s *KVStore) Update(ctx context.Context, fn func(kv.Tx) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.buckets == nil {
-		s.buckets = map[string]*Bucket{}
-		s.ro = map[string]*bucket{}
-	}
 
 	return fn(&Tx{
 		kv:       s,

--- a/inmem/kv_test.go
+++ b/inmem/kv_test.go
@@ -61,7 +61,7 @@ func TestKVStore_Buckets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &inmem.KVStore{}
+			s := inmem.NewKVStore()
 			err := s.Update(context.Background(), func(tx kv.Tx) error {
 				for _, b := range tt.buckets {
 					if _, err := tx.Bucket([]byte(b)); err != nil {


### PR DESCRIPTION
Removes some racy code from `inmem.KVStore`. As long as callers use the correct API (`NewKVStore`) this shouldn't cause problems.