### PR TITLE
chore: add getUserFlags utility function

### DIFF
--- a/ui/src/shared/utils/featureFlag.test.ts
+++ b/ui/src/shared/utils/featureFlag.test.ts
@@ -1,0 +1,31 @@
+import {CLOUD_FLAGS, OSS_FLAGS} from 'src/shared/utils/featureFlag'
+
+describe("getting the user's feature flags", () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('gets the OSS flags by default if CLOUD is not enabled', () => {
+    jest.mock('src/shared/constants/index', () => ({
+      CLOUD: false,
+      CLOUD_BILLING_VISIBLE: true,
+    }))
+    const {getUserFlags} = require('src/shared/utils/featureFlag')
+
+    const flags = getUserFlags()
+    expect(flags).toEqual(OSS_FLAGS)
+  })
+
+  it('gets the cloud flags if CLOUD is enabled', () => {
+    jest.mock('src/shared/constants/index', () => ({
+      CLOUD: true,
+      CLOUD_BILLING_VISIBLE: false,
+    }))
+    const {getUserFlags} = require('src/shared/utils/featureFlag')
+
+    const flags = getUserFlags()
+    expect(flags).toEqual(CLOUD_FLAGS)
+  })
+})
+
+// todo: test the dadgum isFlagEnabled function

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -1,7 +1,7 @@
 import {FunctionComponent} from 'react'
 import {CLOUD, CLOUD_BILLING_VISIBLE} from 'src/shared/constants'
 
-const OSS_FLAGS = {
+export const OSS_FLAGS = {
   alerting: false,
   deleteWithPredicate: false,
   monacoEditor: false,
@@ -9,7 +9,7 @@ const OSS_FLAGS = {
   telegrafEditor: false,
 }
 
-const CLOUD_FLAGS = {
+export const CLOUD_FLAGS = {
   alerting: true,
   deleteWithPredicate: false,
   monacoEditor: false,
@@ -63,36 +63,21 @@ export const FeatureFlag: FunctionComponent<{
   return children as any
 }
 
+export const getUserFlags = function getUserFlags() {
+  const flagKeys = CLOUD ? Object.keys(CLOUD_FLAGS) : Object.keys(OSS_FLAGS)
+
+  const flags = {}
+  flagKeys.forEach(key => {
+    flags[key] = isFlagEnabled(key)
+  })
+
+  return flags
+}
+
 /* eslint-disable no-console */
 const list = () => {
   console.log('Currently Available Feature Flags')
-  if (CLOUD) {
-    console.table(
-      Object.keys(CLOUD_FLAGS)
-        .map(k => [k, isFlagEnabled(k)])
-        .reduce((prev, curr) => {
-          if (typeof curr[0] === 'boolean') {
-            return prev
-          }
-
-          prev[curr[0]] = curr[1]
-          return prev
-        }, {})
-    )
-  } else {
-    console.table(
-      Object.keys(OSS_FLAGS)
-        .map(k => [k, isFlagEnabled(k)])
-        .reduce((prev, curr) => {
-          if (typeof curr[0] === 'boolean') {
-            return prev
-          }
-
-          prev[curr[0]] = curr[1]
-          return prev
-        }, {})
-    )
-  }
+  console.table(getUserFlags())
 }
 /* eslint-enable no-console */
 


### PR DESCRIPTION
Adds a utility function to `featureFlags`, `getUserFlags`. This was part of work I did on #16138 that I pulled out into its own logical commit, hence no issue number.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
