### PR TITLE
fix(flux): Reduce influxd and influx startup time if Flux unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v1.8.0 [unreleased]
 
 -	[#14315](https://github.com/influxdata/influxdb/pull/14315): Update to go 1.12.7
 -	[#15222](https://github.com/influxdata/influxdb/pull/15222): Add options to authenticate pprof and ping endpoints.
+-	[#16709](https://github.com/influxdata/influxdb/pull/16709): Reduce influxd and influx startup time if Flux unused.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/flux.go
+++ b/cmd/influx/cli/flux.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/repl"
-	_ "github.com/influxdata/influxdb/flux/builtin"
+	"github.com/influxdata/influxdb/flux/builtin"
 	"github.com/influxdata/influxdb/flux/client"
 )
 
@@ -32,6 +32,8 @@ func (q *replQuerier) Query(ctx context.Context, deps flux.Dependencies, compile
 }
 
 func getFluxREPL(u url.URL, username, password string) (*repl.REPL, error) {
+	builtin.Initialize()
+
 	c, err := client.NewHTTP(u)
 	if err != nil {
 		return nil, err

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -291,7 +291,9 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.BuildType = "OSS"
 	ss := storage.NewStore(s.TSDBStore, s.MetaClient)
 	srv.Handler.Store = ss
-	srv.Handler.Controller = control.NewController(s.MetaClient, reads.NewReader(ss), authorizer, c.AuthEnabled, s.Logger)
+	if s.config.HTTPD.FluxEnabled {
+		srv.Handler.Controller = control.NewController(s.MetaClient, reads.NewReader(ss), authorizer, c.AuthEnabled, s.Logger)
+	}
 
 	s.Services = append(s.Services, srv)
 }

--- a/flux/builtin/builtin.go
+++ b/flux/builtin/builtin.go
@@ -4,11 +4,20 @@
 package builtin
 
 import (
+	"sync"
+
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/stdlib"
 	_ "github.com/influxdata/influxdb/flux/stdlib"
 )
 
-func init() {
-	flux.FinalizeBuiltIns()
+var once sync.Once
+
+// Initialize ensures all Flux builtins are configured and should be called
+// prior to using the Flux runtime. Initialize is safe to call concurrently
+// and is idempotent.
+func Initialize() {
+	once.Do(func() {
+		flux.FinalizeBuiltIns()
+	})
 }

--- a/flux/control/controller.go
+++ b/flux/control/controller.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/influxdb/coordinator"
-	_ "github.com/influxdata/influxdb/flux/builtin"
+	"github.com/influxdata/influxdb/flux/builtin"
 	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -17,6 +17,8 @@ type MetaClient = coordinator.MetaClient
 type Authorizer = influxdb.Authorizer
 
 func NewController(mc MetaClient, reader influxdb.Reader, auth Authorizer, authEnabled bool, logger *zap.Logger) *Controller {
+	builtin.Initialize()
+
 	storageDeps, err := influxdb.NewDependencies(mc, reader, auth, authEnabled)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR lazily initializes Flux built-in functions when Flux is used.

It significantly reduces the startup time of the `influxd` and `influx` binaries when Flux is disabled / unused.

Before (4.66s):

```
↳ time bin/18/influx
bin/18/influx  4.66s user 0.19s system 198% cpu 2.441 total
```

After (10ms):

```
↳ time bin/18/influx
bin/18/influx  0.01s user 0.01s system 88% cpu 0.021 total
```

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
