### PR TITLE
feat(http): Enforce limits in write handler and expose config options

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -31,6 +31,18 @@ type APIBackend struct {
 	// in a single points batch
 	MaxBatchSizeBytes int64
 
+	// WriteParserMaxBytes specifies the maximum number of bytes that may be allocated when processing a single
+	// write request. A value of zero specifies there is no limit.
+	WriteParserMaxBytes int
+
+	// WriteParserMaxLines specifies the maximum number of lines that may be parsed when processing a single
+	// write request. A value of zero specifies there is no limit.
+	WriteParserMaxLines int
+
+	// WriteParserMaxValues specifies the maximum number of values that may be parsed when processing a single
+	// write request. A value of zero specifies there is no limit.
+	WriteParserMaxValues int
+
 	NewBucketService func(*influxdb.Source) (influxdb.BucketService, error)
 	NewQueryService  func(*influxdb.Source) (query.ProxyQueryService, error)
 
@@ -202,7 +214,12 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 	h.Mount(prefixVariables, NewVariableHandler(b.Logger, variableBackend))
 
 	writeBackend := NewWriteBackend(b.Logger.With(zap.String("handler", "write")), b)
-	h.Mount(prefixWrite, NewWriteHandler(b.Logger, writeBackend, WithMaxBatchSizeBytes(b.MaxBatchSizeBytes)))
+	h.Mount(prefixWrite, NewWriteHandler(b.Logger, writeBackend,
+		WithMaxBatchSizeBytes(b.MaxBatchSizeBytes),
+		WithParserMaxBytes(b.WriteParserMaxBytes),
+		WithParserMaxLines(b.WriteParserMaxLines),
+		WithParserMaxValues(b.WriteParserMaxValues),
+	))
 
 	for _, o := range opts {
 		o(h)

--- a/http/write_handler_test.go
+++ b/http/write_handler_test.go
@@ -80,7 +80,7 @@ func TestWriteHandler_handleWrite(t *testing.T) {
 	// state is the internal state of org and bucket services
 	type state struct {
 		org       *influxdb.Organization // org to return in org service
-		orgErr    error                  // err to return in org servce
+		orgErr    error                  // err to return in org service
 		bucket    *influxdb.Bucket       // bucket to return in bucket service
 		bucketErr error                  // err to return in bucket service
 		writeErr  error                  // err to return from the points writer
@@ -272,6 +272,60 @@ func TestWriteHandler_handleWrite(t *testing.T) {
 			wants: wants{
 				code: 413,
 				body: `{"code":"request too large","message":"unable to read data: points batch is too large"}`,
+			},
+		},
+		{
+			name: "bytes limit rejected",
+			request: request{
+				org:    "043e0780ee2b1000",
+				bucket: "04504b356e23b000",
+				body:   "m1,t1=v1 f1=1",
+				auth:   bucketWritePermission("043e0780ee2b1000", "04504b356e23b000"),
+			},
+			state: state{
+				org:    testOrg("043e0780ee2b1000"),
+				bucket: testBucket("043e0780ee2b1000", "04504b356e23b000"),
+				opts:   []WriteHandlerOption{WithParserMaxBytes(5)},
+			},
+			wants: wants{
+				code: 413,
+				body: `{"code":"request too large","message":"points: number of allocated bytes exceeded"}`,
+			},
+		},
+		{
+			name: "lines limit rejected",
+			request: request{
+				org:    "043e0780ee2b1000",
+				bucket: "04504b356e23b000",
+				body:   "m1,t1=v1 f1=1\nm1,t1=v1 f1=1\nm1,t1=v1 f1=1\n",
+				auth:   bucketWritePermission("043e0780ee2b1000", "04504b356e23b000"),
+			},
+			state: state{
+				org:    testOrg("043e0780ee2b1000"),
+				bucket: testBucket("043e0780ee2b1000", "04504b356e23b000"),
+				opts:   []WriteHandlerOption{WithParserMaxLines(2)},
+			},
+			wants: wants{
+				code: 413,
+				body: `{"code":"request too large","message":"points: number of lines exceeded"}`,
+			},
+		},
+		{
+			name: "values limit rejected",
+			request: request{
+				org:    "043e0780ee2b1000",
+				bucket: "04504b356e23b000",
+				body:   "m1,t1=v1 f1=1,f2=2\nm1,t1=v1 f1=1,f2=2\nm1,t1=v1 f1=1,f2=2\n",
+				auth:   bucketWritePermission("043e0780ee2b1000", "04504b356e23b000"),
+			},
+			state: state{
+				org:    testOrg("043e0780ee2b1000"),
+				bucket: testBucket("043e0780ee2b1000", "04504b356e23b000"),
+				opts:   []WriteHandlerOption{WithParserMaxValues(4)},
+			},
+			wants: wants{
+				code: 413,
+				body: `{"code":"request too large","message":"points: number of values exceeded"}`,
 			},
 		},
 	}


### PR DESCRIPTION
This PR uses the `ParsePointsWithOptions` API for parsing a batch of points submitted to the `/api/v2/write` HTTP endpoint. 

All limits are disabled by default, but may be configured by setting values for the documented fields of the `APIBackend` structure.