### PR TITLE
fix: errors from the editor

### DIFF
--- a/ui/src/external/monaco.fluxSyntax.ts
+++ b/ui/src/external/monaco.fluxSyntax.ts
@@ -1,9 +1,9 @@
-import {loadWASM} from 'onigasm' // peer dependency of 'monaco-textmate'
+import loader from 'src/external/monaco.onigasm'
 import {Registry} from 'monaco-textmate' // peer dependency
 import {wireTmGrammars} from 'monaco-editor-textmate'
 
 export async function addSyntax(monaco) {
-  await loadWASM(require(`onigasm/lib/onigasm.wasm`))
+  await loader()
 
   monaco.languages.register({id: 'flux'})
 

--- a/ui/src/external/monaco.onigasm.ts
+++ b/ui/src/external/monaco.onigasm.ts
@@ -1,0 +1,29 @@
+import {loadWASM} from 'onigasm' // peer dependency of 'monaco-textmate'
+
+let wasm: boolean = false
+let loading: boolean = false
+const queue: Array<() => void> = []
+
+export default function loader() {
+  return new Promise(resolve => {
+    if (wasm) {
+      resolve()
+      return
+    }
+
+    queue.push(resolve)
+
+    if (loading) {
+      return
+    }
+
+    loading = true
+
+    loadWASM(require(`onigasm/lib/onigasm.wasm`))
+      .then(() => {
+        wasm = true
+        queue.forEach((c) => c())
+      })
+  })
+}
+

--- a/ui/src/external/monaco.onigasm.ts
+++ b/ui/src/external/monaco.onigasm.ts
@@ -19,11 +19,9 @@ export default function loader() {
 
     loading = true
 
-    loadWASM(require(`onigasm/lib/onigasm.wasm`))
-      .then(() => {
-        wasm = true
-        queue.forEach((c) => c())
-      })
+    loadWASM(require(`onigasm/lib/onigasm.wasm`)).then(() => {
+      wasm = true
+      queue.forEach(c => c())
+    })
   })
 }
-

--- a/ui/src/external/monaco.tomlSyntax.ts
+++ b/ui/src/external/monaco.tomlSyntax.ts
@@ -1,9 +1,9 @@
-import {loadWASM} from 'onigasm' // peer dependency of 'monaco-textmate'
+import loader from 'src/external/monaco.onigasm'
 import {Registry} from 'monaco-textmate' // peer dependency
 import {wireTmGrammars} from 'monaco-editor-textmate'
 
 export async function addSyntax(monaco) {
-  await loadWASM(require(`onigasm/lib/onigasm.wasm`))
+  await loader()
 
   monaco.languages.register({id: 'toml'})
 

--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -32,7 +32,7 @@ const FluxEditorMonaco: FC<Props> = props => {
       const {position} = evt
       const {onCursorChange} = props
       const pos = {
-        line: position.lineNumber,
+        line: position.lineNumber - 1,
         ch: position.column,
       }
 

--- a/ui/src/tasks/containers/TaskEditPage.tsx
+++ b/ui/src/tasks/containers/TaskEditPage.tsx
@@ -124,7 +124,6 @@ class TaskEditPage extends PureComponent<Props> {
                   suggestions={[]}
                 />
               </FeatureFlag>
-              <FluxEditor />
             </div>
           </div>
         </Page.Contents>


### PR DESCRIPTION
A bunch of honey badger errors came in this morning centered around the monaco editor. this fixes a few:
onigasm is only imported once
function inserts assumed a 0 indexed line number
invisible flux editor on task edit page

closes #16239
closes influxdata/honeybadger-errors#51
closes influxdata/honeybadger-errors#50
closes influxdata/honeybadger-errors#49