### PR TITLE
fix(tsdb): incorrect error type in type switch

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -591,10 +591,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 	var droppedKeys [][]byte
 	if err := engine.CreateSeriesListIfNotExists(keys, names, tagsSlice); err != nil {
 		switch err := err.(type) {
-		// TODO(jmw): why is this a *PartialWriteError when everything else is not a pointer?
-		// Maybe we can just change it to be consistent if we change it also in all
-		// the places that construct it.
-		case *PartialWriteError:
+		case PartialWriteError:
 			reason = err.Reason
 			dropped += err.Dropped
 			droppedKeys = err.DroppedKeys


### PR DESCRIPTION
With 0ccea81729, it should be checking `PartialWriteError` instead of `*PartialWriteError`