### PR TITLE
fix(http): fix /telegrafs panics when using org=org_name parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v2.0.0-beta.2 [Unreleased]
 
+### Bug Fixes
+
+1. [16527](https://github.com/influxdata/influxdb/pull/16527): fix /telegrafs panics when using org=org_name parameter
+
 ### UI Improvements
 
 1. [16203](https://github.com/influxdata/influxdb/pull/16203): Move cloud navigation to top of page instead of within left side navigation

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -295,7 +295,7 @@ func decodeTelegrafConfigFilter(ctx context.Context, r *http.Request) (*platform
 		}
 		f.OrgID = orgID
 	} else if orgNameStr := q.Get("org"); orgNameStr != "" {
-		*f.Organization = orgNameStr
+		f.Organization = &orgNameStr
 	}
 	return f, err
 }


### PR DESCRIPTION
Closes #16495

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
