### PR TITLE
build: run e2e tests hourly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,16 @@ workflows:
   e2e:
     jobs:
       - e2e
+  hourly-e2e:
+    triggers:
+      - schedule:
+          cron: '0 * * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - e2e
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
Signed-off-by: Chris Goller <goller@gmail.com>

To help suss out race-y e2e tests, we'll be running them on an hourly cycle.