### PR TITLE
fix(models): filter out reserved tag keys in points parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 1. [16522](https://github.com/influxdata/influxdb/pull/16522): Introduce resource logger to tasks, buckets and organizations
 
 ### Bug Fixes
+
 1. [16656](https://github.com/influxdata/influxdb/pull/16656): Check engine closed before collecting index metrics
+1. [16412](https://github.com/influxdata/influxdb/pull/16412): Reject writes which use any of the reserved tag keys
 
 ### UI Improvements
 


### PR DESCRIPTION
This is an improvement to the validation done when parsing points. Certain tag keys are reserved and should not be used. This adds a validation step to the points parsing in the models package.
This step throws an error whenever any of the following tag keys are used:
 `"\xff"`
 `"\x00"`
 `"_measurement"`
 `"_field"`
 `"time"`

Before this change was introduced the parsing benchmarks looked like this:
```
goos: darwin
goarch: amd64
pkg: github.com/influxdata/influxdb/models
BenchmarkParsePointsTagsSorted2-16       	 2000000	       664 ns/op	  76.76 MB/s
BenchmarkParsePointsTagsSorted5-16       	 2000000	       855 ns/op	  97.07 MB/s
BenchmarkParsePointsTagsSorted10-16      	 1000000	      1206 ns/op	 118.54 MB/s
BenchmarkParsePointsTagsUnSorted2-16     	 2000000	       789 ns/op	  64.57 MB/s
BenchmarkParsePointsTagsUnSorted5-16     	 1000000	      1117 ns/op	  74.26 MB/s
BenchmarkParsePointsTagsUnSorted10-16    	 1000000	      1838 ns/op	  77.78 MB/s
PASS
ok  	github.com/influxdata/influxdb/models	11.309s
```

Afterwards they look like this:
```
goos: darwin
goarch: amd64
pkg: github.com/influxdata/influxdb/models
BenchmarkParsePointsTagsSorted2-16       	 2000000	       745 ns/op	  68.38 MB/s
BenchmarkParsePointsTagsSorted5-16       	 2000000	       993 ns/op	  83.52 MB/s
BenchmarkParsePointsTagsSorted10-16      	 1000000	      1475 ns/op	  96.94 MB/s
BenchmarkParsePointsTagsUnSorted2-16     	 2000000	       874 ns/op	  58.33 MB/s
BenchmarkParsePointsTagsUnSorted5-16     	 1000000	      1243 ns/op	  66.73 MB/s
BenchmarkParsePointsTagsUnSorted10-16    	 1000000	      2037 ns/op	  70.18 MB/s
PASS
ok  	github.com/influxdata/influxdb/models	12.796s
```

So there is some slow down (roughly 10 - 15% slower). Any suggestions for improvements welcomed.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
