### PR TITLE
feat(cmd): bucket create to accept org name as flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [15836](https://github.com/influxdata/influxdb/pull/16077): Add stacked line layer option to graphs
 1. [16094](https://github.com/influxdata/influxdb/pull/16094): Annotate log messages with trace ID, if available
+1. [16187](https://github.com/influxdata/influxdb/pull/16187): Bucket create to accept an org name flag
 
 ### Bug Fixes
 

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -88,7 +88,7 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 		}
 		b.OrgID = *id
 	} else if bucketCreateFlags.org != "" {
-		orgSvc, err := newOrganizationService(flags)
+		orgSvc, err := newOrganizationService()
 		if err != nil {
 			return fmt.Errorf("failed to initialize organization service client: %v", err)
 		}
@@ -96,7 +96,7 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 		filter := platform.OrganizationFilter{Name: &bucketCreateFlags.org}
 		org, err := orgSvc.FindOrganization(context.Background(), filter)
 		if err != nil {
-			return fmt.Errorf("%v", err)
+			return err
 		}
 
 		b.OrgID = org.ID

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -27,6 +27,7 @@ func bucketF(cmd *cobra.Command, args []string) {
 type BucketCreateFlags struct {
 	name      string
 	orgID     string
+	org       string
 	retention time.Duration
 }
 
@@ -42,6 +43,7 @@ func init() {
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.name, "name", "n", "", "Name of bucket that will be created")
 	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "Duration in nanoseconds data will live in bucket")
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.orgID, "org-id", "", "", "The ID of the organization that owns the bucket")
+	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.org, "org", "o", "", "The org name")
 	bucketCreateCmd.MarkFlagRequired("name")
 
 	bucketCmd.AddCommand(bucketCreateCmd)
@@ -63,8 +65,10 @@ func newBucketService(f Flags) (platform.BucketService, error) {
 }
 
 func bucketCreateF(cmd *cobra.Command, args []string) error {
-	if bucketCreateFlags.orgID == "" {
-		return fmt.Errorf("must specify org-id")
+	if bucketCreateFlags.orgID == "" && bucketCreateFlags.org == "" {
+		return fmt.Errorf("must specify org-id, or org name")
+	} else if bucketCreateFlags.orgID != "" && bucketCreateFlags.org != "" {
+		return fmt.Errorf("must specify org-id, or org name not both")
 	}
 
 	s, err := newBucketService(flags)
@@ -83,6 +87,19 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to decode org id %q: %v", bucketCreateFlags.orgID, err)
 		}
 		b.OrgID = *id
+	} else if bucketCreateFlags.org != "" {
+		orgSvc, err := newOrganizationService(flags)
+		if err != nil {
+			return fmt.Errorf("failed to initialize organization service client: %v", err)
+		}
+
+		filter := platform.OrganizationFilter{Name: &bucketCreateFlags.org}
+		org, err := orgSvc.FindOrganization(context.Background(), filter)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+
+		b.OrgID = org.ID
 	}
 
 	if err := s.CreateBucket(context.Background(), b); err != nil {

--- a/cmd/influx/inspect.go
+++ b/cmd/influx/inspect.go
@@ -63,6 +63,7 @@ in the following ways:
 	inspectReportTSMCommand.Flags().BoolVarP(&inspectReportTSMFlags.detailed, "detailed", "", false, "emit series cardinality segmented by measurements, tag keys and fields. Warning, may take a while.")
 
 	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.orgID, "org-id", "", "", "process only data belonging to organization ID.")
+	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.orgID, "org", "o", "", "process only data belonging to organization ID.")
 	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
 
 	dir, err := fs.InfluxDir()

--- a/cmd/influx/inspect.go
+++ b/cmd/influx/inspect.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -18,8 +19,8 @@ type InspectReportTSMFlags struct {
 	exact    bool
 	detailed bool
 
-	orgID, bucketID string
-	dataDir         string
+	orgID, org, bucketID string
+	dataDir              string
 }
 
 var inspectReportTSMFlags InspectReportTSMFlags
@@ -63,7 +64,7 @@ in the following ways:
 	inspectReportTSMCommand.Flags().BoolVarP(&inspectReportTSMFlags.detailed, "detailed", "", false, "emit series cardinality segmented by measurements, tag keys and fields. Warning, may take a while.")
 
 	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.orgID, "org-id", "", "", "process only data belonging to organization ID.")
