### PR TITLE
fix(tasks): add content length check to decode force run request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 1. [16427](https://github.com/influxdata/influxdb/pull/16427): Fixed underlying issue with disappearing queries made in Advanced Mode
 1. [16439](https://github.com/influxdata/influxdb/pull/16439): Prevent negative zero and allow zero to have decimal places
 1. [16376](https://github.com/influxdata/influxdb/pull/16413): Limit data loader bucket selection to non system buckets
+1. [16458](https://github.com/influxdata/influxdb/pull/16458): Fix EOF error when manually running tasks from the Task Page.
 
 ### UI Improvements
 1. [16444](https://github.com/influxdata/influxdb/pull/16444): Add honeybadger reporting to create checks

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -1085,8 +1085,11 @@ func decodeForceRunRequest(ctx context.Context, r *http.Request) (forceRunReques
 	var req struct {
 		ScheduledFor string `json:"scheduledFor"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return forceRunRequest{}, err
+
+	if r.ContentLength != 0 && r.ContentLength < 1000 { // prevent attempts to use up memory since r.Body should include at most one item (RunManually)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			return forceRunRequest{}, err
+		}
 	}
 
 	var t time.Time


### PR DESCRIPTION
This PR fixes a bug where manually running a task failed with an "EOF" error. The solution was to check for the length of the request body, and only decode the body if it is not empty. We also check that the response body is not too long, since there is only one expected property in the body at most.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
