### PR TITLE
fix(storage): check engine closed before collecting index metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 1. [16504](https://github.com/influxdata/influxdb/pull/16504): Add backup and restore
 1. [16522](https://github.com/influxdata/influxdb/pull/16522): Introduce resource logger to tasks, buckets and organizations
 
+### Bug Fixes
+1. [16656](https://github.com/influxdata/influxdb/pull/16656): Check engine closed before collecting index metrics
+
 ### UI Improvements
 
 1. [16575](https://github.com/influxdata/influxdb/pull/16575): Swap billingURL with checkoutURL


### PR DESCRIPTION
Helps influxdata/idpe#5720

It is possible to collect metrics after engine has closed. This checks for engine closed to prevent nil pointer exception.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass