### PR TITLE
feat(pkger): extend HTTP API to enable users to submit multiple pkgs in one call

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7145,18 +7145,24 @@ components:
           type: string
         package:
           $ref: "#/components/schemas/Pkg"
+        packages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Pkg"
         secrets:
           type: object
           additionalProperties:
             type: string
-        remote:
-          type: object
-          properties:
-            url:
-              type: string
-            contentType:
-              type: string
-          required: ["url"]
+        remotes:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              contentType:
+                type: string
+            required: ["url"]
     PkgCreate:
       type: object
       properties:


### PR DESCRIPTION
references: #16657 

This PR extends the pkger apply HTTP API to support multiple pkg submission.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)