### PR TITLE
fix(CORS): accept OPTIONS preflight request with Origin header

### DIFF
--- a/kit/transport/http/api_test.go
+++ b/kit/transport/http/api_test.go
@@ -233,7 +233,6 @@ func expectInfluxdbError(t *testing.T, expectedCode string, err error) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-
 	iErr, ok := err.(*influxdb.Error)
 	if !ok {
 		t.Fatalf("expected an influxdb error; got=%#v", err)

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -53,9 +53,13 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 
 func SkipOptions(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "OPTIONS" {
+		// Preflight CORS requests from the browser will send an options request,
+		// so we need to make sure we satisfy them
+		if origin := r.Header.Get("Origin"); origin == "" && r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -1,10 +1,12 @@
 package http
 
 import (
+	"net/http"
 	"path"
 	"testing"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/pkg/testttp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,6 +42,54 @@ func Test_normalizePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := normalizePath(tt.path)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCors(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("nextHandler"))
+	})
+
+	tests := []struct {
+		name            string
+		method          string
+		headers         []string
+		expectedStatus  int
+		expectedHeaders map[string]string
+	}{
+		{
+			name:           "OPTIONS without Origin",
+			method:         "OPTIONS",
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:           "OPTIONS with Origin",
+			method:         "OPTIONS",
+			headers:        []string{"Origin", "http://myapp.com"},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "GET with Origin",
+			method:         "GET",
+			headers:        []string{"Origin", "http://anotherapp.com"},
+			expectedStatus: http.StatusOK,
+			expectedHeaders: map[string]string{
+				"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE",
+				"Access-Control-Allow-Origin":  "http://anotherapp.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svr := SkipOptions(SetCORS(nextHandler))
+
+			testttp.
+				HTTP(t, tt.method, "/", nil).
+				Headers("", "", tt.headers...).
+				Do(svr).
+				ExpectStatus(tt.expectedStatus).
+				ExpectHeaders(tt.expectedHeaders)
 		})
 	}
 }

--- a/pkg/testttp/http.go
+++ b/pkg/testttp/http.go
@@ -146,6 +146,15 @@ func (r *Resp) ExpectBody(fn func(body *bytes.Buffer)) *Resp {
 	return r
 }
 
+// ExpectHeaders asserts that multiple headers with values exist in the recorder.
+func (r *Resp) ExpectHeaders(h map[string]string) *Resp {
+	for k, v := range h {
+		r.ExpectHeader(k, v)
+	}
+
+	return r
+}
+
 // ExpectHeader asserts that the header is in the recorder.
 func (r *Resp) ExpectHeader(k, v string) *Resp {
 	r.t.Helper()


### PR DESCRIPTION
Browsers send a preflight `OPTIONS` request with a `Origin` header to validate the CORS policy before sending the real request. Currently we block this from working, disallowing any developer to build their own tooling with the Influx API

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
