### PR TITLE
fix(storage): prevent infinite loop in predicate matcher

### DIFF
--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -621,17 +621,16 @@ func predicatePopTagEscape(series []byte) (tag, value []byte, rest []byte) {
 	for j := uint(0); j < uint(len(series)); {
 		i := bytes.IndexByte(series[j:], ',')
 		if i < 0 {
-			break
+			break // this is the last tag pair
 		}
-		ui := uint(i)
 
-		if ui > 0 && ui-1 < uint(len(series)) && series[ui-1] == '\\' {
+		ui := uint(i) + j                   // make index relative to full series slice
+		if ui > 0 && series[ui-1] == '\\' { // the comma is escaped
 			j = ui + 1
 			continue
 		}
 
-		idx := ui + j
-		series, rest = series[:idx], series[idx+1:]
+		series, rest = series[:ui], series[ui+1:]
 		break
 	}
 
@@ -639,17 +638,15 @@ func predicatePopTagEscape(series []byte) (tag, value []byte, rest []byte) {
 	for j := uint(0); j < uint(len(series)); {
 		i := bytes.IndexByte(series[j:], '=')
 		if i < 0 {
-			break
+			break // there is no tag value
 		}
-		ui := uint(i)
-
-		if ui > 0 && ui-1 < uint(len(series)) && series[ui-1] == '\\' {
+		ui := uint(i) + j                   // make index relative to full series slice
+		if ui > 0 && series[ui-1] == '\\' { // the equals is escaped
 			j = ui + 1
 			continue
 		}
 
-		idx := ui + j
-		tag, value = series[:idx], series[idx+1:]
+		tag, value = series[:ui], series[ui+1:]
 		break
 	}
 


### PR DESCRIPTION
Fixes #15817

This PR addresses a case where a predicate matching against a series key could get stuck in an infinite—and very hot—loop. 

Hitting this loop resulted in the `influxd` process getting stuck and being unresponsive.

Here is an example of a series key that would cause the infinite loop: `hi\ yo\ =w\,est,server=a`. The predicate matcher would use the `predicatePopTagEscape` function to attempt to pop off the first tag key/pair.

1) The function looks for the first comma, which is at `index 11`. It's the first comma in the tag value.
2) The function determines this comma is actually escaped and intends to continue finding next comma in the rest of the key after this escaped comma: `est,server=a`
3) The function finds a comma at `index 3` in this partial key (`t,s`).
4) The function needs to check this comma is not escaped. However, when it checks the byte at `index 2` it checks **against the full series key** `hi\ yo\ =w\,est,server=a` and **not** the partial key `est,server=a`; this is the bug.
5) The byte at index 2 in the full key is a backslash that escapes a space. The function therefore thinks the comma it just found is escaped (it's not) and the function continues checking the key for an unescaped comma.
6) Next it checks the partial key from `index 4`, which means it's checking the sub-slice `yo\ =w\,est,server=a`.
7) It finds a comma at index 7 (the first escaped comma in the tag value). However, we already found this comma previously, so now the function will be stuck in an infinite loop. **GOTO 2**

