### PR TITLE
fix(ui): update giraffe to fix tooltip rendering in scatterplots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [16973](https://github.com/influxdata/influxdb/pull/16973): Calculate correct stacked line cumulative when lines are different lengths
 1. [17010](https://github.com/influxdata/influxdb/pull/17010): Fixed scrollbar issue where resource cards would overflow the parent container rather than be hidden and scrollable
 1. [16992](https://github.com/influxdata/influxdb/pull/16992): Query Builder now groups on column values, not tag values
+1. [17013](https://github.com/influxdata/influxdb/pull/17013): Scatterplots can once again render the tooltip correctly
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -132,7 +132,7 @@
     "@influxdata/clockface": "1.1.5",
     "@influxdata/flux-lsp-browser": "^0.2.2",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.17.5",
+    "@influxdata/giraffe": "0.17.6",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1026,10 +1026,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-parser/-/flux-parser-0.3.0.tgz#b63123ac814ad32c65e46a4097ba3d8b959416a5"
   integrity sha512-nsm801l60kXFulcSWA2YH2YRz9oSsMlTK9Evn6Og9BoQnQMcwUsSUEug8mQRIUljnkNYV58JSs0W0mP8h7Y/ZQ==
 
-"@influxdata/giraffe@0.17.5":
-  version "0.17.5"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.5.tgz#887693c165b14b846bb1fdf2b816ae5b9744beae"
-  integrity sha512-sYEYJqLH4pnE5/B5cID9IuZrYfxY3zTVNTis1F3TregZtceZ3EhJU2XIrUY9ekZNiSr/oQxnjQ9V8bwh8L/gQA==
+"@influxdata/giraffe@0.17.6":
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.6.tgz#33e94a98dea81601f2759488605e206493a34555"
+  integrity sha512-7HayQtfHXDVlxus++RXRa8UzwPeYKvMQOIp0sEuGRuQdsT5D/wo6aT8Q17vCj5230UvMYjU60s7xi58wg/AUcw==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes #16984 

Scatterplots can once again render the tooltip correctly
