### PR TITLE
fix(ui): fix appearance of org names in page titles

### DIFF
--- a/ui/src/shared/utils/pageTitles.ts
+++ b/ui/src/shared/utils/pageTitles.ts
@@ -1,10 +1,10 @@
-import {get} from 'lodash'
+import {getOrg} from 'src/organizations/selectors'
 import {store} from 'src/index'
 
 export const pageTitleSuffixer = (pageTitles: string[]): string => {
   const state = store.getState()
-  const currentOrg = get(state, 'resources.orgs.org.name', null)
-  const titles = [...pageTitles, currentOrg, 'InfluxDB 2.0']
+  const {name} = getOrg(state) || null
+  const titles = [...pageTitles, name, 'InfluxDB 2.0']
 
   return titles.join(' | ')
 }

--- a/ui/src/shared/utils/pageTitles.ts
+++ b/ui/src/shared/utils/pageTitles.ts
@@ -3,7 +3,7 @@ import {store} from 'src/index'
 
 export const pageTitleSuffixer = (pageTitles: string[]): string => {
   const state = store.getState()
-  const currentOrg = get(state, 'orgs.org.name', '')
+  const currentOrg = get(state, 'resources.orgs.org.name', null)
   const titles = [...pageTitles, currentOrg, 'InfluxDB 2.0']
 
   return titles.join(' | ')


### PR DESCRIPTION
Instead of org names in page titles there was a `''` string, this PR makes it good again

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
