### PR TITLE
fix(influxdb): swap billingURL with checkoutURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 
 ### UI Improvements
 
+1. [16575](https://github.com/influxdata/influxdb/pull/16575): Swap billingURL with checkoutURL
 1. [16203](https://github.com/influxdata/influxdb/pull/16203): Move cloud navigation to top of page instead of within left side navigation
 1. [16536](https://github.com/influxdata/influxdb/pull/16536): Adjust aggregate window periods to be more "reasonable". Use duration input with validation.
-
 
 ## v2.0.0-beta.1 [2020-01-08]
 

--- a/ui/src/cloud/components/CheckoutButton.tsx
+++ b/ui/src/cloud/components/CheckoutButton.tsx
@@ -12,11 +12,11 @@ import {
 } from '@influxdata/clockface'
 
 // Constants
-import {CLOUD_BILLING_PATH, CLOUD_URL} from 'src/shared/constants'
+import {CLOUD_CHECKOUT_PATH, CLOUD_URL} from 'src/shared/constants'
 
 const CheckoutButton: FunctionComponent<{}> = () => {
-  const billingURL = `${CLOUD_URL}${CLOUD_BILLING_PATH}`
-  const onClick = () => (window.location.href = billingURL)
+  const checkoutURL = `${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`
+  const onClick = () => (window.location.href = checkoutURL)
 
   return (
     <FeatureFlag name="cloudBilling">

--- a/ui/src/pageLayout/components/CloudNav.tsx
+++ b/ui/src/pageLayout/components/CloudNav.tsx
@@ -20,6 +20,7 @@ import {
   CLOUD_URL,
   CLOUD_USAGE_PATH,
   CLOUD_BILLING_PATH,
+  CLOUD_CHECKOUT_PATH,
   CLOUD_SIGNOUT_URL,
 } from 'src/shared/constants'
 
@@ -39,8 +40,9 @@ interface StateProps {
 const CloudNav: FC<StateProps> = ({org}) => {
   const usageURL = `${CLOUD_URL}${CLOUD_USAGE_PATH}`
   const billingURL = `${CLOUD_URL}${CLOUD_BILLING_PATH}`
+  const checkoutURL = `${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`
   const handleUpgradeClick = () => {
-    window.location.assign(billingURL)
+    window.location.assign(checkoutURL)
   }
 
   if (!org) {


### PR DESCRIPTION
Closes #16568

Replace billingURL with checkoutURL on upgrade CTAs so the user is taken to the checkout flow instead of the Billing page.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass