### PR TITLE
feat(pkger): add ability to provide secrets alongside package when applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1. [16324](https://github.com/influxdata/influxdb/pull/16324): Add support for tasks to pkger export functionality
 1. [16226](https://github.com/influxdata/influxdb/pull/16226): Add group() to Query Builder
 1. [16338](https://github.com/influxdata/influxdb/pull/16338): Add last run status to check and notification rules
+1. [16341](https://github.com/influxdata/influxdb/pull/16341): Extend pkger apply functionality with ability to provide secrets outside of pkg
 
 ### Bug Fixes
 

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -604,7 +604,7 @@ func testPkgWritesToBuffer(newCmdFn func() *cobra.Command, args pkgFileArgs, ass
 type fakePkgSVC struct {
 	createFn func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
 	dryRunFn func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error)
-	applyFn  func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error)
+	applyFn  func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, error)
 }
 
 func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
@@ -621,9 +621,9 @@ func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg 
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, error) {
 	if f.applyFn != nil {
-		return f.applyFn(ctx, orgID, userID, pkg)
+		return f.applyFn(ctx, orgID, userID, pkg, opts...)
 	}
 	panic("not implemented")
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -155,6 +155,7 @@ var blacklistEndpoints = map[string]isValidMethodFn{
 	prefixMe:                         ignoreMethod(),
 	mePasswordPath:                   ignoreMethod(),
 	usersPasswordPath:                ignoreMethod(),
+	prefixPackages + "/apply":        ignoreMethod(),
 	prefixWrite:                      ignoreMethod("POST"),
 	organizationsIDSecretsPath:       ignoreMethod("PATCH"),
 	organizationsIDSecretsDeletePath: ignoreMethod("POST"),

--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -122,9 +122,10 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 type (
 	// ReqApplyPkg is the request body for a json or yaml body for the apply pkg endpoint.
 	ReqApplyPkg struct {
-		DryRun bool       `json:"dryRun" yaml:"dryRun"`
-		OrgID  string     `json:"orgID" yaml:"orgID"`
-		Pkg    *pkger.Pkg `json:"package" yaml:"package"`
+		DryRun  bool              `json:"dryRun" yaml:"dryRun"`
+		OrgID   string            `json:"orgID" yaml:"orgID"`
+		Pkg     *pkger.Pkg        `json:"package" yaml:"package"`
+		Secrets map[string]string `json:"secrets"`
 	}
 
 	// RespApplyPkg is the response body for the apply pkg endpoint.
@@ -185,7 +186,7 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sum, err = s.svc.Apply(r.Context(), *orgID, userID, parsedPkg)
+	sum, err = s.svc.Apply(r.Context(), *orgID, userID, parsedPkg, pkger.ApplyWithSecrets(reqBody.Secrets))
 	if err != nil && !pkger.IsParseErr(err) {
 		s.logger.Error("failed to apply pkg", zap.Error(err))
 		s.HandleHTTPError(r.Context(), err, w)
@@ -288,24 +289,36 @@ func (s *PkgerService) CreatePkg(ctx context.Context, setters ...pkger.CreatePkg
 // for later calls to Apply. This func will be run on an Apply if it has not been run
 // already.
 func (s *PkgerService) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error) {
-	return s.apply(ctx, orgID, pkg, true)
+	reqBody := ReqApplyPkg{
+		OrgID:  orgID.String(),
+		DryRun: true,
+		Pkg:    pkg,
+	}
+	return s.apply(ctx, reqBody)
 }
 
 // Apply will apply all the resources identified in the provided pkg. The entire pkg will be applied
 // in its entirety. If a failure happens midway then the entire pkg will be rolled back to the state
-// from before the pkg were applied.
-func (s *PkgerService) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
-	sum, _, err := s.apply(ctx, orgID, pkg, false)
+// from before the pkg was applied.
+func (s *PkgerService) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, error) {
+	var opt pkger.ApplyOpt
+	for _, o := range opts {
+		if err := o(&opt); err != nil {
+			return pkger.Summary{}, err
+		}
+	}
+
+	reqBody := ReqApplyPkg{
+		OrgID:   orgID.String(),
+		Pkg:     pkg,
+		Secrets: opt.MissingSecrets,
+	}
+
+	sum, _, err := s.apply(ctx, reqBody)
 	return sum, err
 }
 
-func (s *PkgerService) apply(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg, dryRun bool) (pkger.Summary, pkger.Diff, error) {
-	reqBody := ReqApplyPkg{
-		OrgID:  orgID.String(),
-		DryRun: dryRun,
-		Pkg:    pkg,
-	}
-
+func (s *PkgerService) apply(ctx context.Context, reqBody ReqApplyPkg) (pkger.Summary, pkger.Diff, error) {
 	var resp RespApplyPkg
 	err := s.Client.
 		PostJSON(reqBody, prefixPackages, "/apply").

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7130,10 +7130,16 @@ components:
     PkgApply:
       type: object
       properties:
-        apply:
+        dryRun:
           type: boolean
+        orgID:
+          type: string
         package:
           $ref: "#/components/schemas/Pkg"
+        secrets:
+          type: object
+          additionalProperties:
+            type: string
     PkgCreate:
       type: object
       properties:
@@ -7264,6 +7270,10 @@ components:
                     type: string
                   labelID:
                     type: string
+            missingSecrets:
+              type: array
+              items:
+                type: string
             notificationEndpoints:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -541,6 +541,7 @@ type Summary struct {
 	NotificationRules     []SummaryNotificationRule     `json:"notificationRules"`
 	Labels                []SummaryLabel                `json:"labels"`
 	LabelMappings         []SummaryLabelMapping         `json:"labelMappings"`
+	MissingSecrets        []string                      `json:"missingSecrets"`
 	Tasks                 []SummaryTask                 `json:"summaryTask"`
 	TelegrafConfigs       []SummaryTelegraf             `json:"telegrafConfigs"`
 	Variables             []SummaryVariable             `json:"variables"`

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -351,7 +351,7 @@ func TestService(t *testing.T) {
 			})
 		})
 
-		t.Run("secrets not found returns error", func(t *testing.T) {
+		t.Run("secrets not returns missing secrets", func(t *testing.T) {
 			testfileRunner(t, "testdata/notification_endpoint_secrets.yml", func(t *testing.T, pkg *Pkg) {
 				fakeSecretSVC := mock.NewSecretService()
 				fakeSecretSVC.GetSecretKeysFn = func(ctx context.Context, orgID influxdb.ID) ([]string, error) {
@@ -359,8 +359,10 @@ func TestService(t *testing.T) {
 				}
 				svc := newTestService(WithSecretSVC(fakeSecretSVC))
 
-				_, _, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
-				require.Error(t, err)
+				sum, _, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				require.NoError(t, err)
+
+				assert.Equal(t, []string{"routing-key"}, sum.MissingSecrets)
 			})
 		})
 


### PR DESCRIPTION
this provides the ability to add secret refs at runtime instead of adding them to the pkg.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)


examples for providing secrets via the CLI:

```
# using secret flag
$influx pkg -f $PWD/pkger/testdata/notification_endpoint_secrets.yml -o=rg --secret=routing-key-4::routing-key-pair --secret=routing-key-7::someval

# using stdin to provide it
$ influx pkg -f $PWD/pkger/testdata/notification_endpoint_secrets.yml -o=rg
Please provide secret value for key routing-key-6 (optional, press enter to skip):
```