### PR TITLE
feat: add side nav for cloud users

### DIFF
--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -252,19 +252,21 @@ class SideNav extends PureComponent<Props, State> {
           />
         </NavMenu.Item>
         <FeatureFlag name="multiUser">
-          <NavMenu.Item
-            titleLink={className => (
-              <a className={className} href={cloudUsersLink}>
-                Team Members
-              </a>
-            )}
-            iconLink={className => (
-              <a href={cloudUsersLink} className={className}>
-                <Icon glyph={IconFont.UsersTrio} />
-              </a>
-            )}
-            active={getNavItemActivation(['users'], location.pathname)}
-          />
+          <CloudOnly>
+            <NavMenu.Item
+              titleLink={className => (
+                <a className={className} href={cloudUsersLink}>
+                  Team Members
+                </a>
+              )}
+              iconLink={className => (
+                <a href={cloudUsersLink} className={className}>
+                  <Icon glyph={IconFont.UsersTrio} />
+                </a>
+              )}
+              active={getNavItemActivation(['users'], location.pathname)}
+            />
+          </CloudOnly>
         </FeatureFlag>
         <NavMenu.Item
           titleLink={className => (

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -12,7 +12,11 @@ import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
-import {HOMEPAGE_PATHNAME, CLOUD_URL} from 'src/shared/constants'
+import {
+  HOMEPAGE_PATHNAME,
+  CLOUD_URL,
+  CLOUD_USERS_PATH,
+} from 'src/shared/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
@@ -91,7 +95,7 @@ class SideNav extends PureComponent<Props, State> {
       'https://docs.google.com/forms/d/e/1FAIpQLSdGJpnIZGotN1VFJPkgZEhrt4t4f6QY1lMgMSRUnMeN3FjCKA/viewform?usp=sf_link'
 
     // Cloud
-    const cloudUsersLink = `${CLOUD_URL}/users`
+    const cloudUsersLink = `${CLOUD_URL}/${CLOUD_USERS_PATH}`
 
     return (
       <NavMenu>

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -9,9 +9,10 @@ import {NavMenu, Icon} from '@influxdata/clockface'
 import AccountNavSubItem from 'src/pageLayout/components/AccountNavSubItem'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
-import {HOMEPAGE_PATHNAME} from 'src/shared/constants'
+import {HOMEPAGE_PATHNAME, CLOUD_URL} from 'src/shared/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
@@ -88,6 +89,9 @@ class SideNav extends PureComponent<Props, State> {
     // Feedback
     const feedbackLink =
       'https://docs.google.com/forms/d/e/1FAIpQLSdGJpnIZGotN1VFJPkgZEhrt4t4f6QY1lMgMSRUnMeN3FjCKA/viewform?usp=sf_link'
+
+    // Cloud
+    const cloudUsersLink = `${CLOUD_URL}/users`
 
     return (
       <NavMenu>
@@ -247,6 +251,21 @@ class SideNav extends PureComponent<Props, State> {
             key="client-libraries"
           />
         </NavMenu.Item>
+        <FeatureFlag name="multiUser">
+          <NavMenu.Item
+            titleLink={className => (
+              <a className={className} href={cloudUsersLink}>
+                Team Members
+              </a>
+            )}
+            iconLink={className => (
+              <a href={cloudUsersLink} className={className}>
+                <Icon glyph={IconFont.UsersTrio} />
+              </a>
+            )}
+            active={getNavItemActivation(['users'], location.pathname)}
+          />
+        </FeatureFlag>
         <NavMenu.Item
           titleLink={className => (
             <Link className={className} to={settingsLink}>

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -62,6 +62,7 @@ export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'
 export const CLOUD_LOGOUT_PATH = '/logout'
+export const CLOUD_USERS_PATH = '/users'
 
 export const FLUX_RESPONSE_BYTES_LIMIT = CLOUD
   ? 10 * 1024 * 1024 // 10 MiB

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -11,6 +11,7 @@ export const OSS_FLAGS = {
 
 export const CLOUD_FLAGS = {
   deleteWithPredicate: false,
+  multiUser: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
   downloadCellCSV: false,
   telegrafEditor: false,


### PR DESCRIPTION
### What
Adding a cloud only feature flagged "NavBox" to the side nav for the cloud specfic `/users` page. 

### Why
No one could find where it was living in the Quartz nav.