### PR TITLE
fix: query builder groups on columns, not tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ### Bug Fixes
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically
 1. [16934](https://github.com/influxdata/influxdb/pull/16934): Tokens page now sorts by status
-1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the defualt value of tags in a Check
+1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the default value of tags in a Check
 1. [16935](https://github.com/influxdata/influxdb/pull/16935): Fix sort by variable type
 1. [16973](https://github.com/influxdata/influxdb/pull/16973): Calculate correct stacked line cumulative when lines are different lengths
+1. [16992](https://github.com/influxdata/influxdb/pull/16992): Query Builder now groups on column values, not tag values
 
 ## v2.0.0-beta.4 [2020-02-14]
 
@@ -19,7 +20,7 @@
 ### Bug Fixes
 1. [16852](https://github.com/influxdata/influxdb/pull/16852): Revert for bad indexing of UserResourceMappings and Authorizations
 1. [15911](https://github.com/influxdata/influxdb/pull/15911): Gauge no longer allowed to become too small
-1. [16878](https://github.com/influxdata/influxdb/pull/16878): Fix issue with INFLUX_TOKEN env vars being overridden by default token 
+1. [16878](https://github.com/influxdata/influxdb/pull/16878): Fix issue with INFLUX_TOKEN env vars being overridden by default token
 
 ## v2.0.0-beta.3 [2020-02-11]
 

--- a/ui/cypress/e2e/queryBuilder.test.ts
+++ b/ui/cypress/e2e/queryBuilder.test.ts
@@ -90,6 +90,41 @@ describe('The Query Builder', () => {
     })
   })
 
+  describe('the group() function', () => {
+    it('creates a query that has a group() function in it', () => {
+      cy.get('@org').then((org: Organization) => {
+        cy.visit(`orgs/${org.id}/data-explorer`)
+      })
+
+      cy.contains('mem').click('left')
+      cy.getByTestID('builder-card')
+        .last()
+        .contains('Filter')
+        .click()
+        .get('.cf-dropdown--menu-container')
+        .contains('group')
+        .click()
+
+      const groupableColums = []
+
+      cy.getByTestID('builder-card')
+        .last()
+        .then($lastBuilderCard => {
+          $lastBuilderCard.find('.selector-list--item').each((index, $item) => {
+            groupableColums.push($item.innerHTML)
+          })
+
+          expect(groupableColums).to.eql([
+            '_start',
+            '_stop',
+            '_time',
+            '_measurement',
+            '_field',
+          ])
+        })
+    })
+  })
+
   // This is flaky in prod
   // https://circleci.com/gh/influxdata/influxdb/74628#artifacts/containers/0
   describe.skip('from the Dashboard view', () => {

--- a/ui/src/timeMachine/components/TagSelector.tsx
+++ b/ui/src/timeMachine/components/TagSelector.tsx
@@ -48,7 +48,7 @@ import {
 
 const SEARCH_DEBOUNCE_MS = 500
 
-// We don't show these columns in results but they're able to be grouped on
+// We don't show these columns in results but they're able to be grouped on for most queries
 const ADDITIONAL_GROUP_BY_COLUMNS = ['_start', '_stop', '_time']
 
 interface StateProps {

--- a/ui/src/timeMachine/selectors/index.test.ts
+++ b/ui/src/timeMachine/selectors/index.test.ts
@@ -1,8 +1,4 @@
-import {
-  getActiveTagValues,
-  getStartTime,
-  getEndTime,
-} from 'src/timeMachine/selectors/index'
+import {getStartTime, getEndTime} from 'src/timeMachine/selectors/index'
 import moment from 'moment'
 
 import {
@@ -60,90 +56,5 @@ describe('TimeMachine.Selectors.Index', () => {
   const now = moment().valueOf()
   it(`getEndTime should return ${now} when upper is null and lower includes now()`, () => {
     expect(getEndTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(now)
-  })
-})
-
-describe('getting active tag values', () => {
-  const activeQueryTags = [
-    {
-      keys: [
-        '_field',
-        '_measurement',
-        'cpu',
-        'device',
-        'fstype',
-        'host',
-        'interface',
-        'mode',
-        'name',
-        'path',
-      ],
-      values: [
-        'cpu',
-        'disk',
-        'diskio',
-        'mem',
-        'net',
-        'processes',
-        'swap',
-        'system',
-      ],
-    },
-    {
-      keys: ['_field', 'host'],
-      values: [
-        'active',
-        'available',
-        'available_percent',
-        'buffered',
-        'cached',
-        'commit_limit',
-        'committed_as',
-        'dirty',
-        'free',
-        'high_free',
-        'high_total',
-        'huge_page_size',
-        'huge_pages_free',
-        'huge_pages_total',
-        'inactive',
-        'low_free',
-        'low_total',
-        'mapped',
-        'page_tables',
-        'shared',
-        'slab',
-        'swap_cached',
-        'swap_free',
-        'swap_total',
-        'total',
-        'used',
-        'used_percent',
-        'vmalloc_chunk',
-        'vmalloc_total',
-        'vmalloc_used',
-        'wired',
-        'write_back',
-        'write_back_tmp',
-      ],
-    },
-    {
-      keys: ['host'],
-      values: ['foo_computer'],
-    },
-  ]
-
-  it('returns the active query tag values when the function is filter', () => {
-    const actualTags = getActiveTagValues(activeQueryTags, 'filter', 2)
-    expect(actualTags).toEqual(activeQueryTags[2].values)
-  })
-
-  it('returns all previous tag values when the function is group', () => {
-    const actualTags = getActiveTagValues(activeQueryTags, 'group', 2)
-    expect(actualTags).toEqual([
-      ...activeQueryTags[0].values,
-      ...activeQueryTags[1].values,
-      ...activeQueryTags[2].values,
-    ])
   })
 })

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -25,8 +25,6 @@ import {
 // Types
 import {
   QueryView,
-  BuilderAggregateFunctionType,
-  BuilderTagsType,
   DashboardQuery,
   FluxTable,
   AppState,
@@ -242,25 +240,6 @@ export const getActiveTimeRange = (
     return timeRange
   }
   return null
-}
-
-export const getActiveTagValues = (
-  activeQueryBuilderTags: BuilderTagsType[],
-  aggregateFunctionType: BuilderAggregateFunctionType,
-  index: number
-): string[] => {
-  // if we're grouping, we want to be able to group on all previous tags
-  if (aggregateFunctionType === 'group') {
-    const values = []
-    activeQueryBuilderTags.forEach(tag => {
-      tag.values.forEach(value => {
-        values.push(value)
-      })
-    })
-    return values
-  }
-
-  return activeQueryBuilderTags[index].values
 }
 
 export const getSaveableView = (state: AppState): QueryView & {id?: string} => {


### PR DESCRIPTION
Closes #16783 

A picture is worth a thousand words, so here:

**WRONG:**
<img width="946" alt="Screen Shot 2020-02-24 at 2 43 26 PM" src="https://user-images.githubusercontent.com/146112/75198016-8032d980-5714-11ea-9bbb-b76376df2294.png">

**Right:**
<img width="949" alt="Screen Shot 2020-02-24 at 2 42 52 PM" src="https://user-images.githubusercontent.com/146112/75198032-8923ab00-5714-11ea-80e3-56b6215ea310.png">

* **Wrong**: The grouping options map to tag values
* **Right:** The grouping options map to columns


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass