### PR TITLE
chore(codeowners): Add storage team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,7 @@
 # API and monitoring team will help to review swagger.yml changes.
 #
 http/swagger.yml @influxdata/api @influxdata/monitoring-team
+
+# Storage code
+/storage/ @influxdata/storage-team-assigner
+/tsdb/ @influxdata/storage-team-assigner


### PR DESCRIPTION
Storage team owns, and would like to keep an eye on, /storage/ and /tsdb/