### PR TITLE
chore(influx): refactor influx cmd to use factory pattern

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -10,13 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func cmdAuth() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "auth",
-		Aliases: []string{"authorization"},
-		Short:   "Authorization management commands",
-		Run:     seeHelp,
-	}
+func cmdAuth(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("auth", nil)
+	cmd.Aliases = []string{"authorization"}
+	cmd.Short = "Authorization management commands"
+	cmd.Run = seeHelp
+
 	cmd.AddCommand(
 		authActiveCmd(),
 		authCreateCmd(),
@@ -67,7 +66,7 @@ func authCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create authorization",
-		RunE:  wrapCheckSetup(authorizationCreateF),
+		RunE:  checkSetupRunEMiddleware(&flags)(authorizationCreateF),
 	}
 	authCreateFlags.org.register(cmd, false)
 
@@ -282,7 +281,7 @@ func authFindCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "find",
 		Short: "Find authorization",
-		RunE:  wrapCheckSetup(authorizationFindF),
+		RunE:  checkSetupRunEMiddleware(&flags)(authorizationFindF),
 	}
 
 	cmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "The user")
@@ -386,7 +385,7 @@ func authDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete authorization",
-		RunE:  wrapCheckSetup(authorizationDeleteF),
+		RunE:  checkSetupRunEMiddleware(&flags)(authorizationDeleteF),
 	}
 
 	cmd.Flags().StringVarP(&authorizationDeleteFlags.id, "id", "i", "", "The authorization ID (required)")
@@ -452,7 +451,7 @@ func authActiveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "active",
 		Short: "Active authorization",
-		RunE:  wrapCheckSetup(authorizationActiveF),
+		RunE:  checkSetupRunEMiddleware(&flags)(authorizationActiveF),
 	}
 
 	cmd.Flags().StringVarP(&authorizationActiveFlags.id, "id", "i", "", "The authorization ID (required)")
@@ -520,7 +519,7 @@ func authInactiveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inactive",
 		Short: "Inactive authorization",
-		RunE:  wrapCheckSetup(authorizationInactiveF),
+		RunE:  checkSetupRunEMiddleware(&flags)(authorizationInactiveF),
 	}
 
 	cmd.Flags().StringVarP(&authorizationInactiveFlags.id, "id", "i", "", "The authorization ID (required)")

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -14,18 +14,16 @@ import (
 	"go.uber.org/multierr"
 )
 
-func cmdBackup() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "backup",
-		Short: "Backup the data in InfluxDB",
-		Long: fmt.Sprintf(
-			`Backs up data and meta data for the running InfluxDB instance.
+func cmdBackup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("backup", backupF)
+	cmd.Short = "Backup the data in InfluxDB"
+	cmd.Long = fmt.Sprintf(
+		`Backs up data and meta data for the running InfluxDB instance.
 Downloaded files are written to the directory indicated by --path.
 The target directory, and any parent directories, are created automatically.
 Data file have extension .tsm; meta data is written to %s in the same directory.`,
-			bolt.DefaultFilename),
-		RunE: backupF,
-	}
+		bolt.DefaultFilename)
+
 	opts := flagOpts{
 		{
 			DestP:    &backupFlags.Path,

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/influxdata/influxdb"
@@ -13,12 +12,15 @@ import (
 
 type bucketSVCsFn func() (influxdb.BucketService, influxdb.OrganizationService, error)
 
-func cmdBucket(opts ...genericCLIOptFn) *cobra.Command {
-	return newCmdBucketBuilder(newBucketSVCs, opts...).cmd()
+func cmdBucket(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	builder := newCmdBucketBuilder(newBucketSVCs, opt)
+	builder.globalFlags = f
+	return builder.cmd()
 }
 
 type cmdBucketBuilder struct {
 	genericCLIOpts
+	*globalFlags
 
 	svcFn bucketSVCsFn
 
@@ -30,17 +32,9 @@ type cmdBucketBuilder struct {
 	retention   time.Duration
 }
 
-func newCmdBucketBuilder(svcsFn bucketSVCsFn, opts ...genericCLIOptFn) *cmdBucketBuilder {
-	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
+func newCmdBucketBuilder(svcsFn bucketSVCsFn, opts genericCLIOpts) *cmdBucketBuilder {
 	return &cmdBucketBuilder{
-		genericCLIOpts: opt,
+		genericCLIOpts: opts,
 		svcFn:          svcsFn,
 	}
 }

--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -11,14 +11,11 @@ import (
 
 var deleteFlags http.DeleteRequest
 
-func cmdDelete() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "delete points from an influxDB bucket",
-		Short: "Delete points from influxDB",
-		Long: `Delete points from influxDB, by specify start, end time
-	and a sql like predicate string.`,
-		RunE: wrapCheckSetup(fluxDeleteF),
-	}
+func cmdDelete(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("delete", fluxDeleteF)
+	cmd.Short = "Delete points from influxDB"
+	cmd.Long = `Delete points from influxDB, by specify start, end time
+	and a sql like predicate string.`
 
 	opts := flagOpts{
 		{

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/bolt"
@@ -51,7 +52,9 @@ func newHTTPClient() (*httpc.Client, error) {
 }
 
 type (
-	runEWrapFn func(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error
+	cobraRunEFn func(cmd *cobra.Command, args []string) error
+
+	cobraRuneEMiddleware func(fn cobraRunEFn) cobraRunEFn
 
 	genericCLIOptFn func(*genericCLIOpts)
 )
@@ -59,7 +62,7 @@ type (
 type genericCLIOpts struct {
 	in         io.Reader
 	w          io.Writer
-	runEWrapFn runEWrapFn
+	runEWrapFn cobraRuneEMiddleware
 }
 
 func (o genericCLIOpts) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
@@ -91,53 +94,50 @@ func out(w io.Writer) genericCLIOptFn {
 	}
 }
 
-func runEWrap(fn runEWrapFn) genericCLIOptFn {
-	return func(opts *genericCLIOpts) {
-		opts.runEWrapFn = fn
-	}
-}
-
-var flags struct {
+type globalFlags struct {
 	token      string
 	host       string
 	local      bool
 	skipVerify bool
 }
 
-func influxCmd(opts ...genericCLIOptFn) *cobra.Command {
+var flags globalFlags
+
+type cmdInfluxBuilder struct {
+	genericCLIOpts
+
+	once sync.Once
+}
+
+func newInfluxCmdBuilder(opts ...genericCLIOptFn) *cmdInfluxBuilder {
+	builder := new(cmdInfluxBuilder)
+
 	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
+		in:         os.Stdin,
+		w:          os.Stdout,
+		runEWrapFn: checkSetupRunEMiddleware(&flags),
 	}
 	for _, o := range opts {
 		o(&opt)
 	}
 
-	cmd := opt.newCmd("influx", nil)
+	builder.genericCLIOpts = opt
+	return builder
+}
+
+func (b *cmdInfluxBuilder) cmd(childCmdFns ...func(f *globalFlags, opt genericCLIOpts) *cobra.Command) *cobra.Command {
+	b.once.Do(func() {
+		// enforce that viper options only ever get set once
+		setViperOptions()
+	})
+
+	cmd := b.newCmd("influx", nil)
 	cmd.Short = "Influx Client"
 	cmd.SilenceUsage = true
 
-	setViperOptions()
-
-	runEWrapper := runEWrap(wrapCheckSetup)
-
-	cmd.AddCommand(
-		cmdAuth(),
-		cmdBackup(),
-		cmdBucket(runEWrapper),
-		cmdDelete(),
-		cmdOrganization(runEWrapper),
-		cmdPing(),
-		cmdPkg(runEWrapper),
-		cmdQuery(),
-		cmdTranspile(),
-		cmdREPL(),
-		cmdSecret(runEWrapper),
-		cmdSetup(),
-		cmdTask(),
-		cmdUser(runEWrapper),
-		cmdWrite(),
-	)
+	for _, childCmd := range childCmdFns {
+		cmd.AddCommand(childCmd(&flags, b.genericCLIOpts))
+	}
 
 	fOpts := flagOpts{
 		{
@@ -173,6 +173,27 @@ func influxCmd(opts ...genericCLIOptFn) *cobra.Command {
 	})
 
 	return cmd
+}
+
+func influxCmd(opts ...genericCLIOptFn) *cobra.Command {
+	builder := newInfluxCmdBuilder(opts...)
+	return builder.cmd(
+		cmdAuth,
+		cmdBackup,
+		cmdBucket,
+		cmdDelete,
+		cmdOrganization,
+		cmdPing,
+		cmdPkg,
+		cmdQuery,
+		cmdTranspile,
+		cmdREPL,
+		cmdSecret,
+		cmdSetup,
+		cmdTask,
+		cmdUser,
+		cmdWrite,
+	)
 }
 
 func fetchSubCommand(parent *cobra.Command, args []string) *cobra.Command {
@@ -230,10 +251,10 @@ func writeTokenToPath(tok, path, dir string) error {
 	return ioutil.WriteFile(path, []byte(tok), 0600)
 }
 
-func checkSetup(host string) error {
+func checkSetup(host string, skipVerify bool) error {
 	s := &http.SetupService{
-		Addr:               flags.host,
-		InsecureSkipVerify: flags.skipVerify,
+		Addr:               host,
+		InsecureSkipVerify: skipVerify,
 	}
 
 	isOnboarding, err := s.IsOnboarding(context.Background())
@@ -248,29 +269,20 @@ func checkSetup(host string) error {
 	return nil
 }
 
-func wrapCheckSetup(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return wrapErrorFmt(func(cmd *cobra.Command, args []string) error {
-		err := fn(cmd, args)
-		if err == nil {
-			return nil
+func checkSetupRunEMiddleware(f *globalFlags) cobraRuneEMiddleware {
+	return func(fn cobraRunEFn) cobraRunEFn {
+		return func(cmd *cobra.Command, args []string) error {
+			err := fn(cmd, args)
+			if err == nil {
+				return nil
+			}
+
+			if setupErr := checkSetup(f.host, f.skipVerify); setupErr != nil && influxdb.EUnauthorized != influxdb.ErrorCode(setupErr) {
+				return internal.ErrorFmt(setupErr)
+			}
+
+			return internal.ErrorFmt(err)
 		}
-
-		if setupErr := checkSetup(flags.host); setupErr != nil && influxdb.EUnauthorized != influxdb.ErrorCode(setupErr) {
-			return setupErr
-		}
-
-		return err
-	})
-}
-
-func wrapErrorFmt(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		err := fn(cmd, args)
-		if err == nil {
-			return nil
-		}
-
-		return internal.ErrorFmt(err)
 	}
 }
 

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/influxdata/influxdb/http"
 
@@ -14,12 +13,15 @@ import (
 
 type orgSVCFn func() (influxdb.OrganizationService, influxdb.UserResourceMappingService, influxdb.UserService, error)
 
-func cmdOrganization(opts ...genericCLIOptFn) *cobra.Command {
-	return newCmdOrgBuilder(newOrgServices, opts...).cmd()
+func cmdOrganization(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+	builder := newCmdOrgBuilder(newOrgServices, opts)
+	builder.globalFlags = f
+	return builder.cmd()
 }
 
 type cmdOrgBuilder struct {
 	genericCLIOpts
+	*globalFlags
 
 	svcFn orgSVCFn
 
@@ -29,17 +31,9 @@ type cmdOrgBuilder struct {
 	name        string
 }
 
-func newCmdOrgBuilder(svcFn orgSVCFn, opts ...genericCLIOptFn) *cmdOrgBuilder {
-	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
+func newCmdOrgBuilder(svcFn orgSVCFn, opts genericCLIOpts) *cmdOrgBuilder {
 	return &cmdOrgBuilder{
-		genericCLIOpts: opt,
+		genericCLIOpts: opts,
 		svcFn:          svcFn,
 	}
 }

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -10,43 +10,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func cmdPing() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "ping",
-		Short: "Check the InfluxDB /health endpoint",
-		Long:  `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if flags.local {
-				return fmt.Errorf("local flag not supported for ping command")
-			}
+func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+	runE := func(cmd *cobra.Command, args []string) error {
+		if flags.local {
+			return fmt.Errorf("local flag not supported for ping command")
+		}
 
-			c := http.Client{
-				Timeout: 5 * time.Second,
-			}
-			url := flags.host + "/health"
-			resp, err := c.Get(url)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode/100 != 2 {
-				return fmt.Errorf("got %d from '%s'", resp.StatusCode, url)
-			}
+		c := http.Client{
+			Timeout: 5 * time.Second,
+		}
+		url := flags.host + "/health"
+		resp, err := c.Get(url)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			return fmt.Errorf("got %d from '%s'", resp.StatusCode, url)
+		}
 
-			var healthResponse check.Response
-			if err = json.NewDecoder(resp.Body).Decode(&healthResponse); err != nil {
-				return err
-			}
+		var healthResponse check.Response
+		if err = json.NewDecoder(resp.Body).Decode(&healthResponse); err != nil {
+			return err
+		}
 
-			if healthResponse.Status == check.StatusPass {
-				fmt.Println("OK")
-			} else {
-				return fmt.Errorf("health check failed: '%s'", healthResponse.Message)
-			}
+		if healthResponse.Status == check.StatusPass {
+			fmt.Println("OK")
+		} else {
+			return fmt.Errorf("health check failed: '%s'", healthResponse.Message)
+		}
 
-			return nil
-		},
+		return nil
 	}
+
+	cmd := opts.newCmd("ping", runE)
+	cmd.Short = "Check the InfluxDB /health endpoint"
+	cmd.Long = `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`
 
 	return cmd
 }

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -29,8 +29,8 @@ import (
 
 type pkgSVCsFn func() (pkger.SVC, influxdb.OrganizationService, error)
 
-func cmdPkg(opts ...genericCLIOptFn) *cobra.Command {
-	return newCmdPkgBuilder(newPkgerSVC, opts...).cmd()
+func cmdPkg(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+	return newCmdPkgBuilder(newPkgerSVC, opts).cmd()
 }
 
 type cmdPkgBuilder struct {
@@ -67,17 +67,9 @@ type cmdPkgBuilder struct {
 	}
 }
 
-func newCmdPkgBuilder(svcFn pkgSVCsFn, opts ...genericCLIOptFn) *cmdPkgBuilder {
-	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
+func newCmdPkgBuilder(svcFn pkgSVCsFn, opts genericCLIOpts) *cmdPkgBuilder {
 	return &cmdPkgBuilder{
-		genericCLIOpts: opt,
+		genericCLIOpts: opts,
 		svcFn:          svcFn,
 	}
 }

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -14,15 +14,13 @@ var queryFlags struct {
 	org organization
 }
 
-func cmdQuery() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "query [query literal or @/path/to/query.flux]",
-		Short: "Execute a Flux query",
-		Long: `Execute a literal Flux query provided as a string,
-or execute a literal Flux query contained in a file by specifying the file prefixed with an @ sign.`,
-		Args: cobra.ExactArgs(1),
-		RunE: wrapCheckSetup(fluxQueryF),
-	}
+func cmdQuery(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+	cmd := opts.newCmd("query [query literal or @/path/to/query.flux]", fluxQueryF)
+	cmd.Short = "Execute a Flux query"
+	cmd.Long = `Execute a literal Flux query provided as a string,
+or execute a literal Flux query contained in a file by specifying the file prefixed with an @ sign.`
+	cmd.Args = cobra.ExactArgs(1)
+
 	queryFlags.org.register(cmd, true)
 
 	return cmd

--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -18,13 +18,11 @@ var replFlags struct {
 	org organization
 }
 
-func cmdREPL() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "repl",
-		Short: "Interactive Flux REPL (read-eval-print-loop)",
-		Args:  cobra.NoArgs,
-		RunE:  wrapCheckSetup(replF),
-	}
+func cmdREPL(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("repl", replF)
+	cmd.Short = "Interactive Flux REPL (read-eval-print-loop)"
+	cmd.Args = cobra.NoArgs
+
 	replFlags.org.register(cmd, false)
 
 	return cmd

--- a/cmd/influx/secret.go
+++ b/cmd/influx/secret.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http"
@@ -13,12 +12,15 @@ import (
 
 type secretSVCsFn func() (influxdb.SecretService, influxdb.OrganizationService, func(*input.UI) string, error)
 
-func cmdSecret(opts ...genericCLIOptFn) *cobra.Command {
-	return newCmdSecretBuilder(newSecretSVCs, opts...).cmd()
+func cmdSecret(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	builder := newCmdSecretBuilder(newSecretSVCs, opt)
+	builder.globalFlags = f
+	return builder.cmd()
 }
 
 type cmdSecretBuilder struct {
 	genericCLIOpts
+	*globalFlags
 
 	svcFn secretSVCsFn
 
@@ -26,15 +28,7 @@ type cmdSecretBuilder struct {
 	org organization
 }
 
-func newCmdSecretBuilder(svcsFn secretSVCsFn, opts ...genericCLIOptFn) *cmdSecretBuilder {
-	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
+func newCmdSecretBuilder(svcsFn secretSVCsFn, opt genericCLIOpts) *cmdSecretBuilder {
 	return &cmdSecretBuilder{
 		genericCLIOpts: opt,
 		svcFn:          svcsFn,

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -25,12 +25,9 @@ var setupFlags struct {
 	force     bool
 }
 
-func cmdSetup() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "setup",
-		Short: "Setup instance with initial user, org, bucket",
-		RunE:  wrapErrorFmt(setupF),
-	}
+func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("setup", setupF)
+	cmd.Short = "Setup instance with initial user, org, bucket"
 
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
 	cmd.Flags().StringVarP(&setupFlags.password, "password", "p", "", "password for username")

--- a/cmd/influx/transpile.go
+++ b/cmd/influx/transpile.go
@@ -16,18 +16,17 @@ var transpileFlags struct {
 	Now string
 }
 
-func cmdTranspile() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "transpile [InfluxQL query]",
-		Short: "Transpile an InfluxQL query to Flux source code",
-		Long: `Transpile an InfluxQL query to Flux source code.
+func cmdTranspile(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("transpile [InfluxQL query]", transpileF)
+	cmd.Args = cobra.ExactArgs(1)
+	cmd.Short = "Transpile an InfluxQL query to Flux source code"
+	cmd.Long = `Transpile an InfluxQL query to Flux source code.
+
 
 The transpiled query assumes that the bucket name is the of the form '<database>/<retention policy>'.
 
-The transpiled query will be written for absolute time ranges using the provided now() time.`,
-		Args: cobra.ExactArgs(1),
-		RunE: transpileF,
-	}
+The transpiled query will be written for absolute time ranges using the provided now() time.`
+
 	opts := flagOpts{
 		{
 			DestP: &transpileFlags.Now,

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http"
@@ -25,12 +24,15 @@ type cmdUserDeps struct {
 	getPassFn func(*input.UI, bool) string
 }
 
-func cmdUser(opts ...genericCLIOptFn) *cobra.Command {
-	return newCmdUserBuilder(newUserSVC, opts...).cmd()
+func cmdUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	builder := newCmdUserBuilder(newUserSVC, opt)
+	builder.globalFlags = f
+	return builder.cmd()
 }
 
 type cmdUserBuilder struct {
 	genericCLIOpts
+	*globalFlags
 
 	svcFn userSVCsFn
 
@@ -40,15 +42,7 @@ type cmdUserBuilder struct {
 	org      organization
 }
 
-func newCmdUserBuilder(svcsFn userSVCsFn, opts ...genericCLIOptFn) *cmdUserBuilder {
-	opt := genericCLIOpts{
-		in: os.Stdin,
-		w:  os.Stdout,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
-
+func newCmdUserBuilder(svcsFn userSVCsFn, opt genericCLIOpts) *cmdUserBuilder {
 	return &cmdUserBuilder{
 		genericCLIOpts: opt,
 		svcFn:          svcsFn,

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -23,15 +23,12 @@ var writeFlags struct {
 	Precision string
 }
 
-func cmdWrite() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "write line protocol or @/path/to/points.txt",
-		Short: "Write points to InfluxDB",
-		Long: `Write a single line of line protocol to InfluxDB,
-or add an entire file specified with an @ prefix.`,
-		Args: cobra.ExactArgs(1),
-		RunE: wrapCheckSetup(fluxWriteF),
-	}
+func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+	cmd := opt.newCmd("write line protocol or @/path/to/points.txt", fluxWriteF)
+	cmd.Args = cobra.ExactArgs(1)
+	cmd.Short = "Write points to InfluxDB"
+	cmd.Long = `Write a single line of line protocol to InfluxDB,
+or add an entire file specified with an @ prefix.`
 
 	opts := flagOpts{
 		{


### PR DESCRIPTION
refactors test to use full call paths in addition. testing the full API for the `influx` cli tool. This is the first of several PRs to update this. The next ones will deal with eliminating the drift in other cmds that haven't been worked into shape yet.

work is in support of: #16876

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass