### PR TITLE
chore: add more context to honeybadger errors

### DIFF
--- a/ui/src/organizations/actions/orgs.ts
+++ b/ui/src/organizations/actions/orgs.ts
@@ -2,6 +2,7 @@
 import {Dispatch} from 'redux'
 import {ThunkAction} from 'redux-thunk'
 import {push, RouterAction} from 'react-router-redux'
+import HoneyBadger from 'honeybadger-js'
 
 // APIs
 import {getErrorMessage} from 'src/utils/api'
@@ -80,6 +81,9 @@ export interface SetOrg {
 }
 
 export const setOrg = (org: Organization): SetOrg => {
+  HoneyBadger.setContext({
+    orgID: org.id,
+  })
   return {
     type: ActionTypes.SetOrg,
     payload: {org},

--- a/ui/src/shared/actions/me.ts
+++ b/ui/src/shared/actions/me.ts
@@ -1,5 +1,6 @@
 import {MeState} from 'src/shared/reducers/me'
 import {client} from 'src/utils/api'
+import HoneyBadger from 'honeybadger-js'
 
 export enum ActionTypes {
   SetMe = 'SET_ME',
@@ -25,8 +26,12 @@ export const getMe = () => async dispatch => {
   try {
     const user = await client.users.me()
 
+    HoneyBadger.setContext({
+      user_id: user.id,
+    })
+
     dispatch(setMe(user))
-  } catch (e) {
-    console.error(e)
+  } catch (error) {
+    console.error(error)
   }
 }


### PR DESCRIPTION
Closes #16138

1. Adds the user id, org id, and current feature flag status to HoneyBadger error context
1. If the environment is not `CLOUD` print a table of the context that would have been sent to honeybadger

[See the context](https://app.honeybadger.io/projects/61122/faults/58718222#notice-context) on a contrived, but actual HoneyBadger error.

Local context in the console:
<img width="433" alt="Screen Shot 2019-12-18 at 10 31 26 AM" src="https://user-images.githubusercontent.com/146112/71120039-6020f000-2190-11ea-893e-35b25b4de1b9.png">


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass