### PR TITLE
fix: remove duplicate content types from httpc requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1. [16733](https://github.com/influxdata/influxdb/pull/16733): Fix notification rule renaming panics from UI
 1. [16769](https://github.com/influxdata/influxdb/pull/16769): Fix the tooltip for stacked line graphs
+1. [16822](https://github.com/influxdata/influxdb/pull/16822): Fix issue with pkger/http stack crashing on dupe content type
 
 ## v2.0.0-beta.2 [2020-01-24]
 

--- a/pkg/httpc/client.go
+++ b/pkg/httpc/client.go
@@ -152,7 +152,7 @@ func (c *Client) Req(method string, bFn BodyFn, urlPath string, rest ...string) 
 		}
 	}
 	if header != "" {
-		headers.Add(header, headerVal)
+		headers.Set(header, headerVal)
 	}
 	// w.Close here is necessary since we have to close any gzip writer
 	// or other writer that requires closing.


### PR DESCRIPTION
2 issues from investigating this error. First is the status check func
did not identify it was a media unsupported issue adn tries to unmarshal
the empty response body. The 2nd, was the double content type headers were
causing an error. Locally this error does not surface, cannot repoduce on
macos, but in cloud it is persistent.

closes: #16819

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass