### PR TITLE
chore(influx): fixup flag setting in influx tests to use args

### DIFF
--- a/cmd/influx/bucket_test.go
+++ b/cmd/influx/bucket_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
-	"io/ioutil"
 	"time"
 
 	"github.com/influxdata/influxdb"
@@ -114,7 +114,7 @@ func TestCmdBucket(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 
 				cmd := cmdFn(tt.expectedBucket)
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -162,7 +162,7 @@ func TestCmdBucket(t *testing.T) {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expectedID)
 				idFlag := tt.flag + tt.expectedID.String()
-				cmd.LocalFlags().Parse([]string{idFlag})
+				cmd.SetArgs([]string{idFlag})
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -187,6 +187,7 @@ func TestCmdBucket(t *testing.T) {
 			{
 				name:     "org id",
 				flags:    []string{"--org-id=" + influxdb.ID(3).String()},
+				envVars:  envVarsZeroMap,
 				expected: called{orgID: 3},
 			},
 			{
@@ -195,6 +196,7 @@ func TestCmdBucket(t *testing.T) {
 					"--id=" + influxdb.ID(2).String(),
 					"--org-id=" + influxdb.ID(3).String(),
 				},
+				envVars: envVarsZeroMap,
 				expected: called{
 					id:    2,
 					orgID: 3,
@@ -203,11 +205,13 @@ func TestCmdBucket(t *testing.T) {
 			{
 				name:     "org",
 				flags:    []string{"--org=rg"},
+				envVars:  envVarsZeroMap,
 				expected: called{org: "rg"},
 			},
 			{
 				name:     "name",
 				flags:    []string{"--org=rg", "--name=name1"},
+				envVars:  envVarsZeroMap,
 				expected: called{org: "rg", name: "name1"},
 			},
 			{
@@ -217,6 +221,7 @@ func TestCmdBucket(t *testing.T) {
 					"-n=name1",
 					"-i=" + influxdb.ID(1).String(),
 				},
+				envVars:  envVarsZeroMap,
 				expected: called{org: "rg", name: "name1", id: 1},
 			},
 			{
@@ -231,6 +236,7 @@ func TestCmdBucket(t *testing.T) {
 			{
 				name: "env vars 2",
 				envVars: map[string]string{
+					"INFLUX_ORG":         "",
 					"INFLUX_ORG_ID":      influxdb.ID(2).String(),
 					"INFLUX_BUCKET_NAME": "name1",
 				},
@@ -270,7 +276,7 @@ func TestCmdBucket(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 
 				cmd, calls := cmdFn()
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)
@@ -364,7 +370,7 @@ func TestCmdBucket(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 
 				cmd := cmdFn(tt.expected)
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 

--- a/cmd/influx/organization_test.go
+++ b/cmd/influx/organization_test.go
@@ -72,7 +72,7 @@ func TestCmdOrg(t *testing.T) {
 		for _, tt := range tests {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expected)
-				cmd.Flags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -119,7 +119,7 @@ func TestCmdOrg(t *testing.T) {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expectedID)
 				idFlag := tt.flag + tt.expectedID.String()
-				cmd.Flags().Parse([]string{idFlag})
+				cmd.SetArgs([]string{idFlag})
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -142,11 +142,13 @@ func TestCmdOrg(t *testing.T) {
 			{
 				name:     "org id",
 				flags:    []string{"--id=" + influxdb.ID(3).String()},
+				envVars:  envVarsZeroMap,
 				expected: called{id: 3},
 			},
 			{
 				name:     "name",
 				flags:    []string{"--name=name1"},
+				envVars:  envVarsZeroMap,
 				expected: called{name: "name1"},
 			},
 			{
@@ -155,6 +157,7 @@ func TestCmdOrg(t *testing.T) {
 					"-n=name1",
 					"-i=" + influxdb.ID(1).String(),
 				},
+				envVars:  envVarsZeroMap,
 				expected: called{name: "name1", id: 1},
 			},
 			{
@@ -192,7 +195,7 @@ func TestCmdOrg(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 
 				cmd, calls := cmdFn()
-				cmd.Flags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)
@@ -279,7 +282,7 @@ func TestCmdOrg(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 
 				cmd := cmdFn(tt.expected)
-				cmd.Flags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -309,7 +312,7 @@ func TestCmdOrg(t *testing.T) {
 					defer addEnvVars(t, tt.envVars)()
 
 					cmd, calls := cmdFn()
-					cmd.Flags().Parse(tt.memberFlags)
+					cmd.SetArgs(tt.memberFlags)
 
 					require.NoError(t, cmd.Execute())
 					assert.Equal(t, tt.expected, *calls)
@@ -324,26 +327,33 @@ func TestCmdOrg(t *testing.T) {
 				{
 					name:        "org id",
 					memberFlags: []string{"--id=" + influxdb.ID(3).String()},
+					envVars:     envVarsZeroMap,
 					expected:    called{id: 3},
 				},
 				{
 					name:        "org id short",
 					memberFlags: []string{"-i=" + influxdb.ID(3).String()},
+					envVars:     envVarsZeroMap,
 					expected:    called{id: 3},
 				},
 				{
-					name:     "org id env var",
-					envVars:  map[string]string{"INFLUX_ORG_ID": influxdb.ID(3).String()},
+					name: "org id env var",
+					envVars: map[string]string{
+						"INFLUX_ORG":    "",
+						"INFLUX_ORG_ID": influxdb.ID(3).String(),
+					},
 					expected: called{id: 3},
 				},
 				{
 					name:        "name",
 					memberFlags: []string{"--name=name1"},
+					envVars:     envVarsZeroMap,
 					expected:    called{name: "name1"},
 				},
 				{
 					name:        "name short",
 					memberFlags: []string{"-n=name1"},
+					envVars:     envVarsZeroMap,
 					expected:    called{name: "name1"},
 				},
 				{
@@ -407,6 +417,7 @@ func TestCmdOrg(t *testing.T) {
 						"--id=" + influxdb.ID(3).String(),
 						"--member=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{id: 3, memberID: 4},
 				},
 				{
@@ -415,6 +426,7 @@ func TestCmdOrg(t *testing.T) {
 						"-i=" + influxdb.ID(3).String(),
 						"-m=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{id: 3, memberID: 4},
 				},
 				{
@@ -423,6 +435,7 @@ func TestCmdOrg(t *testing.T) {
 						"--name=name1",
 						"--member=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{name: "name1", memberID: 4},
 				},
 				{
@@ -431,6 +444,7 @@ func TestCmdOrg(t *testing.T) {
 						"-n=name1",
 						"-m=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{name: "name1", memberID: 4},
 				},
 			}
@@ -470,6 +484,7 @@ func TestCmdOrg(t *testing.T) {
 						"--id=" + influxdb.ID(3).String(),
 						"--member=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{id: 3, memberID: 4},
 				},
 				{
@@ -478,6 +493,7 @@ func TestCmdOrg(t *testing.T) {
 						"-i=" + influxdb.ID(3).String(),
 						"-m=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{id: 3, memberID: 4},
 				},
 				{
@@ -486,6 +502,7 @@ func TestCmdOrg(t *testing.T) {
 						"--name=name1",
 						"--member=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{name: "name1", memberID: 4},
 				},
 				{
@@ -494,6 +511,7 @@ func TestCmdOrg(t *testing.T) {
 						"-n=name1",
 						"-m=" + influxdb.ID(4).String(),
 					},
+					envVars:  envVarsZeroMap,
 					expected: called{name: "name1", memberID: 4},
 				},
 			}
@@ -501,4 +519,9 @@ func TestCmdOrg(t *testing.T) {
 			testMemberFn(t, cmdFn, addTests...)
 		})
 	})
+}
+
+var envVarsZeroMap = map[string]string{
+	"INFLUX_ORG_ID": "",
+	"INFLUX_ORG":    "",
 }

--- a/cmd/influx/user_test.go
+++ b/cmd/influx/user_test.go
@@ -92,6 +92,7 @@ func TestCmdUser(t *testing.T) {
 					"--password=pass1",
 				},
 				envVars: map[string]string{
+					"INFLUX_ORG":    "",
 					"INFLUX_ORG_ID": influxdb.ID(1).String(),
 				},
 				expected: userResult{
@@ -141,7 +142,7 @@ func TestCmdUser(t *testing.T) {
 			fn := func(t *testing.T) {
 				defer addEnvVars(t, tt.envVars)()
 				cmd := cmdFn(tt.expected)
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				err := cmd.Execute()
 				require.NoError(t, err)
 			}
@@ -190,7 +191,7 @@ func TestCmdUser(t *testing.T) {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expectedID)
 				idFlag := tt.flag + tt.expectedID.String()
-				cmd.LocalFlags().Parse([]string{idFlag})
+				cmd.SetArgs([]string{idFlag})
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -256,7 +257,7 @@ func TestCmdUser(t *testing.T) {
 		for _, tt := range tests {
 			fn := func(t *testing.T) {
 				cmd, calls := cmdFn()
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)
@@ -325,7 +326,7 @@ func TestCmdUser(t *testing.T) {
 		for _, tt := range tests {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expected)
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 
@@ -389,7 +390,7 @@ func TestCmdUser(t *testing.T) {
 		for _, tt := range tests {
 			fn := func(t *testing.T) {
 				cmd := cmdFn(tt.expected)
-				cmd.LocalFlags().Parse(tt.flags)
+				cmd.SetArgs(tt.flags)
 				require.NoError(t, cmd.Execute())
 			}
 


### PR DESCRIPTION
this is inspired by: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cmd_test.go#L73

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass