### PR TITLE
fix(pkger): elminate threshold color requirement for guage charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 1. [17010](https://github.com/influxdata/influxdb/pull/17010): Fixed scrollbar issue where resource cards would overflow the parent container rather than be hidden and scrollable
 1. [16992](https://github.com/influxdata/influxdb/pull/16992): Query Builder now groups on column values, not tag values
 1. [17013](https://github.com/influxdata/influxdb/pull/17013): Scatterplots can once again render the tooltip correctly
+1. [17027](https://github.com/influxdata/influxdb/pull/17027): Drop pkger gauge chart requirement for color threshold type
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2344,7 +2344,7 @@ func (c chart) validProperties() []validationErr {
 	// chart kind specific validations
 	switch c.Kind {
 	case chartKindGauge:
-		fails = append(fails, c.Colors.hasTypes(colorTypeMin, colorTypeThreshold, colorTypeMax)...)
+		fails = append(fails, c.Colors.hasTypes(colorTypeMin, colorTypeMax)...)
 	case chartKindHeatMap:
 		fails = append(fails, c.Axes.hasAxes("x", "y")...)
 	case chartKindHistogram:

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -764,39 +764,6 @@ spec:
 			t.Run("handles invalid config", func(t *testing.T) {
 				tests := []testPkgResourceError{
 					{
-						name:           "missing threshold color type",
-						validationErrs: 1,
-						valFields:      []string{"charts[0].colors"},
-						pkgStr: `apiVersion: influxdata.com/v2alpha1
-kind: Dashboard
-metadata:
-  name: dash_1
-spec:
-  description: desc1
-  charts:
-    - kind:   gauge
-      name:   gauge
-      note: gauge note
-      noteOnEmpty: true
-      xPos:  1
-      yPos:  2
-      width:  6
-      height: 3
-      queries:
-        - query: >
-            from(bucket: v.bucket)  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)  |> filter(fn: (r) => r._measurement == "boltdb_writes_total")  |> filter(fn: (r) => r._field == "counter")
-      colors:
-        - name: laser
-          type: min
-          hex: "#8F8AF4"
-          value: 0
-        - name: laser
-          type: max
-          hex: "#8F8AF4"
-          value: 5000
-`,
-					},
-					{
 						name:           "color mixing a hex value",
 						validationErrs: 1,
 						valFields:      []string{"charts[0].colors[0].hex"},


### PR DESCRIPTION
Closes #17025

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass