### PR TITLE
docs(readme): Update README and CONTRIBUTING for Rust dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,17 +138,26 @@ $ go install ./...
 
 ### Testing
 
+This project is built from various languages. To run test for all langauges and components use:
+
 ```bash
-$ go test -v ./...
-
-# run tests that match some pattern
-$ go test -run=TestDatabase . -v
-
-# run tests and show coverage
-$ go test -coverprofile /tmp/cover . && go tool cover -html /tmp/cover
+$ make test
 ```
 
+To run tests for just the Javascript component use:
+
+```bash
+$ make test-js
+
+To run tests for just the Go/Rust components use:
+
+```bash
+$ make test-go
+```
+
+
 ## Generated Google Protobuf code
+
 Most changes to the source do not require that the generated protocol buffer code be changed.
 But if you need to modify the protocol buffer code, you'll first need to install the protocol buffers toolchain.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This project requires Go 1.13 and Go module support.
 
 Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed.
 
+The project also requires a recent stable version of Rust. We recommend using [rustup](https://rustup.rs/) to install Rust.
+
 If you are getting an `error loading module requirements` error with `bzr executable file not found in $PATH”` on `make`, then you need to ensure you have `bazaar`, `protobuf`, and `yarn` installed.
 
 - OSX: `brew install bazaar yarn`
@@ -186,6 +188,7 @@ Table: keys: [_start, _stop, _field, _measurement]
 2019-12-30T22:22:44.776351000Z  2019-12-30T23:22:44.776351000Z                       v                       m  2019-12-30T23:17:02.000000000Z                             2
 >
 ```
+
 
 ## Introducing Flux
 


### PR DESCRIPTION
Closes #16372 

This change just recommend using the `make` targets for testing etc. Using the `go` command requires a good understand of build tags and cgo to use correctly. 

We have a script `env` at the root of the repo and I tried using it, but it doesn't quite do what we need. It successfully setups up the CGO env vars, but all uses of the `go` command still need the `-tags libflux` args added to them and the script can't do that easily. So for now I just recommend using the `make` command. 

Once we can remove the libflux build tag it should make things much easier and the `go` commands should work better in conjunction with the `env` script. 
