### PR TITLE
fix(meta): remove double index increment of set meta

### DIFF
--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -932,12 +932,7 @@ func (c *Client) DropSubscription(database, rp, name string) error {
 func (c *Client) SetData(data *Data) error {
 	c.mu.Lock()
 
-	// reset the index so the commit will fire a change event
-	c.cacheData.Index = 0
-
-	// increment the index to force the changed channel to fire
 	d := data.Clone()
-	d.Index++
 
 	if err := c.commit(d); err != nil {
 		return err


### PR DESCRIPTION
Closes #16326 

this pr is to remove the double index increment when set meta data,
which is describe in the issue #16326 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
