### PR TITLE
chore(pkger): use http client/server for integration tests

### DIFF
--- a/authorizer/notification_endpoint_test.go
+++ b/authorizer/notification_endpoint_test.go
@@ -51,10 +51,11 @@ func TestNotificationEndpointService_FindNotificationEndpointByID(t *testing.T) 
 			fields: fields{
 				NotificationEndpointService: &mock.NotificationEndpointService{
 					FindNotificationEndpointByIDF: func(ctx context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
+						orgID := influxdb.ID(10)
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    id,
-								OrgID: 10,
+								ID:    &id,
+								OrgID: &orgID,
 							},
 						}, nil
 					},
@@ -79,10 +80,11 @@ func TestNotificationEndpointService_FindNotificationEndpointByID(t *testing.T) 
 			fields: fields{
 				NotificationEndpointService: &mock.NotificationEndpointService{
 					FindNotificationEndpointByIDF: func(ctx context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
+						orgID := influxdb.ID(10)
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    id,
-								OrgID: 10,
+								ID:    &id,
+								OrgID: &orgID,
 							},
 						}, nil
 					},
@@ -146,20 +148,14 @@ func TestNotificationEndpointService_FindNotificationEndpoints(t *testing.T) {
 						return []influxdb.NotificationEndpoint{
 							&endpoint.Slack{
 								Base: endpoint.Base{
-									ID:    1,
-									OrgID: 10,
-								},
-							},
-							&endpoint.Slack{
-								Base: endpoint.Base{
-									ID:    2,
-									OrgID: 10,
+									ID:    idPtr(1),
+									OrgID: idPtr(10),
 								},
 							},
 							&endpoint.HTTP{
 								Base: endpoint.Base{
-									ID:    3,
-									OrgID: 11,
+									ID:    idPtr(1),
+									OrgID: idPtr(10),
 								},
 							},
 						}, 3, nil
@@ -179,14 +175,14 @@ func TestNotificationEndpointService_FindNotificationEndpoints(t *testing.T) {
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:    1,
-							OrgID: 10,
+							ID:    idPtr(1),
+							OrgID: idPtr(10),
 						},
 					},
-					&endpoint.Slack{
+					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:    2,
-							OrgID: 10,
+							ID:    idPtr(1),
+							OrgID: idPtr(10),
 						},
 					},
 				},
