### PR TITLE
feat(http): checks client

### DIFF
--- a/check.go
+++ b/check.go
@@ -60,7 +60,7 @@ type CheckService interface {
 	// FindCheck returns the first check that matches filter.
 	FindCheck(ctx context.Context, filter CheckFilter) (Check, error)
 
-	// FindChecks returns a list of checks that match filter and the total count of matching checkns.
+	// FindChecks returns a list of checks that match filter and the total count of matching checks.
 	// Additional options provide pagination & sorting.
 	FindChecks(ctx context.Context, filter CheckFilter, opt ...FindOptions) ([]Check, int, error)
 

--- a/http/client.go
+++ b/http/client.go
@@ -49,6 +49,7 @@ type Service struct {
 	*VariableService
 	*WriteService
 	DocumentService
+	*CheckService
 }
 
 // NewService returns a service that is an HTTP
@@ -73,6 +74,7 @@ func NewService(addr, token string) (*Service, error) {
 		OrganizationService: &OrganizationService{Client: httpClient},
 		UserService:         &UserService{Client: httpClient},
 		VariableService:     &VariableService{Client: httpClient},
+		CheckService:        &CheckService{Client: httpClient},
 		WriteService: &WriteService{
 			Addr:  addr,
 			Token: token,


### PR DESCRIPTION
Adds a checks API client alongside checks API handlers.

This client does not implement `influxdb.CheckService` because that interface returns an `influxdb.Check` interface, which is not suitable for this use case (because, e.g. it provides a `GetTaskID` method, which would require embedding a task service inside the response object).

New unit tests are not added given this client is a thin wrapper on `httpc`. Tests for that package, as well as the handlers themselves, exercise all meaningful logic on these code paths.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
