### PR TITLE
fix(cmd/write): remove shared buffer access that caused race conditio…

### DIFF
--- a/write/batcher.go
+++ b/write/batcher.go
@@ -69,7 +69,7 @@ func (b *Batcher) read(ctx context.Context, r io.Reader, lines chan<- []byte, er
 	for scanner.Scan() {
 		// exit early if the context is done
 		select {
-		case lines <- scanner.Bytes():
+		case lines <- []byte(scanner.Text()):
 		case <-ctx.Done():
 			errC <- ctx.Err()
 			return


### PR DESCRIPTION
Using `influx write ... ./large_file.linep` fails because the Scanner implementation reuses the same buffer, and we're consuming it in the read and write paths of the import.

This fix switches the write path to use a copy of the buffer, removing the defect

Longer term solution would be to swap out the Scanner usage for shared buffer pools