### PR TITLE
feat(kv): add support for prefixed cursor search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [16523](https://github.com/influxdata/influxdb/pull/16523): Change influx packages to be CRD compliant
 1. [16547](https://github.com/influxdata/influxdb/pull/16547): Allow trailing newline in credentials file and CLI integration
+1. [16545](https://github.com/influxdata/influxdb/pull/16545): Add support for prefixed cursor search to ForwardCursor types
 
 ### UI Improvements
 

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -201,13 +201,18 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 	var (
 		cursor     = b.bucket.Cursor()
 		key, value = cursor.Seek(seek)
+		config     = kv.NewCursorConfig(opts...)
 	)
+
+	if config.Prefix != nil && !bytes.HasPrefix(seek, config.Prefix) {
+		return nil, fmt.Errorf("seek bytes %q not prefixed with %q: %w", string(seek), string(config.Prefix), kv.ErrSeekMissingPrefix)
+	}
 
 	return &Cursor{
 		cursor: cursor,
 		key:    key,
 		value:  value,
-		config: kv.NewCursorConfig(opts...),
+		config: config,
 	}, nil
 }
 

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -240,6 +240,11 @@ type pair struct {
 
 // ForwardCursor returns a directional cursor which starts at the provided seeked key
 func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.ForwardCursor, error) {
+	config := kv.NewCursorConfig(opts...)
+	if config.Prefix != nil && !bytes.HasPrefix(seek, config.Prefix) {
+		return nil, fmt.Errorf("seek bytes %q not prefixed with %q: %w", string(seek), string(config.Prefix), kv.ErrSeekMissingPrefix)
+	}
+
 	var (
 		pairs = make(chan []pair)
 		stop  = make(chan struct{})
@@ -262,20 +267,15 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 
 		var (
 			batch   []pair
-			config  = kv.NewCursorConfig(opts...)
 			fn      = config.Hints.PredicateFn
-			iterate = func(it btree.ItemIterator) {
-				b.btree.AscendGreaterOrEqual(&item{key: seek}, it)
-			}
+			iterate = b.ascend
 		)
 
 		if config.Direction == kv.CursorDescending {
-			iterate = func(it btree.ItemIterator) {
-				b.btree.DescendLessOrEqual(&item{key: seek}, it)
-			}
+			iterate = b.descend
 		}
 
-		iterate(func(i btree.Item) bool {
+		iterate(seek, config, func(i btree.Item) bool {
 			select {
 			case <-stop:
 				// if signalled to stop then exit iteration
@@ -287,6 +287,10 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 			if !ok {
 				batch = append(batch, pair{err: fmt.Errorf("error item is type %T not *item", i)})
 
+				return false
+			}
+
+			if config.Prefix != nil && !bytes.HasPrefix(j.key, config.Prefix) {
 				return false
 			}
 
@@ -315,6 +319,14 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 	}()
 
 	return &ForwardCursor{pairs: pairs, stop: stop}, nil
+}
+
+func (b *Bucket) ascend(seek []byte, config kv.CursorConfig, it btree.ItemIterator) {
+	b.btree.AscendGreaterOrEqual(&item{key: seek}, it)
+}
+
+func (b *Bucket) descend(seek []byte, config kv.CursorConfig, it btree.ItemIterator) {
+	b.btree.DescendLessOrEqual(&item{key: seek}, it)
 }
 
 // ForwardCursor is a kv.ForwardCursor which iterates over an in-memory btree

--- a/kv/store.go
+++ b/kv/store.go
@@ -11,6 +11,9 @@ var (
 	// ErrTxNotWritable is the error returned when an mutable operation is called during
 	// a non-writable transaction.
 	ErrTxNotWritable = errors.New("transaction is not writable")
+	// ErrSeekMissingPrefix is returned when seek bytes is missing the prefix defined via
+	// WithCursorPrefix
+	ErrSeekMissingPrefix = errors.New("seek missing prefix bytes")
 )
 
 // IsNotFound returns a boolean indicating whether the error is known to report that a key or was not found.
@@ -141,6 +144,7 @@ const (
 type CursorConfig struct {
 	Direction CursorDirection
 	Hints     CursorHints
+	Prefix    []byte
 }
 
 // NewCursorConfig constructs and configures a CursorConfig used to configure
@@ -169,5 +173,17 @@ func WithCursorHints(hints ...CursorHint) CursorOption {
 		for _, hint := range hints {
 			hint(&c.Hints)
 		}
+	}
+}
+
+// WithCursorPrefix configures the forward cursor to retrieve keys
+// with a particular prefix. This implies the cursor will start and end
+// at a specific location based on the prefix [prefix, prefix + 1).
+//
+// The value of the seek bytes must be prefixed with the provided
+// prefix, otherwise an error will be returned.
+func WithCursorPrefix(prefix []byte) CursorOption {
+	return func(c *CursorConfig) {
+		c.Prefix = prefix
 	}
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16534

This introduces the new `CursorOption` known as `WithCursorPrefix(prefix)`.

This option configures the returned cursor to only return keys with the provided prefix.

When using `ForwardCursor` with this new option. The provided `seek` bytes must be prefixed with the provided `prefix` bytes, otherwise the forward cursor implementation should return `kv.ErrSeekMissingPrefix` error and a nil cursor.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
