### PR TITLE
fix(ui): retain user input when parsing invalid JSON during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 ### Bug Fixes
 
 1. [16225](https://github.com/influxdata/influxdb/pull/16225): Ensures env vars are applied consistently across cmd, and fixes issue where INFLUX\_ env var prefix was not set globally.
-
 1. [16235](https://github.com/influxdata/influxdb/pull/16235): Removed default frontend sorting when flux queries specify sorting
 1. [16238](https://github.com/influxdata/influxdb/pull/16238): Store canceled task runs in the correct bucket
 1. [16237](https://github.com/influxdata/influxdb/pull/16237): Updated Sortby functionality for table frontend sorts to sort numbers correctly
+1. [16255](https://github.com/influxdata/influxdb/pull/16255): Retain user input when parsing invalid JSON during import
 
 ### UI Improvements
 

--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -74,19 +74,39 @@ describe('Dashboards', () => {
       cy.createDashboardTemplate(id)
     })
 
-    cy.getByTestID('empty-dashboards-list')
-      .getByTestID('add-resource-dropdown--button')
-      .click()
-
-    cy.getByTestID('add-resource-dropdown--template').click()
-
+    cy.getByTestID('empty-dashboards-list').within(() => {
+      cy.getByTestID('add-resource-dropdown--button').click()
+      cy.getByTestID('add-resource-dropdown--template').click()
+    })
     cy.getByTestID('template--Bashboard-Template').click()
-
     cy.getByTestID('template-panel').should('exist')
-
     cy.getByTestID('create-dashboard-button').click()
-
     cy.getByTestID('dashboard-card').should('have.length', 1)
+  })
+
+  it('keeps user input in text area when attempting to import invalid JSON', () => {
+    cy.getByTestID('page-header').within(() => {
+      cy.contains('Create').click()
+    })
+
+    cy.getByTestID('add-resource-dropdown--import').click()
+    cy.contains('Paste').click()
+    cy.getByTestID('import-overlay--textarea')
+      .click()
+      .type('this is invalid JSON')
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid JSON')
+    )
+    cy.getByTestID('import-overlay--textarea').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}'
+    )
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid')
+    )
   })
 
   describe('Dashboard List', () => {

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -77,6 +77,31 @@ http.post(
       .and('contain', taskName)
   })
 
+  it('keeps user input in text area when attempting to import invalid JSON', () => {
+    cy.getByTestID('page-header').within(() => {
+      cy.contains('Create').click()
+    })
+
+    cy.getByTestID('add-resource-dropdown--import').click()
+    cy.contains('Paste').click()
+    cy.getByTestID('import-overlay--textarea')
+      .click()
+      .type('this is invalid JSON')
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid JSON')
+    )
+    cy.getByTestID('import-overlay--textarea').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}'
+    )
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid')
+    )
+  })
+
   describe('When tasks already exist', () => {
     beforeEach(() => {
       cy.get('@org').then(({id}: Organization) => {

--- a/ui/cypress/e2e/templates.test.ts
+++ b/ui/cypress/e2e/templates.test.ts
@@ -1,0 +1,32 @@
+describe('Templates', () => {
+  beforeEach(() => {
+    cy.flush()
+
+    cy.signin().then(({body}) => {
+      cy.wrap(body.org).as('org')
+      cy.visit(`orgs/${body.org.id}/settings/templates`)
+    })
+  })
+
+  it('keeps user input in text area when attempting to import invalid JSON', () => {
+    cy.get('button[title*="Import"]').click()
+
+    cy.contains('Paste').click()
+    cy.getByTestID('import-overlay--textarea')
+      .click()
+      .type('this is invalid JSON')
+    cy.get('button[title*="Import JSON"').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid JSON')
+    )
+    cy.getByTestID('import-overlay--textarea').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}'
+    )
+    cy.get('button[title*="Import JSON"').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid')
+    )
+  })
+})

--- a/ui/cypress/e2e/variables.test.ts
+++ b/ui/cypress/e2e/variables.test.ts
@@ -31,6 +31,31 @@ describe('Variables', () => {
     cy.getByTestID('resource-card').should('have.length', 1)
   })
 
+  it('keeps user input in text area when attempting to import invalid JSON', () => {
+    cy.get('.tabbed-page-section--header').within(() => {
+      cy.contains('Create').click()
+    })
+
+    cy.getByTestID('add-resource-dropdown--import').click()
+    cy.contains('Paste').click()
+    cy.getByTestID('import-overlay--textarea')
+      .click()
+      .type('this is invalid JSON')
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid JSON')
+    )
+    cy.getByTestID('import-overlay--textarea').type(
+      '{backspace}{backspace}{backspace}{backspace}{backspace}'
+    )
+    cy.get('button[title*="Import JSON"]').click()
+    cy.getByTestID('import-overlay--textarea--error').should('have.length', 1)
+    cy.getByTestID('import-overlay--textarea').should($s =>
+      expect($s).to.contain('this is invalid')
+    )
+  })
+
   it.skip('can delete a variable', () => {
     cy.get<Organization>('@org').then(({id}) => {
       cy.createVariable(id)

--- a/ui/package.json
+++ b/ui/package.json
@@ -148,6 +148,7 @@
     "honeybadger-js": "^1.0.2",
     "immer": "^1.9.3",
     "intersection-observer": "^0.7.0",
+    "jsonlint-mod": "^1.7.5",
     "lodash": "^4.3.0",
     "memoize-one": "^4.0.2",
     "moment": "^2.13.0",

--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -29,6 +29,8 @@ interface OwnProps {
   resourceName: string
   onSubmit: (importString: string, orgID: string) => void
   isVisible?: boolean
+  status?: ComponentStatus
+  updateStatus?: (status: ComponentStatus) => void
 }
 
 interface State {
@@ -96,6 +98,7 @@ class ImportOverlay extends PureComponent<Props, State> {
 
   private get importBody(): JSX.Element {
     const {selectedImportOption, importContent} = this.state
+    const {status = ComponentStatus.Default} = this.props
 
     if (selectedImportOption === ImportOption.Upload) {
       return (
@@ -110,7 +113,12 @@ class ImportOverlay extends PureComponent<Props, State> {
     }
     if (selectedImportOption === ImportOption.Paste) {
       return (
-        <TextArea value={importContent} onChange={this.handleChangeTextArea} />
+        <TextArea
+          status={status}
+          value={importContent}
+          onChange={this.handleChangeTextArea}
+          testID="import-overlay--textarea"
+        />
       )
     }
   }
@@ -118,8 +126,10 @@ class ImportOverlay extends PureComponent<Props, State> {
   private handleChangeTextArea = (
     e: ChangeEvent<HTMLTextAreaElement>
   ): void => {
+    const {updateStatus = () => {}} = this.props
     const importContent = e.target.value
     this.handleSetImportContent(importContent)
+    updateStatus(ComponentStatus.Default)
   }
 
   private get submitButton(): JSX.Element {
@@ -154,7 +164,10 @@ class ImportOverlay extends PureComponent<Props, State> {
   }
 
   private clearImportContent = () => {
-    this.setState({importContent: ''})
+    this.setState((state, props) => {
+      const {status = ComponentStatus.Default} = props
+      return status === ComponentStatus.Error ? {...state} : {importContent: ''}
+    })
   }
 
   private onDismiss = () => {

--- a/ui/src/variables/components/VariableImportOverlay.tsx
+++ b/ui/src/variables/components/VariableImportOverlay.tsx
@@ -13,8 +13,17 @@ import {
   createVariableFromTemplate as createVariableFromTemplateAction,
   getVariables as getVariablesAction,
 } from 'src/variables/actions'
-
 import {notify as notifyAction} from 'src/shared/actions/notifications'
+
+// Types
+import {ComponentStatus} from '@influxdata/clockface'
+
+// Utils
+import jsonlint from 'jsonlint-mod'
+
+interface State {
+  status: ComponentStatus
+}
 
 interface DispatchProps {
   createVariableFromTemplate: typeof createVariableFromTemplateAction
@@ -25,12 +34,18 @@ interface DispatchProps {
 type Props = DispatchProps & WithRouterProps
 
 class VariableImportOverlay extends PureComponent<Props> {
+  public state: State = {
+    status: ComponentStatus.Default,
+  }
+
   public render() {
     return (
       <ImportOverlay
         onDismissOverlay={this.onDismiss}
         resourceName="Variable"
         onSubmit={this.handleImportVariable}
+        status={this.state.status}
+        updateStatus={this.updateOverlayStatus}
       />
     )
   }
@@ -41,13 +56,18 @@ class VariableImportOverlay extends PureComponent<Props> {
     router.goBack()
   }
 
+  private updateOverlayStatus = (status: ComponentStatus) =>
+    this.setState(() => ({status}))
+
   private handleImportVariable = (uploadContent: string) => {
     const {createVariableFromTemplate, getVariables, notify} = this.props
 
     let template
+    this.updateOverlayStatus(ComponentStatus.Default)
     try {
-      template = JSON.parse(uploadContent)
+      template = jsonlint.parse(uploadContent)
     } catch (error) {
+      this.updateOverlayStatus(ComponentStatus.Error)
       notify(invalidJSON(error.message))
       return
     }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1754,6 +1754,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+JSV@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+  integrity sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -7103,6 +7108,15 @@ jsonfile@^3.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonlint-mod@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/jsonlint-mod/-/jsonlint-mod-1.7.5.tgz#678d2b600b9d350ec3448373d6f71dcbf09a0e3d"
+  integrity sha512-VqTFtMj9JXv4qGSfcoYTgXgsGkTW4aXZer8u4vR64RAPjK37BUkNKmd3mTjuRTs1vQrE+yuzfzDhgB2SAyPvlA==
+  dependencies:
+    JSV "^4.0.2"
+    chalk "^2.4.2"
+    underscore "^1.9.1"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -11661,6 +11675,11 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
   integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
+
+underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 underscore@~1.4.4:
   version "1.4.4"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16099

Added a third party library that wraps JSON.parse with linting and detailed error messaging.

For now, we are going to put the detailed error messages into the toast. As @hoorayimhelping mentioned, there is a potential for moving the detailed error message into something more permanent and useful for the user.