### PR TITLE
chore(kv): refactor kv.Entity to provide interface for PK and unique keys

### DIFF
--- a/kv/encode.go
+++ b/kv/encode.go
@@ -1,0 +1,49 @@
+package kv
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/influxdata/influxdb"
+)
+
+// EncodeFn returns an encoding when called. Closures are your friend here.
+type EncodeFn func() ([]byte, error)
+
+// Encode concatenates a list of encodings together.
+func Encode(encodings ...EncodeFn) EncodeFn {
+	return func() ([]byte, error) {
+		var key []byte
+		for _, enc := range encodings {
+			part, err := enc()
+			if err != nil {
+				return key, err
+			}
+			key = append(key, part...)
+		}
+		return key, nil
+	}
+}
+
+// EncString encodes a string.
+func EncString(str string) EncodeFn {
+	return func() ([]byte, error) {
+		return []byte(str), nil
+	}
+}
+
+// EncStringCaseInsensitive encodes a string and makes it case insensitive by lower casing
+// everything.
+func EncStringCaseInsensitive(str string) EncodeFn {
+	return EncString(strings.ToLower(str))
+}
+
+// EncID encodes an influx ID.
+func EncID(id influxdb.ID) EncodeFn {
+	return func() ([]byte, error) {
+		if id == 0 {
+			return nil, errors.New("no ID was provided")
+		}
+		return id.Encode()
+	}
+}

--- a/kv/store_index_test.go
+++ b/kv/store_index_test.go
@@ -38,8 +38,7 @@ func TestIndexStore(t *testing.T) {
 		expected := testPutBase(t, inmem, indexStore, indexStore.EntStore.BktName)
 
 		key, err := indexStore.IndexStore.EntKey(context.TODO(), kv.Entity{
-			OrgID: expected.OrgID,
-			Name:  expected.Name,
+			UniqueKey: kv.Encode(kv.EncID(expected.OrgID), kv.EncString(expected.Name)),
 		})
 		require.NoError(t, err)
 
@@ -55,8 +54,7 @@ func TestIndexStore(t *testing.T) {
 
 		err := inmem.View(context.TODO(), func(tx kv.Tx) error {
 			_, err := indexStore.IndexStore.FindEnt(context.TODO(), tx, kv.Entity{
-				OrgID: expected.OrgID,
-				Name:  expected.Name,
+				UniqueKey: expected.UniqueKey,
 			})
 			return err
 		})
@@ -109,8 +107,7 @@ func TestIndexStore(t *testing.T) {
 			var actual interface{}
 			view(t, kvStore, func(tx kv.Tx) error {
 				f, err := base.FindEnt(context.TODO(), tx, kv.Entity{
-					OrgID: expected.OrgID,
-					Name:  expected.Name,
+					UniqueKey: expected.UniqueKey,
 				})
 				actual = f
 				return err

--- a/testing/notification_endpoint.go
+++ b/testing/notification_endpoint.go
@@ -423,15 +423,7 @@ func FindNotificationEndpointByID(
 			ctx := context.Background()
 
 			edp, err := s.FindNotificationEndpointByID(ctx, tt.args.id)
-			if err != nil {
-				if tt.wants.err == nil {
-					require.NoError(t, err)
-				}
-				iErr, ok := err.(*influxdb.Error)
-				require.True(t, ok)
-				assert.Equal(t, tt.wants.err.Code, iErr.Code)
-				assert.Truef(t, strings.HasPrefix(iErr.Error(), tt.wants.err.Error()), "got err: %s", err.Error())
-			}
+			influxErrsEqual(t, tt.wants.err, err)
 			if diff := cmp.Diff(edp, tt.wants.notificationEndpoint, notificationEndpointCmpOptions...); diff != "" {
 				t.Errorf("notification endpoint is different -got/+want\ndiff %s", diff)
 			}
@@ -2175,5 +2167,5 @@ func influxErrsEqual(t *testing.T, expected *influxdb.Error, actual error) {
 	iErr, ok := actual.(*influxdb.Error)
 	require.True(t, ok)
 	assert.Equal(t, expected.Code, iErr.Code)
-	assert.Truef(t, strings.HasPrefix(iErr.Error(), expected.Error()), "got err: %s", actual.Error())
+	assert.Truef(t, strings.HasPrefix(iErr.Error(), expected.Error()), "expected: %s got err: %s", expected.Error(), actual.Error())
 }


### PR DESCRIPTION
this is to make the new `kv.Entity` more generic so that it can be used in more broad applications.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass