### PR TITLE
feat(pkger): add env ref fields for remaining resources

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -553,6 +553,91 @@ metadata:
     envRef:
       key: "bkt-1-name-ref"
 spec:
+---
+apiVersion: %[1]s
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: "label-1-name-ref"
+spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: CheckDeadman
+metadata:
+  name:
+    envRef:
+      key: check-1-name-ref
+spec:
+  every: 5m
+  level: cRiT
+  query:  >
+    from(bucket: "rucket_1") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  statusMessageTemplate: "Check: ${ r._check_name } is: ${ r._level }"
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Dashboard
+metadata:
+  name:
+    envRef:
+      key: dash-1-name-ref
+spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationEndpointSlack
+metadata:
+  name:
+    envRef:
+      key: endpoint-1-name-ref
+spec:
+  url: https://hooks.slack.com/services/bip/piddy/boppidy
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationRule
+metadata:
+  name:
+    envRef:
+      key: rule-1-name-ref
+spec:
+  endpointName:
+    envRef:
+      key: endpoint-1-name-ref
+  every: 10m
+  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
+  statusRules:
+    - currentLevel: WARN
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Telegraf
+metadata:
+  name:
+    envRef:
+      key: telegraf-1-name-ref
+spec:
+  config: |
+    [agent]
+      interval = "10s"
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Task
+metadata:
+  name:
+    envRef:
+      key: task-1-name-ref
+spec:
+  cron: 15 * * * *
+  query:  >
+    from(bucket: "rucket_1")
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Variable
+metadata:
+  name:
+    envRef:
+      key: var-1-name-ref
+spec:
+  type: constant
+  values: [first val]
 `, pkger.APIVersion)
 
 		pkg, err := pkger.Parse(pkger.EncodingYAML, pkger.FromString(pkgStr))
@@ -563,14 +648,59 @@ spec:
 
 		require.Len(t, sum.Buckets, 1)
 		assert.Equal(t, "$bkt-1-name-ref", sum.Buckets[0].Name)
-		assert.Equal(t, []string{"bkt-1-name-ref"}, sum.MissingEnvs)
+		require.Len(t, sum.Checks, 1)
+		assert.Equal(t, "$check-1-name-ref", sum.Checks[0].Check.GetName())
+		require.Len(t, sum.Dashboards, 1)
+		assert.Equal(t, "$dash-1-name-ref", sum.Dashboards[0].Name)
+		require.Len(t, sum.Labels, 1)
+		assert.Equal(t, "$label-1-name-ref", sum.Labels[0].Name)
+		require.Len(t, sum.NotificationEndpoints, 1)
+		assert.Equal(t, "$endpoint-1-name-ref", sum.NotificationEndpoints[0].NotificationEndpoint.GetName())
+		require.Len(t, sum.NotificationRules, 1)
+		assert.Equal(t, "$rule-1-name-ref", sum.NotificationRules[0].Name)
+		require.Len(t, sum.TelegrafConfigs, 1)
+		assert.Equal(t, "$task-1-name-ref", sum.Tasks[0].Name)
+		require.Len(t, sum.TelegrafConfigs, 1)
+		assert.Equal(t, "$telegraf-1-name-ref", sum.TelegrafConfigs[0].TelegrafConfig.Name)
+		require.Len(t, sum.Variables, 1)
+		assert.Equal(t, "$var-1-name-ref", sum.Variables[0].Name)
+
+		expectedMissingEnvs := []string{
+			"bkt-1-name-ref",
+			"check-1-name-ref",
+			"dash-1-name-ref",
+			"endpoint-1-name-ref",
+			"label-1-name-ref",
+			"rule-1-name-ref",
+			"task-1-name-ref",
+			"telegraf-1-name-ref",
+			"var-1-name-ref",
+		}
+		assert.Equal(t, expectedMissingEnvs, sum.MissingEnvs)
 
 		sum, err = svc.Apply(timedCtx(time.Second), l.Org.ID, l.User.ID, pkg, pkger.ApplyWithEnvRefs(map[string]string{
-			"bkt-1-name-ref": "rucket_threeve",
+			"bkt-1-name-ref":      "rucket_threeve",
+			"check-1-name-ref":    "check_threeve",
+			"dash-1-name-ref":     "dash_threeve",
+			"endpoint-1-name-ref": "endpoint_threeve",
+			"label-1-name-ref":    "label_threeve",
+			"rule-1-name-ref":     "rule_threeve",
+			"telegraf-1-name-ref": "telegraf_threeve",
+			"task-1-name-ref":     "task_threeve",
+			"var-1-name-ref":      "var_threeve",
 		}))
 		require.NoError(t, err)
 
 		assert.Equal(t, "rucket_threeve", sum.Buckets[0].Name)
+		assert.Equal(t, "check_threeve", sum.Checks[0].Check.GetName())
+		assert.Equal(t, "dash_threeve", sum.Dashboards[0].Name)
+		assert.Equal(t, "endpoint_threeve", sum.NotificationEndpoints[0].NotificationEndpoint.GetName())
+		assert.Equal(t, "label_threeve", sum.Labels[0].Name)
+		assert.Equal(t, "rule_threeve", sum.NotificationRules[0].Name)
+		assert.Equal(t, "endpoint_threeve", sum.NotificationRules[0].EndpointName)
+		assert.Equal(t, "telegraf_threeve", sum.TelegrafConfigs[0].TelegrafConfig.Name)
+		assert.Equal(t, "task_threeve", sum.Tasks[0].Name)
+		assert.Equal(t, "var_threeve", sum.Variables[0].Name)
 		assert.Empty(t, sum.MissingEnvs)
 	})
 }

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -51,14 +51,14 @@ func TestPkg(t *testing.T) {
 					"2": {
 						id:          influxdb.ID(2),
 						OrgID:       influxdb.ID(100),
-						name:        "name2",
+						name:        &references{val: "name2"},
 						Description: "desc2",
 						Color:       "blurple",
 					},
 					"1": {
 						id:          influxdb.ID(1),
 						OrgID:       influxdb.ID(100),
-						name:        "name1",
+						name:        &references{val: "name1"},
 						Description: "desc1",
 						Color:       "peru",
 					},
@@ -91,7 +91,7 @@ func TestPkg(t *testing.T) {
 			label1 := &label{
 				id:          influxdb.ID(2),
 				OrgID:       influxdb.ID(100),
-				name:        "name2",
+				name:        &references{val: "name2"},
 				Description: "desc2",
 				Color:       "blurple",
 				associationMapping: associationMapping{

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -113,14 +113,14 @@ metadata:
 				require.Len(t, labels, 2)
 
 				expectedLabel1 := label{
-					name:        "label_1",
+					name:        &references{val: "label_1"},
 					Description: "label 1 description",
 					Color:       "#FFFFFF",
 				}
 				assert.Equal(t, expectedLabel1, *labels[0])
 
 				expectedLabel2 := label{
-					name:        "label_2",
+					name:        &references{val: "label_2"},
 					Description: "label 2 description",
 					Color:       "#000000",
 				}
@@ -3346,27 +3346,42 @@ spec:
 		testfileRunner(t, "testdata/env_refs.yml", func(t *testing.T, pkg *Pkg) {
 			sum := pkg.Summary()
 
-			bkts := sum.Buckets
-			require.Len(t, bkts, 1)
-			assert.Equal(t, "$bkt-1-name-ref", bkts[0].Name)
+			require.Len(t, sum.Buckets, 1)
+			assert.Equal(t, "$bkt-1-name-ref", sum.Buckets[0].Name)
 			hasEnv(t, pkg.mEnv, "bkt-1-name-ref")
 
-			endpoints := sum.NotificationEndpoints
-			require.Len(t, endpoints, 1)
+			require.Len(t, sum.Checks, 1)
+			assert.Equal(t, "$check-1-name-ref", sum.Checks[0].Check.GetName())
+			hasEnv(t, pkg.mEnv, "check-1-name-ref")
 
-			expected := &endpoint.PagerDuty{
-				Base: endpoint.Base{
-					Name:   "pager_duty_notification_endpoint",
-					Status: influxdb.TaskStatusActive,
-				},
-				ClientURL: "http://localhost:8080/orgs/7167eb6719fa34e5/alert-history",
-			}
-			actual, ok := endpoints[0].NotificationEndpoint.(*endpoint.PagerDuty)
-			require.True(t, ok)
-			assert.Equal(t, expected.Base.Name, actual.Name)
-			require.Nil(t, actual.RoutingKey.Value)
+			require.Len(t, sum.Dashboards, 1)
+			assert.Equal(t, "$dash-1-name-ref", sum.Dashboards[0].Name)
+			hasEnv(t, pkg.mEnv, "dash-1-name-ref")
 
-			hasEnv(t, pkg.mEnv, "routing-key")
+			require.Len(t, sum.NotificationEndpoints, 1)
+			assert.Equal(t, "$endpoint-1-name-ref", sum.NotificationEndpoints[0].NotificationEndpoint.GetName())
+			hasEnv(t, pkg.mEnv, "endpoint-1-name-ref")
+
+			require.Len(t, sum.Labels, 1)
+			assert.Equal(t, "$label-1-name-ref", sum.Labels[0].Name)
+			hasEnv(t, pkg.mEnv, "label-1-name-ref")
+
+			require.Len(t, sum.NotificationRules, 1)
+			assert.Equal(t, "$rule-1-name-ref", sum.NotificationRules[0].Name)
+			assert.Equal(t, "$endpoint-1-name-ref", sum.NotificationRules[0].EndpointName)
+			hasEnv(t, pkg.mEnv, "rule-1-name-ref")
+
+			require.Len(t, sum.Tasks, 1)
+			assert.Equal(t, "$task-1-name-ref", sum.Tasks[0].Name)
+			hasEnv(t, pkg.mEnv, "task-1-name-ref")
+
+			require.Len(t, sum.TelegrafConfigs, 1)
+			assert.Equal(t, "$telegraf-1-name-ref", sum.TelegrafConfigs[0].TelegrafConfig.Name)
+			hasEnv(t, pkg.mEnv, "telegraf-1-name-ref")
+
+			require.Len(t, sum.Variables, 1)
+			assert.Equal(t, "$var-1-name-ref", sum.Variables[0].Name)
+			hasEnv(t, pkg.mEnv, "var-1-name-ref")
 		})
 	})
 

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -865,9 +865,9 @@ func (s *Service) dryRunNotificationRules(ctx context.Context, orgID influxdb.ID
 
 	diffs := make([]DiffNotificationRule, 0, len(mExisting))
 	for _, r := range pkg.notificationRules() {
-		e, ok := mExisting[r.endpointName]
+		e, ok := mExisting[r.endpointName.String()]
 		if !ok {
-			pkgerEndpoint, ok := pkg.mNotificationEndpoints[r.endpointName]
+			pkgerEndpoint, ok := pkg.mNotificationEndpoints[r.endpointName.String()]
 			if !ok {
 				err := fmt.Errorf("failed to find endpoint by name: %q", r.endpointName)
 				return nil, &influxdb.Error{Code: influxdb.EUnprocessableEntity, Err: err}
@@ -1660,7 +1660,7 @@ func (s *Service) applyNotificationRulesGenerator(ctx context.Context, orgID inf
 
 	var errs applyErrs
 	for _, r := range rules {
-		v, ok := mEndpoints[r.endpointName]
+		v, ok := mEndpoints[r.endpointName.String()]
 		if !ok {
 			errs = append(errs, &applyErrBody{
 				name: r.Name(),
@@ -1851,7 +1851,7 @@ func (s *Service) applyTelegrafs(teles []*telegraf) applier {
 		var cfg influxdb.TelegrafConfig
 		mutex.Do(func() {
 			teles[i].config.OrgID = orgID
-			cfg = teles[i].config
+			cfg = teles[i].summarize().TelegrafConfig
 		})
 
 		err := s.teleSVC.CreateTelegrafConfig(ctx, &cfg, userID)

--- a/pkger/testdata/env_refs.yml
+++ b/pkger/testdata/env_refs.yml
@@ -1,18 +1,97 @@
 apiVersion: influxdata.com/v2alpha1
-kind: NotificationEndpointPagerDuty
-metadata:
-  name: pager_duty_notification_endpoint
-spec:
-  description: pager duty desc
-  url:  http://localhost:8080/orgs/7167eb6719fa34e5/alert-history
-  routingKey:
-    envRef:
-      key: "routing-key"
----
-apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
   name:
     envRef:
-      key: "bkt-1-name-ref"
+      key: bkt-1-name-ref
 spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-1-name-ref
+spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: CheckDeadman
+metadata:
+  name:
+    envRef:
+      key: check-1-name-ref
+spec:
+  every: 5m
+  level: cRiT
+  query:  >
+    from(bucket: "rucket_1") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  statusMessageTemplate: "Check: ${ r._check_name } is: ${ r._level }"
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Dashboard
+metadata:
+  name:
+    envRef:
+      key: dash-1-name-ref
+spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationEndpointSlack
+metadata:
+  name:
+    envRef:
+      key: endpoint-1-name-ref
+spec:
+  url: https://hooks.slack.com/services/bip/piddy/boppidy
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationRule
+metadata:
+  name:
+    envRef:
+      key: rule-1-name-ref
+spec:
+  endpointName:
+    envRef:
+      key: endpoint-1-name-ref
+  every: 10m
+  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
+  statusRules:
+    - currentLevel: WARN
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Telegraf
+metadata:
+  name:
+    envRef:
+      key: telegraf-1-name-ref
+spec:
+  config: |
+    [agent]
+      interval = "10s"
+    [[outputs.influxdb_v2]]
+      urls = ["http://localhost:9999"]
+      token = "$INFLUX_TOKEN"
+      organization = "rg"
+      bucket = "rucket_3"
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Task
+metadata:
+  name:
+    envRef:
+      key: task-1-name-ref
+spec:
+  cron: 15 * * * *
+  query:  >
+    from(bucket: "rucket_1")
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Variable
+metadata:
+  name:
+    envRef:
+      key: var-1-name-ref
+spec:
+  type: constant
+  values: [first val]


### PR DESCRIPTION
rest of resource metadata getting the env refs for pkger

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass