### PR TITLE
feat(pkger): add env refs for associations

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -553,6 +553,11 @@ metadata:
     envRef:
       key: "bkt-1-name-ref"
 spec:
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-1-name-ref
 ---
 apiVersion: %[1]s
 kind: Label
@@ -648,6 +653,7 @@ spec:
 
 		require.Len(t, sum.Buckets, 1)
 		assert.Equal(t, "$bkt-1-name-ref", sum.Buckets[0].Name)
+		assert.Len(t, sum.Buckets[0].LabelAssociations, 1)
 		require.Len(t, sum.Checks, 1)
 		assert.Equal(t, "$check-1-name-ref", sum.Checks[0].Check.GetName())
 		require.Len(t, sum.Dashboards, 1)

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1102,7 +1102,8 @@ func (p *Pkg) parseNestedLabel(nr Resource, fn func(lb *label) error) *validatio
 		return nil
 	}
 
-	lb, found := p.mLabels[nr.Name()]
+	nameRef := nr.references(fieldName)
+	lb, found := p.mLabels[nameRef.String()]
 	if !found {
 		return &validationErr{
 			Field: fieldAssociations,

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3348,14 +3348,17 @@ spec:
 
 			require.Len(t, sum.Buckets, 1)
 			assert.Equal(t, "$bkt-1-name-ref", sum.Buckets[0].Name)
+			assert.Len(t, sum.Buckets[0].LabelAssociations, 1)
 			hasEnv(t, pkg.mEnv, "bkt-1-name-ref")
 
 			require.Len(t, sum.Checks, 1)
 			assert.Equal(t, "$check-1-name-ref", sum.Checks[0].Check.GetName())
+			assert.Len(t, sum.Checks[0].LabelAssociations, 1)
 			hasEnv(t, pkg.mEnv, "check-1-name-ref")
 
 			require.Len(t, sum.Dashboards, 1)
 			assert.Equal(t, "$dash-1-name-ref", sum.Dashboards[0].Name)
+			assert.Len(t, sum.Dashboards[0].LabelAssociations, 1)
 			hasEnv(t, pkg.mEnv, "dash-1-name-ref")
 
 			require.Len(t, sum.NotificationEndpoints, 1)

--- a/pkger/testdata/env_refs.yml
+++ b/pkger/testdata/env_refs.yml
@@ -1,18 +1,23 @@
 apiVersion: influxdata.com/v2alpha1
-kind: Bucket
-metadata:
-  name:
-    envRef:
-      key: bkt-1-name-ref
-spec:
----
-apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
   name:
     envRef:
       key: label-1-name-ref
 spec:
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:
+    envRef:
+      key: bkt-1-name-ref
+spec:
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-1-name-ref
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: CheckDeadman
@@ -26,6 +31,11 @@ spec:
   query:  >
     from(bucket: "rucket_1") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   statusMessageTemplate: "Check: ${ r._check_name } is: ${ r._level }"
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-1-name-ref
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: Dashboard
@@ -34,6 +44,11 @@ metadata:
     envRef:
       key: dash-1-name-ref
 spec:
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-1-name-ref
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: NotificationEndpointSlack


### PR DESCRIPTION
More pkger goodness, this one enables env refs for all associations

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass