### PR TITLE
docs: add developer guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 1. [16348](https://github.com/influxdata/influxdb/pull/16348): Drop legacy bolt service implementation in favor of kv service with bolt dependency
 1. [16014](https://github.com/influxdata/influxdb/pull/16014): While creating check, also display notification rules that would match check based on tag rules
 1. [16389](https://github.com/influxdata/influxdb/pull/16389): Increase default bucket retention period to 30 days
+1. [16418](https://github.com/influxdata/influxdb/pull/16418): Add Developer Documentation
 
 ### Bug Fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,9 @@ Please be clear about your requirements and goals, help us to understand what yo
 If you find your feature request already exists as a Github issue please indicate your support for that feature by using the "thumbs up" reaction.
 
 ## Contributing to the source code
-InfluxDB requires Go 1.12 and uses Go modules.
+InfluxDB requires Go 1.13 and uses Go modules.
 
-You should read our [coding guide](https://github.com/influxdata/influxdb/blob/master/CODING_GUIDELINES.md), to understand better how to write code for InfluxDB.
+You should read our [coding guide](https://github.com/influxdata/influxdb/blob/master/DEVELOPMENT.md), to understand better how to write code for InfluxDB.
 
 ## Submitting a pull request
 To submit a pull request you should fork the InfluxDB repository, and make your change on a feature branch of your fork.
@@ -92,15 +92,15 @@ More details about security vulnerability reporting, including our GPG key, [can
 If you are going to be contributing back to InfluxDB please take a second to sign our CLA, which can be found [on our website](https://influxdata.com/community/cla/).
 
 ## Installing Go
-InfluxDB requires Go 1.12.
+InfluxDB requires Go 1.13.
 
 At InfluxData we find `gvm`, a Go version manager, useful for installing Go.
 For instructions on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
 
 After installing gvm you can install and set the default go version by running the following:
 ```bash
-$ gvm install go1.12
-$ gvm use go1.12 --default
+$ gvm install go1.13
+$ gvm use go1.13 --default
 ```
 
 ## Revision Control Systems

--- a/DEVELOPMENT.MD
+++ b/DEVELOPMENT.MD
@@ -1,0 +1,89 @@
+# Local Development and Writing Code for Influxdb
+
+**Table of Contents**
+* [Quickstart](#quickstart)
+* [Full Length Guide](#full-length-guide)
+* [Getting Some Graphs](#getting-some-graphs)
+* [Getting Help](#getting-help)
+
+## Quickstart
+
+Assuming you have Go 1.13, Node LTS, and yarn installed, and some means of ingesting data locally (e.g. telegraf):
+
+You'll need two terminal tabs to run influxdb from source: one to run the go application server, the other to run the development server that will listen for front-end changes, rebuild the bundle, serve the new bundle, then reload your webpage for you.
+
+Tab 1:
+
+```sh
+go run ./cmd/influxd --assets-path=ui/build
+```
+
+Tab 2:
+
+```sh
+cd ui
+yarn && yarn start
+```
+
+If there are no errors, hit [localhost:8080](http://localhost:8080) and follow the prompts to setup your username and password. *Note the port difference: `8080` vs the production `9999`*
+
+You're set up to develop Influx locally. Any changes you make to front-end code under the `ui/` directory will be updated after the watcher process (that was initiated by running `yarn start`) sees them and rebuilds the bundle. Any changes to go code will need to be re-compiled by re-running the `go run` command above.
+
+See [Getting some Graphs](#getting-some-graphs) for next steps.
+
+## Full-Length Guide
+
+To get started with Influx, you'll need to install these tools if you don't already have them:
+
+1. [Install go](https://golang.org/doc/install)
+1. [Install nodejs](https://nodejs.org/en/download/package-manager/)
+1. [Install yarn](https://yarnpkg.com/lang/en/docs/install/)
+
+Yarn is a package manager for nodejs and an alternative to npm.
+
+To run Influx locally, you'll need two terminal tabs: one to run the go application server, the other to run the development server that will listen for front-end changes, rebuild the bundle, serve the new bundle, then reload your webpage for you.
+
+Tab 1:
+
+```sh
+go run ./cmd/influxd --assets-path=ui/build
+```
+
+This starts the influxdb application server. It handles API requests and can be reached via `localhost:9999`. Any changes to go code will need to be re-compiled by re-running the `go run` command above.
+
+Tab 2:
+
+```sh
+cd ui
+yarn install
+yarn start
+```
+
+This installs front-end dependencies and starts the front-end build server. It will listen to changes to TypeScript and JavaScript files, rebuild the front-end bundle, serve that bundle, then auto reload any pages with changes. If everything went smoothly without errors, you should be able to go to [localhost:8080.](http://localhost:8080) and follow the prompts to login or to setup your username and password.
+
+If you're setting things up for the first time, be sure to check out the [the official getting started guide](https://v2.docs.influxdata.com/v2.0/get-started/) to get make sure you configure everything properly.
+
+### Testing Changes
+
+To make sure everything got wired up properly, we'll want to make a minor change on the frontend and see that it's added.
+
+Add a newline and following log statement to the [entry point to the app:](https://github.com/influxdata/influxdb/blob/master/ui/src/index.tsx#L468)
+
+```js
+console.log('hello, world!')
+```
+
+Your browser should reload the page after you save your changes (sometimes this happens quickly and is hard to spot). Open your browser console and you should see your message after the page reloads.
+
+## Getting some Graphs
+
+If you haven't set up telegraf yet, [following the official telegraf documentation](https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/) is the quickest and most straightforward and hassle-free way of getting some data into your local instance. The documentation there will be kept fresher and and more current than this tutorial.
+
+Learning how to input Line protocol data is a great tool if you need to debug with arbitrary adhoc data. Check out a quick intro to the [Line protocol](https://v2.docs.influxdata.com/v2.0/write-data/#what-you-ll-need), and learn how to [input it via the ui.](https://v2.docs.influxdata.com/v2.0/write-data/#user-interface) *Since we're running `influxd` locally, you can skip step 1.*
+
+## Getting Help
+
+If you get stuck, the following resources might help:
+
+* [Influx Community Slack #V2 channel](https://app.slack.com/client/TH8RGQX5Z/CH8RV8PK5)
+* [InfluxData subreddit](https://www.reddit.com/r/InfluxData/)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We have nightly and weekly versioned Docker images, Debian packages, RPM package
 
 ## Building From Source
 
-This project requires Go 1.11 and Go module support.
+This project requires Go 1.13 and Go module support.
 
 Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed.
 
@@ -88,7 +88,7 @@ They're synonymous with what was previously in InfluxDB 1.x a database and reten
 
 The simplest way to get set up is to point your browser to [http://localhost:9999](http://localhost:9999) and go through the prompts.
 
-**Note**: Port 9999 will be used during the alpha and beta phases of development of InfluxDB v2.0.
+**Note**: Port 9999 will be used by the API server during the alpha and beta phases of development of InfluxDB v2.0.
 This should allow a v2.0-alpha instance to be run alongside a v1.x instance without interfering on port 8086.
 InfluxDB v2.0 will thereafter continue to use 8086.
 


### PR DESCRIPTION
Closes #16407

* Update docs to reference Go 1.13
* Create developer guide

[View the rendered markdown file here](https://github.com/influxdata/influxdb/blob/13805208c18a76c99a868e24e1d608f046f9f27d/DEVELOPMENT.MD)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
