### PR TITLE
style: allow Merge commits in commit messages

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,4 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
 # Always validate the PR title AND all the commits
 titleAndCommits: true
+allowMergeCommits: true


### PR DESCRIPTION
Allow use of Merge commits (eg on "Merge branch 'master' into feature/ride-unicorns")
This is only relevant when using commitsOnly: true (or titleAndCommits: true)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
