### PR TITLE
fix(ui): fixed overflow issue on scrollbar list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-beta.5 [unreleased]
 
 ### Features
+1. [16991](https://github.com/influxdata/influxdb/pull/16991): Update Flux functions list for v0.61
 
 ### Bug Fixes
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Features
 
+1. [16991](https://github.com/influxdata/influxdb/pull/16991): Update Flux functions list for v0.61
+
 ### Bug Fixes
+
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically
 1. [16934](https://github.com/influxdata/influxdb/pull/16934): Tokens page now sorts by status
 1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the defualt value of tags in a Check
@@ -13,14 +16,16 @@
 ## v2.0.0-beta.4 [2020-02-14]
 
 ### Features
+
 1. [16855](https://github.com/influxdata/influxdb/pull/16855): Added labels to buckets in UI
 1. [16842](https://github.com/influxdata/influxdb/pull/16842): Connect monaco editor to Flux LSP server
 1. [16856](https://github.com/influxdata/influxdb/pull/16856): Update Flux to v0.59.6
 
 ### Bug Fixes
+
 1. [16852](https://github.com/influxdata/influxdb/pull/16852): Revert for bad indexing of UserResourceMappings and Authorizations
 1. [15911](https://github.com/influxdata/influxdb/pull/15911): Gauge no longer allowed to become too small
-1. [16878](https://github.com/influxdata/influxdb/pull/16878): Fix issue with INFLUX_TOKEN env vars being overridden by default token 
+1. [16878](https://github.com/influxdata/influxdb/pull/16878): Fix issue with INFLUX_TOKEN env vars being overridden by default token
 
 ## v2.0.0-beta.3 [2020-02-11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## v2.0.0-beta.5 [unreleased]
 
 ### Features
-1. [16991](https://github.com/influxdata/influxdb/pull/16991): Update Flux functions list for v0.61
 
 ### Bug Fixes
 1. [16919](https://github.com/influxdata/influxdb/pull/16919): Sort dashboards on homepage alphabetically
@@ -9,6 +8,7 @@
 1. [16931](https://github.com/influxdata/influxdb/pull/16931): Set the defualt value of tags in a Check
 1. [16935](https://github.com/influxdata/influxdb/pull/16935): Fix sort by variable type
 1. [16973](https://github.com/influxdata/influxdb/pull/16973): Calculate correct stacked line cumulative when lines are different lengths
+1. [17010](https://github.com/influxdata/influxdb/pull/17010): Fixed scrollbar issue where resource cards would overflow the parent container rather than be hidden and scrollable
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/src/alerting/components/AlertingIndex.scss
+++ b/ui/src/alerting/components/AlertingIndex.scss
@@ -6,6 +6,7 @@
 
 .alerting-index--column {
   height: calc(100% - #{$ix-marg-d});
+  overflow: hidden;
 }
 
 .alert-column--empty {
@@ -16,6 +17,8 @@
 .alerting-index--column-body {
   flex: 1 0 0;
   position: relative;
+  height: 90%;
+  padding-bottom: $ix-marg-d;
 }
 
 .alerting-index--list,
@@ -90,13 +93,13 @@
   margin: 0;
   padding-left: 0;
   list-style: none;
-  
+
   .cf-icon {
     display: inline-block;
     margin-right: 5px;
     width: 16px;
   }
-  
+
   &.error {
     color: $c-dreamsicle;
   }

--- a/ui/src/alerting/components/AlertsColumn.tsx
+++ b/ui/src/alerting/components/AlertsColumn.tsx
@@ -68,7 +68,6 @@ const AlertsColumnHeader: FC<Props> = ({
       </div>
       <div className="alerting-index--column-body">
         <DapperScrollbars
-          autoSize={true}
           autoHide={true}
           style={{width: '100%', height: '100%'}}
         >

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -17,7 +17,7 @@ export const FROM: FluxToolbarFunction = {
   package: '',
   desc:
     'Used to retrieve data from an InfluxDB data source. It returns a stream of tables from the specified bucket. Each unique series is contained within its own table. Each record in the table represents a single point in the series.',
-  example: 'from(bucket: "telegraf")',
+  example: 'from(bucket: "example-bucket")',
   category: 'Inputs',
   link:
     'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/inputs/from/',
@@ -3271,10 +3271,10 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'experimental/query',
-    desc: 'Filters input data by measurement.',
+    desc: 'Returns all data from a specified bucket within given time bounds.',
     example:
       'query.fromRange(bucket: "example-bucket", start: v.timeRangeStart)',
-    category: 'Input',
+    category: 'Inputs',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/experimental/query/fromrange/',
   },
@@ -3313,10 +3313,11 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'experimental/query',
-    desc: 'Filters input data by measurement.',
+    desc:
+      'Queries data from a specified bucket within given time bounds, filters data by measurement, field, and optional predicate expressions.',
     example:
       'query.inBucket(bucket: "example-bucket", start: v.timeRangeStart, measurement: "measurement_name", fields: ["field_name"], predicate: (r) => r.host == "host1")',
-    category: 'Input',
+    category: 'Inputs',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/experimental/query/inbucket/',
   },
@@ -4805,7 +4806,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: '',
     desc: 'The `to()` function writes data to an InfluxDB v2.0 bucket.',
-    example: 'to(bucket:"my-bucket", org:"my-org")',
+    example: 'to(bucket: "example-bucket", org: "example-org")',
     category: 'Outputs',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/outputs/to/',
@@ -5002,7 +5003,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of tag keys for a specific measurement.',
-    example: 'v1.measurementTagKeys(bucket: "telegraf", measurement: "mem")',
+    example:
+      'v1.measurementTagKeys(bucket: "example-bucket", measurement: "mem")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/influxdb-v1/measurementtagkeys/',
@@ -5030,7 +5032,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of tag values for a specific measurement.',
     example:
-      'v1.measurementTagValues(bucket: "telegraf", measurement: "mem", tag: "host")',
+      'v1.measurementTagValues(bucket: "example-bucket", measurement: "mem", tag: "host")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/influxdb-v1/measurementtagvalues/',
@@ -5046,7 +5048,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of measurements in a specific bucket.',
-    example: 'v1.measurements(bucket: "telegraf")',
+    example: 'v1.measurements(bucket: "example-bucket")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/influxdb-v1/measurements/',
@@ -5074,7 +5076,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of tag keys for all series that match the predicate.',
-    example: 'v1.tagKeys(bucket: "telegraf")',
+    example: 'v1.tagKeys(bucket: "example-bucket")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/influxdb-v1/tagkeys/',
@@ -5107,7 +5109,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of unique values for a given tag.',
-    example: 'v1.tagValues(bucket: "telegraf")',
+    example: 'v1.tagValues(bucket: "example-bucket")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/influxdb-v1/tagvalues/',


### PR DESCRIPTION
Closes #16827

### Problem

Resource lists were overflowing past the confines of the parent container

### Solution

Updated the CSS to hide the overflow and updated the dimension of the inner div to allow for scrolling

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)

![scrollbar_regression](https://user-images.githubusercontent.com/19984220/75289271-c64e7280-57d2-11ea-8187-06cbd4f0ff4b.gif)
