### PR TITLE
feat(kit/check): Manual Overrides for Readiness Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [16340](https://github.com/influxdata/influxdb/pull/16340): Add last run status to tasks
 1. [16341](https://github.com/influxdata/influxdb/pull/16341): Extend pkger apply functionality with ability to provide secrets outside of pkg
 1. [16345](https://github.com/influxdata/influxdb/pull/16345): Add hide headers flag to influx cli task find cmd
+1. [16336](https://github.com/influxdata/influxdb/pull/16336): Manual Overrides for Readiness Endpoint
 
 ### Bug Fixes
 


### PR DESCRIPTION
With `/health`, it is possible to override the overall status reported. This change adds the same functionality to `/ready`. This allows incident responders to take an unhealthy pod out of a service without killing it—giving them time to gather meaningful forensic data from the pod. The new contract is:

Force not ready:

    GET /ready?force=true&ready=false

Force ready:

    GET /ready?force=true&ready=true

Disable override:

    GET /ready?force=false

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
