### PR TITLE
fix(notification/rule): add alert level filtering to pagerduty rule

### DIFF
--- a/notification/rule/http.go
+++ b/notification/rule/http.go
@@ -60,7 +60,7 @@ func (s *HTTP) generateFluxASTBody(e *endpoint.HTTP) []ast.Statement {
 	statements = append(statements, s.generateFluxASTEndpoint(e))
 	statements = append(statements, s.generateFluxASTNotificationDefinition(e))
 	statements = append(statements, s.generateFluxASTStatuses())
-	statements = append(statements, s.generateAllStateChanges()...)
+	statements = append(statements, s.generateLevelChecks()...)
 	statements = append(statements, s.generateFluxASTNotifyPipe())
 
 	return statements

--- a/notification/rule/pagerduty.go
+++ b/notification/rule/pagerduty.go
@@ -79,6 +79,7 @@ func (s *PagerDuty) generateFluxASTBody(e *endpoint.PagerDuty) []ast.Statement {
 	statements = append(statements, s.generateFluxASTEndpoint(e))
 	statements = append(statements, s.generateFluxASTNotificationDefinition(e))
 	statements = append(statements, s.generateFluxASTStatuses())
+	statements = append(statements, s.generateLevelChecks()...)
 	statements = append(statements, s.generateFluxASTNotifyPipe(e.ClientURL))
 
 	return statements
@@ -170,7 +171,7 @@ func (s *PagerDuty) generateFluxASTNotifyPipe(url string) ast.Statement {
 
 	call := flux.Call(flux.Member("monitor", "notify"), flux.Object(props...))
 
-	return flux.ExpressionStatement(flux.Pipe(flux.Identifier("statuses"), call))
+	return flux.ExpressionStatement(flux.Pipe(flux.Identifier("all_statuses"), call))
 }
 
 func severityFromLevel() *ast.CallExpression {

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -3,6 +3,7 @@ package rule_test
 import (
 	"testing"
 
+	"github.com/andreyvit/diff"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/notification"
 	"github.com/influxdata/influxdb/notification/endpoint"
@@ -10,7 +11,55 @@ import (
 )
 
 func TestPagerDuty_GenerateFlux(t *testing.T) {
-	want := `package main
+	tests := []struct {
+		name     string
+		rule     *rule.PagerDuty
+		endpoint *endpoint.PagerDuty
+		script   string
+	}{
+		{
+			name: "notify on crit",
+			endpoint: &endpoint.PagerDuty{
+				Base: endpoint.Base{
+					ID:   idPtr(2),
+					Name: "foo",
+				},
+				ClientURL: "http://localhost:7777/host/${r.host}",
+				RoutingKey: influxdb.SecretField{
+					Key: "pagerduty_token",
+				},
+			},
+			rule: &rule.PagerDuty{
+				MessageTemplate: "blah",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 2,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: `package main
 // foo
 import "influxdata/influxdb/monitor"
 import "pagerduty"
@@ -28,8 +77,14 @@ notification = {
 }
 statuses = monitor.from(start: -2h, fn: (r) =>
 	(r.foo == "bar" and r.baz == "bang"))
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
+all_statuses = crit
+	|> filter(fn: (r) =>
+		(r._time > experimental.subDuration(from: now(), d: 1h)))
 
-statuses
+all_statuses
 	|> monitor.notify(data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
 		({
 			routingKey: pagerduty_secret,
@@ -42,52 +97,194 @@ statuses
 			source: notification._notification_rule_name,
 			summary: r._message,
 			timestamp: time(v: r._source_timestamp),
-		})))`
-
-	s := &rule.PagerDuty{
-		MessageTemplate: "blah",
-		Base: rule.Base{
-			ID:         1,
-			EndpointID: 2,
-			Name:       "foo",
-			Every:      mustDuration("1h"),
-			TagRules: []notification.TagRule{
-				{
-					Tag: influxdb.Tag{
-						Key:   "foo",
-						Value: "bar",
-					},
-					Operator: influxdb.Equal,
+		})))`,
+		},
+		{
+			name: "notify on info to crit",
+			endpoint: &endpoint.PagerDuty{
+				Base: endpoint.Base{
+					ID:   idPtr(2),
+					Name: "foo",
 				},
-				{
-					Tag: influxdb.Tag{
-						Key:   "baz",
-						Value: "bang",
-					},
-					Operator: influxdb.Equal,
+				ClientURL: "http://localhost:7777/host/${r.host}",
+				RoutingKey: influxdb.SecretField{
+					Key: "pagerduty_token",
 				},
 			},
+			rule: &rule.PagerDuty{
+				MessageTemplate: "blah",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 2,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel:  notification.Critical,
+							PreviousLevel: statusRulePtr(notification.Info),
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "pagerduty"
+import "influxdata/influxdb/secrets"
+
+option task = {name: "foo", every: 1h}
+
+pagerduty_secret = secrets.get(key: "pagerduty_token")
+pagerduty_endpoint = pagerduty.endpoint()
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000002",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor.from(start: -2h, fn: (r) =>
+	(r.foo == "bar" and r.baz == "bang"))
+info_to_crit = statuses
+	|> monitor.stateChanges(fromLevel: "info", toLevel: "crit")
+all_statuses = info_to_crit
+	|> filter(fn: (r) =>
+		(r._time > experimental.subDuration(from: now(), d: 1h)))
+
+all_statuses
+	|> monitor.notify(data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
+		({
+			routingKey: pagerduty_secret,
+			client: "influxdata",
+			clientURL: "http://localhost:7777/host/${r.host}",
+			class: r._check_name,
+			group: r._source_measurement,
+			severity: pagerduty.severityFromLevel(level: r._level),
+			eventAction: pagerduty.actionFromLevel(level: r._level),
+			source: notification._notification_rule_name,
+			summary: r._message,
+			timestamp: time(v: r._source_timestamp),
+		})))`,
+		},
+		{
+			name: "notify on crit or ok to warn",
+			endpoint: &endpoint.PagerDuty{
+				Base: endpoint.Base{
+					ID:   idPtr(2),
+					Name: "foo",
+				},
+				ClientURL: "http://localhost:7777/host/${r.host}",
+				RoutingKey: influxdb.SecretField{
+					Key: "pagerduty_token",
+				},
+			},
+			rule: &rule.PagerDuty{
+				MessageTemplate: "blah",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 2,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+						{
+							CurrentLevel:  notification.Warn,
+							PreviousLevel: statusRulePtr(notification.Ok),
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "pagerduty"
+import "influxdata/influxdb/secrets"
+
+option task = {name: "foo", every: 1h}
+
+pagerduty_secret = secrets.get(key: "pagerduty_token")
+pagerduty_endpoint = pagerduty.endpoint()
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000002",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor.from(start: -2h, fn: (r) =>
+	(r.foo == "bar" and r.baz == "bang"))
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
+ok_to_warn = statuses
+	|> monitor.stateChanges(fromLevel: "ok", toLevel: "warn")
+all_statuses = union(tables: [crit, ok_to_warn])
+	|> sort(columns: ["_time"])
+	|> filter(fn: (r) =>
+		(r._time > experimental.subDuration(from: now(), d: 1h)))
+
+all_statuses
+	|> monitor.notify(data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
+		({
+			routingKey: pagerduty_secret,
+			client: "influxdata",
+			clientURL: "http://localhost:7777/host/${r.host}",
+			class: r._check_name,
+			group: r._source_measurement,
+			severity: pagerduty.severityFromLevel(level: r._level),
+			eventAction: pagerduty.actionFromLevel(level: r._level),
+			source: notification._notification_rule_name,
+			summary: r._message,
+			timestamp: time(v: r._source_timestamp),
+		})))`,
 		},
 	}
 
-	id := influxdb.ID(2)
-	e := &endpoint.PagerDuty{
-		Base: endpoint.Base{
-			ID:   &id,
-			Name: "foo",
-		},
-		ClientURL: "http://localhost:7777/host/${r.host}",
-		RoutingKey: influxdb.SecretField{
-			Key: "pagerduty_token",
-		},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, err := tt.rule.GenerateFlux(tt.endpoint)
+			if err != nil {
+				panic(err)
+			}
+
+			if got, want := script, tt.script; got != want {
+				t.Errorf("\n\nStrings do not match:\n\n%s", diff.LineDiff(got, want))
+
+			}
+
+		})
 	}
 
-	f, err := s.GenerateFlux(e)
-	if err != nil {
-		panic(err)
-	}
-
-	if f != want {
-		t.Errorf("scripts did not match. want:\n%v\n\ngot:\n%v", want, f)
-	}
 }

--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -123,11 +123,11 @@ func (b *Base) generateFluxASTNotificationDefinition(e influxdb.NotificationEndp
 	return flux.DefineVariable("notification", flux.Object(ruleID, ruleName, endpointID, endpointName))
 }
 
-func (b *Base) generateAllStateChanges() []ast.Statement {
+func (b *Base) generateLevelChecks() []ast.Statement {
 	stmts := []ast.Statement{}
 	tables := []ast.Expression{}
 	for _, r := range b.StatusRules {
-		stmt, table := b.generateStateChanges(r)
+		stmt, table := b.generateLevelCheck(r)
 		tables = append(tables, table)
 		stmts = append(stmts, stmt)
 	}
@@ -186,7 +186,7 @@ func (b *Base) generateAllStateChanges() []ast.Statement {
 	return stmts
 }
 
-func (b *Base) generateStateChanges(r notification.StatusRule) (ast.Statement, *ast.Identifier) {
+func (b *Base) generateLevelCheck(r notification.StatusRule) (ast.Statement, *ast.Identifier) {
 	var name string
 	var pipe *ast.PipeExpression
 	if r.PreviousLevel == nil && r.CurrentLevel == notification.Any {

--- a/notification/rule/slack.go
+++ b/notification/rule/slack.go
@@ -49,7 +49,7 @@ func (s *Slack) generateFluxASTBody(e *endpoint.Slack) []ast.Statement {
 	statements = append(statements, s.generateFluxASTEndpoint(e))
 	statements = append(statements, s.generateFluxASTNotificationDefinition(e))
 	statements = append(statements, s.generateFluxASTStatuses())
-	statements = append(statements, s.generateAllStateChanges()...)
+	statements = append(statements, s.generateLevelChecks()...)
 	statements = append(statements, s.generateFluxASTNotifyPipe())
 
 	return statements


### PR DESCRIPTION
An accidental omission of status a level check resulted in all statuses
triggering notifications for pagerduty rules. This was not caught due
to insufficient testing of the pagerduty rule.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