@@ -239,16 +235,16 @@ func TestNotificationEndpointService_UpdateNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
 					UpdateNotificationEndpointF: func(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpoint, userID influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -284,16 +280,16 @@ func TestNotificationEndpointService_UpdateNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
 					UpdateNotificationEndpointF: func(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpoint, userID influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -360,16 +356,16 @@ func TestNotificationEndpointService_PatchNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
 					PatchNotificationEndpointF: func(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpointUpdate) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -405,16 +401,16 @@ func TestNotificationEndpointService_PatchNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
 					PatchNotificationEndpointF: func(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpointUpdate) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -480,8 +476,8 @@ func TestNotificationEndpointService_DeleteNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -520,8 +516,8 @@ func TestNotificationEndpointService_DeleteNotificationEndpoint(t *testing.T) {
 					FindNotificationEndpointByIDF: func(ctc context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 						return &endpoint.Slack{
 							Base: endpoint.Base{
-								ID:    1,
-								OrgID: 10,
+								ID:    idPtr(1),
+								OrgID: idPtr(10),
 							},
 						}, nil
 					},
@@ -669,9 +665,13 @@ func TestNotificationEndpointService_CreateNotificationEndpoint(t *testing.T) {
 
 			err := s.CreateNotificationEndpoint(ctx, &endpoint.Slack{
 				Base: endpoint.Base{
-					OrgID: tt.args.orgID},
+					OrgID: idPtr(tt.args.orgID)},
 			}, influxdb.ID(1))
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}
+}
+
+func idPtr(id influxdb.ID) *influxdb.ID {
+	return &id
 }

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -47,11 +47,6 @@ func newHTTPClient() (*httpc.Client, error) {
 	return httpClient, nil
 }
 
-type httpClientOpts struct {
-	token, addr string
-	skipVerify  bool
-}
-
 type genericCLIOptfn func(*genericCLIOpts)
 
 type genericCLIOpts struct {
@@ -138,14 +133,6 @@ type Flags struct {
 	host       string
 	local      bool
 	skipVerify bool
-}
-
-func (f Flags) httpClientOpts() httpClientOpts {
-	return httpClientOpts{
-		addr:       f.host,
-		token:      f.token,
-		skipVerify: f.skipVerify,
-	}
 }
 
 var flags Flags

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_Pkg(t *testing.T) {
 	fakeSVCFn := func(svc pkger.SVC) pkgSVCsFn {
-		return func(opts httpClientOpts, _ ...pkger.ServiceSetterFn) (pkger.SVC, influxdb.OrganizationService, error) {
+		return func() (pkger.SVC, influxdb.OrganizationService, error) {
 			return svc, &mock.OrganizationService{
 				FindOrganizationF: func(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
 					return &influxdb.Organization{ID: influxdb.ID(9000), Name: "influxdata"}, nil
@@ -481,8 +481,8 @@ func testPkgWritesToBuffer(newCmdFn func() *cobra.Command, args pkgFileArgs, ass
 
 type fakePkgSVC struct {
 	createFn func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
-	dryRunFn func(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error)
-	applyFn  func(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error)
+	dryRunFn func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error)
+	applyFn  func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error)
 }
 
 func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
@@ -492,16 +492,16 @@ func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSe
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) DryRun(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error) {
+func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error) {
 	if f.dryRunFn != nil {
-		return f.dryRunFn(ctx, orgID, pkg)
+		return f.dryRunFn(ctx, orgID, userID, pkg)
 	}
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) Apply(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
 	if f.applyFn != nil {
-		return f.applyFn(ctx, orgID, pkg)
+		return f.applyFn(ctx, orgID, userID, pkg)
 	}
 	panic("not implemented")
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -848,7 +848,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	var pkgHTTPServer *http.HandlerPkg
 	{
-		pkgHTTPServer = http.NewHandlerPkg(m.apibackend.HTTPErrorHandler, pkgSVC)
+		pkgServerLogger := m.log.With(zap.String("handler", "pkger"))
+		pkgHTTPServer = http.NewHandlerPkg(pkgServerLogger, m.apibackend.HTTPErrorHandler, pkgSVC)
 	}
 
 	// HTTP server

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/pkg/httpc"
+	"github.com/influxdata/influxdb/pkger"
 	"github.com/influxdata/influxdb/query"
 )
 
@@ -347,6 +348,10 @@ func (tl *TestLauncher) LabelService(tb testing.TB) *http.LabelService {
 func (tl *TestLauncher) NotificationEndpointService(tb testing.TB) *http.NotificationEndpointService {
 	tb.Helper()
 	return http.NewNotificationEndpointService(tl.HTTPClient(tb))
+}
+
+func (tl *TestLauncher) PkgerService(tb testing.TB) pkger.SVC {
+	return &http.PkgerService{Client: tl.HTTPClient(tb)}
 }
 
 func (tl *TestLauncher) TelegrafService(tb testing.TB) *http.TelegrafService {

--- a/http/notification_endpoint_test.go
+++ b/http/notification_endpoint_test.go
@@ -67,18 +67,18 @@ func TestService_handleGetNotificationEndpoints(t *testing.T) {
 						return []influxdb.NotificationEndpoint{
 							&endpoint.Slack{
 								Base: endpoint.Base{
-									ID:     influxTesting.MustIDBase16("0b501e7e557ab1ed"),
+									ID:     influxTesting.MustIDBase16Ptr("0b501e7e557ab1ed"),
 									Name:   "hello",
-									OrgID:  influxTesting.MustIDBase16("50f7ba1150f7ba11"),
+									OrgID:  influxTesting.MustIDBase16Ptr("50f7ba1150f7ba11"),
 									Status: influxdb.Active,
 								},
 								URL: "http://example.com",
 							},
 							&endpoint.HTTP{
 								Base: endpoint.Base{
-									ID:     influxTesting.MustIDBase16("c0175f0077a77005"),
+									ID:     influxTesting.MustIDBase16Ptr("c0175f0077a77005"),
 									Name:   "example",
-									OrgID:  influxTesting.MustIDBase16("7e55e118dbabb1ed"),
+									OrgID:  influxTesting.MustIDBase16Ptr("7e55e118dbabb1ed"),
 									Status: influxdb.Inactive,
 								},
 								URL:             "example.com",
@@ -285,8 +285,8 @@ func TestService_handleGetNotificationEndpoint(t *testing.T) {
 						if id == influxTesting.MustIDBase16("020f755c3c082000") {
 							return &endpoint.HTTP{
 								Base: endpoint.Base{
-									ID:     influxTesting.MustIDBase16("020f755c3c082000"),
-									OrgID:  influxTesting.MustIDBase16("020f755c3c082000"),
+									ID:     influxTesting.MustIDBase16Ptr("020f755c3c082000"),
+									OrgID:  influxTesting.MustIDBase16Ptr("020f755c3c082000"),
 									Name:   "hello",
 									Status: influxdb.Active,
 								},
@@ -705,9 +705,9 @@ func TestService_handlePatchNotificationEndpoint(t *testing.T) {
 						if id == influxTesting.MustIDBase16("020f755c3c082000") {
 							d := &endpoint.Slack{
 								Base: endpoint.Base{
-									ID:     influxTesting.MustIDBase16("020f755c3c082000"),
+									ID:     influxTesting.MustIDBase16Ptr("020f755c3c082000"),
 									Name:   "hello",
-									OrgID:  influxTesting.MustIDBase16("020f755c3c082000"),
+									OrgID:  influxTesting.MustIDBase16Ptr("020f755c3c082000"),
 									Status: influxdb.Active,
 								},
 								URL: "http://example.com",

--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -10,22 +10,29 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/influxdata/influxdb"
+	pctx "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/influxdata/influxdb/pkg/httpc"
 	"github.com/influxdata/influxdb/pkger"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
+
+const prefixPackages = "/api/v2/packages"
 
 // HandlerPkg is a server that manages the packages HTTP transport.
 type HandlerPkg struct {
 	chi.Router
 	influxdb.HTTPErrorHandler
-	svc pkger.SVC
+	logger *zap.Logger
+	svc    pkger.SVC
 }
 
 // NewHandlerPkg constructs a new http server.
-func NewHandlerPkg(errHandler influxdb.HTTPErrorHandler, svc pkger.SVC) *HandlerPkg {
+func NewHandlerPkg(log *zap.Logger, errHandler influxdb.HTTPErrorHandler, svc pkger.SVC) *HandlerPkg {
 	svr := &HandlerPkg{
 		HTTPErrorHandler: errHandler,
+		logger:           log,
 		svc:              svc,
 	}
 
@@ -48,17 +55,17 @@ func NewHandlerPkg(errHandler influxdb.HTTPErrorHandler, svc pkger.SVC) *Handler
 
 // Prefix provides the prefix to this route tree.
 func (s *HandlerPkg) Prefix() string {
-	return "/api/v2/packages"
+	return prefixPackages
 }
 
 type (
 	// ReqCreatePkg is a request body for the create pkg endpoint.
 	ReqCreatePkg struct {
-		PkgName        string `json:"pkgName"`
-		PkgDescription string `json:"pkgDescription"`
-		PkgVersion     string `json:"pkgVersion"`
-
-		Resources []pkger.ResourceToClone `json:"resources"`
+		PkgName        string                  `json:"pkgName"`
+		PkgDescription string                  `json:"pkgDescription"`
+		PkgVersion     string                  `json:"pkgVersion"`
+		OrgIDs         []string                `json:"orgIDs"`
+		Resources      []pkger.ResourceToClone `json:"resources"`
 	}
 
 	// RespCreatePkg is a response body for the create pkg endpoint.
@@ -76,15 +83,25 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	newPkg, err := s.svc.CreatePkg(r.Context(),
+	opts := []pkger.CreatePkgSetFn{
 		pkger.CreateWithMetadata(pkger.Metadata{
 			Description: reqBody.PkgDescription,
 			Name:        reqBody.PkgName,
 			Version:     reqBody.PkgVersion,
 		}),
 		pkger.CreateWithExistingResources(reqBody.Resources...),
-	)
+	}
+	for _, orgIDStr := range reqBody.OrgIDs {
+		orgID, err := influxdb.IDFromString(orgIDStr)
+		if err != nil {
+			continue
+		}
+		opts = append(opts, pkger.CreateWithAllOrgResources(*orgID))
+	}
+
+	newPkg, err := s.svc.CreatePkg(r.Context(), opts...)
 	if err != nil {
+		s.logger.Error("failed to create pkg", zap.Error(err))
 		s.HandleHTTPError(r.Context(), err, w)
 		return
 	}
@@ -137,8 +154,15 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auth, err := pctx.GetAuthorizer(r.Context())
+	if err != nil {
+		s.HandleHTTPError(r.Context(), err, w)
+		return
+	}
+	userID := auth.GetUserID()
+
 	parsedPkg := reqBody.Pkg
-	sum, diff, err := s.svc.DryRun(r.Context(), *orgID, parsedPkg)
+	sum, diff, err := s.svc.DryRun(r.Context(), *orgID, userID, parsedPkg)
 	if pkger.IsParseErr(err) {
 		s.encJSONResp(r.Context(), w, http.StatusUnprocessableEntity, RespApplyPkg{
 			Diff:    diff,
@@ -148,6 +172,7 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
+		s.logger.Error("failed to dry run pkg", zap.Error(err))
 		s.HandleHTTPError(r.Context(), err, w)
 		return
 	}
@@ -161,8 +186,9 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sum, err = s.svc.Apply(r.Context(), *orgID, parsedPkg)
+	sum, err = s.svc.Apply(r.Context(), *orgID, userID, parsedPkg)
 	if err != nil && !pkger.IsParseErr(err) {
+		s.logger.Error("failed to apply pkg", zap.Error(err))
 		s.HandleHTTPError(r.Context(), err, w)
 		return
 	}
@@ -170,6 +196,7 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 	s.encJSONResp(r.Context(), w, http.StatusCreated, RespApplyPkg{
 		Diff:    diff,
 		Summary: sum,
+		Errors:  convertParseErr(err),
 	})
 }
 
@@ -213,6 +240,83 @@ func (s *HandlerPkg) encResp(ctx context.Context, w http.ResponseWriter, enc enc
 
 func (s *HandlerPkg) encJSONResp(ctx context.Context, w http.ResponseWriter, code int, res interface{}) {
 	s.encResp(ctx, w, newJSONEnc(w), code, res)
+}
+
+// PkgerService provides an http client that is fluent in all things pkger.
+type PkgerService struct {
+	Client *httpc.Client
+}
+
+var _ pkger.SVC = (*PkgerService)(nil)
+
+// CreatePkg will produce a pkg from the parameters provided.
+func (s *PkgerService) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
+	var opt pkger.CreateOpt
+	for _, setter := range setters {
+		if err := setter(&opt); err != nil {
+			return nil, err
+		}
+	}
+	var orgIDs []string
+	for orgID := range opt.OrgIDs {
+		orgIDs = append(orgIDs, orgID.String())
+	}
+
+	reqBody := ReqCreatePkg{
+		PkgDescription: opt.Metadata.Description,
+		PkgName:        opt.Metadata.Name,
+		PkgVersion:     opt.Metadata.Version,
+		OrgIDs:         orgIDs,
+		Resources:      opt.Resources,
+	}
+
+	var newPkg RespCreatePkg
+	err := s.Client.
+		PostJSON(reqBody, prefixPackages).
+		DecodeJSON(&newPkg).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := newPkg.Validate(pkger.ValidWithoutResources()); err != nil {
+		return nil, err
+	}
+	return newPkg.Pkg, nil
+}
+
+// DryRun provides a dry run of the pkg application. The pkg will be marked verified
+// for later calls to Apply. This func will be run on an Apply if it has not been run
+// already.
+func (s *PkgerService) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error) {
+	return s.apply(ctx, orgID, pkg, true)
+}
+
+// Apply will apply all the resources identified in the provided pkg. The entire pkg will be applied
+// in its entirety. If a failure happens midway then the entire pkg will be rolled back to the state
+// from before the pkg were applied.
+func (s *PkgerService) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
+	sum, _, err := s.apply(ctx, orgID, pkg, false)
+	return sum, err
+}
+
+func (s *PkgerService) apply(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg, dryRun bool) (pkger.Summary, pkger.Diff, error) {
+	reqBody := ReqApplyPkg{
+		OrgID:  orgID.String(),
+		DryRun: dryRun,
+		Pkg:    pkg,
+	}
+
+	var resp RespApplyPkg
+	err := s.Client.
+		PostJSON(reqBody, prefixPackages, "/apply").
+		DecodeJSON(&resp).
+		Do(ctx)
+	if err != nil {
+		return pkger.Summary{}, pkger.Diff{}, err
+	}
+
+	return resp.Summary, resp.Diff, pkger.NewParseError(resp.Errors...)
 }
 
 func convertParseErr(err error) []pkger.ValidationErr {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7169,18 +7169,26 @@ components:
             buckets:
               type: array
               items:
-                allOf:
-                  - $ref: "#/components/schemas/Bucket"
-                  - type: object
-                    properties:
-                      labelAssociations:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  orgID:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  retentionPeriod:
+                    type: integer
+                  labelAssociations:
                         type: array
                         items:
-                          $ref: "#/components/schemas/Label"
+                          $ref: "#/components/schemas/PkgSummaryLabel"
             labels:
               type: array
               items:
-                $ref: "#/components/schemas/Label"
+                $ref: "#/components/schemas/PkgSummaryLabel"
             dashboards:
               type: array
               items:
@@ -7242,11 +7250,19 @@ components:
             variables:
               type: array
               items:
-                allOf:
-                  - $ref: "#/components/schemas/Variable"
-                  - type: object
-                    properties:
-                      labelAssociations:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  orgID:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  arguments:
+                    $ref: "#/components/schemas/VariableProperties"
+                  labelAssociations:
                         type: array
                         items:
                           $ref: "#/components/schemas/Label"
@@ -7386,6 +7402,19 @@ components:
                 type: array
                 items:
                   type: integer
+    PkgSummaryLabel:
+      type: object
+      properties:
+        id:
+          type: string
+        orgID:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        retentionPeriod:
+          type: string
     PkgChart:
       type: object
       properties:

--- a/notification/endpoint/endpoint.go
+++ b/notification/endpoint/endpoint.go
@@ -43,16 +43,27 @@ func UnmarshalJSON(b []byte) (influxdb.NotificationEndpoint, error) {
 
 // Base is the embed struct of every notification endpoint.
 type Base struct {
-	ID          influxdb.ID     `json:"id,omitempty"`
+	ID          *influxdb.ID    `json:"id,omitempty"`
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
-	OrgID       influxdb.ID     `json:"orgID,omitempty"`
+	OrgID       *influxdb.ID    `json:"orgID,omitempty"`
 	Status      influxdb.Status `json:"status"`
 	influxdb.CRUDLog
 }
 
+func (b Base) idStr() string {
+	if b.ID == nil {
+		return influxdb.ID(0).String()
+	}
+	return b.ID.String()
+}
+
+func (b Base) validID() bool {
+	return b.ID != nil && b.ID.Valid()
+}
+
 func (b Base) valid() error {
-	if !b.ID.Valid() {
+	if !b.validID() {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "Notification Endpoint ID is invalid",
@@ -75,7 +86,10 @@ func (b Base) valid() error {
 
 // GetID implements influxdb.Getter interface.
 func (b Base) GetID() influxdb.ID {
-	return b.ID
+	if b.ID == nil {
+		return 0
+	}
+	return *b.ID
 }
 
 // GetName implements influxdb.Getter interface.
@@ -85,7 +99,7 @@ func (b *Base) GetName() string {
 
 // GetOrgID implements influxdb.Getter interface.
 func (b Base) GetOrgID() influxdb.ID {
-	return b.OrgID
+	return getID(b.OrgID)
 }
 
 // GetCRUDLog implements influxdb.Getter interface.
@@ -105,12 +119,12 @@ func (b *Base) GetStatus() influxdb.Status {
 
 // SetID will set the primary key.
 func (b *Base) SetID(id influxdb.ID) {
-	b.ID = id
+	b.ID = &id
 }
 
 // SetOrgID will set the org key.
 func (b *Base) SetOrgID(id influxdb.ID) {
-	b.OrgID = id
+	b.OrgID = &id
 }
 
 // SetName implements influxdb.Updator interface.
@@ -126,4 +140,11 @@ func (b *Base) SetDescription(description string) {
 // SetStatus implements influxdb.Updator interface.
 func (b *Base) SetStatus(status influxdb.Status) {
 	b.Status = status
+}
+
+func getID(id *influxdb.ID) influxdb.ID {
+	if id == nil {
+		return 0
+	}
+	return *id
 }

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -19,9 +19,9 @@ const (
 )
 
 var goodBase = endpoint.Base{
-	ID:          influxTesting.MustIDBase16(id1),
+	ID:          influxTesting.MustIDBase16Ptr(id1),
 	Name:        "name1",
-	OrgID:       influxTesting.MustIDBase16(id3),
+	OrgID:       influxTesting.MustIDBase16Ptr(id3),
 	Status:      influxdb.Active,
 	Description: "desc1",
 }
@@ -44,9 +44,9 @@ func TestValidEndpoint(t *testing.T) {
 			name: "invalid status",
 			src: &endpoint.PagerDuty{
 				Base: endpoint.Base{
-					ID:    influxTesting.MustIDBase16(id1),
+					ID:    influxTesting.MustIDBase16Ptr(id1),
 					Name:  "name1",
-					OrgID: influxTesting.MustIDBase16(id3),
+					OrgID: influxTesting.MustIDBase16Ptr(id3),
 				},
 			},
 			err: &influxdb.Error{
@@ -58,8 +58,8 @@ func TestValidEndpoint(t *testing.T) {
 			name: "empty name",
 			src: &endpoint.PagerDuty{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
-					OrgID:  influxTesting.MustIDBase16(id3),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 				},
 				ClientURL:  "https://events.pagerduty.com/v2/enqueue",
@@ -181,9 +181,9 @@ func TestJSON(t *testing.T) {
 			name: "simple Slack",
 			src: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -198,9 +198,9 @@ func TestJSON(t *testing.T) {
 			name: "Slack without token",
 			src: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -214,9 +214,9 @@ func TestJSON(t *testing.T) {
 			name: "simple pagerduty",
 			src: &endpoint.PagerDuty{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -231,9 +231,9 @@ func TestJSON(t *testing.T) {
 			name: "simple http",
 			src: &endpoint.HTTP{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -276,9 +276,9 @@ func TestBackFill(t *testing.T) {
 			name: "simple Slack",
 			src: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -292,9 +292,9 @@ func TestBackFill(t *testing.T) {
 			},
 			target: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -312,9 +312,9 @@ func TestBackFill(t *testing.T) {
 			name: "simple pagerduty",
 			src: &endpoint.PagerDuty{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -328,9 +328,9 @@ func TestBackFill(t *testing.T) {
 			},
 			target: &endpoint.PagerDuty{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -348,9 +348,9 @@ func TestBackFill(t *testing.T) {
 			name: "http with token",
 			src: &endpoint.HTTP{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),
@@ -368,9 +368,9 @@ func TestBackFill(t *testing.T) {
 			},
 			target: &endpoint.HTTP{
 				Base: endpoint.Base{
-					ID:     influxTesting.MustIDBase16(id1),
+					ID:     influxTesting.MustIDBase16Ptr(id1),
 					Name:   "name1",
-					OrgID:  influxTesting.MustIDBase16(id3),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 					CRUDLog: influxdb.CRUDLog{
 						CreatedAt: timeGen1.Now(),

--- a/notification/endpoint/http.go
+++ b/notification/endpoint/http.go
@@ -37,13 +37,13 @@ type HTTP struct {
 // if value of that secret field is not nil.
 func (s *HTTP) BackfillSecretKeys() {
 	if s.Token.Key == "" && s.Token.Value != nil {
-		s.Token.Key = s.ID.String() + httpTokenSuffix
+		s.Token.Key = s.idStr() + httpTokenSuffix
 	}
 	if s.Username.Key == "" && s.Username.Value != nil {
-		s.Username.Key = s.ID.String() + httpUsernameSuffix
+		s.Username.Key = s.idStr() + httpUsernameSuffix
 	}
 	if s.Password.Key == "" && s.Password.Value != nil {
-		s.Password.Key = s.ID.String() + httpPasswordSuffix
+		s.Password.Key = s.idStr() + httpPasswordSuffix
 	}
 }
 

--- a/notification/endpoint/pagerduty.go
+++ b/notification/endpoint/pagerduty.go
@@ -24,7 +24,7 @@ type PagerDuty struct {
 // if value of that secret field is not nil.
 func (s *PagerDuty) BackfillSecretKeys() {
 	if s.RoutingKey.Key == "" && s.RoutingKey.Value != nil {
-		s.RoutingKey.Key = s.ID.String() + routingKeySuffix
+		s.RoutingKey.Key = s.idStr() + routingKeySuffix
 	}
 }
 

--- a/notification/endpoint/slack.go
+++ b/notification/endpoint/slack.go
@@ -27,7 +27,7 @@ type Slack struct {
 // if value of that secret field is not nil.
 func (s *Slack) BackfillSecretKeys() {
 	if s.Token.Key == "" && s.Token.Value != nil {
-		s.Token.Key = s.ID.String() + slackTokenSuffix
+		s.Token.Key = s.idStr() + slackTokenSuffix
 	}
 }
 

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -58,9 +58,10 @@ all_statuses
 		},
 	}
 
+	id := influxdb.ID(2)
 	e := &endpoint.HTTP{
 		Base: endpoint.Base{
-			ID:   2,
+			ID:   &id,
 			Name: "foo",
 		},
 		URL: "http://localhost:7777",
@@ -125,9 +126,10 @@ all_statuses
 		},
 	}
 
+	id := influxdb.ID(2)
 	e := &endpoint.HTTP{
 		Base: endpoint.Base{
-			ID:   2,
+			ID:   &id,
 			Name: "foo",
 		},
 		URL:        "http://localhost:7777",
@@ -200,9 +202,10 @@ all_statuses
 		},
 	}
 
+	id := influxdb.ID(2)
 	e := &endpoint.HTTP{
 		Base: endpoint.Base{
-			ID:   2,
+			ID:   &id,
 			Name: "foo",
 		},
 		URL:        "http://localhost:7777",
@@ -272,9 +275,10 @@ all_statuses
 		},
 	}
 
+	id := influxdb.ID(2)
 	e := &endpoint.HTTP{
 		Base: endpoint.Base{
-			ID:   2,
+			ID:   &id,
 			Name: "foo",
 		},
 		URL:        "http://localhost:7777",

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -69,9 +69,11 @@ statuses
 			},
 		},
 	}
+
+	id := influxdb.ID(2)
 	e := &endpoint.PagerDuty{
 		Base: endpoint.Base{
-			ID:   2,
+			ID:   &id,
 			Name: "foo",
 		},
 		ClientURL: "http://localhost:7777/host/${r.host}",

--- a/notification/rule/slack_test.go
+++ b/notification/rule/slack_test.go
@@ -23,6 +23,11 @@ func statusRulePtr(r notification.CheckLevel) *notification.CheckLevel {
 	return &r
 }
 
+func idPtr(i int) *influxdb.ID {
+	id := influxdb.ID(i)
+	return &id
+}
+
 func TestSlack_GenerateFlux(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -93,7 +98,7 @@ all_statuses
 			},
 			endpoint: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:   2,
+					ID:   idPtr(2),
 					Name: "foo",
 				},
 				URL: "http://localhost:7777",
@@ -169,7 +174,7 @@ all_statuses
 			},
 			endpoint: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:   2,
+					ID:   idPtr(2),
 					Name: "foo",
 				},
 				URL: "http://localhost:7777",
@@ -246,7 +251,7 @@ all_statuses
 			},
 			endpoint: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:   2,
+					ID:   idPtr(2),
 					Name: "foo",
 				},
 				Token: influxdb.SecretField{
@@ -325,7 +330,7 @@ all_statuses
 			},
 			endpoint: &endpoint.Slack{
 				Base: endpoint.Base{
-					ID:   2,
+					ID:   idPtr(2),
 					Name: "foo",
 				},
 				URL: "http://localhost:7777",

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -1,6 +1,7 @@
 package pkger
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -176,8 +177,8 @@ type DiffBucketValues struct {
 
 // DiffBucket is a diff of an individual bucket.
 type DiffBucket struct {
-	ID   SafeID
-	Name string
+	ID   SafeID            `json:"id"`
+	Name string            `json:"name"`
 	New  DiffBucketValues  `json:"new"`
 	Old  *DiffBucketValues `json:"old,omitempty"` // using omitempty here to signal there was no prev state with a nil
 }
@@ -299,6 +300,16 @@ type DiffNotificationEndpointValues struct {
 	influxdb.NotificationEndpoint
 }
 
+// UnmarshalJSON decodes the notification endpoint. This is necessary unfortunately.
+func (d *DiffNotificationEndpointValues) UnmarshalJSON(b []byte) error {
+	e, err := endpoint.UnmarshalJSON(b)
+	if err != nil {
+		fmt.Println("broken here")
+	}
+	d.NotificationEndpoint = e
+	return err
+}
+
 // DiffNotificationEndpoint is a diff of an individual notification endpoint.
 type DiffNotificationEndpoint struct {
 	ID   SafeID                          `json:"id"`
@@ -396,8 +407,13 @@ type Summary struct {
 
 // SummaryBucket provides a summary of a pkg bucket.
 type SummaryBucket struct {
-	influxdb.Bucket
-	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+	ID          SafeID `json:"id,omitempty"`
+	OrgID       SafeID `json:"orgID,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// TODO: return retention rules?
+	RetentionPeriod   time.Duration  `json:"retentionPeriod"`
+	LabelAssociations []SummaryLabel `json:"labelAssociations"`
 }
 
 // SummaryDashboard provides a summary of a pkg dashboard.
@@ -408,7 +424,7 @@ type SummaryDashboard struct {
 	Description string         `json:"description"`
 	Charts      []SummaryChart `json:"charts"`
 
-	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+	LabelAssociations []SummaryLabel `json:"labelAssociations"`
 }
 
 // chartKind identifies what kind of chart is eluded too. Each
@@ -447,7 +463,7 @@ func (c chartKind) title() string {
 
 // SummaryChart provides a summary of a pkg dashboard's chart.
 type SummaryChart struct {
-	Properties influxdb.ViewProperties `json:"properties"`
+	Properties influxdb.ViewProperties `json:"-"`
 
 	XPosition int `json:"xPos"`
 	YPosition int `json:"yPos"`
@@ -455,35 +471,103 @@ type SummaryChart struct {
 	Width     int `json:"width"`
 }
 
+// MarshalJSON marshals a summary chart.
+func (s *SummaryChart) MarshalJSON() ([]byte, error) {
+	b, err := influxdb.MarshalViewPropertiesJSON(s.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	type alias SummaryChart
+
+	out := struct {
+		Props json.RawMessage `json:"properties"`
+		alias
+	}{
+		Props: b,
+		alias: alias(*s),
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON unmarshals a view properities and other data.
+func (s *SummaryChart) UnmarshalJSON(b []byte) error {
+	type alias SummaryChart
+	a := (*alias)(s)
+	if err := json.Unmarshal(b, a); err != nil {
+		return err
+	}
+	s.XPosition = a.XPosition
+	s.XPosition = a.YPosition
+	s.Height = a.Height
+	s.Width = a.Width
+
+	vp, err := influxdb.UnmarshalViewPropertiesJSON(b)
+	if err != nil {
+		return err
+	}
+	s.Properties = vp
+	return nil
+}
+
 // SummaryNotificationEndpoint provides a summary of a pkg endpoint rule.
 type SummaryNotificationEndpoint struct {
-	influxdb.NotificationEndpoint
-	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+	NotificationEndpoint influxdb.NotificationEndpoint `json:"notificationEndpoint"`
+	LabelAssociations    []SummaryLabel                `json:"labelAssociations"`
+}
+
+// UnmarshalJSON unmarshals the notificatio endpoint. This is necessary b/c of
+// the notification endpoint does not have a means ot unmarshal itself.
+func (s *SummaryNotificationEndpoint) UnmarshalJSON(b []byte) error {
+	var a struct {
+		NotificationEndpoint json.RawMessage `json:"notificationEndpoint"`
+		LabelAssociations    []SummaryLabel  `json:"labelAssociations"`
+	}
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	s.LabelAssociations = a.LabelAssociations
+
+	e, err := endpoint.UnmarshalJSON(a.NotificationEndpoint)
+	s.NotificationEndpoint = e
+	return err
 }
 
 // SummaryLabel provides a summary of a pkg label.
 type SummaryLabel struct {
-	influxdb.Label
+	ID         SafeID `json:"id"`
+	OrgID      SafeID `json:"orgID"`
+	Name       string `json:"name"`
+	Properties struct {
+		Color       string `json:"color"`
+		Description string `json:"description"`
+	} `json:"properties"`
 }
 
 // SummaryLabelMapping provides a summary of a label mapped with a single resource.
 type SummaryLabelMapping struct {
 	exists       bool
-	ResourceName string `json:"resourceName"`
-	LabelName    string `json:"labelName"`
-	influxdb.LabelMapping
+	ResourceID   SafeID                `json:"resourceID"`
+	ResourceName string                `json:"resourceName"`
+	ResourceType influxdb.ResourceType `json:"resourceType"`
+	LabelName    string                `json:"labelName"`
+	LabelID      SafeID                `json:"labelID"`
 }
 
 // SummaryTelegraf provides a summary of a pkg telegraf config.
 type SummaryTelegraf struct {
-	influxdb.TelegrafConfig
-	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+	TelegrafConfig    influxdb.TelegrafConfig `json:"telegrafConfig"`
+	LabelAssociations []SummaryLabel          `json:"labelAssociations"`
 }
 
 // SummaryVariable provides a summary of a pkg variable.
 type SummaryVariable struct {
-	influxdb.Variable
-	LabelAssociations []influxdb.Label `json:"labelAssociations"`
+	ID                SafeID                      `json:"id,omitempty"`
+	OrgID             SafeID                      `json:"orgID,omitempty"`
+	Name              string                      `json:"name"`
+	Description       string                      `json:"description"`
+	Arguments         *influxdb.VariableArguments `json:"arguments"`
+	LabelAssociations []SummaryLabel              `json:"labelAssociations"`
 }
 
 const (
@@ -544,14 +628,12 @@ func (b *bucket) Exists() bool {
 
 func (b *bucket) summarize() SummaryBucket {
 	return SummaryBucket{
-		Bucket: influxdb.Bucket{
-			ID:              b.ID(),
-			OrgID:           b.OrgID,
-			Name:            b.Name(),
-			Description:     b.Description,
-			RetentionPeriod: b.RetentionRules.RP(),
-		},
-		LabelAssociations: toInfluxLabels(b.labels...),
+		ID:                SafeID(b.ID()),
+		OrgID:             SafeID(b.OrgID),
+		Name:              b.Name(),
+		Description:       b.Description,
+		RetentionPeriod:   b.RetentionRules.RP(),
+		LabelAssociations: toSummaryLabels(b.labels...),
 	}
 }
 
@@ -730,11 +812,15 @@ func (l *label) shouldApply() bool {
 
 func (l *label) summarize() SummaryLabel {
 	return SummaryLabel{
-		Label: influxdb.Label{
-			ID:         l.ID(),
-			OrgID:      l.OrgID,
-			Name:       l.Name(),
-			Properties: l.properties(),
+		ID:    SafeID(l.ID()),
+		OrgID: SafeID(l.OrgID),
+		Name:  l.Name(),
+		Properties: struct {
+			Color       string `json:"color"`
+			Description string `json:"description"`
+		}{
+			Color:       l.Color,
+			Description: l.Description,
 		},
 	}
 }
@@ -745,13 +831,11 @@ func (l *label) mappingSummary() []SummaryLabelMapping {
 		for _, v := range vals {
 			mappings = append(mappings, SummaryLabelMapping{
 				exists:       v.exists,
+				ResourceID:   SafeID(v.ID()),
 				ResourceName: resource.name,
+				ResourceType: resource.resType,
+				LabelID:      SafeID(l.ID()),
 				LabelName:    l.Name(),
-				LabelMapping: influxdb.LabelMapping{
-					LabelID:      l.ID(),
-					ResourceID:   v.ID(),
-					ResourceType: resource.resType,
-				},
 			})
 		}
 	}
@@ -775,10 +859,10 @@ func (l *label) toInfluxLabel() influxdb.Label {
 	}
 }
 
-func toInfluxLabels(labels ...*label) []influxdb.Label {
-	var iLabels []influxdb.Label
+func toSummaryLabels(labels ...*label) []SummaryLabel {
+	var iLabels []SummaryLabel
 	for _, l := range labels {
-		iLabels = append(iLabels, l.toInfluxLabel())
+		iLabels = append(iLabels, l.summarize())
 	}
 	return iLabels
 }
@@ -864,13 +948,18 @@ func (n *notificationEndpoint) ResourceType() influxdb.ResourceType {
 }
 
 func (n *notificationEndpoint) base() endpoint.Base {
-	return endpoint.Base{
-		ID:          n.ID(),
-		OrgID:       n.OrgID,
+	e := endpoint.Base{
 		Name:        n.Name(),
 		Description: n.description,
 		Status:      influxdb.TaskStatusActive,
 	}
+	if id := n.ID(); id > 0 {
+		e.ID = &id
+	}
+	if orgID := n.OrgID; orgID > 0 {
+		e.OrgID = &orgID
+	}
+	return e
 }
 
 func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
@@ -879,7 +968,7 @@ func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
 		base.Status = influxdb.Status(n.status)
 	}
 	sum := SummaryNotificationEndpoint{
-		LabelAssociations: toInfluxLabels(n.labels...),
+		LabelAssociations: toSummaryLabels(n.labels...),
 	}
 
 	switch n.kind {
@@ -921,7 +1010,7 @@ func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
 	return sum
 }
 
-var validHTTPMethods = map[string]bool{
+var validEndpointHTTPMethods = map[string]bool{
 	"DELETE":  true,
 	"GET":     true,
 	"HEAD":    true,
@@ -952,11 +1041,11 @@ func (n *notificationEndpoint) valid() []validationErr {
 		if n.routingKey == "" {
 			failures = append(failures, validationErr{
 				Field: fieldNotificationEndpointRoutingKey,
-				Msg:   "must provide non empty string",
+				Msg:   "must be provide",
 			})
 		}
 	case notificationKindHTTP:
-		if !validHTTPMethods[n.method] {
+		if !validEndpointHTTPMethods[n.method] {
 			failures = append(failures, validationErr{
 				Field: fieldNotificationEndpointHTTPMethod,
 				Msg:   "http method must be a valid HTTP verb",
@@ -1044,7 +1133,7 @@ func (t *telegraf) Exists() bool {
 func (t *telegraf) summarize() SummaryTelegraf {
 	return SummaryTelegraf{
 		TelegrafConfig:    t.config,
-		LabelAssociations: toInfluxLabels(t.labels...),
+		LabelAssociations: toSummaryLabels(t.labels...),
 	}
 }
 
@@ -1112,14 +1201,12 @@ func (v *variable) shouldApply() bool {
 
 func (v *variable) summarize() SummaryVariable {
 	return SummaryVariable{
-		Variable: influxdb.Variable{
-			ID:             v.ID(),
-			OrganizationID: v.OrgID,
-			Name:           v.Name(),
-			Description:    v.Description,
-			Arguments:      v.influxVarArgs(),
-		},
-		LabelAssociations: toInfluxLabels(v.labels...),
+		ID:                SafeID(v.ID()),
+		OrgID:             SafeID(v.OrgID),
+		Name:              v.Name(),
+		Description:       v.Description,
+		Arguments:         v.influxVarArgs(),
+		LabelAssociations: toSummaryLabels(v.labels...),
 	}
 }
 
@@ -1225,7 +1312,7 @@ func (d *dashboard) summarize() SummaryDashboard {
 		OrgID:             SafeID(d.OrgID),
 		Name:              d.Name(),
 		Description:       d.Description,
-		LabelAssociations: toInfluxLabels(d.labels...),
+		LabelAssociations: toSummaryLabels(d.labels...),
 	}
 	for _, c := range d.Charts {
 		iDash.Charts = append(iDash.Charts, SummaryChart{

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -37,8 +37,8 @@ func TestPkg(t *testing.T) {
 			require.Len(t, summary.Buckets, len(pkg.mBuckets))
 			for i := 1; i <= len(summary.Buckets); i++ {
 				buck := summary.Buckets[i-1]
-				assert.Equal(t, influxdb.ID(i), buck.ID)
-				assert.Equal(t, influxdb.ID(100), buck.OrgID)
+				assert.Equal(t, SafeID(i), buck.ID)
+				assert.Equal(t, SafeID(100), buck.OrgID)
 				assert.Equal(t, "desc"+strconv.Itoa(i), buck.Description)
 				assert.Equal(t, "name"+strconv.Itoa(i), buck.Name)
 				assert.Equal(t, time.Duration(i)*time.Hour, buck.RetentionPeriod)
@@ -69,18 +69,18 @@ func TestPkg(t *testing.T) {
 
 			require.Len(t, summary.Labels, len(pkg.mLabels))
 			label1 := summary.Labels[0]
-			assert.Equal(t, influxdb.ID(1), label1.ID)
-			assert.Equal(t, influxdb.ID(100), label1.OrgID)
-			assert.Equal(t, "desc1", label1.Properties["description"])
+			assert.Equal(t, SafeID(1), label1.ID)
+			assert.Equal(t, SafeID(100), label1.OrgID)
 			assert.Equal(t, "name1", label1.Name)
-			assert.Equal(t, "peru", label1.Properties["color"])
+			assert.Equal(t, "desc1", label1.Properties.Description)
+			assert.Equal(t, "peru", label1.Properties.Color)
 
 			label2 := summary.Labels[1]
-			assert.Equal(t, influxdb.ID(2), label2.ID)
-			assert.Equal(t, influxdb.ID(100), label2.OrgID)
-			assert.Equal(t, "desc2", label2.Properties["description"])
+			assert.Equal(t, SafeID(2), label2.ID)
+			assert.Equal(t, SafeID(100), label2.OrgID)
+			assert.Equal(t, "desc2", label2.Properties.Description)
 			assert.Equal(t, "name2", label2.Name)
-			assert.Equal(t, "blurple", label2.Properties["color"])
+			assert.Equal(t, "blurple", label2.Properties.Color)
 		})
 
 		t.Run("label mappings returned in asc order by name", func(t *testing.T) {
@@ -116,10 +116,10 @@ func TestPkg(t *testing.T) {
 
 			require.Len(t, summary.LabelMappings, 1)
 			mapping1 := summary.LabelMappings[0]
-			assert.Equal(t, bucket1.id, mapping1.ResourceID)
+			assert.Equal(t, SafeID(bucket1.id), mapping1.ResourceID)
 			assert.Equal(t, bucket1.Name(), mapping1.ResourceName)
 			assert.Equal(t, influxdb.BucketsResourceType, mapping1.ResourceType)
-			assert.Equal(t, label1.id, mapping1.LabelID)
+			assert.Equal(t, SafeID(label1.id), mapping1.LabelID)
 			assert.Equal(t, label1.Name(), mapping1.LabelName)
 		})
 	})

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -118,11 +118,9 @@ spec:
 
 				actual := buckets[0]
 				expectedBucket := SummaryBucket{
-					Bucket: influxdb.Bucket{
-						Name:            "rucket_11",
-						Description:     "bucket 1 description",
-						RetentionPeriod: time.Hour,
-					},
+					Name:            "rucket_11",
+					Description:     "bucket 1 description",
+					RetentionPeriod: time.Hour,
 				}
 				assert.Equal(t, expectedBucket, actual)
 			})
@@ -345,7 +343,7 @@ spec:
 
 			require.Len(t, sum.LabelMappings, len(expectedMappings))
 			for i, expected := range expectedMappings {
-				expected.LabelMapping.ResourceType = influxdb.BucketsResourceType
+				expected.ResourceType = influxdb.BucketsResourceType
 				assert.Equal(t, expected, sum.LabelMappings[i])
 			}
 		})
@@ -2605,7 +2603,7 @@ spec:
 			require.Len(t, sum.LabelMappings, len(expectedMappings))
 
 			for i, expected := range expectedMappings {
-				expected.LabelMapping.ResourceType = influxdb.DashboardsResourceType
+				expected.ResourceType = influxdb.DashboardsResourceType
 				assert.Equal(t, expected, sum.LabelMappings[i])
 			}
 		})
@@ -2782,11 +2780,9 @@ spec:
 
 				require.Len(t, sum.LabelMappings, len(expectedEndpoints))
 				expectedMapping := SummaryLabelMapping{
-					ResourceName: expected.GetName(),
+					ResourceName: expected.NotificationEndpoint.GetName(),
 					LabelName:    "label_1",
-					LabelMapping: influxdb.LabelMapping{
-						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
+					ResourceType: influxdb.NotificationEndpointResourceType,
 				}
 				assert.Contains(t, sum.LabelMappings, expectedMapping)
 			}
@@ -3091,8 +3087,8 @@ spec:
 				require.Len(t, sum.TelegrafConfigs, 1)
 
 				actual := sum.TelegrafConfigs[0]
-				assert.Equal(t, "first_tele_config", actual.Name)
-				assert.Equal(t, "desc", actual.Description)
+				assert.Equal(t, "first_tele_config", actual.TelegrafConfig.Name)
+				assert.Equal(t, "desc", actual.TelegrafConfig.Description)
 
 				require.Len(t, actual.LabelAssociations, 1)
 				assert.Equal(t, "label_1", actual.LabelAssociations[0].Name)
@@ -3101,9 +3097,7 @@ spec:
 				expectedMapping := SummaryLabelMapping{
 					ResourceName: "first_tele_config",
 					LabelName:    "label_1",
-					LabelMapping: influxdb.LabelMapping{
-						ResourceType: influxdb.TelegrafsResourceType,
-					},
+					ResourceType: influxdb.TelegrafsResourceType,
 				}
 				assert.Equal(t, expectedMapping, sum.LabelMappings[0])
 			})
@@ -3366,7 +3360,7 @@ spec:
 
 			require.Len(t, sum.LabelMappings, len(expectedMappings))
 			for i, expected := range expectedMappings {
-				expected.LabelMapping.ResourceType = influxdb.VariablesResourceType
+				expected.ResourceType = influxdb.VariablesResourceType
 				assert.Equal(t, expected, sum.LabelMappings[i])
 			}
 		})

--- a/telegraf_test.go
+++ b/telegraf_test.go
@@ -193,15 +193,17 @@ func TestTelegrafConfigJSONCompatibleMode(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		got := new(TelegrafConfig)
-		err := json.Unmarshal(c.src, got)
-		if diff := cmp.Diff(err, c.err); diff != "" {
-			t.Fatalf("%s decode failed, got err: %v, should be %v", c.name, err, c.err)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			got := new(TelegrafConfig)
+			err := json.Unmarshal(c.src, got)
+			if diff := cmp.Diff(err, c.err); diff != "" {
+				t.Fatalf("%s decode failed, got err: %v, should be %v", c.name, err, c.err)
+			}
 
-		if diff := cmp.Diff(got, c.cfg, telegrafCmpOptions...); c.err == nil && diff != "" {
-			t.Errorf("failed %s, telegraf configs are different -got/+want\ndiff %s", c.name, diff)
-		}
+			if diff := cmp.Diff(got, c.cfg, telegrafCmpOptions...); c.err == nil && diff != "" {
+				t.Errorf("failed %s, telegraf configs are different -got/+want\ndiff %s", c.name, diff)
+			}
+		})
 	}
 }
 

--- a/testing/notification_endpoint.go
+++ b/testing/notification_endpoint.go
@@ -109,9 +109,9 @@ func CreateNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -138,7 +138,7 @@ func CreateNotificationEndpoint(
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
 						Name:   "name2",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Active,
 					},
 					ClientURL: "example-pagerduty.com",
@@ -151,9 +151,9 @@ func CreateNotificationEndpoint(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -165,9 +165,9 @@ func CreateNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: fakeDate,
@@ -268,9 +268,9 @@ func FindNotificationEndpointByID(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -282,9 +282,9 @@ func FindNotificationEndpointByID(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -326,9 +326,9 @@ func FindNotificationEndpointByID(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -340,9 +340,9 @@ func FindNotificationEndpointByID(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -384,9 +384,9 @@ func FindNotificationEndpointByID(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -398,9 +398,9 @@ func FindNotificationEndpointByID(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -418,9 +418,9 @@ func FindNotificationEndpointByID(
 			wants: wants{
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
-						ID:     MustIDBase16(twoID),
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name2",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Active,
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: timeGen1.Now(),
@@ -500,9 +500,9 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -514,9 +514,9 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -540,9 +540,9 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -554,9 +554,9 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -605,8 +605,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -615,8 +615,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -625,8 +625,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(oneID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -648,8 +648,8 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(oneID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -689,8 +689,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -699,8 +699,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -710,8 +710,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(oneID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -733,8 +733,8 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -743,8 +743,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -785,8 +785,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -795,8 +795,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -806,8 +806,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -832,8 +832,8 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -842,8 +842,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -891,8 +891,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -901,8 +901,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -912,8 +912,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -938,8 +938,8 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -949,8 +949,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -996,8 +996,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -1006,8 +1006,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -1017,8 +1017,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(oneID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -1040,8 +1040,8 @@ func FindNotificationEndpoints(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(fourID),
-							OrgID:  MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(fourID),
+							OrgID:  MustIDBase16Ptr(oneID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -1087,8 +1087,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -1097,8 +1097,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -1108,8 +1108,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(threeID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(threeID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -1160,8 +1160,8 @@ func FindNotificationEndpoints(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(oneID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp1",
 						},
@@ -1170,8 +1170,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.HTTP{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(twoID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp2",
 						},
@@ -1181,8 +1181,8 @@ func FindNotificationEndpoints(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(threeID),
-							OrgID:  MustIDBase16(fourID),
+							ID:     MustIDBase16Ptr(threeID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							Name:   "edp3",
 						},
@@ -1265,9 +1265,9 @@ func UpdateNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1279,9 +1279,9 @@ func UpdateNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1298,9 +1298,9 @@ func UpdateNotificationEndpoint(
 				orgID:  MustIDBase16(fourID),
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
-						ID:     MustIDBase16(twoID),
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name2",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 					},
 					ClientURL:  "example-pagerduty.com",
@@ -1335,9 +1335,9 @@ func UpdateNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1349,9 +1349,9 @@ func UpdateNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1369,7 +1369,7 @@ func UpdateNotificationEndpoint(
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
 						Name:   "name3",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 					},
 					ClientURL:  "example-pagerduty2.com",
@@ -1379,9 +1379,9 @@ func UpdateNotificationEndpoint(
 			wants: wants{
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
-						ID:     MustIDBase16(twoID),
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name3",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: timeGen1.Now(),
@@ -1414,9 +1414,9 @@ func UpdateNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1428,9 +1428,9 @@ func UpdateNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1449,7 +1449,7 @@ func UpdateNotificationEndpoint(
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
 						Name:   "name3",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 					},
 					ClientURL: "example-pagerduty2.com",
@@ -1462,9 +1462,9 @@ func UpdateNotificationEndpoint(
 			wants: wants{
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
-						ID:     MustIDBase16(twoID),
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name3",
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: timeGen1.Now(),
@@ -1545,9 +1545,9 @@ func PatchNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1559,9 +1559,9 @@ func PatchNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1608,10 +1608,10 @@ func PatchNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
 							Status: influxdb.Active,
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
 								UpdatedAt: timeGen2.Now(),
@@ -1622,10 +1622,10 @@ func PatchNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
 							Status: influxdb.Active,
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
 								UpdatedAt: timeGen2.Now(),
@@ -1646,10 +1646,10 @@ func PatchNotificationEndpoint(
 			wants: wants{
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
-						ID:     MustIDBase16(twoID),
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   name3,
 						Status: status3,
-						OrgID:  MustIDBase16(fourID),
+						OrgID:  MustIDBase16Ptr(fourID),
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: timeGen1.Now(),
 							UpdatedAt: fakeDate,
@@ -1720,9 +1720,9 @@ func DeleteNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1734,9 +1734,9 @@ func DeleteNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1775,9 +1775,9 @@ func DeleteNotificationEndpoint(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1789,9 +1789,9 @@ func DeleteNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1823,9 +1823,9 @@ func DeleteNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1837,9 +1837,9 @@ func DeleteNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1877,9 +1877,9 @@ func DeleteNotificationEndpoint(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1891,9 +1891,9 @@ func DeleteNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1926,9 +1926,9 @@ func DeleteNotificationEndpoint(
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1940,9 +1940,9 @@ func DeleteNotificationEndpoint(
 					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(twoID),
+							ID:     MustIDBase16Ptr(twoID),
 							Name:   "name2",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),
@@ -1975,9 +1975,9 @@ func DeleteNotificationEndpoint(
 				notificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
+							ID:     MustIDBase16Ptr(oneID),
 							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Status: influxdb.Active,
 							CRUDLog: influxdb.CRUDLog{
 								CreatedAt: timeGen1.Now(),

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -118,7 +118,7 @@ func CreateNotificationRule(
 							Value: strPtr("abc123"),
 						},
 						Base: endpoint.Base{
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Name:   "foo",
 							Status: influxdb.Active,
 						},
@@ -1776,7 +1776,7 @@ func UpdateNotificationRule(
 							Value: strPtr("abc123"),
 						},
 						Base: endpoint.Base{
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Name:   "foo",
 							Status: influxdb.Active,
 						},
@@ -2039,7 +2039,7 @@ func PatchNotificationRule(
 							Value: strPtr("abc123"),
 						},
 						Base: endpoint.Base{
-							OrgID:  MustIDBase16(fourID),
+							OrgID:  MustIDBase16Ptr(fourID),
 							Name:   "foo",
 							Status: influxdb.Active,
 						},

--- a/testing/util.go
+++ b/testing/util.go
@@ -57,3 +57,9 @@ func MustIDBase16(s string) platform.ID {
 	}
 	return *id
 }
+
+// MustIDBase16Ptr is an helper to ensure a correct ID ptr ref is built during testing.
+func MustIDBase16Ptr(s string) *platform.ID {
+	id := MustIDBase16(s)
+	return &id
+}


### PR DESCRIPTION
realized as of recent I hadn't set the integration tests to use the server/client. This is a major issue, since I wasn't testing the public API 😳. When changed to use HTTP server, a lot of problems came out of that. This PR remedies the integration tests to use the http server/client and fixes up a bunch of other stuff to make that a reality.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] extend e2e tests to check for dashboard charts (broken atm when going through server, is b/c our dashboard changes only affected the http handler layer, when we remedy the store itself we can axe this)
- [x] fix dashboard to do the looping it has too, unfortunately necessary behind the server side, was never caught b/c e2e tests didn't go through server