### PR TITLE
fix(ui): removed buildActiveQuery func to prevent queries from being reset when timeranges are selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 1. [16374](https://github.com/influxdata/influxdb/pull/16374): Update influx CLI, only show "see help" message, instead of the whole usage.
 1. [16380](https://github.com/influxdata/influxdb/pull/16380): Fix notification tag matching rules and enable tests to verify
 1. [16376](https://github.com/influxdata/influxdb/pull/16376): Extend the y-axis when stacked graph is selected
+1. [16404](https://github.com/influxdata/influxdb/pull/16404): Fixed query reset bug that was resetting query in script editor whenever dates were changed
 
 ### UI Improvements
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -349,7 +349,7 @@ describe('DataExplorer', () => {
     })
   })
 
-  describe('raw script editing', () => {
+  describe.skip('raw script editing', () => {
     beforeEach(() => {
       cy.getByTestID('switch-to-script-editor').click()
     })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -349,7 +349,7 @@ describe('DataExplorer', () => {
     })
   })
 
-  describe.skip('raw script editing', () => {
+  describe('raw script editing', () => {
     beforeEach(() => {
       cy.getByTestID('switch-to-script-editor').click()
     })

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -752,8 +752,6 @@ export const timeMachineReducer = (
 
         draftState.queryBuilder.tags[index].values = values
         draftState.queryBuilder.tags[index].valuesStatus = RemoteDataState.Done
-
-        buildActiveQuery(draftState)
       })
     }
 


### PR DESCRIPTION
Closes #16369

### Problem

Calling `buildActiveQuery` after `SET_BUILDER_TAG_VALUES` was resetting the query whenever the timerange was being set

### Solution

The rationale for calling the `buildActiveQuery` on `SET_BUILDER_TAG_VALUES` was to ensure that:

> it's to build the query when grouping and selecting fields

This seems to already be occurring whenever a query is drafted and is unnecessary. Since this change had originally broken an e2e explorer test, removing this line passes the test.

One key metric to ensure that this is in fact a stable solution would be to:

>  look at switching between filtering and grouping in the query builder

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)