### PR TITLE
fix: keep libraries up to date

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -20,6 +20,7 @@ lint: node_modules $(UISOURCES)
 	yarn lint
 
 test:
+	yarn install
 	yarn generate
 	yarn test
 


### PR DESCRIPTION
Closes #16464
Updates #16468

the problem seems to be caused by having a stale dev environment. this adds a yarn install before running the tests to ensure that all dependencies are up to date.