### PR TITLE
feat(storage): implement backup and restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [16523](https://github.com/influxdata/influxdb/pull/16523): Change influx packages to be CRD compliant
 1. [16547](https://github.com/influxdata/influxdb/pull/16547): Allow trailing newline in credentials file and CLI integration
 1. [16545](https://github.com/influxdata/influxdb/pull/16545): Add support for prefixed cursor search to ForwardCursor types
+1. [16504](https://github.com/influxdata/influxdb/pull/16504): Add backup and restore
 
 ### UI Improvements
 

--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -11,15 +11,23 @@ import (
 // IsAllowed checks to see if an action is authorized by retrieving the authorizer
 // off of context and authorizing the action appropriately.
 func IsAllowed(ctx context.Context, p influxdb.Permission) error {
+	return IsAllowedAll(ctx, []influxdb.Permission{p})
+}
+
+// IsAllowedAll checks to see if an action is authorized by ALL permissions.
+// Also see IsAllowed.
+func IsAllowedAll(ctx context.Context, permissions []influxdb.Permission) error {
 	a, err := influxdbcontext.GetAuthorizer(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !a.Allowed(p) {
-		return &influxdb.Error{
-			Code: influxdb.EUnauthorized,
-			Msg:  fmt.Sprintf("%s is unauthorized", p),
+	for _, p := range permissions {
+		if !a.Allowed(p) {
+			return &influxdb.Error{
+				Code: influxdb.EUnauthorized,
+				Msg:  fmt.Sprintf("%s is unauthorized", p),
+			}
 		}
 	}
 

--- a/authorizer/backup.go
+++ b/authorizer/backup.go
@@ -1,0 +1,48 @@
+package authorizer
+
+import (
+	"context"
+	"io"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
+)
+
+var _ influxdb.BackupService = (*BackupService)(nil)
+
+// BackupService wraps a influxdb.BackupService and authorizes actions
+// against it appropriately.
+type BackupService struct {
+	s influxdb.BackupService
+}
+
+// NewBackupService constructs an instance of an authorizing backup service.
+func NewBackupService(s influxdb.BackupService) *BackupService {
+	return &BackupService{
+		s: s,
+	}
+}
+
+func (b BackupService) CreateBackup(ctx context.Context) (int, []string, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := IsAllowedAll(ctx, influxdb.ReadAllPermissions()); err != nil {
+		return 0, nil, err
+	}
+	return b.s.CreateBackup(ctx)
+}
+
+func (b BackupService) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := IsAllowedAll(ctx, influxdb.ReadAllPermissions()); err != nil {
+		return nil
+	}
+	return b.s.FetchBackupFile(ctx, backupID, backupFile, w)
+}
+
+func (b BackupService) InternalBackupPath(backupID int) string {
+	return b.s.InternalBackupPath(backupID)
+}

--- a/authorizer/backup.go
+++ b/authorizer/backup.go
@@ -38,7 +38,7 @@ func (b BackupService) FetchBackupFile(ctx context.Context, backupID int, backup
 	defer span.Finish()
 
 	if err := IsAllowedAll(ctx, influxdb.ReadAllPermissions()); err != nil {
-		return nil
+		return err
 	}
 	return b.s.FetchBackupFile(ctx, backupID, backupFile, w)
 }

--- a/authz.go
+++ b/authz.go
@@ -335,6 +335,16 @@ func OperPermissions() []Permission {
 	return ps
 }
 
+// ReadAllPermissions represents permission to read all data and metadata.
+// Like OperPermissions, but allows read-only users.
+func ReadAllPermissions() []Permission {
+	ps := make([]Permission, len(AllResourceTypes))
+	for i, t := range AllResourceTypes {
+		ps[i] = Permission{Action: ReadAction, Resource: Resource{Type: t}}
+	}
+	return ps
+}
+
 // OwnerPermissions are the default permissions for those who own a resource.
 func OwnerPermissions(orgID ID) []Permission {
 	ps := []Permission{}

--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,23 @@
+package influxdb
+
+import (
+	"context"
+	"io"
+)
+
+// BackupService represents the data backup functions of InfluxDB.
+type BackupService interface {
+	// CreateBackup creates a local copy (hard links) of the TSM data for all orgs and buckets.
+	// The return values are used to download each backup file.
+	CreateBackup(context.Context) (backupID int, backupFiles []string, err error)
+	// FetchBackupFile downloads one backup file, data or metadata.
+	FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error
+	// InternalBackupPath is a utility to determine the on-disk location of a backup fileset.
+	InternalBackupPath(backupID int) string
+}
+
+// KVBackupService represents the meta data backup functions of InfluxDB.
+type KVBackupService interface {
+	// Backup creates a live backup copy of the metadata database.
+	Backup(ctx context.Context, w io.Writer) error
+}

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -14,6 +14,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const DefaultFilename = "influxd.bolt"
+
 // Client is a client for the boltDB data store.
 type Client struct {
 	Path string

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -121,6 +122,17 @@ func (s *KVStore) Update(ctx context.Context, fn func(tx kv.Tx) error) error {
 			tx:  tx,
 			ctx: ctx,
 		})
+	})
+}
+
+// Backup copies all K:Vs to a writer, in BoltDB format.
+func (s *KVStore) Backup(ctx context.Context, w io.Writer) error {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	return s.db.View(func(tx *bolt.Tx) error {
+		_, err := tx.WriteTo(w)
+		return err
 	})
 }
 

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/http"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/multierr"
+)
+
+func cmdBackup() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Backup the data in InfluxDB",
+		Long: fmt.Sprintf(
+			`Backs up data and meta data for the running InfluxDB instance.
+Downloaded files are written to the directory indicated by --path.
+The target directory, and any parent directories, are created automatically.
+Data file have extension .tsm; meta data is written to %s in the same directory.`,
+			bolt.DefaultFilename),
+		RunE: backupF,
+	}
+	opts := flagOpts{
+		{
+			DestP:    &backupFlags.Path,
+			Flag:     "path",
+			Short:    'p',
+			EnvVar:   "PATH",
+			Desc:     "directory path to write backup files to",
+			Required: true,
+		},
+	}
+	opts.mustRegister(cmd)
+
+	return cmd
+}
+
+var backupFlags struct {
+	Path string
+}
+
+func init() {
+	err := viper.BindEnv("PATH")
+	if err != nil {
+		panic(err)
+	}
+	if h := viper.GetString("PATH"); h != "" {
+		backupFlags.Path = h
+	}
+}
+
+func newBackupService() (influxdb.BackupService, error) {
+	return &http.BackupService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}, nil
+}
+
+func backupF(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if flags.local {
+		return fmt.Errorf("local flag not supported for backup command")
+	}
+
+	if backupFlags.Path == "" {
+		return fmt.Errorf("must specify path")
+	}
+
+	err := os.MkdirAll(backupFlags.Path, 0770)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	backupService, err := newBackupService()
+	if err != nil {
+		return err
+	}
+
+	id, backupFilenames, err := backupService.CreateBackup(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Backup ID %d contains %d files\n", id, len(backupFilenames))
+
+	for _, backupFilename := range backupFilenames {
+		dest := filepath.Join(backupFlags.Path, backupFilename)
+		w, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+		if err != nil {
+			return err
+		}
+		err = backupService.FetchBackupFile(ctx, id, backupFilename, w)
+		if err != nil {
+			return multierr.Append(err, w.Close())
+		}
+		if err = w.Close(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Backup complete")
+
+	return nil
+}

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -98,7 +98,7 @@ func backupF(cmd *cobra.Command, args []string) error {
 		}
 		err = backupService.FetchBackupFile(ctx, id, backupFilename, w)
 		if err != nil {
-			return multierr.Append(err, w.Close())
+			return multierr.Append(fmt.Errorf("error fetching file %s: %v", backupFilename, err), w.Close())
 		}
 		if err = w.Close(); err != nil {
 			return err

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -73,7 +73,7 @@ func backupF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("must specify path")
 	}
 
-	err := os.MkdirAll(backupFlags.Path, 0770)
+	err := os.MkdirAll(backupFlags.Path, 0777)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
@@ -92,7 +92,7 @@ func backupF(cmd *cobra.Command, args []string) error {
 
 	for _, backupFilename := range backupFilenames {
 		dest := filepath.Join(backupFlags.Path, backupFilename)
-		w, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+		w, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 		if err != nil {
 			return err
 		}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -118,6 +118,7 @@ func influxCmd(opts ...genericCLIOptFn) *cobra.Command {
 
 	cmd.AddCommand(
 		cmdAuth(),
+		cmdBackup(),
 		cmdBucket(runEWrapper),
 		cmdDelete(),
 		cmdOrganization(runEWrapper),

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -200,7 +200,7 @@ func defaultTokenPath() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	return filepath.Join(dir, "credentials"), dir, nil
+	return filepath.Join(dir, http.DefaultTokenFile), dir, nil
 }
 
 func getTokenFromDefaultPath() string {

--- a/cmd/influxd/launcher/engine.go
+++ b/cmd/influxd/launcher/engine.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -29,6 +30,7 @@ type Engine interface {
 	storage.PointsWriter
 	storage.BucketDeleter
 	prom.PrometheusCollector
+	influxdb.BackupService
 
 	SeriesCardinality() int64
 
@@ -164,4 +166,16 @@ func (t *TemporaryEngine) Flush(ctx context.Context) {
 	if err := t.Open(ctx); err != nil {
 		t.log.Fatal("unable to open engine", zap.Error(err))
 	}
+}
+
+func (t *TemporaryEngine) CreateBackup(ctx context.Context) (int, []string, error) {
+	return t.engine.CreateBackup(ctx)
+}
+
+func (t *TemporaryEngine) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	return t.engine.FetchBackupFile(ctx, backupID, backupFile, w)
+}
+
+func (t *TemporaryEngine) InternalBackupPath(backupID int) string {
+	return t.engine.InternalBackupPath(backupID)
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -147,7 +147,7 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 		{
 			DestP:   &l.boltPath,
 			Flag:    "bolt-path",
-			Default: filepath.Join(dir, "influxd.bolt"),
+			Default: filepath.Join(dir, bolt.DefaultFilename),
 			Desc:    "path to boltdb database",
 		},
 		{
@@ -581,6 +581,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	var (
 		deleteService platform.DeleteService = m.engine
 		pointsWriter  storage.PointsWriter   = m.engine
+		backupService platform.BackupService = m.engine
 	)
 
 	// TODO(cwolff): Figure out a good default per-query memory limit:
@@ -772,6 +773,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		NewQueryService:      source.NewQueryService,
 		PointsWriter:         pointsWriter,
 		DeleteService:        deleteService,
+		BackupService:        backupService,
+		KVBackupService:      m.kvService,
 		AuthorizationService: authSvc,
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   storage.NewBucketService(bucketSvc, m.engine),

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
 	influxdbcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/kv"
@@ -79,7 +80,7 @@ func RunTestLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *
 
 // Run executes the program with additional arguments to set paths and ports.
 func (tl *TestLauncher) Run(ctx context.Context, args ...string) error {
-	args = append(args, "--bolt-path", filepath.Join(tl.Path, "influxd.bolt"))
+	args = append(args, "--bolt-path", filepath.Join(tl.Path, bolt.DefaultFilename))
 	args = append(args, "--engine-path", filepath.Join(tl.Path, "engine"))
 	args = append(args, "--http-bind-address", "127.0.0.1:0")
 	args = append(args, "--log-level", "debug")

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influxd/generate"
 	"github.com/influxdata/influxdb/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/cmd/influxd/launcher"
+	"github.com/influxdata/influxdb/cmd/influxd/restore"
 	_ "github.com/influxdata/influxdb/query/builtin"
 	_ "github.com/influxdata/influxdb/tsdb/tsi1"
 	_ "github.com/influxdata/influxdb/tsdb/tsm1"
@@ -46,6 +47,7 @@ func init() {
 	rootCmd.AddCommand(launcher.NewCommand())
 	rootCmd.AddCommand(generate.Command)
 	rootCmd.AddCommand(inspect.NewCommand())
+	rootCmd.AddCommand(restore.Command)
 
 	// TODO: this should be removed in the future: https://github.com/influxdata/influxdb/issues/16220
 	if os.Getenv("QUERY_TRACING") == "1" {

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -103,6 +103,10 @@ func restoreE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to move existing bolt file: %v", err)
 	}
 
+	if err := moveCredentials(); err != nil {
+		return fmt.Errorf("failed to move existing credentials file: %v", err)
+	}
+
 	if err := moveEngine(); err != nil {
 		return fmt.Errorf("failed to move existing engine data: %v", err)
 	}
@@ -111,9 +115,14 @@ func restoreE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to restore bolt file: %v", err)
 	}
 
+	if err := restoreCred(); err != nil {
+		return fmt.Errorf("failed to restore credentials file: %v", err)
+	}
+
 	if err := restoreEngine(); err != nil {
 		return fmt.Errorf("failed to restore all TSM files: %v", err)
 	}
+
 
 	if flags.rebuildTSI {
 		sFilePath := filepath.Join(flags.enginePath, storage.DefaultSeriesFileDirectoryName)

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -206,7 +206,7 @@ func restoreBolt() error {
 
 func restoreEngine() error {
 	dataDir := filepath.Join(flags.enginePath, "/data")
-	if err := os.MkdirAll(flags.enginePath, 0777); err != nil {
+	if err := os.MkdirAll(dataDir, 0777); err != nil {
 		return err
 	}
 

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -2,11 +2,16 @@ package restore
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/internal/fs"
 	"github.com/influxdata/influxdb/kit/cli"
+	"github.com/influxdata/influxdb/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +21,13 @@ var Command = &cobra.Command{
 	Long: `
 This command restores data and metadata from a backup fileset.
 
+Any existing metadata and data will be temporarily moved while restore runs
+and deleted after restore completes.
 
+Rebuilding the index and series file uses default options as in
+"influxd inspect build-tsi" with the given target engine path.
+For additional performance options, run restore with "-rebuild-index false"
+and build-tsi afterwards.
 
 NOTES:
 
@@ -30,6 +41,8 @@ NOTES:
 var flags struct {
 	boltPath   string
 	enginePath string
+	backupPath string
+	rebuildTSI bool
 }
 
 func init() {
@@ -48,13 +61,25 @@ func init() {
 			DestP:   &flags.boltPath,
 			Flag:    "bolt-path",
 			Default: filepath.Join(dir, bolt.DefaultFilename),
-			Desc:    "path to boltdb database",
+			Desc:    "path to target boltdb database",
 		},
 		{
 			DestP:   &flags.enginePath,
 			Flag:    "engine-path",
 			Default: filepath.Join(dir, "engine"),
-			Desc:    "path to persistent engine files",
+			Desc:    "path to target persistent engine files",
+		},
+		{
+			DestP:   &flags.backupPath,
+			Flag:    "backup-path",
+			Default: "",
+			Desc:    "path to backup files",
+		},
+		{
+			DestP:   &flags.rebuildTSI,
+			Flag:    "rebuild-index",
+			Default: true,
+			Desc:    "if true, rebuild the TSI index and series file based on the given engine path (equivalent to influxd inspect build-tsi)",
 		},
 	}
 
@@ -62,5 +87,153 @@ func init() {
 }
 
 func restoreE(cmd *cobra.Command, args []string) error {
-	panic("implement me")
+	if flags.backupPath == "" {
+		return fmt.Errorf("no backup path given")
+	}
+
+	if err := moveBolt(); err != nil {
+		return fmt.Errorf("failed to move existing bolt file: %v", err)
+	}
+
+	if err := moveEngine(); err != nil {
+		return fmt.Errorf("failed to move existing engine data: %v", err)
+	}
+
+	if err := restoreBolt(); err != nil {
+		return fmt.Errorf("failed to restore bolt file: %v", err)
+	}
+
+	if err := restoreEngine(); err != nil {
+		return fmt.Errorf("failed to restore all TSM files: %v", err)
+	}
+
+	if flags.rebuildTSI {
+		sFilePath := filepath.Join(flags.enginePath, storage.DefaultSeriesFileDirectoryName)
+		indexPath := filepath.Join(flags.enginePath, storage.DefaultIndexDirectoryName)
+
+		rebuild := inspect.NewBuildTSICommand()
+		rebuild.SetArgs([]string{"--sfile-path", sFilePath, "--tsi-path", indexPath})
+		rebuild.Execute()
+	}
+
+	if err := removeTmpBolt(); err != nil {
+		return fmt.Errorf("restore completed, but failed to cleanup temporary bolt file: %v", err)
+	}
+
+	if err := removeTmpEngine(); err != nil {
+		return fmt.Errorf("restore completed, but failed to cleanup temporary engine data: %v", err)
+	}
+
+	return nil
+}
+
+func moveBolt() error {
+	if _, err := os.Stat(flags.boltPath); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	if err := removeTmpBolt(); err != nil {
+		return err
+	}
+
+	return os.Rename(flags.boltPath, flags.boltPath+".tmp")
+}
+
+func moveEngine() error {
+	if _, err := os.Stat(flags.enginePath); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	if err := removeTmpEngine(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(flags.enginePath, tmpEnginePath()); err != nil {
+		return err
+	}
+
+	return os.Mkdir(flags.enginePath, 0777)
+}
+
+func tmpEnginePath() string {
+	return filepath.Dir(flags.enginePath) + "tmp"
+}
+
+func removeTmpBolt() error {
+	return removeIfExists(flags.boltPath + ".tmp")
+}
+
+func removeTmpEngine() error {
+	return removeIfExists(tmpEnginePath())
+}
+
+func removeIfExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	} else {
+		return os.RemoveAll(path)
+	}
+}
+
+func restoreBolt() error {
+	backupBolt := filepath.Join(flags.backupPath, bolt.DefaultFilename)
+	f, err := os.OpenFile(backupBolt, os.O_RDONLY, 0666)
+	if err != nil {
+		return fmt.Errorf("no bolt file in backup: %v", err)
+	}
+	defer f.Close()
+
+	w, err := os.OpenFile(flags.boltPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	defer w.Close()
+
+	_, err = io.Copy(w, f)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Restored Bolt to %s from %s\n", flags.boltPath, backupBolt)
+	return nil
+}
+
+func restoreEngine() error {
+	dataDir := filepath.Join(flags.enginePath, "/data")
+	if err := os.Mkdir(dataDir, 0777); err != nil {
+		return err
+	}
+
+	count := 0
+	err := filepath.Walk(flags.backupPath, func(path string, info os.FileInfo, err error) error {
+		if strings.Contains(path, ".tsm") {
+			f, err := os.OpenFile(path, os.O_RDONLY, 0600)
+			if err != nil {
+				return fmt.Errorf("error opening TSM file: %v", err)
+			}
+			defer f.Close()
+
+			tsmPath := filepath.Join(dataDir, filepath.Base(path))
+			w, err := os.OpenFile(tsmPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+			if err != nil {
+				return err
+			}
+
+			_, err = io.Copy(w, f)
+			if err != nil {
+				return err
+			}
+			count++
+			return nil
+		}
+		return nil
+	})
+	fmt.Printf("Restored %d TSM files to %v\n", count, dataDir)
+	return err
 }

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -183,7 +183,7 @@ func removeIfExists(path string) error {
 
 func restoreBolt() error {
 	backupBolt := filepath.Join(flags.backupPath, bolt.DefaultFilename)
-	f, err := os.OpenFile(backupBolt, os.O_RDONLY, 0666)
+	f, err := os.Open(backupBolt)
 	if err != nil {
 		return fmt.Errorf("no bolt file in backup: %v", err)
 	}
@@ -206,7 +206,7 @@ func restoreBolt() error {
 
 func restoreEngine() error {
 	dataDir := filepath.Join(flags.enginePath, "/data")
-	if err := os.Mkdir(dataDir, 0777); err != nil {
+	if err := os.MkdirAll(flags.enginePath, 0777); err != nil {
 		return err
 	}
 
@@ -224,6 +224,7 @@ func restoreEngine() error {
 			if err != nil {
 				return err
 			}
+			defer w.Close()
 
 			_, err = io.Copy(w, f)
 			if err != nil {

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -189,6 +189,9 @@ func restoreBolt() error {
 	}
 	defer f.Close()
 
+	if err := os.MkdirAll(filepath.Dir(flags.boltPath), 0777); err != nil {
+		return err
+	}
 	w, err := os.OpenFile(flags.boltPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -62,7 +62,7 @@ func init() {
 		{
 			DestP:   &flags.boltPath,
 			Flag:    "bolt-path",
-			Default: filepath.Join(dir, bolt.DefaultFilename),
+			Default: filepath.Join(dir, http.DefaultTokenFile),
 			Desc:    "path to target boltdb database",
 		},
 		{

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -123,7 +123,6 @@ func restoreE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to restore all TSM files: %v", err)
 	}
 
-
 	if flags.rebuildTSI {
 		sFilePath := filepath.Join(flags.enginePath, storage.DefaultSeriesFileDirectoryName)
 		indexPath := filepath.Join(flags.enginePath, storage.DefaultIndexDirectoryName)

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -1,0 +1,66 @@
+package restore
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/internal/fs"
+	"github.com/influxdata/influxdb/kit/cli"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore data and metadata from a backup",
+	Long: `
+This command restores data and metadata from a backup fileset.
+
+
+
+NOTES:
+
+* The influxd server should not be running when using the restore tool
+  as it replaces all data and metadata.
+`,
+	Args: cobra.ExactArgs(0),
+	RunE: restoreE,
+}
+
+var flags struct {
+	boltPath   string
+	enginePath string
+}
+
+func init() {
+	dir, err := fs.InfluxDir()
+	if err != nil {
+		panic(fmt.Errorf("failed to determine influx directory: %v", err))
+	}
+
+	Command.Flags().SortFlags = false
+
+	pfs := Command.PersistentFlags()
+	pfs.SortFlags = false
+
+	opts := []cli.Opt{
+		{
+			DestP:   &flags.boltPath,
+			Flag:    "bolt-path",
+			Default: filepath.Join(dir, bolt.DefaultFilename),
+			Desc:    "path to boltdb database",
+		},
+		{
+			DestP:   &flags.enginePath,
+			Flag:    "engine-path",
+			Default: filepath.Join(dir, "engine"),
+			Desc:    "path to persistent engine files",
+		},
+	}
+
+	cli.BindOptions(Command, opts)
+}
+
+func restoreE(cmd *cobra.Command, args []string) error {
+	panic("implement me")
+}

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -156,7 +156,7 @@ func moveEngine() error {
 		return err
 	}
 
-	return os.Mkdir(flags.enginePath, 0777)
+	return os.MkdirAll(flags.enginePath, 0777)
 }
 
 func tmpEnginePath() string {

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -235,14 +235,14 @@ func restoreEngine() error {
 	count := 0
 	err := filepath.Walk(flags.backupPath, func(path string, info os.FileInfo, err error) error {
 		if strings.Contains(path, ".tsm") {
-			f, err := os.OpenFile(path, os.O_RDONLY, 0600)
+			f, err := os.OpenFile(path, os.O_RDONLY, 0666)
 			if err != nil {
 				return fmt.Errorf("error opening TSM file: %v", err)
 			}
 			defer f.Close()
 
 			tsmPath := filepath.Join(dataDir, filepath.Base(path))
-			w, err := os.OpenFile(tsmPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+			w, err := os.OpenFile(tsmPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 			if err != nil {
 				return err
 			}

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -50,7 +50,7 @@ var flags struct {
 func init() {
 	dir, err := fs.InfluxDir()
 	if err != nil {
-		panic(fmt.Errorf("failed to determine influx directory: %v", err))
+		panic(fmt.Errorf("failed to determine influx directory: %s", err))
 	}
 
 	Command.Flags().SortFlags = false

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -51,6 +51,8 @@ type APIBackend struct {
 
 	PointsWriter                    storage.PointsWriter
 	DeleteService                   influxdb.DeleteService
+	BackupService                   influxdb.BackupService
+	KVBackupService                 influxdb.KVBackupService
 	AuthorizationService            influxdb.AuthorizationService
 	BucketService                   influxdb.BucketService
 	SessionService                  influxdb.SessionService
@@ -213,6 +215,10 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 	variableBackend.VariableService = authorizer.NewVariableService(b.VariableService)
 	h.Mount(prefixVariables, NewVariableHandler(b.Logger, variableBackend))
 
+	backupBackend := NewBackupBackend(b)
+	backupBackend.BackupService = authorizer.NewBackupService(backupBackend.BackupService)
+	h.Mount(prefixBackup, NewBackupHandler(backupBackend))
+
 	writeBackend := NewWriteBackend(b.Logger.With(zap.String("handler", "write")), b)
 	h.Mount(prefixWrite, NewWriteHandler(b.Logger, writeBackend,
 		WithMaxBatchSizeBytes(b.MaxBatchSizeBytes),
@@ -231,6 +237,7 @@ var apiLinks = map[string]interface{}{
 	// when adding new links, please take care to keep this list alphabetical
 	// as this makes it easier to verify values against the swagger document.
 	"authorizations": "/api/v2/authorizations",
+	"backup":         "/api/v2/backup",
 	"buckets":        "/api/v2/buckets",
 	"dashboards":     "/api/v2/dashboards",
 	"external": map[string]string{

--- a/http/backup_service.go
+++ b/http/backup_service.go
@@ -1,0 +1,226 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/httprouter"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+// BackupBackend is all services and associated parameters required to construct the BackupHandler.
+type BackupBackend struct {
+	Logger *zap.Logger
+	influxdb.HTTPErrorHandler
+
+	BackupService   influxdb.BackupService
+	KVBackupService influxdb.KVBackupService
+}
+
+// NewBackupBackend returns a new instance of BackupBackend.
+func NewBackupBackend(b *APIBackend) *BackupBackend {
+	return &BackupBackend{
+		Logger: b.Logger.With(zap.String("handler", "backup")),
+
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		BackupService:    b.BackupService,
+		KVBackupService:  b.KVBackupService,
+	}
+}
+
+type BackupHandler struct {
+	*httprouter.Router
+	influxdb.HTTPErrorHandler
+	Logger *zap.Logger
+
+	BackupService   influxdb.BackupService
+	KVBackupService influxdb.KVBackupService
+}
+
+const (
+	prefixBackup        = "/api/v2/backup"
+	backupIDParamName   = "backup_id"
+	backupFileParamName = "backup_file"
+	backupFilePath      = prefixBackup + "/:" + backupIDParamName + "/file/:" + backupFileParamName
+
+	httpClientTimeout = time.Hour
+)
+
+func composeBackupFilePath(backupID int, backupFile string) string {
+	return path.Join(prefixBackup, fmt.Sprint(backupID), "file", fmt.Sprint(backupFile))
+}
+
+// NewBackupHandler creates a new handler at /api/v2/backup to receive backup requests.
+func NewBackupHandler(b *BackupBackend) *BackupHandler {
+	h := &BackupHandler{
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Router:           NewRouter(b.HTTPErrorHandler),
+		Logger:           b.Logger,
+		BackupService:    b.BackupService,
+		KVBackupService:  b.KVBackupService,
+	}
+
+	h.HandlerFunc(http.MethodPost, prefixBackup, h.handleCreate)
+	h.HandlerFunc(http.MethodGet, backupFilePath, h.handleFetchFile)
+
+	return h
+}
+
+type backup struct {
+	ID    int      `json:"id,omitempty"`
+	Files []string `json:"files,omitempty"`
+}
+
+func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "BackupHandler.handleCreate")
+	defer span.Finish()
+
+	ctx := r.Context()
+
+	id, files, err := h.BackupService.CreateBackup(ctx)
+	if err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
+	internalBackupPath := h.BackupService.InternalBackupPath(id)
+	metaFilename := filepath.Join(internalBackupPath, bolt.DefaultFilename)
+	metaFile, err := os.OpenFile(metaFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0660)
+	if err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
+	if err = h.KVBackupService.Backup(ctx, metaFile); err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+	files = append(files, bolt.DefaultFilename)
+
+	b := backup{
+		ID:    id,
+		Files: files,
+	}
+	if err = json.NewEncoder(w).Encode(&b); err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+}
+
+func (h *BackupHandler) handleFetchFile(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "BackupHandler.handleFetchFile")
+	defer span.Finish()
+
+	ctx := r.Context()
+
+	params := httprouter.ParamsFromContext(ctx)
+	backupID, err := strconv.Atoi(params.ByName("backup_id"))
+	if err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+	backupFile := params.ByName("backup_file")
+
+	if err = h.BackupService.FetchBackupFile(ctx, backupID, backupFile, w); err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+}
+
+// BackupService is the client implementation of influxdb.BackupService.
+type BackupService struct {
+	Addr               string
+	Token              string
+	InsecureSkipVerify bool
+}
+
+func (s *BackupService) CreateBackup(ctx context.Context) (int, []string, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	u, err := NewURL(s.Addr, prefixBackup)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	SetToken(s.Token, req)
+	req = req.WithContext(ctx)
+
+	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
+	hc.Timeout = httpClientTimeout
+	resp, err := hc.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := CheckError(resp); err != nil {
+		return 0, nil, err
+	}
+
+	var b backup
+	if err = json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		return 0, nil, err
+	}
+
+	return b.ID, b.Files, nil
+}
+
+func (s *BackupService) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	u, err := NewURL(s.Addr, composeBackupFilePath(backupID, backupFile))
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	SetToken(s.Token, req)
+	req = req.WithContext(ctx)
+
+	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
+	hc.Timeout = httpClientTimeout
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := CheckError(resp); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *BackupService) InternalBackupPath(backupID int) string {
+	panic("internal method not implemented here")
+}

--- a/http/client.go
+++ b/http/client.go
@@ -40,6 +40,7 @@ type Service struct {
 	InsecureSkipVerify bool
 
 	*AuthorizationService
+	*BackupService
 	*BucketService
 	*DashboardService
 	*OrganizationService
@@ -60,11 +61,15 @@ func NewService(addr, token string) (*Service, error) {
 		Addr:                 addr,
 		Token:                token,
 		AuthorizationService: &AuthorizationService{Client: httpClient},
-		BucketService:        &BucketService{Client: httpClient},
-		DashboardService:     &DashboardService{Client: httpClient},
-		OrganizationService:  &OrganizationService{Client: httpClient},
-		UserService:          &UserService{Client: httpClient},
-		VariableService:      &VariableService{Client: httpClient},
+		BackupService: &BackupService{
+			Addr:  addr,
+			Token: token,
+		},
+		BucketService:       &BucketService{Client: httpClient},
+		DashboardService:    &DashboardService{Client: httpClient},
+		OrganizationService: &OrganizationService{Client: httpClient},
+		UserService:         &UserService{Client: httpClient},
+		VariableService:     &VariableService{Client: httpClient},
 		WriteService: &WriteService{
 			Addr:  addr,
 			Token: token,

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/google/btree"
@@ -54,6 +55,10 @@ func (s *KVStore) Update(ctx context.Context, fn func(kv.Tx) error) error {
 		writable: true,
 		ctx:      ctx,
 	})
+}
+
+func (s *KVStore) Backup(ctx context.Context, w io.Writer) error {
+	panic("not implemented")
 }
 
 // Flush removes all data from the buckets.  Used for testing.

--- a/kv/backup.go
+++ b/kv/backup.go
@@ -1,0 +1,10 @@
+package kv
+
+import (
+	"context"
+	"io"
+)
+
+func (s *Service) Backup(ctx context.Context, w io.Writer) error {
+	return s.kv.Backup(ctx, w)
+}

--- a/kv/service_test.go
+++ b/kv/service_test.go
@@ -2,6 +2,7 @@ package kv_test
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -18,6 +19,10 @@ func (s mockStore) View(context.Context, func(kv.Tx) error) error {
 }
 
 func (s mockStore) Update(context.Context, func(kv.Tx) error) error {
+	return nil
+}
+
+func (s mockStore) Backup(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/kv/store.go
+++ b/kv/store.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"io"
 )
 
 var (
@@ -29,6 +30,8 @@ type Store interface {
 	View(context.Context, func(Tx) error) error
 	// Update opens up a transaction that will mutate data.
 	Update(context.Context, func(Tx) error) error
+	// Backup copies all K:Vs to a writer, file format determined by implementation.
+	Backup(ctx context.Context, w io.Writer) error
 }
 
 // Tx is a transaction in the store.

--- a/mock/kv.go
+++ b/mock/kv.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"io"
 
 	"github.com/influxdata/influxdb/kv"
 )
@@ -12,6 +13,7 @@ var _ (kv.Store) = (*Store)(nil)
 type Store struct {
 	ViewFn   func(func(kv.Tx) error) error
 	UpdateFn func(func(kv.Tx) error) error
+	BackupFn func(ctx context.Context, w io.Writer) error
 }
 
 // View opens up a transaction that will not write to any data. Implementing interfaces
@@ -23,6 +25,10 @@ func (s *Store) View(ctx context.Context, fn func(kv.Tx) error) error {
 // Update opens up a transaction that will mutate data.
 func (s *Store) Update(ctx context.Context, fn func(kv.Tx) error) error {
 	return s.UpdateFn(fn)
+}
+
+func (s *Store) Backup(ctx context.Context, w io.Writer) error {
+	return s.BackupFn(ctx, w)
 }
 
 var _ (kv.Tx) = (*Tx)(nil)

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -799,8 +799,9 @@ func (e *Engine) WriteSnapshot(ctx context.Context, status CacheStatus) error {
 	if err != nil && err != errCompactionsDisabled {
 		e.logger.Info("Error writing snapshot", zap.Error(err))
 	}
-	e.compactionTracker.SnapshotAttempted(err == nil || err == errCompactionsDisabled ||
-		err == ErrSnapshotInProgress, status, time.Since(start))
+	e.compactionTracker.SnapshotAttempted(
+		err == nil || err == errCompactionsDisabled || err == ErrSnapshotInProgress,
+		status, time.Since(start))
 
 	if err != nil {
 		return err
@@ -932,6 +933,7 @@ const (
 	CacheStatusColdNoWrites                      // The cache has not been written to for long enough that it should be snapshotted.
 	CacheStatusRetention                         // The cache was snapshotted before running retention.
 	CacheStatusFullCompaction                    // The cache was snapshotted as part of a full compaction.
+	CacheStatusBackup                            // The cache was snapshotted before running backup.
 )
 
 // ShouldCompactCache returns a status indicating if the Cache should be

--- a/tsdb/tsm1/file_store_test.go
+++ b/tsdb/tsm1/file_store_test.go
@@ -2724,7 +2724,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
-	s, e := fs.CreateSnapshot(context.Background())
+	_, s, e := fs.CreateSnapshot(context.Background())
 	if e != nil {
 		t.Fatal(e)
 	}


### PR DESCRIPTION
Closes #15603
Closes #15604
Closes #15605
Closes #15606

Implements online backup and offline restore.

To test functionality it was necessary to combine #15558 and #16352 into one PR based on recent master/HEAD. Then:

- wrote some data
- read it back
- backed it up with `influx backup`
- terminated influxd
- restored it with `influxd restore` to existing database directory
- started influxd, read it back, terminated influxd
- restored it with `influxd restore` to empty database directory
- started influxd, read it back, terminated influxd

Check before merging:
- [x] "restored it with `influxd restore` to empty database directory" fails
- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
