### PR TITLE
fix(kv): fix patching panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Undecided
+
+### Bug Fixes
+
+1. [16733](https://github.com/influxdata/influxdb/pull/16733): Fix notification rule renaming panics from UI
+
 ## v2.0.0-beta.2 [2020-01-24]
 
 ### Features

--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -240,6 +240,10 @@ func (s *Service) patchNotificationRule(ctx context.Context, tx Tx, id influxdb.
 	if upd.Description != nil {
 		nr.SetDescription(*upd.Description)
 	}
+	var status *string
+	if upd.Status != nil {
+		status = strPtr(string(*upd.Status))
+	}
 
 	nr.SetUpdatedAt(s.TimeGenerator.Now())
 
@@ -247,7 +251,7 @@ func (s *Service) patchNotificationRule(ctx context.Context, tx Tx, id influxdb.
 		return nil, err
 	}
 
-	_, err = s.updateNotificationTask(ctx, tx, nr, strPtr(string(*upd.Status)))
+	_, err = s.updateNotificationTask(ctx, tx, nr, status)
 	if err != nil {
 		return nil, err
 	}

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -2003,6 +2003,145 @@ func PatchNotificationRule(
 			},
 		},
 		{
+			name: "patch without status",
+			fields: NotificationRuleFields{
+				TimeGenerator: fakeGenerator,
+				IDGenerator:   mock.NewIDGenerator(twoID, t),
+				Tasks: []influxdb.TaskCreate{
+					{
+						OwnerID:        MustIDBase16(sixID),
+						OrganizationID: MustIDBase16(fourID),
+						Flux: `from(bucket: "foo") |> range(start: -1m)
+						option task = {name: "bar", every: 1m}
+						`,
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.NotificationRuleResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.NotificationRuleResourceType,
+					},
+				},
+				Endpoints: []influxdb.NotificationEndpoint{
+					&endpoint.Slack{
+						URL: "http://localhost:7777",
+						Token: influxdb.SecretField{
+							// TODO(desa): not sure why this has to end in token, but it does
+							Key:   "020f755c3c082001-token",
+							Value: strPtr("abc123"),
+						},
+						Base: endpoint.Base{
+							OrgID:  MustIDBase16Ptr(fourID),
+							Name:   "foo",
+							Status: influxdb.Active,
+						},
+					},
+				},
+				NotificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:          MustIDBase16(oneID),
+							Name:        "name1",
+							OwnerID:     MustIDBase16(sixID),
+							OrgID:       MustIDBase16(fourID),
+							EndpointID:  MustIDBase16(twoID),
+							RunbookLink: "runbooklink1",
+							SleepUntil:  &time3,
+							Every:       mustDuration("1h"),
+							StatusRules: []notification.StatusRule{
+								{
+									CurrentLevel: notification.Critical,
+								},
+								{
+									CurrentLevel: notification.Info,
+								},
+							},
+							CRUDLog: influxdb.CRUDLog{
+								CreatedAt: timeGen1.Now(),
+								UpdatedAt: timeGen2.Now(),
+							},
+						},
+						Channel:         "channel1",
+						MessageTemplate: "msg1",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(twoID),
+							Name:       "name2",
+							OwnerID:    MustIDBase16(sixID),
+							EndpointID: MustIDBase16(twoID),
+							TaskID:     MustIDBase16(twoID),
+							StatusRules: []notification.StatusRule{
+								{
+									CurrentLevel: notification.Critical,
+								},
+								{
+									CurrentLevel: notification.Info,
+								},
+							},
+							OrgID:       MustIDBase16(fourID),
+							RunbookLink: "runbooklink2",
+							SleepUntil:  &time3,
+							Every:       mustDuration("1h"),
+							CRUDLog: influxdb.CRUDLog{
+								CreatedAt: timeGen1.Now(),
+								UpdatedAt: timeGen2.Now(),
+							},
+						},
+						MessageTemplate: "msg",
+					},
+				},
+				Orgs: []*influxdb.Organization{
+					{
+						ID:   MustIDBase16(fourID),
+						Name: "foo",
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(twoID),
+				upd: influxdb.NotificationRuleUpdate{
+					Name: &name3,
+				},
+			},
+			wants: wants{
+				notificationRule: &rule.Slack{
+					Base: rule.Base{
+						ID:         MustIDBase16(twoID),
+						Name:       name3,
+						OwnerID:    MustIDBase16(sixID),
+						OrgID:      MustIDBase16(fourID),
+						EndpointID: MustIDBase16(twoID),
+						TaskID:     MustIDBase16(twoID),
+						StatusRules: []notification.StatusRule{
+							{
+								CurrentLevel: notification.Critical,
+							},
+							{
+								CurrentLevel: notification.Info,
+							},
+						},
+						RunbookLink: "runbooklink2",
+						SleepUntil:  &time3,
+						Every:       mustDuration("1h"),
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: timeGen1.Now(),
+							UpdatedAt: fakeDate,
+						},
+					},
+					MessageTemplate: "msg",
+				},
+			},
+		},
+		{
 			name: "regular patch",
 			fields: NotificationRuleFields{
 				TimeGenerator: fakeGenerator,


### PR DESCRIPTION
Closes #16293

When sending a patching request without status, notification rule will try to dereference the status, which results a panic. This ticket fixes the issue, adding a new test case for patching without status


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
