### PR TITLE
fix(ui): make localeFormattedValue less confusing

### DIFF
--- a/ui/src/shared/components/Gauge.tsx
+++ b/ui/src/shared/components/Gauge.tsx
@@ -282,7 +282,7 @@ class Gauge extends Component<Props> {
     maxValue
   ) => {
     const {tickPrefix, tickSuffix, decimalPlaces} = this.props
-    let {prefix, suffix} = this.props 
+    let {prefix, suffix} = this.props
     const {degree, lineCount, labelColor, labelFontSize} = GAUGE_SPECS
 
     const tickValues = [
@@ -290,12 +290,12 @@ class Gauge extends Component<Props> {
       maxValue,
     ]
 
-    if(tickPrefix === "true"){
-      prefix = "";
+    if (tickPrefix === 'true') {
+      prefix = ''
     }
-    
-    if(tickSuffix === "true"){
-      suffix = "";
+
+    if (tickSuffix === 'true') {
+      suffix = ''
     }
 
     const labels = tickValues.map(tick =>
@@ -351,7 +351,7 @@ class Gauge extends Component<Props> {
     const textContent = formatStatValue(gaugePosition, {
       decimalPlaces,
       prefix,
-      suffix
+      suffix,
     })
 
     ctx.fillText(textContent, 0, textY)

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -236,8 +236,7 @@ class InlineLabelsEditor extends Component<Props, State> {
       await onCreateLabel(label)
       const newLabel = this.props.labels.find(l => l.name === label.name)
       await onAddLabel(newLabel)
-    } catch (error) {
-    }
+    } catch (error) {}
   }
 
   private handleStartCreatingLabel = (): void => {

--- a/ui/src/shared/utils/formatStatValue.ts
+++ b/ui/src/shared/utils/formatStatValue.ts
@@ -20,7 +20,7 @@ export const formatStatValue = (
   value: number | string = 0,
   {decimalPlaces, prefix, suffix}: FormatStatValueOptions = {}
 ): string => {
-  let localeFormattedValue = ''
+  let localeFormattedValue // undefined, string, or number
 
   if (isNumber(value)) {
     let digits: number
@@ -45,7 +45,7 @@ export const formatStatValue = (
     return 'Data cannot be displayed'
   }
 
-  localeFormattedValue = '' + preventNegativeZero(localeFormattedValue)
+  localeFormattedValue = preventNegativeZero(localeFormattedValue)
   const formattedValue = `${prefix || ''}${localeFormattedValue}${suffix || ''}`
 
   return formattedValue

--- a/ui/src/shared/utils/view.ts
+++ b/ui/src/shared/utils/view.ts
@@ -89,9 +89,9 @@ function defaultGaugeViewProperties() {
     queries: [defaultViewQuery()],
     colors: DEFAULT_GAUGE_COLORS as Color[],
     prefix: '',
-    tickPrefix:'',
+    tickPrefix: '',
     suffix: '',
-    tickSuffix:'',
+    tickSuffix: '',
     note: '',
     showNoteWhenEmpty: false,
     decimalPlaces: {
@@ -106,9 +106,9 @@ function defaultSingleStatViewProperties() {
     queries: [defaultViewQuery()],
     colors: DEFAULT_THRESHOLDS_LIST_COLORS as Color[],
     prefix: '',
-    tickPrefix:'',
+    tickPrefix: '',
     suffix: '',
-    tickSuffix:'',
+    tickSuffix: '',
     note: '',
     showNoteWhenEmpty: false,
     decimalPlaces: {

--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -331,7 +331,6 @@ export const setTickSuffix = (tickSuffix: string): SetTickSuffix => ({
   payload: {tickSuffix},
 })
 
-
 interface SetStaticLegend {
   type: 'SET_STATIC_LEGEND'
   payload: {staticLegend: boolean}

--- a/ui/src/timeMachine/components/view_options/Affixes.tsx
+++ b/ui/src/timeMachine/components/view_options/Affixes.tsx
@@ -11,7 +11,7 @@ import {
   InputLabel,
   FlexBox,
   AlignItems,
-  ComponentSize
+  ComponentSize,
 } from '@influxdata/clockface'
 
 // Types
@@ -55,7 +55,7 @@ class Affixes extends PureComponent<Props> {
         <Grid.Column widthXS={Columns.Six}>
           <FlexBox alignItems={AlignItems.Center} margin={ComponentSize.Small}>
             <Toggle
-              id='prefixoptional'
+              id="prefixoptional"
               type={InputToggleType.Checkbox}
               value={tickPrefix}
               onChange={this.handleUpdateTickPrefix}
@@ -67,7 +67,7 @@ class Affixes extends PureComponent<Props> {
         <Grid.Column widthXS={Columns.Six}>
           <FlexBox alignItems={AlignItems.Center} margin={ComponentSize.Small}>
             <Toggle
-              id='suffixoptional'
+              id="suffixoptional"
               type={InputToggleType.Checkbox}
               value={tickSuffix}
               onChange={this.handleUpdateTickSuffix}

--- a/ui/src/timeMachine/components/view_options/SingleStatOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/SingleStatOptions.tsx
@@ -106,7 +106,14 @@ const mstp = (state: AppState) => {
   const view = getActiveTimeMachine(state).view as NewView<
     SingleStatViewProperties
   >
-  const {colors, prefix, suffix, decimalPlaces, tickPrefix, tickSuffix} = view.properties
+  const {
+    colors,
+    prefix,
+    suffix,
+    decimalPlaces,
+    tickPrefix,
+    tickSuffix,
+  } = view.properties
 
   return {colors, prefix, suffix, decimalPlaces, tickPrefix, tickSuffix}
 }

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -89,8 +89,8 @@ export const getActiveWindowPeriod = (state: AppState) => {
   return getWindowPeriod(text, variables)
 }
 
-const getTablesMemoized = memoizeOne((files: string[]): FluxTable[] =>
-  files ? flatMap(files, parseResponse) : []
+const getTablesMemoized = memoizeOne(
+  (files: string[]): FluxTable[] => (files ? flatMap(files, parseResponse) : [])
 )
 
 export const getTables = (state: AppState): FluxTable[] =>


### PR DESCRIPTION
Fixes issues related to recent PRs.

- localeFormattedValue does not need to be coerced, because it is not the return value of the function
- run prettier
