### PR TITLE
fix: escaping tag values

### DIFF
--- a/ui/src/timeMachine/apis/queryBuilder.ts
+++ b/ui/src/timeMachine/apis/queryBuilder.ts
@@ -8,6 +8,7 @@ import {parseResponse} from 'src/shared/parsing/flux/response'
 // Utils
 import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
 import {formatExpression} from 'src/variables/utils/formatExpression'
+import {tagToFlux} from 'src/timeMachine/utils/queryBuilder'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -156,13 +157,7 @@ export function formatTagFilterPredicate(
   }
 
   const calls = validSelections
-    .map(({key, values}) => {
-      const body = values
-        .map(value => `r.${key} == "${value.replace(/\\/g, '\\\\')}"`)
-        .join(' or ')
-
-      return `(${body})`
-    })
+    .map((tag) => `(${tagToFlux(tag)})`)
     .join(' and ')
 
   return `(r) => ${calls}`

--- a/ui/src/timeMachine/apis/queryBuilder.ts
+++ b/ui/src/timeMachine/apis/queryBuilder.ts
@@ -157,7 +157,9 @@ export function formatTagFilterPredicate(
 
   const calls = validSelections
     .map(({key, values}) => {
-      const body = values.map(value => `r.${key} == "${value}"`).join(' or ')
+      const body = values
+        .map(value => `r.${key} == "${value.replace(/\\/g, '\\\\')}"`)
+        .join(' or ')
 
       return `(${body})`
     })

--- a/ui/src/timeMachine/apis/queryBuilder.ts
+++ b/ui/src/timeMachine/apis/queryBuilder.ts
@@ -156,9 +156,7 @@ export function formatTagFilterPredicate(
     return '(r) => true'
   }
 
-  const calls = validSelections
-    .map((tag) => `(${tagToFlux(tag)})`)
-    .join(' and ')
+  const calls = validSelections.map(tag => `(${tagToFlux(tag)})`).join(' and ')
 
   return `(r) => ${calls}`
 }

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -172,12 +172,10 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
   return ''
 }
 
-export const tagToFlux = function tagToFlux(
-    tag: BuilderTagType
-) {
-    return tag.values
-      .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
-      .join(' or ')
+export const tagToFlux = function tagToFlux(tag: BuilderTagType) {
+  return tag.values
+    .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
+    .join(' or ')
 }
 
 const formatPeriod = (period: string): string => {

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -157,7 +157,7 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
     }
 
     const fnBody = tag.values
-      .map(value => `r.${tag.key} == "${value}"`)
+      .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
       .join(' or ')
     return `\n  |> filter(fn: (r) => ${fnBody})`
   }

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -172,7 +172,7 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
   return ''
 }
 
-export const tagToFlux = function tagToFlux(tag: BuilderTagType) {
+export const tagToFlux = function tagToFlux(tag: BuilderTagsType) {
   return tag.values
     .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
     .join(' or ')

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -156,10 +156,7 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
       return ''
     }
 
-    const fnBody = tag.values
-      .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
-      .join(' or ')
-    return `\n  |> filter(fn: (r) => ${fnBody})`
+    return `\n  |> filter(fn: (r) => ${tagToFlux(tag)})`
   }
 
   if (tag.aggregateFunctionType === 'group') {
@@ -173,6 +170,14 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
   }
 
   return ''
+}
+
+export const tagToFlux = function tagToFlux(
+    tag: BuilderTagType
+) {
+    return tag.values
+      .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
+      .join(' or ')
 }
 
 const formatPeriod = (period: string): string => {


### PR DESCRIPTION
Closes #16229

we escape some flux variables right before they get shot off into the aether 

![Kapture 2020-02-19 at 14 49 22](https://user-images.githubusercontent.com/1434802/74884053-26eb3480-5327-11ea-99f6-e0113ca8366a.gif)
