### PR TITLE
feat(pkger): add support for env references for buckets

### DIFF
--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -95,7 +95,7 @@ func TestCmdPkg(t *testing.T) {
 					pkg.Objects = append(pkg.Objects, pkger.Object{
 						APIVersion: pkger.APIVersion,
 						Type:       pkger.KindBucket,
-						Metadata:   pkger.Metadata{Name: "bucket1"},
+						Metadata:   pkger.Resource{"name": "bucket1"},
 					})
 					return &pkg, nil
 				},
@@ -211,7 +211,7 @@ func TestCmdPkg(t *testing.T) {
 						pkg.Objects = append(pkg.Objects, pkger.Object{
 							APIVersion: pkger.APIVersion,
 							Type:       rc.Kind,
-							Metadata:   pkger.Metadata{Name: name},
+							Metadata:   pkger.Resource{"name": name},
 						})
 					}
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7284,6 +7284,10 @@ components:
                     type: string
                   labelID:
                     type: string
+            missingEnvRefs:
+              type: array
+              items:
+                type: string
             missingSecrets:
               type: array
               items:

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -64,7 +64,7 @@ func bucketToObject(bkt influxdb.Bucket, name string) Object {
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindBucket,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec:       make(Resource),
 	}
 	assignNonZeroStrings(k.Spec, map[string]string{fieldDescription: bkt.Description})
@@ -80,7 +80,7 @@ func checkToObject(ch influxdb.Check, name string) Object {
 	}
 	k := Object{
 		APIVersion: APIVersion,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec: Resource{
 			fieldStatus: influxdb.TaskStatusActive,
 		},
@@ -391,7 +391,7 @@ func DashboardToObject(dash influxdb.Dashboard, name string) Object {
 	return Object{
 		APIVersion: APIVersion,
 		Type:       KindDashboard,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec: Resource{
 			fieldDescription: dash.Description,
 			fieldDashCharts:  charts,
@@ -406,7 +406,7 @@ func labelToObject(l influxdb.Label, name string) Object {
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindLabel,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec:       make(Resource),
 	}
 
@@ -423,7 +423,7 @@ func endpointKind(e influxdb.NotificationEndpoint, name string) Object {
 	}
 	k := Object{
 		APIVersion: APIVersion,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec:       make(Resource),
 	}
 	assignNonZeroStrings(k.Spec, map[string]string{
@@ -466,7 +466,7 @@ func ruleToObject(iRule influxdb.NotificationRule, endpointName, name string) Ob
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindNotificationRule,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec: Resource{
 			fieldNotificationRuleEndpointName: endpointName,
 		},
@@ -536,7 +536,7 @@ func taskToObject(t influxdb.Task, name string) Object {
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindTask,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec: Resource{
 			fieldQuery: strings.TrimSpace(query),
 		},
@@ -557,7 +557,7 @@ func telegrafToObject(t influxdb.TelegrafConfig, name string) Object {
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindTelegraf,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec: Resource{
 			fieldTelegrafConfig: t.Config,
 		},
@@ -577,7 +577,7 @@ func VariableToObject(v influxdb.Variable, name string) Object {
 	k := Object{
 		APIVersion: APIVersion,
 		Type:       KindVariable,
-		Metadata:   Metadata{Name: name},
+		Metadata:   convertToMetadataResource(name),
 		Spec:       make(Resource),
 	}
 	assignNonZeroStrings(k.Spec, map[string]string{fieldDescription: v.Description})
@@ -608,6 +608,12 @@ func VariableToObject(v influxdb.Variable, name string) Object {
 	}
 
 	return k
+}
+
+func convertToMetadataResource(name string) Resource {
+	return Resource{
+		"name": name,
+	}
 }
 
 func assignNonZeroFluxDurs(r Resource, m map[string]*notification.Duration) {

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -87,6 +87,7 @@ func (s *HTTPRemoteService) Apply(ctx context.Context, orgID, userID influxdb.ID
 
 	reqBody := ReqApplyPkg{
 		OrgID:   orgID.String(),
+		EnvRefs: opt.EnvRefs,
 		Secrets: opt.MissingSecrets,
 		RawPkg:  b,
 	}

--- a/pkger/http_server.go
+++ b/pkger/http_server.go
@@ -154,6 +154,7 @@ type ReqApplyPkg struct {
 	OrgID   string            `json:"orgID" yaml:"orgID"`
 	Remote  PkgRemote         `json:"remote" yaml:"remote"`
 	RawPkg  json.RawMessage   `json:"package" yaml:"package"`
+	EnvRefs map[string]string `json:"envRefs"`
 	Secrets map[string]string `json:"secrets"`
 }
 
@@ -230,7 +231,7 @@ func (s *HTTPServer) applyPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sum, err = s.svc.Apply(r.Context(), *orgID, userID, parsedPkg, ApplyWithSecrets(reqBody.Secrets))
+	sum, err = s.svc.Apply(r.Context(), *orgID, userID, parsedPkg, ApplyWithEnvRefs(reqBody.EnvRefs), ApplyWithSecrets(reqBody.Secrets))
 	if err != nil && !IsParseErr(err) {
 		s.api.Err(w, err)
 		return

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -19,13 +19,13 @@ func TestPkg(t *testing.T) {
 						id:             influxdb.ID(2),
 						OrgID:          influxdb.ID(100),
 						Description:    "desc2",
-						name:           "name2",
+						name:           &references{val: "name2"},
 						RetentionRules: retentionRules{newRetentionRule(2 * time.Hour)},
 					},
 					"buck_1": {
 						id:             influxdb.ID(1),
 						OrgID:          influxdb.ID(100),
-						name:           "name1",
+						name:           &references{val: "name1"},
 						Description:    "desc1",
 						RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 					},
@@ -86,7 +86,7 @@ func TestPkg(t *testing.T) {
 		t.Run("label mappings returned in asc order by name", func(t *testing.T) {
 			bucket1 := &bucket{
 				id:   influxdb.ID(20),
-				name: "b1",
+				name: &references{val: "b1"},
 			}
 			label1 := &label{
 				id:          influxdb.ID(2),

--- a/pkger/testdata/env_refs.yml
+++ b/pkger/testdata/env_refs.yml
@@ -1,0 +1,18 @@
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationEndpointPagerDuty
+metadata:
+  name: pager_duty_notification_endpoint
+spec:
+  description: pager duty desc
+  url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
+  routingKey:
+    envRef:
+      key: "routing-key"
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:
+    envRef:
+      key: "bkt-1-name-ref"
+spec:


### PR DESCRIPTION
references: #16472

this is the first (of many) PRs to add environment references for pkgs. This enables pkgs to ask for user input, be it http or cli.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)