### PR TITLE
feat(pkger): add export functionality to notification endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+1. [16234](https://github.com/influxdata/influxdb/pull/16234): add support for notification endpoints to influx templates/pkgs. 
+
 ### Bug Fixes
 
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -53,6 +53,7 @@ type cmdPkgBuilder struct {
 		resourceType string
 		buckets      string
 		dashboards   string
+		endpoints    string
 		labels       string
 		telegrafs    string
 		variables    string
@@ -231,6 +232,7 @@ func (b *cmdPkgBuilder) cmdPkgExport() *cobra.Command {
 	cmd.Flags().StringVar(&b.exportOpts.resourceType, "resource-type", "", "The resource type provided will be associated with all IDs via stdin.")
 	cmd.Flags().StringVar(&b.exportOpts.buckets, "buckets", "", "List of bucket ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.dashboards, "dashboards", "", "List of dashboard ids comma separated")
+	cmd.Flags().StringVar(&b.exportOpts.endpoints, "endpoints", "", "List of notification endpoint ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.labels, "labels", "", "List of label ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.telegrafs, "telegraf-configs", "", "List of telegraf config ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.variables, "variables", "", "List of variable ids comma separated")
@@ -255,6 +257,7 @@ func (b *cmdPkgBuilder) pkgExportRunEFn() func(*cobra.Command, []string) error {
 		}{
 			{kind: pkger.KindBucket, idStrs: strings.Split(b.exportOpts.buckets, ",")},
 			{kind: pkger.KindDashboard, idStrs: strings.Split(b.exportOpts.dashboards, ",")},
+			{kind: pkger.KindNotificationEndpoint, idStrs: strings.Split(b.exportOpts.endpoints, ",")},
 			{kind: pkger.KindLabel, idStrs: strings.Split(b.exportOpts.labels, ",")},
 			{kind: pkger.KindTelegraf, idStrs: strings.Split(b.exportOpts.telegrafs, ",")},
 			{kind: pkger.KindVariable, idStrs: strings.Split(b.exportOpts.variables, ",")},

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -842,6 +842,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 			pkger.WithDashboardSVC(authorizer.NewDashboardService(b.DashboardService)),
 			pkger.WithLabelSVC(authorizer.NewLabelService(b.LabelService)),
 			pkger.WithNoticationEndpointSVC(authorizer.NewNotificationEndpointService(b.NotificationEndpointService, b.UserResourceMappingService, b.OrganizationService)),
+			pkger.WithSecretSVC(authorizer.NewSecretService(b.SecretService)),
 			pkger.WithTelegrafSVC(authorizer.NewTelegrafConfigService(b.TelegrafService, b.UserResourceMappingService)),
 			pkger.WithVariableSVC(authorizer.NewVariableService(b.VariableService)),
 		)

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -286,7 +286,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointPagerDuty
+    - kind: Notification_Endpoint_Pager_Duty
       name: pager_duty_notification_endpoint
       url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
       routingKey: secret-sauce
@@ -310,7 +310,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointPagerDuty
+    - kind: Notification_Endpoint_Pager_Duty
       name: pager_duty_notification_endpoint
       url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
       routingKey:
@@ -341,6 +341,10 @@ spec:
 				{
 					Kind: pkger.KindLabel,
 					ID:   influxdb.ID(labels[0].ID),
+				},
+				{
+					Kind: pkger.KindNotificationEndpoint,
+					ID:   endpoints[0].NotificationEndpoint.GetID(),
 				},
 				{
 					Kind: pkger.KindTelegraf,
@@ -392,9 +396,16 @@ spec:
 			require.Len(t, dashs[0].Charts, 1)
 			assert.Equal(t, influxdb.ViewPropertyTypeSingleStat, dashs[0].Charts[0].Properties.GetType())
 
+			newEndpoints := newSum.NotificationEndpoints
+			require.Len(t, newEndpoints, 1)
+			assert.Equal(t, endpoints[0].NotificationEndpoint.GetName(), newEndpoints[0].NotificationEndpoint.GetName())
+			assert.Equal(t, endpoints[0].NotificationEndpoint.GetDescription(), newEndpoints[0].NotificationEndpoint.GetDescription())
+			hasLabelAssociations(t, newEndpoints[0].LabelAssociations, 1, "label_1")
+
 			require.Len(t, newSum.TelegrafConfigs, 1)
 			assert.Equal(t, teles[0].TelegrafConfig.Name, newSum.TelegrafConfigs[0].TelegrafConfig.Name)
 			assert.Equal(t, teles[0].TelegrafConfig.Description, newSum.TelegrafConfigs[0].TelegrafConfig.Description)
+			hasLabelAssociations(t, newSum.TelegrafConfigs[0].LabelAssociations, 1, "label_1")
 
 			vars := newSum.Variables
 			require.Len(t, vars, 1)
@@ -528,7 +539,7 @@ spec:
           bucket = "rucket_3"
         [[inputs.cpu]]
           percpu = true
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: http_none_auth_notification_endpoint
       type: none
       description: http none auth desc
@@ -567,7 +578,7 @@ spec:
       associations:
         - kind: Label
           name: label_1
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: http_none_auth_notification_endpoint
       type: none
       description: new desc

--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -410,7 +410,8 @@ func (h *NotificationEndpointHandler) handlePostNotificationEndpoint(w http.Resp
 		return
 	}
 
-	if err := h.NotificationEndpointService.CreateNotificationEndpoint(ctx, edp.NotificationEndpoint, auth.GetUserID()); err != nil {
+	err = h.NotificationEndpointService.CreateNotificationEndpoint(ctx, edp.NotificationEndpoint, auth.GetUserID())
+	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7131,6 +7131,7 @@ components:
                 - bucket
                 - dashboard
                 - label
+                - notification_endpoint
                 - variable
             name:
               type: string

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -20,10 +20,10 @@ const (
 	KindBucket                        Kind = "bucket"
 	KindDashboard                     Kind = "dashboard"
 	KindLabel                         Kind = "label"
-	KindNotificationEndpoint          Kind = "notificationendpoint"
-	KindNotificationEndpointPagerDuty Kind = "notificationendpointpagerduty"
-	KindNotificationEndpointHTTP      Kind = "notificationendpointhttp"
-	KindNotificationEndpointSlack     Kind = "notificationendpointslack"
+	KindNotificationEndpoint          Kind = "notification_endpoint"
+	KindNotificationEndpointPagerDuty Kind = "notification_endpoint_pager_duty"
+	KindNotificationEndpointHTTP      Kind = "notification_endpoint_http"
+	KindNotificationEndpointSlack     Kind = "notification_endpoint_slack"
 	KindPackage                       Kind = "package"
 	KindTelegraf                      Kind = "telegraf"
 	KindVariable                      Kind = "variable"
@@ -33,6 +33,7 @@ var kinds = map[Kind]bool{
 	KindBucket:                        true,
 	KindDashboard:                     true,
 	KindLabel:                         true,
+	KindNotificationEndpoint:          true,
 	KindNotificationEndpointHTTP:      true,
 	KindNotificationEndpointPagerDuty: true,
 	KindNotificationEndpointSlack:     true,

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -573,6 +573,7 @@ type SummaryVariable struct {
 const (
 	fieldAssociations = "associations"
 	fieldDescription  = "description"
+	fieldKey          = "key"
 	fieldKind         = "kind"
 	fieldLanguage     = "language"
 	fieldName         = "name"
@@ -911,13 +912,13 @@ type notificationEndpoint struct {
 	name        string
 	description string
 	method      string
-	password    string
-	routingKey  string
+	password    references
+	routingKey  references
 	status      string
-	token       string
+	token       references
 	httpType    string
 	url         string
-	username    string
+	username    references
 
 	labels sortedLabels
 
@@ -979,34 +980,30 @@ func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
 			Method: n.method,
 		}
 		switch n.httpType {
-		case notificationHTTPAuthTypeNone:
-			e.AuthMethod = notificationHTTPAuthTypeNone
+		case notificationHTTPAuthTypeBasic:
+			e.AuthMethod = notificationHTTPAuthTypeBasic
+			e.Password = n.password.SecretField()
+			e.Username = n.username.SecretField()
 		case notificationHTTPAuthTypeBearer:
 			e.AuthMethod = notificationHTTPAuthTypeBearer
-			e.Token = influxdb.SecretField{Value: &n.token}
-		default:
-			e.AuthMethod = notificationHTTPAuthTypeBasic
-			e.Password = influxdb.SecretField{Value: &n.password}
-			e.Username = influxdb.SecretField{Value: &n.username}
+			e.Token = n.token.SecretField()
+		case notificationHTTPAuthTypeNone:
+			e.AuthMethod = notificationHTTPAuthTypeNone
 		}
 		sum.NotificationEndpoint = e
 	case notificationKindPagerDuty:
 		sum.NotificationEndpoint = &endpoint.PagerDuty{
 			Base:       base,
 			ClientURL:  n.url,
-			RoutingKey: influxdb.SecretField{Value: &n.routingKey},
+			RoutingKey: n.routingKey.SecretField(),
 		}
 	case notificationKindSlack:
-		e := &endpoint.Slack{
-			Base: base,
-			URL:  n.url,
+		sum.NotificationEndpoint = &endpoint.Slack{
+			Base:  base,
+			URL:   n.url,
+			Token: n.token.SecretField(),
 		}
-		if n.token != "" {
-			e.Token = influxdb.SecretField{Value: &n.token}
-		}
-		sum.NotificationEndpoint = e
 	}
-	sum.NotificationEndpoint.BackfillSecretKeys()
 	return sum
 }
 
@@ -1038,7 +1035,7 @@ func (n *notificationEndpoint) valid() []validationErr {
 
 	switch n.kind {
 	case notificationKindPagerDuty:
-		if n.routingKey == "" {
+		if !n.routingKey.hasValue() {
 			failures = append(failures, validationErr{
 				Field: fieldNotificationEndpointRoutingKey,
 				Msg:   "must be provide",
@@ -1054,20 +1051,20 @@ func (n *notificationEndpoint) valid() []validationErr {
 
 		switch n.httpType {
 		case notificationHTTPAuthTypeBasic:
-			if n.password == "" {
+			if !n.password.hasValue() {
 				failures = append(failures, validationErr{
 					Field: fieldNotificationEndpointPassword,
 					Msg:   "must provide non empty string",
 				})
 			}
-			if n.username == "" {
+			if !n.username.hasValue() {
 				failures = append(failures, validationErr{
 					Field: fieldNotificationEndpointUsername,
 					Msg:   "must provide non empty string",
 				})
 			}
 		case notificationHTTPAuthTypeBearer:
-			if n.token == "" {
+			if !n.token.hasValue() {
 				failures = append(failures, validationErr{
 					Field: fieldNotificationEndpointToken,
 					Msg:   "must provide non empty string",
@@ -1831,6 +1828,37 @@ func (l legend) influxLegend() influxdb.Legend {
 		Type:        l.Type,
 		Orientation: l.Orientation,
 	}
+}
+
+const (
+	fieldReferencesSecret = "secretRef"
+)
+
+type references struct {
+	val    interface{}
+	Secret string `json:"secretRef"`
+}
+
+func (r references) hasValue() bool {
+	return r.Secret != "" || r.val != nil
+}
+
+func (r references) String() string {
+	if r.val != nil {
+		s, _ := r.val.(string)
+		return s
+	}
+	return ""
+}
+
+func (r references) SecretField() influxdb.SecretField {
+	if secret := r.Secret; secret != "" {
+		return influxdb.SecretField{Key: secret}
+	}
+	if str := r.String(); str != "" {
+		return influxdb.SecretField{Value: &str}
+	}
+	return influxdb.SecretField{}
 }
 
 func flt64Ptr(f float64) *float64 {

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -2807,7 +2807,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointSlack
+    - kind: Notification_Endpoint_Slack
       name: name1
 `,
 					},
@@ -2826,7 +2826,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointPagerDuty
+    - kind: Notification_Endpoint_Pager_Duty
       name: name1
 `,
 					},
@@ -2845,7 +2845,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       method: GET
 `,
@@ -2865,7 +2865,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: none
       method: POST
@@ -2887,7 +2887,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: none
       url: http://example.com
@@ -2908,7 +2908,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: none
       method: GUT
@@ -2930,7 +2930,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: basic
       url: example.com
@@ -2953,7 +2953,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: basic
       method: POST
@@ -2976,7 +2976,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: basic
       method: POST
@@ -2998,7 +2998,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: bearer
       method: GET
@@ -3020,7 +3020,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: name1
       type: threeve
       method: GET
@@ -3042,10 +3042,10 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointSlack
+    - kind: Notification_Endpoint_Slack
       name: dupe
       url: example.com
-    - kind: NotificationEndpointSlack
+    - kind: Notification_Endpoint_Slack
       name: dupe
       url: example.com
 `,
@@ -3065,7 +3065,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointSlack
+    - kind: Notification_Endpoint_Slack
       name: dupe
       url: example.com
       status: rando bad status

--- a/pkger/testdata/notification_endpoint.json
+++ b/pkger/testdata/notification_endpoint.json
@@ -13,7 +13,7 @@
         "name": "label_1"
       },
       {
-        "kind": "NotificationEndpointSlack",
+        "kind": "Notification_Endpoint_Slack",
         "name": "slack_notification_endpoint",
         "description": "slack desc",
         "url": "https://hooks.slack.com/services/bip/piddy/boppidy",
@@ -27,7 +27,7 @@
         ]
       },
       {
-        "kind": "NotificationEndpointHTTP",
+        "kind": "Notification_Endpoint_HTTP",
         "name": "http_none_auth_notification_endpoint",
         "description": "http none auth desc",
         "method": "GET",
@@ -42,7 +42,7 @@
         ]
       },
       {
-        "kind": "NotificationEndpointHTTP",
+        "kind": "Notification_Endpoint_HTTP",
         "name": "http_basic_auth_notification_endpoint",
         "description": "http basic auth desc",
         "method": "POST",
@@ -59,7 +59,7 @@
         ]
       },
       {
-        "kind": "NotificationEndpointHTTP",
+        "kind": "Notification_Endpoint_HTTP",
         "name": "http_bearer_auth_notification_endpoint",
         "description": "http bearer auth desc",
         "type": "bearer",
@@ -74,7 +74,7 @@
         ]
       },
       {
-        "kind": "NotificationEndpointPagerDuty",
+        "kind": "Notification_Endpoint_Pager_Duty",
         "name": "pager_duty_notification_endpoint",
         "description": "pager duty desc",
         "url": "http://localhost:8080/orgs/7167eb6719fa34e5/alert-history",

--- a/pkger/testdata/notification_endpoint.yml
+++ b/pkger/testdata/notification_endpoint.yml
@@ -8,7 +8,7 @@ spec:
   resources:
     - kind: Label
       name: label_1
-    - kind: NotificationEndpointSlack
+    - kind: Notification_Endpoint_Slack
       name: slack_notification_endpoint
       description: slack desc
       url: https://hooks.slack.com/services/bip/piddy/boppidy
@@ -17,7 +17,7 @@ spec:
       associations:
         - kind: Label
           name: label_1
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: http_none_auth_notification_endpoint
       type: none
       description: http none auth desc
@@ -27,7 +27,7 @@ spec:
       associations:
         - kind: Label
           name: label_1
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: http_basic_auth_notification_endpoint
       description: http basic auth desc
       type: basic
@@ -39,7 +39,7 @@ spec:
       associations:
         - kind: Label
           name: label_1
-    - kind: NotificationEndpointHTTP
+    - kind: Notification_Endpoint_HTTP
       name: http_bearer_auth_notification_endpoint
       description: http bearer auth desc
       type: bearer
@@ -49,7 +49,7 @@ spec:
       associations:
         - kind: Label
           name: label_1
-    - kind: NotificationEndpointPagerDuty
+    - kind: Notification_Endpoint_Pager_Duty
       name: pager_duty_notification_endpoint
       description: pager duty desc
       url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history

--- a/pkger/testdata/notification_endpoint_secrets.yml
+++ b/pkger/testdata/notification_endpoint_secrets.yml
@@ -1,0 +1,14 @@
+apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: NotificationEndpointPagerDuty
+      name: pager_duty_notification_endpoint
+      url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
+      routingKey:
+        secretRef:
+          key: "routing-key"

--- a/pkger/testdata/notification_endpoint_secrets.yml
+++ b/pkger/testdata/notification_endpoint_secrets.yml
@@ -6,7 +6,7 @@ meta:
   description:  pack description
 spec:
   resources:
-    - kind: NotificationEndpointPagerDuty
+    - kind: Notification_Endpoint_Pager_Duty
       name: pager_duty_notification_endpoint
       url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
       routingKey:


### PR DESCRIPTION
also provides secret refs to be supported

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)