### PR TITLE
feat(pkger): add dry run functionality for task resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [16305](https://github.com/influxdata/influxdb/pull/16305): Add support for notification rule pkger apply functionality
 1. [16312](https://github.com/influxdata/influxdb/pull/16312): Add support for notification rule pkger export functionality
 1. [16320](https://github.com/influxdata/influxdb/pull/16320): Add support for tasks to pkger parser
+1. [16322](https://github.com/influxdata/influxdb/pull/16322): Add support for tasks to pkger dry run functionality
 
 ### Bug Fixes
 

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -689,10 +689,22 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) {
 		})
 	}
 
-	if teles := diff.Telegrafs; len(diff.Telegrafs) > 0 {
+	if teles := diff.Telegrafs; len(teles) > 0 {
 		headers := []string{"New", "Name", "Description"}
 		tablePrintFn("TELEGRAF CONFIGS", headers, len(teles), func(i int) []string {
 			t := teles[i]
+			return []string{
+				boolDiff(true),
+				t.Name,
+				green(t.Description),
+			}
+		})
+	}
+
+	if tasks := diff.Tasks; len(tasks) > 0 {
+		headers := []string{"New", "Name", "Description"}
+		tablePrintFn("TASKS", headers, len(tasks), func(i int) []string {
+			t := tasks[i]
 			return []string{
 				boolDiff(true),
 				t.Name,

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7499,6 +7499,25 @@ components:
                           type: string
                         operator:
                           type: string
+            tasks:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  cron:
+                    type: string
+                  description:
+                    type: string
+                  every:
+                    type: string
+                  offset:
+                    type: string
+                  query:
+                    type: string
+                  status:
+                    type: string
             telegrafConfigs:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -181,6 +181,7 @@ type Diff struct {
 	LabelMappings         []DiffLabelMapping         `json:"labelMappings"`
 	NotificationEndpoints []DiffNotificationEndpoint `json:"notificationEndpoints"`
 	NotificationRules     []DiffNotificationRule     `json:"notificationRules"`
+	Tasks                 []DiffTask                 `json:"tasks"`
 	Telegrafs             []DiffTelegraf             `json:"telegrafConfigs"`
 	Variables             []DiffVariable             `json:"variables"`
 }
@@ -452,6 +453,29 @@ func newDiffNotificationRule(r *notificationRule, iEndpoint influxdb.Notificatio
 	}
 
 	return sum
+}
+
+// DiffTask is a diff of an individual task. This resource is always new.
+type DiffTask struct {
+	Name        string          `json:"name"`
+	Cron        string          `json:"cron"`
+	Description string          `json:"description"`
+	Every       string          `json:"every"`
+	Offset      string          `json:"offset"`
+	Query       string          `json:"query"`
+	Status      influxdb.Status `json:"status"`
+}
+
+func newDiffTask(t *task) DiffTask {
+	return DiffTask{
+		Name:        t.name,
+		Cron:        t.cron,
+		Description: t.description,
+		Every:       durToStr(t.every),
+		Offset:      durToStr(t.offset),
+		Query:       t.query,
+		Status:      t.Status(),
+	}
 }
 
 // DiffTelegraf is a diff of an individual telegraf. This resource is always new.

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -138,7 +138,7 @@ type Pkg struct {
 	mDashboards            []*dashboard
 	mNotificationEndpoints map[string]*notificationEndpoint
 	mNotificationRules     []*notificationRule
-	mTasks                 map[string]*task
+	mTasks                 []*task
 	mTelegrafs             []*telegraf
 	mVariables             map[string]*variable
 
@@ -316,10 +316,7 @@ func (p *Pkg) secrets() map[string]bool {
 }
 
 func (p *Pkg) tasks() []*task {
-	tasks := make([]*task, 0, len(p.mTasks))
-	for _, t := range p.mTasks {
-		tasks = append(tasks, t)
-	}
+	tasks := p.mTasks[:]
 
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Name() < tasks[j].Name() })
 
@@ -750,7 +747,7 @@ func (p *Pkg) graphNotificationRules() *parseErr {
 }
 
 func (p *Pkg) graphTasks() *parseErr {
-	p.mTasks = make(map[string]*task)
+	p.mTasks = make([]*task, 0)
 	return p.eachResource(KindTask, 1, func(r Resource) []validationErr {
 		t := &task{
 			name:        r.Name(),
@@ -769,7 +766,7 @@ func (p *Pkg) graphTasks() *parseErr {
 		})
 		sort.Sort(t.labels)
 
-		p.mTasks[r.Name()] = t
+		p.mTasks = append(p.mTasks, t)
 		return append(failures, t.valid()...)
 	})
 }

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -647,6 +647,7 @@ func (s *Service) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pk
 		Checks:     s.dryRunChecks(ctx, orgID, pkg),
 		Dashboards: s.dryRunDashboards(pkg),
 		Labels:     s.dryRunLabels(ctx, orgID, pkg),
+		Tasks:      s.dryRunTasks(pkg),
 		Telegrafs:  s.dryRunTelegraf(pkg),
 		Variables:  s.dryRunVariables(ctx, orgID, pkg),
 	}
@@ -867,6 +868,14 @@ func (s *Service) dryRunSecrets(ctx context.Context, orgID influxdb.ID, pkg *Pkg
 	sort.Strings(missing)
 	err = fmt.Errorf("secrets to not exist for secret reference keys: %s", strings.Join(missing, ", "))
 	return &influxdb.Error{Code: influxdb.EUnprocessableEntity, Err: err}
+}
+
+func (s *Service) dryRunTasks(pkg *Pkg) []DiffTask {
+	var diffs []DiffTask
+	for _, t := range pkg.tasks() {
+		diffs = append(diffs, newDiffTask(t))
+	}
+	return diffs
 }
 
 func (s *Service) dryRunTelegraf(pkg *Pkg) []DiffTelegraf {


### PR DESCRIPTION
adds dry run functionality for tasks

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
