### PR TITLE
chore: refactor notication endpoints into a service with dep injection

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/cmd/influxd/inspect"
+	"github.com/influxdata/influxdb/endpoints"
 	"github.com/influxdata/influxdb/gather"
 	"github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/inmem"
@@ -524,27 +525,27 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	m.reg.MustRegister(m.boltClient)
 
 	var (
-		orgSvc                  platform.OrganizationService             = m.kvService
-		authSvc                 platform.AuthorizationService            = m.kvService
-		userSvc                 platform.UserService                     = m.kvService
-		variableSvc             platform.VariableService                 = m.kvService
-		bucketSvc               platform.BucketService                   = m.kvService
-		sourceSvc               platform.SourceService                   = m.kvService
-		sessionSvc              platform.SessionService                  = m.kvService
-		passwdsSvc              platform.PasswordsService                = m.kvService
-		dashboardSvc            platform.DashboardService                = m.kvService
-		dashboardLogSvc         platform.DashboardOperationLogService    = m.kvService
-		userLogSvc              platform.UserOperationLogService         = m.kvService
-		bucketLogSvc            platform.BucketOperationLogService       = m.kvService
-		orgLogSvc               platform.OrganizationOperationLogService = m.kvService
-		onboardingSvc           platform.OnboardingService               = m.kvService
-		scraperTargetSvc        platform.ScraperTargetStoreService       = m.kvService
-		telegrafSvc             platform.TelegrafConfigStore             = m.kvService
-		userResourceSvc         platform.UserResourceMappingService      = m.kvService
-		labelSvc                platform.LabelService                    = m.kvService
-		secretSvc               platform.SecretService                   = m.kvService
-		lookupSvc               platform.LookupService                   = m.kvService
-		notificationEndpointSvc platform.NotificationEndpointService     = m.kvService
+		orgSvc                    platform.OrganizationService             = m.kvService
+		authSvc                   platform.AuthorizationService            = m.kvService
+		userSvc                   platform.UserService                     = m.kvService
+		variableSvc               platform.VariableService                 = m.kvService
+		bucketSvc                 platform.BucketService                   = m.kvService
+		sourceSvc                 platform.SourceService                   = m.kvService
+		sessionSvc                platform.SessionService                  = m.kvService
+		passwdsSvc                platform.PasswordsService                = m.kvService
+		dashboardSvc              platform.DashboardService                = m.kvService
+		dashboardLogSvc           platform.DashboardOperationLogService    = m.kvService
+		userLogSvc                platform.UserOperationLogService         = m.kvService
+		bucketLogSvc              platform.BucketOperationLogService       = m.kvService
+		orgLogSvc                 platform.OrganizationOperationLogService = m.kvService
+		onboardingSvc             platform.OnboardingService               = m.kvService
+		scraperTargetSvc          platform.ScraperTargetStoreService       = m.kvService
+		telegrafSvc               platform.TelegrafConfigStore             = m.kvService
+		userResourceSvc           platform.UserResourceMappingService      = m.kvService
+		labelSvc                  platform.LabelService                    = m.kvService
+		secretSvc                 platform.SecretService                   = m.kvService
+		lookupSvc                 platform.LookupService                   = m.kvService
+		notificationEndpointStore platform.NotificationEndpointService     = m.kvService
 	)
 
 	switch m.secretStore {
@@ -818,7 +819,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		TaskService:                     taskSvc,
 		TelegrafService:                 telegrafSvc,
 		NotificationRuleStore:           notificationRuleSvc,
-		NotificationEndpointService:     notificationEndpointSvc,
+		NotificationEndpointService:     endpoints.NewService(notificationEndpointStore, secretSvc, userResourceSvc, orgSvc),
 		CheckService:                    checkSvc,
 		ScraperTargetStoreService:       scraperTargetSvc,
 		ChronografService:               chronografSvc,

--- a/endpoints/service.go
+++ b/endpoints/service.go
@@ -1,0 +1,98 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+// Service provides all the notification endpoint service behavior.
+type Service struct {
+	endpointStore influxdb.NotificationEndpointService
+	secretSVC     influxdb.SecretService
+
+	// TODO(jsteenb2): NUKE THESE 2 embedded services after fixing up the domain!
+	influxdb.UserResourceMappingService
+	influxdb.OrganizationService
+}
+
+// NewService constructs a new Service.
+func NewService(store influxdb.NotificationEndpointService, secretSVC influxdb.SecretService, urmSVC influxdb.UserResourceMappingService, orgSVC influxdb.OrganizationService) *Service {
+	return &Service{
+		endpointStore:              store,
+		secretSVC:                  secretSVC,
+		UserResourceMappingService: urmSVC,
+		OrganizationService:        orgSVC,
+	}
+}
+
+var _ influxdb.NotificationEndpointService = (*Service)(nil)
+
+// FindNotificationEndpointByID returns a single notification endpoint by ID.
+func (s *Service) FindNotificationEndpointByID(ctx context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
+	return s.endpointStore.FindNotificationEndpointByID(ctx, id)
+}
+
+// FindNotificationEndpoints returns a list of notification endpoints that match filter and the total count of matching notification endpoints.
+// Additional options provide pagination & sorting.
+func (s *Service) FindNotificationEndpoints(ctx context.Context, filter influxdb.NotificationEndpointFilter, opt ...influxdb.FindOptions) ([]influxdb.NotificationEndpoint, int, error) {
+	return s.endpointStore.FindNotificationEndpoints(ctx, filter, opt...)
+}
+
+// CreateNotificationEndpoint creates a new notification endpoint and sets b.ID with the new identifier.
+func (s *Service) CreateNotificationEndpoint(ctx context.Context, edp influxdb.NotificationEndpoint, userID influxdb.ID) error {
+	err := s.endpointStore.CreateNotificationEndpoint(ctx, edp, userID)
+	if err != nil {
+		return err
+	}
+
+	secrets := make(map[string]string)
+	for _, fld := range edp.SecretFields() {
+		if fld.Value != nil {
+			secrets[fld.Key] = *fld.Value
+		}
+	}
+	if len(secrets) == 0 {
+		return nil
+	}
+
+	return s.secretSVC.PutSecrets(ctx, edp.GetOrgID(), secrets)
+}
+
+// UpdateNotificationEndpoint updates a single notification endpoint.
+// Returns the new notification endpoint after update.
+func (s *Service) UpdateNotificationEndpoint(ctx context.Context, id influxdb.ID, nr influxdb.NotificationEndpoint, userID influxdb.ID) (influxdb.NotificationEndpoint, error) {
+	nr.BackfillSecretKeys() // :sadpanda:
+	updatedEndpoint, err := s.endpointStore.UpdateNotificationEndpoint(ctx, id, nr, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	secrets := make(map[string]string)
+	for _, fld := range updatedEndpoint.SecretFields() {
+		if fld.Value != nil {
+			secrets[fld.Key] = *fld.Value
+		}
+	}
+
+	if len(secrets) == 0 {
+		return updatedEndpoint, nil
+	}
+
+	if err := s.secretSVC.PutSecrets(ctx, updatedEndpoint.GetOrgID(), secrets); err != nil {
+		return nil, err
+	}
+
+	return updatedEndpoint, nil
+}
+
+// PatchNotificationEndpoint updates a single  notification endpoint with changeset.
+// Returns the new notification endpoint state after update.
+func (s *Service) PatchNotificationEndpoint(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpointUpdate) (influxdb.NotificationEndpoint, error) {
+	return s.endpointStore.PatchNotificationEndpoint(ctx, id, upd)
+}
+
+// DeleteNotificationEndpoint removes a notification endpoint by ID, returns secret fields, orgID for further deletion.
+func (s *Service) DeleteNotificationEndpoint(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error) {
+	return s.endpointStore.DeleteNotificationEndpoint(ctx, id)
+}

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -1882,7 +1882,6 @@ func TestService_handlePostDashboardLabel(t *testing.T) {
 }
 
 func jsonEqual(s1, s2 string) (eq bool, diff string, err error) {
-	var o1, o2 interface{}
 	if s1 == s2 {
 		return true, "", nil
 	}
@@ -1895,10 +1894,12 @@ func jsonEqual(s1, s2 string) (eq bool, diff string, err error) {
 		return false, s1, fmt.Errorf("s2 is empty")
 	}
 
+	var o1 interface{}
 	if err = json.Unmarshal([]byte(s1), &o1); err != nil {
 		return
 	}
 
+	var o2 interface{}
 	if err = json.Unmarshal([]byte(s2), &o2); err != nil {
 		return
 	}

--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/influxdata/httprouter"
@@ -26,7 +27,6 @@ type NotificationEndpointBackend struct {
 	LabelService                influxdb.LabelService
 	UserService                 influxdb.UserService
 	OrganizationService         influxdb.OrganizationService
-	SecretService               influxdb.SecretService
 }
 
 // NewNotificationEndpointBackend returns a new instance of NotificationEndpointBackend.
@@ -40,7 +40,6 @@ func NewNotificationEndpointBackend(log *zap.Logger, b *APIBackend) *Notificatio
 		LabelService:                b.LabelService,
 		UserService:                 b.UserService,
 		OrganizationService:         b.OrganizationService,
-		SecretService:               b.SecretService,
 	}
 }
 
@@ -59,7 +58,6 @@ type NotificationEndpointHandler struct {
 	LabelService                influxdb.LabelService
 	UserService                 influxdb.UserService
 	OrganizationService         influxdb.OrganizationService
-	SecretService               influxdb.SecretService
 }
 
 const (
@@ -85,7 +83,6 @@ func NewNotificationEndpointHandler(log *zap.Logger, b *NotificationEndpointBack
 		LabelService:                b.LabelService,
 		UserService:                 b.UserService,
 		OrganizationService:         b.OrganizationService,
-		SecretService:               b.SecretService,
 	}
 	h.HandlerFunc("POST", prefixNotificationEndpoints, h.handlePostNotificationEndpoint)
 	h.HandlerFunc("GET", prefixNotificationEndpoints, h.handleGetNotificationEndpoints)
@@ -307,36 +304,34 @@ func decodeNotificationEndpointFilter(ctx context.Context, r *http.Request) (inf
 }
 
 func decodePostNotificationEndpointRequest(r *http.Request) (postNotificationEndpointRequest, error) {
-	var req postNotificationEndpointRequest
-	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(r.Body)
+	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return req, &influxdb.Error{
+		return postNotificationEndpointRequest{}, &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Err:  err,
 		}
 	}
 	defer r.Body.Close()
-	edp, err := endpoint.UnmarshalJSON(buf.Bytes())
+	edp, err := endpoint.UnmarshalJSON(b)
 	if err != nil {
-		return req, &influxdb.Error{
+		return postNotificationEndpointRequest{}, &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Err:  err,
 		}
 	}
 
 	var dl decodeLabels
-	if err := json.Unmarshal(buf.Bytes(), &dl); err != nil {
-		return req, &influxdb.Error{
+	if err := json.Unmarshal(b, &dl); err != nil {
+		return postNotificationEndpointRequest{}, &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Err:  err,
 		}
 	}
 
-	req.NotificationEndpoint = edp
-	req.Labels = dl.Labels
-
-	return req, nil
+	return postNotificationEndpointRequest{
+		NotificationEndpoint: edp,
+		Labels:               dl.Labels,
+	}, nil
 }
 
 func decodePutNotificationEndpointRequest(ctx context.Context, r *http.Request) (influxdb.NotificationEndpoint, error) {
@@ -419,18 +414,6 @@ func (h *NotificationEndpointHandler) handlePostNotificationEndpoint(w http.Resp
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	for _, fld := range edp.SecretFields() {
-		if fld.Value != nil {
-			if err := h.SecretService.PutSecret(ctx, edp.GetOrgID(),
-				fld.Key, *fld.Value); err != nil {
-				h.HandleHTTPError(ctx, &influxdb.Error{
-					Op:  "http/handlePostNotificationEndpoint",
-					Err: err,
-				}, w)
-				return
-			}
-		}
-	}
 
 	labels := h.mapNewNotificationEndpointLabels(ctx, edp.NotificationEndpoint, edp.Labels)
 
@@ -494,19 +477,6 @@ func (h *NotificationEndpointHandler) handlePutNotificationEndpoint(w http.Respo
 		return
 	}
 
-	for _, fld := range edp.SecretFields() {
-		if fld.Value != nil {
-			if err := h.SecretService.PutSecret(ctx, edp.GetOrgID(),
-				fld.Key, *fld.Value); err != nil {
-				h.HandleHTTPError(ctx, &influxdb.Error{
-					Op:  "http/handlePutNotificationEndpoint",
-					Err: err,
-				}, w)
-				return
-			}
-		}
-	}
-
 	labels, err := h.LabelService.FindResourceLabels(ctx, influxdb.LabelMappingFilter{ResourceID: edp.GetID()})
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
@@ -557,7 +527,7 @@ func (h *NotificationEndpointHandler) handleDeleteNotificationEndpoint(w http.Re
 		return
 	}
 
-	flds, orgID, err := h.NotificationEndpointService.DeleteNotificationEndpoint(ctx, i)
+	flds, _, err := h.NotificationEndpointService.DeleteNotificationEndpoint(ctx, i)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
@@ -572,13 +542,6 @@ func (h *NotificationEndpointHandler) handleDeleteNotificationEndpoint(w http.Re
 			return
 		}
 		keys[k] = fld.Key
-	}
-	if err := h.SecretService.DeleteSecret(ctx, orgID, keys...); err != nil {
-		h.HandleHTTPError(ctx, &influxdb.Error{
-			Op:  "http/handleDeleteNotificationEndpoint",
-			Err: err,
-		}, w)
-		return
 	}
 	h.log.Debug("NotificationEndpoint deleted", zap.String("notificationEndpointID", fmt.Sprint(i)))
 

--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -109,7 +109,7 @@ func (s *Service) createNotificationRule(ctx context.Context, tx Tx, nr influxdb
 }
 
 func (s *Service) createNotificationTask(ctx context.Context, tx Tx, r influxdb.NotificationRuleCreate) (*influxdb.Task, error) {
-	ep, _, _, err := s.findNotificationEndpointByID(ctx, tx, r.GetEndpointID())
+	ep, _, _, err := s.findNotificationEndpointByID(tx, r.GetEndpointID())
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *Service) createNotificationTask(ctx context.Context, tx Tx, r influxdb.
 }
 
 func (s *Service) updateNotificationTask(ctx context.Context, tx Tx, r influxdb.NotificationRule, status *string) (*influxdb.Task, error) {
-	ep, _, _, err := s.findNotificationEndpointByID(ctx, tx, r.GetEndpointID())
+	ep, _, _, err := s.findNotificationEndpointByID(tx, r.GetEndpointID())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testttp/http.go
+++ b/pkg/testttp/http.go
@@ -91,9 +91,16 @@ func (r *Req) Headers(k, v string, rest ...string) *Req {
 	return r
 }
 
+// WithCtx sets the ctx on the request.
 func (r *Req) WithCtx(ctx context.Context) *Req {
 	r.req = r.req.WithContext(ctx)
 	return r
+}
+
+// WrapCtx provides means to wrap a request context. This is useful for stuffing in the
+// auth stuffs that are required at times.
+func (r *Req) WrapCtx(fn func(ctx context.Context) context.Context) *Req {
+	return r.WithCtx(fn(r.req.Context()))
 }
 
 // Resp is a http recorder wrapper.
@@ -121,7 +128,7 @@ func (r *Resp) ExpectStatus(code int) *Resp {
 }
 
 // ExpectBody provides an assertion against the recorder body.
-func (r *Resp) ExpectBody(fn func(*bytes.Buffer)) *Resp {
+func (r *Resp) ExpectBody(fn func(body *bytes.Buffer)) *Resp {
 	fn(r.Rec.Body)
 	return r
 }

--- a/testing/notification_endpoint.go
+++ b/testing/notification_endpoint.go
@@ -11,6 +11,8 @@ import (
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/notification/endpoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // NotificationEndpointFields includes prepopulated data for mapping tests.
@@ -38,11 +40,11 @@ var notificationEndpointCmpOptions = cmp.Options{
 
 // NotificationEndpointService tests all the service functions.
 func NotificationEndpointService(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()), t *testing.T,
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()), t *testing.T,
 ) {
 	tests := []struct {
 		name string
-		fn   func(init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+		fn   func(init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 			t *testing.T)
 	}{
 		{
@@ -79,7 +81,7 @@ func NotificationEndpointService(
 
 // CreateNotificationEndpoint testing.
 func CreateNotificationEndpoint(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 	type args struct {
@@ -106,24 +108,7 @@ func CreateNotificationEndpoint(
 				Orgs: []*influxdb.Organization{
 					{ID: MustIDBase16(fourID), Name: "org1"},
 				},
-				NotificationEndpoints: []influxdb.NotificationEndpoint{
-					&endpoint.Slack{
-						Base: endpoint.Base{
-							ID:     MustIDBase16Ptr(oneID),
-							Name:   "name1",
-							OrgID:  MustIDBase16Ptr(fourID),
-							Status: influxdb.Active,
-							CRUDLog: influxdb.CRUDLog{
-								CreatedAt: timeGen1.Now(),
-								UpdatedAt: timeGen2.Now(),
-							},
-						},
-						URL: "example-slack.com",
-						Token: influxdb.SecretField{
-							Key: oneID + "-token",
-						},
-					},
-				},
+				NotificationEndpoints: []influxdb.NotificationEndpoint{},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
 					{
 						ResourceID:   MustIDBase16(oneID),
@@ -149,20 +134,6 @@ func CreateNotificationEndpoint(
 			},
 			wants: wants{
 				notificationEndpoints: []influxdb.NotificationEndpoint{
-					&endpoint.Slack{
-						Base: endpoint.Base{
-							ID:     MustIDBase16Ptr(oneID),
-							Name:   "name1",
-							OrgID:  MustIDBase16Ptr(fourID),
-							Status: influxdb.Active,
-							CRUDLog: influxdb.CRUDLog{
-								CreatedAt: timeGen1.Now(),
-								UpdatedAt: timeGen2.Now(),
-							},
-						},
-						URL:   "example-slack.com",
-						Token: influxdb.SecretField{Key: oneID + "-token"},
-					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
 							ID:     MustIDBase16Ptr(twoID),
@@ -198,8 +169,9 @@ func CreateNotificationEndpoint(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, secretSVC, done := init(tt.fields, t)
 			defer done()
+
 			ctx := context.Background()
 			err := s.CreateNotificationEndpoint(ctx, tt.args.notificationEndpoint, tt.args.userID)
 			ErrorsEqual(t, err, tt.wants.err)
@@ -225,13 +197,23 @@ func CreateNotificationEndpoint(
 			if diff := cmp.Diff(urms, tt.wants.userResourceMapping, userResourceMappingCmpOptions...); diff != "" {
 				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
 			}
+
+			for _, edp := range tt.wants.notificationEndpoints {
+				secrets, err := secretSVC.GetSecretKeys(ctx, edp.GetOrgID())
+				if err != nil {
+					t.Errorf("failed to retrieve secrets for endpoint: %v", err)
+				}
+				for _, expected := range edp.SecretFields() {
+					assert.Contains(t, secrets, expected.Key)
+				}
+			}
 		})
 	}
 }
 
 // FindNotificationEndpointByID testing.
 func FindNotificationEndpointByID(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 	type args struct {
@@ -435,7 +417,7 @@ func FindNotificationEndpointByID(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -450,7 +432,7 @@ func FindNotificationEndpointByID(
 
 // FindNotificationEndpoints testing
 func FindNotificationEndpoints(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 	type args struct {
@@ -1205,7 +1187,7 @@ func FindNotificationEndpoints(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1224,7 +1206,7 @@ func FindNotificationEndpoints(
 
 // UpdateNotificationEndpoint testing.
 func UpdateNotificationEndpoint(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 	type args struct {
@@ -1368,12 +1350,13 @@ func UpdateNotificationEndpoint(
 				orgID:  MustIDBase16(fourID),
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name3",
 						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 					},
 					ClientURL:  "example-pagerduty2.com",
-					RoutingKey: influxdb.SecretField{Key: twoID + "-routing-key"},
+					RoutingKey: influxdb.SecretField{Value: strPtr("secret value")},
 				},
 			},
 			wants: wants{
@@ -1412,20 +1395,6 @@ func UpdateNotificationEndpoint(
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
-					&endpoint.Slack{
-						Base: endpoint.Base{
-							ID:     MustIDBase16Ptr(oneID),
-							Name:   "name1",
-							OrgID:  MustIDBase16Ptr(fourID),
-							Status: influxdb.Active,
-							CRUDLog: influxdb.CRUDLog{
-								CreatedAt: timeGen1.Now(),
-								UpdatedAt: timeGen2.Now(),
-							},
-						},
-						URL:   "example-slack.com",
-						Token: influxdb.SecretField{Key: oneID + "-token"},
-					},
 					&endpoint.PagerDuty{
 						Base: endpoint.Base{
 							ID:     MustIDBase16Ptr(twoID),
@@ -1448,13 +1417,13 @@ func UpdateNotificationEndpoint(
 				orgID:  MustIDBase16(fourID),
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
+						ID:     MustIDBase16Ptr(twoID),
 						Name:   "name3",
 						OrgID:  MustIDBase16Ptr(fourID),
 						Status: influxdb.Inactive,
 					},
 					ClientURL: "example-pagerduty2.com",
 					RoutingKey: influxdb.SecretField{
-						Key:   twoID + "-routing-key",
 						Value: strPtr("pager-duty-value2"),
 					},
 				},
@@ -1472,28 +1441,41 @@ func UpdateNotificationEndpoint(
 						},
 					},
 					ClientURL: "example-pagerduty2.com",
-					RoutingKey: influxdb.SecretField{
-						Key:   twoID + "-routing-key",
-						Value: strPtr("pager-duty-value2"),
-					},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, secretSVC, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
-			edp, err := s.UpdateNotificationEndpoint(ctx, tt.args.id,
-				tt.args.notificationEndpoint, tt.args.userID)
+			edp, err := s.UpdateNotificationEndpoint(ctx, tt.args.id, tt.args.notificationEndpoint, tt.args.userID)
 			ErrorsEqual(t, err, tt.wants.err)
-			if diff := cmp.Diff(edp, tt.wants.notificationEndpoint, notificationEndpointCmpOptions...); tt.wants.err == nil && diff != "" {
-				t.Errorf("notificationEndpoints are different -got/+want\ndiff %s", diff)
-			}
 			if err != nil {
 				return
+			}
+
+			if tt.wants.notificationEndpoint != nil {
+				secrets, err := secretSVC.GetSecretKeys(ctx, edp.GetOrgID())
+				if err != nil {
+					t.Errorf("failed to retrieve secrets for endpoint: %v", err)
+				}
+				for _, actual := range edp.SecretFields() {
+					assert.Contains(t, secrets, actual.Key)
+				}
+
+				actual, ok := edp.(*endpoint.PagerDuty)
+				require.Truef(t, ok, "did not get a pager duty endpoint; got: %#v", edp)
+				wanted := tt.wants.notificationEndpoint.(*endpoint.PagerDuty)
+
+				wb, ab := wanted.Base, actual.Base
+				require.NotZero(t, ab.CRUDLog)
+				wb.CRUDLog, ab.CRUDLog = influxdb.CRUDLog{}, influxdb.CRUDLog{} // zero out times
+				assert.Equal(t, wb, ab)
+				assert.Equal(t, wanted.ClientURL, actual.ClientURL)
+				assert.NotEqual(t, wanted.RoutingKey, actual.RoutingKey)
 			}
 		})
 	}
@@ -1501,7 +1483,7 @@ func UpdateNotificationEndpoint(
 
 // PatchNotificationEndpoint testing.
 func PatchNotificationEndpoint(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 
@@ -1663,7 +1645,7 @@ func PatchNotificationEndpoint(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1678,7 +1660,7 @@ func PatchNotificationEndpoint(
 
 // DeleteNotificationEndpoint testing.
 func DeleteNotificationEndpoint(
-	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, func()),
+	init func(NotificationEndpointFields, *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()),
 	t *testing.T,
 ) {
 	type args struct {
@@ -1993,8 +1975,9 @@ func DeleteNotificationEndpoint(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, done := init(tt.fields, t)
+			s, secretSVC, done := init(tt.fields, t)
 			defer done()
+
 			ctx := context.Background()
 			flds, orgID, err := s.DeleteNotificationEndpoint(ctx, tt.args.id)
 			ErrorsEqual(t, err, tt.wants.err)
@@ -2035,6 +2018,23 @@ func DeleteNotificationEndpoint(
 			}
 			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
 				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
+			}
+
+			var deletedEndpoint influxdb.NotificationEndpoint
+			for _, ne := range tt.fields.NotificationEndpoints {
+				if ne.GetID() == tt.args.id {
+					deletedEndpoint = ne
+					break
+				}
+			}
+			if deletedEndpoint == nil {
+				return
+			}
+
+			secrets, err := secretSVC.GetSecretKeys(ctx, deletedEndpoint.GetOrgID())
+			require.NoError(t, err)
+			for _, deleted := range deletedEndpoint.SecretFields() {
+				assert.NotContains(t, secrets, deleted.Key)
 			}
 		})
 	}


### PR DESCRIPTION
this is a blocker for anyone who hits the endpoint services internally(pkger work surfaced this). They had to know that they need to also know of hte secret service then do all that put/delete alongside the operation. This makes that unified inside the store tx. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] update upstream