### PR TITLE
chore(flux): added onEmpty parameter to flux filter function

### DIFF
--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -1095,6 +1095,12 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
           'A single argument function that evaluates true or false. Records are passed to the function. Those that evaluate to true are included in the output tables.',
         type: 'Function',
       },
+      {
+        name: 'onEmpty',
+        desc:
+          'Defines the behavior for empty tables. Potential values are `keep` and `drop`. Defaults to `drop`.',
+        type: 'String',
+      },
     ],
     package: '',
     desc:


### PR DESCRIPTION
Added the `onEmpty` parameter to the `filter()` function in `fluxFunctions.ts`.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass