### PR TITLE
fix(influx): drop persistent pre run func taht double prints help cmd

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -87,12 +87,6 @@ func influxCmd() *cobra.Command {
 		Use:          "influx",
 		Short:        "Influx Client",
 		SilenceUsage: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if err := checkSetup(flags.host); err != nil {
-				fmt.Printf("Note: %v\n", internal.ErrorFmt(err))
-			}
-			seeHelp(cmd, args)
-		},
 	}
 
 	setViperOptions()


### PR DESCRIPTION
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
