### PR TITLE
fix: speeding them tests right up

### DIFF
--- a/ui/jestSetup.ts
+++ b/ui/jestSetup.ts
@@ -1,5 +1,7 @@
 import {cleanup} from 'react-testing-library'
 
+jest.mock('honeybadger-js', () => () => null)
+
 process.env.API_PREFIX = '/'
 // cleans up state between react-testing-library tests
 afterEach(() => {


### PR DESCRIPTION
tests jumped from ~1min to ~20min on circleci some time last week, prompting parallelization of those tests in order to run in a usable test window. This worked fine until someone made a good case for running the tests outside of the CI pipeline, in which tests took up to 6hrs on one user's machine.

i did some sleuthing

and it turns out that the problem was just that honey badger is being included in all of these tests as of this PR: https://github.com/influxdata/influxdb/pull/16194

so our tests were breaking our tests

I mocked honey badger from the jest tests in the test setup file (applies to all tests), and now tests are back down to ~1min