### PR TITLE
build: remove -tags libflux and FLUX_PARSER_TYPE from build and circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
             # filter internal/promqltests because it has special go.mod
             TESTFILES=$(go list ./... | grep -v internal/promqltests | circleci tests split --split-by=timings)
             echo $TESTFILES
-            GOTRACEBACK=all GO111MODULE=on FLUX_PARSER_TYPE=rust CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 -tags 'libflux' $TESTFILES
+            GOTRACEBACK=all GO111MODULE=on CGO_LDFLAGS="$(cat .cgo_ldflags)" gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 $TESTFILES
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}
@@ -295,7 +295,7 @@ jobs:
       - run: make checktidy
       - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
       - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
-      - run: GO111MODULE=on staticcheck ./...
+      - run: GO111MODULE=on ./env staticcheck ./...
       - save_cache:
           name: Saving GOCACHE
           key: influxdb-gocache-{{ .Branch }}-{{ .Revision }}

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@
 # SUBDIRS are directories that have their own Makefile.
 # It is required that all SUBDIRS have the `all` and `clean` targets.
 SUBDIRS := http ui chronograf query storage
-# The 'libflux' tag is required for instructing the flux to be compiled with the Rust parser
-GO_TAGS=libflux
+GO_TAGS=
 GO_ARGS=-tags '$(GO_TAGS)'
 ifeq ($(OS), Windows_NT)
 	VERSION := $(shell git describe --exact-match --tags 2>nil)
@@ -34,7 +33,7 @@ endif
 export GOOS=$(shell go env GOOS)
 export GO_BUILD=env GO111MODULE=on CGO_LDFLAGS="$$(cat .cgo_ldflags)" go build $(GO_ARGS) -ldflags "$(LDFLAGS)"
 export GO_INSTALL=env GO111MODULE=on CGO_LDFLAGS="$$(cat .cgo_ldflags)" go install $(GO_ARGS) -ldflags "$(LDFLAGS)"
-export GO_TEST=env FLUX_PARSER_TYPE=rust GOTRACEBACK=all GO111MODULE=on CGO_LDFLAGS="$$(cat .cgo_ldflags)" go test $(GO_ARGS)
+export GO_TEST=env GOTRACEBACK=all GO111MODULE=on CGO_LDFLAGS="$$(cat .cgo_ldflags)" go test $(GO_ARGS)
 # Do not add GO111MODULE=on to the call to go generate so it doesn't pollute the environment.
 export GO_GENERATE=go generate $(GO_ARGS)
 export GO_VET=env GO111MODULE=on CGO_LDFLAGS="$$(cat .cgo_ldflags)" go vet $(GO_ARGS)

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62
-	github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3
+	github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3 h1:hHJ2hjGq/X2IthJEcU3e7EM6R1pfygDp22ZThE065eA=
-github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7 h1:msGvptJLvtXDsRSHtb73qkKg5ALGGQYLegPhguNNBg0=
+github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3
+	github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -286,8 +286,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3 h1:hHJ2hjGq/X2IthJEcU3e7EM6R1pfygDp22ZThE065eA=
-github.com/influxdata/flux v0.59.1-0.20200211170827-d3317e8efff3/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7 h1:msGvptJLvtXDsRSHtb73qkKg5ALGGQYLegPhguNNBg0=
+github.com/influxdata/flux v0.59.1-0.20200212184221-b1a33fc2a6f7/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=


### PR DESCRIPTION
This also prepends the `env` script (which sets CGO environment variables) that lets `staticcheck` pass.

The `continuous integration` tests will continue to fail until idpe is also green.

The `e2e` test failures seem related to notifications, that might be related to this?
https://github.com/influxdata/influxdb/issues/16809