### PR TITLE
fix(kv): Don't stop when key not found from index

### DIFF
--- a/kv/urm.go
+++ b/kv/urm.go
@@ -234,10 +234,12 @@ func (s *Service) findUserResourceMappingsByIndex(ctx context.Context, tx Tx, fi
 
 		nv, err := bkt.Get(v)
 		if err != nil {
-			return nil, &influxdb.Error{
-				Code: influxdb.ENotFound,
-				Err:  err,
-			}
+			s.log.Info(
+				"key not found",
+				zap.String("function", "findUserResourceMappingsByIndex"),
+				zap.String("key", string(v)),
+			)
+			continue
 		}
 
 		m := &influxdb.UserResourceMapping{}


### PR DESCRIPTION
In the event that an index references a key that does not exist, do not bail. Keep going so that we finish the delete operation.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
