### PR TITLE
feat(query): adds support for influxql as language type for queries

### DIFF
--- a/http/query.go
+++ b/http/query.go
@@ -23,17 +23,23 @@ import (
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/jsonweb"
 	"github.com/influxdata/influxdb/query"
+	transpiler "github.com/influxdata/influxdb/query/influxql"
 	"github.com/influxdata/influxql"
 )
 
 // QueryRequest is a flux query request.
 type QueryRequest struct {
+	Type  string `json:"type"`
+	Query string `json:"query"`
+
+	// Flux fields
 	Extern  *ast.File    `json:"extern,omitempty"`
 	Spec    *flux.Spec   `json:"spec,omitempty"`
 	AST     *ast.Package `json:"ast,omitempty"`
-	Query   string       `json:"query"`
-	Type    string       `json:"type"`
 	Dialect QueryDialect `json:"dialect"`
+
+	// InfluxQL fields
+	Bucket string `json:"bucket,omitempty"`
 
 	Org *influxdb.Organization `json:"-"`
 
@@ -97,8 +103,12 @@ func (r QueryRequest) Validate() error {
 		}
 	}
 
-	if r.Type != "flux" {
+	if r.Type != "flux" && r.Type != "influxql" {
 		return fmt.Errorf(`unknown query type: %s`, r.Type)
+	}
+
+	if r.Type == "influxql" && r.Bucket == "" {
+		return fmt.Errorf("bucket parameter is required for influxql queries")
 	}
 
 	if len(r.Dialect.CommentPrefix) > 1 {
@@ -245,10 +255,22 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 	// Query is preferred over AST
 	var compiler flux.Compiler
 	if r.Query != "" {
-		compiler = lang.FluxCompiler{
-			Now:    now(),
-			Extern: r.Extern,
-			Query:  r.Query,
+		switch r.Type {
+		case "influxql":
+			n := now()
+			compiler = &transpiler.Compiler{
+				Now:    &n,
+				Query:  r.Query,
+				Bucket: r.Bucket,
+			}
+		case "flux":
+			fallthrough
+		default:
+			compiler = lang.FluxCompiler{
+				Now:    now(),
+				Extern: r.Extern,
+				Query:  r.Query,
+			}
 		}
 	} else if r.AST != nil {
 		c := lang.ASTCompiler{
@@ -276,20 +298,25 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 	if r.PreferNoContent {
 		dialect = &query.NoContentDialect{}
 	} else {
-		// TODO(nathanielc): Use commentPrefix and dateTimeFormat
-		// once they are supported.
-		encConfig := csv.ResultEncoderConfig{
-			NoHeader:    noHeader,
-			Delimiter:   delimiter,
-			Annotations: r.Dialect.Annotations,
-		}
-		if r.PreferNoContentWithError {
-			dialect = &query.NoContentWithErrorDialect{
-				ResultEncoderConfig: encConfig,
-			}
+		if r.Type == "influxql" {
+			// Use default transpiler dialect
+			dialect = &transpiler.Dialect{}
 		} else {
-			dialect = &csv.Dialect{
-				ResultEncoderConfig: encConfig,
+			// TODO(nathanielc): Use commentPrefix and dateTimeFormat
+			// once they are supported.
+			encConfig := csv.ResultEncoderConfig{
+				NoHeader:    noHeader,
+				Delimiter:   delimiter,
+				Annotations: r.Dialect.Annotations,
+			}
+			if r.PreferNoContentWithError {
+				dialect = &query.NoContentWithErrorDialect{
+					ResultEncoderConfig: encConfig,
+				}
+			} else {
+				dialect = &csv.Dialect{
+					ResultEncoderConfig: encConfig,
+				}
 			}
 		}
 	}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3214,7 +3214,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Query"
+                oneOf:
+                  - $ref: "#/components/schemas/Query"
+                  - $ref: "#/components/schemas/InfluxQLQuery"
             application/vnd.flux:
               schema:
                 type: string
@@ -6274,7 +6276,7 @@ components:
           description: Flux query script to be analyzed
           type: string
     Query:
-      description: Query influx with specific return formatting.
+      description: Query influx using the Flux language
       type: object
       required:
         - query
@@ -6285,23 +6287,29 @@ components:
           description: Query script to execute.
           type: string
         type:
-          description: The type of query.
+          description: The type of query. Must be "flux".
           type: string
-          default: flux
           enum:
             - flux
-            - influxql
-        db:
-          description: Required for `influxql` type queries.
-          type: string
-        rp:
-          description: Required for `influxql` type queries.
-          type: string
-        cluster:
-          description: Required for `influxql` type queries.
-          type: string
         dialect:
           $ref: "#/components/schemas/Dialect"
+    InfluxQLQuery:
+      description: Query influx using the InfluxQL language
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          description: InfluxQL query execute.
+          type: string
+        type:
+          description: The type of query. Must be "influxql".
+          type: string
+          enum:
+            - influxql
+        bucket:
+          description: Bucket is to be used instead of the database and retention policy specified in the InfluxQL query.
+          type: string
     Package:
       description: Represents a complete package source tree.
       type: object

--- a/query/influxql/compiler.go
+++ b/query/influxql/compiler.go
@@ -24,6 +24,7 @@ type Compiler struct {
 	Cluster string     `json:"cluster,omitempty"`
 	DB      string     `json:"db,omitempty"`
 	RP      string     `json:"rp,omitempty"`
+	Bucket  string     `json:"bucket,omitempty"`
 	Query   string     `json:"query"`
 	Now     *time.Time `json:"now,omitempty"`
 
@@ -51,6 +52,7 @@ func (c *Compiler) Compile(ctx context.Context) (flux.Program, error) {
 	transpiler := NewTranspilerWithConfig(
 		c.dbrpMappingSvc,
 		Config{
+			Bucket:                 c.Bucket,
 			Cluster:                c.Cluster,
 			DefaultDatabase:        c.DB,
 			DefaultRetentionPolicy: c.RP,

--- a/query/influxql/config.go
+++ b/query/influxql/config.go
@@ -6,10 +6,13 @@ import (
 
 // Config modifies the behavior of the Transpiler.
 type Config struct {
+	// Bucket is the name of a bucket to use instead of the db/rp from the query.
+	// If bucket is empty then the dbrp mapping is used.
+	Bucket                 string
 	DefaultDatabase        string
 	DefaultRetentionPolicy string
-	Now                    time.Time
 	Cluster                string
+	Now                    time.Time
 	// FallbackToDBRP if true will use the naming convention of `db/rp`
 	// for a bucket name when an mapping is not found
 	FallbackToDBRP bool

--- a/query/influxql/transpiler.go
+++ b/query/influxql/transpiler.go
@@ -3,28 +3,27 @@ package influxql
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/influxdata/flux/ast"
-	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxql"
 )
 
 // Transpiler converts InfluxQL queries into a query spec.
 type Transpiler struct {
 	Config         *Config
-	dbrpMappingSvc platform.DBRPMappingService
+	dbrpMappingSvc influxdb.DBRPMappingService
 }
 
-func NewTranspiler(dbrpMappingSvc platform.DBRPMappingService) *Transpiler {
+func NewTranspiler(dbrpMappingSvc influxdb.DBRPMappingService) *Transpiler {
 	return NewTranspilerWithConfig(dbrpMappingSvc, Config{})
 }
 
-func NewTranspilerWithConfig(dbrpMappingSvc platform.DBRPMappingService, cfg Config) *Transpiler {
+func NewTranspilerWithConfig(dbrpMappingSvc influxdb.DBRPMappingService, cfg Config) *Transpiler {
 	return &Transpiler{
 		Config:         &cfg,
 		dbrpMappingSvc: dbrpMappingSvc,
@@ -57,10 +56,10 @@ type transpilerState struct {
 	config         Config
 	file           *ast.File
 	assignments    map[string]ast.Expression
-	dbrpMappingSvc platform.DBRPMappingService
+	dbrpMappingSvc influxdb.DBRPMappingService
 }
 
-func newTranspilerState(dbrpMappingSvc platform.DBRPMappingService, config *Config) *transpilerState {
+func newTranspilerState(dbrpMappingSvc influxdb.DBRPMappingService, config *Config) *transpilerState {
 	state := &transpilerState{
 		file: &ast.File{
 			Package: &ast.PackageClause{
@@ -623,7 +622,10 @@ func (t *transpilerState) transpileSelect(ctx context.Context, stmt *influxql.Se
 	if err != nil {
 		return nil, err
 	} else if len(groups) == 0 {
-		return nil, errors.New("at least 1 non-time field must be queried")
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "unable to transpile: at least one non-time field must be queried",
+		}
 	}
 
 	cursors := make([]cursor, 0, len(groups))
@@ -653,36 +655,9 @@ func (t *transpilerState) mapType(ref *influxql.VarRef) influxql.DataType {
 }
 
 func (t *transpilerState) from(m *influxql.Measurement) (ast.Expression, error) {
-	db, rp := m.Database, m.RetentionPolicy
-	if db == "" {
-		if t.config.DefaultDatabase == "" {
-			return nil, errors.New("database is required")
-		}
-		db = t.config.DefaultDatabase
-	}
-	if rp == "" {
-		if t.config.DefaultRetentionPolicy != "" {
-			rp = t.config.DefaultRetentionPolicy
-		}
-	}
-
-	var filter platform.DBRPMappingFilter
-	filter.Cluster = &t.config.Cluster
-	if db != "" {
-		filter.Database = &db
-	}
-	if rp != "" {
-		filter.RetentionPolicy = &rp
-	}
-	defaultRP := rp == ""
-	filter.Default = &defaultRP
-	mapping, err := t.dbrpMappingSvc.Find(context.TODO(), filter)
 	var args []ast.Expression
-	if err != nil {
-		if !t.config.FallbackToDBRP {
-			return nil, err
-		}
-		// use `db/rp` naming convention
+	// Use the bucket inteasd of dbrp mapping if it exists.
+	if t.config.Bucket != "" {
 		args = []ast.Expression{
 			&ast.ObjectExpression{
 				Properties: []*ast.Property{
@@ -691,27 +666,81 @@ func (t *transpilerState) from(m *influxql.Measurement) (ast.Expression, error) 
 							Name: "bucket",
 						},
 						Value: &ast.StringLiteral{
-							Value: fmt.Sprintf("%s/%s", db, rp),
+							Value: t.config.Bucket,
 						},
 					},
 				},
 			},
 		}
 	} else {
-		// use mapping bucket id
-		args = []ast.Expression{
-			&ast.ObjectExpression{
-				Properties: []*ast.Property{
-					{
-						Key: &ast.Identifier{
-							Name: "bucketID",
-						},
-						Value: &ast.StringLiteral{
-							Value: mapping.BucketID.String(),
+		if t.dbrpMappingSvc == nil {
+			return nil, &influxdb.Error{
+				Code: influxdb.EInternal,
+				Msg:  "unable to transpile: db and rp mappings need to be created by some way",
+			}
+		}
+		db, rp := m.Database, m.RetentionPolicy
+		if db == "" {
+			if t.config.DefaultDatabase == "" {
+				return nil, &influxdb.Error{
+					Code: influxdb.EInvalid,
+					Msg:  "unable to transpile: database is required",
+				}
+			}
+			db = t.config.DefaultDatabase
+		}
+		if rp == "" {
+			if t.config.DefaultRetentionPolicy != "" {
+				rp = t.config.DefaultRetentionPolicy
+			}
+		}
+
+		var filter influxdb.DBRPMappingFilter
+		filter.Cluster = &t.config.Cluster
+		if db != "" {
+			filter.Database = &db
+		}
+		if rp != "" {
+			filter.RetentionPolicy = &rp
+		}
+		defaultRP := rp == ""
+		filter.Default = &defaultRP
+		mapping, err := t.dbrpMappingSvc.Find(context.TODO(), filter)
+		if err != nil {
+			if !t.config.FallbackToDBRP {
+				return nil, err
+			}
+			// use `db/rp` naming convention
+			args = []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: []*ast.Property{
+						{
+							Key: &ast.Identifier{
+								Name: "bucket",
+							},
+							Value: &ast.StringLiteral{
+								Value: fmt.Sprintf("%s/%s", db, rp),
+							},
 						},
 					},
 				},
-			},
+			}
+		} else {
+			// use mapping bucket id
+			args = []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: []*ast.Property{
+						{
+							Key: &ast.Identifier{
+								Name: "bucketID",
+							},
+							Value: &ast.StringLiteral{
+								Value: mapping.BucketID.String(),
+							},
+						},
+					},
+				},
+			}
 		}
 	}
 

--- a/query/influxql/transpiler_test.go
+++ b/query/influxql/transpiler_test.go
@@ -149,7 +149,7 @@ func TestTranspiler_Compile(t *testing.T) {
 		{s: `SELECT log10(value) FROM cpu`},
 		{s: `SELECT sin(value) - sin(1.3) FROM cpu`},
 		{s: `SELECT value FROM cpu WHERE sin(value) > 0.5`},
-		{s: `SELECT time FROM cpu`, err: `at least 1 non-time field must be queried`},
+		{s: `SELECT time FROM cpu`, err: `unable to transpile: at least one non-time field must be queried`},
 		{s: `SELECT value, mean(value) FROM cpu`, err: `mixing aggregate and non-aggregate queries is not supported`},
 		{s: `SELECT value, max(value), min(value) FROM cpu`, err: `mixing multiple selector functions with tags or fields is not supported`},
 		{s: `SELECT top(value, 10), max(value) FROM cpu`, err: `selector function top() cannot be combined with other functions`},


### PR DESCRIPTION
This change allows for the InfluxQL language type to be used with the
/v2/query API endpoint.

This change also introduces a way to give the transpiler an explicit
bucket name instead of using the DBRPMapping service.
Requests to the endpoint will know the bucket name directly but will
likely not have run the migration step to populate the DBRP mappings.
