### PR TITLE
fix(cmd): use list instead of find in cli

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -279,9 +279,10 @@ var authorizationFindFlags struct {
 
 func authFindCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "find",
-		Short: "Find authorization",
-		RunE:  checkSetupRunEMiddleware(&flags)(authorizationFindF),
+		Use:     "list",
+		Short:   "List authorizations",
+		Aliases: []string{"find", "ls"},
+		RunE:    checkSetupRunEMiddleware(&flags)(authorizationFindF),
 	}
 
 	cmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "The user")

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -160,8 +160,9 @@ func (b *cmdBucketBuilder) cmdDeleteRunEFn(cmd *cobra.Command, args []string) er
 }
 
 func (b *cmdBucketBuilder) cmdFind() *cobra.Command {
-	cmd := b.newCmd("find", b.cmdFindRunEFn)
-	cmd.Short = "Find buckets"
+	cmd := b.newCmd("list", b.cmdFindRunEFn)
+	cmd.Short = "List buckets"
+	cmd.Aliases = []string{"find", "ls"}
 
 	opts := flagOpts{
 		{

--- a/cmd/influx/bucket_test.go
+++ b/cmd/influx/bucket_test.go
@@ -305,7 +305,7 @@ func TestCmdBucket(t *testing.T) {
 				cmd := builder.cmd(cmdFn)
 
 				if tt.command == "" {
-					tt.command = "find"
+					tt.command = "list"
 				}
 
 				cmd.SetArgs(append([]string{"bucket", tt.command}, tt.flags...))

--- a/cmd/influx/bucket_test.go
+++ b/cmd/influx/bucket_test.go
@@ -177,7 +177,7 @@ func TestCmdBucket(t *testing.T) {
 		}
 	})
 
-	t.Run("find", func(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
 		type called struct {
 			name  string
 			id    influxdb.ID
@@ -189,6 +189,7 @@ func TestCmdBucket(t *testing.T) {
 			name     string
 			expected called
 			flags    []string
+			command  string
 			envVars  map[string]string
 		}{
 			{
@@ -250,6 +251,20 @@ func TestCmdBucket(t *testing.T) {
 				flags:    []string{"-i=" + influxdb.ID(1).String()},
 				expected: called{orgID: 2, name: "name1", id: 1},
 			},
+			{
+				name:     "ls alias",
+				command:  "ls",
+				envVars:  envVarsZeroMap,
+				flags:    []string{"--org-id=" + influxdb.ID(3).String()},
+				expected: called{orgID: 3},
+			},
+			{
+				name:     "find alias",
+				command:  "find",
+				envVars:  envVarsZeroMap,
+				flags:    []string{"--org-id=" + influxdb.ID(3).String()},
+				expected: called{orgID: 3},
+			},
 		}
 
 		cmdFn := func() (func(*globalFlags, genericCLIOpts) *cobra.Command, *called) {
@@ -289,7 +304,11 @@ func TestCmdBucket(t *testing.T) {
 				cmdFn, calls := cmdFn()
 				cmd := builder.cmd(cmdFn)
 
-				cmd.SetArgs(append([]string{"bucket", "find"}, tt.flags...))
+				if tt.command == "" {
+					tt.command = "find"
+				}
+
+				cmd.SetArgs(append([]string{"bucket", tt.command}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -109,7 +109,7 @@ type cmdInfluxBuilder struct {
 	once sync.Once
 }
 
-func newInfluxCmdBuilder(opts ...genericCLIOptFn) *cmdInfluxBuilder {
+func newInfluxCmdBuilder(optFns ...genericCLIOptFn) *cmdInfluxBuilder {
 	builder := new(cmdInfluxBuilder)
 
 	opt := genericCLIOpts{
@@ -117,8 +117,8 @@ func newInfluxCmdBuilder(opts ...genericCLIOptFn) *cmdInfluxBuilder {
 		w:          os.Stdout,
 		runEWrapFn: checkSetupRunEMiddleware(&flags),
 	}
-	for _, o := range opts {
-		o(&opt)
+	for _, optFn := range optFns {
+		optFn(&opt)
 	}
 
 	builder.genericCLIOpts = opt

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -144,8 +144,9 @@ func (b *cmdOrgBuilder) deleteRunEFn(cmd *cobra.Command, args []string) error {
 }
 
 func (b *cmdOrgBuilder) cmdFind() *cobra.Command {
-	cmd := b.newCmd("find", b.findRunEFn)
-	cmd.Short = "Find organizations"
+	cmd := b.newCmd("list", b.findRunEFn)
+	cmd.Short = "List organizations"
+	cmd.Aliases = []string{"find", "ls"}
 
 	opts := flagOpts{
 		{
@@ -290,6 +291,7 @@ func (b *cmdOrgBuilder) cmdMember() *cobra.Command {
 func (b *cmdOrgBuilder) cmdMemberList() *cobra.Command {
 	cmd := b.newCmd("list", b.memberListRunEFn)
 	cmd.Short = "List organization members"
+	cmd.Aliases = []string{"find", "ls"}
 
 	opts := flagOpts{
 		{

--- a/cmd/influx/organization_test.go
+++ b/cmd/influx/organization_test.go
@@ -137,7 +137,7 @@ func TestCmdOrg(t *testing.T) {
 		}
 	})
 
-	t.Run("find", func(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
 		type called struct {
 			name string
 			id   influxdb.ID
@@ -147,6 +147,7 @@ func TestCmdOrg(t *testing.T) {
 			name     string
 			expected called
 			flags    []string
+			command  string
 			envVars  map[string]string
 		}{
 			{
@@ -178,6 +179,20 @@ func TestCmdOrg(t *testing.T) {
 				},
 				flags:    []string{"-i=" + influxdb.ID(1).String()},
 				expected: called{name: "name1", id: 1},
+			},
+			{
+				name:     "ls alias",
+				command:  "ls",
+				flags:    []string{"--name=name1"},
+				envVars:  envVarsZeroMap,
+				expected: called{name: "name1"},
+			},
+			{
+				name:     "find alias",
+				command:  "find",
+				flags:    []string{"--name=name1"},
+				envVars:  envVarsZeroMap,
+				expected: called{name: "name1"},
 			},
 		}
 
@@ -211,7 +226,12 @@ func TestCmdOrg(t *testing.T) {
 				)
 				cmdFn, calls := cmdFn()
 				cmd := builder.cmd(cmdFn)
-				cmd.SetArgs(append([]string{"org", "find"}, tt.flags...))
+
+				if tt.command == "" {
+					tt.command = "find"
+				}
+
+				cmd.SetArgs(append([]string{"org", tt.command}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)
@@ -411,6 +431,8 @@ func TestCmdOrg(t *testing.T) {
 			}
 
 			testMemberFn(t, "list", cmdFn, tests...)
+			testMemberFn(t, "ls", cmdFn, tests[:0]...)
+			testMemberFn(t, "find", cmdFn, tests[:0]...)
 		})
 
 		t.Run("add", func(t *testing.T) {

--- a/cmd/influx/organization_test.go
+++ b/cmd/influx/organization_test.go
@@ -431,8 +431,8 @@ func TestCmdOrg(t *testing.T) {
 			}
 
 			testMemberFn(t, "list", cmdFn, tests...)
-			testMemberFn(t, "ls", cmdFn, tests[:0]...)
-			testMemberFn(t, "find", cmdFn, tests[:0]...)
+			testMemberFn(t, "ls", cmdFn, tests[0:1]...)
+			testMemberFn(t, "find", cmdFn, tests[0:1]...)
 		})
 
 		t.Run("add", func(t *testing.T) {

--- a/cmd/influx/organization_test.go
+++ b/cmd/influx/organization_test.go
@@ -228,7 +228,7 @@ func TestCmdOrg(t *testing.T) {
 				cmd := builder.cmd(cmdFn)
 
 				if tt.command == "" {
-					tt.command = "find"
+					tt.command = "list"
 				}
 
 				cmd.SetArgs(append([]string{"org", tt.command}, tt.flags...))

--- a/cmd/influx/secret.go
+++ b/cmd/influx/secret.go
@@ -137,8 +137,9 @@ func (b *cmdSecretBuilder) cmdDeleteRunEFn(cmd *cobra.Command, args []string) er
 }
 
 func (b *cmdSecretBuilder) cmdFind() *cobra.Command {
-	cmd := b.newCmd("find", b.cmdFindRunEFn)
-	cmd.Short = "Find secrets"
+	cmd := b.newCmd("list", b.cmdFindRunEFn)
+	cmd.Short = "List secrets"
+	cmd.Aliases = []string{"find", "ls"}
 	b.org.register(cmd, false)
 
 	return cmd

--- a/cmd/influx/secret_test.go
+++ b/cmd/influx/secret_test.go
@@ -28,12 +28,13 @@ func TestCmdSecret(t *testing.T) {
 		}
 	}
 
-	t.Run("find", func(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
 		type called []string
 		tests := []struct {
 			name     string
 			expected called
 			flags    []string
+			command  string
 			envVars  map[string]string
 		}{
 			{
@@ -54,6 +55,21 @@ func TestCmdSecret(t *testing.T) {
 					"INFLUX_ORG": "rg",
 				},
 				flags:    []string{},
+				expected: called{"k1", "k2", "k3"},
+			},
+			// if alias commands fail with "unknown flag: --org-id", it's because the alias is missing
+			{
+				name:     "ls alias",
+				command:  "ls",
+				flags:    []string{"--org=rg"},
+				envVars:  envVarsZeroMap,
+				expected: called{"k1", "k2", "k3"},
+			},
+			{
+				name:     "find alias",
+				command:  "find",
+				flags:    []string{"--org=rg"},
+				envVars:  envVarsZeroMap,
 				expected: called{"k1", "k2", "k3"},
 			},
 		}
@@ -85,7 +101,12 @@ func TestCmdSecret(t *testing.T) {
 				)
 				nestedCmdFn, calls := cmdFn()
 				cmd := builder.cmd(nestedCmdFn)
-				cmd.SetArgs(append([]string{"secret", "find"}, tt.flags...))
+
+				if tt.command == "" {
+					tt.command = "find"
+				}
+
+				cmd.SetArgs(append([]string{"secret", tt.command}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
 				assert.Equal(t, tt.expected, *calls)

--- a/cmd/influx/secret_test.go
+++ b/cmd/influx/secret_test.go
@@ -57,7 +57,6 @@ func TestCmdSecret(t *testing.T) {
 				flags:    []string{},
 				expected: called{"k1", "k2", "k3"},
 			},
-			// if alias commands fail with "unknown flag: --org-id", it's because the alias is missing
 			{
 				name:     "ls alias",
 				command:  "ls",
@@ -103,7 +102,7 @@ func TestCmdSecret(t *testing.T) {
 				cmd := builder.cmd(nestedCmdFn)
 
 				if tt.command == "" {
-					tt.command = "find"
+					tt.command = "list"
 				}
 
 				cmd.SetArgs(append([]string{"secret", tt.command}, tt.flags...))

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -127,8 +127,9 @@ var taskFindFlags struct {
 }
 
 func taskFindCmd(opt genericCLIOpts) *cobra.Command {
-	cmd := opt.newCmd("find", taskFindF)
-	cmd.Short = "Find tasks"
+	cmd := opt.newCmd("list", taskFindF)
+	cmd.Short = "List tasks"
+	cmd.Aliases = []string{"find", "ls"}
 
 	taskFindFlags.org.register(cmd, false)
 	cmd.Flags().StringVarP(&taskFindFlags.id, "id", "i", "", "task ID")
@@ -387,8 +388,9 @@ var taskLogFindFlags struct {
 }
 
 func taskLogFindCmd(opt genericCLIOpts) *cobra.Command {
-	cmd := opt.newCmd("find", taskLogFindF)
-	cmd.Short = "find logs for task"
+	cmd := opt.newCmd("list", taskLogFindF)
+	cmd.Short = "List logs for task"
+	cmd.Aliases = []string{"find", "ls"}
 
 	cmd.Flags().StringVarP(&taskLogFindFlags.taskID, "task-id", "", "", "task id (required)")
 	cmd.Flags().StringVarP(&taskLogFindFlags.runID, "run-id", "", "", "run id")
@@ -450,7 +452,7 @@ func taskLogFindF(cmd *cobra.Command, args []string) error {
 func taskRunCmd(opt genericCLIOpts) *cobra.Command {
 	cmd := opt.newCmd("run", nil)
 	cmd.Run = seeHelp
-	cmd.Short = "find runs for a task"
+	cmd.Short = "List runs for a task"
 	cmd.AddCommand(
 		taskRunFindCmd(opt),
 		taskRunRetryCmd(opt),
@@ -468,8 +470,9 @@ var taskRunFindFlags struct {
 }
 
 func taskRunFindCmd(opt genericCLIOpts) *cobra.Command {
-	cmd := opt.newCmd("find", taskRunFindF)
-	cmd.Short = "find runs for a task"
+	cmd := opt.newCmd("list", taskRunFindF)
+	cmd.Short = "List runs for a task"
+	cmd.Aliases = []string{"find", "ls"}
 
 	cmd.Flags().StringVarP(&taskRunFindFlags.taskID, "task-id", "", "", "task id (required)")
 	cmd.Flags().StringVarP(&taskRunFindFlags.runID, "run-id", "", "", "run id")

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -280,8 +280,9 @@ func (b *cmdUserBuilder) cmdCreateRunEFn(*cobra.Command, []string) error {
 }
 
 func (b *cmdUserBuilder) cmdFind() *cobra.Command {
-	cmd := b.newCmd("find", b.cmdFindRunEFn)
-	cmd.Short = "Find user"
+	cmd := b.newCmd("list", b.cmdFindRunEFn)
+	cmd.Short = "List users"
+	cmd.Aliases = []string{"find", "ls"}
 
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "The user ID")
 	cmd.Flags().StringVarP(&b.name, "name", "n", "", "The user name")

--- a/cmd/influx/user_test.go
+++ b/cmd/influx/user_test.go
@@ -292,7 +292,7 @@ func TestCmdUser(t *testing.T) {
 				cmd := builder.cmd(nestedCmdFn)
 
 				if tt.command == "" {
-					tt.command = "find"
+					tt.command = "list"
 				}
 
 				cmd.SetArgs(append([]string{"user", tt.command}, tt.flags...))

--- a/cmd/influx/user_test.go
+++ b/cmd/influx/user_test.go
@@ -240,7 +240,6 @@ func TestCmdUser(t *testing.T) {
 				},
 				expected: called{name: "name1", id: 1},
 			},
-			// if alias commands fail with "unknown flag: --org-id", it's because the alias is missing
 			{
 				name:    "ls alias",
 				command: "ls",


### PR DESCRIPTION
long-running ask from @sanderson :)

Change all places in the CLI where we have `find` to use `list`. We inconsistently use the two in our CLI, so this adds more consistency in the UX.

Also adds `find` (to make this non-breaking) and `ls` (to be more unixy) as aliases for the command.