### PR TITLE
chore(kv): define failing test for URM on delete

### DIFF
--- a/kv/urm_test.go
+++ b/kv/urm_test.go
@@ -49,9 +49,27 @@ func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFi
 		t.Fatalf("error initializing urm service: %v", err)
 	}
 
+	for _, o := range f.Organizations {
+		if err := svc.CreateOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to create org %q", err)
+		}
+	}
+
+	for _, u := range f.Users {
+		if err := svc.CreateUser(ctx, u); err != nil {
+			t.Fatalf("failed to create user %q", err)
+		}
+	}
+
+	for _, b := range f.Buckets {
+		if err := svc.PutBucket(ctx, b); err != nil {
+			t.Fatalf("failed to create bucket %q", err)
+		}
+	}
+
 	for _, m := range f.UserResourceMappings {
 		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
-			t.Fatalf("failed to populate mappings")
+			t.Fatalf("failed to populate mappings %q", err)
 		}
 	}
 
@@ -59,6 +77,24 @@ func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFi
 		for _, m := range f.UserResourceMappings {
 			if err := svc.DeleteUserResourceMapping(ctx, m.ResourceID, m.UserID); err != nil {
 				t.Logf("failed to remove user resource mapping: %v", err)
+			}
+		}
+
+		for _, b := range f.Buckets {
+			if err := svc.DeleteBucket(ctx, b.ID); err != nil {
+				t.Logf("failed to delete org", err)
+			}
+		}
+
+		for _, u := range f.Users {
+			if err := svc.DeleteUser(ctx, u.ID); err != nil {
+				t.Fatalf("failed to delete user %q", err)
+			}
+		}
+
+		for _, o := range f.Organizations {
+			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {
+				t.Logf("failed to delete org", err)
 			}
 		}
 	}

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -39,6 +39,9 @@ var mappingCmpOptions = cmp.Options{
 
 // UserResourceFields includes prepopulated data for mapping tests
 type UserResourceFields struct {
+	Organizations        []*platform.Organization
+	Users                []*platform.User
+	Buckets              []*platform.Bucket
 	UserResourceMappings []*platform.UserResourceMapping
 }
 
@@ -241,6 +244,46 @@ func DeleteUserResourceMapping(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{},
 				err:      fmt.Errorf("user to resource mapping not found"),
+			},
+		},
+		{
+			name: "delete user resource mapping for org",
+			fields: UserResourceFields{
+				Organizations: []*platform.Organization{
+					{
+						ID:   MustIDBase16(orgOneID),
+						Name: "organization1",
+					},
+				},
+				Users: []*platform.User{
+					{
+						ID:   MustIDBase16(userOneID),
+						Name: "user1",
+					},
+				},
+				Buckets: []*platform.Bucket{
+					{
+						ID:    MustIDBase16(bucketOneID),
+						Name:  "bucket1",
+						OrgID: MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: platform.OrgsResourceType,
+						MappingType:  platform.UserMappingType,
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+					},
+				},
+			},
+			args: args{
+				resourceID: MustIDBase16(orgOneID),
+				userID:     MustIDBase16(userOneID),
+			},
+			wants: wants{
+				mappings: []*platform.UserResourceMapping{},
 			},
 		},
 	}


### PR DESCRIPTION
Define test for failure to delete Organization type URM.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
