### PR TITLE
fix(ui): fixed false success message that stemmed from error-swallowing throughout post process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1. [16733](https://github.com/influxdata/influxdb/pull/16733): Fix notification rule renaming panics from UI
 1. [16769](https://github.com/influxdata/influxdb/pull/16769): Fix the tooltip for stacked line graphs
+1. [16825](https://github.com/influxdata/influxdb/pull/16825): Fixed false success notification for read-only users creating dashboards
 
 ## v2.0.0-beta.2 [2020-01-24]
 

--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -99,6 +99,7 @@ export const createCellWithView = (
 
     // Create the cell
     const cellResp = await api.postDashboardsCell({dashboardID, data: cell})
+
     if (cellResp.status !== 201) {
       throw new Error(cellResp.data.message)
     }

--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -99,7 +99,6 @@ export const createCellWithView = (
 
     // Create the cell
     const cellResp = await api.postDashboardsCell({dashboardID, data: cell})
-
     if (cellResp.status !== 201) {
       throw new Error(cellResp.data.message)
     }
@@ -123,8 +122,9 @@ export const createCellWithView = (
 
     dispatch(setView(cellID, RemoteDataState.Done, normView))
     dispatch(setCell(cellID, RemoteDataState.Done, normCell))
-  } catch {
+  } catch (err) {
     notify(copy.cellAddFailed())
+    throw err
   }
 }
 

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -209,7 +209,6 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       }
 
       const resp = await postDashboard({data: newDashboard})
-
       if (resp.status !== 201) {
         throw new Error(resp.data.message)
       }
@@ -217,6 +216,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       onCreateCellWithView(resp.data.id, view)
     } catch (error) {
       console.error(error)
+      throw error
     }
   }
 

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -209,6 +209,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       }
 
       const resp = await postDashboard({data: newDashboard})
+
       if (resp.status !== 201) {
         throw new Error(resp.data.message)
       }


### PR DESCRIPTION
Closes #15956 

### Problem

Read-only users were being notified that created dashboards were successful even though no dashboards were being created

### Solution

The dashboard creation process was ingesting any potential errors thrown throughout the process so the default success notification was being triggered. Continued bubbling errors so that the ultimate error was being caught

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)