### PR TITLE
fix(checkmetacard): fix for tags being null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically
+1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the defualt value of tags in a Check
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/src/checks/components/CheckMetaCard.tsx
+++ b/ui/src/checks/components/CheckMetaCard.tsx
@@ -104,7 +104,11 @@ const CheckMetaCard: FC<Props> = ({
 }
 
 const mstp = ({alertBuilder: {tags, offset, every}}: AppState): StateProps => {
-  return {tags, offset, every}
+  return {
+    tags: tags || [],
+    offset,
+    every
+  }
 }
 
 const mdtp: DispatchProps = {

--- a/ui/src/checks/components/CheckMetaCard.tsx
+++ b/ui/src/checks/components/CheckMetaCard.tsx
@@ -107,7 +107,7 @@ const mstp = ({alertBuilder: {tags, offset, every}}: AppState): StateProps => {
   return {
     tags: tags || [],
     offset,
-    every
+    every,
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16460

sets a default value for tags in case it comes in null.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
