### PR TITLE
fix: ignore cluster specific hoopla

### DIFF
--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -6,7 +6,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {postSignout} from 'src/client'
 
 // Constants
-import {CLOUD, CLOUD_URL, CLOUD_LOGOUT_URL} from 'src/shared/constants'
+import {CLOUD, CLOUD_URL, CLOUD_LOGOUT_PATH} from 'src/shared/constants'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -25,7 +25,7 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     if (CLOUD) {
-      window.location.href = `${CLOUD_URL}${CLOUD_LOGOUT_URL}`
+      window.location.href = `${CLOUD_URL}${CLOUD_LOGOUT_PATH}`
       return
     } else {
       const resp = await postSignout({})

--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -6,7 +6,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {postSignout} from 'src/client'
 
 // Constants
-import {CLOUD, CLOUD_SIGNOUT_URL} from 'src/shared/constants'
+import {CLOUD, CLOUD_URL, CLOUD_LOGOUT_URL} from 'src/shared/constants'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -25,7 +25,7 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     if (CLOUD) {
-      window.location.href = CLOUD_SIGNOUT_URL
+      window.location.href = `${CLOUD_URL}${CLOUD_LOGOUT_URL}`
       return
     } else {
       const resp = await postSignout({})

--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -16,7 +16,7 @@ const LogoutButton: SFC = () => (
       </Link>
     </CloudExclude>
     <CloudOnly>
-      <a href={`${CLOUD_URL}${CLOUD_LOGOUT_PATH}`>
+      <a href={`${CLOUD_URL}${CLOUD_LOGOUT_PATH}`}>
         <Button text="Logout" size={ComponentSize.ExtraSmall} />
       </a>
     </CloudOnly>

--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -6,7 +6,7 @@ import {Link} from 'react-router'
 import {Button, ComponentSize} from '@influxdata/clockface'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
-import {CLOUD_SIGNOUT_URL} from 'src/shared/constants'
+import {CLOUD_URL, CLOUD_LOGOUT_PATH} from 'src/shared/constants'
 
 const LogoutButton: SFC = () => (
   <>
@@ -16,7 +16,7 @@ const LogoutButton: SFC = () => (
       </Link>
     </CloudExclude>
     <CloudOnly>
-      <a href={CLOUD_SIGNOUT_URL}>
+      <a href={`${CLOUD_URL}${CLOUD_LOGOUT_PATH}`>
         <Button text="Logout" size={ComponentSize.ExtraSmall} />
       </a>
     </CloudOnly>

--- a/ui/src/pageLayout/components/CloudNav.tsx
+++ b/ui/src/pageLayout/components/CloudNav.tsx
@@ -21,7 +21,7 @@ import {
   CLOUD_USAGE_PATH,
   CLOUD_BILLING_PATH,
   CLOUD_CHECKOUT_PATH,
-  CLOUD_SIGNOUT_URL,
+  CLOUD_LOGOUT_PATH,
 } from 'src/shared/constants'
 
 // Types
@@ -41,6 +41,7 @@ const CloudNav: FC<StateProps> = ({org}) => {
   const usageURL = `${CLOUD_URL}${CLOUD_USAGE_PATH}`
   const billingURL = `${CLOUD_URL}${CLOUD_BILLING_PATH}`
   const checkoutURL = `${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`
+  const logoutURL = `${CLOUD_URL}${CLOUD_LOGOUT_PATH}`
   const handleUpgradeClick = () => {
     window.location.assign(checkoutURL)
   }
@@ -94,7 +95,7 @@ const CloudNav: FC<StateProps> = ({org}) => {
           <PopNav.Item
             active={false}
             titleLink={className => (
-              <a className={className} href={CLOUD_SIGNOUT_URL}>
+              <a className={className} href={logoutURL}>
                 Logout
               </a>
             )}

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -54,14 +54,14 @@ export const GIT_SHA = process.env.GIT_SHA
 export const BASE_PATH = process.env.STATIC_PREFIX
 export const API_BASE_PATH = process.env.API_PREFIX
 
-export const CLOUD = !!(process.env.CLOUD_URL && process.env.CLOUD_LOGOUT_URL)
+export const CLOUD = !!(process.env.CLOUD_URL)
 export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'
-export const CLOUD_SIGNOUT_URL = process.env.CLOUD_LOGOUT_URL
 export const CLOUD_BILLING_VISIBLE = CLOUD
 export const CLOUD_URL = process.env.CLOUD_URL
 export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'
+export const CLOUD_LOGOUT_PATH = '/logout'
 
 export const FLUX_RESPONSE_BYTES_LIMIT = CLOUD
   ? 10 * 1024 * 1024 // 10 MiB

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -54,7 +54,7 @@ export const GIT_SHA = process.env.GIT_SHA
 export const BASE_PATH = process.env.STATIC_PREFIX
 export const API_BASE_PATH = process.env.API_PREFIX
 
-export const CLOUD = !!(process.env.CLOUD_URL)
+export const CLOUD = !!process.env.CLOUD_URL
 export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'
 export const CLOUD_BILLING_VISIBLE = CLOUD
 export const CLOUD_URL = process.env.CLOUD_URL


### PR DESCRIPTION
this reduces our frontend's image configuration down to one variable in the jenkins pipeline, which we can use as an injection point for some fancy redirect rules.

Instead of:
`influxdb-ui => cloud2.influxdata.com/logout`
where we have to change that last variable for our different cloud environments, now we can use:
`influxdb-ui => influxdb-ui/auth/logout`
where the `/auth` path contains a redirect and rewrite within our ingress rules that maps to our auth provider for the cluster (`cloud2.influxdata.com` in the previous example)

Once the rewrite rules are in place (which can be done after this is deployed), we just need to change this: 
https://github.com/influxdata/monitor-ci/blob/master/deploy/Jenkinsfile.deploy#L526

from `https://cloud2.influxdata.com` to `/auth`