### PR TITLE
fix(storage): remove data-races in delete predicates

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -4,6 +4,7 @@ import "context"
 
 // Predicate is something that can match on a series key.
 type Predicate interface {
+	Clone() Predicate
 	Matches(key []byte) bool
 	Marshal() ([]byte, error)
 }

--- a/tsdb/tsm1/cache_test.go
+++ b/tsdb/tsm1/cache_test.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage/wal"
 
 	"github.com/golang/snappy"
@@ -278,8 +279,9 @@ func TestCache_DeleteBucketRange_NonExistent(t *testing.T) {
 
 type stringPredicate string
 
-func (s stringPredicate) Matches(k []byte) bool    { return string(s) == string(k) }
-func (s stringPredicate) Marshal() ([]byte, error) { return nil, errors.New("unused") }
+func (s stringPredicate) Clone() influxdb.Predicate { return s }
+func (s stringPredicate) Matches(k []byte) bool     { return string(s) == string(k) }
+func (s stringPredicate) Marshal() ([]byte, error)  { return nil, errors.New("unused") }
 
 func TestCache_Cache_DeleteBucketRange_WithPredicate(t *testing.T) {
 	v0 := NewValue(1, 1.0)

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -518,6 +518,8 @@ func (f *FileStore) ForEachFile(fn func(f TSMFile) bool) {
 	f.mu.RUnlock()
 }
 
+// Apply calls fn on each TSMFile in the store concurrently. The level of
+// concurrency is set to GOMAXPROCS.
 func (f *FileStore) Apply(fn func(r TSMFile) error) error {
 	// Limit apply fn to number of cores
 	limiter := limiter.NewFixed(runtime.GOMAXPROCS(0))

--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 )
 
 // Predicate is something that can match on a series key.
 type Predicate interface {
+	Clone() influxdb.Predicate
 	Matches(key []byte) bool
 	Marshal() ([]byte, error)
 }
@@ -107,6 +109,17 @@ type predicateMatcher struct {
 	pred  *datatypes.Predicate
 	state *predicateState
 	root  predicateNode
+}
+
+// Clone returns a deep copy of p's state and root node.
+//
+// It is not safe to modify p.pred on the returned clone.
+func (p *predicateMatcher) Clone() influxdb.Predicate {
+	return &predicateMatcher{
+		pred:  p.pred,
+		state: p.state.Clone(),
+		root:  p.root.Clone(),
+	}
 }
 
 // Matches checks if the key matches the predicate by feeding individual tags into the
@@ -316,6 +329,22 @@ func newPredicateState(locs map[string]int) *predicateState {
 	}
 }
 
+// Clone returns a deep copy of p.
+func (p *predicateState) Clone() *predicateState {
+	q := &predicateState{
+		gen:    p.gen,
+		locs:   make(map[string]int, len(p.locs)),
+		values: make([][]byte, len(p.values)),
+	}
+
+	for k, v := range p.locs {
+		q.locs[k] = v
+	}
+	copy(q.values, p.values)
+
+	return q
+}
+
 // Reset clears any set values for the state.
 func (p *predicateState) Reset() {
 	p.gen++
@@ -356,6 +385,15 @@ func newPredicateCache(state *predicateState) predicateCache {
 	}
 }
 
+// Clone returns a deep copy of p.
+func (p *predicateCache) Clone() *predicateCache {
+	return &predicateCache{
+		state: p.state.Clone(),
+		gen:   p.gen,
+		resp:  p.resp,
+	}
+}
+
 // Cached returns the cached response and a boolean indicating if it is valid.
 func (p *predicateCache) Cached() (predicateResponse, bool) {
 	return p.resp, p.gen == p.state.gen
@@ -376,12 +414,24 @@ type predicateNode interface {
 	// Update informs the node that the state has been updated and asks it to return
 	// a response.
 	Update() predicateResponse
+
+	// Clone returns a deep copy of the node.
+	Clone() predicateNode
 }
 
 // predicateNodeAnd combines two predicate nodes with an And.
 type predicateNodeAnd struct {
 	predicateCache
 	left, right predicateNode
+}
+
+// Clone returns a deep copy of p.
+func (p *predicateNodeAnd) Clone() predicateNode {
+	return &predicateNodeAnd{
+		predicateCache: *p.predicateCache.Clone(),
+		left:           p.left.Clone(),
+		right:          p.right.Clone(),
+	}
 }
 
 // Update checks if both of the left and right nodes are true. If either is false
@@ -414,6 +464,15 @@ func (p *predicateNodeAnd) Update() predicateResponse {
 type predicateNodeOr struct {
 	predicateCache
 	left, right predicateNode
+}
+
+// Clone returns a deep copy of p.
+func (p *predicateNodeOr) Clone() predicateNode {
+	return &predicateNodeAnd{
+		predicateCache: *p.predicateCache.Clone(),
+		left:           p.left.Clone(),
+		right:          p.right.Clone(),
+	}
 }
 
 // Update checks if either the left and right nodes are true. If both nodes
@@ -452,6 +511,23 @@ type predicateNodeComparison struct {
 	rightLiteral []byte
 	leftIndex    int
 	rightIndex   int
+}
+
+// Clone returns a deep copy of p.
+func (p *predicateNodeComparison) Clone() predicateNode {
+	q := &predicateNodeComparison{
+		predicateCache: *p.predicateCache.Clone(),
+		comp:           p.comp,
+		// skip rightReg as it shouldn't be mutated
+		leftLiteral:  make([]byte, len(p.leftLiteral)),
+		rightLiteral: make([]byte, len(p.rightLiteral)),
+		leftIndex:    p.leftIndex,
+		rightIndex:   p.rightIndex,
+	}
+
+	copy(q.leftLiteral, p.leftLiteral)
+	copy(q.rightLiteral, p.rightLiteral)
+	return q
 }
 
 // Update checks if both sides of the comparison are determined, and if so, evaluates


### PR DESCRIPTION
Fixes #15817

This commit addresses several data-races on the `tsm1.Predicate` type
that were causing a live-lock or similar in rare cases during a delete.

Because `tsm1/FileStore.Apply` executes concurrently across TSM files, the state of the delete's predicate was being unsafely mutated.

This commit adds a `Clone` method to the `influxdb.Predicate` type, which should be used whenever an `influxdb.Predicate` implementation needs to be used concurrently. This means that a copy of the predicate is used for each TSM file that is having the delete applied to it.