### PR TITLE
fix(influx): fix description for reuable org/ord id type

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -296,14 +296,14 @@ func (o *organization) register(cmd *cobra.Command, persistent bool) {
 		{
 			DestP:      &o.id,
 			Flag:       "org-id",
-			Desc:       "The ID of the organization that owns the bucket",
+			Desc:       "The ID of the organization",
 			Persistent: persistent,
 		},
 		{
 			DestP:      &o.name,
 			Flag:       "org",
 			Short:      'o',
-			Desc:       "The name of the organization that owns the bucket",
+			Desc:       "The name of the organization",
 			Persistent: persistent,
 		},
 	}


### PR DESCRIPTION
closes: #16579

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
