### PR TITLE
feat(pkger): add support for inspecting url paths to grab extension for pkger decoding

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -417,13 +418,16 @@ func (b *cmdPkgBuilder) readLines(r io.Reader) ([]string, error) {
 }
 
 func (b *cmdPkgBuilder) applyEncoding() pkger.Encoding {
+	urlBase := path.Ext(b.applyOpts.url)
 	ext := filepath.Ext(b.file)
 	switch {
-	case ext == ".json" || b.encoding == "json":
+	case ext == ".json" || b.encoding == "json" || urlBase == ".json":
 		return pkger.EncodingJSON
-	case ext == ".yml" || ext == ".yaml" || b.encoding == "yml" || b.encoding == "yaml":
+	case ext == ".yml" || ext == ".yaml" ||
+		b.encoding == "yml" || b.encoding == "yaml" ||
+		urlBase == ".yml" || urlBase == ".yaml":
 		return pkger.EncodingYAML
-	case ext == ".jsonnet" || b.encoding == "jsonnet":
+	case ext == ".jsonnet" || b.encoding == "jsonnet" || urlBase == ".jsonnet":
 		return pkger.EncodingJsonnet
 	default:
 		return pkger.EncodingSource

--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/go-chi/chi"
@@ -135,12 +136,14 @@ type PkgRemote struct {
 
 // Encoding returns the encoding type that corresponds to the given content type.
 func (p PkgRemote) Encoding() pkger.Encoding {
-	switch strings.ToLower(p.ContentType) {
-	case "json":
-		return pkger.EncodingJSON
-	case "jsonnet":
+	ct := strings.ToLower(p.ContentType)
+	urlBase := path.Ext(p.URL)
+	switch {
+	case ct == "jsonnet" || urlBase == ".jsonnet":
 		return pkger.EncodingJsonnet
-	case "yml", "yaml":
+	case ct == "json" || urlBase == ".json":
+		return pkger.EncodingJSON
+	case ct == "yml" || ct == "yaml" || urlBase == ".yml" || urlBase == ".yaml":
 		return pkger.EncodingYAML
 	default:
 		return pkger.EncodingSource

--- a/http/pkger_http_server_test.go
+++ b/http/pkger_http_server_test.go
@@ -104,8 +104,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
 						Remote: fluxTTP.PkgRemote{
-							URL:         "https://gist.githubusercontent.com/jsteenb2/3a3b2b5fcbd6179b2494c2b54aa2feb0/raw/540e65305a18bfca6123714e6c8868b1b465c7ef/bucket_pkg_json",
-							ContentType: "jsonnet",
+							URL: "https://gist.githubusercontent.com/jsteenb2/3a3b2b5fcbd6179b2494c2b54aa2feb0/raw/989d361db7a851a3c388eaed0b59dce7fca7fdf3/bucket_pkg.json",
 						},
 					},
 				},


### PR DESCRIPTION
little idea that spawned out of demo question

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass