### PR TITLE
fix(ui): sort by modified now integrated

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -164,18 +164,20 @@ export const setDashboards = (
   status: RemoteDataState,
   list?: Dashboard[]
 ): SetDashboardsAction => {
-  list = list.map(obj => {
-    if (obj.name !== undefined) {
-      obj.name = ''
-    }
-    if (obj.meta !== undefined) {
-      obj.meta = {}
-    }
-    if (obj.meta.updatedAt !== undefined) {
-      obj.meta.updatedAt = new Date().toDateString()
-    }
-    return obj
-  })
+  if (list) {
+    list = list.map(obj => {
+      if (obj.name === undefined) {
+        obj.name = ''
+      }
+      if (obj.meta === undefined) {
+        obj.meta = {}
+      }
+      if (obj.meta.updatedAt === undefined) {
+        obj.meta.updatedAt = new Date().toDateString()
+      }
+      return obj
+    })
+  }
 
   return {
     type: ActionTypes.SetDashboards,

--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -163,13 +163,28 @@ export const editDashboard = (dashboard: Dashboard): EditDashboardAction => ({
 export const setDashboards = (
   status: RemoteDataState,
   list?: Dashboard[]
-): SetDashboardsAction => ({
-  type: ActionTypes.SetDashboards,
-  payload: {
-    status,
-    list,
-  },
-})
+): SetDashboardsAction => {
+  list = list.map(obj => {
+    if (obj.name !== undefined) {
+      obj.name = ''
+    }
+    if (obj.meta !== undefined) {
+      obj.meta = {}
+    }
+    if (obj.meta.updatedAt !== undefined) {
+      obj.meta.updatedAt = new Date().toDateString()
+    }
+    return obj
+  })
+
+  return {
+    type: ActionTypes.SetDashboards,
+    payload: {
+      status,
+      list,
+    },
+  }
+}
 
 export const setDashboard = (dashboard: Dashboard): SetDashboardAction => ({
   type: ActionTypes.SetDashboard,

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -59,14 +59,14 @@ class DashboardsTable extends PureComponent<Props, State> {
         <ResourceList.Header filterComponent={filterComponent}>
           <ResourceList.Sorter
             name="name"
-            sortKey={this.headerKeys[0]}
-            sort={sortKey === this.headerKeys[0] ? sortDirection : Sort.None}
+            sortKey="name"
+            sort={sortKey === 'name' ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <ResourceList.Sorter
             name="modified"
-            sortKey={this.headerKeys[1]}
-            sort={sortKey === this.headerKeys[1] ? sortDirection : Sort.None}
+            sortKey="meta.updatedAt"
+            sort={sortKey === 'meta.updatedAt' ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
         </ResourceList.Header>
@@ -89,10 +89,6 @@ class DashboardsTable extends PureComponent<Props, State> {
         </ResourceList.Body>
       </ResourceList>
     )
-  }
-
-  private get headerKeys(): SortKey[] {
-    return ['name', 'meta.updatedAt']
   }
 
   private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -31,7 +31,7 @@ interface State {
   sortType: SortTypes
 }
 
-type SortKey = keyof Dashboard | 'modified'
+type SortKey = keyof Dashboard | 'meta.updatedAt'
 
 type Props = OwnProps & WithRouterProps
 
@@ -58,13 +58,13 @@ class DashboardsTable extends PureComponent<Props, State> {
       <ResourceList>
         <ResourceList.Header filterComponent={filterComponent}>
           <ResourceList.Sorter
-            name={this.headerKeys[0]}
+            name="name"
             sortKey={this.headerKeys[0]}
             sort={sortKey === this.headerKeys[0] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <ResourceList.Sorter
-            name={this.headerKeys[1]}
+            name="modified"
             sortKey={this.headerKeys[1]}
             sort={sortKey === this.headerKeys[1] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
@@ -92,13 +92,12 @@ class DashboardsTable extends PureComponent<Props, State> {
   }
 
   private get headerKeys(): SortKey[] {
-    return ['name', 'modified']
+    return ['name', 'meta.updatedAt']
   }
 
   private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {
     let sortType = SortTypes.String
-
-    if (sortKey === 'modified') {
+    if (sortKey === 'meta.updatedAt') {
       sortType = SortTypes.Date
     }
 

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -1,6 +1,7 @@
 // Libraries
 import {useMemo} from 'react'
 import {NumericColumnData} from '@influxdata/giraffe'
+import {isNull} from 'lodash'
 
 // Utils
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
@@ -22,7 +23,7 @@ export const getValidRange = (
   timeRange: TimeRange | null
 ) => {
   const range = extent((data as number[]) || [])
-  if (!timeRange) {
+  if (isNull(timeRange)) {
     return range
   }
   if (range && range.length >= 2) {


### PR DESCRIPTION
Closes #15610

### Problem

Sorting dashboards by modified dates defaulted to sorting by name

### Solution

Pass in the correct property to sort by so that the orderby function can sort the elements by their appropriate props

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)