### PR TITLE
fix(storage): skip TSM files with block read errors

### DIFF
--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,7 +297,8 @@ func TestCompactor_DecodeError(t *testing.T) {
 	compactor.Open()
 
 	files, err = compactor.CompactFull([]string{f1, f2, f3})
-	if err == nil || err.Error() != "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp" {
+	if err == nil ||
+		!strings.Contains(err.Error(), "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp") {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2175,11 +2175,10 @@ func (s *compactionStrategy) compactGroup() {
 		if _, ok := err.(errBlockRead); ok {
 			path := err.(errBlockRead).file
 			log.Info("Renaming a corrupt TSM file due to compaction error", zap.Error(err))
-			if e := os.Rename(path, path+"."+BadTSMFileExtension); e != nil {
-				log.Info("Error renaming corrupt TSM file", zap.Error((err)))
-			}
 			if err := s.fileStore.ReplaceWithCallback([]string{path}, nil, nil); err != nil {
 				log.Info("Error removing bad TSM file", zap.Error(err))
+			} else if e := os.Rename(path, path+"."+BadTSMFileExtension); e != nil {
+				log.Info("Error renaming corrupt TSM file", zap.Error((err)))
 			}
 		}
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2170,6 +2170,19 @@ func (s *compactionStrategy) compactGroup() {
 		}
 
 		log.Info("Error compacting TSM files", zap.Error(err))
+
+		// We hit a bad TSM file - rename so the next compaction can proceed.
+		if _, ok := err.(errBlockRead); ok {
+			path := err.(errBlockRead).file
+			log.Info("Renaming a corrupt TSM file due to compaction error", zap.Error(err))
+			if e := os.Rename(path, path+"."+BadTSMFileExtension); e != nil {
+				log.Info("Error renaming corrupt TSM file", zap.Error((err)))
+			}
+			if err := s.fileStore.ReplaceWithCallback([]string{path}, nil, nil); err != nil {
+				log.Info("Error removing bad TSM file", zap.Error(err))
+			}
+		}
+
 		atomic.AddInt64(s.errorStat, 1)
 		time.Sleep(time.Second)
 		return

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -198,6 +198,7 @@ func (b *BlockIterator) Read() (key []byte, minTime int64, maxTime int64, typ by
 	}
 	checksum, buf, err = b.r.ReadBytes(&b.entries[0], nil)
 	if err != nil {
+		b.err = err
 		return nil, 0, 0, 0, 0, nil, err
 	}
 	return b.key, b.entries[0].MinTime, b.entries[0].MaxTime, b.typ, checksum, buf, err


### PR DESCRIPTION
When we find a bad TSM file during compaction, propagate the error up and move
the bad file aside. The engine will disregard the file so the next compaction
will not hit the same error.

Backport of https://github.com/influxdata/influxdb/pull/15885