### PR TITLE
fix(kv): Prevent infinite loop condition when listing tasks by org.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting
 1. [16238](https://github.com/influxdata/influxdb/pull/16238): Store canceled task runs in the correct bucket
 1. [16237](https://github.com/influxdata/influxdb/pull/16237): Updated Sortby functionality for table frontend sorts to sort numbers correctly
+1. [16249](https://github.com/influxdata/influxdb/pull/16249): Prevent potential infinite loop when finding tasks by organization.
 1. [16255](https://github.com/influxdata/influxdb/pull/16255): Retain user input when parsing invalid JSON during import
 
 ### UI Improvements

--- a/kv/task.go
+++ b/kv/task.go
@@ -399,6 +399,7 @@ func (s *Service) findTasksByOrg(ctx context.Context, tx Tx, filter influxdb.Tas
 		if err != nil {
 			if err == influxdb.ErrTaskNotFound {
 				// we might have some crufty index's
+				k, v = c.Next()
 				continue
 			}
 			return nil, 0, err


### PR DESCRIPTION
Closes influxdata/idpe#5592

In the event that `findTaskByIDWithAuth` cannot find the task ID contained in the bucket, the outer loop will never terminate.

This ensures that we are calling `Next()` along-side any calls to `continue` while using a `Cursor`.

**Notes:**

I investigated improving the overall ergonomics of these cursor-based loops by hoisting the cursor advancement to the top of the iterations—instead of being at the tail-end of them. However, due to seeking behavior, the pre-conditions of the loop become a bit trickier. Perhaps this is an area of further improvement. Generally, loops that have cross-iteration state interaction tend to cause surprising behavior like this when `continue` gets involved.
