### PR TITLE
fix(ui): update giraffe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 1. [16380](https://github.com/influxdata/influxdb/pull/16380): Fix notification tag matching rules and enable tests to verify
 1. [16376](https://github.com/influxdata/influxdb/pull/16376): Extend the y-axis when stacked graph is selected
 1. [16404](https://github.com/influxdata/influxdb/pull/16404): Fixed query reset bug that was resetting query in script editor whenever dates were changed
+1. [16435](https://github.com/influxdata/influxdb/pull/16435): Time labels are no longer squished to the left
 
 ### UI Improvements
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -131,7 +131,7 @@
   "dependencies": {
     "@influxdata/clockface": "1.1.0",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.17.1",
+    "@influxdata/giraffe": "0.17.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1021,10 +1021,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-parser/-/flux-parser-0.3.0.tgz#b63123ac814ad32c65e46a4097ba3d8b959416a5"
   integrity sha512-nsm801l60kXFulcSWA2YH2YRz9oSsMlTK9Evn6Og9BoQnQMcwUsSUEug8mQRIUljnkNYV58JSs0W0mP8h7Y/ZQ==
 
-"@influxdata/giraffe@0.17.1":
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.1.tgz#75c4c70bbcf78866f2c127ca94ad31d05267d9ab"
-  integrity sha512-s/51Ax12qcwMBwyh/4B7OccfMBscBxh7ZDPGJxuSoh4rAxGUUk25J4gAO1PpyGaKL6P874so2Ejtu6wfQrZ66A==
+"@influxdata/giraffe@0.17.2":
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.2.tgz#fa1a2aa45c00f3c5162b6427cbea47a962600c9a"
+  integrity sha512-AgxHptrT6V8SvJmL7nH+z34SCNn53NcXNXtwejWsr3afq2pcJO+466iVErRWLJ+q8drYZBAPB/gVE3S/Rtjx7A==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16395

Updates giraffe to use new logic to determine the optimal spacing of the time labels and use as many labels as d3 can fit in the time axis.
