### PR TITLE
fix: enabling prettier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
             set +e
             cd ui
             yarn install --frozen-lockfile
+            yarn prettier
           name: "Install Dependencies"
       - run: make ui_client
       - run:

--- a/ui/cypress/e2e/variables.test.ts
+++ b/ui/cypress/e2e/variables.test.ts
@@ -69,8 +69,12 @@ describe('Variables', () => {
 
     cy.getByTestID('resource-card').should('have.length', 2)
 
-    cy.getByTestID('context-delete-menu').first().click({force: true})
-    cy.getByTestID('context-delete-variable').first().click({force: true})
+    cy.getByTestID('context-delete-menu')
+      .first()
+      .click({force: true})
+    cy.getByTestID('context-delete-variable')
+      .first()
+      .click({force: true})
 
     cy.getByTestID('resource-card').should('have.length', 1)
   })


### PR DESCRIPTION
this turns prettier back on in the jstest target on circleci. should be the last step in getting CI back in order