### PR TITLE
fix(pkger): fixes issue where pkger can't discern the mime/content type of a package

### DIFF
--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -287,16 +287,11 @@ func TestCmdPkg(t *testing.T) {
 		})
 
 		t.Run("pkg is invalid returns error", func(t *testing.T) {
-			// pkgYml is invalid because it is missing a name
+			// pkgYml is invalid because it is missing a name and wrong apiVersion
 			const pkgYml = `apiVersion: 0.1.0
-kind: Package
-meta:
-  pkgName:      pkg_name
-  pkgVersion:   1
-spec:
-  resources:
-    - kind: Bucket`
-
+kind: Bucket
+metadata:
+`
 			b := newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), in(strings.NewReader(pkgYml)), out(ioutil.Discard))
 			cmd := b.cmdPkgValidate()
 			require.Error(t, cmd.Execute())

--- a/http/pkger_http_server_test.go
+++ b/http/pkger_http_server_test.go
@@ -103,7 +103,10 @@ func TestPkgerHTTPServer(t *testing.T) {
 					reqBody: fluxTTP.ReqApplyPkg{
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
-						URL:    "https://gist.githubusercontent.com/jsteenb2/3a3b2b5fcbd6179b2494c2b54aa2feb0/raw/540e65305a18bfca6123714e6c8868b1b465c7ef/bucket_pkg_json",
+						Remote: fluxTTP.PkgRemote{
+							URL:         "https://gist.githubusercontent.com/jsteenb2/3a3b2b5fcbd6179b2494c2b54aa2feb0/raw/540e65305a18bfca6123714e6c8868b1b465c7ef/bucket_pkg_json",
+							ContentType: "jsonnet",
+						},
 					},
 				},
 				{

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7143,8 +7143,14 @@ components:
           type: object
           additionalProperties:
             type: string
-        url:
-          type: string
+        remote:
+          type: object
+          properties:
+            url:
+              type: string
+            contentType:
+              type: string
+          required: ["url"]
     PkgCreate:
       type: object
       properties:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -50,7 +50,6 @@ var kinds = map[Kind]bool{
 	KindNotificationEndpointPagerDuty: true,
 	KindNotificationEndpointSlack:     true,
 	KindNotificationRule:              true,
-	KindPackage:                       true,
 	KindTask:                          true,
 	KindTelegraf:                      true,
 	KindVariable:                      true,

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -162,7 +162,7 @@ func parseSource(r io.Reader, opts ...ValidateOptFn) (*Pkg, error) {
 		strings.Contains(contentType, "yml"):
 		return parseYAML(bytes.NewReader(b), opts...)
 	default:
-		return parseJsonnet(bytes.NewReader(b), opts...)
+		return parseYAML(bytes.NewReader(b), opts...)
 	}
 }
 


### PR DESCRIPTION
also makes the yaml decoder the default. To foten we end up in application/octet-stream
which is the default for many different mime types. This provides a mechanism
around that so that when the automagical detection fails it can allow the user
to provide it via the CLI.

Closes issues I noticed during testing since the url bits got merged

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
