### PR TITLE
ci: run go race tests in parallel over 8 containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,8 @@ jobs:
           name: parallel go race tests
           command: |
             set +e
-            TESTFILES=$(go list ./... | circleci tests split --split-by=timings)
+            # filter internal/promqltests because it has special go.mod
+            TESTFILES=$(go list ./... | grep -v internal/promqltests | circleci tests split --split-by=timings)
             echo $TESTFILES
             GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,7 @@ jobs:
           command: |
             set +e
             TESTFILES=$(go list ./... | circleci tests split --split-by=timings)
+            echo $TESTFILES
             GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' -mod=readonly $TESTFILES
       - save_cache:
           name: Saving GOCACHE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,7 @@ jobs:
       GOFLAGS: "-mod=readonly -p=2" # Go on Circle thinks 32 CPUs are available, but there aren't.
       TEST_RESULTS: /tmp/test-results
     working_directory: /go/src/github.com/influxdata/influxdb
+    parallelism: 8
     steps:
       - checkout
 
@@ -227,7 +228,12 @@ jobs:
       - install_rust_compiler
       - run: mkdir -p $TEST_RESULTS
       - run: make test-go # This uses the test cache so it may succeed or fail quickly.
-      - run: GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' ./...
+      - run:
+          name: parallel go race tests
+          command: |
+            set +e
+            TESTFILES=$(go list ./... | circleci tests split)
+            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
             set +e
             TESTFILES=$(go list ./... | circleci tests split --split-by=timings)
             echo $TESTFILES
-            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' -mod=readonly $TESTFILES
+            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
           name: parallel go race tests
           command: |
             set +e
-            TESTFILES=$(go list ./... | grep -v internal | circleci tests split --split-by=timings)
+            TESTFILES=$(go list ./... | circleci tests split --split-by=timings)
             GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
       - save_cache:
           name: Saving GOCACHE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
           name: parallel go race tests
           command: |
             set +e
-            TESTFILES=$(go list ./... | circleci tests split)
+            TESTFILES=$(go list ./... | grep -v internal | circleci tests split --split-by=timings)
             GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
       - save_cache:
           name: Saving GOCACHE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
           command: |
             set +e
             TESTFILES=$(go list ./... | circleci tests split --split-by=timings)
-            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
+            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' -mod=readonly $TESTFILES
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
Similar to #16274, this parallelizes the go race tests across 8 circle containers.

This speeds up the tests from 19 to 11m

<img width="596" alt="Screen Shot 2019-12-18 at 3 24 55 PM" src="https://user-images.githubusercontent.com/1922921/71147216-b53f1f00-21ed-11ea-966c-53a290502f15.png">

<img width="596" alt="Screen Shot 2019-12-18 at 11 21 28 PM" src="https://user-images.githubusercontent.com/1922921/71147221-b83a0f80-21ed-11ea-89e7-335863983672.png">


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
