### PR TITLE
fix(kv): use forward cursor in find all buckets

### DIFF
--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -273,6 +273,10 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 
 		if config.Direction == kv.CursorDescending {
 			iterate = b.descend
+			if len(seek) == 0 {
+				seek = b.btree.Max().(*item).key
+
+			}
 		}
 
 		iterate(seek, config, func(i btree.Item) bool {


### PR DESCRIPTION
Use the new forward cursor when finding all buckets in the bucket service.

This also fixes a bug we discovered while trying to use the few forward cursor. This bug was in the way the bolt implementation performed descending curse.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
