### PR TITLE
feat: generate types for tests

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -9,15 +9,18 @@ node_modules:
 	yarn install
 
 e2e: node_modules
+	yarn generate
 	yarn test:junit
 
 build: node_modules $(UISOURCES)
 	yarn build
 
 lint: node_modules $(UISOURCES)
+	yarn generate
 	yarn lint
 
 test:
+	yarn generate
 	yarn test
 
 clean:


### PR DESCRIPTION
tests are failing from the makefile because types aren't being generated from swagger. this runs the generate command more often