### PR TITLE
fix: return the telegraf module based on Loadable's interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1. [16194](https://github.com/influxdata/influxdb/pull/16194): Fixed windowPeriod issue that stemmed from webpack rules
 1. [16175](https://github.com/influxdata/influxdb/pull/16175): Added delete functionality to note cells so that they can be deleted
 1. [16204](https://github.com/influxdata/influxdb/pull/16204): Fix failure to create labels when creating telegraf configs
+1. [16207](https://github.com/influxdata/influxdb/pull/16207): Fix crash when editing a Telegraf config
 
 ### UI Improvements
 

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -358,7 +358,7 @@ describe('Collectors', () => {
     })
 
     // fix for https://github.com/influxdata/influxdb/issues/15730
-    it('creates a configuration with a unique label', () => {
+    it('creates a configuration with a unique label and opens it', () => {
       cy.contains('Create Configuration').click()
 
       cy.contains('Docker').click()
@@ -370,14 +370,19 @@ describe('Collectors', () => {
       cy.get('[name="endpoint"]').type('http://localhost')
 
       cy.contains('Done').click()
-      cy.get('input[title="Telegraf Configuration Name"]').type('Label 1')
+      cy.get('input[title="Telegraf Configuration Name"]').type(
+        '{selectall}Label 1'
+      )
       cy.get('input[title="Telegraf Configuration Description"]').type(
         'Description 1'
       )
 
       cy.contains('Create and Verify').click()
-
+      cy.contains('Finish').click()
       cy.contains('Your configurations have been saved')
+
+      cy.contains('Label 1').click()
+      cy.contains('Telegraf Configuration - Label 1').should('exist')
     })
 
     describe('Label creation and searching', () => {

--- a/ui/src/telegrafs/components/TelegrafConfig.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfig.tsx
@@ -8,8 +8,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 const spinner = <div className="time-machine-editor--loading" />
 const Editor = Loadable({
-  loader: () =>
-    import('react-codemirror2').then(module => ({default: module.Controlled})),
+  loader: () => import('react-codemirror2').then(module => module.Controlled),
   loading() {
     return spinner
   },


### PR DESCRIPTION
Closes #16205

Changes what is exported from `Loadable` so that it properly conforms and returns an element.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
