### PR TITLE
feat(endpoints): drop id prefix req endpoint secret key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ### Features
 
 1. [16234](https://github.com/influxdata/influxdb/pull/16234): add support for notification endpoints to influx templates/pkgs.
+2. [16242](https://github.com/influxdata/influxdb/pull/16242): drop id prefix for secret key requirement for notification endpoints 
 
 ### Bug Fixes
 
 1. [16225](https://github.com/influxdata/influxdb/pull/16225): Ensures env vars are applied consistently across cmd, and fixes issue where INFLUX\_ env var prefix was not set globally.
-
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting
 1. [16238](https://github.com/influxdata/influxdb/pull/16238): Store canceled task runs in the correct bucket
 1. [16237](https://github.com/influxdata/influxdb/pull/16237): Updated Sortby functionality for table frontend sorts to sort numbers correctly

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -71,13 +71,13 @@ func TestValidEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "empty slack url and token",
+			name: "empty slack url",
 			src: &endpoint.Slack{
 				Base: goodBase,
 			},
 			err: &influxdb.Error{
 				Code: influxdb.EInvalid,
-				Msg:  "slack endpoint URL and token are empty",
+				Msg:  "slack endpoint URL must be provided",
 			},
 		},
 		{
@@ -98,30 +98,6 @@ func TestValidEndpoint(t *testing.T) {
 				URL:  "localhost",
 			},
 			err: nil,
-		},
-		{
-			name: "invalid slack token",
-			src: &endpoint.Slack{
-				Base:  goodBase,
-				URL:   "localhost",
-				Token: influxdb.SecretField{Key: "bad-key"},
-			},
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "slack endpoint token is invalid",
-			},
-		},
-		{
-			name: "invalid routine key",
-			src: &endpoint.PagerDuty{
-				Base:       goodBase,
-				ClientURL:  "localhost",
-				RoutingKey: influxdb.SecretField{Key: "bad-key"},
-			},
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "pagerduty routing key is invalid",
-			},
 		},
 		{
 			name: "empty http http method",

--- a/notification/endpoint/http.go
+++ b/notification/endpoint/http.go
@@ -103,15 +103,13 @@ func (s HTTP) Valid() error {
 			Msg:  "invalid http auth method",
 		}
 	}
-	if s.AuthMethod == "basic" &&
-		(s.Username.Key != s.ID.String()+httpUsernameSuffix ||
-			s.Password.Key != s.ID.String()+httpPasswordSuffix) {
+	if s.AuthMethod == "basic" && (s.Username.Key == "" || s.Password.Key == "") {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "invalid http username/password for basic auth",
 		}
 	}
-	if s.AuthMethod == "bearer" && s.Token.Key != s.ID.String()+httpTokenSuffix {
+	if s.AuthMethod == "bearer" && s.Token.Key == "" {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "invalid http token for bearer auth",

--- a/notification/endpoint/pagerduty.go
+++ b/notification/endpoint/pagerduty.go
@@ -40,7 +40,7 @@ func (s PagerDuty) Valid() error {
 	if err := s.Base.valid(); err != nil {
 		return err
 	}
-	if s.RoutingKey.Key != s.ID.String()+routingKeySuffix {
+	if s.RoutingKey.Key == "" {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "pagerduty routing key is invalid",

--- a/notification/endpoint/slack.go
+++ b/notification/endpoint/slack.go
@@ -45,10 +45,10 @@ func (s Slack) Valid() error {
 	if err := s.Base.valid(); err != nil {
 		return err
 	}
-	if s.URL == "" && s.Token.Key == "" {
+	if s.URL == "" {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
-			Msg:  "slack endpoint URL and token are empty",
+			Msg:  "slack endpoint URL must be provided",
 		}
 	}
 	if s.URL != "" {
@@ -57,13 +57,6 @@ func (s Slack) Valid() error {
 				Code: influxdb.EInvalid,
 				Msg:  fmt.Sprintf("slack endpoint URL is invalid: %s", err.Error()),
 			}
-		}
-	}
-	// TODO(desa): this requirement seems odd
-	if s.Token.Key != "" && s.Token.Key != s.ID.String()+slackTokenSuffix {
-		return &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "slack endpoint token is invalid",
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #16240 

Relaxes the rigid validation on endpoints to not require the id be prefixed.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass