### PR TITLE
feat: add tool to migrate 1.x chronograf dashboards and variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ vendor
 
 # binary databases
 influxd.bolt
+*.db
 
 # Project distribution
 /dist

--- a/chronograf/bolt/internal/internal.go
+++ b/chronograf/bolt/internal/internal.go
@@ -246,6 +246,7 @@ func MarshalDashboard(d chronograf.Dashboard) ([]byte, error) {
 				Label:   q.Label,
 				Range:   r,
 				Source:  q.Source,
+				Type:    q.Type,
 			}
 
 			shifts := make([]*TimeShift, len(q.Shifts))
@@ -388,6 +389,7 @@ func UnmarshalDashboard(data []byte, d *chronograf.Dashboard) error {
 				Command: q.Command,
 				Label:   q.Label,
 				Source:  q.Source,
+				Type:    q.Type,
 			}
 
 			if q.Range.Upper != q.Range.Lower {

--- a/chronograf/bolt/internal/internal.pb.go
+++ b/chronograf/bolt/internal/internal.pb.go
@@ -3,9 +3,11 @@
 
 package internal
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
+	proto "github.com/gogo/protobuf/proto"
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -42,7 +44,7 @@ func (m *Source) Reset()         { *m = Source{} }
 func (m *Source) String() string { return proto.CompactTextString(m) }
 func (*Source) ProtoMessage()    {}
 func (*Source) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{0}
+	return fileDescriptor_41f4a519b878ee3b, []int{0}
 }
 func (m *Source) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Source.Unmarshal(m, b)
@@ -50,8 +52,8 @@ func (m *Source) XXX_Unmarshal(b []byte) error {
 func (m *Source) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Source.Marshal(b, m, deterministic)
 }
-func (dst *Source) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Source.Merge(dst, src)
+func (m *Source) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Source.Merge(m, src)
 }
 func (m *Source) XXX_Size() int {
 	return xxx_messageInfo_Source.Size(m)
@@ -163,8 +165,8 @@ func (m *Source) GetDefaultRP() string {
 type Dashboard struct {
 	ID                   int64            `protobuf:"varint,1,opt,name=ID,proto3" json:"ID,omitempty"`
 	Name                 string           `protobuf:"bytes,2,opt,name=Name,proto3" json:"Name,omitempty"`
-	Cells                []*DashboardCell `protobuf:"bytes,3,rep,name=cells" json:"cells,omitempty"`
-	Templates            []*Template      `protobuf:"bytes,4,rep,name=templates" json:"templates,omitempty"`
+	Cells                []*DashboardCell `protobuf:"bytes,3,rep,name=cells,proto3" json:"cells,omitempty"`
+	Templates            []*Template      `protobuf:"bytes,4,rep,name=templates,proto3" json:"templates,omitempty"`
 	Organization         string           `protobuf:"bytes,5,opt,name=Organization,proto3" json:"Organization,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
@@ -175,7 +177,7 @@ func (m *Dashboard) Reset()         { *m = Dashboard{} }
 func (m *Dashboard) String() string { return proto.CompactTextString(m) }
 func (*Dashboard) ProtoMessage()    {}
 func (*Dashboard) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{1}
+	return fileDescriptor_41f4a519b878ee3b, []int{1}
 }
 func (m *Dashboard) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Dashboard.Unmarshal(m, b)
@@ -183,8 +185,8 @@ func (m *Dashboard) XXX_Unmarshal(b []byte) error {
 func (m *Dashboard) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Dashboard.Marshal(b, m, deterministic)
 }
-func (dst *Dashboard) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Dashboard.Merge(dst, src)
+func (m *Dashboard) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Dashboard.Merge(m, src)
 }
 func (m *Dashboard) XXX_Size() int {
 	return xxx_messageInfo_Dashboard.Size(m)
@@ -235,17 +237,17 @@ type DashboardCell struct {
 	Y                    int32             `protobuf:"varint,2,opt,name=y,proto3" json:"y,omitempty"`
 	W                    int32             `protobuf:"varint,3,opt,name=w,proto3" json:"w,omitempty"`
 	H                    int32             `protobuf:"varint,4,opt,name=h,proto3" json:"h,omitempty"`
-	Queries              []*Query          `protobuf:"bytes,5,rep,name=queries" json:"queries,omitempty"`
+	Queries              []*Query          `protobuf:"bytes,5,rep,name=queries,proto3" json:"queries,omitempty"`
 	Name                 string            `protobuf:"bytes,6,opt,name=name,proto3" json:"name,omitempty"`
 	Type                 string            `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`
 	ID                   string            `protobuf:"bytes,8,opt,name=ID,proto3" json:"ID,omitempty"`
-	Axes                 map[string]*Axis  `protobuf:"bytes,9,rep,name=axes" json:"axes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value"`
-	Colors               []*Color          `protobuf:"bytes,10,rep,name=colors" json:"colors,omitempty"`
-	Legend               *Legend           `protobuf:"bytes,11,opt,name=legend" json:"legend,omitempty"`
-	TableOptions         *TableOptions     `protobuf:"bytes,12,opt,name=tableOptions" json:"tableOptions,omitempty"`
-	FieldOptions         []*RenamableField `protobuf:"bytes,13,rep,name=fieldOptions" json:"fieldOptions,omitempty"`
+	Axes                 map[string]*Axis  `protobuf:"bytes,9,rep,name=axes,proto3" json:"axes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Colors               []*Color          `protobuf:"bytes,10,rep,name=colors,proto3" json:"colors,omitempty"`
+	Legend               *Legend           `protobuf:"bytes,11,opt,name=legend,proto3" json:"legend,omitempty"`
+	TableOptions         *TableOptions     `protobuf:"bytes,12,opt,name=tableOptions,proto3" json:"tableOptions,omitempty"`
+	FieldOptions         []*RenamableField `protobuf:"bytes,13,rep,name=fieldOptions,proto3" json:"fieldOptions,omitempty"`
 	TimeFormat           string            `protobuf:"bytes,14,opt,name=timeFormat,proto3" json:"timeFormat,omitempty"`
-	DecimalPlaces        *DecimalPlaces    `protobuf:"bytes,15,opt,name=decimalPlaces" json:"decimalPlaces,omitempty"`
+	DecimalPlaces        *DecimalPlaces    `protobuf:"bytes,15,opt,name=decimalPlaces,proto3" json:"decimalPlaces,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -255,7 +257,7 @@ func (m *DashboardCell) Reset()         { *m = DashboardCell{} }
 func (m *DashboardCell) String() string { return proto.CompactTextString(m) }
 func (*DashboardCell) ProtoMessage()    {}
 func (*DashboardCell) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{2}
+	return fileDescriptor_41f4a519b878ee3b, []int{2}
 }
 func (m *DashboardCell) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DashboardCell.Unmarshal(m, b)
@@ -263,8 +265,8 @@ func (m *DashboardCell) XXX_Unmarshal(b []byte) error {
 func (m *DashboardCell) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DashboardCell.Marshal(b, m, deterministic)
 }
-func (dst *DashboardCell) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DashboardCell.Merge(dst, src)
+func (m *DashboardCell) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DashboardCell.Merge(m, src)
 }
 func (m *DashboardCell) XXX_Size() int {
 	return xxx_messageInfo_DashboardCell.Size(m)
@@ -392,7 +394,7 @@ func (m *DecimalPlaces) Reset()         { *m = DecimalPlaces{} }
 func (m *DecimalPlaces) String() string { return proto.CompactTextString(m) }
 func (*DecimalPlaces) ProtoMessage()    {}
 func (*DecimalPlaces) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{3}
+	return fileDescriptor_41f4a519b878ee3b, []int{3}
 }
 func (m *DecimalPlaces) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DecimalPlaces.Unmarshal(m, b)
@@ -400,8 +402,8 @@ func (m *DecimalPlaces) XXX_Unmarshal(b []byte) error {
 func (m *DecimalPlaces) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DecimalPlaces.Marshal(b, m, deterministic)
 }
-func (dst *DecimalPlaces) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DecimalPlaces.Merge(dst, src)
+func (m *DecimalPlaces) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DecimalPlaces.Merge(m, src)
 }
 func (m *DecimalPlaces) XXX_Size() int {
 	return xxx_messageInfo_DecimalPlaces.Size(m)
@@ -428,7 +430,7 @@ func (m *DecimalPlaces) GetDigits() int32 {
 
 type TableOptions struct {
 	VerticalTimeAxis     bool            `protobuf:"varint,2,opt,name=verticalTimeAxis,proto3" json:"verticalTimeAxis,omitempty"`
-	SortBy               *RenamableField `protobuf:"bytes,3,opt,name=sortBy" json:"sortBy,omitempty"`
+	SortBy               *RenamableField `protobuf:"bytes,3,opt,name=sortBy,proto3" json:"sortBy,omitempty"`
 	Wrapping             string          `protobuf:"bytes,4,opt,name=wrapping,proto3" json:"wrapping,omitempty"`
 	FixFirstColumn       bool            `protobuf:"varint,6,opt,name=fixFirstColumn,proto3" json:"fixFirstColumn,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
@@ -440,7 +442,7 @@ func (m *TableOptions) Reset()         { *m = TableOptions{} }
 func (m *TableOptions) String() string { return proto.CompactTextString(m) }
 func (*TableOptions) ProtoMessage()    {}
 func (*TableOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{4}
+	return fileDescriptor_41f4a519b878ee3b, []int{4}
 }
 func (m *TableOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TableOptions.Unmarshal(m, b)
@@ -448,8 +450,8 @@ func (m *TableOptions) XXX_Unmarshal(b []byte) error {
 func (m *TableOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TableOptions.Marshal(b, m, deterministic)
 }
-func (dst *TableOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TableOptions.Merge(dst, src)
+func (m *TableOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TableOptions.Merge(m, src)
 }
 func (m *TableOptions) XXX_Size() int {
 	return xxx_messageInfo_TableOptions.Size(m)
@@ -501,7 +503,7 @@ func (m *RenamableField) Reset()         { *m = RenamableField{} }
 func (m *RenamableField) String() string { return proto.CompactTextString(m) }
 func (*RenamableField) ProtoMessage()    {}
 func (*RenamableField) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{5}
+	return fileDescriptor_41f4a519b878ee3b, []int{5}
 }
 func (m *RenamableField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RenamableField.Unmarshal(m, b)
@@ -509,8 +511,8 @@ func (m *RenamableField) XXX_Unmarshal(b []byte) error {
 func (m *RenamableField) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RenamableField.Marshal(b, m, deterministic)
 }
-func (dst *RenamableField) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RenamableField.Merge(dst, src)
+func (m *RenamableField) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RenamableField.Merge(m, src)
 }
 func (m *RenamableField) XXX_Size() int {
 	return xxx_messageInfo_RenamableField.Size(m)
@@ -557,7 +559,7 @@ func (m *Color) Reset()         { *m = Color{} }
 func (m *Color) String() string { return proto.CompactTextString(m) }
 func (*Color) ProtoMessage()    {}
 func (*Color) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{6}
+	return fileDescriptor_41f4a519b878ee3b, []int{6}
 }
 func (m *Color) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Color.Unmarshal(m, b)
@@ -565,8 +567,8 @@ func (m *Color) XXX_Unmarshal(b []byte) error {
 func (m *Color) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Color.Marshal(b, m, deterministic)
 }
-func (dst *Color) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Color.Merge(dst, src)
+func (m *Color) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Color.Merge(m, src)
 }
 func (m *Color) XXX_Size() int {
 	return xxx_messageInfo_Color.Size(m)
@@ -624,7 +626,7 @@ func (m *Legend) Reset()         { *m = Legend{} }
 func (m *Legend) String() string { return proto.CompactTextString(m) }
 func (*Legend) ProtoMessage()    {}
 func (*Legend) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{7}
+	return fileDescriptor_41f4a519b878ee3b, []int{7}
 }
 func (m *Legend) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Legend.Unmarshal(m, b)
@@ -632,8 +634,8 @@ func (m *Legend) XXX_Unmarshal(b []byte) error {
 func (m *Legend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Legend.Marshal(b, m, deterministic)
 }
-func (dst *Legend) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Legend.Merge(dst, src)
+func (m *Legend) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Legend.Merge(m, src)
 }
 func (m *Legend) XXX_Size() int {
 	return xxx_messageInfo_Legend.Size(m)
@@ -659,8 +661,8 @@ func (m *Legend) GetOrientation() string {
 }
 
 type Axis struct {
-	LegacyBounds         []int64  `protobuf:"varint,1,rep,packed,name=legacyBounds" json:"legacyBounds,omitempty"`
-	Bounds               []string `protobuf:"bytes,2,rep,name=bounds" json:"bounds,omitempty"`
+	LegacyBounds         []int64  `protobuf:"varint,1,rep,packed,name=legacyBounds,proto3" json:"legacyBounds,omitempty"`
+	Bounds               []string `protobuf:"bytes,2,rep,name=bounds,proto3" json:"bounds,omitempty"`
 	Label                string   `protobuf:"bytes,3,opt,name=label,proto3" json:"label,omitempty"`
 	Prefix               string   `protobuf:"bytes,4,opt,name=prefix,proto3" json:"prefix,omitempty"`
 	Suffix               string   `protobuf:"bytes,5,opt,name=suffix,proto3" json:"suffix,omitempty"`
@@ -675,7 +677,7 @@ func (m *Axis) Reset()         { *m = Axis{} }
 func (m *Axis) String() string { return proto.CompactTextString(m) }
 func (*Axis) ProtoMessage()    {}
 func (*Axis) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{8}
+	return fileDescriptor_41f4a519b878ee3b, []int{8}
 }
 func (m *Axis) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Axis.Unmarshal(m, b)
@@ -683,8 +685,8 @@ func (m *Axis) XXX_Unmarshal(b []byte) error {
 func (m *Axis) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Axis.Marshal(b, m, deterministic)
 }
-func (dst *Axis) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Axis.Merge(dst, src)
+func (m *Axis) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Axis.Merge(m, src)
 }
 func (m *Axis) XXX_Size() int {
 	return xxx_messageInfo_Axis.Size(m)
@@ -747,10 +749,10 @@ func (m *Axis) GetScale() string {
 type Template struct {
 	ID                   string           `protobuf:"bytes,1,opt,name=ID,proto3" json:"ID,omitempty"`
 	TempVar              string           `protobuf:"bytes,2,opt,name=temp_var,json=tempVar,proto3" json:"temp_var,omitempty"`
-	Values               []*TemplateValue `protobuf:"bytes,3,rep,name=values" json:"values,omitempty"`
+	Values               []*TemplateValue `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
 	Type                 string           `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
 	Label                string           `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
-	Query                *TemplateQuery   `protobuf:"bytes,6,opt,name=query" json:"query,omitempty"`
+	Query                *TemplateQuery   `protobuf:"bytes,6,opt,name=query,proto3" json:"query,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -760,7 +762,7 @@ func (m *Template) Reset()         { *m = Template{} }
 func (m *Template) String() string { return proto.CompactTextString(m) }
 func (*Template) ProtoMessage()    {}
 func (*Template) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{9}
+	return fileDescriptor_41f4a519b878ee3b, []int{9}
 }
 func (m *Template) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Template.Unmarshal(m, b)
@@ -768,8 +770,8 @@ func (m *Template) XXX_Unmarshal(b []byte) error {
 func (m *Template) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Template.Marshal(b, m, deterministic)
 }
-func (dst *Template) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Template.Merge(dst, src)
+func (m *Template) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Template.Merge(m, src)
 }
 func (m *Template) XXX_Size() int {
 	return xxx_messageInfo_Template.Size(m)
@@ -836,7 +838,7 @@ func (m *TemplateValue) Reset()         { *m = TemplateValue{} }
 func (m *TemplateValue) String() string { return proto.CompactTextString(m) }
 func (*TemplateValue) ProtoMessage()    {}
 func (*TemplateValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{10}
+	return fileDescriptor_41f4a519b878ee3b, []int{10}
 }
 func (m *TemplateValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TemplateValue.Unmarshal(m, b)
@@ -844,8 +846,8 @@ func (m *TemplateValue) XXX_Unmarshal(b []byte) error {
 func (m *TemplateValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TemplateValue.Marshal(b, m, deterministic)
 }
-func (dst *TemplateValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TemplateValue.Merge(dst, src)
+func (m *TemplateValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TemplateValue.Merge(m, src)
 }
 func (m *TemplateValue) XXX_Size() int {
 	return xxx_messageInfo_TemplateValue.Size(m)
@@ -900,7 +902,7 @@ func (m *TemplateQuery) Reset()         { *m = TemplateQuery{} }
 func (m *TemplateQuery) String() string { return proto.CompactTextString(m) }
 func (*TemplateQuery) ProtoMessage()    {}
 func (*TemplateQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{11}
+	return fileDescriptor_41f4a519b878ee3b, []int{11}
 }
 func (m *TemplateQuery) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TemplateQuery.Unmarshal(m, b)
@@ -908,8 +910,8 @@ func (m *TemplateQuery) XXX_Unmarshal(b []byte) error {
 func (m *TemplateQuery) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TemplateQuery.Marshal(b, m, deterministic)
 }
-func (dst *TemplateQuery) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TemplateQuery.Merge(dst, src)
+func (m *TemplateQuery) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TemplateQuery.Merge(m, src)
 }
 func (m *TemplateQuery) XXX_Size() int {
 	return xxx_messageInfo_TemplateQuery.Size(m)
@@ -983,7 +985,7 @@ func (m *Server) Reset()         { *m = Server{} }
 func (m *Server) String() string { return proto.CompactTextString(m) }
 func (*Server) ProtoMessage()    {}
 func (*Server) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{12}
+	return fileDescriptor_41f4a519b878ee3b, []int{12}
 }
 func (m *Server) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Server.Unmarshal(m, b)
@@ -991,8 +993,8 @@ func (m *Server) XXX_Unmarshal(b []byte) error {
 func (m *Server) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Server.Marshal(b, m, deterministic)
 }
-func (dst *Server) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Server.Merge(dst, src)
+func (m *Server) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Server.Merge(m, src)
 }
 func (m *Server) XXX_Size() int {
 	return xxx_messageInfo_Server.Size(m)
@@ -1084,7 +1086,7 @@ type Layout struct {
 	ID                   string   `protobuf:"bytes,1,opt,name=ID,proto3" json:"ID,omitempty"`
 	Application          string   `protobuf:"bytes,2,opt,name=Application,proto3" json:"Application,omitempty"`
 	Measurement          string   `protobuf:"bytes,3,opt,name=Measurement,proto3" json:"Measurement,omitempty"`
-	Cells                []*Cell  `protobuf:"bytes,4,rep,name=Cells" json:"Cells,omitempty"`
+	Cells                []*Cell  `protobuf:"bytes,4,rep,name=Cells,proto3" json:"Cells,omitempty"`
 	Autoflow             bool     `protobuf:"varint,5,opt,name=Autoflow,proto3" json:"Autoflow,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1095,7 +1097,7 @@ func (m *Layout) Reset()         { *m = Layout{} }
 func (m *Layout) String() string { return proto.CompactTextString(m) }
 func (*Layout) ProtoMessage()    {}
 func (*Layout) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{13}
+	return fileDescriptor_41f4a519b878ee3b, []int{13}
 }
 func (m *Layout) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Layout.Unmarshal(m, b)
@@ -1103,8 +1105,8 @@ func (m *Layout) XXX_Unmarshal(b []byte) error {
 func (m *Layout) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Layout.Marshal(b, m, deterministic)
 }
-func (dst *Layout) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Layout.Merge(dst, src)
+func (m *Layout) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Layout.Merge(m, src)
 }
 func (m *Layout) XXX_Size() int {
 	return xxx_messageInfo_Layout.Size(m)
@@ -1155,13 +1157,13 @@ type Cell struct {
 	Y                    int32            `protobuf:"varint,2,opt,name=y,proto3" json:"y,omitempty"`
 	W                    int32            `protobuf:"varint,3,opt,name=w,proto3" json:"w,omitempty"`
 	H                    int32            `protobuf:"varint,4,opt,name=h,proto3" json:"h,omitempty"`
-	Queries              []*Query         `protobuf:"bytes,5,rep,name=queries" json:"queries,omitempty"`
+	Queries              []*Query         `protobuf:"bytes,5,rep,name=queries,proto3" json:"queries,omitempty"`
 	I                    string           `protobuf:"bytes,6,opt,name=i,proto3" json:"i,omitempty"`
 	Name                 string           `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
-	Yranges              []int64          `protobuf:"varint,8,rep,packed,name=yranges" json:"yranges,omitempty"`
-	Ylabels              []string         `protobuf:"bytes,9,rep,name=ylabels" json:"ylabels,omitempty"`
+	Yranges              []int64          `protobuf:"varint,8,rep,packed,name=yranges,proto3" json:"yranges,omitempty"`
+	Ylabels              []string         `protobuf:"bytes,9,rep,name=ylabels,proto3" json:"ylabels,omitempty"`
 	Type                 string           `protobuf:"bytes,10,opt,name=type,proto3" json:"type,omitempty"`
-	Axes                 map[string]*Axis `protobuf:"bytes,11,rep,name=axes" json:"axes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value"`
+	Axes                 map[string]*Axis `protobuf:"bytes,11,rep,name=axes,proto3" json:"axes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -1171,7 +1173,7 @@ func (m *Cell) Reset()         { *m = Cell{} }
 func (m *Cell) String() string { return proto.CompactTextString(m) }
 func (*Cell) ProtoMessage()    {}
 func (*Cell) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{14}
+	return fileDescriptor_41f4a519b878ee3b, []int{14}
 }
 func (m *Cell) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Cell.Unmarshal(m, b)
@@ -1179,8 +1181,8 @@ func (m *Cell) XXX_Unmarshal(b []byte) error {
 func (m *Cell) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Cell.Marshal(b, m, deterministic)
 }
-func (dst *Cell) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Cell.Merge(dst, src)
+func (m *Cell) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Cell.Merge(m, src)
 }
 func (m *Cell) XXX_Size() int {
 	return xxx_messageInfo_Cell.Size(m)
@@ -1272,12 +1274,13 @@ type Query struct {
 	Command              string       `protobuf:"bytes,1,opt,name=Command,proto3" json:"Command,omitempty"`
 	DB                   string       `protobuf:"bytes,2,opt,name=DB,proto3" json:"DB,omitempty"`
 	RP                   string       `protobuf:"bytes,3,opt,name=RP,proto3" json:"RP,omitempty"`
-	GroupBys             []string     `protobuf:"bytes,4,rep,name=GroupBys" json:"GroupBys,omitempty"`
-	Wheres               []string     `protobuf:"bytes,5,rep,name=Wheres" json:"Wheres,omitempty"`
+	GroupBys             []string     `protobuf:"bytes,4,rep,name=GroupBys,proto3" json:"GroupBys,omitempty"`
+	Wheres               []string     `protobuf:"bytes,5,rep,name=Wheres,proto3" json:"Wheres,omitempty"`
 	Label                string       `protobuf:"bytes,6,opt,name=Label,proto3" json:"Label,omitempty"`
-	Range                *Range       `protobuf:"bytes,7,opt,name=Range" json:"Range,omitempty"`
+	Range                *Range       `protobuf:"bytes,7,opt,name=Range,proto3" json:"Range,omitempty"`
 	Source               string       `protobuf:"bytes,8,opt,name=Source,proto3" json:"Source,omitempty"`
-	Shifts               []*TimeShift `protobuf:"bytes,9,rep,name=Shifts" json:"Shifts,omitempty"`
+	Shifts               []*TimeShift `protobuf:"bytes,9,rep,name=Shifts,proto3" json:"Shifts,omitempty"`
+	Type                 string       `protobuf:"bytes,10,opt,name=Type,proto3" json:"Type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -1287,7 +1290,7 @@ func (m *Query) Reset()         { *m = Query{} }
 func (m *Query) String() string { return proto.CompactTextString(m) }
 func (*Query) ProtoMessage()    {}
 func (*Query) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{15}
+	return fileDescriptor_41f4a519b878ee3b, []int{15}
 }
 func (m *Query) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Query.Unmarshal(m, b)
@@ -1295,8 +1298,8 @@ func (m *Query) XXX_Unmarshal(b []byte) error {
 func (m *Query) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Query.Marshal(b, m, deterministic)
 }
-func (dst *Query) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Query.Merge(dst, src)
+func (m *Query) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Query.Merge(m, src)
 }
 func (m *Query) XXX_Size() int {
 	return xxx_messageInfo_Query.Size(m)
@@ -1370,6 +1373,13 @@ func (m *Query) GetShifts() []*TimeShift {
 	return nil
 }
 
+func (m *Query) GetType() string {
+	if m != nil {
+		return m.Type
+	}
+	return ""
+}
+
 type TimeShift struct {
 	Label                string   `protobuf:"bytes,1,opt,name=Label,proto3" json:"Label,omitempty"`
 	Unit                 string   `protobuf:"bytes,2,opt,name=Unit,proto3" json:"Unit,omitempty"`
@@ -1383,7 +1393,7 @@ func (m *TimeShift) Reset()         { *m = TimeShift{} }
 func (m *TimeShift) String() string { return proto.CompactTextString(m) }
 func (*TimeShift) ProtoMessage()    {}
 func (*TimeShift) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{16}
+	return fileDescriptor_41f4a519b878ee3b, []int{16}
 }
 func (m *TimeShift) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TimeShift.Unmarshal(m, b)
@@ -1391,8 +1401,8 @@ func (m *TimeShift) XXX_Unmarshal(b []byte) error {
 func (m *TimeShift) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TimeShift.Marshal(b, m, deterministic)
 }
-func (dst *TimeShift) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TimeShift.Merge(dst, src)
+func (m *TimeShift) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TimeShift.Merge(m, src)
 }
 func (m *TimeShift) XXX_Size() int {
 	return xxx_messageInfo_TimeShift.Size(m)
@@ -1436,7 +1446,7 @@ func (m *Range) Reset()         { *m = Range{} }
 func (m *Range) String() string { return proto.CompactTextString(m) }
 func (*Range) ProtoMessage()    {}
 func (*Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{17}
+	return fileDescriptor_41f4a519b878ee3b, []int{17}
 }
 func (m *Range) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Range.Unmarshal(m, b)
@@ -1444,8 +1454,8 @@ func (m *Range) XXX_Unmarshal(b []byte) error {
 func (m *Range) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Range.Marshal(b, m, deterministic)
 }
-func (dst *Range) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Range.Merge(dst, src)
+func (m *Range) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Range.Merge(m, src)
 }
 func (m *Range) XXX_Size() int {
 	return xxx_messageInfo_Range.Size(m)
@@ -1484,7 +1494,7 @@ func (m *AlertRule) Reset()         { *m = AlertRule{} }
 func (m *AlertRule) String() string { return proto.CompactTextString(m) }
 func (*AlertRule) ProtoMessage()    {}
 func (*AlertRule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{18}
+	return fileDescriptor_41f4a519b878ee3b, []int{18}
 }
 func (m *AlertRule) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AlertRule.Unmarshal(m, b)
@@ -1492,8 +1502,8 @@ func (m *AlertRule) XXX_Unmarshal(b []byte) error {
 func (m *AlertRule) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AlertRule.Marshal(b, m, deterministic)
 }
-func (dst *AlertRule) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AlertRule.Merge(dst, src)
+func (m *AlertRule) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AlertRule.Merge(m, src)
 }
 func (m *AlertRule) XXX_Size() int {
 	return xxx_messageInfo_AlertRule.Size(m)
@@ -1537,7 +1547,7 @@ type User struct {
 	Name                 string   `protobuf:"bytes,2,opt,name=Name,proto3" json:"Name,omitempty"`
 	Provider             string   `protobuf:"bytes,3,opt,name=Provider,proto3" json:"Provider,omitempty"`
 	Scheme               string   `protobuf:"bytes,4,opt,name=Scheme,proto3" json:"Scheme,omitempty"`
-	Roles                []*Role  `protobuf:"bytes,5,rep,name=Roles" json:"Roles,omitempty"`
+	Roles                []*Role  `protobuf:"bytes,5,rep,name=Roles,proto3" json:"Roles,omitempty"`
 	SuperAdmin           bool     `protobuf:"varint,6,opt,name=SuperAdmin,proto3" json:"SuperAdmin,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1548,7 +1558,7 @@ func (m *User) Reset()         { *m = User{} }
 func (m *User) String() string { return proto.CompactTextString(m) }
 func (*User) ProtoMessage()    {}
 func (*User) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{19}
+	return fileDescriptor_41f4a519b878ee3b, []int{19}
 }
 func (m *User) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_User.Unmarshal(m, b)
@@ -1556,8 +1566,8 @@ func (m *User) XXX_Unmarshal(b []byte) error {
 func (m *User) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_User.Marshal(b, m, deterministic)
 }
-func (dst *User) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_User.Merge(dst, src)
+func (m *User) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_User.Merge(m, src)
 }
 func (m *User) XXX_Size() int {
 	return xxx_messageInfo_User.Size(m)
@@ -1622,7 +1632,7 @@ func (m *Role) Reset()         { *m = Role{} }
 func (m *Role) String() string { return proto.CompactTextString(m) }
 func (*Role) ProtoMessage()    {}
 func (*Role) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{20}
+	return fileDescriptor_41f4a519b878ee3b, []int{20}
 }
 func (m *Role) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Role.Unmarshal(m, b)
@@ -1630,8 +1640,8 @@ func (m *Role) XXX_Unmarshal(b []byte) error {
 func (m *Role) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Role.Marshal(b, m, deterministic)
 }
-func (dst *Role) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Role.Merge(dst, src)
+func (m *Role) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Role.Merge(m, src)
 }
 func (m *Role) XXX_Size() int {
 	return xxx_messageInfo_Role.Size(m)
@@ -1671,7 +1681,7 @@ func (m *Mapping) Reset()         { *m = Mapping{} }
 func (m *Mapping) String() string { return proto.CompactTextString(m) }
 func (*Mapping) ProtoMessage()    {}
 func (*Mapping) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{21}
+	return fileDescriptor_41f4a519b878ee3b, []int{21}
 }
 func (m *Mapping) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Mapping.Unmarshal(m, b)
@@ -1679,8 +1689,8 @@ func (m *Mapping) XXX_Unmarshal(b []byte) error {
 func (m *Mapping) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Mapping.Marshal(b, m, deterministic)
 }
-func (dst *Mapping) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Mapping.Merge(dst, src)
+func (m *Mapping) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Mapping.Merge(m, src)
 }
 func (m *Mapping) XXX_Size() int {
 	return xxx_messageInfo_Mapping.Size(m)
@@ -1739,7 +1749,7 @@ func (m *Organization) Reset()         { *m = Organization{} }
 func (m *Organization) String() string { return proto.CompactTextString(m) }
 func (*Organization) ProtoMessage()    {}
 func (*Organization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{22}
+	return fileDescriptor_41f4a519b878ee3b, []int{22}
 }
 func (m *Organization) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Organization.Unmarshal(m, b)
@@ -1747,8 +1757,8 @@ func (m *Organization) XXX_Unmarshal(b []byte) error {
 func (m *Organization) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Organization.Marshal(b, m, deterministic)
 }
-func (dst *Organization) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Organization.Merge(dst, src)
+func (m *Organization) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Organization.Merge(m, src)
 }
 func (m *Organization) XXX_Size() int {
 	return xxx_messageInfo_Organization.Size(m)
@@ -1781,7 +1791,7 @@ func (m *Organization) GetDefaultRole() string {
 }
 
 type Config struct {
-	Auth                 *AuthConfig `protobuf:"bytes,1,opt,name=Auth" json:"Auth,omitempty"`
+	Auth                 *AuthConfig `protobuf:"bytes,1,opt,name=Auth,proto3" json:"Auth,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
 	XXX_unrecognized     []byte      `json:"-"`
 	XXX_sizecache        int32       `json:"-"`
@@ -1791,7 +1801,7 @@ func (m *Config) Reset()         { *m = Config{} }
 func (m *Config) String() string { return proto.CompactTextString(m) }
 func (*Config) ProtoMessage()    {}
 func (*Config) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{23}
+	return fileDescriptor_41f4a519b878ee3b, []int{23}
 }
 func (m *Config) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Config.Unmarshal(m, b)
@@ -1799,8 +1809,8 @@ func (m *Config) XXX_Unmarshal(b []byte) error {
 func (m *Config) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Config.Marshal(b, m, deterministic)
 }
-func (dst *Config) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Config.Merge(dst, src)
+func (m *Config) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Config.Merge(m, src)
 }
 func (m *Config) XXX_Size() int {
 	return xxx_messageInfo_Config.Size(m)
@@ -1829,7 +1839,7 @@ func (m *AuthConfig) Reset()         { *m = AuthConfig{} }
 func (m *AuthConfig) String() string { return proto.CompactTextString(m) }
 func (*AuthConfig) ProtoMessage()    {}
 func (*AuthConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{24}
+	return fileDescriptor_41f4a519b878ee3b, []int{24}
 }
 func (m *AuthConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AuthConfig.Unmarshal(m, b)
@@ -1837,8 +1847,8 @@ func (m *AuthConfig) XXX_Unmarshal(b []byte) error {
 func (m *AuthConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AuthConfig.Marshal(b, m, deterministic)
 }
-func (dst *AuthConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AuthConfig.Merge(dst, src)
+func (m *AuthConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AuthConfig.Merge(m, src)
 }
 func (m *AuthConfig) XXX_Size() int {
 	return xxx_messageInfo_AuthConfig.Size(m)
@@ -1858,7 +1868,7 @@ func (m *AuthConfig) GetSuperAdminNewUsers() bool {
 
 type OrganizationConfig struct {
 	OrganizationID       string           `protobuf:"bytes,1,opt,name=OrganizationID,proto3" json:"OrganizationID,omitempty"`
-	LogViewer            *LogViewerConfig `protobuf:"bytes,2,opt,name=LogViewer" json:"LogViewer,omitempty"`
+	LogViewer            *LogViewerConfig `protobuf:"bytes,2,opt,name=LogViewer,proto3" json:"LogViewer,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -1868,7 +1878,7 @@ func (m *OrganizationConfig) Reset()         { *m = OrganizationConfig{} }
 func (m *OrganizationConfig) String() string { return proto.CompactTextString(m) }
 func (*OrganizationConfig) ProtoMessage()    {}
 func (*OrganizationConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{25}
+	return fileDescriptor_41f4a519b878ee3b, []int{25}
 }
 func (m *OrganizationConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OrganizationConfig.Unmarshal(m, b)
@@ -1876,8 +1886,8 @@ func (m *OrganizationConfig) XXX_Unmarshal(b []byte) error {
 func (m *OrganizationConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OrganizationConfig.Marshal(b, m, deterministic)
 }
-func (dst *OrganizationConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OrganizationConfig.Merge(dst, src)
+func (m *OrganizationConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OrganizationConfig.Merge(m, src)
 }
 func (m *OrganizationConfig) XXX_Size() int {
 	return xxx_messageInfo_OrganizationConfig.Size(m)
@@ -1903,7 +1913,7 @@ func (m *OrganizationConfig) GetLogViewer() *LogViewerConfig {
 }
 
 type LogViewerConfig struct {
-	Columns              []*LogViewerColumn `protobuf:"bytes,1,rep,name=Columns" json:"Columns,omitempty"`
+	Columns              []*LogViewerColumn `protobuf:"bytes,1,rep,name=Columns,proto3" json:"Columns,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -1913,7 +1923,7 @@ func (m *LogViewerConfig) Reset()         { *m = LogViewerConfig{} }
 func (m *LogViewerConfig) String() string { return proto.CompactTextString(m) }
 func (*LogViewerConfig) ProtoMessage()    {}
 func (*LogViewerConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{26}
+	return fileDescriptor_41f4a519b878ee3b, []int{26}
 }
 func (m *LogViewerConfig) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LogViewerConfig.Unmarshal(m, b)
@@ -1921,8 +1931,8 @@ func (m *LogViewerConfig) XXX_Unmarshal(b []byte) error {
 func (m *LogViewerConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LogViewerConfig.Marshal(b, m, deterministic)
 }
-func (dst *LogViewerConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LogViewerConfig.Merge(dst, src)
+func (m *LogViewerConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LogViewerConfig.Merge(m, src)
 }
 func (m *LogViewerConfig) XXX_Size() int {
 	return xxx_messageInfo_LogViewerConfig.Size(m)
@@ -1943,7 +1953,7 @@ func (m *LogViewerConfig) GetColumns() []*LogViewerColumn {
 type LogViewerColumn struct {
 	Name                 string            `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
 	Position             int32             `protobuf:"varint,2,opt,name=Position,proto3" json:"Position,omitempty"`
-	Encodings            []*ColumnEncoding `protobuf:"bytes,3,rep,name=Encodings" json:"Encodings,omitempty"`
+	Encodings            []*ColumnEncoding `protobuf:"bytes,3,rep,name=Encodings,proto3" json:"Encodings,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -1953,7 +1963,7 @@ func (m *LogViewerColumn) Reset()         { *m = LogViewerColumn{} }
 func (m *LogViewerColumn) String() string { return proto.CompactTextString(m) }
 func (*LogViewerColumn) ProtoMessage()    {}
 func (*LogViewerColumn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{27}
+	return fileDescriptor_41f4a519b878ee3b, []int{27}
 }
 func (m *LogViewerColumn) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LogViewerColumn.Unmarshal(m, b)
@@ -1961,8 +1971,8 @@ func (m *LogViewerColumn) XXX_Unmarshal(b []byte) error {
 func (m *LogViewerColumn) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LogViewerColumn.Marshal(b, m, deterministic)
 }
-func (dst *LogViewerColumn) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LogViewerColumn.Merge(dst, src)
+func (m *LogViewerColumn) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LogViewerColumn.Merge(m, src)
 }
 func (m *LogViewerColumn) XXX_Size() int {
 	return xxx_messageInfo_LogViewerColumn.Size(m)
@@ -2007,7 +2017,7 @@ func (m *ColumnEncoding) Reset()         { *m = ColumnEncoding{} }
 func (m *ColumnEncoding) String() string { return proto.CompactTextString(m) }
 func (*ColumnEncoding) ProtoMessage()    {}
 func (*ColumnEncoding) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{28}
+	return fileDescriptor_41f4a519b878ee3b, []int{28}
 }
 func (m *ColumnEncoding) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ColumnEncoding.Unmarshal(m, b)
@@ -2015,8 +2025,8 @@ func (m *ColumnEncoding) XXX_Unmarshal(b []byte) error {
 func (m *ColumnEncoding) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ColumnEncoding.Marshal(b, m, deterministic)
 }
-func (dst *ColumnEncoding) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ColumnEncoding.Merge(dst, src)
+func (m *ColumnEncoding) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ColumnEncoding.Merge(m, src)
 }
 func (m *ColumnEncoding) XXX_Size() int {
 	return xxx_messageInfo_ColumnEncoding.Size(m)
@@ -2060,7 +2070,7 @@ func (m *BuildInfo) Reset()         { *m = BuildInfo{} }
 func (m *BuildInfo) String() string { return proto.CompactTextString(m) }
 func (*BuildInfo) ProtoMessage()    {}
 func (*BuildInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_internal_6148f2d00a5dfb1b, []int{29}
+	return fileDescriptor_41f4a519b878ee3b, []int{29}
 }
 func (m *BuildInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BuildInfo.Unmarshal(m, b)
@@ -2068,8 +2078,8 @@ func (m *BuildInfo) XXX_Unmarshal(b []byte) error {
 func (m *BuildInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BuildInfo.Marshal(b, m, deterministic)
 }
-func (dst *BuildInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BuildInfo.Merge(dst, src)
+func (m *BuildInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BuildInfo.Merge(m, src)
 }
 func (m *BuildInfo) XXX_Size() int {
 	return xxx_messageInfo_BuildInfo.Size(m)
@@ -2129,16 +2139,16 @@ func init() {
 	proto.RegisterType((*BuildInfo)(nil), "internal.BuildInfo")
 }
 
-func init() { proto.RegisterFile("internal.proto", fileDescriptor_internal_6148f2d00a5dfb1b) }
+func init() { proto.RegisterFile("internal.proto", fileDescriptor_41f4a519b878ee3b) }
 
-var fileDescriptor_internal_6148f2d00a5dfb1b = []byte{
-	// 1807 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_41f4a519b878ee3b = []byte{
+	// 1810 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x58, 0x4b, 0x6f, 0xdc, 0xc8,
 	0x11, 0x06, 0x67, 0x86, 0xa3, 0x61, 0x8d, 0x24, 0x0b, 0x1d, 0x63, 0x97, 0xbb, 0x09, 0x82, 0x09,
 	0x91, 0x6c, 0x94, 0xc7, 0x3a, 0x0b, 0x19, 0x79, 0x60, 0xb1, 0xbb, 0x80, 0x1e, 0xb6, 0x23, 0x5b,
 	0xb6, 0xe5, 0x96, 0xac, 0x9c, 0x82, 0x45, 0x8b, 0xec, 0x99, 0x69, 0x98, 0x43, 0x32, 0x4d, 0x52,
-	0x12, 0x73, 0xce, 0xef, 0x08, 0x10, 0x20, 0xb9, 0x07, 0x41, 0x8e, 0x01, 0x72, 0xcf, 0x0f, 0xc8,
-	0x5f, 0xc9, 0x35, 0xa8, 0x7e, 0x90, 0x4d, 0x69, 0x6c, 0x38, 0x40, 0xb0, 0xb7, 0xfe, 0xaa, 0x6a,
+	0x12, 0x73, 0xce, 0x2d, 0xff, 0x21, 0x40, 0x80, 0xe4, 0x1e, 0x04, 0x39, 0x06, 0xc8, 0x3d, 0x3f,
+	0x20, 0xbf, 0x27, 0xa8, 0x7e, 0x90, 0x4d, 0x69, 0x6c, 0x38, 0x40, 0xb0, 0xb7, 0xfe, 0xaa, 0x6a,
 	0xaa, 0xab, 0xab, 0xab, 0xbe, 0x2e, 0x0e, 0x6c, 0x8b, 0xac, 0xe2, 0x32, 0x63, 0xe9, 0x83, 0x42,
 	0xe6, 0x55, 0x4e, 0x26, 0x16, 0x47, 0x7f, 0x18, 0xc2, 0xf8, 0x2c, 0xaf, 0x65, 0xcc, 0xc9, 0x36,
 	0x0c, 0x8e, 0x8f, 0x42, 0x6f, 0xe6, 0xed, 0x0e, 0xe9, 0xe0, 0xf8, 0x88, 0x10, 0x18, 0xbd, 0x60,
@@ -2152,11 +2162,11 @@ var fileDescriptor_internal_6148f2d00a5dfb1b = []byte{
 	0x92, 0x08, 0x36, 0xcf, 0x96, 0x4c, 0xf2, 0xe4, 0x8c, 0xc7, 0x92, 0x57, 0xe1, 0x54, 0xa9, 0x7b,
 	0x32, 0xb4, 0x79, 0x29, 0x17, 0x2c, 0x13, 0xbf, 0x67, 0x95, 0xc8, 0xb3, 0x70, 0x53, 0xdb, 0xb8,
 	0x32, 0xcc, 0x12, 0xcd, 0x53, 0x1e, 0x6e, 0xe9, 0x2c, 0xe1, 0x9a, 0x7c, 0x07, 0x02, 0x73, 0x18,
-	0x7a, 0x1a, 0x6e, 0x2b, 0x45, 0x27, 0x88, 0xfe, 0xee, 0x41, 0x70, 0xc4, 0xca, 0xe5, 0x65, 0xce,
+	0x7a, 0x1a, 0x6e, 0x2b, 0x45, 0x27, 0x88, 0xfe, 0xe1, 0x41, 0x70, 0xc4, 0xca, 0xe5, 0x65, 0xce,
 	0x64, 0xf2, 0x5e, 0x37, 0xf1, 0x29, 0xf8, 0x31, 0x4f, 0xd3, 0x32, 0x1c, 0xce, 0x86, 0xbb, 0xd3,
 	0xbd, 0x0f, 0x1f, 0xb4, 0x57, 0xdc, 0xfa, 0x39, 0xe4, 0x69, 0x4a, 0xb5, 0x15, 0xf9, 0x0c, 0x82,
 	0x8a, 0xaf, 0x8a, 0x94, 0x55, 0xbc, 0x0c, 0x47, 0xea, 0x27, 0xa4, 0xfb, 0xc9, 0xb9, 0x51, 0xd1,
-	0xce, 0xe8, 0xce, 0x41, 0xfd, 0xbb, 0x07, 0x8d, 0xfe, 0x3d, 0x82, 0xad, 0xde, 0x76, 0x64, 0x13,
+	0xce, 0xe8, 0xce, 0x41, 0xfd, 0xbb, 0x07, 0x8d, 0xfe, 0x33, 0x82, 0xad, 0xde, 0x76, 0x64, 0x13,
 	0xbc, 0x1b, 0x15, 0xb9, 0x4f, 0xbd, 0x1b, 0x44, 0x8d, 0x8a, 0xda, 0xa7, 0x5e, 0x83, 0xe8, 0x5a,
 	0x55, 0x8e, 0x4f, 0xbd, 0x6b, 0x44, 0x4b, 0x55, 0x2f, 0x3e, 0xf5, 0x96, 0xe4, 0x47, 0xb0, 0xf1,
 	0xbb, 0x9a, 0x4b, 0xc1, 0xcb, 0xd0, 0x57, 0xd1, 0xdd, 0xeb, 0xa2, 0x7b, 0x55, 0x73, 0xd9, 0x50,
@@ -2174,7 +2184,7 @@ var fileDescriptor_internal_6148f2d00a5dfb1b = []byte{
 	0xf0, 0x46, 0x15, 0x43, 0x40, 0x71, 0x49, 0xbe, 0x0f, 0xfe, 0x15, 0x4b, 0x6b, 0x5d, 0xc8, 0xd3,
 	0xbd, 0xed, 0xce, 0xeb, 0xfe, 0x8d, 0x28, 0xa9, 0x56, 0x7e, 0x3e, 0xf8, 0x95, 0x17, 0x3d, 0x81,
 	0xad, 0xde, 0x46, 0x18, 0xb8, 0x28, 0x1f, 0x65, 0xf3, 0x5c, 0xc6, 0x3c, 0x51, 0x3e, 0x27, 0xd4,
-	0x91, 0x90, 0x0f, 0x60, 0x9c, 0x88, 0x85, 0xa8, 0x4a, 0x53, 0x6e, 0x06, 0x45, 0xff, 0xf0, 0x60,
+	0x91, 0x90, 0x0f, 0x60, 0x9c, 0x88, 0x85, 0xa8, 0x4a, 0x53, 0x6e, 0x06, 0x45, 0xff, 0xf4, 0x60,
 	0xd3, 0xcd, 0x26, 0xf9, 0x31, 0xec, 0x5c, 0x71, 0x59, 0x89, 0x98, 0xa5, 0xe7, 0x62, 0xc5, 0x71,
 	0x63, 0xf5, 0x93, 0x09, 0xbd, 0x23, 0x27, 0x9f, 0xc1, 0xb8, 0xcc, 0x65, 0x75, 0xd0, 0xa8, 0xaa,
 	0x7d, 0x57, 0x96, 0x8d, 0x1d, 0xf2, 0xd4, 0xb5, 0x64, 0x45, 0x21, 0xb2, 0x85, 0xe5, 0x42, 0x8b,
@@ -2186,64 +2196,65 @@ var fileDescriptor_internal_6148f2d00a5dfb1b = []byte{
 	0xa2, 0xfe, 0x81, 0x43, 0xfd, 0x3b, 0x30, 0xfc, 0x35, 0xbf, 0x31, 0xaf, 0x01, 0x2e, 0x5b, 0xaa,
 	0x1a, 0x39, 0x54, 0x75, 0x1f, 0xfc, 0x0b, 0x75, 0xed, 0x9a, 0x42, 0x34, 0x88, 0xbe, 0x82, 0xb1,
 	0x6e, 0x8b, 0xd6, 0xb3, 0xe7, 0x78, 0x9e, 0xc1, 0xf4, 0xa5, 0x14, 0x3c, 0xab, 0x34, 0xf9, 0x98,
-	0x23, 0x38, 0xa2, 0xe8, 0x6f, 0x1e, 0x8c, 0xd4, 0x2d, 0x45, 0xb0, 0x99, 0xf2, 0x05, 0x8b, 0x9b,
+	0x23, 0x38, 0xa2, 0xe8, 0xef, 0x1e, 0x8c, 0xd4, 0x2d, 0x45, 0xb0, 0x99, 0xf2, 0x05, 0x8b, 0x9b,
 	0x83, 0xbc, 0xce, 0x92, 0x32, 0xf4, 0x66, 0xc3, 0xdd, 0x21, 0xed, 0xc9, 0xb0, 0x3c, 0x2e, 0xb5,
 	0x76, 0x30, 0x1b, 0xee, 0x06, 0xd4, 0x20, 0x0c, 0x2d, 0x65, 0x97, 0x3c, 0x35, 0x47, 0xd0, 0x00,
 	0xad, 0x0b, 0xc9, 0xe7, 0xe2, 0xc6, 0x1c, 0xc3, 0x20, 0x94, 0x97, 0xf5, 0x1c, 0xe5, 0xfa, 0x24,
 	0x06, 0xe1, 0x01, 0x2e, 0x59, 0xd9, 0x32, 0x12, 0xae, 0xd1, 0x73, 0x19, 0xb3, 0xd4, 0x52, 0x92,
-	0x06, 0xd1, 0x3f, 0x3d, 0x7c, 0xc8, 0x34, 0xc5, 0xde, 0xc9, 0xf0, 0x47, 0x30, 0x41, 0xfa, 0xfd,
+	0x06, 0xd1, 0xbf, 0x3c, 0x7c, 0xc8, 0x34, 0xc5, 0xde, 0xc9, 0xf0, 0x47, 0x30, 0x41, 0xfa, 0xfd,
 	0xfa, 0x8a, 0x49, 0x73, 0xe0, 0x0d, 0xc4, 0x17, 0x4c, 0x92, 0x9f, 0xc1, 0x58, 0x35, 0xc7, 0x1a,
 	0xba, 0xb7, 0xee, 0x54, 0x56, 0xa9, 0x31, 0x6b, 0x09, 0x71, 0xe4, 0x10, 0x62, 0x7b, 0x58, 0xdf,
 	0x3d, 0xec, 0xa7, 0xe0, 0x23, 0xb3, 0x36, 0x2a, 0xfa, 0xb5, 0x9e, 0x35, 0xff, 0x6a, 0xab, 0x68,
 	0x01, 0x5b, 0xbd, 0x1d, 0xdb, 0x9d, 0xbc, 0xfe, 0x4e, 0x5d, 0xa3, 0x07, 0xa6, 0xb1, 0xb1, 0x39,
 	0x4a, 0x9e, 0xf2, 0xb8, 0xe2, 0x89, 0xa9, 0xba, 0x16, 0x5b, 0xb2, 0x18, 0xb5, 0x64, 0x11, 0xfd,
-	0xc9, 0xeb, 0x76, 0x52, 0x11, 0x60, 0xd1, 0xc6, 0xf9, 0x6a, 0xc5, 0xb2, 0xc4, 0x6c, 0x66, 0x21,
+	0xd9, 0xeb, 0x76, 0x52, 0x11, 0x60, 0xd1, 0xc6, 0xf9, 0x6a, 0xc5, 0xb2, 0xc4, 0x6c, 0x66, 0x21,
 	0x66, 0x32, 0xb9, 0x34, 0x9b, 0x0d, 0x92, 0x4b, 0xc4, 0xb2, 0x30, 0x77, 0x3a, 0x90, 0x05, 0x56,
 	0xd3, 0x8a, 0xb3, 0xb2, 0x96, 0x7c, 0xc5, 0xb3, 0xca, 0xec, 0xe2, 0x8a, 0xc8, 0x87, 0xb0, 0x51,
 	0xb1, 0xc5, 0xd7, 0x18, 0x83, 0xb9, 0xdb, 0x8a, 0x2d, 0x9e, 0xf1, 0x86, 0x7c, 0x1b, 0x02, 0xc5,
-	0xa0, 0x4a, 0xa5, 0x2f, 0x78, 0xa2, 0x04, 0xcf, 0x78, 0x13, 0xfd, 0x75, 0x00, 0xe3, 0x33, 0x2e,
+	0xa0, 0x4a, 0xa5, 0x2f, 0x78, 0xa2, 0x04, 0xcf, 0x78, 0x13, 0xfd, 0x6d, 0x00, 0xe3, 0x33, 0x2e,
 	0xaf, 0xb8, 0x7c, 0xaf, 0x37, 0xdb, 0x9d, 0x94, 0x86, 0xef, 0x98, 0x94, 0x46, 0xeb, 0x27, 0x25,
 	0xbf, 0x9b, 0x94, 0xee, 0x83, 0x7f, 0x26, 0xe3, 0xe3, 0x23, 0x15, 0xd1, 0x90, 0x6a, 0x80, 0xf5,
 	0xb9, 0x1f, 0x57, 0xe2, 0x8a, 0x9b, 0xf1, 0xc9, 0xa0, 0x3b, 0x4f, 0xf9, 0x64, 0xcd, 0xcc, 0xf2,
 	0xbf, 0x4e, 0x51, 0xb6, 0x69, 0xc1, 0x69, 0xda, 0x08, 0x36, 0x71, 0x94, 0x4a, 0x58, 0xc5, 0x9e,
-	0x9e, 0xbd, 0x7c, 0x61, 0xe7, 0x27, 0x57, 0x16, 0xfd, 0xd1, 0x83, 0xf1, 0x09, 0x6b, 0xf2, 0xba,
+	0x9e, 0xbd, 0x7c, 0x61, 0xe7, 0x27, 0x57, 0x16, 0xfd, 0xc9, 0x83, 0xf1, 0x09, 0x6b, 0xf2, 0xba,
 	0xba, 0x53, 0xff, 0x33, 0x98, 0xee, 0x17, 0x45, 0x2a, 0xe2, 0x5e, 0xcf, 0x3b, 0x22, 0xb4, 0x78,
 	0xee, 0xdc, 0xa3, 0xce, 0xa1, 0x2b, 0xc2, 0x27, 0xe6, 0x50, 0x8d, 0x45, 0x7a, 0xc6, 0x71, 0x9e,
 	0x18, 0x3d, 0x0d, 0x29, 0x25, 0x26, 0x7b, 0xbf, 0xae, 0xf2, 0x79, 0x9a, 0x5f, 0xab, 0xac, 0x4e,
-	0x68, 0x8b, 0xa3, 0x7f, 0x0d, 0x60, 0xf4, 0x4d, 0x8d, 0x32, 0x9b, 0xe0, 0x09, 0x53, 0x54, 0x9e,
+	0x68, 0x8b, 0xa3, 0x7f, 0x0f, 0x60, 0xf4, 0x4d, 0x8d, 0x32, 0x9b, 0xe0, 0x09, 0x53, 0x54, 0x9e,
 	0x68, 0x07, 0x9b, 0x0d, 0x67, 0xb0, 0x09, 0x61, 0xa3, 0x91, 0x2c, 0x5b, 0xf0, 0x32, 0x9c, 0x28,
 	0x5e, 0xb3, 0x50, 0x69, 0x54, 0x07, 0xeb, 0x89, 0x26, 0xa0, 0x16, 0xb6, 0x1d, 0x09, 0x4e, 0x47,
-	0xfe, 0xd4, 0x0c, 0x3f, 0xd3, 0xdb, 0xe3, 0xc2, 0xba, 0x99, 0xe7, 0xff, 0xf7, 0x8e, 0xff, 0xc7,
-	0x03, 0xbf, 0x6d, 0xde, 0xc3, 0x7e, 0xf3, 0x1e, 0x76, 0xcd, 0x7b, 0x74, 0x60, 0x9b, 0xf7, 0xe8,
-	0x00, 0x31, 0x3d, 0xb5, 0xcd, 0x4b, 0x4f, 0xf1, 0xb2, 0x9e, 0xc8, 0xbc, 0x2e, 0x0e, 0x1a, 0x7d,
-	0xab, 0x01, 0x6d, 0x31, 0x56, 0xfc, 0x6f, 0x96, 0x5c, 0x9a, 0x54, 0x07, 0xd4, 0x20, 0xec, 0x8f,
-	0x13, 0x45, 0x75, 0x3a, 0xb9, 0x1a, 0x90, 0x1f, 0x80, 0x4f, 0x31, 0x79, 0x2a, 0xc3, 0xbd, 0x7b,
-	0x51, 0x62, 0xaa, 0xb5, 0xe8, 0x54, 0x7f, 0x12, 0x99, 0x46, 0xb1, 0x1f, 0x48, 0x3f, 0x81, 0xf1,
-	0xd9, 0x52, 0xcc, 0x2b, 0x3b, 0x42, 0x7e, 0xcb, 0xa1, 0x4a, 0xb1, 0xe2, 0x4a, 0x47, 0x8d, 0x49,
-	0xf4, 0x0a, 0x82, 0x56, 0xd8, 0x85, 0xe3, 0xb9, 0xe1, 0x10, 0x18, 0xbd, 0xce, 0x44, 0x65, 0x29,
-	0x02, 0xd7, 0x78, 0xd8, 0x57, 0x35, 0xcb, 0x2a, 0x51, 0x35, 0x96, 0x22, 0x2c, 0x8e, 0x1e, 0x9a,
-	0xf0, 0xd1, 0xdd, 0xeb, 0xa2, 0xe0, 0xd2, 0xd0, 0x8d, 0x06, 0x6a, 0x93, 0xfc, 0x9a, 0xeb, 0xb7,
-	0x63, 0x48, 0x35, 0x88, 0x7e, 0x0b, 0xc1, 0x7e, 0xca, 0x65, 0x45, 0xeb, 0x94, 0xaf, 0x7b, 0xd3,
-	0x55, 0xa3, 0x9a, 0x08, 0x70, 0xdd, 0x51, 0xcb, 0xf0, 0x16, 0xb5, 0x3c, 0x63, 0x05, 0x3b, 0x3e,
-	0x52, 0x75, 0x3e, 0xa4, 0x06, 0x45, 0x7f, 0xf6, 0x60, 0x84, 0x1c, 0xe6, 0xb8, 0x1e, 0xbd, 0x8b,
-	0xff, 0x4e, 0x65, 0x7e, 0x25, 0x12, 0x2e, 0xed, 0xe1, 0x2c, 0x56, 0x49, 0x8f, 0x97, 0xbc, 0x1d,
-	0x1d, 0x0c, 0xc2, 0x5a, 0xc3, 0xef, 0x27, 0xdb, 0x4b, 0x4e, 0xad, 0xa1, 0x98, 0x6a, 0x25, 0x8e,
-	0x87, 0x67, 0x75, 0xc1, 0xe5, 0x7e, 0xb2, 0x12, 0x76, 0xae, 0x72, 0x24, 0xd1, 0x57, 0xfa, 0x8b,
-	0xec, 0x0e, 0x13, 0x7a, 0xeb, 0xbf, 0xde, 0x6e, 0x47, 0x1e, 0xfd, 0xc5, 0x83, 0x8d, 0xe7, 0x66,
-	0x8e, 0x73, 0x4f, 0xe1, 0xbd, 0xf5, 0x14, 0x83, 0xde, 0x29, 0xf6, 0xe0, 0xbe, 0xb5, 0xe9, 0xed,
-	0xaf, 0xb3, 0xb0, 0x56, 0x67, 0x32, 0x3a, 0x6a, 0x2f, 0xeb, 0x7d, 0x3e, 0xc8, 0xce, 0xfb, 0x36,
-	0xeb, 0x2e, 0xfc, 0xce, 0xad, 0xcc, 0x60, 0x6a, 0x3f, 0x44, 0xf3, 0xd4, 0x3e, 0x4c, 0xae, 0x28,
-	0xda, 0x83, 0xf1, 0x61, 0x9e, 0xcd, 0xc5, 0x82, 0xec, 0xc2, 0x68, 0xbf, 0xae, 0x96, 0xca, 0xe3,
-	0x74, 0xef, 0xbe, 0xd3, 0xf8, 0x75, 0xb5, 0xd4, 0x36, 0x54, 0x59, 0x44, 0x5f, 0x00, 0x74, 0x32,
-	0x7c, 0x5d, 0xba, 0xdb, 0x78, 0xc1, 0xaf, 0xb1, 0x64, 0x4a, 0x33, 0xc6, 0xaf, 0xd1, 0x44, 0x35,
-	0x10, 0xf7, 0x1c, 0xc6, 0xcb, 0x27, 0xb0, 0xed, 0x4a, 0xdb, 0x93, 0xdd, 0x92, 0x92, 0x5f, 0x42,
-	0x70, 0x92, 0x2f, 0x2e, 0x04, 0xb7, 0xdd, 0x30, 0xdd, 0xfb, 0xc8, 0xf9, 0x18, 0xb3, 0x2a, 0x13,
-	0x6f, 0x67, 0x1b, 0x3d, 0x86, 0x7b, 0xb7, 0xb4, 0xe4, 0x21, 0xf2, 0x16, 0xce, 0xe5, 0x7a, 0xb0,
-	0x7c, 0x9b, 0x27, 0xb4, 0xa0, 0xd6, 0x32, 0x6a, 0x7a, 0x7e, 0x50, 0xd6, 0x66, 0xde, 0xbb, 0xd5,
-	0x0f, 0x79, 0x29, 0xda, 0xd7, 0xce, 0xa7, 0x2d, 0x26, 0xbf, 0x80, 0xe0, 0x51, 0x16, 0xe7, 0x89,
-	0xc8, 0x16, 0x76, 0xe8, 0x0b, 0x7b, 0x5f, 0x9e, 0xf5, 0x2a, 0xb3, 0x06, 0xb4, 0x33, 0x8d, 0x5e,
-	0xc0, 0x76, 0x5f, 0xb9, 0x76, 0xbc, 0x6e, 0x47, 0xf2, 0x81, 0x33, 0x92, 0xb7, 0x31, 0x0e, 0x9d,
-	0xca, 0xff, 0x12, 0x82, 0x83, 0x5a, 0xa4, 0xc9, 0x71, 0x36, 0xcf, 0x91, 0xc4, 0x2f, 0xb8, 0x2c,
-	0xbb, 0xce, 0xb1, 0x10, 0x0b, 0x1f, 0xf9, 0xbc, 0x65, 0x33, 0x83, 0x2e, 0xc7, 0xea, 0x0f, 0xa7,
-	0x87, 0xff, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x58, 0xd6, 0x93, 0x3e, 0x82, 0x12, 0x00, 0x00,
+	0xfe, 0xd4, 0x0c, 0x3f, 0xd3, 0xdb, 0xe3, 0xc2, 0xba, 0x99, 0xe7, 0xff, 0xf7, 0x8e, 0xff, 0x71,
+	0x00, 0x7e, 0xdb, 0xbc, 0x87, 0xfd, 0xe6, 0x3d, 0xec, 0x9a, 0xf7, 0xe8, 0xc0, 0x36, 0xef, 0xd1,
+	0x01, 0x62, 0x7a, 0x6a, 0x9b, 0x97, 0x9e, 0xe2, 0x65, 0x3d, 0x91, 0x79, 0x5d, 0x1c, 0x34, 0xfa,
+	0x56, 0x03, 0xda, 0x62, 0xac, 0xf8, 0xdf, 0x2c, 0xb9, 0x34, 0xa9, 0x0e, 0xa8, 0x41, 0xd8, 0x1f,
+	0x27, 0x8a, 0xea, 0x74, 0x72, 0x35, 0x20, 0x3f, 0x00, 0x9f, 0x62, 0xf2, 0x54, 0x86, 0x7b, 0xf7,
+	0xa2, 0xc4, 0x54, 0x6b, 0xd1, 0xa9, 0xfe, 0x24, 0x32, 0x8d, 0x62, 0x3f, 0x90, 0x7e, 0x02, 0xe3,
+	0xb3, 0xa5, 0x98, 0x57, 0x76, 0x84, 0xfc, 0x96, 0x43, 0x95, 0x62, 0xc5, 0x95, 0x8e, 0x1a, 0x93,
+	0x75, 0xfd, 0x11, 0xbd, 0x82, 0xa0, 0x35, 0xec, 0x42, 0xf4, 0xdc, 0x10, 0x09, 0x8c, 0x5e, 0x67,
+	0xa2, 0xb2, 0xb4, 0x81, 0x6b, 0x4c, 0xc0, 0xab, 0x9a, 0x65, 0x95, 0xa8, 0x1a, 0x4b, 0x1b, 0x16,
+	0x47, 0x0f, 0xcd, 0x91, 0xd0, 0xdd, 0xeb, 0xa2, 0xe0, 0xd2, 0x50, 0x90, 0x06, 0x6a, 0x93, 0xfc,
+	0x9a, 0xeb, 0xf7, 0x64, 0x48, 0x35, 0x88, 0x7e, 0x0b, 0xc1, 0x7e, 0xca, 0x65, 0x45, 0xeb, 0x94,
+	0xaf, 0x7b, 0xe7, 0x55, 0xf3, 0x9a, 0x08, 0x70, 0xdd, 0xd1, 0xcd, 0xf0, 0x16, 0xdd, 0x3c, 0x63,
+	0x05, 0x3b, 0x3e, 0x52, 0xb5, 0x3f, 0xa4, 0x06, 0x45, 0x7f, 0xf1, 0x60, 0x84, 0xbc, 0xe6, 0xb8,
+	0x1e, 0xbd, 0x8b, 0x13, 0x4f, 0x65, 0x7e, 0x25, 0x12, 0x2e, 0xed, 0xe1, 0x2c, 0x56, 0x17, 0x11,
+	0x2f, 0x79, 0x3b, 0x4e, 0x18, 0x84, 0xf5, 0x87, 0xdf, 0x54, 0xb6, 0xbf, 0x9c, 0xfa, 0x43, 0x31,
+	0xd5, 0x4a, 0x1c, 0x19, 0xcf, 0xea, 0x82, 0xcb, 0xfd, 0x64, 0x25, 0xec, 0xac, 0xe5, 0x48, 0xa2,
+	0xaf, 0xf4, 0x57, 0xda, 0x1d, 0x76, 0xf4, 0xd6, 0x7f, 0xd1, 0xdd, 0x8e, 0x3c, 0xfa, 0xab, 0x07,
+	0x1b, 0xcf, 0xcd, 0x6c, 0xe7, 0x9e, 0xc2, 0x7b, 0xeb, 0x29, 0x06, 0xbd, 0x53, 0xec, 0xc1, 0x7d,
+	0x6b, 0xd3, 0xdb, 0x5f, 0x67, 0x61, 0xad, 0xce, 0x64, 0x74, 0xd4, 0x5e, 0xd6, 0xfb, 0x7c, 0xa4,
+	0x9d, 0xf7, 0x6d, 0xd6, 0x5d, 0xf8, 0x9d, 0x5b, 0x99, 0xc1, 0xd4, 0x7e, 0x9c, 0xe6, 0xa9, 0x7d,
+	0xac, 0x5c, 0x51, 0xb4, 0x07, 0xe3, 0xc3, 0x3c, 0x9b, 0x8b, 0x05, 0xd9, 0x85, 0xd1, 0x7e, 0x5d,
+	0x2d, 0x95, 0xc7, 0xe9, 0xde, 0x7d, 0x87, 0x0c, 0xea, 0x6a, 0xa9, 0x6d, 0xa8, 0xb2, 0x88, 0xbe,
+	0x00, 0xe8, 0x64, 0xf8, 0xe2, 0x74, 0xb7, 0xf1, 0x82, 0x5f, 0x63, 0xc9, 0x94, 0x66, 0xb4, 0x5f,
+	0xa3, 0x89, 0x6a, 0x20, 0xee, 0x39, 0x8c, 0x97, 0x4f, 0x60, 0xdb, 0x95, 0xb6, 0x27, 0xbb, 0x25,
+	0x25, 0xbf, 0x84, 0xe0, 0x24, 0x5f, 0x5c, 0x08, 0x6e, 0xbb, 0x61, 0xba, 0xf7, 0x91, 0xf3, 0x81,
+	0x66, 0x55, 0x26, 0xde, 0xce, 0x36, 0x7a, 0x0c, 0xf7, 0x6e, 0x69, 0xc9, 0x43, 0xe4, 0x32, 0x9c,
+	0xd5, 0xf5, 0xb0, 0xf9, 0x36, 0x4f, 0x68, 0x41, 0xad, 0x65, 0xd4, 0xf4, 0xfc, 0xa0, 0xac, 0xcd,
+	0xbc, 0x77, 0xab, 0x1f, 0xf2, 0x52, 0xb4, 0x2f, 0xa0, 0x4f, 0x5b, 0x4c, 0x7e, 0x01, 0xc1, 0xa3,
+	0x2c, 0xce, 0x13, 0x91, 0x2d, 0xec, 0x20, 0x18, 0xf6, 0xbe, 0x46, 0xeb, 0x55, 0x66, 0x0d, 0x68,
+	0x67, 0x1a, 0xbd, 0x80, 0xed, 0xbe, 0x72, 0xed, 0xc8, 0xdd, 0x8e, 0xe9, 0x03, 0x67, 0x4c, 0x6f,
+	0x63, 0x1c, 0x3a, 0x95, 0xff, 0x25, 0x04, 0x07, 0xb5, 0x48, 0x93, 0xe3, 0x6c, 0x9e, 0x23, 0xb1,
+	0x5f, 0x70, 0x59, 0x76, 0x9d, 0x63, 0x21, 0x16, 0x3e, 0x72, 0x7c, 0xcb, 0x66, 0x06, 0x5d, 0x8e,
+	0xd5, 0x9f, 0x50, 0x0f, 0xff, 0x1b, 0x00, 0x00, 0xff, 0xff, 0xff, 0x9a, 0x3e, 0x9f, 0x96, 0x12,
+	0x00, 0x00,
 }

--- a/chronograf/bolt/internal/internal.proto
+++ b/chronograf/bolt/internal/internal.proto
@@ -158,6 +158,7 @@ message Query {
 	Range Range               = 7; // Range is the upper and lower bound of the Y-Axis
 	string Source             = 8; // Source is the optional URI to the data source
 	repeated TimeShift Shifts = 9; // TimeShift represents a shift to apply to an influxql query's time range
+  string Type               = 10;
 }
 
 message TimeShift {

--- a/chronograf/chronograf.go
+++ b/chronograf/chronograf.go
@@ -224,6 +224,8 @@ type DashboardQuery struct {
 	QueryConfig QueryConfig `json:"queryConfig,omitempty"` // QueryConfig represents the query state that is understood by the data explorer
 	Source      string      `json:"source"`                // Source is the optional URI to the data source for this queryConfig
 	Shifts      []TimeShift `json:"-"`                     // Shifts represents shifts to apply to an influxql query's time range.  Clients expect the shift to be in the generated QueryConfig
+	// This was added after this code was brought over to influxdb.
+	Type string `json:"type,omitempty"`
 }
 
 // TemplateQuery is used to retrieve choices for template replacement
@@ -600,6 +602,9 @@ type DashboardCell struct {
 	FieldOptions  []RenamableField `json:"fieldOptions"`
 	TimeFormat    string           `json:"timeFormat"`
 	DecimalPlaces DecimalPlaces    `json:"decimalPlaces"`
+	// These were added after this code was brought over to influxdb.
+	Note           string `json:"note,omitempty"`
+	NoteVisibility string `json:"noteVisibility,omitempty"`
 }
 
 // RenamableField is a column/row field in a DashboardCell of type Table

--- a/cmd/chronograf-migrator/README.md
+++ b/cmd/chronograf-migrator/README.md
@@ -1,0 +1,20 @@
+# Chronograf Migrator
+
+This tool is used to migrate `1.x` Chronograf `Dashboards` and `Template Variables` to their `2.x`
+equivalents using `pkger` packages. The tool expects the user to have the 1.x Chronograf database.
+
+```sh
+chronograf-migrator -h
+Usage of chronograf-migrator:
+  -db string
+    	path to the chronograf database
+  -output string
+    	path to the output yaml file (default "dashboards.yml")
+```
+
+## Example Usage
+
+```sh
+$ chronograf-migrator -db chronograf-v1.db -output dashboards.yml
+$ INFLUX_TOKEN=<token> influx pkg -o <org-name> -f dashboards.yml
+```

--- a/cmd/chronograf-migrator/dashboard.go
+++ b/cmd/chronograf-migrator/dashboard.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/chronograf"
+	"github.com/influxdata/influxdb/query/influxql"
+)
+
+func convert1To2Cell(cell chronograf.DashboardCell) *influxdb.Cell {
+	c := &influxdb.Cell{
+		ID: 1,
+		CellProperty: influxdb.CellProperty{
+			X: cell.X,
+			Y: cell.Y,
+			W: cell.W,
+			H: cell.H,
+		},
+	}
+
+	v := influxdb.View{
+		ViewContents: influxdb.ViewContents{
+			Name: cell.Name,
+		},
+	}
+
+	switch cell.Type {
+	case "line":
+		v.Properties = influxdb.XYViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			Axes:       convertAxes(cell.Axes),
+			Type:       "xy",
+			Legend:     convertLegend(cell.Legend),
+			Geom:       "line",
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			Position:   "overlaid",
+		}
+	case "line-stacked":
+		v.Properties = influxdb.XYViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			Axes:       convertAxes(cell.Axes),
+			Type:       "xy",
+			Legend:     convertLegend(cell.Legend),
+			Geom:       "line", // TODO(desa): maybe this needs to be stacked?
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			Position:   "stacked",
+		}
+	case "line-stepplot":
+		v.Properties = influxdb.XYViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			Axes:       convertAxes(cell.Axes),
+			Type:       "xy",
+			Legend:     convertLegend(cell.Legend),
+			Geom:       "step",
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			Position:   "overlaid",
+		}
+	case "bar":
+		v.Properties = influxdb.XYViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			Axes:       convertAxes(cell.Axes),
+			Type:       "xy",
+			Legend:     convertLegend(cell.Legend),
+			Geom:       "bar",
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			Position:   "overlaid",
+		}
+	case "line-plus-single-stat":
+		v.Properties = influxdb.LinePlusSingleStatProperties{
+			Queries:    convertQueries(cell.Queries),
+			Axes:       convertAxes(cell.Axes),
+			Legend:     convertLegend(cell.Legend),
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			Position:   "overlaid",
+		}
+	case "single-stat":
+		v.Properties = influxdb.SingleStatViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			// TODO(desa): what to do about ShowNoteWhenEmpty?
+		}
+	case "gauge":
+		v.Properties = influxdb.GaugeViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			ViewColors: convertColors(cell.CellColors),
+			Note:       cell.Note,
+			// TODO(desa): what to do about ShowNoteWhenEmpty?
+		}
+	case "table":
+		v.Properties = influxdb.TableViewProperties{
+			Queries:    convertQueries(cell.Queries),
+			ViewColors: convertColors(cell.CellColors),
+			//TableOptions
+			//FieldOptions
+			Note: cell.Note,
+			// TODO(desa): what to do about ShowNoteWhenEmpty?
+		}
+	case "note":
+		v.Properties = influxdb.MarkdownViewProperties{
+			Note: cell.Note,
+		}
+	case "alerts", "news", "guide":
+		// TODO(desa): these do not have 2.x equivalents
+		v.Properties = influxdb.EmptyViewProperties{}
+	default:
+		v.Properties = influxdb.EmptyViewProperties{}
+	}
+
+	c.View = &v
+
+	return c
+}
+
+func convert1To2Variable(t chronograf.Template) (influxdb.Variable, error) {
+	v := influxdb.Variable{
+		Description: t.Label,
+		Name:        t.Var[1 : len(t.Var)-1], // trims `:` from variables prefix and suffix
+	}
+
+	switch t.Type {
+	case "influxql", "databases", "fieldKeys", "tagKeys", "tagValues", "measurements":
+		if t.Query == nil {
+			return v, fmt.Errorf("expected template variable to have non-nil query")
+		}
+	}
+
+	switch t.Type {
+	case "influxql":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// %s", t.Query.Command),
+				Language: "flux",
+			},
+		}
+	case "databases":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// SHOW DATABASES %s", t.Query.DB),
+				Language: "flux",
+			},
+		}
+	case "fieldKeys":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// SHOW FIELD KEYS FOR %s", t.Query.Measurement),
+				Language: "flux",
+			},
+		}
+	case "tagKeys":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// SHOW TAG KEYS FOR %s", t.Query.Measurement),
+				Language: "flux",
+			},
+		}
+	case "tagValues":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// SHOW TAG VALUES FOR %s", t.Query.TagKey),
+				Language: "flux",
+			},
+		}
+	case "measurements":
+		v.Arguments = &influxdb.VariableArguments{
+			Type: "query",
+			Values: influxdb.VariableQueryValues{
+				Query:    fmt.Sprintf("// SHOW MEASUREMENTS ON %s", t.Query.DB),
+				Language: "flux",
+			},
+		}
+	case "csv", "constant", "text":
+		values := influxdb.VariableConstantValues{}
+		for _, val := range t.Values {
+			values = append(values, val.Value)
+		}
+		v.Arguments = &influxdb.VariableArguments{
+			Type:   "constant",
+			Values: values,
+		}
+	case "map":
+		values := influxdb.VariableMapValues{}
+		for _, val := range t.Values {
+			values[val.Key] = val.Value
+		}
+		v.Arguments = &influxdb.VariableArguments{
+			Type:   "map",
+			Values: values,
+		}
+	default:
+		return v, fmt.Errorf("unknown variable type %s", t.Type)
+	}
+
+	return v, nil
+}
+
+func Convert1To2Dashboard(d1 chronograf.Dashboard) (influxdb.Dashboard, []influxdb.Variable, error) {
+	cells := []*influxdb.Cell{}
+	for _, cell := range d1.Cells {
+		cells = append(cells, convert1To2Cell(cell))
+	}
+
+	d2 := influxdb.Dashboard{
+		Name:  d1.Name,
+		Cells: cells,
+	}
+
+	vars := []influxdb.Variable{}
+	for _, template := range d1.Templates {
+		v, err := convert1To2Variable(template)
+		if err != nil {
+			return influxdb.Dashboard{}, nil, err
+		}
+
+		vars = append(vars, v)
+	}
+
+	return d2, vars, nil
+}
+
+func convertAxes(a map[string]chronograf.Axis) map[string]influxdb.Axis {
+	m := map[string]influxdb.Axis{}
+	for k, v := range a {
+		m[k] = influxdb.Axis{
+			Bounds: v.Bounds,
+			Label:  v.Label,
+			Prefix: v.Prefix,
+			Suffix: v.Suffix,
+			Base:   v.Base,
+			Scale:  v.Scale,
+		}
+	}
+
+	if _, exists := m["x"]; !exists {
+		m["x"] = influxdb.Axis{}
+	}
+	if _, exists := m["y"]; !exists {
+		m["y"] = influxdb.Axis{}
+	}
+
+	return m
+}
+
+func convertLegend(l chronograf.Legend) influxdb.Legend {
+	return influxdb.Legend{
+		Type:        l.Type,
+		Orientation: l.Orientation,
+	}
+}
+
+func convertColors(cs []chronograf.CellColor) []influxdb.ViewColor {
+	vs := []influxdb.ViewColor{}
+
+	hasTextColor := false
+	hasThresholdColor := false
+	for _, c := range cs {
+		if c.Type == "text" {
+			hasTextColor = true
+		}
+		if c.Type == "threshold" {
+			hasThresholdColor = true
+		}
+
+		v := influxdb.ViewColor{
+			ID:   c.ID,
+			Type: c.Type,
+			Hex:  c.Hex,
+			Name: c.Name,
+		}
+		vs = append(vs, v)
+	}
+
+	if !hasTextColor {
+		vs = append(vs, influxdb.ViewColor{
+			ID:    "base",
+			Type:  "text",
+			Hex:   "#00C9FF",
+			Name:  "laser",
+			Value: 0,
+		})
+	}
+
+	if !hasThresholdColor {
+		vs = append(vs, influxdb.ViewColor{
+			ID:    "t",
+			Type:  "threshold",
+			Hex:   "#4591ED",
+			Name:  "ocean",
+			Value: 80,
+		})
+	}
+
+	return vs
+}
+
+var influxQLVarPattern = regexp.MustCompile(`'?:(\w+):'?`)
+
+func transpileQuery(q string) (string, error) {
+	now := time.Now()
+	t := influxql.NewTranspilerWithConfig(dbrpMapper{}, influxql.Config{
+		Now:            now,
+		FallbackToDBRP: true,
+	})
+
+	query := q
+	query = strings.Replace(query, ":interval:", "8675309ns", -1)
+	query = strings.Replace(query, ":dashboardTime:", "now() - 15m", 1)
+	query = strings.Replace(query, ":upperDashboardTime:", "now()", 1)
+
+	// TODO(desa): replace all variables not using this hack
+	query = influxQLVarPattern.ReplaceAllString(query, "'$1'")
+
+	pkg, err := t.Transpile(context.Background(), query)
+	if err != nil {
+		return "", err
+	}
+
+	return ast.Format(pkg), nil
+}
+
+func convertQueries(qs []chronograf.DashboardQuery) []influxdb.DashboardQuery {
+
+	ds := []influxdb.DashboardQuery{}
+	for _, q := range qs {
+		queryText := q.Command
+		if q.Type == "influxql" {
+			// if the query is influxql, add it as a comment and attempt to
+			// compile it to flux
+			queryText = fmt.Sprintf("// %s", queryText)
+
+			tq, err := transpileQuery(q.Command)
+			if err != nil {
+				queryText = fmt.Sprintf("// Failed to transpile query: %v\n%s", err, queryText)
+			} else {
+				queryText = fmt.Sprintf("// Original Query:\n%s\n\n%s", queryText, tq)
+			}
+		}
+
+		d := influxdb.DashboardQuery{
+			Text:     queryText,
+			EditMode: "advanced",
+		}
+
+		ds = append(ds, d)
+	}
+
+	if len(ds) == 0 {
+		d := influxdb.DashboardQuery{
+			Text:     "// cell had no queries",
+			EditMode: "advanced",
+			BuilderConfig: influxdb.BuilderConfig{
+				// TODO(desa): foo
+				Buckets: []string{"bucket"},
+			},
+		}
+		ds = append(ds, d)
+	}
+
+	return ds
+}
+
+type dbrpMapper struct {
+}
+
+func (m dbrpMapper) FindBy(ctx context.Context, cluster string, db string, rp string) (*influxdb.DBRPMapping, error) {
+	return nil, errors.New("mapping not found")
+}
+func (m dbrpMapper) Find(ctx context.Context, filter influxdb.DBRPMappingFilter) (*influxdb.DBRPMapping, error) {
+	return nil, errors.New("mapping not found")
+}
+func (m dbrpMapper) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.DBRPMapping, int, error) {
+	return nil, 0, errors.New("mapping not found")
+
+}
+func (m dbrpMapper) Create(ctx context.Context, dbrpMap *influxdb.DBRPMapping) error {
+	return errors.New("dbrpMapper does not support creating new mappings")
+}
+func (m dbrpMapper) Delete(ctx context.Context, cluster string, db string, rp string) error {
+	return errors.New("dbrpMapper does not support deleteing mappings")
+}

--- a/cmd/chronograf-migrator/main.go
+++ b/cmd/chronograf-migrator/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/influxdata/influxdb/chronograf"
+	"github.com/influxdata/influxdb/chronograf/bolt"
+	"github.com/influxdata/influxdb/pkger"
+	"gopkg.in/yaml.v3"
+)
+
+var chronografDBPath string
+var outputFile string
+
+func exec(dbPath, out string) error {
+	logger := log.New(os.Stdout, "", 0)
+
+	c := bolt.NewClient()
+	c.Path = dbPath
+
+	ctx := context.Background()
+
+	if err := c.Open(ctx, nil, chronograf.BuildInfo{}); err != nil {
+		return err
+	}
+
+	dashboardStore := c.DashboardsStore
+
+	ds, err := dashboardStore.All(ctx)
+	if err != nil {
+		return err
+	}
+
+	pkg := &pkger.Pkg{
+		APIVersion: pkger.APIVersion,
+		Kind:       pkger.KindPackage,
+		Metadata: pkger.Metadata{
+			Description: "Dashboards from 1.x chronograf that are migrated to the new format",
+			Name:        "Migrated Dashboards",
+			Version:     "1",
+		},
+		Spec: struct {
+			Resources []pkger.Resource `yaml:"resources" json:"resources"`
+		}{
+			Resources: make([]pkger.Resource, 0),
+		},
+	}
+
+	hasVar := map[string]bool{}
+	for _, d1 := range ds {
+		d2, vs, err := Convert1To2Dashboard(d1)
+		if err != nil {
+			return err
+		}
+
+		pkg.Spec.Resources = append(pkg.Spec.Resources, pkger.DashboardToResource(d2, d2.Name))
+
+		for _, v := range vs {
+			name := strings.ToLower(v.Name)
+			if hasVar[name] {
+				// TODO(desa): not sure what we actually want to do here
+				logger.Printf("Found duplicate variables with name %q skipping\n", name)
+				continue
+			}
+			hasVar[name] = true
+
+			pkg.Spec.Resources = append(pkg.Spec.Resources, pkger.VariableToResource(v, name))
+		}
+	}
+
+	f, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := yaml.NewEncoder(f).Encode(pkg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	flag.StringVar(&chronografDBPath, "db", "", "path to the chronograf database")
+	flag.StringVar(&outputFile, "output", "dashboards.yml", "path to the output yaml file")
+	flag.Parse()
+
+	if chronografDBPath == "" {
+		fmt.Fprintln(os.Stdout, "must supply db flag")
+		return
+	}
+
+	if err := exec(chronografDBPath, outputFile); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
+}

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -164,7 +164,6 @@ func assignRangeThreshold(r Resource, rangeThreshold icheck.Range) {
 	r[fieldMax] = rangeThreshold.Max
 	r[fieldMin] = rangeThreshold.Min
 }
-
 func convertCellView(cell influxdb.Cell) chart {
 	var name string
 	if cell.View != nil {
@@ -351,7 +350,8 @@ func convertQueries(iQueries []influxdb.DashboardQuery) queries {
 	return out
 }
 
-func dashboardToResource(dash influxdb.Dashboard, name string) Resource {
+// DashboardToResource converts an influxdb.Dashboard to a pkger.Resource.
+func DashboardToResource(dash influxdb.Dashboard, name string) Resource {
 	if name == "" {
 		name = dash.Name
 	}
@@ -540,7 +540,8 @@ func telegrafToResource(t influxdb.TelegrafConfig, name string) Resource {
 	return r
 }
 
-func variableToResource(v influxdb.Variable, name string) Resource {
+// VariableToResource converts an influxdb.Variable to a pkger.Resource.
+func VariableToResource(v influxdb.Variable, name string) Resource {
 	if name == "" {
 		name = v.Name
 	}

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2545,8 +2545,8 @@ func (q queries) influxDashQueries() []influxdb.DashboardQuery {
 			Text:     qq.Query,
 			EditMode: "advanced",
 		}
-		// TODO: axe thsi buidler configs when issue https://github.com/influxdata/influxdb/issues/15708 is fixed up
-		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement"))
+		// TODO: axe this builder configs when issue https://github.com/influxdata/influxdb/issues/15708 is fixed up
+		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", ""))
 		iQueries = append(iQueries, newQuery)
 	}
 	return iQueries

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -566,7 +566,7 @@ func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone
 		if err != nil {
 			return nil, err
 		}
-		newResource = dashboardToResource(*dash, r.Name)
+		newResource = DashboardToResource(*dash, r.Name)
 	case r.Kind.is(KindLabel):
 		l, err := s.labelSVC.FindLabelByID(ctx, r.ID)
 		if err != nil {
@@ -605,7 +605,7 @@ func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone
 		if err != nil {
 			return nil, err
 		}
-		newResource = variableToResource(*v, r.Name)
+		newResource = VariableToResource(*v, r.Name)
 	default:
 		return nil, errors.New("unsupported kind provided: " + string(r.Kind))
 	}

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1576,7 +1576,7 @@ func TestService(t *testing.T) {
 					EditMode: "advanced",
 				}
 				// TODO: remove this when issue that forced the builder tag to be here to render in UI.
-				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement"))
+				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", ""))
 				return q
 			}
 


### PR DESCRIPTION
This PR introduces `chonograf-migrator`, a tool that is used to migrate 1.x chronograf dashboards into their 2.0 equivalents. We attempt to compile any existing influxql queries into influx. If we are unable to, we add the influxql as a comment and note the error that we encountered while compiling.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
