### PR TITLE
feat(pkger): fixup flux query normalization in exporting of task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 1. [16249](https://github.com/influxdata/influxdb/pull/16249): Prevent potential infinite loop when finding tasks by organization.
 1. [16255](https://github.com/influxdata/influxdb/pull/16255): Retain user input when parsing invalid JSON during import
 1. [16268](https://github.com/influxdata/influxdb/pull/16268): Fixed test flakiness that stemmed from multiple flush/signins being called in the same test suite
+1. [16346](https://github.com/influxdata/influxdb/pull/16346): Update pkger task export to only trim out option task and not all vars provided
 
 ### UI Improvements
 

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -502,18 +502,14 @@ func ruleToResource(iRule influxdb.NotificationRule, endpointName, name string) 
 }
 
 // regex used to rip out the hard coded task option stuffs
-var taskFluxRegex = regexp.MustCompile(`option task = {(.|\n)*}`)
+var taskFluxRegex = regexp.MustCompile(`option task = {(.|\n)*?}`)
 
 func taskToResource(t influxdb.Task, name string) Resource {
 	if name == "" {
 		name = t.Name
 	}
 
-	var query = t.Flux
-	groups := taskFluxRegex.Split(t.Flux, 2)
-	if len(groups) > 1 {
-		query = strings.TrimSpace(groups[1])
-	}
+	query := strings.TrimSpace(taskFluxRegex.ReplaceAllString(t.Flux, ""))
 
 	r := Resource{
 		fieldKind:  KindTask.title(),


### PR DESCRIPTION
Closes #16342 

Right now we have this duality of making the name/offset/every stuffs both inside the flux query and as siblings on the influxdb.Task type.  For pgker, it needs just the query and not the hand jammed `option task` stuffs, b/c of the brittleness of the current Task API. This makes the initial regex no longer greedy, it was capturing too much. The regex playground below is useful if you want to test drive some more stuffs at it:

regex playground for this fix: https://regex101.com/r/xV9wL4/30


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
