### PR TITLE
fix(cmd/influx): ui change for secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [16992](https://github.com/influxdata/influxdb/pull/16992): Query Builder now groups on column values, not tag values
 1. [17013](https://github.com/influxdata/influxdb/pull/17013): Scatterplots can once again render the tooltip correctly
 1. [17027](https://github.com/influxdata/influxdb/pull/17027): Drop pkger gauge chart requirement for color threshold type
+1. [16961](https://github.com/influxdata/influxdb/pull/16961): Remove cli confirmation of secret, add an optional parameter of secret value
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/cmd/influx/secret_test.go
+++ b/cmd/influx/secret_test.go
@@ -160,9 +160,21 @@ func TestCmdSecret(t *testing.T) {
 				},
 			},
 			{
+				name:        "with key and value",
+				expectedKey: "key1",
+				flags: []string{
+					"--org=org name", "--key=key1", "--value=v1",
+				},
+			},
+			{
 				name:        "shorts",
 				expectedKey: "key1",
 				flags:       []string{"-o=" + orgID.String(), "-k=key1"},
+			},
+			{
+				name:        "shorts with value",
+				expectedKey: "key1",
+				flags:       []string{"-o=" + orgID.String(), "-k=key1", "-v=v1"},
 			},
 		}
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16475

removes the confirmation of secret input, add an optional parameter for secret value

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
