### PR TITLE
fix: add custom marshaler to dashboard builder config to stop breaking api consumers

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -880,6 +880,29 @@ type BuilderConfig struct {
 	} `json:"aggregateWindow"`
 }
 
+// MarshalJSON is necessary for the time being. UI keeps breaking
+// b/c it relies on these slices being populated/not nil. Other
+// consumers may have same issue.
+func (b BuilderConfig) MarshalJSON() ([]byte, error) {
+	type alias BuilderConfig
+	copyCfg := alias(b)
+	if copyCfg.Buckets == nil {
+		copyCfg.Buckets = []string{}
+	}
+	if copyCfg.Tags == nil {
+		copyCfg.Tags = []struct {
+			Key    string   `json:"key"`
+			Values []string `json:"values"`
+		}{}
+	}
+	if copyCfg.Functions == nil {
+		copyCfg.Functions = []struct {
+			Name string `json:"name"`
+		}{}
+	}
+	return json.Marshal(copyCfg)
+}
+
 // NewBuilderTag is a constructor for the builder config types. This
 // isn't technically required, but working with struct literals with embedded
 // struct tags is really painful. This is to get around that bit. Would be nicer

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -147,9 +147,9 @@ func TestService_handleGetChecks(t *testing.T) {
 					"aggregateWindow": {
 						"period": ""
 					},
-					"buckets": null,
-					"functions": null,
-					"tags": null
+					"buckets": [],
+					"functions": [],
+					"tags": []
 				},
 				"editMode": "",
 				"name": "",
@@ -188,9 +188,9 @@ func TestService_handleGetChecks(t *testing.T) {
 					"aggregateWindow": {
 						"period": ""
 					},
-					"buckets": null,
-					"functions": null,
-					"tags": null
+					"buckets": [],
+					"functions": [],
+					"tags": []
 				},
 				"editMode": "",
 				"name": "",
@@ -505,9 +505,9 @@ func TestService_handleGetCheck(t *testing.T) {
               "aggregateWindow": {
                 "period": ""
               },
-              "buckets": null,
-              "functions": null,
-              "tags": null
+              "buckets": [],
+              "functions": [],
+              "tags": []
             },
             "editMode": "",
             "name": "",
@@ -683,9 +683,9 @@ func TestService_handlePostCheck(t *testing.T) {
     "aggregateWindow": {
       "period": ""
     },
-    "buckets": null,
-    "functions": null,
-    "tags": null
+    "buckets": [],
+    "functions": [],
+    "tags": []
   },
   "editMode": "",
   "name": "",
@@ -936,9 +936,9 @@ func TestService_handlePatchCheck(t *testing.T) {
 					"aggregateWindow": {
 						"period": ""
 					},
-					"buckets": null,
-					"functions": null,
-					"tags": null
+					"buckets": [],
+					"functions": [],
+					"tags": []
 				},
 				"editMode": "",
 				"name": "",
@@ -1117,9 +1117,9 @@ func TestService_handleUpdateCheck(t *testing.T) {
               "aggregateWindow": {
                 "period": ""
               },
-              "buckets": null,
-              "functions": null,
-              "tags": null
+              "buckets": [],
+              "functions": [],
+              "tags": []
             },
             "editMode": "",
             "name": "",

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -15,8 +15,6 @@ import (
 	"testing"
 	"time"
 
-	tracetesting "github.com/influxdata/influxdb/kit/tracing/testing"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
@@ -27,6 +25,7 @@ import (
 	"github.com/influxdata/influxdb/http/metric"
 	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kit/check"
+	tracetesting "github.com/influxdata/influxdb/kit/tracing/testing"
 	influxmock "github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/mock"

--- a/notification/check/check_test.go
+++ b/notification/check/check_test.go
@@ -168,6 +168,18 @@ func TestJSON(t *testing.T) {
 					Name:    "name1",
 					OrgID:   influxTesting.MustIDBase16(id3),
 					Every:   mustDuration("1h"),
+					Query: influxdb.DashboardQuery{
+						BuilderConfig: influxdb.BuilderConfig{
+							Buckets: []string{},
+							Tags: []struct {
+								Key    string   `json:"key"`
+								Values []string `json:"values"`
+							}{},
+							Functions: []struct {
+								Name string `json:"name"`
+							}{},
+						},
+					},
 					Tags: []influxdb.Tag{
 						{
 							Key:   "k1",
@@ -197,6 +209,18 @@ func TestJSON(t *testing.T) {
 					OwnerID: influxTesting.MustIDBase16(id2),
 					OrgID:   influxTesting.MustIDBase16(id3),
 					Every:   mustDuration("1h"),
+					Query: influxdb.DashboardQuery{
+						BuilderConfig: influxdb.BuilderConfig{
+							Buckets: []string{},
+							Tags: []struct {
+								Key    string   `json:"key"`
+								Values []string `json:"values"`
+							}{},
+							Functions: []struct {
+								Name string `json:"name"`
+							}{},
+						},
+					},
 					Tags: []influxdb.Tag{
 						{
 							Key:   "k1",
@@ -221,16 +245,19 @@ func TestJSON(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		b, err := json.Marshal(c.src)
-		if err != nil {
-			t.Fatalf("%s marshal failed, err: %s", c.name, err.Error())
+		fn := func(t *testing.T) {
+			b, err := json.Marshal(c.src)
+			if err != nil {
+				t.Fatalf("%s marshal failed, err: %s", c.name, err.Error())
+			}
+			got, err := check.UnmarshalJSON(b)
+			if err != nil {
+				t.Fatalf("%s unmarshal failed, err: %s", c.name, err.Error())
+			}
+			if diff := cmp.Diff(got, c.src, cmpopts.IgnoreFields(notification.Duration{}, "BaseNode")); diff != "" {
+				t.Errorf("failed %s, Check are different -got/+want\ndiff %s", c.name, diff)
+			}
 		}
-		got, err := check.UnmarshalJSON(b)
-		if err != nil {
-			t.Fatalf("%s unmarshal failed, err: %s", c.name, err.Error())
-		}
-		if diff := cmp.Diff(got, c.src, cmpopts.IgnoreFields(notification.Duration{}, "BaseNode")); diff != "" {
-			t.Errorf("failed %s, Check are different -got/+want\ndiff %s", c.name, diff)
-		}
+		t.Run(c.name, fn)
 	}
 }

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -43,6 +43,21 @@ var deadman1 = &check.Deadman{
 		TaskID:      1,
 		Query: influxdb.DashboardQuery{
 			Text: script,
+			BuilderConfig: influxdb.BuilderConfig{
+				Buckets: []string{},
+				Tags: []struct {
+					Key    string   `json:"key"`
+					Values []string `json:"values"`
+				}{
+					{
+						Key:    "_field",
+						Values: []string{"usage_user"},
+					},
+				},
+				Functions: []struct {
+					Name string `json:"name"`
+				}{},
+			},
 		},
 		Every:                 mustDuration("1m"),
 		StatusMessageTemplate: "msg1",
@@ -73,6 +88,16 @@ var threshold1 = &check.Threshold{
 		Every:                 mustDuration("1m"),
 		Query: influxdb.DashboardQuery{
 			Text: script,
+			BuilderConfig: influxdb.BuilderConfig{
+				Buckets: []string{},
+				Tags: []struct {
+					Key    string   `json:"key"`
+					Values []string `json:"values"`
+				}{},
+				Functions: []struct {
+					Name string `json:"name"`
+				}{},
+			},
 		},
 		Tags: []influxdb.Tag{
 			{Key: "k11", Value: "v11"},
@@ -299,6 +324,7 @@ func CreateCheck(
 							Query: influxdb.DashboardQuery{
 								Text: script,
 								BuilderConfig: influxdb.BuilderConfig{
+									Buckets: []string{},
 									Tags: []struct {
 										Key    string   `json:"key"`
 										Values []string `json:"values"`
@@ -308,6 +334,9 @@ func CreateCheck(
 											Values: []string{"usage_user"},
 										},
 									},
+									Functions: []struct {
+										Name string `json:"name"`
+									}{},
 								},
 							},
 							Every:                 mustDuration("1m"),
@@ -626,6 +655,7 @@ func CreateCheck(
 							Query: influxdb.DashboardQuery{
 								Text: script,
 								BuilderConfig: influxdb.BuilderConfig{
+									Buckets: []string{},
 									Tags: []struct {
 										Key    string   `json:"key"`
 										Values []string `json:"values"`
@@ -635,6 +665,9 @@ func CreateCheck(
 											Values: []string{"usage_user"},
 										},
 									},
+									Functions: []struct {
+										Name string `json:"name"`
+									}{},
 								},
 							},
 							OwnerID:               MustIDBase16(twoID),
@@ -1727,6 +1760,21 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 						Description: "desc changed",
 						Query: influxdb.DashboardQuery{
 							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Buckets: []string{},
+								Tags: []struct {
+									Key    string   `json:"key"`
+									Values []string `json:"values"`
+								}{
+									{
+										Key:    "_field",
+										Values: []string{"usage_user"},
+									},
+								},
+								Functions: []struct {
+									Name string `json:"name"`
+								}{},
+							},
 						},
 						StatusMessageTemplate: "msg1",
 						Tags: []influxdb.Tag{


### PR DESCRIPTION
UI in partricular is expecting non nil array vals, this remedies that issue so those are always populated.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
