### PR TITLE
fix(influx): update influx pkg cmd flag secrets delimter to match vault

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -104,7 +104,7 @@ func (b *cmdPkgBuilder) cmdPkgApply() *cobra.Command {
 	cmd.Flags().BoolVar(&b.hasTableBorders, "table-borders", true, "Enable table borders, defaults true")
 
 	b.applyOpts.secrets = []string{}
-	cmd.Flags().StringSliceVar(&b.applyOpts.secrets, "secret", nil, "Secrets to provide alongside the package; format should --secret=SECRET_KEY::SECRET_VALUE --secret=SECRET_KEY_2::SECRET_VALUE_2")
+	cmd.Flags().StringSliceVar(&b.applyOpts.secrets, "secret", nil, "Secrets to provide alongside the package; format should --secret=SECRET_KEY=SECRET_VALUE --secret=SECRET_KEY_2=SECRET_VALUE_2")
 
 	cmd.RunE = b.pkgApplyRunEFn()
 
@@ -147,7 +147,7 @@ func (b *cmdPkgBuilder) pkgApplyRunEFn() func(*cobra.Command, []string) error {
 			providedSecrets[secretKey] = ""
 		}
 		for _, secretPair := range b.applyOpts.secrets {
-			pieces := strings.Split(secretPair, "::")
+			pieces := strings.SplitN(secretPair, "=", 2)
 			if len(pieces) < 2 {
 				continue
 			}


### PR DESCRIPTION
switch from the wonky `::` to `=` delimiter

Closes #16476 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass