### PR TITLE
chore(pkger): consolidate pkger http server into pkger

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -501,7 +501,7 @@ func newPkgerSVC() (pkger.SVC, influxdb.OrganizationService, error) {
 		Client: httpClient,
 	}
 
-	return &ihttp.PkgerService{Client: httpClient}, orgSvc, nil
+	return &pkger.HTTPRemoteService{Client: httpClient}, orgSvc, nil
 }
 
 func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/influxdb/kit/prom"
 	"github.com/influxdata/influxdb/kit/signals"
 	"github.com/influxdata/influxdb/kit/tracing"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	influxlogger "github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/nats"
@@ -766,7 +767,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	m.apibackend = &http.APIBackend{
 		AssetsPath:           m.assetsPath,
-		HTTPErrorHandler:     http.ErrorHandler(0),
+		HTTPErrorHandler:     kithttp.ErrorHandler(0),
 		Logger:               m.log,
 		SessionRenewDisabled: m.sessionRenewDisabled,
 		NewBucketService:     source.NewBucketService,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -836,10 +836,10 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		pkgSVC = pkger.MWLogging(pkgerLogger)(pkgSVC)
 	}
 
-	var pkgHTTPServer *http.HandlerPkg
+	var pkgHTTPServer *pkger.HTTPServer
 	{
 		pkgServerLogger := m.log.With(zap.String("handler", "pkger"))
-		pkgHTTPServer = http.NewHandlerPkg(pkgServerLogger, m.apibackend.HTTPErrorHandler, pkgSVC)
+		pkgHTTPServer = pkger.NewHTTPServer(pkgServerLogger, m.apibackend.HTTPErrorHandler, pkgSVC)
 	}
 
 	{

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -360,7 +360,7 @@ func (tl *TestLauncher) NotificationRuleService() platform.NotificationRuleStore
 }
 
 func (tl *TestLauncher) PkgerService(tb testing.TB) pkger.SVC {
-	return &http.PkgerService{Client: tl.HTTPClient(tb)}
+	return &pkger.HTTPRemoteService{Client: tl.HTTPClient(tb)}
 }
 
 func (tl *TestLauncher) TaskServiceKV() platform.TaskService {

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/http/metric"
 	"github.com/influxdata/influxdb/kit/prom"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,20 +100,12 @@ func (b *APIBackend) PrometheusCollectors() []prometheus.Collector {
 	return cs
 }
 
-// ResourceHandler is an HTTP handler for a resource. The prefix
-// describes the url path prefix that relates to the handler
-// endpoints.
-type ResourceHandler interface {
-	Prefix() string
-	http.Handler
-}
-
 // APIHandlerOptFn is a functional input param to set parameters on
 // the APIHandler.
 type APIHandlerOptFn func(chi.Router)
 
 // WithResourceHandler registers a resource handler on the APIHandler.
-func WithResourceHandler(resHandler ResourceHandler) APIHandlerOptFn {
+func WithResourceHandler(resHandler kithttp.ResourceHandler) APIHandlerOptFn {
 	return func(h chi.Router) {
 		h.Mount(resHandler.Prefix(), resHandler)
 	}

--- a/http/api_handler_test.go
+++ b/http/api_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -50,7 +51,7 @@ func TestAPIHandler_NotFound(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			b := &APIBackend{
-				HTTPErrorHandler: ErrorHandler(0),
+				HTTPErrorHandler: kithttp.ErrorHandler(0),
 				Logger:           zaptest.NewLogger(t),
 			}
 

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -14,6 +14,7 @@ import (
 	platform "github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -331,7 +332,7 @@ func TestService_handleGetAuthorizations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend(t)
-			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
+			authorizationBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -516,7 +517,7 @@ func TestService_handleGetAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend(t)
-			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
+			authorizationBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -696,7 +697,7 @@ func TestService_handlePostAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend(t)
-			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
+			authorizationBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -810,7 +811,7 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend(t)
-			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
+			authorizationBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -904,7 +905,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 	}
 
 	authorizationBackend := NewMockAuthorizationBackend(t)
-	authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
+	authorizationBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	authorizationBackend.AuthorizationService = svc
 	authorizationBackend.UserService = mus
 	authorizationBackend.OrganizationService = svc
@@ -921,7 +922,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 	}
 
 	authZ := NewAuthorizationHandler(zaptest.NewLogger(t), authorizationBackend)
-	authN := NewAuthenticationHandler(zaptest.NewLogger(t), ErrorHandler(0))
+	authN := NewAuthenticationHandler(zaptest.NewLogger(t), kithttp.ErrorHandler(0))
 	authN.AuthorizationService = svc
 	authN.Handler = authZ
 	authN.UserService = mus

--- a/http/authentication_test.go
+++ b/http/authentication_test.go
@@ -13,6 +13,7 @@ import (
 	platform "github.com/influxdata/influxdb"
 	platformhttp "github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/jsonweb"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	"go.uber.org/zap/zaptest"
 )
@@ -209,7 +210,7 @@ func TestAuthenticationHandler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenticationHandler(zaptest.NewLogger(t), platformhttp.ErrorHandler(0))
+			h := platformhttp.NewAuthenticationHandler(zaptest.NewLogger(t), kithttp.ErrorHandler(0))
 			h.AuthorizationService = tt.fields.AuthorizationService
 			h.SessionService = tt.fields.SessionService
 			h.UserService = &mock.UserService{
@@ -376,7 +377,7 @@ func TestAuthenticationHandler_NoAuthRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenticationHandler(zaptest.NewLogger(t), platformhttp.ErrorHandler(0))
+			h := platformhttp.NewAuthenticationHandler(zaptest.NewLogger(t), kithttp.ErrorHandler(0))
 			h.AuthorizationService = mock.NewAuthorizationService()
 			h.SessionService = mock.NewSessionService()
 			h.Handler = handler

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/pkg/httpc"
@@ -324,7 +325,7 @@ func TestService_handleGetBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend(t)
-			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
+			bucketBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)
 
@@ -463,7 +464,7 @@ func TestService_handlePostBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend(t)
-			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
+			bucketBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			bucketBackend.OrganizationService = tt.fields.OrganizationService
 			h := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)
@@ -562,7 +563,7 @@ func TestService_handleDeleteBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend(t)
-			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
+			bucketBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)
 
@@ -929,7 +930,7 @@ func TestService_handlePatchBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend(t)
-			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
+			bucketBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)
 
@@ -1198,7 +1199,7 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (platform.B
 	}
 
 	bucketBackend := NewMockBucketBackend(t)
-	bucketBackend.HTTPErrorHandler = ErrorHandler(0)
+	bucketBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	bucketBackend.BucketService = svc
 	bucketBackend.OrganizationService = svc
 	handler := NewBucketHandler(zaptest.NewLogger(t), bucketBackend)

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/httprouter"
 	"github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/notification"
 	"github.com/influxdata/influxdb/notification/check"
@@ -415,7 +416,7 @@ func TestService_handleGetCheckQuery(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend(t)
-			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.TaskService = &mock.TaskService{
 				FindTaskByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
@@ -555,7 +556,7 @@ func TestService_handleGetCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend(t)
-			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.TaskService = &mock.TaskService{
 				FindTaskByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
@@ -824,7 +825,7 @@ func TestService_handleDeleteCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend(t)
-			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.TaskService = &mock.TaskService{
 				FindTaskByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
@@ -989,7 +990,7 @@ func TestService_handlePatchCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend(t)
-			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.TaskService = &mock.TaskService{
 				FindTaskByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
@@ -1182,7 +1183,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend(t)
-			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.TaskService = &mock.TaskService{
 				FindTaskByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/httprouter"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -332,7 +333,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.LabelService = tt.fields.LabelService
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
@@ -747,7 +748,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1014,7 +1015,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1110,7 +1111,7 @@ func TestService_handleDeleteDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1294,7 +1295,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1475,7 +1476,7 @@ func TestService_handlePostDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 			buf := new(bytes.Buffer)
@@ -1559,7 +1560,7 @@ func TestService_handleDeleteDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1674,7 +1675,7 @@ func TestService_handlePatchDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 
@@ -1768,7 +1769,7 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 	}
 
 	dashboardBackend := NewMockDashboardBackend(t)
-	dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+	dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	dashboardBackend.DashboardService = svc
 	h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 	server := httptest.NewServer(h)
@@ -1850,7 +1851,7 @@ func TestService_handlePostDashboardLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend(t)
-			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
+			dashboardBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			dashboardBackend.LabelService = tt.fields.LabelService
 			h := NewDashboardHandler(zaptest.NewLogger(t), dashboardBackend)
 

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	influxtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
@@ -338,7 +339,7 @@ func TestDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			deleteBackend := NewMockDeleteBackend(t)
-			deleteBackend.HTTPErrorHandler = ErrorHandler(0)
+			deleteBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			deleteBackend.DeleteService = tt.fields.DeleteService
 			deleteBackend.OrganizationService = tt.fields.OrganizationService
 			deleteBackend.BucketService = tt.fields.BucketService

--- a/http/document_test.go
+++ b/http/document_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/httprouter"
 	"github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	influxtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
@@ -291,7 +292,7 @@ func TestService_handleDeleteDocumentLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend(t)
-			documentBackend.HTTPErrorHandler = ErrorHandler(0)
+			documentBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -477,7 +478,7 @@ func TestService_handlePostDocumentLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend(t)
-			documentBackend.HTTPErrorHandler = ErrorHandler(0)
+			documentBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -582,7 +583,7 @@ func TestService_handleGetDocumentLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend(t)
-			documentBackend.HTTPErrorHandler = ErrorHandler(0)
+			documentBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -706,7 +707,7 @@ func TestService_handleGetDocuments(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend(t)
-			documentBackend.HTTPErrorHandler = ErrorHandler(0)
+			documentBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			h := NewDocumentHandler(documentBackend)
 			r := httptest.NewRequest("GET", "http://any.url", nil)
@@ -906,7 +907,7 @@ func TestService_handlePostDocuments(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend(t)
-			documentBackend.HTTPErrorHandler = ErrorHandler(0)
+			documentBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
-	"fmt"
 	"io"
 	"net/http/httptest"
 	"testing"
@@ -12,53 +11,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/pkg/errors"
 )
-
-func TestEncodeError(t *testing.T) {
-	ctx := context.TODO()
-
-	w := httptest.NewRecorder()
-
-	http.ErrorHandler(0).HandleHTTPError(ctx, nil, w)
-
-	if w.Code != 200 {
-		t.Errorf("expected status code 200, got: %d", w.Code)
-	}
-}
-
-func TestEncodeErrorWithError(t *testing.T) {
-	ctx := context.TODO()
-	err := &influxdb.Error{
-		Code: influxdb.EInternal,
-		Msg:  "an error occurred",
-		Err:  fmt.Errorf("there's an error here, be aware"),
-	}
-
-	w := httptest.NewRecorder()
-
-	http.ErrorHandler(0).HandleHTTPError(ctx, err, w)
-
-	if w.Code != 500 {
-		t.Errorf("expected status code 500, got: %d", w.Code)
-	}
-
-	errHeader := w.Header().Get("X-Platform-Error-Code")
-	if errHeader != influxdb.EInternal {
-		t.Errorf("expected X-Platform-Error-Code: %s, got: %s", influxdb.EInternal, errHeader)
-	}
-
-	// The http handler will flatten the message and it will not
-	// have an error property, so reading the serialization results
-	// in a different error.
-	pe := http.CheckError(w.Result()).(*influxdb.Error)
-	if want, got := influxdb.EInternal, pe.Code; want != got {
-		t.Errorf("unexpected code -want/+got:\n\t- %q\n\t+ %q", want, got)
-	}
-	if want, got := "an error occurred: there's an error here, be aware", pe.Msg; want != got {
-		t.Errorf("unexpected message -want/+got:\n\t- %q\n\t+ %q", want, got)
-	}
-}
 
 func TestCheckError(t *testing.T) {
 	for _, tt := range []struct {
@@ -69,7 +24,7 @@ func TestCheckError(t *testing.T) {
 		{
 			name: "platform error",
 			write: func(w *httptest.ResponseRecorder) {
-				h := http.ErrorHandler(0)
+				h := kithttp.ErrorHandler(0)
 				err := &influxdb.Error{
 					Msg:  "expected",
 					Code: influxdb.EInvalid,

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/httprouter"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -111,7 +112,7 @@ func TestService_handleGetLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, ErrorHandler(0))
+			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, kithttp.ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -219,7 +220,7 @@ func TestService_handleGetLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, ErrorHandler(0))
+			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, kithttp.ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -314,7 +315,7 @@ func TestService_handlePostLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, ErrorHandler(0))
+			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, kithttp.ErrorHandler(0))
 
 			l, err := json.Marshal(tt.args.label)
 			if err != nil {
@@ -405,7 +406,7 @@ func TestService_handleDeleteLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, ErrorHandler(0))
+			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, kithttp.ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -544,7 +545,7 @@ func TestService_handlePatchLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, ErrorHandler(0))
+			h := NewLabelHandler(zaptest.NewLogger(t), tt.fields.LabelService, kithttp.ErrorHandler(0))
 
 			upd := platform.LabelUpdate{}
 			if len(tt.args.properties) > 0 {
@@ -614,7 +615,7 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 		}
 	}
 
-	handler := NewLabelHandler(zaptest.NewLogger(t), svc, ErrorHandler(0))
+	handler := NewLabelHandler(zaptest.NewLogger(t), svc, kithttp.ErrorHandler(0))
 	server := httptest.NewServer(handler)
 	client := LabelService{
 		Client: mustNewHTTPClient(t, server.URL, ""),

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -27,13 +27,13 @@ func LoggingMW(log *zap.Logger) kithttp.Middleware {
 
 			defer func(start time.Time) {
 				errField := zap.Skip()
-				if errStr := w.Header().Get(PlatformErrorCodeHeader); errStr != "" {
+				if errStr := w.Header().Get(kithttp.PlatformErrorCodeHeader); errStr != "" {
 					errField = zap.Error(errors.New(errStr))
 				}
 
 				errReferenceField := zap.Skip()
-				if errReference := w.Header().Get(PlatformErrorCodeHeader); errReference != "" {
-					errReferenceField = zap.String("error_code", PlatformErrorCodeHeader)
+				if errReference := w.Header().Get(kithttp.PlatformErrorCodeHeader); errReference != "" {
+					errReferenceField = zap.String("error_code", kithttp.PlatformErrorCodeHeader)
 				}
 
 				fields := []zap.Field{
@@ -125,13 +125,14 @@ func ignoreMethod(ignoredMethods ...string) isValidMethodFn {
 	}
 }
 
+// TODO(@jsteenb2): make this a stronger type that handlers can register routes that should not be logged.
 var blacklistEndpoints = map[string]isValidMethodFn{
 	prefixSignIn:                     ignoreMethod(),
 	prefixSignOut:                    ignoreMethod(),
 	prefixMe:                         ignoreMethod(),
 	mePasswordPath:                   ignoreMethod(),
 	usersPasswordPath:                ignoreMethod(),
-	prefixPackages + "/apply":        ignoreMethod(),
+	"/api/v2/packages/apply":         ignoreMethod(),
 	prefixWrite:                      ignoreMethod("POST"),
 	organizationsIDSecretsPath:       ignoreMethod("PATCH"),
 	organizationsIDSecretsDeletePath: ignoreMethod("POST"),

--- a/http/notification_endpoint_test.go
+++ b/http/notification_endpoint_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/notification/endpoint"
@@ -28,7 +29,7 @@ import (
 func NewMockNotificationEndpointBackend(t *testing.T) *NotificationEndpointBackend {
 	return &NotificationEndpointBackend{
 		log:                         zaptest.NewLogger(t),
-		HTTPErrorHandler:            ErrorHandler(0),
+		HTTPErrorHandler:            kithttp.ErrorHandler(0),
 		NotificationEndpointService: &mock.NotificationEndpointService{},
 		UserResourceMappingService:  mock.NewUserResourceMappingService(),
 		LabelService:                mock.NewLabelService(),
@@ -357,7 +358,7 @@ func TestService_handleGetNotificationEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notificationEndpointBackend := NewMockNotificationEndpointBackend(t)
-			notificationEndpointBackend.HTTPErrorHandler = ErrorHandler(0)
+			notificationEndpointBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			notificationEndpointBackend.NotificationEndpointService = tt.fields.NotificationEndpointService
 			h := NewNotificationEndpointHandler(zaptest.NewLogger(t), notificationEndpointBackend)
 
@@ -576,7 +577,7 @@ func TestService_handleDeleteNotificationEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notificationEndpointBackend := NewMockNotificationEndpointBackend(t)
-			notificationEndpointBackend.HTTPErrorHandler = ErrorHandler(0)
+			notificationEndpointBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			notificationEndpointBackend.NotificationEndpointService = tt.fields.NotificationEndpointService
 
 			testttp.
@@ -697,7 +698,7 @@ func TestService_handlePatchNotificationEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notificationEndpointBackend := NewMockNotificationEndpointBackend(t)
-			notificationEndpointBackend.HTTPErrorHandler = ErrorHandler(0)
+			notificationEndpointBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			notificationEndpointBackend.NotificationEndpointService = tt.fields.NotificationEndpointService
 			h := NewNotificationEndpointHandler(zaptest.NewLogger(t), notificationEndpointBackend)
 
@@ -848,7 +849,7 @@ func TestService_handleUpdateNotificationEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notificationEndpointBackend := NewMockNotificationEndpointBackend(t)
-			notificationEndpointBackend.HTTPErrorHandler = ErrorHandler(0)
+			notificationEndpointBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			notificationEndpointBackend.NotificationEndpointService = tt.fields.NotificationEndpointService
 
 			resp := testttp.

--- a/http/onboarding_test.go
+++ b/http/onboarding_test.go
@@ -7,6 +7,7 @@ import (
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -38,7 +39,7 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	}
 
 	setupBackend := NewMockSetupBackend(t)
-	setupBackend.HTTPErrorHandler = ErrorHandler(0)
+	setupBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	setupBackend.OnboardingService = svc
 	handler := NewSetupHandler(zaptest.NewLogger(t), setupBackend)
 	server := httptest.NewServer(handler)

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -12,6 +12,7 @@ import (
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -54,7 +55,7 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 	}
 
 	orgBackend := NewMockOrgBackend(t)
-	orgBackend.HTTPErrorHandler = ErrorHandler(0)
+	orgBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	orgBackend.OrganizationService = svc
 	handler := NewOrgHandler(zaptest.NewLogger(t), orgBackend)
 	server := httptest.NewServer(handler)
@@ -181,7 +182,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend(t)
-			orgBackend.HTTPErrorHandler = ErrorHandler(0)
+			orgBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(zaptest.NewLogger(t), orgBackend)
 
@@ -257,7 +258,7 @@ func TestSecretService_handlePatchSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend(t)
-			orgBackend.HTTPErrorHandler = ErrorHandler(0)
+			orgBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(zaptest.NewLogger(t), orgBackend)
 
@@ -339,7 +340,7 @@ func TestSecretService_handleDeleteSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend(t)
-			orgBackend.HTTPErrorHandler = ErrorHandler(0)
+			orgBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(zaptest.NewLogger(t), orgBackend)
 

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/influxdata/influxdb/http/metric"
 	"github.com/influxdata/influxdb/kit/check"
 	tracetesting "github.com/influxdata/influxdb/kit/tracing/testing"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	influxmock "github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/mock"
@@ -100,7 +101,7 @@ func TestFluxService_Query(t *testing.T) {
 				if reqID := r.URL.Query().Get(OrgID); reqID == "" {
 					if name := r.URL.Query().Get(Org); name == "" {
 						// Request must have org or orgID.
-						ErrorHandler(0).HandleHTTPError(context.TODO(), influxdb.ErrInvalidOrgFilter, w)
+						kithttp.ErrorHandler(0).HandleHTTPError(context.TODO(), influxdb.ErrInvalidOrgFilter, w)
 						return
 					}
 				}
@@ -258,7 +259,7 @@ func TestFluxHandler_postFluxAST(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &FluxHandler{
-				HTTPErrorHandler: ErrorHandler(0),
+				HTTPErrorHandler: kithttp.ErrorHandler(0),
 			}
 			h.postFluxAST(tt.w, tt.r)
 			if got := tt.w.Body.String(); got != tt.want {
@@ -325,7 +326,7 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 
 	orgSVC := newInMemKVSVC(t)
 	b := &FluxBackend{
-		HTTPErrorHandler:    ErrorHandler(0),
+		HTTPErrorHandler:    kithttp.ErrorHandler(0),
 		log:                 zaptest.NewLogger(t),
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: orgSVC,
@@ -491,7 +492,7 @@ func TestFluxService_Query_gzip(t *testing.T) {
 	}
 
 	fluxBackend := &FluxBackend{
-		HTTPErrorHandler:    ErrorHandler(0),
+		HTTPErrorHandler:    kithttp.ErrorHandler(0),
 		log:                 zaptest.NewLogger(t),
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: orgService,
@@ -503,7 +504,7 @@ func TestFluxService_Query_gzip(t *testing.T) {
 	// fluxHandling expects authorization to be on the request context.
 	// AuthenticationHandler extracts the token from headers and places
 	// the auth on context.
-	auth := NewAuthenticationHandler(zaptest.NewLogger(t), ErrorHandler(0))
+	auth := NewAuthenticationHandler(zaptest.NewLogger(t), kithttp.ErrorHandler(0))
 	auth.AuthorizationService = authService
 	auth.Handler = fluxHandler
 	auth.UserService = &influxmock.UserService{
@@ -627,7 +628,7 @@ func benchmarkQuery(b *testing.B, disableCompression bool) {
 	}
 
 	fluxBackend := &FluxBackend{
-		HTTPErrorHandler:    ErrorHandler(0),
+		HTTPErrorHandler:    kithttp.ErrorHandler(0),
 		log:                 zaptest.NewLogger(b),
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: orgService,
@@ -639,7 +640,7 @@ func benchmarkQuery(b *testing.B, disableCompression bool) {
 	// fluxHandling expects authorization to be on the request context.
 	// AuthenticationHandler extracts the token from headers and places
 	// the auth on context.
-	auth := NewAuthenticationHandler(zaptest.NewLogger(b), ErrorHandler(0))
+	auth := NewAuthenticationHandler(zaptest.NewLogger(b), kithttp.ErrorHandler(0))
 	auth.AuthorizationService = authService
 	auth.Handler = fluxHandler
 

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -82,7 +83,7 @@ func TestRouter_NotFound(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router := NewRouter(ErrorHandler(0))
+			router := NewRouter(kithttp.ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)
@@ -189,7 +190,7 @@ func TestRouter_Panic(t *testing.T) {
 			tw := newTestLogWriter(t)
 			panicLogger = zaptest.NewLogger(tw)
 
-			router := NewRouter(ErrorHandler(0))
+			router := NewRouter(kithttp.ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)
@@ -288,7 +289,7 @@ func TestRouter_MethodNotAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router := NewRouter(ErrorHandler(0))
+			router := NewRouter(kithttp.ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb"
 	platcontext "github.com/influxdata/influxdb/context"
 	httpMock "github.com/influxdata/influxdb/http/mock"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
@@ -205,7 +206,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend(t)
-			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+			scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -342,7 +343,7 @@ func TestService_handleGetScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend(t)
-			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+			scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -450,7 +451,7 @@ func TestService_handleDeleteScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend(t)
-			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+			scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.Service
 			h := NewScraperHandler(zaptest.NewLogger(t), scraperBackend)
 
@@ -581,7 +582,7 @@ func TestService_handlePostScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend(t)
-			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+			scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -759,7 +760,7 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend(t)
-			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+			scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -835,7 +836,7 @@ func initScraperService(f platformtesting.TargetFields, t *testing.T) (influxdb.
 	}
 
 	scraperBackend := NewMockScraperBackend(t)
-	scraperBackend.HTTPErrorHandler = ErrorHandler(0)
+	scraperBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	scraperBackend.ScraperStorageService = svc
 	scraperBackend.OrganizationService = svc
 	scraperBackend.BucketService = &mock.BucketService{

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/httprouter"
 	platform "github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	_ "github.com/influxdata/influxdb/query/builtin"
 	"github.com/influxdata/influxdb/task/backend"
@@ -392,7 +393,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			taskBackend := NewMockTaskBackend(t)
-			taskBackend.HTTPErrorHandler = ErrorHandler(0)
+			taskBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			taskBackend.LabelService = tt.fields.labelService
 			h := NewTaskHandler(zaptest.NewLogger(t), taskBackend)
@@ -559,7 +560,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			taskBackend := NewMockTaskBackend(t)
-			taskBackend.HTTPErrorHandler = ErrorHandler(0)
+			taskBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(zaptest.NewLogger(t), taskBackend)
 			h.handlePostTask(w, r)
@@ -673,7 +674,7 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 			r = r.WithContext(pcontext.SetAuthorizer(r.Context(), &platform.Authorization{Permissions: platform.OperPermissions()}))
 			w := httptest.NewRecorder()
 			taskBackend := NewMockTaskBackend(t)
-			taskBackend.HTTPErrorHandler = ErrorHandler(0)
+			taskBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(zaptest.NewLogger(t), taskBackend)
 			h.handleGetRun(w, r)
@@ -791,7 +792,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 			r = r.WithContext(pcontext.SetAuthorizer(r.Context(), &platform.Authorization{Permissions: platform.OperPermissions()}))
 			w := httptest.NewRecorder()
 			taskBackend := NewMockTaskBackend(t)
-			taskBackend.HTTPErrorHandler = ErrorHandler(0)
+			taskBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(zaptest.NewLogger(t), taskBackend)
 			h.handleGetRuns(w, r)
@@ -822,7 +823,7 @@ func TestTaskHandler_NotFoundStatus(t *testing.T) {
 
 	im := newInMemKVSVC(t)
 	taskBackend := NewMockTaskBackend(t)
-	taskBackend.HTTPErrorHandler = ErrorHandler(0)
+	taskBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	h := NewTaskHandler(zaptest.NewLogger(t), taskBackend)
 	h.UserResourceMappingService = im
 	h.LabelService = im
@@ -1345,7 +1346,7 @@ func TestTaskHandler_Sessions(t *testing.T) {
 
 	newHandler := func(t *testing.T, ts *mock.TaskService) *TaskHandler {
 		return NewTaskHandler(zaptest.NewLogger(t), &TaskBackend{
-			HTTPErrorHandler: ErrorHandler(0),
+			HTTPErrorHandler: kithttp.ErrorHandler(0),
 			log:              zaptest.NewLogger(t),
 
 			TaskService:                ts,

--- a/http/user_test.go
+++ b/http/user_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	platform "github.com/influxdata/influxdb"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/pkg/testttp"
 	platformtesting "github.com/influxdata/influxdb/testing"
@@ -22,7 +23,7 @@ func NewMockUserBackend(t *testing.T) *UserBackend {
 		UserService:             mock.NewUserService(),
 		UserOperationLogService: mock.NewUserOperationLogService(),
 		PasswordsService:        mock.NewPasswordsService(),
-		HTTPErrorHandler:        ErrorHandler(0),
+		HTTPErrorHandler:        kithttp.ErrorHandler(0),
 	}
 }
 
@@ -39,7 +40,7 @@ func initUserService(f platformtesting.UserFields, t *testing.T) (platform.UserS
 	}
 
 	userBackend := NewMockUserBackend(t)
-	userBackend.HTTPErrorHandler = ErrorHandler(0)
+	userBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 	userBackend.UserService = svc
 	handler := NewUserHandler(zaptest.NewLogger(t), userBackend)
 	server := httptest.NewServer(handler)

--- a/http/variable_test.go
+++ b/http/variable_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/influxdata/httprouter"
 	platform "github.com/influxdata/influxdb"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
@@ -23,7 +24,7 @@ var faketime = time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)
 // NewMockVariableBackend returns a VariableBackend with mock services.
 func NewMockVariableBackend(t *testing.T) *VariableBackend {
 	return &VariableBackend{
-		HTTPErrorHandler: ErrorHandler(0),
+		HTTPErrorHandler: kithttp.ErrorHandler(0),
 		log:              zaptest.NewLogger(t),
 		VariableService:  mock.NewVariableService(),
 		LabelService:     mock.NewLabelService(),
@@ -295,7 +296,7 @@ func TestVariableService_handleGetVariables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.LabelService = tt.fields.LabelService
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
@@ -427,7 +428,7 @@ func TestVariableService_handleGetVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", nil)
@@ -566,7 +567,7 @@ func TestVariableService_handlePostVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", bytes.NewReader([]byte(tt.args.variable)))
@@ -666,7 +667,7 @@ func TestVariableService_handlePatchVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", bytes.NewReader([]byte(tt.args.update)))
@@ -760,7 +761,7 @@ func TestVariableService_handleDeleteVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", nil)
@@ -853,7 +854,7 @@ func TestService_handlePostVariableLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend(t)
-			variableBackend.HTTPErrorHandler = ErrorHandler(0)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
 			variableBackend.LabelService = tt.fields.LabelService
 			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
 

--- a/http/write_handler_test.go
+++ b/http/write_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http/metric"
 	httpmock "github.com/influxdata/influxdb/http/mock"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	influxtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
@@ -375,7 +376,7 @@ func TestWriteHandler_handleWrite(t *testing.T) {
 	}
 }
 
-var DefaultErrorHandler = ErrorHandler(0)
+var DefaultErrorHandler = kithttp.ErrorHandler(0)
 
 func bucketWritePermission(org, bucket string) *influxdb.Authorization {
 	oid := influxtesting.MustIDBase16(org)

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -1,0 +1,62 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/influxdata/influxdb"
+)
+
+// PlatformErrorCodeHeader shows the error code of platform error.
+const PlatformErrorCodeHeader = "X-Platform-Error-Code"
+
+// ErrorHandler is the error handler in http package.
+type ErrorHandler int
+
+// HandleHTTPError encodes err with the appropriate status code and format,
+// sets the X-Platform-Error-Code headers on the response.
+// We're no longer using X-Influx-Error and X-Influx-Reference.
+// and sets the response status to the corresponding status code.
+func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.ResponseWriter) {
+	if err == nil {
+		return
+	}
+
+	code := influxdb.ErrorCode(err)
+	httpCode, ok := statusCodePlatformError[code]
+	if !ok {
+		httpCode = http.StatusBadRequest
+	}
+	w.Header().Set(PlatformErrorCodeHeader, code)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(httpCode)
+	var e struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	e.Code = influxdb.ErrorCode(err)
+	if err, ok := err.(*influxdb.Error); ok {
+		e.Message = err.Error()
+	} else {
+		e.Message = "An internal error has occurred"
+	}
+	b, _ := json.Marshal(e)
+	_, _ = w.Write(b)
+}
+
+// statusCodePlatformError is the map convert platform.Error to error
+var statusCodePlatformError = map[string]int{
+	influxdb.EInternal:            http.StatusInternalServerError,
+	influxdb.EInvalid:             http.StatusBadRequest,
+	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
+	influxdb.EEmptyValue:          http.StatusBadRequest,
+	influxdb.EConflict:            http.StatusUnprocessableEntity,
+	influxdb.ENotFound:            http.StatusNotFound,
+	influxdb.EUnavailable:         http.StatusServiceUnavailable,
+	influxdb.EForbidden:           http.StatusForbidden,
+	influxdb.ETooManyRequests:     http.StatusTooManyRequests,
+	influxdb.EUnauthorized:        http.StatusUnauthorized,
+	influxdb.EMethodNotAllowed:    http.StatusMethodNotAllowed,
+	influxdb.ETooLarge:            http.StatusRequestEntityTooLarge,
+}

--- a/kit/transport/http/error_handler_test.go
+++ b/kit/transport/http/error_handler_test.go
@@ -1,0 +1,57 @@
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/http"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
+)
+
+func TestEncodeError(t *testing.T) {
+	ctx := context.TODO()
+
+	w := httptest.NewRecorder()
+
+	kithttp.ErrorHandler(0).HandleHTTPError(ctx, nil, w)
+
+	if w.Code != 200 {
+		t.Errorf("expected status code 200, got: %d", w.Code)
+	}
+}
+
+func TestEncodeErrorWithError(t *testing.T) {
+	ctx := context.TODO()
+	err := &influxdb.Error{
+		Code: influxdb.EInternal,
+		Msg:  "an error occurred",
+		Err:  fmt.Errorf("there's an error here, be aware"),
+	}
+
+	w := httptest.NewRecorder()
+
+	kithttp.ErrorHandler(0).HandleHTTPError(ctx, err, w)
+
+	if w.Code != 500 {
+		t.Errorf("expected status code 500, got: %d", w.Code)
+	}
+
+	errHeader := w.Header().Get("X-Platform-Error-Code")
+	if errHeader != influxdb.EInternal {
+		t.Errorf("expected X-Platform-Error-Code: %s, got: %s", influxdb.EInternal, errHeader)
+	}
+
+	// The http handler will flatten the message and it will not
+	// have an error property, so reading the serialization results
+	// in a different error.
+	pe := http.CheckError(w.Result()).(*influxdb.Error)
+	if want, got := influxdb.EInternal, pe.Code; want != got {
+		t.Errorf("unexpected code -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if want, got := "an error occurred: there's an error here, be aware", pe.Msg; want != got {
+		t.Errorf("unexpected message -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}

--- a/kit/transport/http/handler.go
+++ b/kit/transport/http/handler.go
@@ -1,0 +1,11 @@
+package http
+
+import "net/http"
+
+// ResourceHandler is an HTTP handler for a resource. The prefix
+// describes the url path prefix that relates to the handler
+// endpoints.
+type ResourceHandler interface {
+	Prefix() string
+	http.Handler
+}

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -1,0 +1,109 @@
+package pkger
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/pkg/httpc"
+)
+
+// HTTPRemoteService provides an http client that is fluent in all things pkger.
+type HTTPRemoteService struct {
+	Client *httpc.Client
+}
+
+var _ SVC = (*HTTPRemoteService)(nil)
+
+// CreatePkg will produce a pkg from the parameters provided.
+func (s *HTTPRemoteService) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error) {
+	var opt CreateOpt
+	for _, setter := range setters {
+		if err := setter(&opt); err != nil {
+			return nil, err
+		}
+	}
+	var orgIDs []string
+	for orgID := range opt.OrgIDs {
+		orgIDs = append(orgIDs, orgID.String())
+	}
+
+	reqBody := ReqCreatePkg{
+		OrgIDs:    orgIDs,
+		Resources: opt.Resources,
+	}
+
+	var newPkg *Pkg
+	err := s.Client.
+		PostJSON(reqBody, RoutePrefix).
+		Decode(func(resp *http.Response) error {
+			pkg, err := Parse(EncodingJSON, FromReader(resp.Body))
+			newPkg = pkg
+			return err
+		}).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := newPkg.Validate(ValidWithoutResources()); err != nil {
+		return nil, err
+	}
+	return newPkg, nil
+}
+
+// DryRun provides a dry run of the pkg application. The pkg will be marked verified
+// for later calls to Apply. This func will be run on an Apply if it has not been run
+// already.
+func (s *HTTPRemoteService) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg) (Summary, Diff, error) {
+	b, err := pkg.Encode(EncodingJSON)
+	if err != nil {
+		return Summary{}, Diff{}, err
+	}
+
+	reqBody := ReqApplyPkg{
+		OrgID:  orgID.String(),
+		DryRun: true,
+		RawPkg: b,
+	}
+	return s.apply(ctx, reqBody)
+}
+
+// Apply will apply all the resources identified in the provided pkg. The entire pkg will be applied
+// in its entirety. If a failure happens midway then the entire pkg will be rolled back to the state
+// from before the pkg was applied.
+func (s *HTTPRemoteService) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, error) {
+	var opt ApplyOpt
+	for _, o := range opts {
+		if err := o(&opt); err != nil {
+			return Summary{}, err
+		}
+	}
+
+	b, err := pkg.Encode(EncodingJSON)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	reqBody := ReqApplyPkg{
+		OrgID:   orgID.String(),
+		Secrets: opt.MissingSecrets,
+		RawPkg:  b,
+	}
+
+	sum, _, err := s.apply(ctx, reqBody)
+	return sum, err
+}
+
+func (s *HTTPRemoteService) apply(ctx context.Context, reqBody ReqApplyPkg) (Summary, Diff, error) {
+	var resp RespApplyPkg
+	err := s.Client.
+		PostJSON(reqBody, RoutePrefix, "/apply").
+		DecodeJSON(&resp).
+		Do(ctx)
+	if err != nil {
+		return Summary{}, Diff{}, err
+	}
+
+	return resp.Summary, resp.Diff, NewParseError(resp.Errors...)
+}

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -1,4 +1,4 @@
-package http_test
+package pkger_test
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
-	fluxTTP "github.com/influxdata/influxdb/http"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/pkg/testttp"
 	"github.com/influxdata/influxdb/pkger"
@@ -32,11 +32,11 @@ func TestPkgerHTTPServer(t *testing.T) {
 				}, nil
 			}
 			svc := pkger.NewService(pkger.WithLabelSVC(fakeLabelSVC))
-			pkgHandler := fluxTTP.NewHandlerPkg(zap.NewNop(), fluxTTP.ErrorHandler(0), svc)
+			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), kithttp.ErrorHandler(0), svc)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			testttp.
-				PostJSON(t, "/api/v2/packages", fluxTTP.ReqCreatePkg{
+				PostJSON(t, "/api/v2/packages", pkger.ReqCreatePkg{
 					Resources: []pkger.ResourceToClone{
 						{
 							Kind: pkger.KindLabel,
@@ -62,11 +62,11 @@ func TestPkgerHTTPServer(t *testing.T) {
 		})
 
 		t.Run("should be invalid if not org ids or resources provided", func(t *testing.T) {
-			pkgHandler := fluxTTP.NewHandlerPkg(zap.NewNop(), fluxTTP.ErrorHandler(0), nil)
+			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), kithttp.ErrorHandler(0), nil)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			testttp.
-				PostJSON(t, "/api/v2/packages", fluxTTP.ReqCreatePkg{}).
+				PostJSON(t, "/api/v2/packages", pkger.ReqCreatePkg{}).
 				Headers("Content-Type", "application/json").
 				Do(svr).
 				ExpectStatus(http.StatusUnprocessableEntity)
@@ -79,12 +79,12 @@ func TestPkgerHTTPServer(t *testing.T) {
 			tests := []struct {
 				name        string
 				contentType string
-				reqBody     fluxTTP.ReqApplyPkg
+				reqBody     pkger.ReqApplyPkg
 			}{
 				{
 					name:        "app json",
 					contentType: "application/json",
-					reqBody: fluxTTP.ReqApplyPkg{
+					reqBody: pkger.ReqApplyPkg{
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
 						RawPkg: bucketPkgKinds(t, pkger.EncodingJSON),
@@ -92,7 +92,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 				},
 				{
 					name: "defaults json when no content type",
-					reqBody: fluxTTP.ReqApplyPkg{
+					reqBody: pkger.ReqApplyPkg{
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
 						RawPkg: bucketPkgKinds(t, pkger.EncodingJSON),
@@ -100,10 +100,10 @@ func TestPkgerHTTPServer(t *testing.T) {
 				},
 				{
 					name: "retrieves package from a URL",
-					reqBody: fluxTTP.ReqApplyPkg{
+					reqBody: pkger.ReqApplyPkg{
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
-						Remote: fluxTTP.PkgRemote{
+						Remote: pkger.PkgRemote{
 							URL: "https://gist.githubusercontent.com/jsteenb2/3a3b2b5fcbd6179b2494c2b54aa2feb0/raw/989d361db7a851a3c388eaed0b59dce7fca7fdf3/bucket_pkg.json",
 						},
 					},
@@ -111,7 +111,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 				{
 					name:        "app jsonnet",
 					contentType: "application/x-jsonnet",
-					reqBody: fluxTTP.ReqApplyPkg{
+					reqBody: pkger.ReqApplyPkg{
 						DryRun: true,
 						OrgID:  influxdb.ID(9000).String(),
 						RawPkg: bucketPkgKinds(t, pkger.EncodingJsonnet),
@@ -137,7 +137,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := fluxTTP.NewHandlerPkg(zap.NewNop(), fluxTTP.ErrorHandler(0), svc)
+					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), kithttp.ErrorHandler(0), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -146,7 +146,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						Do(svr).
 						ExpectStatus(http.StatusOK).
 						ExpectBody(func(buf *bytes.Buffer) {
-							var resp fluxTTP.RespApplyPkg
+							var resp pkger.RespApplyPkg
 							decodeBody(t, buf, &resp)
 
 							assert.Len(t, resp.Summary.Buckets, 1)
@@ -191,7 +191,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := fluxTTP.NewHandlerPkg(zap.NewNop(), fluxTTP.ErrorHandler(0), svc)
+					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), kithttp.ErrorHandler(0), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					body := newReqApplyYMLBody(t, influxdb.ID(9000), true)
@@ -202,7 +202,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						Do(svr).
 						ExpectStatus(http.StatusOK).
 						ExpectBody(func(buf *bytes.Buffer) {
-							var resp fluxTTP.RespApplyPkg
+							var resp pkger.RespApplyPkg
 							decodeBody(t, buf, &resp)
 
 							assert.Len(t, resp.Summary.Buckets, 1)
@@ -243,11 +243,11 @@ func TestPkgerHTTPServer(t *testing.T) {
 			},
 		}
 
-		pkgHandler := fluxTTP.NewHandlerPkg(zap.NewNop(), fluxTTP.ErrorHandler(0), svc)
+		pkgHandler := pkger.NewHTTPServer(zap.NewNop(), kithttp.ErrorHandler(0), svc)
 		svr := newMountedHandler(pkgHandler, 1)
 
 		testttp.
-			PostJSON(t, "/api/v2/packages/apply", fluxTTP.ReqApplyPkg{
+			PostJSON(t, "/api/v2/packages/apply", pkger.ReqApplyPkg{
 				OrgID:   influxdb.ID(9000).String(),
 				Secrets: map[string]string{"secret1": "val1"},
 				RawPkg:  bucketPkgKinds(t, pkger.EncodingJSON),
@@ -255,7 +255,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 			Do(svr).
 			ExpectStatus(http.StatusCreated).
 			ExpectBody(func(buf *bytes.Buffer) {
-				var resp fluxTTP.RespApplyPkg
+				var resp pkger.RespApplyPkg
 				decodeBody(t, buf, &resp)
 
 				assert.Len(t, resp.Summary.Buckets, 1)
@@ -326,7 +326,7 @@ func newReqApplyYMLBody(t *testing.T, orgID influxdb.ID, dryRun bool) *bytes.Buf
 	t.Helper()
 
 	var buf bytes.Buffer
-	err := yaml.NewEncoder(&buf).Encode(fluxTTP.ReqApplyPkg{
+	err := yaml.NewEncoder(&buf).Encode(pkger.ReqApplyPkg{
 		DryRun: dryRun,
 		OrgID:  orgID.String(),
 		RawPkg: bucketPkgKinds(t, pkger.EncodingYAML),
@@ -367,7 +367,7 @@ func (f *fakeSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkg
 	return f.ApplyFn(ctx, orgID, userID, pkg, opts...)
 }
 
-func newMountedHandler(rh fluxTTP.ResourceHandler, userID influxdb.ID) chi.Router {
+func newMountedHandler(rh kithttp.ResourceHandler, userID influxdb.ID) chi.Router {
 	r := chi.NewRouter()
 	r.Mount(rh.Prefix(), authMW(userID)(rh))
 	return r


### PR DESCRIPTION
this is the last step for pkger to follow the service definition pattern
that is in the works. Some bits from http were moved into kit/transport/http
for reusability. End result is to hopefully axe most if not all of current platform http pkg for resuable types in kit. its a ways off still but we're closing in on some reusable types.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass