### PR TITLE
chore(kv): drop duplicative bolt service tests

### DIFF
--- a/kv/auth_test.go
+++ b/kv/auth_test.go
@@ -14,25 +14,8 @@ func TestBoltAuthorizationService(t *testing.T) {
 	influxdbtesting.AuthorizationService(initBoltAuthorizationService, t)
 }
 
-func TestInmemAuthorizationService(t *testing.T) {
-	influxdbtesting.AuthorizationService(initInmemAuthorizationService, t)
-}
-
 func initBoltAuthorizationService(f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initAuthorizationService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemAuthorizationService(f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/bucket_test.go
+++ b/kv/bucket_test.go
@@ -14,25 +14,8 @@ func TestBoltBucketService(t *testing.T) {
 	influxdbtesting.BucketService(initBoltBucketService, t)
 }
 
-func TestInmemBucketService(t *testing.T) {
-	influxdbtesting.BucketService(initInmemBucketService, t)
-}
-
 func initBoltBucketService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initBucketService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemBucketService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/check_test.go
+++ b/kv/check_test.go
@@ -14,25 +14,8 @@ func TestBoltCheckService(t *testing.T) {
 	influxdbtesting.CheckService(initBoltCheckService, t)
 }
 
-func TestInmemCheckService(t *testing.T) {
-	influxdbtesting.CheckService(initInmemCheckService, t)
-}
-
 func initBoltCheckService(f influxdbtesting.CheckFields, t *testing.T) (influxdb.CheckService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initCheckService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemCheckService(f influxdbtesting.CheckFields, t *testing.T) (influxdb.CheckService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/dashboard_test.go
+++ b/kv/dashboard_test.go
@@ -14,25 +14,8 @@ func TestBoltDashboardService(t *testing.T) {
 	influxdbtesting.DashboardService(initBoltDashboardService, t)
 }
 
-func TestInmemDashboardService(t *testing.T) {
-	influxdbtesting.DashboardService(initInmemDashboardService, t)
-}
-
 func initBoltDashboardService(f influxdbtesting.DashboardFields, t *testing.T) (influxdb.DashboardService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initDashboardService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemDashboardService(f influxdbtesting.DashboardFields, t *testing.T) (influxdb.DashboardService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/document_test.go
+++ b/kv/document_test.go
@@ -15,15 +15,3 @@ func TestBoltDocumentStore(t *testing.T) {
 
 	t.Run("bolt", influxdbtesting.NewDocumentIntegrationTest(boltStore))
 }
-
-func TestInmemDocumentStore(t *testing.T) {
-	t.Skip("https://github.com/influxdata/influxdb/issues/12403")
-	inmemStore, closeInmem, err := NewTestInmemStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new inmem kv store: %v", err)
-	}
-	defer closeInmem()
-
-	t.Run("inmem", influxdbtesting.NewDocumentIntegrationTest(inmemStore))
-
-}

--- a/kv/kvlog_test.go
+++ b/kv/kvlog_test.go
@@ -14,25 +14,8 @@ func TestBoltKeyValueLog(t *testing.T) {
 	influxdbtesting.KeyValueLog(initBoltKeyValueLog, t)
 }
 
-func TestInmemKeyValueLog(t *testing.T) {
-	influxdbtesting.KeyValueLog(initInmemKeyValueLog, t)
-}
-
 func initBoltKeyValueLog(f influxdbtesting.KeyValueLogFields, t *testing.T) (influxdb.KeyValueLog, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, closeSvc := initKeyValueLog(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemKeyValueLog(f influxdbtesting.KeyValueLogFields, t *testing.T) (influxdb.KeyValueLog, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/label_test.go
+++ b/kv/label_test.go
@@ -14,25 +14,8 @@ func TestBoltLabelService(t *testing.T) {
 	influxdbtesting.LabelService(initBoltLabelService, t)
 }
 
-func TestInmemLabelService(t *testing.T) {
-	influxdbtesting.LabelService(initInmemLabelService, t)
-}
-
 func initBoltLabelService(f influxdbtesting.LabelFields, t *testing.T) (influxdb.LabelService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initLabelService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemLabelService(f influxdbtesting.LabelFields, t *testing.T) (influxdb.LabelService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/lookup_service_test.go
+++ b/kv/lookup_service_test.go
@@ -24,10 +24,6 @@ func TestLookupService_Name_WithBolt(t *testing.T) {
 	testLookupName(NewTestBoltStore, t)
 }
 
-func TestLookupService_Name_WithInMem(t *testing.T) {
-	testLookupName(NewTestInmemStore, t)
-}
-
 func testLookupName(newStore StoreFn, t *testing.T) {
 	type initFn func(context.Context, *kv.Service) error
 	type args struct {

--- a/kv/notification_endpoint_test.go
+++ b/kv/notification_endpoint_test.go
@@ -20,10 +20,6 @@ func TestNotificationEndpointService(t *testing.T) {
 			name: "bolt",
 			fn:   initBoltNotificationEndpointService,
 		},
-		{
-			name: "inmem",
-			fn:   initInmemNotificationEndpointService,
-		},
 	}
 
 	for _, tt := range tests {
@@ -43,19 +39,6 @@ func initBoltNotificationEndpointService(f influxdbtesting.NotificationEndpointF
 	return svc, secretSVC, func() {
 		closeSvc()
 		closeBolt()
-	}
-}
-
-func initInmemNotificationEndpointService(f influxdbtesting.NotificationEndpointFields, t *testing.T) (influxdb.NotificationEndpointService, influxdb.SecretService, func()) {
-	s, closeInmem, err := NewTestInmemStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, secretSVC, closeSvc := initNotificationEndpointService(s, f, t)
-	return svc, secretSVC, func() {
-		closeSvc()
-		closeInmem()
 	}
 }
 

--- a/kv/notification_rule_test.go
+++ b/kv/notification_rule_test.go
@@ -15,26 +15,8 @@ func TestBoltNotificationRuleStore(t *testing.T) {
 	influxdbtesting.NotificationRuleStore(initBoltNotificationRuleStore, t)
 }
 
-func TestNotificationRuleStore(t *testing.T) {
-	t.Skip("https://github.com/influxdata/influxdb/issues/14799")
-	influxdbtesting.NotificationRuleStore(initInmemNotificationRuleStore, t)
-}
-
 func initBoltNotificationRuleStore(f influxdbtesting.NotificationRuleFields, t *testing.T) (influxdb.NotificationRuleStore, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, closeSvc := initNotificationRuleStore(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemNotificationRuleStore(f influxdbtesting.NotificationRuleFields, t *testing.T) (influxdb.NotificationRuleStore, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/onboarding_test.go
+++ b/kv/onboarding_test.go
@@ -14,27 +14,10 @@ func TestBoltOnboardingService(t *testing.T) {
 	influxdbtesting.Generate(initBoltOnboardingService, t)
 }
 
-func TestInmemOnboardingService(t *testing.T) {
-	influxdbtesting.Generate(initInmemOnboardingService, t)
-}
-
 func initBoltOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
 	s, closeStore, err := NewTestBoltStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new bolt kv store: %v", err)
-	}
-
-	svc, closeSvc := initOnboardingService(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeStore()
-	}
-}
-
-func initInmemOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
-	s, closeStore, err := NewTestInmemStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new inmem kv store: %v", err)
 	}
 
 	svc, closeSvc := initOnboardingService(s, f, t)

--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -14,25 +14,8 @@ func TestBoltOrganizationService(t *testing.T) {
 	influxdbtesting.OrganizationService(initBoltOrganizationService, t)
 }
 
-func TestInmemOrganizationService(t *testing.T) {
-	influxdbtesting.OrganizationService(initInmemOrganizationService, t)
-}
-
 func initBoltOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initOrganizationService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/passwords_test.go
+++ b/kv/passwords_test.go
@@ -17,27 +17,10 @@ func TestBoltPasswordService(t *testing.T) {
 	influxdbtesting.PasswordsService(initBoltPasswordsService, t)
 }
 
-func TestInmemPasswordService(t *testing.T) {
-	influxdbtesting.PasswordsService(initInmemPasswordsService, t)
-}
-
 func initBoltPasswordsService(f influxdbtesting.PasswordFields, t *testing.T) (influxdb.PasswordsService, func()) {
 	s, closeStore, err := NewTestBoltStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new bolt kv store: %v", err)
-	}
-
-	svc, closeSvc := initPasswordsService(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeStore()
-	}
-}
-
-func initInmemPasswordsService(f influxdbtesting.PasswordFields, t *testing.T) (influxdb.PasswordsService, func()) {
-	s, closeStore, err := NewTestInmemStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new inmem kv store: %v", err)
 	}
 
 	svc, closeSvc := initPasswordsService(s, f, t)

--- a/kv/scrapers_test.go
+++ b/kv/scrapers_test.go
@@ -14,25 +14,8 @@ func TestBoltScraperTargetStoreService(t *testing.T) {
 	influxdbtesting.ScraperService(initBoltTargetService, t)
 }
 
-func TestInmemScraperTargetStoreService(t *testing.T) {
-	influxdbtesting.ScraperService(initInmemTargetService, t)
-}
-
 func initBoltTargetService(f influxdbtesting.TargetFields, t *testing.T) (influxdb.ScraperTargetStoreService, string, func()) {
 	s, closeFn, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initScraperTargetStoreService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeFn()
-	}
-}
-
-func initInmemTargetService(f influxdbtesting.TargetFields, t *testing.T) (influxdb.ScraperTargetStoreService, string, func()) {
-	s, closeFn, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/secret_test.go
+++ b/kv/secret_test.go
@@ -14,25 +14,8 @@ func TestBoltSecretService(t *testing.T) {
 	influxdbtesting.SecretService(initBoltSecretService, t)
 }
 
-func TestInmemSecretService(t *testing.T) {
-	influxdbtesting.SecretService(initInmemSecretService, t)
-}
-
 func initBoltSecretService(f influxdbtesting.SecretServiceFields, t *testing.T) (influxdb.SecretService, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, closeSvc := initSecretService(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemSecretService(f influxdbtesting.SecretServiceFields, t *testing.T) (influxdb.SecretService, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/session_test.go
+++ b/kv/session_test.go
@@ -14,25 +14,8 @@ func TestBoltSessionService(t *testing.T) {
 	influxdbtesting.SessionService(initBoltSessionService, t)
 }
 
-func TestInmemSessionService(t *testing.T) {
-	influxdbtesting.SessionService(initInmemSessionService, t)
-}
-
 func initBoltSessionService(f influxdbtesting.SessionFields, t *testing.T) (influxdb.SessionService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initSessionService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemSessionService(f influxdbtesting.SessionFields, t *testing.T) (influxdb.SessionService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/source_test.go
+++ b/kv/source_test.go
@@ -17,28 +17,8 @@ func TestBoltSourceService(t *testing.T) {
 	t.Run("DeleteSource", func(t *testing.T) { influxdbtesting.DeleteSource(initBoltSourceService, t) })
 }
 
-func TestInmemSourceService(t *testing.T) {
-	t.Run("CreateSource", func(t *testing.T) { influxdbtesting.CreateSource(initInmemSourceService, t) })
-	t.Run("FindSourceByID", func(t *testing.T) { influxdbtesting.FindSourceByID(initInmemSourceService, t) })
-	t.Run("FindSources", func(t *testing.T) { influxdbtesting.FindSources(initInmemSourceService, t) })
-	t.Run("DeleteSource", func(t *testing.T) { influxdbtesting.DeleteSource(initInmemSourceService, t) })
-}
-
 func initBoltSourceService(f influxdbtesting.SourceFields, t *testing.T) (influxdb.SourceService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initSourceService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemSourceService(f influxdbtesting.SourceFields, t *testing.T) (influxdb.SourceService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -18,38 +18,6 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func TestInmemTaskService(t *testing.T) {
-	servicetest.TestTaskService(
-		t,
-		func(t *testing.T) (*servicetest.System, context.CancelFunc) {
-			store, close, err := NewTestInmemStore(t)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			service := kv.NewService(zaptest.NewLogger(t), store)
-			ctx, cancelFunc := context.WithCancel(context.Background())
-
-			if err := service.Initialize(ctx); err != nil {
-				t.Fatalf("error initializing urm service: %v", err)
-			}
-
-			go func() {
-				<-ctx.Done()
-				close()
-			}()
-
-			return &servicetest.System{
-				TaskControlService: service,
-				TaskService:        service,
-				I:                  service,
-				Ctx:                ctx,
-			}, cancelFunc
-		},
-		"transactional",
-	)
-}
-
 func TestBoltTaskService(t *testing.T) {
 	servicetest.TestTaskService(
 		t,

--- a/kv/telegraf_test.go
+++ b/kv/telegraf_test.go
@@ -14,25 +14,8 @@ func TestBoltTelegrafService(t *testing.T) {
 	influxdbtesting.TelegrafConfigStore(initBoltTelegrafService, t)
 }
 
-func TestInmemTelegrafService(t *testing.T) {
-	influxdbtesting.TelegrafConfigStore(initInmemTelegrafService, t)
-}
-
 func initBoltTelegrafService(f influxdbtesting.TelegrafConfigFields, t *testing.T) (influxdb.TelegrafConfigStore, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, closeSvc := initTelegrafService(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemTelegrafService(f influxdbtesting.TelegrafConfigFields, t *testing.T) (influxdb.TelegrafConfigStore, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/urm_test.go
+++ b/kv/urm_test.go
@@ -14,25 +14,8 @@ func TestBoltUserResourceMappingService(t *testing.T) {
 	influxdbtesting.UserResourceMappingService(initBoltUserResourceMappingService, t)
 }
 
-func TestInmemUserResourceMappingService(t *testing.T) {
-	influxdbtesting.UserResourceMappingService(initInmemUserResourceMappingService, t)
-}
-
 func initBoltUserResourceMappingService(f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, closeSvc := initUserResourceMappingService(s, f, t)
-	return svc, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemUserResourceMappingService(f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/user_test.go
+++ b/kv/user_test.go
@@ -14,25 +14,8 @@ func TestBoltUserService(t *testing.T) {
 	influxdbtesting.UserService(initBoltUserService, t)
 }
 
-func TestInmemUserService(t *testing.T) {
-	influxdbtesting.UserService(initInmemUserService, t)
-}
-
 func initBoltUserService(f influxdbtesting.UserFields, t *testing.T) (influxdb.UserService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initUserService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemUserService(f influxdbtesting.UserFields, t *testing.T) (influxdb.UserService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}

--- a/kv/variable_test.go
+++ b/kv/variable_test.go
@@ -14,25 +14,8 @@ func TestBoltVariableService(t *testing.T) {
 	influxdbtesting.VariableService(initBoltVariableService, t)
 }
 
-func TestInmemVariableService(t *testing.T) {
-	influxdbtesting.VariableService(initInmemVariableService, t)
-}
-
 func initBoltVariableService(f influxdbtesting.VariableFields, t *testing.T) (influxdb.VariableService, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
-	if err != nil {
-		t.Fatalf("failed to create new kv store: %v", err)
-	}
-
-	svc, op, closeSvc := initVariableService(s, f, t)
-	return svc, op, func() {
-		closeSvc()
-		closeBolt()
-	}
-}
-
-func initInmemVariableService(f influxdbtesting.VariableFields, t *testing.T) (influxdb.VariableService, string, func()) {
-	s, closeBolt, err := NewTestInmemStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}


### PR DESCRIPTION
no need to test both inmem and bolt. The stores are tested to satisfy the
kv.Store interface already. No need to go through the service layer tests.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass