### PR TITLE
fix: enable skipped tests for notification rules and fixup issue in tag matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 1. [16268](https://github.com/influxdata/influxdb/pull/16268): Fixed test flakiness that stemmed from multiple flush/signins being called in the same test suite
 1. [16346](https://github.com/influxdata/influxdb/pull/16346): Update pkger task export to only trim out option task and not all vars provided
 1. [16374](https://github.com/influxdata/influxdb/pull/16374): Update influx CLI, only show "see help" message, instead of the whole usage.
+1. [16380](https://github.com/influxdata/influxdb/pull/16380): Fix notification tag matching rules and enable tests to verify
 
 ### UI Improvements
 

--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -435,9 +435,7 @@ func (s *Service) forEachNotificationRule(ctx context.Context, tx Tx, descending
 	return nil
 }
 
-func filterNotificationRulesFn(
-	idMap map[influxdb.ID]bool,
-	filter influxdb.NotificationRuleFilter) func(nr influxdb.NotificationRule) bool {
+func filterNotificationRulesFn(idMap map[influxdb.ID]bool, filter influxdb.NotificationRuleFilter) func(nr influxdb.NotificationRule) bool {
 	if filter.OrgID != nil {
 		return func(nr influxdb.NotificationRule) bool {
 			if !nr.MatchesTags(filter.Tags) {

--- a/kv/notification_rule_test.go
+++ b/kv/notification_rule_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestBoltNotificationRuleStore(t *testing.T) {
-	t.Skip("https://github.com/influxdata/influxdb/issues/14799")
 	influxdbtesting.NotificationRuleStore(initBoltNotificationRuleStore, t)
 }
 

--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -337,7 +337,9 @@ func (b *Base) ClearPrivateData() {
 
 // MatchesTags returns true if the Rule matches all of the tags
 func (b *Base) MatchesTags(tags []influxdb.Tag) bool {
-
+	if len(tags) == 0 {
+		return true
+	}
 	// for each tag in NR
 	// if there exists
 	// a key value match with operator == equal in tags

--- a/notification/rule/rule_test.go
+++ b/notification/rule/rule_test.go
@@ -476,6 +476,20 @@ func TestMatchingRules(t *testing.T) {
 			exp: true,
 		},
 		{
+			name: "Non empty tag rule matches empty filter tags",
+			tagRules: []notification.TagRule{
+				{
+					Tag: influxdb.Tag{
+						Key:   "c",
+						Value: "d",
+					},
+					Operator: influxdb.NotEqual,
+				},
+			},
+			filterTags: []influxdb.Tag{},
+			exp:        true,
+		},
+		{
 			name:       "Empty tag rule matches empty filter tags",
 			tagRules:   []notification.TagRule{},
 			filterTags: []influxdb.Tag{},


### PR DESCRIPTION
some awkward looping made it hard to reason about the correctness of the tag matching algorithm. Upon closer inspection of a test through the debugger, it was returning false negatives and was causing issues in the `FindNotificiationRules` call.

seeing issues with this upstream, these tests can be enabled. The issue was in tag matcher. Tests pass here and should pass upstream now.

solves for the failures here: https://github.com/influxdata/influxdb/pull/16379

Closes #14799 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass