### PR TITLE
feat(cmd): apply env vars consistently across cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Bug Fixes
+1. [16225](https://github.com/influxdata/influxdb/pull/16225): Ensures env vars are applied consistently across cmd, and fixes issue where INFLUX_ env var prefix was not set globally.
 
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting
 1. [16238](https://github.com/influxdata/influxdb/pull/16238): Store canceled task runs in the correct bucket

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx/internal"
 	"github.com/influxdata/influxdb/http"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // AuthorizationCreateFlags are command line args used when creating a authorization
@@ -77,6 +78,10 @@ func authCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&authCreateFlags.org, "org", "o", "", "The organization name (required)")
 	cmd.MarkFlagRequired("org")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		authCreateFlags.org = h
+	}
 
 	cmd.Flags().StringVarP(&authCreateFlags.user, "user", "u", "", "The user name")
 
@@ -297,7 +302,16 @@ func authFindCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "The user")
 	cmd.Flags().StringVarP(&authorizationFindFlags.userID, "user-id", "", "", "The user ID")
 	cmd.Flags().StringVarP(&authorizationFindFlags.org, "org", "o", "", "The org")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		authorizationFindFlags.org = h
+	}
+
 	cmd.Flags().StringVarP(&authorizationFindFlags.orgID, "org-id", "", "", "The org ID")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		authorizationFindFlags.orgID = h
+	}
 	cmd.Flags().StringVarP(&authorizationFindFlags.id, "id", "i", "", "The authorization ID")
 
 	return cmd

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx/internal"
 	"github.com/influxdata/influxdb/http"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // Bucket Command
@@ -25,9 +26,8 @@ func bucketF(cmd *cobra.Command, args []string) {
 
 // BucketCreateFlags define the Create Command
 type BucketCreateFlags struct {
-	name      string
-	orgID     string
-	org       string
+	name string
+	organization
 	retention time.Duration
 }
 
@@ -42,9 +42,8 @@ func init() {
 
 	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.name, "name", "n", "", "Name of bucket that will be created")
 	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "Duration in nanoseconds data will live in bucket")
-	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.orgID, "org-id", "", "", "The ID of the organization that owns the bucket")
-	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.org, "org", "o", "", "The org name")
 	bucketCreateCmd.MarkFlagRequired("name")
+	bucketCreateFlags.organization.register(bucketCreateCmd)
 
 	bucketCmd.AddCommand(bucketCreateCmd)
 }
@@ -65,10 +64,8 @@ func newBucketService(f Flags) (platform.BucketService, error) {
 }
 
 func bucketCreateF(cmd *cobra.Command, args []string) error {
-	if bucketCreateFlags.orgID == "" && bucketCreateFlags.org == "" {
-		return fmt.Errorf("must specify org-id, or org name")
-	} else if bucketCreateFlags.orgID != "" && bucketCreateFlags.org != "" {
-		return fmt.Errorf("must specify org-id, or org name not both")
+	if err := bucketCreateFlags.organization.validOrgFlags(); err != nil {
+		return err
 	}
 
 	s, err := newBucketService(flags)
@@ -86,7 +83,7 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	b.OrgID, err = getOrgID(orgSvc, bucketCreateFlags.orgID, bucketCreateFlags.org)
+	b.OrgID, err = bucketCreateFlags.organization.getID(orgSvc)
 	if err != nil {
 		return err
 	}
@@ -117,9 +114,8 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 type BucketFindFlags struct {
 	name    string
 	id      string
-	org     string
-	orgID   string
 	headers bool
+	organization
 }
 
 var bucketFindFlags BucketFindFlags
@@ -132,10 +128,13 @@ func init() {
 	}
 
 	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.name, "name", "n", "", "The bucket name")
+	viper.BindEnv("BUCKET_NAME")
+	if h := viper.GetString("BUCKET_NAME"); h != "" {
+		bucketFindFlags.name = h
+	}
 	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.id, "id", "i", "", "The bucket ID")
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.orgID, "org-id", "", "", "The bucket organization ID")
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.org, "org", "o", "", "The bucket organization name")
 	bucketFindCmd.Flags().BoolVar(&bucketFindFlags.headers, "headers", true, "To print the table headers; defaults true")
+	bucketFindFlags.organization.register(bucketFindCmd)
 
 	bucketCmd.AddCommand(bucketFindCmd)
 }
@@ -159,20 +158,20 @@ func bucketFindF(cmd *cobra.Command, args []string) error {
 		filter.ID = id
 	}
 
