### PR TITLE
feat: route user to no orgs page

### DIFF
--- a/ui/cypress/e2e/orgs.test.ts
+++ b/ui/cypress/e2e/orgs.test.ts
@@ -1,0 +1,19 @@
+describe('Orgs', () => {
+  beforeEach(() => {
+    cy.flush()
+  })
+
+  describe('when there is a user with no orgs', () => {
+    beforeEach(() => {
+      cy.signin().then(({body}) => {
+        cy.deleteOrg(body.org.id)
+      })
+
+      cy.visit('/')
+    })
+
+    it('forwards the user to the No Orgs Page', () => {
+      cy.url().should('contain', 'no-org')
+    })
+  })
+})

--- a/ui/cypress/e2e/orgs.test.ts
+++ b/ui/cypress/e2e/orgs.test.ts
@@ -14,6 +14,8 @@ describe('Orgs', () => {
 
     it('forwards the user to the No Orgs Page', () => {
       cy.url().should('contain', 'no-org')
+      cy.contains('Sign In').click()
+      cy.url().should('contain', 'signin')
     })
   })
 })

--- a/ui/cypress/index.d.ts
+++ b/ui/cypress/index.d.ts
@@ -8,6 +8,7 @@ import {
   createCell,
   createOrg,
   createSource,
+  deleteOrg,
   flush,
   getByTestID,
   getByInputName,
@@ -48,6 +49,7 @@ declare global {
       createDashWithViewAndVar: typeof createDashWithViewAndVar
       createView: typeof createView
       createOrg: typeof createOrg
+      deleteOrg: typeof deleteOrg
       flush: typeof flush
       getByTestID: typeof getByTestID
       getByInputName: typeof getByInputName

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -123,6 +123,13 @@ export const createOrg = (): Cypress.Chainable<Cypress.Response> => {
   })
 }
 
+export const deleteOrg = (id: string): Cypress.Chainable<Cypress.Response> => {
+  return cy.request({
+    method: 'DELETE',
+    url: `/api/v2/orgs/${id}`,
+  })
+}
+
 export const createBucket = (
   orgID?: string,
   organization?: string,
@@ -452,6 +459,7 @@ Cypress.Commands.add('createView', createView)
 
 // orgs
 Cypress.Commands.add('createOrg', createOrg)
+Cypress.Commands.add('deleteOrg', deleteOrg)
 
 // buckets
 Cypress.Commands.add('createBucket', createBucket)

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -88,6 +88,7 @@ import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay
 import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
 import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
 import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
+import NoOrgsPage from 'src/organizations/containers/NoOrgsPage'
 
 // Overlays
 import OverlayHandler, {
@@ -196,6 +197,7 @@ class Root extends PureComponent {
                 <Route component={GetMe}>
                   <Route component={GetOrganizations}>
                     <Route path="/">
+                      <Route path="no-orgs" component={NoOrgsPage} />
                       <IndexRoute component={RouteToOrg} />
                       <Route path="orgs" component={App}>
                         <Route path="new" component={CreateOrgOverlay} />

--- a/ui/src/organizations/containers/NoOrgsPage.tsx
+++ b/ui/src/organizations/containers/NoOrgsPage.tsx
@@ -1,9 +1,19 @@
 // Libraries
 import React, {FC} from 'react'
-import {FunnelPage, Button} from '@influxdata/clockface'
+import {FunnelPage, Button, ComponentColor} from '@influxdata/clockface'
 import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
 
-const NoOrgsPage: FC<WithRouterProps> = ({router}) => {
+// Types
+import {AppState} from 'src/types'
+
+interface DispatchProps {
+  me: AppState['me']
+}
+
+type Props = DispatchProps & WithRouterProps
+
+const NoOrgsPage: FC<Props> = ({router, me}) => {
   const handleClick = () => {
     router.push('/signin')
   }
@@ -16,11 +26,24 @@ const NoOrgsPage: FC<WithRouterProps> = ({router}) => {
           width="170"
         />
       </div>
-      <h1 className="cf-funnel-page--title">Whoops, no orgs!</h1>
-      <p>Add this user to an organization to continue</p>
-      <Button text="Sign In" onClick={handleClick} />
+      <h1 className="cf-funnel-page--title">Whoops!</h1>
+      <p className="cf-funnel-page--subtitle">
+        You don't belong to an organization.
+        <br />
+        Add user <strong>{`"${me.name}"`}</strong> to an organization to
+        continue
+      </p>
+      <Button
+        text="Sign In"
+        color={ComponentColor.Primary}
+        onClick={handleClick}
+      />
     </FunnelPage>
   )
 }
 
-export default withRouter(NoOrgsPage)
+const mstp = ({me}: AppState) => {
+  return {me}
+}
+
+export default connect(mstp)(withRouter(NoOrgsPage))

--- a/ui/src/organizations/containers/NoOrgsPage.tsx
+++ b/ui/src/organizations/containers/NoOrgsPage.tsx
@@ -1,0 +1,26 @@
+// Libraries
+import React, {FC} from 'react'
+import {FunnelPage, Button} from '@influxdata/clockface'
+import {withRouter, WithRouterProps} from 'react-router'
+
+const NoOrgsPage: FC<WithRouterProps> = ({router}) => {
+  const handleClick = () => {
+    router.push('/signin')
+  }
+
+  return (
+    <FunnelPage>
+      <div className="cf-funnel-page--logo" data-testid="funnel-page--logo">
+        <img
+          src="https://influxdata.github.io/branding/img/downloads/influxdata-logo--full--white-alpha.png"
+          width="170"
+        />
+      </div>
+      <h1 className="cf-funnel-page--title">Whoops, no orgs!</h1>
+      <p>Add this user to an organization to continue</p>
+      <Button text="Sign In" onClick={handleClick} />
+    </FunnelPage>
+  )
+}
+
+export default withRouter(NoOrgsPage)

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -1448,7 +1448,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         name: 'timeout',
         desc: 'Timeout for the GET request. Default is `30s`.',
         type: 'Duration',
-      }
+      },
     ],
     package: 'experimental/http',
     desc:

--- a/ui/src/shared/containers/RouteToOrg.tsx
+++ b/ui/src/shared/containers/RouteToOrg.tsx
@@ -5,6 +5,7 @@ import {WithRouterProps} from 'react-router'
 
 // Types
 import {AppState, Organization} from 'src/types'
+import organizations from '@influxdata/influx/dist/wrappers/organizations'
 
 // Decorators
 
@@ -18,6 +19,11 @@ type Props = StateProps & WithRouterProps
 class RouteToOrg extends PureComponent<Props> {
   public componentDidMount() {
     const {orgs, router, org} = this.props
+
+    if (!orgs || !orgs.length) {
+      router.push(`/no-orgs`)
+      return
+    }
 
     // org from local storage
     if (org && org.id) {

--- a/ui/src/shared/containers/RouteToOrg.tsx
+++ b/ui/src/shared/containers/RouteToOrg.tsx
@@ -5,9 +5,6 @@ import {WithRouterProps} from 'react-router'
 
 // Types
 import {AppState, Organization} from 'src/types'
-import organizations from '@influxdata/influx/dist/wrappers/organizations'
-
-// Decorators
 
 interface StateProps {
   orgs: Organization[]


### PR DESCRIPTION
Closes https://github.com/influxdata/honeybadger-errors/issues/22

### The Problem
Technically, a user does not need to belong to an organization.  However, the UI is organized around an org context.  Most every page is scoped under `orgs/:orgID`.  So, when a user without an org attempted to use the UI, the app would throw.  

### The Solution
If the user does not belong to an org, direct them to a page instructing them on what they need to do to continue.

<img width="887" alt="Screen Shot 2019-12-11 at 2 40 46 PM" src="https://user-images.githubusercontent.com/7582765/70666819-55aca680-1c24-11ea-9b60-9283941f3ec0.png">
