### PR TITLE
fix(kv): Store canceled task runs in the correct bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting
+1. [16238](https://github.com/influxdata/influxdb/pull/16238): Store canceled task runs in the correct bucket
 
 ### UI Improvements
 

--- a/kv/task.go
+++ b/kv/task.go
@@ -1051,7 +1051,7 @@ func (s *Service) cancelRun(ctx context.Context, tx Tx, taskID, runID influxdb.I
 	run.Status = "canceled"
 
 	// save
-	bucket, err := tx.Bucket(taskBucket)
+	bucket, err := tx.Bucket(taskRunBucket)
 	if err != nil {
 		return influxdb.ErrUnexpectedTaskBucketErr(err)
 	}


### PR DESCRIPTION
Task runs are stored and retrieved from the `taskRunsv1` bucket, but when they are canceled they are incorrectly placed in the `tasksv1` bucket. Once this has been done, further look ups of the task run fail, because it is located in the wrong bucket.

This addresses the problem by placing them back into the `taskRunsv1` bucket. An additional test has been added to ensure we are able to successfully read a canceled run.