### PR TITLE
feat(kv): add cursor option skip first item

### DIFF
--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -226,12 +226,18 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 		return nil, fmt.Errorf("seek bytes %q not prefixed with %q: %w", string(seek), string(config.Prefix), kv.ErrSeekMissingPrefix)
 	}
 
-	return &Cursor{
+	c := &Cursor{
 		cursor: cursor,
-		key:    key,
-		value:  value,
 		config: config,
-	}, nil
+	}
+
+	// only remember first seeked item if not skipped
+	if !config.SkipFirst {
+		c.key = key
+		c.value = value
+	}
+
+	return c, nil
 }
 
 // Cursor retrieves a cursor for iterating through the entries

--- a/kv/store.go
+++ b/kv/store.go
@@ -148,6 +148,7 @@ type CursorConfig struct {
 	Direction CursorDirection
 	Hints     CursorHints
 	Prefix    []byte
+	SkipFirst bool
 }
 
 // NewCursorConfig constructs and configures a CursorConfig used to configure
@@ -188,5 +189,13 @@ func WithCursorHints(hints ...CursorHint) CursorOption {
 func WithCursorPrefix(prefix []byte) CursorOption {
 	return func(c *CursorConfig) {
 		c.Prefix = prefix
+	}
+}
+
+// WithCursorSkipFirstItem skips returning the first item found within
+// the seek.
+func WithCursorSkipFirstItem() CursorOption {
+	return func(c *CursorConfig) {
+		c.SkipFirst = true
 	}
 }

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -738,6 +738,25 @@ func KVForwardCursor(
 			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03"},
 		},
 		{
+			name: "prefix - skip first",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa/00",
+				until: "bbb/02",
+				opts: []kv.CursorOption{
+					kv.WithCursorPrefix([]byte("aaa")),
+					kv.WithCursorSkipFirstItem(),
+				},
+			},
+			exp: []string{"aaa/01", "aaa/02", "aaa/03"},
+		},
+		{
 			name: "prefix - does not prefix seek",
 			fields: KVStoreFields{
 				Bucket: []byte("bucket"),


### PR DESCRIPTION
Add support for `WithCursorSkipFirstItem()` which steps over the first item in the cursor.

This is useful for seeking after the provided `seek` bytes.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
