### PR TITLE
refactor(repl): remove the querier from the repl

### DIFF
--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -42,19 +42,20 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load query: %v", err)
 	}
 
-	orgSvc, err := newOrganizationService()
-	if err != nil {
-		return fmt.Errorf("failed to initialized organization service client: %v", err)
-	}
-
-	orgID, err := queryFlags.org.getID(orgSvc)
-	if err != nil {
-		return err
-	}
+	// TODO(jsternberg): Restore this when the influxdb client source is merged.
+	// orgSvc, err := newOrganizationService()
+	// if err != nil {
+	// 	return fmt.Errorf("failed to initialized organization service client: %v", err)
+	// }
+	//
+	// orgID, err := queryFlags.org.getID(orgSvc)
+	// if err != nil {
+	// 	return err
+	// }
 
 	runtime.FinalizeBuiltIns()
 
-	r, err := getFluxREPL(flags.host, flags.token, flags.skipVerify, orgID)
+	r, err := getFluxREPL()
 	if err != nil {
 		return fmt.Errorf("failed to get the flux REPL: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62
-	github.com/influxdata/flux v0.60.1-0.20200225201047-16af5831aa38
+	github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.60.1-0.20200225201047-16af5831aa38 h1:o2NmZqM5uu80aErKWfbmifrpDzxMsRLbIeLKY71ZrEQ=
-github.com/influxdata/flux v0.60.1-0.20200225201047-16af5831aa38/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2 h1:sJzGdrFAeUz+qjb+h24P5wc7VDsMYUZtq5edPHu33NU=
+github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.60.1-0.20200225201047-16af5831aa38
+	github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -286,9 +286,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62 h1:YipnPuvJKPAzyBhr7eXIMA49L2Eooga/NSytWdLLI8U=
 github.com/influxdata/cron v0.0.0-20191112133922-ad5847cfab62/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.60.1-0.20200221220910-5416e8e69d66 h1:9SxufhGiuxU+W0P5hzkfxH2dmOHyE4MqCIoCpQyizzo=
-github.com/influxdata/flux v0.60.1-0.20200221220910-5416e8e69d66/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
-github.com/influxdata/flux v0.60.1-0.20200225201047-16af5831aa38/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
+github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2 h1:sJzGdrFAeUz+qjb+h24P5wc7VDsMYUZtq5edPHu33NU=
+github.com/influxdata/flux v0.60.1-0.20200227152158-9f38d6a339f2/go.mod h1:T5bbA6I4vC3gEf4uqdCKBYrXiZfTOoB69OsAZO881vQ=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=


### PR DESCRIPTION
The repl no longer takes in a querier and it will run everything
locally. The spec interface will now not be used and will be removed
from the http endpoint at some point.