### PR TITLE
fix(tasks): use LatestCompleted if LatestScheduled is behind

### DIFF
--- a/task/backend/coordinator/coordinator.go
+++ b/task/backend/coordinator/coordinator.go
@@ -76,18 +76,18 @@ func NewSchedulableTask(task *influxdb.Task) (SchedulableTask, error) {
 	}
 	effCron := task.EffectiveCron()
 	ts := task.CreatedAt
-	if !task.LatestScheduled.IsZero() {
-		ts = task.LatestScheduled
-	} else if !task.LatestCompleted.IsZero() {
+	if task.LatestScheduled.IsZero() || task.LatestScheduled.Before(task.LatestCompleted) {
 		ts = task.LatestCompleted
+	} else if !task.LatestScheduled.IsZero() {
+		ts = task.LatestScheduled
 	}
+
 	var sch scheduler.Schedule
 	var err error
 	sch, ts, err = scheduler.NewSchedule(effCron, ts)
 	if err != nil {
 		return SchedulableTask{}, err
 	}
-
 	return SchedulableTask{Task: task, sch: sch, lsc: ts}, nil
 }
 


### PR DESCRIPTION
This PR introduces an improvement that allows for a situation where tasks continue to run and update the `LatestCompleted` date but fail to update the `LatestScheduled`. When a task is added to the scheduler, scheduling begins from the later of either `LatestScheduled` or `LatestCompleted`.

### Why

This situation was not anticipated whilst both the old and new scheduler existed as an option. Specifically, the old scheduler did not maintain the `LatestScheduled` field, so running it and then returning to the new scheduler could result in tasks rerunning.