### PR TITLE
fix(dataloader-buckets): default bucket selection should not be system bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 1. [16435](https://github.com/influxdata/influxdb/pull/16435): Time labels are no longer squished to the left
 1. [16427](https://github.com/influxdata/influxdb/pull/16427): Fixed underlying issue with disappearing queries made in Advanced Mode
 1. [16439](https://github.com/influxdata/influxdb/pull/16439): Prevent negative zero and allow zero to have decimal places
+1. [16376](https://github.com/influxdata/influxdb/pull/16413): Limit data loader bucket selection to non system buckets
 
 ### UI Improvements
 

--- a/ui/src/dataLoaders/components/BucketsDropdown.tsx
+++ b/ui/src/dataLoaders/components/BucketsDropdown.tsx
@@ -70,11 +70,9 @@ class BucketsDropdown extends PureComponent<Props> {
       return []
     }
 
-    const nonSystemBuckets = buckets.filter(bucket => {
-      if (!isSystemBucket(bucket.name)) {
-        return bucket
-      }
-    })
+    const nonSystemBuckets = buckets.filter(
+      bucket => !isSystemBucket(bucket.name)
+    )
 
     return nonSystemBuckets.map(b => (
       <Dropdown.Item

--- a/ui/src/onboarding/actions/index.ts
+++ b/ui/src/onboarding/actions/index.ts
@@ -59,12 +59,12 @@ const setOrganizationID = (orgID: string): SetOrganizationID => ({
 })
 
 interface SetBucketID {
-  type: 'SET_BUCKET_ID'
+  type: 'SET_ONBOARDING_BUCKET_ID'
   payload: {bucketID: string}
 }
 
 export const setBucketID = (bucketID: string): SetBucketID => ({
-  type: 'SET_BUCKET_ID',
+  type: 'SET_ONBOARDING_BUCKET_ID',
   payload: {bucketID},
 })
 

--- a/ui/src/onboarding/reducers/index.ts
+++ b/ui/src/onboarding/reducers/index.ts
@@ -29,7 +29,7 @@ export default (state = INITIAL_STATE, action: Action): OnboardingState => {
       return {...state, stepStatuses}
     case 'SET_ORG_ID':
       return {...state, orgID: action.payload.orgID}
-    case 'SET_BUCKET_ID':
+    case 'SET_ONBOARDING_BUCKET_ID':
       return {...state, bucketID: action.payload.bucketID}
     default:
       return state

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -24,7 +24,6 @@ import NoBucketsWarning from 'src/buckets/components/NoBucketsWarning'
 import GetResources from 'src/shared/components/GetResources'
 
 // Actions
-import {setBucketInfo} from 'src/dataLoaders/actions/steps'
 import {updateTelegraf, deleteTelegraf} from 'src/telegrafs/actions/thunks'
 
 // Decorators
@@ -33,12 +32,10 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {Telegraf, OverlayState, AppState, Bucket, ResourceType} from 'src/types'
 import {
-  setDataLoadersType,
   setTelegrafConfigID,
   setTelegrafConfigName,
   clearDataLoaders,
 } from 'src/dataLoaders/actions/dataLoaders'
-import {DataLoaderType} from 'src/types/dataLoaders'
 import {SortTypes} from 'src/shared/utils/sort'
 
 // Selectors
@@ -52,8 +49,6 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  onSetBucketInfo: typeof setBucketInfo
-  onSetDataLoadersType: typeof setDataLoadersType
   onSetTelegrafConfigID: typeof setTelegrafConfigID
   onSetTelegrafConfigName: typeof setTelegrafConfigName
   onClearDataLoaders: typeof clearDataLoaders
@@ -193,19 +188,9 @@ class Collectors extends PureComponent<Props, State> {
 
   private handleAddCollector = () => {
     const {
-      buckets,
-      onSetBucketInfo,
-      onSetDataLoadersType,
       router,
       params: {orgID},
     } = this.props
-
-    if (buckets && buckets.length) {
-      const {orgID, name, id} = buckets[0]
-      onSetBucketInfo(orgID, name, id)
-    }
-
-    onSetDataLoadersType(DataLoaderType.Scraping)
 
     router.push(`/orgs/${orgID}/load-data/telegrafs/new`)
   }
@@ -273,8 +258,6 @@ const mstp = (state: AppState): StateProps => {
 }
 
 const mdtp: DispatchProps = {
-  onSetBucketInfo: setBucketInfo,
-  onSetDataLoadersType: setDataLoadersType,
   onSetTelegrafConfigID: setTelegrafConfigID,
   onSetTelegrafConfigName: setTelegrafConfigName,
   onClearDataLoaders: clearDataLoaders,


### PR DESCRIPTION
Closes #15659 

Data loader bucket selection was being made in several places, and though the dropdown buckets were filtered to remove system buckets, the default selection was choosing among all buckets. This PR filters system buckets before selecting default. 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
