### PR TITLE
feat(kv): define forward cursor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 4. [16262](https://github.com/influxdata/influxdb/pull/16262): add support for check resource dry run functionality 
 5. [16275](https://github.com/influxdata/influxdb/pull/16275): add support for check resource apply functionality 
 6. [16283](https://github.com/influxdata/influxdb/pull/16283): add support for check resource export functionality 
+1. [16212](https://github.com/influxdata/influxdb/pull/16212): Add new kv.ForwardCursor interface
 
 ### Bug Fixes
 

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -13,6 +13,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// check that *KVStore implement kv.Store interface.
+var _ (kv.Store) = (*KVStore)(nil)
+
 // KVStore is a kv.Store backed by boltdb.
 type KVStore struct {
 	path string
@@ -224,10 +227,21 @@ type Cursor struct {
 	key, value []byte
 
 	config kv.CursorConfig
+	closed bool
+}
+
+// Close sets the closed to closed
+func (c *Cursor) Close() error {
+	c.closed = true
+
+	return nil
 }
 
 // Seek seeks for the first key that matches the prefix provided.
 func (c *Cursor) Seek(prefix []byte) ([]byte, []byte) {
+	if c.closed {
+		return nil, nil
+	}
 	k, v := c.cursor.Seek(prefix)
 	if len(k) == 0 && len(v) == 0 {
 		return nil, nil
@@ -237,6 +251,9 @@ func (c *Cursor) Seek(prefix []byte) ([]byte, []byte) {
 
 // First retrieves the first key value pair in the bucket.
 func (c *Cursor) First() ([]byte, []byte) {
+	if c.closed {
+		return nil, nil
+	}
 	k, v := c.cursor.First()
 	if len(k) == 0 && len(v) == 0 {
 		return nil, nil
@@ -246,6 +263,9 @@ func (c *Cursor) First() ([]byte, []byte) {
 
 // Last retrieves the last key value pair in the bucket.
 func (c *Cursor) Last() ([]byte, []byte) {
+	if c.closed {
+		return nil, nil
+	}
 	k, v := c.cursor.Last()
 	if len(k) == 0 && len(v) == 0 {
 		return nil, nil
@@ -255,6 +275,9 @@ func (c *Cursor) Last() ([]byte, []byte) {
 
 // Next retrieves the next key in the bucket.
 func (c *Cursor) Next() (k []byte, v []byte) {
+	if c.closed {
+		return nil, nil
+	}
 	// get and unset previously seeked values if they exist
 	k, v, c.key, c.value = c.key, c.value, nil, nil
 	if len(k) > 0 && len(v) > 0 {
@@ -275,6 +298,9 @@ func (c *Cursor) Next() (k []byte, v []byte) {
 
 // Prev retrieves the previous key in the bucket.
 func (c *Cursor) Prev() (k []byte, v []byte) {
+	if c.closed {
+		return nil, nil
+	}
 	// get and unset previously seeked values if they exist
 	k, v, c.key, c.value = c.key, c.value, nil, nil
 	if len(k) > 0 && len(v) > 0 {

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -292,3 +292,8 @@ func (c *Cursor) Prev() (k []byte, v []byte) {
 	}
 	return k, v
 }
+
+// Err always returns nil as nothing can go wrong™ during iteration
+func (c *Cursor) Err() error {
+	return nil
+}

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -233,9 +233,14 @@ func (b *Bucket) getAll(o *kv.CursorHints) ([]kv.Pair, error) {
 	return pairs, nil
 }
 
+type pair struct {
+	kv.Pair
+	err error
+}
+
 // ForwardCursor returns a directional cursor which starts at the provided seeked key
 func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.ForwardCursor, error) {
-	pairs := make(chan []kv.Pair)
+	pairs := make(chan []pair)
 	go func() {
 		defer close(pairs)
 
@@ -253,18 +258,18 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 			}
 		}
 
-		var batch []kv.Pair
+		var batch []pair
 
 		iterate(func(i btree.Item) bool {
 			j, ok := i.(*item)
 			if !ok {
-				batch = append(batch, kv.Pair{Err: fmt.Errorf("error item is type %T not *item", i)})
+				batch = append(batch, pair{err: fmt.Errorf("error item is type %T not *item", i)})
 
 				return false
 			}
 
 			if fn == nil || fn(j.key, j.value) {
-				batch = append(batch, kv.Pair{Key: j.key, Value: j.value})
+				batch = append(batch, pair{Pair: kv.Pair{Key: j.key, Value: j.value}})
 			}
 
 			if len(batch) < cursorBatchSize {
@@ -289,9 +294,9 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 
 // ForwardCursor is a kv.ForwardCursor which iterates over an in-memory btree
 type ForwardCursor struct {
-	pairs <-chan []kv.Pair
+	pairs <-chan []pair
 
-	cur []kv.Pair
+	cur []pair
 	n   int
 
 	// error found during iteration
@@ -305,6 +310,10 @@ func (c *ForwardCursor) Err() error {
 
 // Next returns the next key/value pair in the cursor
 func (c *ForwardCursor) Next() ([]byte, []byte) {
+	if c.err != nil {
+		return nil, nil
+	}
+
 	if c.n >= len(c.cur) {
 		var ok bool
 		c.cur, ok = <-c.pairs
@@ -316,7 +325,7 @@ func (c *ForwardCursor) Next() ([]byte, []byte) {
 	}
 
 	pair := c.cur[c.n]
-	c.err = pair.Err
+	c.err = pair.err
 	c.n++
 
 	return pair.Key, pair.Value

--- a/kv/cursor.go
+++ b/kv/cursor.go
@@ -18,7 +18,6 @@ type staticCursor struct {
 type Pair struct {
 	Key   []byte
 	Value []byte
-	Err   error
 }
 
 // NewStaticCursor returns an instance of a StaticCursor. It

--- a/kv/cursor.go
+++ b/kv/cursor.go
@@ -13,9 +13,12 @@ type staticCursor struct {
 }
 
 // Pair is a struct for key value pairs.
+// It also includes an error which should only be non-nil
+// when the Key and Value are nil.
 type Pair struct {
 	Key   []byte
 	Value []byte
+	Err   error
 }
 
 // NewStaticCursor returns an instance of a StaticCursor. It

--- a/kv/cursor.go
+++ b/kv/cursor.go
@@ -13,8 +13,6 @@ type staticCursor struct {
 }
 
 // Pair is a struct for key value pairs.
-// It also includes an error which should only be non-nil
-// when the Key and Value are nil.
 type Pair struct {
 	Key   []byte
 	Value []byte

--- a/kv/store.go
+++ b/kv/store.go
@@ -113,7 +113,7 @@ type Cursor interface {
 	Prev() (k []byte, v []byte)
 }
 
-// ForwardCursor is an abstraction for interating/ranging through data in one direction.
+// ForwardCursor is an abstraction for interacting/ranging through data in one direction.
 type ForwardCursor interface {
 	// Next moves the cursor to the next key in the bucket.
 	Next() (k, v []byte)

--- a/kv/store.go
+++ b/kv/store.go
@@ -94,19 +94,64 @@ type Bucket interface {
 	Put(key, value []byte) error
 	// Delete should error if the transaction it was called in is not writable.
 	Delete(key []byte) error
+	// ForwardCursor returns a forward cursor from the seek position provided.
+	// Other options can be supplied to provide direction and hints.
+	ForwardCursor(seek []byte, opts ...CursorOption) (ForwardCursor, error)
 }
 
 // Cursor is an abstraction for iterating/ranging through data. A concrete implementation
 // of a cursor can be found in cursor.go.
 type Cursor interface {
+	ForwardCursor
 	// Seek moves the cursor forward until reaching prefix in the key name.
 	Seek(prefix []byte) (k []byte, v []byte)
 	// First moves the cursor to the first key in the bucket.
 	First() (k []byte, v []byte)
 	// Last moves the cursor to the last key in the bucket.
 	Last() (k []byte, v []byte)
-	// Next moves the cursor to the next key in the bucket.
-	Next() (k []byte, v []byte)
 	// Prev moves the cursor to the prev key in the bucket.
 	Prev() (k []byte, v []byte)
+}
+
+// ForwardCursor is an abstraction for interating/ranging through data in one direction.
+type ForwardCursor interface {
+	// Next moves the cursor to the next key in the bucket.
+	Next() (k, v []byte)
+}
+
+// CursorDirection is an integer used to define the direction
+// a request cursor operates in.
+type CursorDirection int
+
+const (
+	// CursorAscending directs a cursor to range in ascending order
+	CursorAscending CursorDirection = iota
+	// CursorAscending directs a cursor to range in descending order
+	CursorDescending
+)
+
+// CursorConfig is a type used to configure a new forward cursor.
+// It includes a direction and a set of hints
+type CursorConfig struct {
+	Direction CursorDirection
+	Hints     CursorHints
+}
+
+// CursorOption is a functional option for configuring a forward cursor
+type CursorOption func(*CursorConfig)
+
+// WithCursorDirection sets the cursor direction on a provided cursor config
+func WithCursorDirection(direction CursorDirection) CursorOption {
+	return func(c *CursorConfig) {
+		c.Direction = direction
+	}
+}
+
+// WithCursorHints configs the provided hints on the cursor config
+func WithCursorHints(hints ...CursorHint) CursorOption {
+	return func(c *CursorConfig) {
+		for _, hint := range hints {
+			hint(&c.Hints)
+		}
+	}
 }

--- a/kv/store.go
+++ b/kv/store.go
@@ -102,14 +102,14 @@ type Bucket interface {
 // Cursor is an abstraction for iterating/ranging through data. A concrete implementation
 // of a cursor can be found in cursor.go.
 type Cursor interface {
-	// Next moves the cursor to the next key in the bucket.
-	Next() (k, v []byte)
 	// Seek moves the cursor forward until reaching prefix in the key name.
 	Seek(prefix []byte) (k []byte, v []byte)
 	// First moves the cursor to the first key in the bucket.
 	First() (k []byte, v []byte)
 	// Last moves the cursor to the last key in the bucket.
 	Last() (k []byte, v []byte)
+	// Next moves the cursor to the next key in the bucket.
+	Next() (k []byte, v []byte)
 	// Prev moves the cursor to the prev key in the bucket.
 	Prev() (k []byte, v []byte)
 }
@@ -121,6 +121,8 @@ type ForwardCursor interface {
 	// Err returns non-nil if an error occurred during cursor iteration.
 	// This should always be checked after Next returns a nil key/value.
 	Err() error
+	// Close is reponsible for freeing any resources created by the cursor.
+	Close() error
 }
 
 // CursorDirection is an integer used to define the direction

--- a/kv/store.go
+++ b/kv/store.go
@@ -102,7 +102,8 @@ type Bucket interface {
 // Cursor is an abstraction for iterating/ranging through data. A concrete implementation
 // of a cursor can be found in cursor.go.
 type Cursor interface {
-	ForwardCursor
+	// Next moves the cursor to the next key in the bucket.
+	Next() (k, v []byte)
 	// Seek moves the cursor forward until reaching prefix in the key name.
 	Seek(prefix []byte) (k []byte, v []byte)
 	// First moves the cursor to the first key in the bucket.
@@ -117,6 +118,9 @@ type Cursor interface {
 type ForwardCursor interface {
 	// Next moves the cursor to the next key in the bucket.
 	Next() (k, v []byte)
+	// Err returns non-nil if an error occurred during cursor iteration.
+	// This should always be checked after Next returns a nil key/value.
+	Err() error
 }
 
 // CursorDirection is an integer used to define the direction

--- a/kv/store.go
+++ b/kv/store.go
@@ -137,6 +137,16 @@ type CursorConfig struct {
 	Hints     CursorHints
 }
 
+// NewCursorConfig constructs and configures a CursorConfig used to configure
+// a forward cursor.
+func NewCursorConfig(opts ...CursorOption) CursorConfig {
+	conf := CursorConfig{}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	return conf
+}
+
 // CursorOption is a functional option for configuring a forward cursor
 type CursorOption func(*CursorConfig)
 

--- a/mock/kv.go
+++ b/mock/kv.go
@@ -54,10 +54,11 @@ var _ (kv.Bucket) = (*Bucket)(nil)
 // Bucket is the abstraction used to perform get/put/delete/get-many operations
 // in a key value store
 type Bucket struct {
-	GetFn    func(key []byte) ([]byte, error)
-	CursorFn func() (kv.Cursor, error)
-	PutFn    func(key, value []byte) error
-	DeleteFn func(key []byte) error
+	GetFn           func(key []byte) ([]byte, error)
+	CursorFn        func() (kv.Cursor, error)
+	PutFn           func(key, value []byte) error
+	DeleteFn        func(key []byte) error
+	ForwardCursorFn func([]byte, ...kv.CursorOption) kv.ForwardCursor
 }
 
 // Get returns a key within this bucket. Errors if key does not exist.
@@ -78,6 +79,11 @@ func (b *Bucket) Put(key, value []byte) error {
 // Delete should error if the transaction it was called in is not writable.
 func (b *Bucket) Delete(key []byte) error {
 	return b.DeleteFn(key)
+}
+
+// ForwardCursor returns a cursor from the seek points in the configured direction.
+func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.ForwardCursor, error) {
+	return b.ForwardCursorFn(seek, opts...), nil
 }
 
 var _ (kv.Cursor) = (*Cursor)(nil)

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -51,6 +51,10 @@ func KVStore(
 			fn:   KVCursorWithHints,
 		},
 		{
+			name: "ForwardCursor",
+			fn:   KVForwardCursor,
+		},
+		{
 			name: "View",
 			fn:   KVView,
 		},
@@ -655,6 +659,239 @@ func KVCursorWithHints(
 					if string(k) == tt.args.until {
 						break
 					}
+					k, _ = cur.Next()
+				}
+
+				if exp := tt.exp; !cmp.Equal(got, exp) {
+					t.Errorf("unexpected cursor values: -got/+exp\n%v", cmp.Diff(got, exp))
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				t.Fatalf("error during view transaction: %v", err)
+			}
+		})
+	}
+}
+
+// KVForwardCursor tests the forward cursor contract for the key value store.
+func KVForwardCursor(
+	init func(KVStoreFields, *testing.T) (kv.Store, func()),
+	t *testing.T,
+) {
+	type args struct {
+		seek      string
+		direction kv.CursorDirection
+		until     string
+		hints     []kv.CursorHint
+	}
+
+	pairs := func(keys ...string) []kv.Pair {
+		p := make([]kv.Pair, len(keys))
+		for i, k := range keys {
+			p[i].Key = []byte(k)
+			p[i].Value = []byte("val:" + k)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name   string
+		fields KVStoreFields
+		args   args
+		exp    []string
+	}{
+		{
+			name: "no hints",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa",
+				until: "bbb/00",
+			},
+			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03", "bbb/00"},
+		},
+		{
+			name: "prefix hint",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa",
+				until: "aaa/03",
+				hints: []kv.CursorHint{kv.WithCursorHintPrefix("aaa/")},
+			},
+			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03"},
+		},
+		{
+			name: "start hint",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa",
+				until: "bbb/00",
+				hints: []kv.CursorHint{kv.WithCursorHintKeyStart("aaa/")},
+			},
+			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03", "bbb/00"},
+		},
+		{
+			name: "predicate for key",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa",
+				until: "aaa/03",
+				hints: []kv.CursorHint{
+					kv.WithCursorHintPredicate(func(key, _ []byte) bool {
+						return len(key) < 3 || string(key[:3]) == "aaa"
+					})},
+			},
+			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03"},
+		},
+		{
+			name: "predicate for value",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "",
+				until: "aa/01",
+				hints: []kv.CursorHint{
+					kv.WithCursorHintPredicate(func(_, val []byte) bool {
+						return len(val) < 7 || string(val[:7]) == "val:aa/"
+					})},
+			},
+			exp: []string{"aa/00", "aa/01"},
+		},
+		{
+			name: "no hints - descending",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:      "bbb/00",
+				until:     "aaa/00",
+				direction: kv.CursorDescending,
+			},
+			exp: []string{"bbb/00", "aaa/03", "aaa/02", "aaa/01", "aaa/00"},
+		},
+		{
+			name: "start hint - descending",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:      "bbb/00",
+				until:     "aaa/00",
+				direction: kv.CursorDescending,
+				hints:     []kv.CursorHint{kv.WithCursorHintKeyStart("aaa/")},
+			},
+			exp: []string{"bbb/00", "aaa/03", "aaa/02", "aaa/01", "aaa/00"},
+		},
+		{
+			name: "predicate for key - descending",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:      "aaa/03",
+				until:     "aaa/00",
+				direction: kv.CursorDescending,
+				hints: []kv.CursorHint{
+					kv.WithCursorHintPredicate(func(key, _ []byte) bool {
+						return len(key) < 3 || string(key[:3]) == "aaa"
+					})},
+			},
+			exp: []string{"aaa/03", "aaa/02", "aaa/01", "aaa/00"},
+		},
+		{
+			name: "predicate for value - descending",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:      "aa/01",
+				until:     "aa/00",
+				direction: kv.CursorDescending,
+				hints: []kv.CursorHint{
+					kv.WithCursorHintPredicate(func(_, val []byte) bool {
+						return len(val) >= 7 && string(val[:7]) == "val:aa/"
+					})},
+			},
+			exp: []string{"aa/01", "aa/00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, fin := init(tt.fields, t)
+			defer fin()
+
+			err := s.View(context.Background(), func(tx kv.Tx) error {
+				b, err := tx.Bucket([]byte("bucket"))
+				if err != nil {
+					t.Errorf("unexpected error retrieving bucket: %v", err)
+					return err
+				}
+
+				cur, err := b.ForwardCursor([]byte(tt.args.seek),
+					kv.WithCursorDirection(tt.args.direction),
+					kv.WithCursorHints(tt.args.hints...))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return err
+				}
+
+				var got []string
+
+				k, _ := cur.Next()
+				for len(k) > 0 {
+					got = append(got, string(k))
+					if string(k) == tt.args.until {
+						break
+					}
+
 					k, _ = cur.Next()
 				}
 

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -702,6 +702,7 @@ func KVForwardCursor(
 		fields KVStoreFields
 		args   args
 		exp    []string
+		expErr error
 	}{
 		{
 			name: "no hints",
@@ -897,6 +898,14 @@ func KVForwardCursor(
 
 				if exp := tt.exp; !cmp.Equal(got, exp) {
 					t.Errorf("unexpected cursor values: -got/+exp\n%v", cmp.Diff(got, exp))
+				}
+
+				if err := cur.Err(); !cmp.Equal(err, tt.expErr) {
+					t.Errorf("expected error to be %v, got %v", tt.expErr, err)
+				}
+
+				if err := cur.Close(); err != nil {
+					t.Errorf("expected cursor to close with nil error, found %v", err)
 				}
 
 				return nil


### PR DESCRIPTION
Closes #5367

This PR introduces the concept for a `ForwardCursor` as described in the issue above. It's purpose is to create a contract in cursor creators declare upfront the direction and start position in which to create a cursor. This will promote healthier access patterns to the existing cursor. Allowing us to optimize a lot easier in the kv bucket implementations.

1. Define the forward cursor interface. A single direction cursor which is configured with a direction on creation.
```go
c := bucket.ForwardCursor([]byte("runs/"),
        kv.WithCursorDirection(kv.CursorDescending),
        kv.WithCursorHints(kv.WithCursorHintKeyStart("runs/12345")))
```
2. Update all bucket implementations to adhere to new `ForwardCursor()` method.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
