### PR TITLE
fix(kv): add legacy variable orgs index back

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -147,6 +147,10 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeVariablesOrgIndex(tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeChecks(ctx, tx); err != nil {
 			return err
 		}


### PR DESCRIPTION
issue here is that the unique by name index for variables was implemented
and has the same functionality about it that this orgs index has. The duplicative
orgs index was nuked. The migration to hydrate the org/name index never
happened. This is a stop gap until that migration is in place.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
