### PR TITLE
feat(tasks): remove flux stats from run log and replace with trace id

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -112,7 +112,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	log := h.log.With(logger.TraceFields(ctx)...)
-	if id, _, found := logger.TraceInfo(ctx); found {
+	if id, _, found := tracing.InfoFromContext(ctx); found {
 		w.Header().Set(traceIDHeader, id)
 	}
 

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb/kit/tracing"
+	tracetesting "github.com/influxdata/influxdb/kit/tracing/testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
@@ -323,7 +323,7 @@ var _ metric.EventRecorder = noopEventRecorder{}
 
 // Certain error cases must be encoded as influxdb.Error so they can be properly decoded clientside.
 func TestFluxHandler_PostQuery_Errors(t *testing.T) {
-	defer tracing.JaegerTestSetupAndTeardown(t.Name())()
+	defer tracetesting.SetupInMemoryTracing(t.Name())()
 
 	i := inmem.NewService()
 	b := &FluxBackend{

--- a/kit/tracing/testing/testing.go
+++ b/kit/tracing/testing/testing.go
@@ -1,0 +1,24 @@
+package testing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+)
+
+// SetupInMemoryTracing sets the global tracer to an in memory Jaeger instance for testing.
+// The returned function should be deferred by the caller to tear down this setup after testing is complete.
+func SetupInMemoryTracing(name string) func() {
+	var (
+		old            = opentracing.GlobalTracer()
+		tracer, closer = jaeger.NewTracer(name,
+			jaeger.NewConstSampler(true),
+			jaeger.NewInMemoryReporter(),
+		)
+	)
+
+	opentracing.SetGlobalTracer(tracer)
+	return func() {
+		_ = closer.Close()
+		opentracing.SetGlobalTracer(old)
+	}
+}

--- a/query/logging.go
+++ b/query/logging.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/influxdata/influxdb/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -51,7 +50,7 @@ func (s *LoggingProxyQueryService) Query(ctx context.Context, w io.Writer, req *
 				entry.Write(zap.Error(err))
 			}
 		}
-		traceID, sampled, _ := logger.TraceInfo(ctx)
+		traceID, sampled, _ := tracing.InfoFromContext(ctx)
 		log := Log{
 			OrganizationID: req.Request.OrganizationID,
 			TraceID:        traceID,

--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -14,7 +14,6 @@ import (
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/backend/scheduler"
-	"github.com/uber/jaeger-client-go"
 	"go.uber.org/zap"
 )
 
@@ -401,8 +400,8 @@ func (w *worker) executeQuery(p *promise) {
 	it.Release()
 
 	// log the trace id and whether or not it was sampled into the run log
-	if sctx, ok := span.Context().(jaeger.SpanContext); ok {
-		msg := fmt.Sprintf("trace_id=%s is_sampled=%t", sctx.TraceID(), sctx.IsSampled())
+	if traceID, isSampled, ok := tracing.InfoFromSpan(span); ok {
+		msg := fmt.Sprintf("trace_id=%s is_sampled=%t", traceID, isSampled)
 		w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now().UTC(), msg)
 	}
 

--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/backend/scheduler"
+	"github.com/uber/jaeger-client-go"
 	"go.uber.org/zap"
 )
 
@@ -400,12 +400,10 @@ func (w *worker) executeQuery(p *promise) {
 
 	it.Release()
 
-	// log the statistics on the run
-	stats := it.Statistics()
-
-	b, err := json.Marshal(stats)
-	if err == nil {
-		w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now().UTC(), string(b))
+	// log the trace id and whether or not it was sampled into the run log
+	if sctx, ok := span.Context().(jaeger.SpanContext); ok {
+		msg := fmt.Sprintf("trace_id=%s is_sampled=%t", sctx.TraceID(), sctx.IsSampled())
+		w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now().UTC(), msg)
 	}
 
 	if runErr != nil {

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kit/prom"
 	"github.com/influxdata/influxdb/kit/prom/promtest"
+	tracetest "github.com/influxdata/influxdb/kit/tracing/testing"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/task/backend"
@@ -28,16 +29,7 @@ import (
 func TestMain(m *testing.M) {
 	var code int
 	func() {
-		// backup old tracer
-		oldTracer := opentracing.GlobalTracer()
-		defer opentracing.SetGlobalTracer(oldTracer)
-
-		// setup in-memory tracer for task tests
-		sampler := jaeger.NewConstSampler(true)
-		tracer, closer := jaeger.NewTracer("task_backend_tests", sampler, jaeger.NewInMemoryReporter())
-		defer closer.Close()
-
-		opentracing.SetGlobalTracer(tracer)
+		defer tracetest.SetupInMemoryTracing("task_backend_tests")()
 
 		code = m.Run()
 	}()


### PR DESCRIPTION
This removes the flux statistics from the task run log.

In place of the flux statistics we now have the trace ID and whether the trace was sampled.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
