### PR TITLE
fix(ui): added check to ensure that windowperiod isn't calculated when the query is undefined

### DIFF
--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -12,6 +12,8 @@ if (CLOUD) {
 
 interface AdditionalOptions {
   component?: string
+  context?: object
+  name?: string
 }
 
 export const reportError = (
@@ -26,9 +28,9 @@ export const reportError = (
 /*
   Parse React's error boundary info message to provide the name of the
   component an error occured in.
- 
+
   For example, given the following info message:
- 
+
       The above error occurred in the <MePage> component:
           in MePage (created by ErrorBoundary(MePage))
           in ErrorBoundary (created by ErrorBoundary(MePage))
@@ -36,7 +38,7 @@ export const reportError = (
           in Connect(ErrorBoundary(MePage)) (created by RouterContext)
           in SpinnerContainer (created by SetOrg)
           ...
- 
+
   We will extract "MePage" as the component name.
 */
 export const parseComponentName = (errorInfo: ErrorInfo): string => {

--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -12,7 +12,7 @@ if (CLOUD) {
 
 interface AdditionalOptions {
   component?: string
-  context?: object
+  context?: {[key: string]: any}
   name?: string
 }
 

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -51,6 +51,9 @@ export const getWindowPeriod = (
   query: string,
   variables: VariableAssignment[]
 ): number | null => {
+  if (query === undefined || query.length === 0) {
+    return null
+  }
   try {
     const ast = parse(query)
 
@@ -64,7 +67,8 @@ export const getWindowPeriod = (
 
     return Math.round(queryDuration / DESIRED_POINTS_PER_GRAPH)
   } catch (error) {
-    reportError(error)
+    console.error(error)
+    reportError(error, {component: 'getWindowPeriod function'})
     return null
   }
 }

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -68,7 +68,7 @@ export const getWindowPeriod = (
     return Math.round(queryDuration / DESIRED_POINTS_PER_GRAPH)
   } catch (error) {
     console.error(error)
-    reportError(error, {context: { query }, component: 'getWindowPeriod function'})
+    reportError(error, {component: `getWindowPeriod query: ${query}`})
     return null
   }
 }

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -51,7 +51,7 @@ export const getWindowPeriod = (
   query: string,
   variables: VariableAssignment[]
 ): number | null => {
-  if (query === undefined || query.length === 0) {
+  if (query.length === 0) {
     return null
   }
   try {

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -68,7 +68,10 @@ export const getWindowPeriod = (
     return Math.round(queryDuration / DESIRED_POINTS_PER_GRAPH)
   } catch (error) {
     console.error(error)
-    reportError(error, {component: `getWindowPeriod query: ${query}`})
+    reportError(error, {
+      context: {query},
+      name: 'getWindowPeriod function',
+    })
     return null
   }
 }

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -68,7 +68,7 @@ export const getWindowPeriod = (
     return Math.round(queryDuration / DESIRED_POINTS_PER_GRAPH)
   } catch (error) {
     console.error(error)
-    reportError(error, {component: 'getWindowPeriod function'})
+    reportError(error, {context: { query }, component: 'getWindowPeriod function'})
     return null
   }
 }


### PR DESCRIPTION
Closes https://app.honeybadger.io/projects/61122/faults/58676136

### Problem

The `FunctionSelector` component was triggering the `getWindowPeriod` function with an empty query when the component was initialized. The query would be blank at this time, so the `getMinDurationFromAST` function would throw an error, resulting a repetitive (not blocking) honeybadger error

### Solution

Added a check before running the `getWindowPeriod` function to see if the `query` is undefined or an empty string to ensure that the error won't be thrown due to an `invalid time range`

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)