### PR TITLE
fix(influxql): add explicit routing to influxql service

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -793,7 +793,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		VariableService:                 variableSvc,
 		PasswordsService:                passwdsSvc,
 		OnboardingService:               onboardingSvc,
-		InfluxQLService:                 nil, // No InfluxQL support
+		InfluxQLService:                 storageQueryService,
 		FluxService:                     storageQueryService,
 		TaskService:                     taskSvc,
 		TelegrafService:                 telegrafSvc,


### PR DESCRIPTION
Prior to this change influxql requests were sent to the same back end as Flux queries.
This MAY not always be the case. Now InfluxQL queries are specifically routed to the InfluxQLService.
In the case of this OSS build the FluxService and InfluxQLService are the same.
