### PR TITLE
ci: split go and js linting into separate circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,10 @@ jobs:
             - 'yarn-packages-{{ checksum "yarn.lock" }}'
           name: "Restore Yarn Package Cache"
       - run:
-          command: "yarn install --frozen-lockfile"
+          command: |
+            set +e
+            cd ui
+            yarn install --frozen-lockfile
           name: "Install Dependencies"
       - run: make ui_client
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,11 +160,18 @@ jobs:
     docker:
       - image: circleci/golang:1.12-node-browsers
     working_directory: /go/src/github.com/influxdata/influxdb
+    parallelism: 8
     steps:
       - checkout
       - run: make node_modules
       - run: make ui_client
-      - run: make chronograf_lint
+      - run:
+         name: eslint
+         command: |
+           set +e
+           cd ui
+           TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
+           yarn eslint:circleci $TESTFILES
   gotest:
     docker:
       - image: circleci/golang:1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,16 @@ jobs:
     parallelism: 8
     steps:
       - checkout
-      - run: make node_modules
+      - restore_cache:
+          keys:
+            - 'yarn-cached-packages-{{ checksum "yarn.lock" }}'
+          name: "Restore Yarn Package Cache"
+      - run:
+          command: |
+            set +e
+            cd ui
+            yarn install --frozen-lockfile
+          name: "Install Dependencies"
       - run: make ui_client
       - run:
           name: jest tests
@@ -156,6 +165,11 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: raw-test-output
+      - save_cache:
+          key: 'yarn-cached-packages-{{ checksum "yarn.lock" }}'
+          name: "Save Yarn Package Cache"
+          paths:
+            - ~/.cache/yarn
   jslint:
     docker:
       - image: circleci/golang:1.12-node-browsers
@@ -165,7 +179,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - 'yarn-packages-{{ checksum "yarn.lock" }}'
+            - 'yarn-cached-packages-{{ checksum "yarn.lock" }}'
           name: "Restore Yarn Package Cache"
       - run:
           command: |
@@ -182,7 +196,7 @@ jobs:
             TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
             yarn eslint:circleci $TESTFILES
       - save_cache:
-          key: 'yarn-packages-{{ checksum "yarn.lock" }}'
+          key: 'yarn-cached-packages-{{ checksum "yarn.lock" }}'
           name: "Save Yarn Package Cache"
           paths:
             - ~/.cache/yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
           key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           name: "Save Yarn Package Cache"
           paths:
-            - /go/src/github.com/influxdata/influxdb/ui/.cache/yarn
+            - ~/.cache/yarn
   gotest:
     docker:
       - image: circleci/golang:1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,13 @@ jobs:
     parallelism: 8
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - "yarn-packages-{{ checksum \"yarn.lock\" }}"
+          name: "Restore Yarn Package Cache"
+      - run:
+          command: "yarn install --frozen-lockfile"
+          name: "Install Dependencies"
       - run: make node_modules
       - run: make ui_client
       - run:
@@ -172,6 +179,11 @@ jobs:
            cd ui
            TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
            yarn eslint:circleci $TESTFILES
+      - save_cache:
+         key: "yarn-packages-{{ checksum \"yarn.lock\" }}"
+           name: "Save Yarn Package Cache"
+           paths:
+             -  /go/src/github.com/influxdata/influxdb/ui/.cache/yarn
   gotest:
     docker:
       - image: circleci/golang:1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           name: "Install Dependencies"
       - run: make ui_client
       - run:
-          name: eslint
+          name: parallel eslint
           command: |
             set +e
             cd ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,16 +184,7 @@ jobs:
       - install_rust_compiler
       - run: mkdir -p $TEST_RESULTS
       - run: make test-go # This uses the test cache so it may succeed or fail quickly.
-      - run: make vet
-      - run: make checkfmt
-      - run: make checktidy
-      - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
-      - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
-      - run: GO111MODULE=on staticcheck ./...
       - run: GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-verbose --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' ./...
-      # TODO add these checks to the Makefile
-      # - run: go get -v -t -d ./...
-
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}
@@ -210,6 +201,55 @@ jobs:
           path: /tmp/test-results
           destination: raw-test-output
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: /tmp/test-results
+  golint:
+    docker:
+      - image: circleci/golang:1.12
+    environment:
+      GOCACHE: /tmp/go-cache
+      GOFLAGS: '-mod=readonly -p=2' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      TEST_RESULTS: /tmp/test-results
+    working_directory: /go/src/github.com/influxdata/influxdb
+    steps:
+      - checkout
+
+      # Populate GOCACHE.
+      - restore_cache:
+          name: Restoring GOCACHE
+          keys:
+            - influxdb-gocache-{{ .Branch }}-{{ .Revision }} # Matches when retrying a single run.
+            - influxdb-gocache-{{ .Branch }}- # Matches a new commit on an existing branch.
+            - influxdb-gocache- # Matches a new branch.
+      # Populate GOPATH/pkg.
+      - restore_cache:
+          name: Restoring GOPATH/pkg/mod
+          keys:
+            - influxdb-gomod-{{ checksum "go.sum" }} # Matches based on go.sum checksum.
+      - run: sudo apt-get install -y bzr
+      - install_rust_compiler
+      - run: mkdir -p $TEST_RESULTS
+      - run: make vet
+      - run: make checkfmt
+      - run: make checktidy
+      - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
+      - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
+      - run: GO111MODULE=on staticcheck ./...
+      - save_cache:
+          name: Saving GOCACHE
+          key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /tmp/go-cache
+          when: always
+      - save_cache:
+          name: Saving GOPATH/pkg/mod
+          key: influxdb-gomod-{{ checksum "go.sum" }}
+          paths:
+            - /go/pkg/mod
+          when: always
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+      - store_test_results:
           path: /tmp/test-results
   build:
     docker:
@@ -312,6 +352,7 @@ workflows:
   build:
     jobs:
       - gotest
+      - golint
       - jstest
       - build
       - litmus_daily:
@@ -333,10 +374,12 @@ workflows:
                 - master
     jobs:
       - gotest
+      - golint
       - jstest
       - deploy-nightly:
           requires:
             - gotest
+            - golint
             - jstest
           filters:
             branches:
@@ -355,7 +398,12 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
-
+      - golint:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
       - jstest:
           filters:
             branches:
@@ -365,6 +413,7 @@ workflows:
       - release:
           requires:
             - gotest
+            - golint
             - jstest
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
           name: "Install Dependencies"
       - run: make ui_client
       - run:
-          name: jest tests
+          name: parallel jest tests
           command: |
             set +e
             cd ui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - install_rust_compiler
       - run: mkdir -p $TEST_RESULTS
       - run: make test-go # This uses the test cache so it may succeed or fail quickly.
-      - run: GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-verbose --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' ./...
+      - run: GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' ./...
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,12 +151,20 @@ jobs:
            cd ui
            TESTFILES=$(circleci tests glob "src/**/*.test.ts*" | circleci tests split --split-by=timings)
            yarn test:circleci $TESTFILES
-      - run: make chronograf_lint
       - store_test_results:
           path: coverage
       - store_artifacts:
           path: coverage
           destination: raw-test-output
+  jslint:
+    docker:
+      - image: circleci/golang:1.12-node-browsers
+    working_directory: /go/src/github.com/influxdata/influxdb
+    steps:
+      - checkout
+      - run: make node_modules
+      - run: make ui_client
+      - run: make chronograf_lint
   gotest:
     docker:
       - image: circleci/golang:1.12
@@ -354,6 +362,7 @@ workflows:
       - gotest
       - golint
       - jstest
+      - jslint
       - build
       - litmus_daily:
           requires:
@@ -376,11 +385,13 @@ workflows:
       - gotest
       - golint
       - jstest
+      - jslint
       - deploy-nightly:
           requires:
             - gotest
             - golint
             - jstest
+            - jslint
           filters:
             branches:
               only: master
@@ -410,11 +421,18 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
+      - jslint:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
       - release:
           requires:
             - gotest
             - golint
             - jstest
+            - jslint
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: "2.1"
 
 commands:
   install_rust_compiler:
@@ -64,7 +64,7 @@ jobs:
       - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -100,37 +100,37 @@ jobs:
     docker:
       - image: circleci/node:13.0.1-stretch-browsers
       - image: quay.io/influxdb/influx:nightly
-        command: [ --e2e-testing=true ]
+        command: [--e2e-testing=true]
     steps:
       - checkout
       - run:
-         name: Environment check
-         command: |
-           git --version
-           node --version && npm --version
-           docker --version
-           google-chrome --version && which google-chrome && chromedriver --version && which chromedriver
-           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9999)" != "200" ]]; do sleep 5; done' || false
+          name: Environment check
+          command: |
+            git --version
+            node --version && npm --version
+            docker --version
+            google-chrome --version && which google-chrome && chromedriver --version && which chromedriver
+            timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9999)" != "200" ]]; do sleep 5; done' || false
       - run:
-         name: Checkout Tests
-         command: git clone --single-branch --branch 2.0-Alpha https://github.com/bonitoo-io/selenium-accept-infl2.git
+          name: Checkout Tests
+          command: git clone --single-branch --branch 2.0-Alpha https://github.com/bonitoo-io/selenium-accept-infl2.git
       - run:
-         name: Selenium tests
-         command: |
-           set +e
-           cd selenium-accept-infl2
-           npm install
-           npm test; TEST_RESULT=$?
-           npm run report:html
-           npm run report:junit
-           mkdir -p ~/test-results/cucumber
-           mkdir -p ~/artifacts/html
-           cp ~/project/selenium-accept-infl2/report/cucumber_report.html ~/artifacts/html/cucumber_report.html
-           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/test-results/cucumber/report.xml
-           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/artifacts/report.xml
-           cp -r ~/project/selenium-accept-infl2/screenshots ~/artifacts
-           ls -al
-           exit $TEST_RESULT
+          name: Selenium tests
+          command: |
+            set +e
+            cd selenium-accept-infl2
+            npm install
+            npm test; TEST_RESULT=$?
+            npm run report:html
+            npm run report:junit
+            mkdir -p ~/test-results/cucumber
+            mkdir -p ~/artifacts/html
+            cp ~/project/selenium-accept-infl2/report/cucumber_report.html ~/artifacts/html/cucumber_report.html
+            cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/test-results/cucumber/report.xml
+            cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/artifacts/report.xml
+            cp -r ~/project/selenium-accept-infl2/screenshots ~/artifacts
+            ls -al
+            exit $TEST_RESULT
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
@@ -145,12 +145,12 @@ jobs:
       - run: make node_modules
       - run: make ui_client
       - run:
-         name: jest tests
-         command: |
-           set +e
-           cd ui
-           TESTFILES=$(circleci tests glob "src/**/*.test.ts*" | circleci tests split --split-by=timings)
-           yarn test:circleci $TESTFILES
+          name: jest tests
+          command: |
+            set +e
+            cd ui
+            TESTFILES=$(circleci tests glob "src/**/*.test.ts*" | circleci tests split --split-by=timings)
+            yarn test:circleci $TESTFILES
       - store_test_results:
           path: coverage
       - store_artifacts:
@@ -165,31 +165,30 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - "yarn-packages-{{ checksum \"yarn.lock\" }}"
+            - 'yarn-packages-{{ checksum "yarn.lock" }}'
           name: "Restore Yarn Package Cache"
       - run:
           command: "yarn install --frozen-lockfile"
           name: "Install Dependencies"
-      - run: make node_modules
       - run: make ui_client
       - run:
-         name: eslint
-         command: |
-           set +e
-           cd ui
-           TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
-           yarn eslint:circleci $TESTFILES
+          name: eslint
+          command: |
+            set +e
+            cd ui
+            TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
+            yarn eslint:circleci $TESTFILES
       - save_cache:
