### PR TITLE
fix: remove orgs from token permission list

### DIFF
--- a/ui/src/authorizations/utils/permissions.test.ts
+++ b/ui/src/authorizations/utils/permissions.test.ts
@@ -1,0 +1,240 @@
+import {allAccessPermissions} from './permissions'
+import {Permission} from 'src/types'
+
+const hvhs: Permission[] = [
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'authorizations',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'authorizations',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'checks',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'checks',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'dashboards',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'dashboards',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'documents',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'documents',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'labels',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'labels',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'notificationRules',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'notificationRules',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'notificationEndpoints',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'notificationEndpoints',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      id: 'bulldogs',
+      type: 'orgs',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'secrets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'secrets',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'scrapers',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'scrapers',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'sources',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'sources',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'tasks',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'tasks',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'telegrafs',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'telegrafs',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'users',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'users',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'variables',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'variables',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'views',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'views',
+    },
+  },
+]
+
+test('should return proper object', () => {
+  expect(allAccessPermissions('bulldogs')).toMatchObject(hvhs)
+})

--- a/ui/src/authorizations/utils/permissions.test.ts
+++ b/ui/src/authorizations/utils/permissions.test.ts
@@ -235,6 +235,6 @@ const hvhs: Permission[] = [
   },
 ]
 
-test('should return proper object', () => {
+test('all-access tokens/authorizations production test', () => {
   expect(allAccessPermissions('bulldogs')).toMatchObject(hvhs)
 })

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -1,12 +1,12 @@
 import {Bucket, Permission} from 'src/types'
 
-type PermissionTypeValues = Permission['resource']['type']
+type PermissionTypes = Permission['resource']['type']
 
 function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x)
 }
 
-const allPermissionTypes: PermissionTypeValues[] = [
+const allPermissionTypes: PermissionTypes[] = [
   'authorizations',
   'buckets',
   'checks',
@@ -27,10 +27,10 @@ const allPermissionTypes: PermissionTypeValues[] = [
 ]
 
 // The switch statement below will cause a TS error
-// if all allowable PermissionTypeValues generated in the client
+// if all allowable PermissionTypes generated in the client
 // generatedRoutes are not included in the switch statement BUT
 // they will need to be added to both the switch statement AND the allPermissionTypes array.
-const ensureT = (orgID: string) => (t) => {
+const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
   switch (t) {
     case 'authorizations':
     case 'buckets':

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -15,7 +15,6 @@ const allPermissionTypes: PermissionTypes[] = [
   'labels',
   'notificationRules',
   'notificationEndpoints',
-  'orgs',
   'secrets',
   'scrapers',
   'sources',
@@ -40,7 +39,6 @@ const ensureT = (orgID: string) => (t: PermissionTypes) => {
     case 'labels':
     case 'notificationRules':
     case 'notificationEndpoints':
-    case 'orgs':
     case 'secrets':
     case 'scrapers':
     case 'sources':

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -1,12 +1,12 @@
 import {Bucket, Permission} from 'src/types'
 
-type PermissionTypes = Permission['resource']['type']
+type PermissionTypeValues = Permission['resource']['type']
 
 function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x)
 }
 
-const allPermissionTypes: PermissionTypes[] = [
+const allPermissionTypes: PermissionTypeValues[] = [
   'authorizations',
   'buckets',
   'checks',
@@ -15,6 +15,7 @@ const allPermissionTypes: PermissionTypes[] = [
   'labels',
   'notificationRules',
   'notificationEndpoints',
+  'orgs',
   'secrets',
   'scrapers',
   'sources',
@@ -26,10 +27,10 @@ const allPermissionTypes: PermissionTypes[] = [
 ]
 
 // The switch statement below will cause a TS error
-// if all allowable PermissionTypes generated in the client
+// if all allowable PermissionTypeValues generated in the client
 // generatedRoutes are not included in the switch statement BUT
 // they will need to be added to both the switch statement AND the allPermissionTypes array.
-const ensureT = (orgID: string) => (t: PermissionTypes) => {
+const ensureT = (orgID: string) => (t) => {
   switch (t) {
     case 'authorizations':
     case 'buckets':
@@ -55,6 +56,13 @@ const ensureT = (orgID: string) => (t: PermissionTypes) => {
         {
           action: 'write' as 'write',
           resource: {type: t, orgID},
+        },
+      ]
+    case 'orgs':
+      return [
+        {
+          action: 'read' as 'read',
+          resource: {type: t, id: orgID},
         },
       ]
     default:

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -59,6 +59,8 @@ const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
         },
       ]
     case 'orgs':
+      // 'orgs' used to only have read permissions so that's all we'll give again.
+      // In production, orgs with an orgID returns a permissions error.
       return [
         {
           action: 'read' as 'read',


### PR DESCRIPTION
Closes #influxdata/idpe#5940

Error message received when creating all access token:
```json
{
  "code": "forbidden",
  "message": "permission read:orgs/03cf84c67a620000/orgs is not allowed: read:orgs/03cf84c67a620000/orgs is unauthorized"
}
```

Resource `/orgs/{orgID}/orgs` isn't defined, removed the `orgs` entry from the authorizations portion.

Probably works.

<!---
also, check this out!
![image](https://user-images.githubusercontent.com/2653109/73972229-a9aed100-48dd-11ea-83d6-2f2e01a9bbc3.png)
--->
