### PR TITLE
fix(ui): update giraffe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [16934](https://github.com/influxdata/influxdb/pull/16934): Tokens page now sorts by status
 1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the defualt value of tags in a Check
 1. [16935](https://github.com/influxdata/influxdb/pull/16935): Fix sort by variable type
+1. [16973](https://github.com/influxdata/influxdb/pull/16973): Calculate correct stacked line cumulative when lines are different lengths
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -132,7 +132,7 @@
     "@influxdata/clockface": "1.1.5",
     "@influxdata/flux-lsp-browser": "^0.2.2",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.17.4",
+    "@influxdata/giraffe": "0.17.5",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1026,10 +1026,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-parser/-/flux-parser-0.3.0.tgz#b63123ac814ad32c65e46a4097ba3d8b959416a5"
   integrity sha512-nsm801l60kXFulcSWA2YH2YRz9oSsMlTK9Evn6Og9BoQnQMcwUsSUEug8mQRIUljnkNYV58JSs0W0mP8h7Y/ZQ==
 
-"@influxdata/giraffe@0.17.4":
-  version "0.17.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.4.tgz#58a1cb23b70d0ac7aa3f833ffab5a92b933c824c"
-  integrity sha512-4hIZTmbBiJAtNvE4zQu2JwkDgNP1rFZqGiZR9SuMKAH/6Dg88A/UrMBTjN1pX+u9LkLEtsny93BHhJfGR3y7Dw==
+"@influxdata/giraffe@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.5.tgz#887693c165b14b846bb1fdf2b816ae5b9744beae"
+  integrity sha512-sYEYJqLH4pnE5/B5cID9IuZrYfxY3zTVNTis1F3TregZtceZ3EhJU2XIrUY9ekZNiSr/oQxnjQ9V8bwh8L/gQA==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes https://github.com/influxdata/giraffe/issues/158

Updates giraffe to consume the new version
- Correctly calculates the cumulative values for stacked line graphs when lines are different lengths
