### PR TITLE
feat(pkger): add export support for tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [16320](https://github.com/influxdata/influxdb/pull/16320): Add support for tasks to pkger parser
 1. [16322](https://github.com/influxdata/influxdb/pull/16322): Add support for tasks to pkger dry run functionality
 1. [16323](https://github.com/influxdata/influxdb/pull/16323): Add support for tasks to pkger apply functionality
+1. [16324](https://github.com/influxdata/influxdb/pull/16324): Add support for tasks to pkger export functionality
 
 ### Bug Fixes
 

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -56,6 +56,7 @@ type cmdPkgBuilder struct {
 		endpoints    string
 		labels       string
 		rules        string
+		tasks        string
 		telegrafs    string
 		variables    string
 	}
@@ -231,6 +232,7 @@ func (b *cmdPkgBuilder) cmdPkgExport() *cobra.Command {
 	cmd.Flags().StringVar(&b.exportOpts.endpoints, "endpoints", "", "List of notification endpoint ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.labels, "labels", "", "List of label ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.rules, "rules", "", "List of notification rule ids comma separated")
+	cmd.Flags().StringVar(&b.exportOpts.tasks, "tasks", "", "List of task ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.telegrafs, "telegraf-configs", "", "List of telegraf config ids comma separated")
 	cmd.Flags().StringVar(&b.exportOpts.variables, "variables", "", "List of variable ids comma separated")
 
@@ -258,6 +260,7 @@ func (b *cmdPkgBuilder) pkgExportRunEFn() func(*cobra.Command, []string) error {
 			{kind: pkger.KindLabel, idStrs: strings.Split(b.exportOpts.labels, ",")},
 			{kind: pkger.KindNotificationEndpoint, idStrs: strings.Split(b.exportOpts.endpoints, ",")},
 			{kind: pkger.KindNotificationRule, idStrs: strings.Split(b.exportOpts.rules, ",")},
+			{kind: pkger.KindTask, idStrs: strings.Split(b.exportOpts.tasks, ",")},
 			{kind: pkger.KindTelegraf, idStrs: strings.Split(b.exportOpts.telegrafs, ",")},
 			{kind: pkger.KindVariable, idStrs: strings.Split(b.exportOpts.variables, ",")},
 		}

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -417,6 +417,10 @@ spec:
 					ID:   endpoints[0].NotificationEndpoint.GetID(),
 				},
 				{
+					Kind: pkger.KindTask,
+					ID:   influxdb.ID(task.ID),
+				},
+				{
 					Kind: pkger.KindTelegraf,
 					ID:   teles[0].TelegrafConfig.ID,
 				},
@@ -491,6 +495,16 @@ spec:
 			assert.Zero(t, newRule.EndpointID)
 			assert.Equal(t, rule.EndpointName, newRule.EndpointName)
 			hasLabelAssociations(t, newRule.LabelAssociations, 1, "label_1")
+
+			require.Len(t, newSum.Tasks, 1)
+			newTask := newSum.Tasks[0]
+			assert.Equal(t, task.Name, newTask.Name)
+			assert.Equal(t, task.Description, newTask.Description)
+			assert.Equal(t, task.Cron, newTask.Cron)
+			assert.Equal(t, task.Every, newTask.Every)
+			assert.Equal(t, task.Offset, newTask.Offset)
+			assert.Equal(t, task.Query, newTask.Query)
+			assert.Equal(t, task.Status, newTask.Status)
 
 			require.Len(t, newSum.TelegrafConfigs, 1)
 			assert.Equal(t, teles[0].TelegrafConfig.Name, newSum.TelegrafConfigs[0].TelegrafConfig.Name)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7157,6 +7157,7 @@ components:
                 - label
                 - notification_endpoint
                 - notification_rule
+                - task
                 - telegraf
                 - variable
             name:

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -198,6 +198,7 @@ func (p *Pkg) Summary() Summary {
 type (
 	validateOpt struct {
 		minResources bool
+		skipValidate bool
 	}
 
 	// ValidateOptFn provides a means to disable desired validation checks.
@@ -210,6 +211,15 @@ type (
 func ValidWithoutResources() ValidateOptFn {
 	return func(opt *validateOpt) {
 		opt.minResources = false
+	}
+}
+
+// ValidSkipParseError ignores the validation check from the  of resources. This
+// is useful for the service Create to ignore this and allow the creation of a
+// pkg without resources.
+func ValidSkipParseError() ValidateOptFn {
+	return func(opt *validateOpt) {
+		opt.skipValidate = true
 	}
 }
 
@@ -238,7 +248,7 @@ func (p *Pkg) Validate(opts ...ValidateOptFn) error {
 		}
 	}
 
-	if len(pErr.Resources) > 0 {
+	if len(pErr.Resources) > 0 && !opt.skipValidate {
 		return &pErr
 	}
 


### PR DESCRIPTION
lo and behold, our last PR before an MVP can be realized. This is to supply tasks for exporting:

```sh
$ influx pkg export --tasks=04f90352681d3000
apiVersion: 0.1.0
kind: package
meta:
    description: ""
    pkgName: new_6868142840635702249
    pkgVersion: v1
spec:
    resources:
      - every: 1h
        kind: Task
        name: task1
        offset: 10m0s
        query: |-
            from(bucket: "rucket1")
             |> yield()

```

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)