### PR TITLE
feat(bucket): Increase default retention to 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 1. [16347](https://github.com/influxdata/influxdb/pull/16347): Drop legacy inmem service implementation in favor of kv service with inmem dependency
 1. [16348](https://github.com/influxdata/influxdb/pull/16348): Drop legacy bolt service implementation in favor of kv service with bolt dependency
 1. [16014](https://github.com/influxdata/influxdb/pull/16014): While creating check, also display notification rules that would match check based on tag rules
-1. [TBD](https://github.com/influxdata/influxdb/pull/TBD): Increase default bucket retention period to 30 days
+1. [16389](https://github.com/influxdata/influxdb/pull/16389): Increase default bucket retention period to 30 days
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 1. [16347](https://github.com/influxdata/influxdb/pull/16347): Drop legacy inmem service implementation in favor of kv service with inmem dependency
 1. [16348](https://github.com/influxdata/influxdb/pull/16348): Drop legacy bolt service implementation in favor of kv service with bolt dependency
 1. [16014](https://github.com/influxdata/influxdb/pull/16014): While creating check, also display notification rules that would match check based on tag rules
+1. [TBD](https://github.com/influxdata/influxdb/pull/TBD): Increase default bucket retention period to 30 days
 
 ### Bug Fixes
 

--- a/ui/src/buckets/components/Retention.tsx
+++ b/ui/src/buckets/components/Retention.tsx
@@ -15,7 +15,7 @@ import {extractBucketMaxRetentionSeconds} from 'src/cloud/utils/limits'
 // Types
 import {AppState} from 'src/types'
 
-export const DEFAULT_SECONDS = 259200 // 72 hours
+export const DEFAULT_SECONDS = 30 * 24 * 60 * 60 // 30 days
 
 export const DURATION_OPTIONS: DurationOption[] = [
   {duration: '1h', displayText: '1 hour'},


### PR DESCRIPTION
Currently, when choosing to apply retention limits to new buckets, the default retention period is 72 hours (3 days).

With recent increases to the maximum retention period for free-tier cloud users, we'd like the default to be 30 days instead for all users.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

Before:
![Screen Shot 2019-12-31 at 12 14 40 PM](https://user-images.githubusercontent.com/1406203/71695364-be3ffc80-2d66-11ea-80fd-fb9719ffa44b.png)

After:
![Screen Shot 2019-12-31 at 12 15 29 PM](https://user-images.githubusercontent.com/1406203/71695370-c26c1a00-2d66-11ea-8f2f-bc64642b7a11.png)
