### PR TITLE
fix: clear variable editor on close

### DIFF
--- a/ui/src/variables/components/VariableFormContext.tsx
+++ b/ui/src/variables/components/VariableFormContext.tsx
@@ -67,9 +67,10 @@ type Props = ComponentProps & DispatchProps & StateProps
 class VariableFormContext extends PureComponent<Props> {
   render() {
     const props = {
-      onHideOverlay: this.handleHideOverlay,
       ...this.props,
+      onHideOverlay: this.handleHideOverlay,
     }
+
     return <VariableForm {...props} />
   }
 


### PR DESCRIPTION
Closes #16622

no idea how this one didn't show up earlier, but it's all about props not overriding when they needed to