### PR TITLE
fix(storage): simple8b passes checkptr (#15512)

### DIFF
--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -468,6 +468,8 @@ func Decode(dst *[240]uint64, v uint64) (n int, err error) {
 
 // Decode writes the uncompressed values from src to dst.  It returns the number
 // of values written or an error.
+//go:nocheckptr
+// nocheckptr while the underlying struct layout doesn't change
 func DecodeAll(dst, src []uint64) (value int, err error) {
 	j := 0
 	for _, v := range src {
@@ -480,6 +482,8 @@ func DecodeAll(dst, src []uint64) (value int, err error) {
 
 // DecodeBytesBigEndian writes the compressed, big-endian values from src to dst.  It returns the number
 // of values written or an error.
+//go:nocheckptr
+// nocheckptr while the underlying struct layout doesn't change
 func DecodeBytesBigEndian(dst []uint64, src []byte) (value int, err error) {
 	if len(src)&7 != 0 {
 		return 0, errors.New("src length is not multiple of 8")
@@ -503,11 +507,6 @@ func canPack(src []uint64, n, bits int) bool {
 		return false
 	}
 
-	end := len(src)
-	if n < end {
-		end = n
-	}
-
 	// Selector 0,1 are special and use 0 bits to encode runs of 1's
 	if bits == 0 {
 		for _, v := range src {
@@ -520,8 +519,8 @@ func canPack(src []uint64, n, bits int) bool {
 
 	max := uint64((1 << uint64(bits)) - 1)
 
-	for i := 0; i < end; i++ {
-		if src[i] > max {
+	for _, s := range src[:n] {
+		if s > max {
 			return false
 		}
 	}
@@ -541,6 +540,7 @@ func pack120(src []uint64) uint64 {
 
 // pack60 packs 60 values from in using 1 bit each
 func pack60(src []uint64) uint64 {
+	_ = src[59] // eliminate multiple bounds checks
 	return 2<<60 |
 		src[0] |
 		src[1]<<1 |
@@ -607,6 +607,7 @@ func pack60(src []uint64) uint64 {
 
 // pack30 packs 30 values from in using 2 bits each
 func pack30(src []uint64) uint64 {
+	_ = src[29] // eliminate multiple bounds checks
 	return 3<<60 |
 		src[0] |
 		src[1]<<2 |
@@ -642,6 +643,7 @@ func pack30(src []uint64) uint64 {
 
 // pack20 packs 20 values from in using 3 bits each
 func pack20(src []uint64) uint64 {
+	_ = src[19] // eliminate multiple bounds checks
 	return 4<<60 |
 		src[0] |
 		src[1]<<3 |
@@ -667,6 +669,7 @@ func pack20(src []uint64) uint64 {
 
 // pack15 packs 15 values from in using 3 bits each
 func pack15(src []uint64) uint64 {
+	_ = src[14] // eliminate multiple bounds checks
 	return 5<<60 |
 		src[0] |
 		src[1]<<4 |
@@ -687,6 +690,7 @@ func pack15(src []uint64) uint64 {
 
 // pack12 packs 12 values from in using 5 bits each
 func pack12(src []uint64) uint64 {
+	_ = src[11] // eliminate multiple bounds checks
 	return 6<<60 |
 		src[0] |
 		src[1]<<5 |
@@ -704,6 +708,7 @@ func pack12(src []uint64) uint64 {
 
 // pack10 packs 10 values from in using 6 bits each
 func pack10(src []uint64) uint64 {
+	_ = src[9] // eliminate multiple bounds checks
 	return 7<<60 |
 		src[0] |
 		src[1]<<6 |
@@ -719,6 +724,7 @@ func pack10(src []uint64) uint64 {
 
 // pack8 packs 8 values from in using 7 bits each
 func pack8(src []uint64) uint64 {
+	_ = src[7] // eliminate multiple bounds checks
 	return 8<<60 |
 		src[0] |
 		src[1]<<7 |
@@ -732,6 +738,7 @@ func pack8(src []uint64) uint64 {
 
 // pack7 packs 7 values from in using 8 bits each
 func pack7(src []uint64) uint64 {
+	_ = src[6] // eliminate multiple bounds checks
 	return 9<<60 |
 		src[0] |
 		src[1]<<8 |
@@ -744,6 +751,7 @@ func pack7(src []uint64) uint64 {
 
 // pack6 packs 6 values from in using 10 bits each
 func pack6(src []uint64) uint64 {
+	_ = src[5] // eliminate multiple bounds checks
 	return 10<<60 |
 		src[0] |
 		src[1]<<10 |
@@ -755,6 +763,7 @@ func pack6(src []uint64) uint64 {
 
 // pack5 packs 5 values from in using 12 bits each
 func pack5(src []uint64) uint64 {
+	_ = src[4] // eliminate multiple bounds checks
 	return 11<<60 |
 		src[0] |
 		src[1]<<12 |
@@ -765,6 +774,7 @@ func pack5(src []uint64) uint64 {
 
 // pack4 packs 4 values from in using 15 bits each
 func pack4(src []uint64) uint64 {
+	_ = src[3] // eliminate multiple bounds checks
 	return 12<<60 |
 		src[0] |
 		src[1]<<15 |
@@ -774,6 +784,7 @@ func pack4(src []uint64) uint64 {
 
 // pack3 packs 3 values from in using 20 bits each
 func pack3(src []uint64) uint64 {
+	_ = src[2] // eliminate multiple bounds checks
 	return 13<<60 |
 		src[0] |
 		src[1]<<20 |
@@ -782,6 +793,7 @@ func pack3(src []uint64) uint64 {
 
 // pack2 packs 2 values from in using 30 bits each
 func pack2(src []uint64) uint64 {
+	_ = src[1] // eliminate multiple bounds checks
 	return 14<<60 |
 		src[0] |
 		src[1]<<30


### PR DESCRIPTION
Cherry-pick of 8f665ec from 1.8.

* fix(simple8b): disable checkptr on batch decodes

* perf: improve performance of simple8b encoding

```
name                      old time/op    new time/op    delta
EncodeAll/1_bit-24          35.8µs ± 2%    35.8µs ± 2%     ~     (p=0.887 n=10+7)
EncodeAll/2_bits-24         35.7µs ± 4%    35.6µs ± 3%     ~     (p=0.684 n=10+10)
EncodeAll/3_bits-24         36.5µs ± 3%    36.4µs ± 4%     ~     (p=0.780 n=10+9)
EncodeAll/4_bits-24         36.4µs ± 3%    37.8µs ± 2%   +3.71%  (p=0.000 n=10+10)
EncodeAll/5_bits-24         38.0µs ± 3%    38.3µs ± 2%     ~     (p=0.280 n=10+10)
EncodeAll/6_bits-24         39.4µs ± 1%    38.5µs ± 2%   -2.43%  (p=0.001 n=10+9)
EncodeAll/7_bits-24         39.6µs ± 3%    38.9µs ± 3%   -1.83%  (p=0.029 n=10+10)
EncodeAll/8_bits-24         40.3µs ± 3%    40.5µs ± 4%     ~     (p=0.278 n=10+9)
EncodeAll/10_bits-24        42.6µs ± 3%    41.9µs ± 2%     ~     (p=0.075 n=10+10)
EncodeAll/12_bits-24        44.2µs ± 2%    42.8µs ± 2%   -3.11%  (p=0.000 n=10+10)
EncodeAll/15_bits-24        46.0µs ± 1%    46.1µs ± 3%     ~     (p=0.447 n=9+10)
EncodeAll/20_bits-24        51.4µs ± 2%    50.0µs ± 2%   -2.86%  (p=0.000 n=10+10)
EncodeAll/30_bits-24        60.6µs ± 1%    58.1µs ± 2%   -4.02%  (p=0.000 n=10+10)
EncodeAll/60_bits-24        90.2µs ± 2%    85.2µs ± 1%   -5.50%  (p=0.000 n=10+10)
EncodeAll/combination-24     782µs ± 3%     762µs ± 5%     ~     (p=0.063 n=10+10)
Encode-24                   3.08µs ± 2%    3.09µs ± 1%     ~     (p=0.656 n=9+8)
Encoder-24                  4.58µs ± 0%    4.40µs ± 1%   -4.04%  (p=0.000 n=8+8)

```

Closes #15509

