### PR TITLE
fix: bail webpack build on tsc error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ ifeq ($(GOARCH), arm64)
 else
     all: GO_ARGS=-tags 'assets $(GO_TAGS)'
 endif
-all: subdirs generate $(CMDS)
+all: $(SUBDIRS) generate $(CMDS)
 
 # Target to build subdirs.
 # Each subdirs must support the `all` target.
-subdirs: $(SUBDIRS)
-	@for d in $^; do $(MAKE) -C $$d all; done
+$(SUBDIRS):
+	$(MAKE) -C $@ all
 
 #
 # Define targets for commands
@@ -135,7 +135,7 @@ checkgenerate:
 checkcommit:
 	./etc/circle-detect-committed-binaries.sh
 
-generate: subdirs
+generate: $(SUBDIRS)
 
 test-js: node_modules
 	make -C ui test
@@ -191,7 +191,7 @@ define CHRONOGIRAFFE
 ,"   ##    /
 endef
 export CHRONOGIRAFFE
-chronogiraffe: subdirs generate $(CMDS)
+chronogiraffe: $(SUBDIRS) generate $(CMDS)
 	@echo "$$CHRONOGIRAFFE"
 
 run: chronogiraffe
@@ -207,4 +207,4 @@ protoc:
 	chmod +x /go/bin/protoc
 
 # .PHONY targets represent actions that do not create an actual file.
-.PHONY: all subdirs $(SUBDIRS) run fmt checkfmt tidy checktidy checkgenerate test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe dist ping protoc e2e run-e2e influxd libflux
+.PHONY: all $(SUBDIRS) run fmt checkfmt tidy checktidy checkgenerate test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe dist ping protoc e2e run-e2e influxd libflux

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "start:dev-cloud": "cross-env CLOUD_LOGOUT_URL=http://localhost:8080/api/v2/signout CLOUD_URL=http://localhost:9999 webpack-dev-server --config ./webpack.dev.ts",
     "start:docker": "yarn generate && yarn build:vendor && yarn run start:dev",
     "build": "yarn install --silent && yarn build:ci",
-    "build:ci": "yarn generate && yarn build:vendor && webpack --config webpack.prod.ts",
+    "build:ci": "yarn generate && yarn build:vendor && webpack --config webpack.prod.ts --bail",
     "build:vendor": "webpack --config webpack.vendor.ts",
     "clean": "rm -rf ./build && rm -rf ./.cache && rm -rf node_modules && rm -rf cypress/screenshots && rm -rf cypress/videos && rm -f junit-results/* ",
     "test": "jest --maxWorkers=2",


### PR DESCRIPTION
This is a clone of #16551 that i messed up because i zigged instead of zagged

The Problem
Firstly, webpack did not exit with a non-zero status code if there was a TypeScript compilation error. Secondly, the Makefile subdirs target loop did not consider the exit codes of each sub-make, so it didn't stop. Therefore, only the final status code bubbled up in CI. See this for more details.

Solution
Copy answers from stack overflow.

Related: #16468