### PR TITLE
fix(tokenlist): fix sort by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically
+1. [16934](https://github.com/influxdata/influxdb/pull/16934): Tokens page now sorts by status
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/src/authorizations/components/TokenList.tsx
+++ b/ui/src/authorizations/components/TokenList.tsx
@@ -61,8 +61,8 @@ export default class TokenList extends PureComponent<Props, State> {
               width="50%"
             />
             <IndexList.HeaderCell
-              sortKey={this.headerKeys[0]}
-              sort={sortKey === this.headerKeys[0] ? sortDirection : Sort.None}
+              sortKey={this.headerKeys[1]}
+              sort={sortKey === this.headerKeys[1] ? sortDirection : Sort.None}
               columnName="Status"
               onClick={onClickColumn}
               width="50%"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15301

Fixes a bug where the tokens page wasn't able to be sorted by status

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
