### PR TITLE
KV base interface data driven

### DIFF
--- a/kv/encode.go
+++ b/kv/encode.go
@@ -10,6 +10,28 @@ import (
 // EncodeFn returns an encoding when called. Closures are your friend here.
 type EncodeFn func() ([]byte, error)
 
+type IDPK influxdb.ID
+
+func (i IDPK) PrimaryKey() ([]byte, error) {
+	if i == 0 {
+		return nil, errors.New("no ID was provided")
+	}
+	return influxdb.ID(i).Encode()
+}
+
+// Encode2 concatenates a list of encodings together.
+func Encode2(encodings ...EncodeFn) ([]byte, error) {
+	var key []byte
+	for _, enc := range encodings {
+		part, err := enc()
+		if err != nil {
+			return key, err
+		}
+		key = append(key, part...)
+	}
+	return key, nil
+}
+
 // Encode concatenates a list of encodings together.
 func Encode(encodings ...EncodeFn) EncodeFn {
 	return func() ([]byte, error) {

--- a/kv/store_base_2.go
+++ b/kv/store_base_2.go
@@ -1,0 +1,313 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
+)
+
+type (
+	PrimaryKey interface {
+		PrimaryKey() ([]byte, error)
+	}
+
+	EntityInt interface {
+		PrimaryKey
+		Encode() ([]byte, error)
+	}
+
+	UniqueIdentifiers interface {
+		PrimaryKey
+		UniqueKey() ([]byte, error)
+	}
+
+	EntityUnique interface {
+		UniqueIdentifiers
+		Encode() ([]byte, error)
+	}
+
+	DecodeBucketValFn2 func(key, val []byte) (ent EntityInt, err error)
+)
+
+// StoreBase2 is the base behavior for accessing buckets in kv. It provides mechanisms that can
+// be used in composing stores together (i.e. IndexStore).
+type StoreBase2 struct {
+	Resource string
+	BktName  []byte
+	DecodeFn DecodeBucketValFn2
+}
+
+// NewStoreBase2 creates a new store base.
+func NewStoreBase2(resource string, bktName []byte, decFn DecodeBucketValFn2) *StoreBase2 {
+	return &StoreBase2{
+		Resource: resource,
+		BktName:  bktName,
+		DecodeFn: decFn,
+	}
+}
+
+// Init creates the buckets.
+func (s *StoreBase2) Init(ctx context.Context, tx Tx) error {
+	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "bucket_"+string(s.BktName))
+	defer span.Finish()
+
+	if _, err := s.bucket(ctx, tx); err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("failed to create bucket: %s", string(s.BktName)),
+			Err:  err,
+		}
+	}
+	return nil
+}
+
+// Delete deletes entities by the provided options.
+func (s *StoreBase2) Delete(ctx context.Context, tx Tx, opts DeleteOpts) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if opts.FilterFn == nil {
+		return nil
+	}
+
+	findOpts := FindOpts{
+		CaptureFn: func(k []byte, v interface{}) error {
+			for _, deleteFn := range opts.DeleteRelationFns {
+				if err := deleteFn(k, v); err != nil {
+					return err
+				}
+			}
+			return s.bucketDelete(ctx, tx, k)
+		},
+		FilterEntFn: opts.FilterFn,
+	}
+	return s.Find(ctx, tx, findOpts)
+}
+
+// DeleteEnt deletes an entity.
+func (s *StoreBase2) DeleteEnt(ctx context.Context, tx Tx, ent PrimaryKey) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	pk, err := s.encode(ctx, ent.PrimaryKey, "primary key")
+	if err != nil {
+		return err
+	}
+	return s.bucketDelete(ctx, tx, pk)
+}
+
+func (s *StoreBase2) Find(ctx context.Context, tx Tx, opts FindOpts) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cur, err := s.bucketCursor(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	iter := &iterator{
+		cursor:     cur,
+		descending: opts.Descending,
+		limit:      opts.Limit,
+		offset:     opts.Offset,
+		prefix:     opts.Prefix,
+		decodeFn: func(key, val []byte) ([]byte, interface{}, error) {
+			v, err := s.DecodeFn(key, val)
+			return key, v, err
+		},
+		filterFn: opts.FilterEntFn,
+	}
+
+	for k, v, err := iter.Next(ctx); k != nil; k, v, err = iter.Next(ctx) {
+		if err != nil {
+			return err
+		}
+		if err := opts.CaptureFn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FindEnt returns the decoded entity body via the provided entity.
+// An example entity should not include a Body, but rather the ID,
+// Name, or OrgID.
+func (s *StoreBase2) FindEnt(ctx context.Context, tx Tx, entDec PrimaryKey) (EntityInt, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	pk, err := s.encode(ctx, entDec.PrimaryKey, "primary key")
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := s.bucketGet(ctx, tx, pk)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.DecodeFn(pk, body)
+}
+
+func (s *StoreBase2) Put(ctx context.Context, tx Tx, ent EntityInt) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	pk, err := s.encode(ctx, ent.PrimaryKey, "primary key")
+	if err != nil {
+		return err
+	}
+
+	body, err := s.encode(ctx, ent.Encode, "body")
+	if err != nil {
+		return err
+	}
+
+	return s.bucketPut(ctx, tx, pk, body)
+}
+
+func (s *StoreBase2) bucket(ctx context.Context, tx Tx) (Bucket, error) {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	bkt, err := tx.Bucket(s.BktName)
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("unexpected error retrieving bucket %q; Err %v", string(s.BktName), err),
+			Err:  err,
+		}
+	}
+	return bkt, nil
+}
+
+func (s *StoreBase2) bucketCursor(ctx context.Context, tx Tx) (Cursor, error) {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	b, err := s.bucket(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("failed to retrieve cursor"),
+			Err:  err,
+		}
+	}
+	return cur, nil
+}
+
+func (s *StoreBase2) bucketDelete(ctx context.Context, tx Tx, key []byte) error {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	b, err := s.bucket(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	err = b.Delete(key)
+	if err == nil {
+		return nil
+	}
+
+	iErr := &influxdb.Error{
+		Code: influxdb.EInternal,
+		Err:  err,
+	}
+	if IsNotFound(err) {
+		iErr.Code = influxdb.ENotFound
+		iErr.Msg = fmt.Sprintf("%s does exist for key: %q", s.Resource, string(key))
+	}
+	return iErr
+}
+
+func (s *StoreBase2) bucketGet(ctx context.Context, tx Tx, key []byte) ([]byte, error) {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	b, err := s.bucket(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := b.Get(key)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  fmt.Sprintf("%s not found for key %q", s.Resource, string(key)),
+		}
+	}
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInternal,
+			Err:  err,
+		}
+	}
+
+	return body, nil
+}
+
+func (s *StoreBase2) bucketPut(ctx context.Context, tx Tx, key, body []byte) error {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	b, err := s.bucket(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(key, body); err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Err:  err,
+		}
+	}
+	return nil
+}
+
+func (s *StoreBase2) decode(ctx context.Context, key, body []byte) (EntityInt, error) {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	ent, err := s.DecodeFn(key, body)
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("failed to decode %s body", s.Resource),
+			Err:  err,
+		}
+	}
+	return ent, nil
+}
+
+func (s *StoreBase2) encode(ctx context.Context, fn EncodeFn, field string) ([]byte, error) {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if fn == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  fmt.Sprintf("no key was provided for %s", s.Resource),
+		}
+	}
+
+	encoded, err := fn()
+	if err != nil {
+		return encoded, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  fmt.Sprintf("provided %s %s is an invalid format", s.Resource, field),
+			Err:  err,
+		}
+	}
+	return encoded, nil
+}

--- a/kv/store_base_2_test.go
+++ b/kv/store_base_2_test.go
@@ -1,0 +1,345 @@
+package kv_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreBase2(t *testing.T) {
+	newStoreBase := func(t *testing.T, bktSuffix string) (*kv.StoreBase2, func(), kv.Store) {
+		t.Helper()
+
+		inmemSVC, done, err := NewTestBoltStore(t)
+		require.NoError(t, err)
+
+		decFn := func(_, val []byte) (kv.EntityInt, error) {
+			var v foo2
+			return &v, json.Unmarshal(val, &v)
+		}
+
+		store := kv.NewStoreBase2("foo", []byte("foo_"+bktSuffix), decFn)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		require.NoError(t, inmemSVC.Update(ctx, func(tx kv.Tx) error {
+			return store.Init(ctx, tx)
+		}))
+		return store, done, inmemSVC
+	}
+
+	t.Run("Put", func(t *testing.T) {
+		base, done, inmemStore := newStoreBase(t, "put")
+		defer done()
+		testPutBase2(t, inmemStore, base, base.BktName)
+	})
+
+	t.Run("DeleteEnt", func(t *testing.T) {
+		base, done, inmemStore := newStoreBase(t, "delete_ent")
+		defer done()
+
+		testDeleteEntBase2(t, inmemStore, base)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		testDeleteBase2(t, func(t *testing.T, suffix string) (storeBase2, func(), kv.Store) {
+			return newStoreBase(t, suffix)
+		})
+	})
+
+	t.Run("FindEnt", func(t *testing.T) {
+		base, done, inmemStore := newStoreBase(t, "find_ent")
+		defer done()
+
+		testFindEnt2(t, inmemStore, base)
+	})
+
+	t.Run("Find", func(t *testing.T) {
+		testFind2(t, func(t *testing.T, suffix string) (storeBase2, func(), kv.Store) {
+			return newStoreBase(t, suffix)
+		})
+	})
+}
+
+func testPutBase2(t *testing.T, kvStore kv.Store, base storeBase2, bktName []byte) foo2 {
+	t.Helper()
+
+	expected := foo2{
+		ID:    1,
+		OrgID: 9000,
+		Name:  "foo_1",
+	}
+
+	update(t, kvStore, func(tx kv.Tx) error {
+		return base.Put(context.TODO(), tx, &expected)
+	})
+
+	var actual foo2
+	decodeJSON(t, getEntRaw(t, kvStore, bktName, encodeID(t, expected.ID)), &actual)
+
+	assert.Equal(t, expected, actual)
+
+	return expected
+}
+
+func testDeleteEntBase2(t *testing.T, kvStore kv.Store, base storeBase2) kv.EntityInt {
+	t.Helper()
+
+	expected := foo2{1, 9000, "foo_1"}
+	seedEntInts(t, kvStore, base, &expected)
+
+	update(t, kvStore, func(tx kv.Tx) error {
+		return base.DeleteEnt(context.TODO(), tx, kv.IDPK(1))
+	})
+
+	err := kvStore.View(context.TODO(), func(tx kv.Tx) error {
+		_, err := base.FindEnt(context.TODO(), tx, fooDecoder{IDPK: 1})
+		return err
+	})
+	isNotFoundErr(t, err)
+	return &expected
+}
+
+func testDeleteBase2(t *testing.T, fn func(t *testing.T, suffix string) (storeBase2, func(), kv.Store), assertFns ...func(*testing.T, kv.Store, storeBase2, []*foo2)) {
+	expectedEnts := []kv.EntityInt{
+		&foo2{1, 9000, "foo_0"},
+		&foo2{2, 9000, "foo_1"},
+		&foo2{3, 9003, "foo_2"},
+		&foo2{4, 9004, "foo_3"},
+	}
+
+	tests := []struct {
+		name     string
+		opts     kv.DeleteOpts
+		expected []kv.EntityInt
+	}{
+		{
+			name: "delete all",
+			opts: kv.DeleteOpts{
+				FilterFn: func(k []byte, v interface{}) bool {
+					return true
+				},
+			},
+		},
+		{
+			name: "delete IDs less than 4",
+			opts: kv.DeleteOpts{
+				FilterFn: func(k []byte, v interface{}) bool {
+					if f, ok := v.(*foo2); ok {
+						return f.ID < 4
+					}
+					return true
+				},
+			},
+			expected: expectedEnts[3:],
+		},
+	}
+
+	for _, tt := range tests {
+		fn := func(t *testing.T) {
+			t.Helper()
+
+			base, done, inmemStore := fn(t, "delete")
+			defer done()
+
+			seedEntInts(t, inmemStore, base, expectedEnts...)
+
+			update(t, inmemStore, func(tx kv.Tx) error {
+				return base.Delete(context.TODO(), tx, tt.opts)
+			})
+
+			var actuals []kv.EntityInt
+			view(t, inmemStore, func(tx kv.Tx) error {
+				return base.Find(context.TODO(), tx, kv.FindOpts{
+					CaptureFn: func(key []byte, decodedVal interface{}) error {
+						f, ok := decodedVal.(*foo2)
+						if !ok {
+							return errors.New("did not get a foo")
+						}
+						actuals = append(actuals, f)
+						return nil
+					},
+				})
+			})
+
+			assert.Equal(t, tt.expected, actuals)
+
+			var entsLeft []*foo2
+			for _, expected := range tt.expected {
+				ent, ok := expected.(*foo2)
+				require.Truef(t, ok, "got: %#v", expected)
+				entsLeft = append(entsLeft, ent)
+			}
+
+			for _, assertFn := range assertFns {
+				assertFn(t, inmemStore, base, entsLeft)
+			}
+		}
+		t.Run(tt.name, fn)
+	}
+}
+
+func testFindEnt2(t *testing.T, kvStore kv.Store, base storeBase2) kv.EntityInt {
+	t.Helper()
+
+	expected := foo2{1, 9000, "foo_1"}
+	seedEntInts(t, kvStore, base, &expected)
+
+	var actual kv.EntityInt
+	view(t, kvStore, func(tx kv.Tx) error {
+		f, err := base.FindEnt(context.TODO(), tx, fooDecoder{IDPK: 1})
+		actual = f
+		return err
+	})
+
+	assert.Equal(t, &expected, actual)
+
+	return &expected
+}
+
+func testFind2(t *testing.T, fn func(t *testing.T, suffix string) (storeBase2, func(), kv.Store)) {
+	t.Helper()
+
+	expectedEnts := []kv.EntityInt{
+		&foo2{1, 9000, "foo_0"},
+		&foo2{2, 9000, "foo_1"},
+		&foo2{3, 9003, "foo_2"},
+		&foo2{4, 9004, "foo_3"},
+	}
+
+	tests := []struct {
+		name     string
+		opts     kv.FindOpts
+		expected []kv.EntityInt
+	}{
+		{
+			name:     "no options",
+			expected: expectedEnts,
+		},
+		{
+			name: "with order descending",
+			opts: kv.FindOpts{Descending: true},
+			expected: []kv.EntityInt{
+				expectedEnts[3],
+				expectedEnts[2],
+				expectedEnts[1],
+				expectedEnts[0],
+			},
+		},
+		{
+			name:     "with limit",
+			opts:     kv.FindOpts{Limit: 1},
+			expected: expectedEnts[:1],
+		},
+		{
+			name:     "with offset",
+			opts:     kv.FindOpts{Offset: 1},
+			expected: expectedEnts[1:],
+		},
+		{
+			name: "with offset and limit",
+			opts: kv.FindOpts{
+				Limit:  1,
+				Offset: 1,
+			},
+			expected: expectedEnts[1:2],
+		},
+		{
+			name: "with descending, offset, and limit",
+			opts: kv.FindOpts{
+				Descending: true,
+				Limit:      1,
+				Offset:     1,
+			},
+			expected: expectedEnts[2:3],
+		},
+	}
+
+	for _, tt := range tests {
+		fn := func(t *testing.T) {
+			base, done, kvStore := fn(t, "find")
+			defer done()
+
+			seedEntInts(t, kvStore, base, expectedEnts...)
+
+			var actuals []kv.EntityInt
+			tt.opts.CaptureFn = func(key []byte, decodedVal interface{}) error {
+				f, ok := decodedVal.(*foo2)
+				if !ok {
+					return errors.New("did not get a foo")
+				}
+				actuals = append(actuals, f)
+				return nil
+			}
+
+			view(t, kvStore, func(tx kv.Tx) error {
+				return base.Find(context.TODO(), tx, tt.opts)
+			})
+
+			assert.Equal(t, tt.expected, actuals)
+		}
+		t.Run(tt.name, fn)
+	}
+}
+
+type fooDecoder struct {
+	kv.IDPK
+}
+
+func (f fooDecoder) Decode(b []byte) (kv.EntityInt, error) {
+	var ff foo2
+	if err := json.Unmarshal(b, &ff); err != nil {
+		return nil, err
+	}
+	return &ff, nil
+}
+
+type foo2 struct {
+	ID    influxdb.ID
+	OrgID influxdb.ID
+
+	Name string
+}
+
+func (f *foo2) PrimaryKey() ([]byte, error) {
+	return kv.EncID(f.ID)()
+}
+
+func (f *foo2) UniqueKey() ([]byte, error) {
+	return kv.Encode2(kv.EncID(f.OrgID), kv.EncString(f.Name))
+}
+
+func (f *foo2) Encode() ([]byte, error) {
+	return json.Marshal(f)
+}
+
+func (f *foo2) Decode(b []byte) error {
+	return json.Unmarshal(b, f)
+}
+
+type storeBase2 interface {
+	Delete(ctx context.Context, tx kv.Tx, opts kv.DeleteOpts) error
+	DeleteEnt(ctx context.Context, tx kv.Tx, ent kv.PrimaryKey) error
+	FindEnt(ctx context.Context, tx kv.Tx, ent kv.PrimaryKey) (kv.EntityInt, error)
+	Find(ctx context.Context, tx kv.Tx, opts kv.FindOpts) error
+	Put(ctx context.Context, tx kv.Tx, ent kv.EntityInt) error
+}
+
+func seedEntInts(t *testing.T, kvStore kv.Store, store storeBase2, ents ...kv.EntityInt) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, ent := range ents {
+		update(t, kvStore, func(tx kv.Tx) error { return store.Put(ctx, tx, ent) })
+	}
+}


### PR DESCRIPTION
SOme WIP towards making the base store data driven using an interface.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)