### PR TITLE
chore(ui): update clockface versions from 1.1.0 -> 1.1.5

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -383,7 +383,7 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('switch-query-builder-confirm--popover--contents').within(
         () => {
-          cy.getByTestID('button').click()
+          cy.getByTestID('switch-query-builder-confirm--confirm-button').click()
         }
       )
 

--- a/ui/cypress/e2e/tokens.test.ts
+++ b/ui/cypress/e2e/tokens.test.ts
@@ -210,7 +210,7 @@ describe('tokens', () => {
       })
       .then(() => {
         cy.getByTestID('delete-token--popover--contents').within(() => {
-          cy.getByTestID('button').click()
+          cy.getByTestID('delete-token--confirm-button').click()
         })
       })
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -129,7 +129,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "1.1.0",
+    "@influxdata/clockface": "1.1.5",
     "@influxdata/flux-parser": "^0.3.0",
     "@influxdata/giraffe": "0.17.4",
     "@influxdata/influx": "0.5.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1011,10 +1011,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-1.1.0.tgz#beadb0ebdb9c29af1020137943a359474eca463e"
-  integrity sha512-nXvGGZ/n3r8vxd+xNyQk2BEM294N1v/KNEH6tivNGdFWFkuHKDn7/a/2y8fISK+qzIEPN/LF6Xi9eOKb7G8EFg==
+"@influxdata/clockface@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-1.1.5.tgz#dfedc4f59788717d5e92bd00935dda35c0c60fc8"
+  integrity sha512-5+RDswLCiOBX21rey6e1j4vrwQ6obwMv+qcP6ucH7y0vTRnAaMk9lqKqHH3FGUqUEfBNegtj4Ho8430ywfS6ag==
 
 "@influxdata/flux-parser@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This PR is meant to update the current influxdb version of clockface in order to enable social sign-up functionality without creating confusion later on down the line. Below is a release history for clockface versions:

* [1.1.5](https://github.com/influxdata/clockface/releases/tag/v1.1.5) - Fixes Notification Component exports bug (added exports to Notification component so that it can be imported)
* [1.1.4](https://github.com/influxdata/clockface/releases/tag/v1.1.4) - Added VisibilityInput Component - allows users to toggle an input icon to hide/show their password
* [1.1.3](https://github.com/influxdata/clockface/releases/tag/v1.1.3) - Fixes LinkButton Component exports bug (added exports to LinkButton component so that it can be imported)
* [1.1.2](https://github.com/influxdata/clockface/releases/tag/v1.1.2) - LinkButton styles and exclusion rule added
* [1.1.1](https://github.com/influxdata/clockface/releases/tag/v1.1.1) - Introduces the LinkButton component, renders an empty state when ResourceList.Body receives boolean false as children, updated several components to accept testID prop to overwrite default data-testid, added new RightClickMenuItem option as a clickhandler 