### PR TITLE
fix(tests): make sure NATS port is open for unit tests

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -727,7 +727,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	// still open.
 	//
 	// This atrocity checks if the port is free, and if it's not, moves on to the
-	// next one.
+	// next one. This best-effort approach may still fail occasionally when, for example,
+	// two tests race on isAddressPortAvailable.
 	var total int
 	for {
 		portAvailable, err := isAddressPortAvailable(natsOpts.Host, natsOpts.Port)


### PR DESCRIPTION
Fixes #10628 again

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

Manually tested #10628 is fixed:
- run influxd
- lsof to verify influxd is listening on port 4222
- git checkout master
- `go test ./cmd/...` fails due to NATS port 4222
- git checkout jgm-fix-nats (this branch)
- `got test ./cmd/...` does not fail