### PR TITLE
feat(kv): add migrations to kv store

### DIFF
--- a/kv/store_migration.go
+++ b/kv/store_migration.go
@@ -1,0 +1,168 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	ierrors "github.com/influxdata/influxdb/kit/errors"
+
+	"github.com/influxdata/influxdb/kit/tracing"
+
+	"github.com/influxdata/influxdb"
+)
+
+type Migration struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	RunAt       time.Time `json:"runAt"`
+
+	Up func(ctx context.Context, tx Tx, store *IndexStore) error `json:"-"`
+}
+
+type MigrationIndexStore struct {
+	migStore *StoreBase
+
+	*IndexStore
+}
+
+func NewMigrationIndexStore(indexStore *IndexStore) *MigrationIndexStore {
+	var encEntKey EncodeEntFn = func(ent Entity) ([]byte, string, error) {
+		mig, ok := ent.Body.(Migration)
+		if err := errUnexpectedDecodeVal(ok); err != nil {
+			return nil, "body", err
+		}
+		if mig.Name == "" {
+			return nil, "body", errors.New("no migration name provided")
+		}
+		return []byte(mig.Name), "body", nil
+	}
+
+	var decEntVal DecodeBucketValFn = func(key, val []byte) ([]byte, interface{}, error) {
+		var mig Migration
+		if err := json.Unmarshal(val, &mig); err != nil {
+			return nil, nil, &influxdb.Error{Code: influxdb.EInternal, Err: err}
+		}
+		fmt.Print(mig)
+		return key, mig, nil
+	}
+
+	var decodedValToEnt ConvertValToEntFn = func(k []byte, v interface{}) (Entity, error) {
+		mig, ok := v.(Migration)
+		if err := errUnexpectedDecodeVal(ok); err != nil {
+			return Entity{}, err
+		}
+		return Entity{Body: mig}, nil
+	}
+
+	bktName := []byte(string(indexStore.EntStore.BktName) + "_migrations")
+	return &MigrationIndexStore{
+		IndexStore: indexStore,
+		migStore:   NewStoreBase(indexStore.Resource, bktName, encEntKey, EncBodyJSON, decEntVal, decodedValToEnt),
+	}
+}
+
+func (s *MigrationIndexStore) Init(ctx context.Context, tx Tx) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := s.EntStore.Init(ctx, tx); err != nil {
+		return err
+	}
+	return s.IndexStore.Init(ctx, tx)
+}
+
+func (s *MigrationIndexStore) Up(ctx context.Context, tx Tx, migrations ...Migration) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if len(migrations) == 0 {
+		return nil
+	}
+
+	existingMigs, err := s.List(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	mMigs := make(map[string]Migration)
+	var errs []string
+	for _, mig := range migrations {
+		if _, ok := mMigs[mig.Name]; ok {
+			errs = append(errs, fmt.Sprintf("duplicate migrations provided for name: %s", mig.Name))
+			continue
+		}
+		mMigs[mig.Name] = mig
+	}
+	if len(errs) > 0 {
+		return &influxdb.Error{Code: influxdb.EConflict, Msg: strings.Join(errs, "\n")}
+	}
+
+	for _, existing := range existingMigs {
+		delete(mMigs, existing.Name)
+	}
+
+	for _, mig := range mMigs {
+		if err := s.apply(ctx, tx, mig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *MigrationIndexStore) apply(ctx context.Context, tx Tx, mig Migration) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	mig.RunAt = time.Now()
+
+	if err := s.migStore.Put(ctx, tx, Entity{Body: mig}); err != nil {
+		return err
+	}
+
+	if err := mig.Up(ctx, tx, s.IndexStore); err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("migration %q failed", mig.Name),
+			Err:  err,
+		}
+	}
+	return nil
+}
+
+func (s *MigrationIndexStore) List(ctx context.Context, tx Tx) ([]Migration, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	var migs []Migration
+	err := s.migStore.Find(ctx, tx, FindOpts{
+		Descending: true,
+		CaptureFn: func(key []byte, decodedVal interface{}) error {
+			migs = append(migs, decodedVal.(Migration))
+			return nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return migs, nil
+}
+
+// MigrationSyncIndexStore adds an index entry for all entities.
+func MigrationSyncIndexStore(ctx context.Context, tx Tx, store *IndexStore) error {
+	return store.EntStore.Find(ctx, tx, FindOpts{
+		CaptureFn: func(key []byte, decodedVal interface{}) error {
+			ent, err := store.EntStore.ConvertValToEntFn(key, decodedVal)
+			if err != nil {
+				return err
+			}
+			if err := store.IndexStore.Put(ctx, tx, ent); err != nil {
+				return ierrors.Wrap(err, "index put failed")
+			}
+			return nil
+		},
+	})
+}

--- a/kv/store_migration_test.go
+++ b/kv/store_migration_test.go
@@ -1,0 +1,154 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb/kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationIndexStore(t *testing.T) {
+	newStoreBase := func(resource string, bktName []byte, encKeyFn, encBodyFn kv.EncodeEntFn, decFn kv.DecodeBucketValFn, decToEntFn kv.ConvertValToEntFn) *kv.StoreBase {
+		return kv.NewStoreBase(resource, bktName, encKeyFn, encBodyFn, decFn, decToEntFn)
+	}
+
+	newFooMigrationIndexStore := func(t *testing.T, bktSuffix string) (*kv.MigrationIndexStore, func(), kv.Store) {
+		t.Helper()
+
+		bolt, done, err := NewTestBoltStore(t)
+		require.NoError(t, err)
+
+		const resource = "foo"
+
+		indexStore := &kv.IndexStore{
+			Resource:   resource,
+			EntStore:   newStoreBase(resource, []byte("foo_ent_"+bktSuffix), kv.EncIDKey, kv.EncBodyJSON, decJSONFooFn, decFooEntFn),
+			IndexStore: kv.NewOrgNameKeyStore(resource, []byte("foo_idx_"+bktSuffix), false),
+		}
+
+		migStore := kv.NewMigrationIndexStore(indexStore)
+		update(t, bolt, func(tx kv.Tx) error {
+			return migStore.Init(context.TODO(), tx)
+		})
+
+		return migStore, done, bolt
+	}
+
+	t.Run("up", func(t *testing.T) {
+		expectedEnts := []kv.Entity{
+			newFooEnt(1, 9000, "foo_0"),
+			newFooEnt(2, 9000, "foo_1"),
+			newFooEnt(3, 9003, "foo_2"),
+			newFooEnt(4, 9004, "foo_3"),
+		}
+
+		t.Run("apply migration to sync index and entity stores", func(t *testing.T) {
+			migStore, done, kvStore := newFooMigrationIndexStore(t, "up")
+			defer done()
+
+			// seed ents to the entity store so that the entity store and index store
+			// are out of sync, represents adding an index that hasn't been synced
+			// with entity store.
+			seedEnts(t, kvStore, migStore.EntStore, expectedEnts...)
+
+			allIndexesFn := func(t *testing.T) []interface{} {
+				t.Helper()
+
+				var actuals []interface{}
+				view(t, kvStore, func(tx kv.Tx) error {
+					return migStore.IndexStore.IndexStore.Find(context.TODO(), tx, kv.FindOpts{
+						CaptureFn: func(key []byte, decodedVal interface{}) error {
+							actuals = append(actuals, decodedVal)
+							return nil
+						},
+					})
+				})
+				return actuals
+			}
+			require.Empty(t, allIndexesFn(t))
+
+			mig := kv.Migration{
+				Name:        "mig_1",
+				Description: "sync ",
+				Up:          kv.MigrationSyncIndexStore,
+			}
+
+			update(t, kvStore, func(tx kv.Tx) error {
+				return migStore.Up(context.TODO(), tx, mig)
+			})
+
+			var expected []interface{}
+			for _, ent := range expectedEnts {
+				f, ok := ent.Body.(foo)
+				require.True(t, ok)
+				expected = append(expected, f.ID)
+			}
+			assert.Equal(t, expected, allIndexesFn(t))
+		})
+
+		t.Run("apply migration to update entities", func(t *testing.T) {
+			migStore, done, kvStore := newFooMigrationIndexStore(t, "up")
+			defer done()
+
+			// seed ents to the entity store so that the entity store and index store
+			// are out of sync, represents adding an index that hasn't been synced
+			// with entity store.
+			seedEnts(t, kvStore, migStore, expectedEnts...)
+
+			mig := kv.Migration{
+				Name:        "mig_1",
+				Description: "sync ",
+				Up: func(ctx context.Context, tx kv.Tx, store *kv.IndexStore) error {
+					return store.Find(ctx, tx, kv.FindOpts{
+						FilterEntFn: func(key []byte, decodedVal interface{}) bool {
+							return decodedVal.(foo).OrgID > 9000
+						},
+						CaptureFn: func(key []byte, decodedVal interface{}) error {
+							f := decodedVal.(foo)
+							f.Name = f.Name + "_new"
+							ent, err := store.EntStore.ConvertValToEntFn(key, f)
+							if err != nil {
+								return err
+							}
+							return store.Put(ctx, tx, ent)
+						},
+					})
+				},
+			}
+
+			update(t, kvStore, func(tx kv.Tx) error {
+				return migStore.Up(context.TODO(), tx, mig)
+			})
+
+			var actuals []interface{}
+			view(t, kvStore, func(tx kv.Tx) error {
+				return migStore.Find(context.TODO(), tx, kv.FindOpts{
+					CaptureFn: func(key []byte, decodedVal interface{}) error {
+						actuals = append(actuals, decodedVal)
+						return nil
+					},
+				})
+			})
+
+			var expected []interface{}
+			for _, ent := range expectedEnts {
+				f := ent.Body.(foo)
+				if f.OrgID > 9000 {
+					f.Name = f.Name + "_new"
+				}
+				view(t, kvStore, func(tx kv.Tx) error {
+					// search the index
+					ff, err := migStore.FindEnt(context.TODO(), tx, kv.Entity{
+						UniqueKey: kv.Encode(kv.EncID(f.OrgID), kv.EncString(f.Name)),
+					})
+					assert.Equal(t, f, ff)
+					return err
+				})
+				expected = append(expected, f)
+			}
+			assert.Equal(t, expected, actuals)
+		})
+	})
+}


### PR DESCRIPTION
we currently have need to be able to make changes to the kv layer. There are issues at different times with out of sync indexes and other goodies. This is a POC for a stab at correcting that.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