-         key: "yarn-packages-{{ checksum \"yarn.lock\" }}"
-           name: "Save Yarn Package Cache"
-           paths:
-             -  /go/src/github.com/influxdata/influxdb/ui/.cache/yarn
+          key: 'yarn-packages-{{ checksum "yarn.lock" }}'
+          name: "Save Yarn Package Cache"
+          paths:
+            - /go/src/github.com/influxdata/influxdb/ui/.cache/yarn
   gotest:
     docker:
       - image: circleci/golang:1.12
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=2' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=2" # Go on Circle thinks 32 CPUs are available, but there aren't.
       TEST_RESULTS: /tmp/test-results
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
@@ -234,7 +233,7 @@ jobs:
       - image: circleci/golang:1.12
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=2' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=2" # Go on Circle thinks 32 CPUs are available, but there aren't.
       TEST_RESULTS: /tmp/test-results
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
@@ -283,7 +282,7 @@ jobs:
       - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -315,7 +314,7 @@ jobs:
       - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -331,12 +330,12 @@ jobs:
             - influxdb-gomod-{{ checksum "go.sum" }} # Just match the go.sum checksum cache.
       - setup_remote_docker
       - run:
-          name: 'Docker Login'
+          name: "Docker Login"
           command: docker login -u "$QUAY_USER" -p $QUAY_PASS quay.io
       - run: sudo apt-get install -y bzr
       - run: make protoc # installs protoc
       - run:
-          name: 'Build nightly'
+          name: "Build nightly"
           command: make nightly
       - persist_to_workspace:
           root: .
@@ -349,7 +348,7 @@ jobs:
       - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
-      GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      GOFLAGS: "-mod=readonly -p=4" # Go on Circle thinks 32 CPUs are available, but there aren't.
       DOCKER_VERSION: 2.0.0-alpha
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
@@ -366,12 +365,12 @@ jobs:
             - influxdb-gomod-{{ checksum "go.sum" }} # Just match the go.sum checksum cache.
       - setup_remote_docker
       - run:
-          name: 'Docker Login'
+          name: "Docker Login"
           command: docker login -u "$QUAY_USER" -p $QUAY_PASS quay.io
       - run: sudo apt-get install -y bzr
       - run: make protoc # installs protoc
       - run:
-          name: 'Build release'
+          name: "Build release"
           command: make release
 
 workflows:
@@ -395,7 +394,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: '0 7 * * *'
+          cron: "0 7 * * *"
           filters:
             branches:
               only:

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=\"./coverage\" jest --ci --coverage",
     "lint": "yarn tsc && yarn prettier && yarn eslint",
     "eslint": "eslint '{src,cypress}/**/*.{ts,tsx}'",
+    "eslint:circleci": "eslint",
     "eslint:fix": "eslint --fix '{src,cypress}/**/*.{ts,tsx}'",
     "prettier": "prettier --config .prettierrc.json --check '{src,cypress}/**/*.{ts,tsx}'",
     "prettier:fix": "prettier --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",


### PR DESCRIPTION
This splits the go and js linting steps out of the tests.  This allows them to be run in parallel.

Speeds up the entire js flow from 13 to 9 minutes and go tests from 22 minutes to 19.

<img width="579" alt="after parallel jest" src="https://user-images.githubusercontent.com/1922921/71129162-72ad2080-21b4-11ea-9e32-7cd633070a3d.png">

<img width="579" alt="after lint split" src="https://user-images.githubusercontent.com/1922921/71129223-97a19380-21b4-11ea-9928-1da55f4ba235.png">

Additionally, I paralleled eslint over 8 containers so the linter goes from 9 to 4.5 minutes.

<img width="596" alt="image" src="https://user-images.githubusercontent.com/1922921/71129392-f5ce7680-21b4-11ea-8e10-5f47e996098c.png">

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
