### PR TITLE
fix: add a timestamp to the telegraf label creation to insure uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 1. [16172](https://github.com/influxdata/influxdb/pull/16172): Fixed table ui threshold colorization issue where setting thresholds would not change table UI
 1. [16194](https://github.com/influxdata/influxdb/pull/16194): Fixed windowPeriod issue that stemmed from webpack rules
 1. [16175](https://github.com/influxdata/influxdb/pull/16175): Added delete functionality to note cells so that they can be deleted
+1. [16204](https://github.com/influxdata/influxdb/pull/16204): Fix failure to create labels when creating telegraf configs
 
 ### UI Improvements
 

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -356,6 +356,30 @@ describe('Collectors', () => {
           })
       })
     })
+
+    // fix for https://github.com/influxdata/influxdb/issues/15730
+    it('creates a configuration with a unique label', () => {
+      cy.contains('Create Configuration').click()
+
+      cy.contains('Docker').click()
+
+      cy.contains('Continue').click()
+
+      cy.contains('docker').click()
+
+      cy.get('[name="endpoint"]').type('http://localhost')
+
+      cy.contains('Done').click()
+      cy.get('input[title="Telegraf Configuration Name"]').type('Label 1')
+      cy.get('input[title="Telegraf Configuration Description"]').type(
+        'Description 1'
+      )
+
+      cy.contains('Create and Verify').click()
+
+      cy.contains('Your configurations have been saved')
+    })
+
     describe('Label creation and searching', () => {
       beforeEach(() => {
         const description = 'Config Description'

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -454,7 +454,7 @@ const createTelegraf = async (dispatch, getState, plugins) => {
 
     const createdLabel = await client.labels.create({
       orgID: org.id,
-      name: '@influxdata.token',
+      name: `@influxdata.token-${new Date().getTime()}`, // fix for https://github.com/influxdata/influxdb/issues/15730
       properties,
     })
 

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -1448,7 +1448,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         name: 'timeout',
         desc: 'Timeout for the GET request. Default is `30s`.',
         type: 'Duration',
-      }
+      },
     ],
     package: 'experimental/http',
     desc:


### PR DESCRIPTION
Closes #15730

Labels require unique names. The buggy behavior when we create a telegraf config is to create a label for the config and to name every label `@influxdata.name`. This fix appends a timestamp to `@influxdata.name` (that string is being filtered on, so we want keep `@influxdata.name`)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
