### PR TITLE
feat(query/stdlib): prevent a filter push down if the filter needs to keep empty tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62
-	github.com/influxdata/flux v0.57.0
+	github.com/influxdata/flux v0.57.1-0.20191219182109-2fa9b34f588f
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.57.0 h1:AIU5dVeAGjybtp35yBZVtlQydisbVF5BKEmQkcV/R+w=
-github.com/influxdata/flux v0.57.0/go.mod h1:rXPJ9Su3L5mye6I7YpB2szyYo485QU0cuGGHfC9mJA8=
+github.com/influxdata/flux v0.57.1-0.20191219182109-2fa9b34f588f h1:ynUzS3JOAaZYmHdE6bR2Sqj3nov2NxKj33PkzTtMxKA=
+github.com/influxdata/flux v0.57.1-0.20191219182109-2fa9b34f588f/go.mod h1:rXPJ9Su3L5mye6I7YpB2szyYo485QU0cuGGHfC9mJA8=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.57.0
+	github.com/influxdata/flux v0.57.1-0.20191219182109-2fa9b34f588f
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -286,6 +286,7 @@ github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBh
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
 github.com/influxdata/flux v0.57.0 h1:AIU5dVeAGjybtp35yBZVtlQydisbVF5BKEmQkcV/R+w=
 github.com/influxdata/flux v0.57.0/go.mod h1:rXPJ9Su3L5mye6I7YpB2szyYo485QU0cuGGHfC9mJA8=
+github.com/influxdata/flux v0.57.1-0.20191219182109-2fa9b34f588f/go.mod h1:rXPJ9Su3L5mye6I7YpB2szyYo485QU0cuGGHfC9mJA8=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -101,6 +101,11 @@ func (PushDownFilterRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
 	fromNode := pn.Predecessors()[0]
 	fromSpec := fromNode.ProcedureSpec().(*ReadRangePhysSpec)
 
+	// Cannot push down when keeping empty tables.
+	if filterSpec.KeepEmptyTables {
+		return pn, false, nil
+	}
+
 	bodyExpr, ok := filterSpec.Fn.Fn.Block.Body.(semantic.Expression)
 	if !ok {
 		return pn, false, nil

--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -62,8 +62,8 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 		"keys":               "group key mismatch",
 
 		// failed to read meta data errors: the CSV encoding is incomplete probably due to data schema errors.  needs more detailed investigation to find root cause of error
-		"filter_by_regex":             "failed to read metadata",
-		"filter_by_tags":              "failed to read metadata",
+		// "filter_by_regex":             "failed to read metadata",
+		// "filter_by_tags":              "failed to read metadata",
 		"group":                       "failed to read metadata",
 		"group_except":                "failed to read metadata",
 		"group_ungroup":               "failed to read metadata",


### PR DESCRIPTION
The storage engine isn't capable of sending back empty tables when a
series is empty. Because of this, we disable the push down and let flux
do the filtering in the case where there is a filter and it is specified
to keep the empty tables.

Related to influxdata/flux#2287.