### PR TITLE
fix(timeMachine): do not set activeQueryIndex when deleting last tab

### DIFF
--- a/ui/src/timeMachine/reducers/index.test.ts
+++ b/ui/src/timeMachine/reducers/index.test.ts
@@ -153,4 +153,40 @@ describe('the Time Machine reducer', () => {
       )
     })
   })
+
+  // Assertion of bugfix for https://github.com/influxdata/influxdb/issues/16426
+  describe('setting the active query index', () => {
+    const store = createStore(timeMachinesReducer, initialState())
+    store.dispatch({type: 'ADD_QUERY'})
+    store.dispatch({type: 'ADD_QUERY'})
+
+    it('sets the activeQueryIndex when the value is less than the length of draftQueries', () => {
+      const activeQueryIndex = 2
+      store.dispatch({
+        type: 'SET_ACTIVE_QUERY_INDEX',
+        payload: {activeQueryIndex},
+      })
+
+      const actualState = store.getState()
+      const activeTimeMachine =
+        actualState.timeMachines[actualState.activeTimeMachineID]
+      expect(activeTimeMachine.activeQueryIndex).toBe(activeQueryIndex)
+    })
+
+    it('does not set the activeQueryIndex when the value is greater than the length of draftQueries', () => {
+      const activeQueryIndex = 5
+      const originalActiveQueryIndex = store.getState().timeMachines[
+        store.getState().activeTimeMachineID
+      ].activeQueryIndex
+      store.dispatch({
+        type: 'SET_ACTIVE_QUERY_INDEX',
+        payload: {activeQueryIndex},
+      })
+
+      const actualState = store.getState()
+      const activeTimeMachine =
+        actualState.timeMachines[actualState.activeTimeMachineID]
+      expect(activeTimeMachine.activeQueryIndex).toBe(originalActiveQueryIndex)
+    })
+  })
 })

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -633,9 +633,10 @@ export const timeMachineReducer = (
       return produce(state, draftState => {
         const {activeQueryIndex} = action.payload
 
-        draftState.activeQueryIndex = activeQueryIndex
-
-        resetBuilderState(draftState)
+        if (activeQueryIndex < draftState.draftQueries.length) {
+          draftState.activeQueryIndex = activeQueryIndex
+          resetBuilderState(draftState)
+        }
       })
     }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16426

if you had multiple tabs, and you deleted the last tab (which you weren't on), we were incorrectly setting the value of activeQueryIndex. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
