### PR TITLE
fix: ensure cells are done before mapping them

### DIFF
--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -15,8 +15,7 @@ import {fastMap} from 'src/utils/fast'
 import {LAYOUT_MARGIN, DASHBOARD_LAYOUT_ROW_HEIGHT} from 'src/shared/constants'
 
 // Types
-import {Cell} from 'src/types'
-import {TimeRange} from 'src/types'
+import {Cell, TimeRange, RemoteDataState} from 'src/types'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 

--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -66,7 +66,9 @@ class Cells extends Component<Props & WithRouterProps> {
   }
 
   private get cells(): Layout[] {
-    return this.props.cells.map(c => ({
+    return this.props.cells
+    .filter(c => c.status === RemoteDataState.Done)
+    .map(c => ({
       ...c,
       x: c.x,
       y: c.y,

--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -67,15 +67,15 @@ class Cells extends Component<Props & WithRouterProps> {
 
   private get cells(): Layout[] {
     return this.props.cells
-    .filter(c => c.status === RemoteDataState.Done)
-    .map(c => ({
-      ...c,
-      x: c.x,
-      y: c.y,
-      h: c.h,
-      w: c.w,
-      i: c.id,
-    }))
+      .filter(c => c.status === RemoteDataState.Done)
+      .map(c => ({
+        ...c,
+        x: c.x,
+        y: c.y,
+        h: c.h,
+        w: c.w,
+        i: c.id,
+      }))
   }
 
   private get isDashboard(): boolean {


### PR DESCRIPTION
Closes influxdata/honeybadger-errors#149
Closes influxdata/honeybadger-errors#148
Closes influxdata/honeybadger-errors#144

idk if this is the right place to put it, but it feels like you'd want to return all of the cells with the selector in case you wanted to display the loading state differently.