### PR TITLE
fix(pkger): fix bug where tasks are exported for notification rules

### DIFF
--- a/pkger/service.go
+++ b/pkger/service.go
@@ -454,6 +454,13 @@ func (s *Service) cloneOrgTasks(ctx context.Context, orgID influxdb.ID) ([]Resou
 		return nil, err
 	}
 
+	rules, _, err := s.ruleSVC.FindNotificationRules(ctx, influxdb.NotificationRuleFilter{
+		OrgID: &orgID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	mTeles := make(map[influxdb.ID]*influxdb.Task)
 	for i := range teles {
 		t := teles[i]
@@ -464,6 +471,9 @@ func (s *Service) cloneOrgTasks(ctx context.Context, orgID influxdb.ID) ([]Resou
 	}
 	for _, c := range checks {
 		delete(mTeles, c.GetTaskID())
+	}
+	for _, r := range rules {
+		delete(mTeles, r.GetTaskID())
 	}
 
 	resources := make([]ResourceToClone, 0, len(mTeles))


### PR DESCRIPTION
references #17038

first piece of fixing this bug. Still exploring if there are more issues with the root tasks themselves.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass