### PR TITLE
refactor(query): let influxdb build against algo-w branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62
-	github.com/influxdata/flux v0.59.4
+	github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.59.4 h1:JOiYbPRsGQ1hfSq6xlIZBREhiNaM8ZlmpnzWpKOn9x8=
-github.com/influxdata/flux v0.59.4/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b h1:LrrT2b/2By1rwsKdIAiiMU5V4dtShVkL9yxT96WqIm0=
+github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.59.4
+	github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -286,8 +286,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.59.4 h1:JOiYbPRsGQ1hfSq6xlIZBREhiNaM8ZlmpnzWpKOn9x8=
-github.com/influxdata/flux v0.59.4/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b h1:LrrT2b/2By1rwsKdIAiiMU5V4dtShVkL9yxT96WqIm0=
+github.com/influxdata/flux v0.59.1-0.20200124223221-507c0dcfcf0b/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
@@ -734,8 +734,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652 h1:VKvJ/mQ4BgCjZUDggYFxTe0qv9jPMHsZPD4Xt91Y5H4=
-gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71 h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/query/stdlib/experimental/to.go
+++ b/query/stdlib/experimental/to.go
@@ -33,19 +33,8 @@ type ToOpSpec struct {
 }
 
 func init() {
-	toSignature := flux.FunctionSignature(
-		map[string]semantic.PolyType{
-			"bucket":   semantic.String,
-			"bucketID": semantic.String,
-			"org":      semantic.String,
-			"orgID":    semantic.String,
-			"host":     semantic.String,
-			"token":    semantic.String,
-		},
-		[]string{},
-	)
-
-	flux.ReplacePackageValue("experimental", "to", flux.FunctionValueWithSideEffect("to", createToOpSpec, toSignature))
+	toSignature := semantic.MustLookupBuiltinType("experimental", "to")
+	flux.ReplacePackageValue("experimental", "to", flux.MustValue(flux.FunctionValueWithSideEffect("to", createToOpSpec, toSignature)))
 	flux.RegisterOpSpec(ExperimentalToKind, func() flux.OperationSpec { return &ToOpSpec{} })
 	plan.RegisterProcedureSpecWithSideEffect(ExperimentalToKind, newToProcedure, ExperimentalToKind)
 	execute.RegisterTransformation(ExperimentalToKind, createToTransformation)
@@ -437,7 +426,7 @@ func (t *ToTransformation) writeTable(ctx context.Context, tbl flux.Table) error
 				}
 
 				var fields models.Fields
-				switch fieldVal.Type() {
+				switch fieldVal.Type().Nature() {
 				case semantic.Float:
 					fields = models.Fields{lao.Label: fieldVal.Float()}
 				case semantic.Int:

--- a/query/stdlib/influxdata/influxdb/from.go
+++ b/query/stdlib/influxdata/influxdb/from.go
@@ -19,16 +19,8 @@ type FromOpSpec struct {
 }
 
 func init() {
-	fromSignature := semantic.FunctionPolySignature{
-		Parameters: map[string]semantic.PolyType{
-			"bucket":   semantic.String,
-			"bucketID": semantic.String,
-		},
-		Required: nil,
-		Return:   flux.TableObjectType,
-	}
-
-	flux.ReplacePackageValue("influxdata/influxdb", influxdb.FromKind, flux.FunctionValue(FromKind, createFromOpSpec, fromSignature))
+	fromSignature := semantic.MustLookupBuiltinType("influxdata/influxdb", "from")
+	flux.ReplacePackageValue("influxdata/influxdb", influxdb.FromKind, flux.MustValue(flux.FunctionValue(FromKind, createFromOpSpec, fromSignature)))
 	flux.RegisterOpSpec(FromKind, newFromOp)
 	plan.RegisterProcedureSpec(FromKind, newFromProcedure, FromKind)
 }

--- a/query/stdlib/influxdata/influxdb/v1/databases.go
+++ b/query/stdlib/influxdata/influxdb/v1/databases.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
 	"github.com/influxdata/flux/values"
 	platform "github.com/influxdata/influxdb"
@@ -22,7 +23,8 @@ type DatabasesOpSpec struct {
 }
 
 func init() {
-	flux.ReplacePackageValue("influxdata/influxdb/v1", DatabasesKind, flux.FunctionValue(DatabasesKind, createDatabasesOpSpec, v1.DatabasesSignature))
+	databasesSignature := semantic.MustLookupBuiltinType("influxdata/influxdb/v1", DatabasesKind)
+	flux.ReplacePackageValue("influxdata/influxdb/v1", DatabasesKind, flux.MustValue(flux.FunctionValue(DatabasesKind, createDatabasesOpSpec, databasesSignature)))
 	flux.RegisterOpSpec(DatabasesKind, newDatabasesOp)
 	plan.RegisterProcedureSpec(DatabasesKind, newDatabasesProcedure, DatabasesKind)
 }

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -224,7 +224,7 @@ func FromScript(script string) (Options, error) {
 		return opt, ErrMissingRequiredTaskOption("task")
 	}
 	// check to make sure task is an object
-	if err := checkNature(task.PolyType().Nature(), semantic.Object); err != nil {
+	if err := checkNature(task.Type().Nature(), semantic.Object); err != nil {
 		return opt, err
 	}
 	optObject := task.Object()
@@ -237,7 +237,7 @@ func FromScript(script string) (Options, error) {
 		return opt, ErrMissingRequiredTaskOption("name")
 	}
 
-	if err := checkNature(nameVal.PolyType().Nature(), semantic.String); err != nil {
+	if err := checkNature(nameVal.Type().Nature(), semantic.String); err != nil {
 		return opt, err
 	}
 	opt.Name = nameVal.Str()
@@ -252,14 +252,14 @@ func FromScript(script string) (Options, error) {
 	}
 
 	if cronOK {
-		if err := checkNature(crVal.PolyType().Nature(), semantic.String); err != nil {
+		if err := checkNature(crVal.Type().Nature(), semantic.String); err != nil {
 			return opt, err
 		}
 		opt.Cron = crVal.Str()
 	}
 
 	if everyOK {
-		if err := checkNature(everyVal.PolyType().Nature(), semantic.Duration); err != nil {
+		if err := checkNature(everyVal.Type().Nature(), semantic.Duration); err != nil {
 			return opt, err
 		}
 		dur, ok := durTypes["every"]
@@ -280,7 +280,7 @@ func FromScript(script string) (Options, error) {
 	}
 
 	if offsetVal, ok := optObject.Get(optOffset); ok {
-		if err := checkNature(offsetVal.PolyType().Nature(), semantic.Duration); err != nil {
+		if err := checkNature(offsetVal.Type().Nature(), semantic.Duration); err != nil {
 			return opt, err
 		}
 		dur, ok := durTypes["offset"]
@@ -300,14 +300,14 @@ func FromScript(script string) (Options, error) {
 	}
 
 	if concurrencyVal, ok := optObject.Get(optConcurrency); ok {
-		if err := checkNature(concurrencyVal.PolyType().Nature(), semantic.Int); err != nil {
+		if err := checkNature(concurrencyVal.Type().Nature(), semantic.Int); err != nil {
 			return opt, err
 		}
 		opt.Concurrency = pointer.Int64(concurrencyVal.Int())
 	}
 
 	if retryVal, ok := optObject.Get(optRetry); ok {
-		if err := checkNature(retryVal.PolyType().Nature(), semantic.Int); err != nil {
+		if err := checkNature(retryVal.Type().Nature(), semantic.Int); err != nil {
 			return opt, err
 		}
 		opt.Retry = pointer.Int64(retryVal.Int())


### PR DESCRIPTION
This PR merges commits into `feat/use-algo-w` which is currently the same as the latest master.

1. Update `go.mod` to point at the latest commit on the `flux` `feat/use-algo-w` branch
2. Updates function registration to use new lookup method
3. Updates usages of `Type` methods