### PR TITLE
fix(http): improve error handling and response to api consumer for org service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [16656](https://github.com/influxdata/influxdb/pull/16656): Check engine closed before collecting index metrics
 1. [16412](https://github.com/influxdata/influxdb/pull/16412): Reject writes which use any of the reserved tag keys
 1. [16715](https://github.com/influxdata/influxdb/pull/16715): Fixed dashboard mapping for getDashboards to map correct prop
+1. [16716](https://github.com/influxdata/influxdb/pull/16716): Improve the lacking error responses for unmarshal errors in org service
 
 ### Bug Fixes
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -479,7 +479,7 @@ func decodeGetBucketLogRequest(ctx context.Context, r *http.Request) (*getBucket
 		return nil, err
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func decodeGetBucketsRequest(ctx context.Context, r *http.Request) (*getBucketsR
 	qp := r.URL.Query()
 	req := &getBucketsRequest{}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -360,7 +360,7 @@ func decodeCheckFilter(ctx context.Context, r *http.Request) (*influxdb.CheckFil
 		},
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return f, nil, err
 	}

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -399,7 +399,7 @@ func decodeGetDashboardsRequest(ctx context.Context, r *http.Request) (*getDashb
 	qp := r.URL.Query()
 	req := &getDashboardsRequest{}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}
@@ -591,7 +591,7 @@ func decodeGetDashboardLogRequest(ctx context.Context, r *http.Request) (*getDas
 		return nil, err
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}

--- a/http/helpers.go
+++ b/http/helpers.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/influxdata/httprouter"
+	"github.com/influxdata/influxdb"
+)
+
+func decodeIDFromCtx(ctx context.Context, name string) (influxdb.ID, error) {
+	params := httprouter.ParamsFromContext(ctx)
+	idStr := params.ByName(name)
+
+	if idStr == "" {
+		return 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "url missing " + name,
+		}
+	}
+
+	var i influxdb.ID
+	if err := i.DecodeFromString(idStr); err != nil {
+		return 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	return i, nil
+}
+
+func decodeIDFromQuery(v url.Values, key string) (influxdb.ID, error) {
+	idStr := v.Get(key)
+	if idStr == "" {
+		return 0, nil
+	}
+
+	id, err := influxdb.IDFromString(idStr)
+	if err != nil {
+		return 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+	return *id, nil
+}

--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -272,7 +272,7 @@ func decodeNotificationEndpointFilter(ctx context.Context, r *http.Request) (inf
 		},
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return influxdb.NotificationEndpointFilter{}, influxdb.FindOptions{}, err
 	}

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -354,7 +354,7 @@ func decodeNotificationRuleFilter(ctx context.Context, r *http.Request) (*influx
 		f.UserResourceMappingFilter = *urm
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return f, nil, err
 	}

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -99,7 +99,7 @@ func (h *SetupHandler) handlePostSetup(w http.ResponseWriter, r *http.Request) {
 type onboardingResponse struct {
 	User         *UserResponse   `json:"user"`
 	Bucket       *bucketResponse `json:"bucket"`
-	Organization *orgResponse    `json:"org"`
+	Organization orgResponse     `json:"org"`
 	Auth         *authResponse   `json:"auth"`
 }
 
@@ -119,7 +119,7 @@ func newOnboardingResponse(results *platform.OnboardingResults) *onboardingRespo
 	return &onboardingResponse{
 		User:         newUserResponse(results.User),
 		Bucket:       newBucketResponse(results.Bucket, []*platform.Label{}),
-		Organization: newOrgResponse(results.Org),
+		Organization: newOrgResponse(*results.Org),
 		Auth:         newAuthResponse(results.Auth, results.Org, results.User, ps),
 	}
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -47,10 +46,10 @@ func NewOrgBackend(log *zap.Logger, b *APIBackend) *OrgBackend {
 // OrgHandler represents an HTTP API handler for orgs.
 type OrgHandler struct {
 	*httprouter.Router
-	influxdb.HTTPErrorHandler
+	*kithttp.API
 	log *zap.Logger
 
-	OrganizationService             influxdb.OrganizationService
+	OrgSVC                          influxdb.OrganizationService
 	OrganizationOperationLogService influxdb.OrganizationOperationLogService
 	UserResourceMappingService      influxdb.UserResourceMappingService
 	SecretService                   influxdb.SecretService
@@ -73,19 +72,18 @@ const (
 	organizationsIDLabelsIDPath      = "/api/v2/orgs/:id/labels/:lid"
 )
 
-func checkOrganziationExists(handler *OrgHandler) kithttp.Middleware {
+func checkOrganizationExists(orgHandler *OrgHandler) kithttp.Middleware {
 	fn := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			req, err := decodeGetOrgRequest(ctx, r)
+			orgID, err := decodeIDFromCtx(ctx, "id")
 			if err != nil {
-				handler.HandleHTTPError(ctx, err, w)
+				orgHandler.API.Err(w, err)
 				return
 			}
 
-			_, err = handler.OrganizationService.FindOrganizationByID(ctx, req.OrgID)
-			if err != nil {
-				handler.HandleHTTPError(ctx, err, w)
+			if _, err := orgHandler.OrgSVC.FindOrganizationByID(ctx, orgID); err != nil {
+				orgHandler.API.Err(w, err)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -98,11 +96,11 @@ func checkOrganziationExists(handler *OrgHandler) kithttp.Middleware {
 // NewOrgHandler returns a new instance of OrgHandler.
 func NewOrgHandler(log *zap.Logger, b *OrgBackend) *OrgHandler {
 	h := &OrgHandler{
-		Router:           NewRouter(b.HTTPErrorHandler),
-		HTTPErrorHandler: b.HTTPErrorHandler,
-		log:              log,
+		Router: NewRouter(b.HTTPErrorHandler),
+		API:    kithttp.NewAPI(kithttp.WithLog(log)),
+		log:    log,
 
-		OrganizationService:             b.OrganizationService,
+		OrgSVC:                          b.OrganizationService,
 		OrganizationOperationLogService: b.OrganizationOperationLogService,
 		UserResourceMappingService:      b.UserResourceMappingService,
 		SecretService:                   b.SecretService,
@@ -126,7 +124,7 @@ func NewOrgHandler(log *zap.Logger, b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDMembersPath, newPostMemberHandler(memberBackend))
-	h.Handler("GET", organizationsIDMembersPath, applyMW(newGetMembersHandler(memberBackend), checkOrganziationExists(h)))
+	h.Handler("GET", organizationsIDMembersPath, applyMW(newGetMembersHandler(memberBackend), checkOrganizationExists(h)))
 	h.HandlerFunc("DELETE", organizationsIDMembersIDPath, newDeleteMemberHandler(memberBackend))
 
 	ownerBackend := MemberBackend{
@@ -138,7 +136,7 @@ func NewOrgHandler(log *zap.Logger, b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDOwnersPath, newPostMemberHandler(ownerBackend))
-	h.Handler("GET", organizationsIDOwnersPath, applyMW(newGetMembersHandler(ownerBackend), checkOrganziationExists(h)))
+	h.Handler("GET", organizationsIDOwnersPath, applyMW(newGetMembersHandler(ownerBackend), checkOrganizationExists(h)))
 	h.HandlerFunc("DELETE", organizationsIDOwnersIDPath, newDeleteMemberHandler(ownerBackend))
 
 	h.HandlerFunc("GET", organizationsIDSecretsPath, h.handleGetSecrets)
@@ -161,10 +159,10 @@ func NewOrgHandler(log *zap.Logger, b *OrgBackend) *OrgHandler {
 
 type orgsResponse struct {
 	Links         map[string]string `json:"links"`
-	Organizations []*orgResponse    `json:"orgs"`
+	Organizations []orgResponse     `json:"orgs"`
 }
 
-func (o orgsResponse) Toinfluxdb() []*influxdb.Organization {
+func (o orgsResponse) toInfluxdb() []*influxdb.Organization {
 	orgs := make([]*influxdb.Organization, len(o.Organizations))
 	for i := range o.Organizations {
 		orgs[i] = &o.Organizations[i].Organization
@@ -177,10 +175,10 @@ func newOrgsResponse(orgs []*influxdb.Organization) *orgsResponse {
 		Links: map[string]string{
 			"self": "/api/v2/orgs",
 		},
-		Organizations: []*orgResponse{},
+		Organizations: []orgResponse{},
 	}
 	for _, org := range orgs {
-		res.Organizations = append(res.Organizations, newOrgResponse(org))
+		res.Organizations = append(res.Organizations, newOrgResponse(*org))
 	}
 	return &res
 }
@@ -190,8 +188,8 @@ type orgResponse struct {
 	influxdb.Organization
 }
 
-func newOrgResponse(o *influxdb.Organization) *orgResponse {
-	return &orgResponse{
+func newOrgResponse(o influxdb.Organization) orgResponse {
+	return orgResponse{
 		Links: map[string]string{
 			"self":       fmt.Sprintf("/api/v2/orgs/%s", o.ID),
 			"logs":       fmt.Sprintf("/api/v2/orgs/%s/logs", o.ID),
@@ -203,8 +201,111 @@ func newOrgResponse(o *influxdb.Organization) *orgResponse {
 			"tasks":      fmt.Sprintf("/api/v2/tasks?org=%s", o.Name),
 			"dashboards": fmt.Sprintf("/api/v2/dashboards?org=%s", o.Name),
 		},
-		Organization: *o,
+		Organization: o,
 	}
+}
+
+// handlePostOrg is the HTTP handler for the POST /api/v2/orgs route.
+func (h *OrgHandler) handlePostOrg(w http.ResponseWriter, r *http.Request) {
+	var org influxdb.Organization
+	if err := h.API.DecodeJSON(r.Body, &org); err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	if err := h.OrgSVC.CreateOrganization(r.Context(), &org); err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Org created", zap.String("org", fmt.Sprint(org)))
+
+	h.API.Respond(w, http.StatusCreated, newOrgResponse(org))
+}
+
+// handleGetOrg is the HTTP handler for the GET /api/v2/orgs/:id route.
+func (h *OrgHandler) handleGetOrg(w http.ResponseWriter, r *http.Request) {
+	id, err := decodeIDFromCtx(r.Context(), "id")
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	org, err := h.OrgSVC.FindOrganizationByID(r.Context(), id)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Org retrieved", zap.String("org", fmt.Sprint(org)))
+
+	h.API.Respond(w, http.StatusOK, newOrgResponse(*org))
+}
+
+// handleGetOrgs is the HTTP handler for the GET /api/v2/orgs route.
+func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
+	var filter influxdb.OrganizationFilter
+	qp := r.URL.Query()
+	if name := qp.Get(Org); name != "" {
+		filter.Name = &name
+	}
+	id, err := decodeIDFromQuery(qp, OrgID)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	if id > 0 {
+		filter.ID = &id
+	}
+
+	orgs, _, err := h.OrgSVC.FindOrganizations(r.Context(), filter)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
+
+	h.API.Respond(w, http.StatusOK, newOrgsResponse(orgs))
+}
+
+// handleDeleteOrganization is the HTTP handler for the DELETE /api/v2/orgs/:id route.
+func (h *OrgHandler) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
+	id, err := decodeIDFromCtx(r.Context(), "id")
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	ctx := r.Context()
+	if err := h.OrgSVC.DeleteOrganization(ctx, id); err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Org deleted", zap.String("orgID", fmt.Sprint(id)))
+
+	h.API.Respond(w, http.StatusNoContent, nil)
+}
+
+// handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.
+func (h *OrgHandler) handlePatchOrg(w http.ResponseWriter, r *http.Request) {
+	id, err := decodeIDFromCtx(r.Context(), "id")
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	var upd influxdb.OrganizationUpdate
+	if err := h.API.DecodeJSON(r.Body, &upd); err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	org, err := h.OrgSVC.UpdateOrganization(r.Context(), id, upd)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Org updated", zap.String("org", fmt.Sprint(org)))
+
+	h.API.Respond(w, http.StatusOK, newOrgResponse(*org))
 }
 
 type secretsResponse struct {
@@ -213,6 +314,9 @@ type secretsResponse struct {
 }
 
 func newSecretsResponse(orgID influxdb.ID, ks []string) *secretsResponse {
+	if ks == nil {
+		ks = []string{}
+	}
 	return &secretsResponse{
 		Links: map[string]string{
 			"org":  fmt.Sprintf("/api/v2/orgs/%s", orgID),
@@ -222,379 +326,105 @@ func newSecretsResponse(orgID influxdb.ID, ks []string) *secretsResponse {
 	}
 }
 
-// handlePostOrg is the HTTP handler for the POST /api/v2/orgs route.
-func (h *OrgHandler) handlePostOrg(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodePostOrgRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	if err := h.OrganizationService.CreateOrganization(ctx, req.Org); err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Org created", zap.String("org", fmt.Sprint(req.Org)))
-
-	if err := encodeResponse(ctx, w, http.StatusCreated, newOrgResponse(req.Org)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type postOrgRequest struct {
-	Org *influxdb.Organization
-}
-
-func decodePostOrgRequest(ctx context.Context, r *http.Request) (*postOrgRequest, error) {
-	o := &influxdb.Organization{}
-	if err := json.NewDecoder(r.Body).Decode(o); err != nil {
-		return nil, err
-	}
-
-	return &postOrgRequest{
-		Org: o,
-	}, nil
-}
-
-// handleGetOrg is the HTTP handler for the GET /api/v2/orgs/:id route.
-func (h *OrgHandler) handleGetOrg(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodeGetOrgRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	b, err := h.OrganizationService.FindOrganizationByID(ctx, req.OrgID)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Org retrieved", zap.String("org", fmt.Sprint(b)))
-
-	if err := encodeResponse(ctx, w, http.StatusOK, newOrgResponse(b)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type getOrgRequest struct {
-	OrgID influxdb.ID
-}
-
-func decodeGetOrgRequest(ctx context.Context, r *http.Request) (*getOrgRequest, error) {
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-
-	req := &getOrgRequest{
-		OrgID: i,
-	}
-
-	return req, nil
-}
-
-// handleGetOrgs is the HTTP handler for the GET /api/v2/orgs route.
-func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodeGetOrgsRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	orgs, _, err := h.OrganizationService.FindOrganizations(ctx, req.filter)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
-
-	if err := encodeResponse(ctx, w, http.StatusOK, newOrgsResponse(orgs)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type getOrgsRequest struct {
-	filter influxdb.OrganizationFilter
-}
-
-func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest, error) {
-	qp := r.URL.Query()
-	req := &getOrgsRequest{}
-
-	if orgID := qp.Get(OrgID); orgID != "" {
-		id, err := influxdb.IDFromString(orgID)
-		if err != nil {
-			return nil, err
-		}
-		req.filter.ID = id
-	}
-
-	if name := qp.Get(Org); name != "" {
-		req.filter.Name = &name
-	}
-
-	return req, nil
-}
-
-// handleDeleteOrganization is the HTTP handler for the DELETE /api/v2/orgs/:id route.
-func (h *OrgHandler) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodeDeleteOrganizationRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	if err := h.OrganizationService.DeleteOrganization(ctx, req.OrganizationID); err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Org deleted", zap.String("orgID", fmt.Sprint(req.OrganizationID)))
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
-type deleteOrganizationRequest struct {
-	OrganizationID influxdb.ID
-}
-
-func decodeDeleteOrganizationRequest(ctx context.Context, r *http.Request) (*deleteOrganizationRequest, error) {
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "bad org id",
-			Err:  err,
-		}
-	}
-	req := &deleteOrganizationRequest{
-		OrganizationID: i,
-	}
-
-	return req, nil
-}
-
-// handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.
-func (h *OrgHandler) handlePatchOrg(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodePatchOrgRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	o, err := h.OrganizationService.UpdateOrganization(ctx, req.OrgID, req.Update)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Org updated", zap.String("org", fmt.Sprint(o)))
-
-	if err := encodeResponse(ctx, w, http.StatusOK, newOrgResponse(o)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type patchOrgRequest struct {
-	Update influxdb.OrganizationUpdate
-	OrgID  influxdb.ID
-}
-
-func decodePatchOrgRequest(ctx context.Context, r *http.Request) (*patchOrgRequest, error) {
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-
-	var upd influxdb.OrganizationUpdate
-	if err := json.NewDecoder(r.Body).Decode(&upd); err != nil {
-		return nil, err
-	}
-
-	return &patchOrgRequest{
-		Update: upd,
-		OrgID:  i,
-	}, nil
-}
-
 // handleGetSecrets is the HTTP handler for the GET /api/v2/orgs/:id/secrets route.
 func (h *OrgHandler) handleGetSecrets(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	req, err := decodeGetSecretsRequest(ctx, r)
+	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
+		h.API.Err(w, err)
 		return
 	}
 
-	ks, err := h.SecretService.GetSecretKeys(ctx, req.orgID)
+	ks, err := h.SecretService.GetSecretKeys(r.Context(), orgID)
 	if err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
-		h.HandleHTTPError(ctx, err, w)
+		h.API.Err(w, err)
 		return
 	}
 
-	if err := encodeResponse(ctx, w, http.StatusOK, newSecretsResponse(req.orgID, ks)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type getSecretsRequest struct {
-	orgID influxdb.ID
-}
-
-func decodeGetSecretsRequest(ctx context.Context, r *http.Request) (*getSecretsRequest, error) {
-	req := &getSecretsRequest{}
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-	req.orgID = i
-
-	return req, nil
+	h.API.Respond(w, http.StatusOK, newSecretsResponse(orgID, ks))
 }
 
 // handleGetPatchSecrets is the HTTP handler for the PATCH /api/v2/orgs/:id/secrets route.
 func (h *OrgHandler) handlePatchSecrets(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	req, err := decodePatchSecretsRequest(ctx, r)
+	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
+		h.API.Err(w, err)
 		return
 	}
 
-	if err := h.SecretService.PatchSecrets(ctx, req.orgID, req.secrets); err != nil {
-		h.HandleHTTPError(ctx, err, w)
+	var secrets map[string]string
+	if err := h.API.DecodeJSON(r.Body, &secrets); err != nil {
+		h.API.Err(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
-}
-
-type patchSecretsRequest struct {
-	orgID   influxdb.ID
-	secrets map[string]string
-}
-
-func decodePatchSecretsRequest(ctx context.Context, r *http.Request) (*patchSecretsRequest, error) {
-	req := &patchSecretsRequest{}
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
+	if err := h.SecretService.PatchSecrets(r.Context(), orgID, secrets); err != nil {
+		h.API.Err(w, err)
+		return
 	}
 
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-	req.orgID = i
-	req.secrets = map[string]string{}
-
-	if err := json.NewDecoder(r.Body).Decode(&req.secrets); err != nil {
-		return nil, err
-	}
-
-	return req, nil
+	h.API.Respond(w, http.StatusNoContent, nil)
 }
 
 // handleDeleteSecrets is the HTTP handler for the DELETE /api/v2/orgs/:id/secrets route.
 func (h *OrgHandler) handleDeleteSecrets(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	req, err := decodeDeleteSecretsRequest(ctx, r)
+	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
+		h.API.Err(w, err)
 		return
 	}
 
-	if err := h.SecretService.DeleteSecret(ctx, req.orgID, req.Secrets...); err != nil {
-		h.HandleHTTPError(ctx, err, w)
+	var reqBody struct {
+		Secrets []string `json:"secrets"`
+	}
+	if err := h.API.DecodeJSON(r.Body, &reqBody); err != nil {
+		h.API.Err(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
-}
-
-type deleteSecretsRequest struct {
-	orgID   influxdb.ID
-	Secrets []string `json:"secrets"`
-}
-
-func decodeDeleteSecretsRequest(ctx context.Context, r *http.Request) (*deleteSecretsRequest, error) {
-	req := &deleteSecretsRequest{}
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
+	if err := h.SecretService.DeleteSecret(r.Context(), orgID, reqBody.Secrets...); err != nil {
+		h.API.Err(w, err)
+		return
 	}
 
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-	req.Secrets = []string{}
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, err
-	}
-	req.orgID = i
-	return req, nil
+	h.API.Respond(w, http.StatusNoContent, nil)
 }
 
-const (
-	organizationPath = "/api/v2/orgs"
-)
+// hanldeGetOrganizationLog retrieves a organization log by the organizations ID.
+func (h *OrgHandler) handleGetOrgLog(w http.ResponseWriter, r *http.Request) {
+	orgID, err := decodeIDFromCtx(r.Context(), "id")
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	opts, err := decodeFindOptions(r)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+
+	log, _, err := h.OrganizationOperationLogService.GetOrganizationOperationLog(r.Context(), orgID, *opts)
+	if err != nil {
+		h.API.Err(w, err)
+		return
+	}
+	h.log.Debug("Org logs retrieved", zap.String("log", fmt.Sprint(log)))
+
+	h.API.Respond(w, http.StatusOK, newOrganizationLogResponse(orgID, log))
+}
+
+func newOrganizationLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
+	logs := make([]*operationLogEntryResponse, 0, len(es))
+	for _, e := range es {
+		logs = append(logs, newOperationLogEntryResponse(e))
+	}
+	return &operationLogResponse{
+		Links: map[string]string{
+			"self": fmt.Sprintf("/api/v2/orgs/%s/logs", id),
+		},
+		Logs: logs,
+	}
+}
 
 // OrganizationService connects to Influx via HTTP using tokens to manage organizations.
 type OrganizationService struct {
@@ -669,7 +499,7 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 
 	var os orgsResponse
 	err := s.Client.
-		Get(organizationPath).
+		Get(prefixOrganizations).
 		QueryParams(params...).
 		DecodeJSON(&os).
 		Do(ctx)
@@ -677,7 +507,7 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 		return nil, 0, err
 	}
 
-	orgs := os.Toinfluxdb()
+	orgs := os.toInfluxdb()
 	return orgs, len(orgs), nil
 }
 
@@ -694,7 +524,7 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *influxd
 	}
 
 	return s.Client.
-		PostJSON(o, organizationPath).
+		PostJSON(o, prefixOrganizations).
 		DecodeJSON(o).
 		Do(ctx)
 }
@@ -709,7 +539,7 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id influxd
 
 	var o influxdb.Organization
 	err := s.Client.
-		PatchJSON(upd, organizationPath, id.String()).
+		PatchJSON(upd, prefixOrganizations, id.String()).
 		DecodeJSON(&o).
 		Do(ctx)
 	if err != nil {
@@ -725,76 +555,10 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id influxd
 	defer span.Finish()
 
 	return s.Client.
-		Delete(organizationPath, id.String()).
+		Delete(prefixOrganizations, id.String()).
 		Do(ctx)
 }
 
 func organizationIDPath(id influxdb.ID) string {
-	return path.Join(organizationPath, id.String())
-}
-
-// hanldeGetOrganizationLog retrieves a organization log by the organizations ID.
-func (h *OrgHandler) handleGetOrgLog(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodeGetOrganizationLogRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	log, _, err := h.OrganizationOperationLogService.GetOrganizationOperationLog(ctx, req.OrganizationID, req.opts)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	h.log.Debug("Org logs retrieved", zap.String("log", fmt.Sprint(log)))
-
-	if err := encodeResponse(ctx, w, http.StatusOK, newOrganizationLogResponse(req.OrganizationID, log)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type getOrganizationLogRequest struct {
-	OrganizationID influxdb.ID
-	opts           influxdb.FindOptions
-}
-
-func decodeGetOrganizationLogRequest(ctx context.Context, r *http.Request) (*getOrganizationLogRequest, error) {
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-
-	opts, err := decodeFindOptions(ctx, r)
-	if err != nil {
-		return nil, err
-	}
-
-	return &getOrganizationLogRequest{
-		OrganizationID: i,
-		opts:           *opts,
-	}, nil
-}
-
-func newOrganizationLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
-	logs := make([]*operationLogEntryResponse, 0, len(es))
-	for _, e := range es {
-		logs = append(logs, newOperationLogEntryResponse(e))
-	}
-	return &operationLogResponse{
-		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/orgs/%s/logs", id),
-		},
-		Logs: logs,
-	}
+	return path.Join(prefixOrganizations, id.String())
 }

--- a/http/org_service_test.go
+++ b/http/org_service_test.go
@@ -68,7 +68,6 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 }
 
 func TestOrganizationService(t *testing.T) {
-
 	t.Parallel()
 	platformtesting.OrganizationService(initOrganizationService, t)
 }
@@ -344,7 +343,9 @@ func TestSecretService_handleDeleteSecrets(t *testing.T) {
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(zaptest.NewLogger(t), orgBackend)
 
-			b, err := json.Marshal(deleteSecretsRequest{
+			b, err := json.Marshal(struct {
+				Secrets []string `json:"secrets"`
+			}{
 				Secrets: tt.args.secrets,
 			})
 			if err != nil {

--- a/http/paging.go
+++ b/http/paging.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,7 +10,7 @@ import (
 )
 
 // decodeFindOptions returns a FindOptions decoded from http request.
-func decodeFindOptions(ctx context.Context, r *http.Request) (*platform.FindOptions, error) {
+func decodeFindOptions(r *http.Request) (*platform.FindOptions, error) {
 	opts := &platform.FindOptions{}
 	qp := r.URL.Query()
 

--- a/http/paging_test.go
+++ b/http/paging_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -68,7 +67,7 @@ func TestPaging_decodeFindOptions(t *testing.T) {
 			}
 			r.URL.RawQuery = qp.Encode()
 
-			opts, err := decodeFindOptions(context.Background(), r)
+			opts, err := decodeFindOptions(r)
 			if err != nil {
 				t.Errorf("%q failed, err: %s", tt.name, err.Error())
 			}

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -378,7 +378,7 @@ func decodeGetUserLogRequest(ctx context.Context, r *http.Request) (*getUserLogR
 		return nil, err
 	}
 
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}

--- a/http/variable_service.go
+++ b/http/variable_service.go
@@ -115,7 +115,7 @@ type getVariablesRequest struct {
 }
 
 func decodeGetVariablesRequest(ctx context.Context, r *http.Request) (*getVariablesRequest, error) {
-	opts, err := decodeFindOptions(ctx, r)
+	opts, err := decodeFindOptions(r)
 	if err != nil {
 		return nil, err
 	}

--- a/kit/transport/http/api.go
+++ b/kit/transport/http/api.go
@@ -1,0 +1,245 @@
+package http
+
+import (
+	"compress/gzip"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/influxdata/influxdb"
+	"go.uber.org/zap"
+)
+
+// PlatformErrorCodeHeader shows the error code of platform error.
+const PlatformErrorCodeHeader = "X-Platform-Error-Code"
+
+// API provides a consolidated means for handling API interface concerns.
+// Concerns such as decoding/encoding request and response bodies as well
+// as adding headers for content type and content encoding.
+type API struct {
+	logger *zap.Logger
+
+	prettyJSON bool
+	encodeGZIP bool
+
+	unmarshalErrFn func(encoding string, err error) error
+	okErrFn        func(err error) error
+	errFn          func(err error) (interface{}, int, error)
+}
+
+// APIOptFn is a functional option for setting fields on the API type.
+type APIOptFn func(*API)
+
+// WithLog sets the logger.
+func WithLog(logger *zap.Logger) APIOptFn {
+	return func(api *API) {
+		api.logger = logger
+	}
+}
+
+// WithErrFn sets the err handling func for issues when writing to the response body.
+func WithErrFn(fn func(err error) (interface{}, int, error)) APIOptFn {
+	return func(api *API) {
+		api.errFn = fn
+	}
+}
+
+// WithOKErrFn is an error handler for failing validation for request bodies.
+func WithOKErrFn(fn func(err error) error) APIOptFn {
+	return func(api *API) {
+		api.okErrFn = fn
+	}
+}
+
+// WithPrettyJSON sets the json encoder to marshal indent or not.
+func WithPrettyJSON(b bool) APIOptFn {
+	return func(api *API) {
+		api.prettyJSON = b
+	}
+}
+
+// WithEncodeGZIP sets the encoder to gzip contents.
+func WithEncodeGZIP() APIOptFn {
+	return func(api *API) {
+		api.encodeGZIP = true
+	}
+}
+
+// WithUnmarshalErrFn sets the error handler for errors that occur when unmarshaling
+// the request body.
+func WithUnmarshalErrFn(fn func(encoding string, err error) error) APIOptFn {
+	return func(api *API) {
+		api.unmarshalErrFn = fn
+	}
+}
+
+// NewAPI creates a new API type.
+func NewAPI(opts ...APIOptFn) *API {
+	api := API{
+		logger:     zap.NewNop(),
+		prettyJSON: true,
+		unmarshalErrFn: func(encoding string, err error) error {
+			return &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  fmt.Sprintf("failed to unmarshal %s: %s", encoding, err),
+			}
+		},
+		errFn: func(err error) (interface{}, int, error) {
+			code := influxdb.ErrorCode(err)
+			httpStatusCode, ok := statusCodePlatformError[code]
+			if !ok {
+				httpStatusCode = http.StatusBadRequest
+			}
+			msg := err.Error()
+			if msg == "" {
+				msg = "an internal error has occurred"
+			}
+			return ErrBody{
+				Code: code,
+				Msg:  msg,
+			}, httpStatusCode, nil
+		},
+	}
+	for _, o := range opts {
+		o(&api)
+	}
+	return &api
+}
+
+// DecodeJSON decodes reader with json.
+func (a *API) DecodeJSON(r io.Reader, v interface{}) error {
+	return a.decode("json", json.NewDecoder(r), v)
+}
+
+// DecodeGob decodes reader with gob.
+func (a *API) DecodeGob(r io.Reader, v interface{}) error {
+	return a.decode("gob", gob.NewDecoder(r), v)
+}
+
+type (
+	decoder interface {
+		Decode(interface{}) error
+	}
+
+	oker interface {
+		OK() error
+	}
+)
+
+func (a *API) decode(encoding string, dec decoder, v interface{}) error {
+	if err := dec.Decode(v); err != nil {
+		if a != nil && a.unmarshalErrFn != nil {
+			return a.unmarshalErrFn(encoding, err)
+		}
+		return err
+	}
+
+	if vv, ok := v.(oker); ok {
+		err := vv.OK()
+		if a != nil && a.okErrFn != nil {
+			return a.okErrFn(err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Respond writes to the response writer, handling all errors in writing.
+func (a *API) Respond(w http.ResponseWriter, status int, v interface{}) {
+	if status == http.StatusNoContent {
+		w.WriteHeader(status)
+		return
+	}
+
+	var writer io.WriteCloser = noopCloser{Writer: w}
+	// we'll double close to make sure its always closed even
+	//on issues before the write
+	defer writer.Close()
+
+	if a != nil && a.encodeGZIP {
+		w.Header().Set("Content-Encoding", "gzip")
+		writer = gzip.NewWriter(w)
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(writer)
+	if a == nil || a.prettyJSON {
+		enc.SetIndent("", "\t")
+	}
+
+	w.WriteHeader(status)
+	if err := enc.Encode(v); err != nil {
+		a.Err(w, err)
+		return
+	}
+
+	if err := writer.Close(); err != nil {
+		a.Err(w, err)
+		return
+	}
+}
+
+// Err is used for writing an error to the response.
+func (a *API) Err(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+
+	a.logErr("api error encountered", zap.Error(err))
+
+	v, status, err := a.errFn(err)
+	if err != nil {
+		a.logErr("failed to write err to response writer", zap.Error(err))
+		a.Respond(w, http.StatusInternalServerError, ErrBody{
+			Code: "internal error",
+			Msg:  "an unexpected error occured",
+		})
+		return
+	}
+
+	if eb, ok := v.(ErrBody); ok {
+		w.Header().Set(PlatformErrorCodeHeader, eb.Code)
+	}
+
+	a.Respond(w, status, v)
+}
+
+func (a *API) logErr(msg string, fields ...zap.Field) {
+	if a == nil || a.logger == nil {
+		return
+	}
+	a.logger.Error(msg, fields...)
+}
+
+type noopCloser struct {
+	io.Writer
+}
+
+func (n noopCloser) Close() error {
+	return nil
+}
+
+// ErrBody is an err response body.
+type ErrBody struct {
+	Code string `json:"code"`
+	Msg  string `json:"message"`
+}
+
+// statusCodePlatformError is the map convert platform.Error to error
+var statusCodePlatformError = map[string]int{
+	influxdb.EInternal:            http.StatusInternalServerError,
+	influxdb.EInvalid:             http.StatusBadRequest,
+	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
+	influxdb.EEmptyValue:          http.StatusBadRequest,
+	influxdb.EConflict:            http.StatusUnprocessableEntity,
+	influxdb.ENotFound:            http.StatusNotFound,
+	influxdb.EUnavailable:         http.StatusServiceUnavailable,
+	influxdb.EForbidden:           http.StatusForbidden,
+	influxdb.ETooManyRequests:     http.StatusTooManyRequests,
+	influxdb.EUnauthorized:        http.StatusUnauthorized,
+	influxdb.EMethodNotAllowed:    http.StatusMethodNotAllowed,
+	influxdb.ETooLarge:            http.StatusRequestEntityTooLarge,
+}

--- a/kit/transport/http/api_test.go
+++ b/kit/transport/http/api_test.go
@@ -1,0 +1,310 @@
+package http_test
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	kithttp "github.com/influxdata/influxdb/kit/transport/http"
+	"github.com/influxdata/influxdb/pkg/testttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_API(t *testing.T) {
+	t.Run("Decode", func(t *testing.T) {
+		t.Run("valid foo no errors", func(t *testing.T) {
+			expected := validatFoo{
+				Foo: "valid",
+				Bar: 10,
+			}
+
+			t.Run("json", func(t *testing.T) {
+				var api *kithttp.API // shows it is safe to use a nil value
+
+				var out validatFoo
+				err := api.DecodeJSON(encodeJSON(t, expected), &out)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+
+				if expected != out {
+					t.Fatalf("unexpected vals:\n\texpected: %#v\n\tgot: %#v", expected, out)
+				}
+			})
+
+			t.Run("gob", func(t *testing.T) {
+				var out validatFoo
+				err := kithttp.NewAPI().DecodeGob(encodeGob(t, expected), &out)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+
+				if expected != out {
+					t.Fatalf("unexpected vals:\n\texpected: %#v\n\tgot: %#v", expected, out)
+				}
+			})
+		})
+
+		t.Run("unmarshals fine with ok error", func(t *testing.T) {
+			badFoo := validatFoo{
+				Foo: "",
+				Bar: 0,
+			}
+
+			t.Run("json", func(t *testing.T) {
+				var out validatFoo
+				err := kithttp.NewAPI().DecodeJSON(encodeJSON(t, badFoo), &out)
+				if err == nil {
+					t.Fatal("expected an err")
+				}
+			})
+
+			t.Run("gob", func(t *testing.T) {
+				var out validatFoo
+				err := kithttp.NewAPI().DecodeGob(encodeGob(t, badFoo), &out)
+				if err == nil {
+					t.Fatal("expected an err")
+				}
+			})
+		})
+
+		t.Run("unmarshal error", func(t *testing.T) {
+			invalidBody := []byte("[}-{]")
+
+			var out validatFoo
+			err := kithttp.NewAPI().DecodeJSON(bytes.NewReader(invalidBody), &out)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+
+		t.Run("unmarshal err fn wraps unmarshaling error", func(t *testing.T) {
+			t.Run("json", func(t *testing.T) {
+				invalidBody := []byte("[}-{]")
+
+				api := kithttp.NewAPI(kithttp.WithUnmarshalErrFn(unmarshalErrFn))
+
+				var out validatFoo
+				err := api.DecodeJSON(bytes.NewReader(invalidBody), &out)
+				expectInfluxdbError(t, influxdb.EInvalid, err)
+			})
+
+			t.Run("gob", func(t *testing.T) {
+				invalidBody := []byte("[}-{]")
+
+				api := kithttp.NewAPI(kithttp.WithUnmarshalErrFn(unmarshalErrFn))
+
+				var out validatFoo
+				err := api.DecodeGob(bytes.NewReader(invalidBody), &out)
+				expectInfluxdbError(t, influxdb.EInvalid, err)
+			})
+		})
+
+		t.Run("ok error fn wraps ok error", func(t *testing.T) {
+			badFoo := validatFoo{Foo: ""}
+
+			t.Run("json", func(t *testing.T) {
+				api := kithttp.NewAPI(kithttp.WithOKErrFn(okErrFn))
+
+				var out validatFoo
+				err := api.DecodeJSON(encodeJSON(t, badFoo), &out)
+				expectInfluxdbError(t, influxdb.EUnprocessableEntity, err)
+			})
+
+			t.Run("gob", func(t *testing.T) {
+				api := kithttp.NewAPI(kithttp.WithOKErrFn(okErrFn))
+
+				var out validatFoo
+				err := api.DecodeGob(encodeGob(t, badFoo), &out)
+				expectInfluxdbError(t, influxdb.EUnprocessableEntity, err)
+			})
+		})
+	})
+
+	t.Run("Respond", func(t *testing.T) {
+		tests := []int{
+			http.StatusCreated,
+			http.StatusOK,
+			http.StatusNoContent,
+			http.StatusForbidden,
+			http.StatusInternalServerError,
+		}
+
+		for _, statusCode := range tests {
+			fn := func(t *testing.T) {
+				responder := kithttp.NewAPI()
+
+				svr := func(w http.ResponseWriter, r *http.Request) {
+					responder.Respond(w, statusCode, map[string]string{
+						"foo": "bar",
+					})
+				}
+
+				expectedBodyFn := func(body *bytes.Buffer) {
+					var resp map[string]string
+					require.NoError(t, json.NewDecoder(body).Decode(&resp))
+					assert.Equal(t, "bar", resp["foo"])
+				}
+				if statusCode == http.StatusNoContent {
+					expectedBodyFn = func(body *bytes.Buffer) {
+						require.Zero(t, body.Len())
+					}
+				}
+
+				testttp.
+					Get(t, "/foo").
+					Do(http.HandlerFunc(svr)).
+					ExpectStatus(statusCode).
+					ExpectBody(expectedBodyFn)
+			}
+			t.Run(http.StatusText(statusCode), fn)
+		}
+	})
+
+	t.Run("Err", func(t *testing.T) {
+		tests := []struct {
+			statusCode  int
+			expectedErr *influxdb.Error
+		}{
+			{
+				statusCode: http.StatusBadRequest,
+				expectedErr: &influxdb.Error{
+					Code: influxdb.EInvalid,
+					Msg:  "failed to unmarshal",
+				},
+			},
+			{
+				statusCode: http.StatusForbidden,
+				expectedErr: &influxdb.Error{
+					Code: influxdb.EForbidden,
+					Msg:  "forbidden",
+				},
+			},
+			{
+				statusCode: http.StatusUnprocessableEntity,
+				expectedErr: &influxdb.Error{
+					Code: influxdb.EUnprocessableEntity,
+					Msg:  "failed validation",
+				},
+			},
+			{
+				statusCode: http.StatusInternalServerError,
+				expectedErr: &influxdb.Error{
+					Code: influxdb.EInternal,
+					Msg:  "internal error",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			fn := func(t *testing.T) {
+				responder := kithttp.NewAPI()
+
+				svr := func(w http.ResponseWriter, r *http.Request) {
+					responder.Err(w, tt.expectedErr)
+				}
+
+				testttp.
+					Get(t, "/foo").
+					Do(http.HandlerFunc(svr)).
+					ExpectStatus(tt.statusCode).
+					ExpectBody(func(body *bytes.Buffer) {
+						var err kithttp.ErrBody
+						require.NoError(t, json.NewDecoder(body).Decode(&err))
+						assert.Equal(t, tt.expectedErr.Msg, err.Msg)
+						assert.Equal(t, tt.expectedErr.Code, err.Code)
+					})
+			}
+			t.Run(http.StatusText(tt.statusCode), fn)
+		}
+	})
+}
+
+func expectInfluxdbError(t *testing.T, expectedCode string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	iErr, ok := err.(*influxdb.Error)
+	if !ok {
+		t.Fatalf("expected an influxdb error; got=%#v", err)
+	}
+
+	if got := iErr.Code; expectedCode != got {
+		t.Fatalf("unexpected error code; expected=%s  got=%s", expectedCode, got)
+	}
+}
+
+func encodeGob(t *testing.T, v interface{}) io.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func encodeJSON(t *testing.T, v interface{}) io.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func okErrFn(err error) error {
+	return &influxdb.Error{
+		Code: influxdb.EUnprocessableEntity,
+		Msg:  "failed validation",
+		Err:  err,
+	}
+}
+
+func unmarshalErrFn(encoding string, err error) error {
+	return &influxdb.Error{
+		Code: influxdb.EInvalid,
+		Msg:  fmt.Sprintf("invalid %s request body", encoding),
+		Err:  err,
+	}
+}
+
+type validatFoo struct {
+	Foo string `gob:"foo"`
+	Bar int    `gob:"bar"`
+}
+
+func (v *validatFoo) OK() error {
+	var errs multiErr
+	if v.Foo == "" {
+		errs = append(errs, "foo must be at least 1 char")
+	}
+	if v.Bar < 0 {
+		errs = append(errs, "bar must be a postive real number")
+	}
+	return errs.toError()
+}
+
+type multiErr []string
+
+func (m multiErr) toError() error {
+	if len(m) > 0 {
+		return m
+	}
+	return nil
+}
+
+func (m multiErr) Error() string {
+	return strings.Join(m, "; ")
+}

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -8,9 +8,6 @@ import (
 	"github.com/influxdata/influxdb"
 )
 
-// PlatformErrorCodeHeader shows the error code of platform error.
-const PlatformErrorCodeHeader = "X-Platform-Error-Code"
-
 // ErrorHandler is the error handler in http package.
 type ErrorHandler int
 
@@ -43,20 +40,4 @@ func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.Res
 	}
 	b, _ := json.Marshal(e)
 	_, _ = w.Write(b)
-}
-
-// statusCodePlatformError is the map convert platform.Error to error
-var statusCodePlatformError = map[string]int{
-	influxdb.EInternal:            http.StatusInternalServerError,
-	influxdb.EInvalid:             http.StatusBadRequest,
-	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
-	influxdb.EEmptyValue:          http.StatusBadRequest,
-	influxdb.EConflict:            http.StatusUnprocessableEntity,
-	influxdb.ENotFound:            http.StatusNotFound,
-	influxdb.EUnavailable:         http.StatusServiceUnavailable,
-	influxdb.EForbidden:           http.StatusForbidden,
-	influxdb.ETooManyRequests:     http.StatusTooManyRequests,
-	influxdb.EUnauthorized:        http.StatusUnauthorized,
-	influxdb.EMethodNotAllowed:    http.StatusMethodNotAllowed,
-	influxdb.ETooLarge:            http.StatusRequestEntityTooLarge,
 }

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -291,39 +291,6 @@ func CreateOrganization(
 				},
 			},
 		},
-		{
-			name: "names should be unique",
-			fields: OrganizationFields{
-				IDGenerator:   mock.NewMockIDGenerator(),
-				OrgBucketIDs:  orgBucketsIDGenerator,
-				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
-				Organizations: []*influxdb.Organization{
-					{
-						ID:   MustIDBase16(orgOneID),
-						Name: "organization1",
-					},
-				},
-			},
-			args: args{
-				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
-					Name: "organization1",
-				},
-			},
-			wants: wants{
-				organizations: []*influxdb.Organization{
-					{
-						ID:   MustIDBase16(orgOneID),
-						Name: "organization1",
-					},
-				},
-				err: &influxdb.Error{
-					Code: influxdb.EConflict,
-					Op:   influxdb.OpCreateOrganization,
-					Msg:  "organization with name organization1 already exists",
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -337,7 +304,6 @@ func CreateOrganization(
 			// Delete only newly created organizations
 			// if tt.args.organization.ID != nil {
 			defer s.DeleteOrganization(ctx, tt.args.organization.ID)
-			// }
 
 			organizations, _, err := s.FindOrganizations(ctx, influxdb.OrganizationFilter{})
 			diffPlatformErrors(tt.name, err, nil, opPrefix, t)


### PR DESCRIPTION
Closes #16498

add a reusable api type for decoding and responding to http requests. Improves error handling.

Work is broken up into 2 commits, first one for creating the API decoder/responder, and the 2nd for using it within the org service. The new API type normalizes handling of decoding issues and failed write issues amongst. It is also very extensible, more we can do with it than what meets the eye.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass