### PR TITLE
fix: update giraffe to fix graph tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [16733](https://github.com/influxdata/influxdb/pull/16733): Fix notification rule renaming panics from UI
+1. [16769](https://github.com/influxdata/influxdb/pull/16769): Fix the tooltip for stacked line graphs
 
 ## v2.0.0-beta.2 [2020-01-24]
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -131,7 +131,7 @@
   "dependencies": {
     "@influxdata/clockface": "1.1.0",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.17.2",
+    "@influxdata/giraffe": "0.17.3",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1021,10 +1021,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-parser/-/flux-parser-0.3.0.tgz#b63123ac814ad32c65e46a4097ba3d8b959416a5"
   integrity sha512-nsm801l60kXFulcSWA2YH2YRz9oSsMlTK9Evn6Og9BoQnQMcwUsSUEug8mQRIUljnkNYV58JSs0W0mP8h7Y/ZQ==
 
-"@influxdata/giraffe@0.17.2":
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.2.tgz#fa1a2aa45c00f3c5162b6427cbea47a962600c9a"
-  integrity sha512-AgxHptrT6V8SvJmL7nH+z34SCNn53NcXNXtwejWsr3afq2pcJO+466iVErRWLJ+q8drYZBAPB/gVE3S/Rtjx7A==
+"@influxdata/giraffe@0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.3.tgz#811a1328b019f9c1dd08a6e5cf4dc2064484e0fd"
+  integrity sha512-uT8bwKZ25huCdGoCzBHKA3rcSuKUqnOQDUgRVqmG5FoyHUGaR2xzFXxYFL3BHgymoXRXZOVdsh9mX4UXI4VwSQ==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16489

Updates giraffe to fix the tooltip for stacked line graphs
