### PR TITLE
fix: dont crash on malformed label data

### DIFF
--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -164,7 +164,11 @@ class InlineLabelsEditor extends Component<Props, State> {
     const {availableLabels} = this
     const {isPopoverVisible} = this.state
 
-    if (_.isEmpty(availableLabels) && !isPopoverVisible) {
+    if (_.isEmpty(availableLabels)) {
+      if (isPopoverVisible) {
+        return
+      }
+
       return this.setState({
         isPopoverVisible: true,
         selectedItemID: null,


### PR DESCRIPTION
Closes influxdata/honeybadger-errors#131

this broke when this.availableLabels[0] didn't exist because it didn't account for a list being empty AND the popover being open