### PR TITLE
fix: allow dashboard description editing

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -168,9 +168,9 @@ class DashboardCard extends PureComponent<Props> {
   }
 
   private handleUpdateDescription = (description: string) => {
-    const {onUpdateDashboard, params} = this.props
+    const {id, onUpdateDashboard} = this.props
 
-    onUpdateDashboard(params.dashboardID, {description})
+    onUpdateDashboard(id, {description})
   }
 
   private handleAddLabel = (label: Label) => {


### PR DESCRIPTION
Closes #16620

no idea how i missed that when i was in here the other day fixing the same thing for clone and export, but it was still expecting the dashboard id to come from the url instead of relying on the props