### PR TITLE
fix(pkger): make pkger skip system tasks when exporting all tasks

### DIFF
--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -2639,8 +2639,9 @@ func TestService(t *testing.T) {
 			taskSVC.FindTasksFn = func(ctx context.Context, f influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 				return []*influxdb.Task{
 					{ID: 31},
-					{ID: expectedCheck.TaskID}, // this one should be ignored in the return
-				}, 2, nil
+					{ID: expectedCheck.TaskID},              // this one should be ignored in the return
+					{ID: 99, Type: influxdb.TaskSystemType}, // this one should be skipped since it is a system task
+				}, 3, nil
 			}
 			taskSVC.FindTaskByIDFn = func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
 				if id != 31 {


### PR DESCRIPTION
references #16342 

the tasks export all exports system tasks, which this PR is to remove.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass