### PR TITLE
feat: query builder - hide the keys search dropdown when grouping

### DIFF
--- a/ui/src/timeMachine/components/TagSelector.tsx
+++ b/ui/src/timeMachine/components/TagSelector.tsx
@@ -123,6 +123,7 @@ class TagSelector extends PureComponent<Props> {
 
   private get body() {
     const {
+      aggregateFunctionType,
       index,
       keys,
       keysStatus,
@@ -151,26 +152,28 @@ class TagSelector extends PureComponent<Props> {
     return (
       <>
         <BuilderCard.Menu testID={`tag-selector--container ${index}`}>
-          <FlexBox
-            direction={FlexDirection.Row}
-            alignItems={AlignItems.Center}
-            margin={ComponentSize.Small}
-          >
-            <SearchableDropdown
-              searchTerm={keysSearchTerm}
-              emptyText="No Tags Found"
-              searchPlaceholder="Search keys..."
-              selectedOption={selectedKey}
-              onSelect={this.handleSelectTag}
-              buttonStatus={toComponentStatus(keysStatus)}
-              onChangeSearchTerm={this.handleKeysSearch}
-              testID="tag-selector--dropdown"
-              buttonTestID="tag-selector--dropdown-button"
-              menuTestID="tag-selector--dropdown-menu"
-              options={keys}
-            />
-            {this.selectedCounter}
-          </FlexBox>
+          {aggregateFunctionType !== 'group' && (
+            <FlexBox
+              direction={FlexDirection.Row}
+              alignItems={AlignItems.Center}
+              margin={ComponentSize.Small}
+            >
+              <SearchableDropdown
+                searchTerm={keysSearchTerm}
+                emptyText="No Tags Found"
+                searchPlaceholder="Search keys..."
+                selectedOption={selectedKey}
+                onSelect={this.handleSelectTag}
+                buttonStatus={toComponentStatus(keysStatus)}
+                onChangeSearchTerm={this.handleKeysSearch}
+                testID="tag-selector--dropdown"
+                buttonTestID="tag-selector--dropdown-button"
+                menuTestID="tag-selector--dropdown-menu"
+                options={keys}
+              />
+              {this.selectedCounter}
+            </FlexBox>
+          )}
           <Input
             value={valuesSearchTerm}
             placeholder={`Search ${selectedKey} tag values`}

--- a/ui/src/timeMachine/selectors/index.test.ts
+++ b/ui/src/timeMachine/selectors/index.test.ts
@@ -168,6 +168,7 @@ describe('getting active tag values', () => {
     expect(actualTags).toEqual([
       ...activeQueryTags[0].values,
       ...activeQueryTags[1].values,
+      ...activeQueryTags[2].values,
     ])
   })
 })

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -89,8 +89,8 @@ export const getActiveWindowPeriod = (state: AppState) => {
   return getWindowPeriod(text, variables)
 }
 
-const getTablesMemoized = memoizeOne(
-  (files: string[]): FluxTable[] => (files ? flatMap(files, parseResponse) : [])
+const getTablesMemoized = memoizeOne((files: string[]): FluxTable[] =>
+  files ? flatMap(files, parseResponse) : []
 )
 
 export const getTables = (state: AppState): FluxTable[] =>
@@ -328,11 +328,7 @@ export const getActiveTagValues = (
     aggregateFunctionType === 'group'
   ) {
     const values = []
-    activeQueryBuilderTags.forEach((tag, i) => {
-      // if we don't skip the current set of tags, we'll double render them at the bottom of the selector list
-      if (i === index) {
-        return
-      }
+    activeQueryBuilderTags.forEach(tag => {
       tag.values.forEach(value => {
         values.push(value)
       })


### PR DESCRIPTION
Closes #16518 

Hides the selector to search for keys when grouping. Also shows all the keys that are no longer searchable 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass