### PR TITLE
fix(backup): handle backup with no credentials file

### DIFF
--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -136,6 +136,10 @@ func restoreE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("restore completed, but failed to cleanup temporary bolt file: %v", err)
 	}
 
+	if err := removeTmpCred(); err != nil {
+		return fmt.Errorf("restore completed, but failed to cleanup temporary credentials file: %v", err)
+	}
+
 	if err := removeTmpEngine(); err != nil {
 		return fmt.Errorf("restore completed, but failed to cleanup temporary engine data: %v", err)
 	}
@@ -283,6 +287,14 @@ func restoreFile(backup string, target string, filetype string) error {
 
 func restoreCred() error {
 	backupCred := filepath.Join(flags.backupPath, http.DefaultTokenFile)
+
+	_, err := os.Stat(backupCred)
+	if os.IsNotExist(err) {
+		fmt.Printf("No credentials file found in backup, skipping.\n")
+		return nil
+	} else if err != nil {
+		return err
+	}
 
 	if err := restoreFile(backupCred, flags.credPath, "credentials"); err != nil {
 		return err

--- a/http/backup_service.go
+++ b/http/backup_service.go
@@ -121,6 +121,7 @@ func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
+		return
 	}
 
 	if credsExist {

--- a/http/backup_service.go
+++ b/http/backup_service.go
@@ -117,25 +117,15 @@ func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	files = append(files, bolt.DefaultFilename)
 
-	credBackupPath := filepath.Join(internalBackupPath, DefaultTokenFile)
+	credsExist, err := h.backupCredentials(internalBackupPath)
 
-	credPath, err := defaultTokenPath()
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	token, err := ioutil.ReadFile(credPath)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
 	}
 
-	if err := ioutil.WriteFile(credBackupPath, []byte(token), 0600); err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
+	if credsExist {
+		files = append(files, DefaultTokenFile)
 	}
-
-	files = append(files, DefaultTokenFile)
 
 	b := backup{
 		ID:    id,
@@ -146,6 +136,26 @@ func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
+}
+
+func (h *BackupHandler) backupCredentials(internalBackupPath string) (bool, error) {
+	credBackupPath := filepath.Join(internalBackupPath, DefaultTokenFile)
+
+	credPath, err := defaultTokenPath()
+	if err != nil {
+		return false, err
+	}
+	token, err := ioutil.ReadFile(credPath)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err := ioutil.WriteFile(credBackupPath, []byte(token), 0600); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (h *BackupHandler) handleFetchFile(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Backups and restores should work whether or not the original installation uses
a credentials file and whether or not the backup contains a credentials file.

Closes #16723