### PR TITLE
chore(pkg): remove ambiguity in wrong cmd calls within influx pkg cmd

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -64,6 +64,7 @@ type genericCLIOpts struct {
 
 func (o genericCLIOpts) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := &cobra.Command{
+		Args: cobra.NoArgs,
 		Use:  use,
 		RunE: runE,
 	}


### PR DESCRIPTION
there was an issue where you could call, `influx pkg summarize`
and the influx cli would actually prescribe that to `influx pkg` cmd
and pass summarize as an arg. This removes that ambiguity

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass