### PR TITLE
feat: adding in a simple regexp

### DIFF
--- a/ui/src/shared/components/tables/TableCell.tsx
+++ b/ui/src/shared/components/tables/TableCell.tsx
@@ -31,6 +31,41 @@ interface Props extends CellRendererProps {
   timeFormatter: (time: string) => string
 }
 
+const URL_REGEXP = /(https?:\/\/[^\s]+)/g
+
+function asLink(str) {
+  if (!URL_REGEXP.test('' + str)) {
+    return str
+  }
+
+  const regex = RegExp(URL_REGEXP.source, URL_REGEXP.flags),
+    out = []
+  let idx = 0,
+    link,
+    m
+
+  do {
+    m = regex.exec(str)
+
+    if (m) {
+      if (m.index - idx > 0) {
+        out.push(str.slice(idx, m.index))
+      }
+
+      link = str.slice(m.index, m.index + m[1].length)
+      out.push(
+        <a href={link} target="_blank">
+          {link}
+        </a>
+      )
+
+      idx = m.index + m[1].length
+    }
+  } while (m)
+
+  return out
+}
+
 class TableCell extends PureComponent<Props> {
   public render() {
     const {data, rowIndex, columnIndex, onHover} = this.props
@@ -60,7 +95,7 @@ class TableCell extends PureComponent<Props> {
         onMouseOver={onHover}
         title={this.contents}
       >
-        {this.contents}
+        {asLink(this.contents)}
       </div>
     )
   }

--- a/ui/src/shared/components/tables/TableCell.tsx
+++ b/ui/src/shared/components/tables/TableCell.tsx
@@ -33,6 +33,8 @@ interface Props extends CellRendererProps {
 
 const URL_REGEXP = /(https?:\/\/[^\s]+)/g
 
+// NOTE: rip this out if you spend time any here as per:
+// https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501
 function asLink(str) {
   if (!URL_REGEXP.test('' + str)) {
     return str


### PR DESCRIPTION
Closes #16168

this takes the cells within the table view and sees if they match a simple url regexp. if they do, it makes them a link.

![Screenshot from 2020-02-13 14-04-13](https://user-images.githubusercontent.com/1434802/74483722-daf24880-4e6b-11ea-949a-57982b659622.png)


before it's brought up: https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501

this isn't that big of a deal if it fails, as the interaction just reverts to normal, or it's a link that no one wants to go to anyways.