-	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.orgID, "org", "o", "", "process only data belonging to organization ID.")
+	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.org, "org", "o", "", "process only data belonging to organization name.")
 	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
 
 	dir, err := fs.InfluxDir()
@@ -76,6 +77,11 @@ in the following ways:
 
 // inspectReportTSMF runs the report-tsm tool.
 func inspectReportTSMF(cmd *cobra.Command, args []string) error {
+	if inspectReportTSMFlags.orgID == "" && inspectReportTSMFlags.org == "" {
+		return fmt.Errorf("must specify org-id, or org name")
+	} else if inspectReportTSMFlags.orgID != "" && inspectReportTSMFlags.org != "" {
+		return fmt.Errorf("must specify org-id, or org name not both")
+	}
 	report := &tsm1.Report{
 		Stderr:   os.Stderr,
 		Stdout:   os.Stdout,
@@ -85,16 +91,28 @@ func inspectReportTSMF(cmd *cobra.Command, args []string) error {
 		Exact:    inspectReportTSMFlags.exact,
 	}
 
-	if inspectReportTSMFlags.orgID == "" && inspectReportTSMFlags.bucketID != "" {
+	if (inspectReportTSMFlags.org == "" || inspectReportTSMFlags.orgID == "") && inspectReportTSMFlags.bucketID != "" {
 		return errors.New("org-id must be set for non-empty bucket-id")
 	}
 
 	if inspectReportTSMFlags.orgID != "" {
-		orgID, err := influxdb.IDFromString(inspectReportTSMFlags.orgID)
+		var err error
+		report.OrgID, err = influxdb.IDFromString(inspectReportTSMFlags.orgID)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid org ID provided: %s", err.Error())
 		}
-		report.OrgID = orgID
+	} else if inspectReportTSMFlags.org != "" {
+		orgSvc, err := newOrganizationService()
+		if err != nil {
+			return fmt.Errorf("failed to initialize organization service client: %v", err)
+		}
+
+		filter := influxdb.OrganizationFilter{Name: &inspectReportTSMFlags.org}
+		org, err := orgSvc.FindOrganization(context.Background(), filter)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		report.OrgID = &org.ID
 	}
 
 	if inspectReportTSMFlags.bucketID != "" {

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -70,7 +70,7 @@ func init() {
 		RunE:  wrapCheckSetup(taskCreateF),
 	}
 
-	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.org, "org", "", "", "organization name")
+	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.org, "org", "o", "", "organization name")
 	taskCreateCmd.Flags().StringVarP(&taskCreateFlags.orgID, "org-id", "", "", "id of the organization that owns the task")
 	taskCreateCmd.MarkFlagRequired("flux")
 
@@ -155,7 +155,7 @@ func init() {
 
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.id, "id", "i", "", "task ID")
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.user, "user-id", "n", "", "task owner ID")
-	taskFindCmd.Flags().StringVarP(&taskFindFlags.org, "org", "", "", "task organization name")
+	taskFindCmd.Flags().StringVarP(&taskFindFlags.org, "org", "o", "", "task organization name")
 	taskFindCmd.Flags().StringVarP(&taskFindFlags.orgID, "org-id", "", "", "task organization ID")
 	taskFindCmd.Flags().IntVarP(&taskFindFlags.limit, "limit", "", platform.TaskDefaultPageSize, "the number of tasks to find")
 
@@ -163,6 +163,11 @@ func init() {
 }
 
 func taskFindF(cmd *cobra.Command, args []string) error {
+	if taskFindFlags.orgID == "" && taskFindFlags.org == "" {
+		return fmt.Errorf("must specify org-id, or org name")
+	} else if taskFindFlags.orgID != "" && taskFindFlags.org != "" {
+		return fmt.Errorf("must specify org-id, or org name not both")
+	}
 	s := &http.TaskService{
 		Addr:               flags.host,
 		Token:              flags.token,


### PR DESCRIPTION
enables a user to specify an organization name when creating a bucket from the influx cli.

Closes #15828

The influx bucket create command doesn't seem to have a -o flag for specifying the organization name. This PR adds a flag `--org` or `-o` for specifying the org name to avoid the overhead of having to lookup an organization id

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
