### PR TITLE
feat(kv): Index Authorizations by User ID

### DIFF
--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -957,7 +957,10 @@ func TestAuthorizationService_FindAuthorizationByToken(t *testing.T) {
 }
 
 func TestAuthorizationService_FindAuthorizations(t *testing.T) {
-	platformtesting.FindAuthorizations(initAuthorizationService, t)
+	// with pre-populated index
+	platformtesting.FindAuthorizations(initAuthorizationService, t, true)
+	// without pre-populated index
+	platformtesting.FindAuthorizations(initAuthorizationService, t, false)
 }
 
 func TestAuthorizationService_DeleteAuthorization(t *testing.T) {

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -964,7 +964,10 @@ func TestAuthorizationService_FindAuthorizations(t *testing.T) {
 }
 
 func TestAuthorizationService_DeleteAuthorization(t *testing.T) {
-	platformtesting.DeleteAuthorization(initAuthorizationService, t)
+	// with pre-populated index
+	platformtesting.DeleteAuthorization(initAuthorizationService, t, true)
+	// without pre-populated index
+	platformtesting.DeleteAuthorization(initAuthorizationService, t, false)
 }
 
 func TestAuthorizationService_UpdateAuthorization(t *testing.T) {

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/influxdata/httprouter"
@@ -857,12 +858,12 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 
 func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.T) (platform.AuthorizationService, string, func()) {
 	t.Helper()
-	if t.Name() == "TestAuthorizationService_FindAuthorizations/find_authorization_by_token" {
+	if strings.Contains(t.Name(), "find_authorization_by_token") {
 		/*
 			TODO(goller): need a secure way to communicate get
 			 authorization by token string via headers or something
 		*/
-		t.Skip("TestAuthorizationService_FindAuthorizations/find_authorization_by_token skipped because user tokens cannot be queried")
+		t.Skipf("%s skipped because user tokens cannot be queried", t.Name())
 	}
 
 	if t.Name() == "TestAuthorizationService_CreateAuthorization/providing_a_non_existing_user_is_invalid" {
@@ -964,10 +965,8 @@ func TestAuthorizationService_FindAuthorizations(t *testing.T) {
 }
 
 func TestAuthorizationService_DeleteAuthorization(t *testing.T) {
-	// with pre-populated index
-	platformtesting.DeleteAuthorization(initAuthorizationService, t, true)
 	// without pre-populated index
-	platformtesting.DeleteAuthorization(initAuthorizationService, t, false)
+	platformtesting.DeleteAuthorization(initAuthorizationService, t, true)
 }
 
 func TestAuthorizationService_UpdateAuthorization(t *testing.T) {

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -538,7 +538,7 @@ func (s *Service) putAuthorization(ctx context.Context, tx Tx, a *influxdb.Autho
 
 	// this should only be configurable via test package
 	// it is used to test behavior with empty caches
-	if authDoSkipIndexOnPut(ctx) {
+	if !authDoSkipIndexOnPut(ctx) {
 		fk := authByUserIndexKey(a.UserID, a.ID)
 		if err := idx.Put([]byte(fk), encodedID); err != nil {
 			return &influxdb.Error{
@@ -643,6 +643,11 @@ func (s *Service) deleteAuthorization(ctx context.Context, tx Tx, id influxdb.ID
 			Err: err,
 		}
 	}
+
+	if err := idx.Delete([]byte(authByUserIndexKey(a.UserID, id))); err != nil {
+		return err
+	}
+
 	encodedID, err := id.Encode()
 	if err != nil {
 		return &influxdb.Error{

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -378,9 +378,15 @@ type findConfig struct {
 }
 
 func newFindConfig(opts ...findOption) findConfig {
-	return findConfig{
+	config := findConfig{
 		visit: func(*influxdb.Authorization) {},
 	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	return config
 }
 
 type findOption func(*findConfig)

--- a/kv/service.go
+++ b/kv/service.go
@@ -93,12 +93,6 @@ type ServiceConfig struct {
 	Clock         clock.Clock
 
 	indexer indexer
-	// this flag configures whether or not to populate the auth by user index
-	// when creation new authorizations. It used for testing to ensure we capture
-	// the behavior of auth lookup by user ID works both when the index is populated
-	// and when it is not.
-	// this should be false in production cases.
-	authsSkipIndexOnPut bool
 }
 
 // Initialize creates Buckets needed.

--- a/kv/service.go
+++ b/kv/service.go
@@ -66,7 +66,6 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		checkStore:     newCheckStore(),
 		endpointStore:  newEndpointStore(),
 		variableStore:  newVariableStore(),
-		indexer:        NewIndexer(log, kv),
 	}
 
 	if len(configs) > 0 {
@@ -80,6 +79,11 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		s.clock = clock.New()
 	}
 
+	s.indexer = s.Config.indexer
+	if s.indexer == nil {
+		s.indexer = NewIndexer(log, kv)
+	}
+
 	return s
 }
 
@@ -87,6 +91,14 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 type ServiceConfig struct {
 	SessionLength time.Duration
 	Clock         clock.Clock
+
+	indexer indexer
+	// this flag configures whether or not to populate the auth by user index
+	// when creation new authorizations. It used for testing to ensure we capture
+	// the behavior of auth lookup by user ID works both when the index is populated
+	// and when it is not.
+	// this should be false in production cases.
+	authsSkipIndexOnPut bool
 }
 
 // Initialize creates Buckets needed.

--- a/kv/service_private_test.go
+++ b/kv/service_private_test.go
@@ -20,6 +20,8 @@ func AuthSkipIndexOnPut(ctx context.Context) context.Context {
 	return context.WithValue(ctx, authSkipIndexOnPutContextKey{}, struct{}{})
 }
 
+// AssertIndexesWereCreated allows locally defined tests in external packages
+// to perform introspection on how the indexer was called during the test
 func AssertIndexesWereCreated(t *testing.T, service *Service, calls ...AddToIndexCall) {
 	idx, ok := service.indexer.(*spyIndexer)
 	if !ok {
@@ -44,6 +46,6 @@ func (m *spyIndexer) AddToIndex(bkt []byte, keys map[string][]byte) {
 }
 
 type AddToIndexCall struct {
-	bucket []byte
-	keys   map[string][]byte
+	Bucket []byte
+	Keys   map[string][]byte
 }

--- a/kv/service_private_test.go
+++ b/kv/service_private_test.go
@@ -1,0 +1,55 @@
+package kv
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb"
+)
+
+type ServiceConfigOption func(*ServiceConfig)
+
+// WithoutIndexingOnPut skips indexing authorizations by user ID when putting authorizations.
+// This is a test only option as it is used to validate auth by user ID lookup
+// when the index has yet to be populated.
+func WithoutIndexingOnPut(c *ServiceConfig) {
+	c.authsSkipIndexOnPut = true
+}
+
+func ServiceConfigForTest(opts ...ServiceConfigOption) (conf ServiceConfig) {
+	conf.SessionLength = influxdb.DefaultSessionLength
+	conf.indexer = &spyIndexer{}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	return
+}
+
+func AssertIndexesWereCreated(t *testing.T, service *Service, calls ...AddToIndexCall) {
+	idx, ok := service.indexer.(*spyIndexer)
+	if !ok {
+		t.Fatal("indexer was not configured as spy")
+	}
+
+	if !reflect.DeepEqual(calls, idx.calls) {
+		t.Errorf("expected %#v, found %#v", calls, idx.calls)
+	}
+}
+
+type spyIndexer struct {
+	calls []AddToIndexCall
+	mu    sync.Mutex
+}
+
+func (m *spyIndexer) AddToIndex(bkt []byte, keys map[string][]byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, AddToIndexCall{bkt, keys})
+}
+
+type AddToIndexCall struct {
+	bucket []byte
+	keys   map[string][]byte
+}

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -34,12 +34,13 @@ var authorizationCmpOptions = cmp.Options{
 
 // AuthorizationFields will include the IDGenerator, and authorizations
 type AuthorizationFields struct {
-	IDGenerator    platform.IDGenerator
-	TokenGenerator platform.TokenGenerator
-	TimeGenerator  platform.TimeGenerator
-	Authorizations []*platform.Authorization
-	Users          []*platform.User
-	Orgs           []*platform.Organization
+	IDGenerator             platform.IDGenerator
+	TokenGenerator          platform.TokenGenerator
+	TimeGenerator           platform.TimeGenerator
+	Authorizations          []*platform.Authorization
+	Users                   []*platform.User
+	Orgs                    []*platform.Organization
+	AuthsPopulateIndexOnPut bool
 }
 
 // AuthorizationService tests all the service functions.
@@ -48,8 +49,10 @@ func AuthorizationService(
 ) {
 	tests := []struct {
 		name string
-		fn   func(init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
-			t *testing.T)
+		fn   func(
+			init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
+			t *testing.T,
+		)
 	}{
 		{
 			name: "CreateAuthorization",
@@ -68,8 +71,22 @@ func AuthorizationService(
 			fn:   UpdateAuthorization,
 		},
 		{
-			name: "FindAuthorizations",
-			fn:   FindAuthorizations,
+			name: "FindAuthorizations without populated index",
+			fn: func(
+				init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
+				t *testing.T,
+			) {
+				FindAuthorizations(init, t, false)
+			},
+		},
+		{
+			name: "FindAuthorizations with populated index",
+			fn: func(
+				init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
+				t *testing.T,
+			) {
+				FindAuthorizations(init, t, true)
+			},
 		},
 		{
 			name: "DeleteAuthorization",
@@ -842,6 +859,7 @@ func FindAuthorizationByToken(
 func FindAuthorizations(
 	init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
 	t *testing.T,
+	authsPopulateIndexOnPut bool,
 ) {
 	type args struct {
 		ID     platform.ID
@@ -895,6 +913,7 @@ func FindAuthorizations(
 						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{},
 			wants: wants{
@@ -961,6 +980,7 @@ func FindAuthorizations(
 						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				UserID: MustIDBase16(userOneID),
@@ -1031,6 +1051,7 @@ func FindAuthorizations(
 						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				OrgID: MustIDBase16(orgOneID),
@@ -1113,6 +1134,7 @@ func FindAuthorizations(
 						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				UserID: MustIDBase16(userOneID),
@@ -1180,6 +1202,7 @@ func FindAuthorizations(
 						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				token: "rand2",

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -89,8 +89,22 @@ func AuthorizationService(
 			},
 		},
 		{
-			name: "DeleteAuthorization",
-			fn:   DeleteAuthorization,
+			name: "DeleteAuthorization without populated index",
+			fn: func(
+				init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
+				t *testing.T,
+			) {
+				DeleteAuthorization(init, t, false)
+			},
+		},
+		{
+			name: "DeleteAuthorization with populated index",
+			fn: func(
+				init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
+				t *testing.T,
+			) {
+				DeleteAuthorization(init, t, true)
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1255,6 +1269,7 @@ func FindAuthorizations(
 func DeleteAuthorization(
 	init func(AuthorizationFields, *testing.T) (platform.AuthorizationService, string, func()),
 	t *testing.T,
+	authsPopulateIndexOnPut bool,
 ) {
 	type args struct {
 		ID platform.ID
@@ -1305,6 +1320,7 @@ func DeleteAuthorization(
 						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				ID: MustIDBase16(authOneID),
@@ -1357,6 +1373,7 @@ func DeleteAuthorization(
 						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
 					},
 				},
+				AuthsPopulateIndexOnPut: authsPopulateIndexOnPut,
 			},
 			args: args{
 				ID: MustIDBase16(authThreeID),


### PR DESCRIPTION
This integrates auth lookup via index and also publishes auths not indexed to the new indexer.

When `FindAuthorizations` is called with a non-nil user or user ID, then an index lookup is first performed. Given there are not authorizations in the index, it falls back to full keyspace scan and publishes anything found in the keyspace to the new indexer type.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