-	if bucketFindFlags.orgID != "" && bucketFindFlags.org != "" {
-		return fmt.Errorf("must specify at exactly one of org and org-id")
+	if err := bucketFindFlags.organization.validOrgFlags(); err != nil {
+		return err
 	}
 
-	if bucketFindFlags.orgID != "" {
-		orgID, err := platform.IDFromString(bucketFindFlags.orgID)
+	if bucketFindFlags.organization.id != "" {
+		orgID, err := platform.IDFromString(bucketFindFlags.organization.id)
 		if err != nil {
-			return fmt.Errorf("failed to decode org id %q: %v", bucketFindFlags.orgID, err)
+			return fmt.Errorf("failed to decode org id %q: %v", bucketFindFlags.organization.id, err)
 		}
 		filter.OrganizationID = orgID
 	}
 
-	if bucketFindFlags.org != "" {
-		filter.Org = &bucketFindFlags.org
+	if bucketFindFlags.organization.name != "" {
+		filter.Org = &bucketFindFlags.organization.name
 	}
 
 	buckets, _, err := s.FindBuckets(context.Background(), filter)
@@ -219,6 +218,11 @@ func init() {
 
 	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.id, "id", "i", "", "The bucket ID (required)")
 	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.name, "name", "n", "", "New bucket name")
+	viper.BindEnv("BUCKET_NAME")
+	if h := viper.GetString("BUCKET_NAME"); h != "" {
+		bucketFindFlags.name = h
+	}
+
 	bucketUpdateCmd.Flags().DurationVarP(&bucketUpdateFlags.retention, "retention", "r", 0, "New duration data will live in bucket")
 	bucketUpdateCmd.MarkFlagRequired("id")
 

--- a/cmd/influx/inspect.go
+++ b/cmd/influx/inspect.go
@@ -17,9 +17,9 @@ type InspectReportTSMFlags struct {
 	pattern  string
 	exact    bool
 	detailed bool
-
-	orgID, org, bucketID string
-	dataDir              string
+	organization
+	bucketID string
+	dataDir  string
 }
 
 var inspectReportTSMFlags InspectReportTSMFlags
@@ -62,8 +62,7 @@ in the following ways:
 	inspectReportTSMCommand.Flags().BoolVarP(&inspectReportTSMFlags.exact, "exact", "", false, "calculate and exact cardinality count. Warning, may use significant memory...")
 	inspectReportTSMCommand.Flags().BoolVarP(&inspectReportTSMFlags.detailed, "detailed", "", false, "emit series cardinality segmented by measurements, tag keys and fields. Warning, may take a while.")
 
-	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.orgID, "org-id", "", "", "process only data belonging to organization ID.")
-	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.org, "org", "o", "", "process only data belonging to organization name.")
+	inspectReportTSMFlags.organization.register(inspectReportTSMCommand)
 	inspectReportTSMCommand.Flags().StringVarP(&inspectReportTSMFlags.bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
 
 	dir, err := fs.InfluxDir()
@@ -76,10 +75,8 @@ in the following ways:
 
 // inspectReportTSMF runs the report-tsm tool.
 func inspectReportTSMF(cmd *cobra.Command, args []string) error {
-	if inspectReportTSMFlags.orgID == "" && inspectReportTSMFlags.org == "" {
-		return fmt.Errorf("must specify org-id, or org name")
-	} else if inspectReportTSMFlags.orgID != "" && inspectReportTSMFlags.org != "" {
-		return fmt.Errorf("must specify org-id, or org name not both")
+	if err := inspectReportTSMFlags.organization.validOrgFlags(); err != nil {
+		return err
 	}
 	report := &tsm1.Report{
 		Stderr:   os.Stderr,
@@ -90,7 +87,7 @@ func inspectReportTSMF(cmd *cobra.Command, args []string) error {
 		Exact:    inspectReportTSMFlags.exact,
 	}
 
-	if (inspectReportTSMFlags.org == "" || inspectReportTSMFlags.orgID == "") && inspectReportTSMFlags.bucketID != "" {
+	if (inspectReportTSMFlags.organization.name == "" || inspectReportTSMFlags.organization.id == "") && inspectReportTSMFlags.bucketID != "" {
 		return errors.New("org-id must be set for non-empty bucket-id")
 	}
 
@@ -98,7 +95,7 @@ func inspectReportTSMF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return nil
 	}
-	id, err := getOrgID(orgSvc, bucketCreateFlags.orgID, bucketCreateFlags.org)
+	id, err := inspectReportTSMFlags.organization.getID(orgSvc)
 	if err != nil {
 		return nil
 	}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -83,6 +83,9 @@ func influxCmd() *cobra.Command {
 			cmd.Usage()
 		},
 	}
+
+	viper.SetEnvPrefix("INFLUX")
+
 	cmd.AddCommand(
 		authCmd(),
 		bucketCmd,
@@ -98,8 +101,6 @@ func influxCmd() *cobra.Command {
 		userCmd(),
 		writeCmd,
 	)
-
-	viper.SetEnvPrefix("INFLUX")
 
 	cmd.PersistentFlags().StringVarP(&flags.token, "token", "t", "", "API token to be used throughout client calls")
 	viper.BindEnv("TOKEN")
@@ -230,22 +231,47 @@ func newLocalKVService() (*kv.Service, error) {
 	return kv.NewService(zap.NewNop(), store), nil
 }
 
-func getOrgID(orgSVC influxdb.OrganizationService, id string, name string) (influxdb.ID, error) {
-	if id != "" {
-		influxOrgID, err := influxdb.IDFromString(id)
+type organization struct {
+	id, name string
+}
+
+func (org *organization) register(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&org.id, "org-id", "", "", "The ID of the organization that owns the bucket")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		org.id = h
+	}
+	cmd.Flags().StringVarP(&org.name, "org", "o", "", "The name of the organization that owns the bucket")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		org.name = h
+	}
+}
+
+func (org *organization) getID(orgSVC influxdb.OrganizationService) (influxdb.ID, error) {
+	if org.id != "" {
+		influxOrgID, err := influxdb.IDFromString(org.id)
 		if err != nil {
 			return 0, fmt.Errorf("invalid org ID provided: %s", err.Error())
 		}
 		return *influxOrgID, nil
-	} else if name != "" {
+	} else if org.name != "" {
 		org, err := orgSVC.FindOrganization(context.Background(), influxdb.OrganizationFilter{
-			Name: &name,
+			Name: &org.name,
 		})
 		if err != nil {
 			return 0, fmt.Errorf("%v", err)
 		}
 		return org.ID, nil
 	}
+	return 0, fmt.Errorf("failed to locate an organization id")
+}
 
-	return 0, fmt.Errorf("")
+func (org *organization) validOrgFlags() error {
+	if org.id == "" && org.name == "" {
+		return fmt.Errorf("must specify org-id, or org name")
+	} else if org.id != "" && org.name != "" {
+		return fmt.Errorf("must specify org-id, or org name not both")
+	}
+	return nil
 }

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx/internal"
 	"github.com/influxdata/influxdb/http"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func organizationCmd() *cobra.Command {
@@ -113,7 +114,15 @@ func orgFindCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&organizationFindFlags.name, "name", "n", "", "The organization name")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		organizationFindFlags.name = h
+	}
 	cmd.Flags().StringVarP(&organizationFindFlags.id, "id", "i", "", "The organization ID")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationFindFlags.id = h
+	}
 
 	return cmd
 }
@@ -174,8 +183,17 @@ func orgUpdateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&organizationUpdateFlags.id, "id", "i", "", "The organization ID (required)")
-	cmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "The organization name")
 	cmd.MarkFlagRequired("id")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationUpdateFlags.id = h
+	}
+
+	cmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "The organization name")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		organizationUpdateFlags.name = h
+	}
 
 	return cmd
 }
@@ -268,6 +286,10 @@ func orgDeleteCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&organizationDeleteFlags.id, "id", "i", "", "The organization ID (required)")
 	cmd.MarkFlagRequired("id")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationUpdateFlags.id = h
+	}
 
 	return cmd
 }
@@ -340,7 +362,15 @@ func orgMembersListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&organizationMembersListFlags.id, "id", "i", "", "The organization ID")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationMembersListFlags.id = h
+	}
 	cmd.Flags().StringVarP(&organizationMembersListFlags.name, "name", "n", "", "The organization name")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		organizationMembersListFlags.name = h
+	}
 
 	return cmd
 }
@@ -411,7 +441,16 @@ func orgMembersAddCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&organizationMembersAddFlags.id, "id", "i", "", "The organization ID")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationMembersAddFlags.id = h
+	}
 	cmd.Flags().StringVarP(&organizationMembersAddFlags.name, "name", "n", "", "The organization name")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		organizationMembersAddFlags.name = h
+	}
+
 	cmd.Flags().StringVarP(&organizationMembersAddFlags.memberID, "member", "o", "", "The member ID")
 	cmd.MarkFlagRequired("member")
 
@@ -478,7 +517,15 @@ func orgMembersRemoveCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.id, "id", "i", "", "The organization ID")
+	viper.BindEnv("ORG_ID")
+	if h := viper.GetString("ORG_ID"); h != "" {
+		organizationMembersAddFlags.id = h
+	}
 	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.name, "name", "n", "", "The organization name")
+	viper.BindEnv("ORG")
+	if h := viper.GetString("ORG"); h != "" {
+		organizationMembersRemoveFlags.name = h
+	}
 	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.memberID, "member", "o", "", "The member ID")
 	cmd.MarkFlagRequired("member")
 

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -42,8 +42,7 @@ type cmdPkgBuilder struct {
 	hasColor        bool
 	hasTableBorders bool
 	meta            pkger.Metadata
-	orgID           string
-	org             string
+	org             organization
 	quiet           bool
 
 	applyOpts struct {
@@ -94,8 +93,7 @@ func (b *cmdPkgBuilder) cmdPkgApply() *cobra.Command {
 	cmd.Flags().BoolVarP(&b.quiet, "quiet", "q", false, "disable output printing")
 	cmd.Flags().StringVar(&b.applyOpts.force, "force", "", `TTY input, if package will have destructive changes, proceed if set "true".`)
 
-	cmd.Flags().StringVarP(&b.orgID, "org-id", "", "", "The ID of the organization that owns the bucket")
-	cmd.Flags().StringVarP(&b.org, "org", "o", "", "The name of the organization that owns the bucket")
+	b.org.register(cmd)
 
 	cmd.Flags().BoolVarP(&b.hasColor, "color", "c", true, "Enable color in output, defaults true")
 	cmd.Flags().BoolVar(&b.hasTableBorders, "table-borders", true, "Enable table borders, defaults true")
@@ -105,18 +103,9 @@ func (b *cmdPkgBuilder) cmdPkgApply() *cobra.Command {
 	return cmd
 }
 
-func (b *cmdPkgBuilder) validOrgFlags() error {
-	if b.orgID == "" && b.org == "" {
-		return fmt.Errorf("must specify org-id, or org name")
-	} else if b.orgID != "" && b.org != "" {
-		return fmt.Errorf("must specify org-id, or org name not both")
-	}
-	return nil
-}
-
 func (b *cmdPkgBuilder) pkgApplyRunEFn() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) (e error) {
-		if err := b.validOrgFlags(); err != nil {
+		if err := b.org.validOrgFlags(); err != nil {
 			return err
 		}
 		color.NoColor = !b.hasColor
@@ -126,7 +115,11 @@ func (b *cmdPkgBuilder) pkgApplyRunEFn() func(*cobra.Command, []string) error {
 			return err
 		}
 
-		influxOrgID, err := getOrgID(orgSVC, b.orgID, b.org)
+		if err := b.org.validOrgFlags(); err != nil {
+			return err
+		}
+
+		influxOrgID, err := b.org.getID(orgSVC)
 		if err != nil {
 			return nil
 		}
@@ -297,8 +290,9 @@ func (b *cmdPkgBuilder) cmdPkgExportAll() *cobra.Command {
 	cmd.Short = "Export all existing resources for an organization as a package"
 
 	cmd.Flags().StringVarP(&b.file, "file", "f", "", "output file for created pkg; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding")
-	cmd.Flags().StringVarP(&b.orgID, "org-id", "", "", "organization id")
-	cmd.Flags().StringVarP(&b.org, "org", "o", "", "The name of the organization that owns the bucket")
+
+	b.org.register(cmd)
+
 	cmd.Flags().StringVarP(&b.meta.Name, "name", "n", "", "name for new pkg")
 	cmd.Flags().StringVarP(&b.meta.Description, "description", "d", "", "description for new pkg")
 	cmd.Flags().StringVarP(&b.meta.Version, "version", "v", "", "version for new pkg")
@@ -317,7 +311,7 @@ func (b *cmdPkgBuilder) pkgExportAllRunEFn() func(*cobra.Command, []string) erro
 
 		opts := []pkger.CreatePkgSetFn{pkger.CreateWithMetadata(b.meta)}
 
-		orgID, err := getOrgID(orgSVC, b.orgID, b.org)
+		orgID, err := b.org.getID(orgSVC)
 		if err != nil {
 			return err
 		}

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -149,6 +149,42 @@ func Test_Pkg(t *testing.T) {
 					Version:     "new version",
 				},
 			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "yaml out",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+					},
+					envVars: []struct{ key, val string }{{key: "ORG", val: "influxdata"}},
+				},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "yaml out",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+					},
+					envVars: []struct{ key, val string }{{key: "ORG_ID", val: expectedOrgID.String()}},
+				},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
 		}
 
 		cmdFn := func() *cobra.Command {
@@ -294,28 +330,6 @@ func Test_Pkg(t *testing.T) {
 					Version:     "new version",
 				},
 			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "mixed",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
-					flags: []flagArg{
-						{name: "name", val: "new name"},
-						{name: "description", val: "new desc"},
-						{name: "version", val: "new version"},
-					},
-				},
-				bucketIDs:   []influxdb.ID{1, 2},
-				dashIDs:     []influxdb.ID{3, 4},
-				labelIDs:    []influxdb.ID{5, 6},
-				varIDs:      []influxdb.ID{7, 8},
-				telegrafIDs: []influxdb.ID{9, 10},
-				expectedMeta: pkger.Metadata{
-					Name:        "new name",
-					Description: "new desc",
-					Version:     "new version",
-				},
-			},
 		}
 
 		cmdFn := func() *cobra.Command {
@@ -418,6 +432,9 @@ type pkgFileArgs struct {
 	filename string
 	encoding pkger.Encoding
 	flags    []flagArg
+	envVars  []struct {
+		key, val string
+	}
 }
 
 func testPkgWrites(t *testing.T, newCmdFn func() *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) {
@@ -427,6 +444,30 @@ func testPkgWrites(t *testing.T, newCmdFn func() *cobra.Command, args pkgFileArg
 		return cmd
 	}
 
+	// we'll memoize the current env vars if defined in args.envVars, then set the env vars defined in each test
+	var initialEnvVars []struct{ key, val string }
+	for _, envVar := range args.envVars {
+		if k := os.Getenv(envVar.key); k != "" {
+			initialEnvVars = append(initialEnvVars, struct{ key, val string }{
+				key: envVar.key,
+				val: k,
+			})
+		}
+
+		require.NoError(t, os.Setenv(envVar.key, envVar.val))
+	}
+
+	defer func() {
+		// unset the env vars set by the test
+		for _, envVar := range args.envVars {
+			require.NoError(t, os.Unsetenv(envVar.key))
+		}
+
+		// set the test env vars back to the initial state
+		for _, envVar := range initialEnvVars {
+			require.NoError(t, os.Setenv(envVar.key, envVar.val))
+		}
+	}()
 	t.Run(path.Join(args.name, "file"), testPkgWritesFile(wrappedCmdFn, args, assertFn))
 	t.Run(path.Join(args.name, "buffer"), testPkgWritesToBuffer(wrappedCmdFn, args, assertFn))
 }

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -112,8 +112,7 @@ func userUpdateF(cmd *cobra.Command, args []string) error {
 var userCreateFlags struct {
 	name     string
 	password string
-	orgID    string
-	org      string
+	organization
 }
 
 func userCreateCmd() *cobra.Command {
@@ -126,17 +125,14 @@ func userCreateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&userCreateFlags.name, "name", "n", "", "The user name (required)")
 	cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVarP(&userCreateFlags.password, "password", "p", "", "The user password")
-	cmd.Flags().StringVarP(&userCreateFlags.orgID, "org-id", "", "", "The organization id the user belongs to. Is required if password provided.")
-	cmd.Flags().StringVarP(&userCreateFlags.org, "org", "o", "", "The organization name the user belongs to. Is required if password provided.")
+	userCreateFlags.organization.register(cmd)
 
 	return cmd
 }
 
 func userCreateF(cmd *cobra.Command, args []string) error {
-	if userCreateFlags.orgID == "" && userCreateFlags.org == "" {
-		return errors.New("must specify org-id, or org name")
-	} else if userCreateFlags.orgID != "" && userCreateFlags.org != "" {
-		return errors.New("must specify org-id, or org name not both")
+	if err := userCreateFlags.organization.validOrgFlags(); err != nil {
+		return err
 	}
 
 	s, err := newUserService()
@@ -174,7 +170,7 @@ func userCreateF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	orgID, err := getOrgID(orgSVC, userCreateFlags.orgID, userCreateFlags.org)
+	orgID, err := userCreateFlags.organization.getID(orgSVC)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #16214 

Consistently applies env vars to cli commands using flags that could be interchanged with env vars (ie. --org-id INFLUX_ORG_ID, --bucket-name INFLUX_BUCKET_NAME, etc). See https://github.com/influxdata/influxdb/issues/16048 for a more detailed list of env vars.

Also fixes a small bug where we were not setting globally the `INFLUX` prefix before any cobra commands were init.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
