### PR TITLE
remove vendor from prod builds

### DIFF
--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -1,8 +1,5 @@
 // Constants
-import {
-    FLUX_RESPONSE_BYTES_LIMIT,
-    API_BASE_PATH,
-} from 'src/shared/constants'
+import {FLUX_RESPONSE_BYTES_LIMIT, API_BASE_PATH} from 'src/shared/constants'
 import {
   RATE_LIMIT_ERROR_STATUS,
   RATE_LIMIT_ERROR_TEXT,

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -1,6 +1,8 @@
 // Constants
-import {FLUX_RESPONSE_BYTES_LIMIT} from 'src/shared/constants'
-import { API_BASE_PATH } from 'src/utils/env'
+import {
+    FLUX_RESPONSE_BYTES_LIMIT,
+    API_BASE_PATH,
+} from 'src/shared/constants'
 import {
   RATE_LIMIT_ERROR_STATUS,
   RATE_LIMIT_ERROR_TEXT,

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -40,7 +40,7 @@ export const runQuery = (
   query: string,
   extern?: File
 ): CancelBox<RunQueryResult> => {
-  const url = `${API_BASE_PATH}/api/v2/query?${new URLSearchParams({orgID})}`
+  const url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`
 
   const headers = {
     'Content-Type': 'application/json',

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -1,5 +1,6 @@
 // Constants
 import {FLUX_RESPONSE_BYTES_LIMIT} from 'src/shared/constants'
+import { API_BASE_PATH } from 'src/utils/env'
 import {
   RATE_LIMIT_ERROR_STATUS,
   RATE_LIMIT_ERROR_TEXT,
@@ -37,7 +38,7 @@ export const runQuery = (
   query: string,
   extern?: File
 ): CancelBox<RunQueryResult> => {
-  const url = `/api/v2/query?${new URLSearchParams({orgID})}`
+  const url = `${API_BASE_PATH}/api/v2/query?${new URLSearchParams({orgID})}`
 
   const headers = {
     'Content-Type': 'application/json',

--- a/ui/webpack.common.ts
+++ b/ui/webpack.common.ts
@@ -112,10 +112,6 @@ module.exports = {
       filename: `${STATIC_DIRECTORY}[contenthash:10].css`,
       chunkFilename: `${STATIC_DIRECTORY}[id].[contenthash:10].css`,
     }),
-    new webpack.DllReferencePlugin({
-      context: path.join(__dirname, 'build'),
-      manifest: require('./build/vendor-manifest.json'),
-    }),
     new ForkTsCheckerWebpackPlugin(),
     new webpack.ProgressPlugin(),
     new webpack.EnvironmentPlugin({

--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -30,6 +30,10 @@ module.exports = merge(common, {
     public: PUBLIC,
   },
   plugins: [
+    new webpack.DllReferencePlugin({
+      context: path.join(__dirname, 'build'),
+      manifest: require('./build/vendor-manifest.json'),
+    }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'server',
       analyzerHost: '0.0.0.0',


### PR DESCRIPTION
this removes the requirement for the prod builds to use the vendor cache to build. They receive no benefit from the speed up as they're only run once, and there are some weird artifacts that show up when building the vendor webpack at times (i'm looking at you monaco).

I figured it shouldn't cause friction for deployments.

also found a hard coded api route, so i added a prefix to it because i needed it for a project.