### PR TITLE
fix(ui): fixed issue where dashboard header interval dropdown wasn't setting correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [16992](https://github.com/influxdata/influxdb/pull/16992): Query Builder now groups on column values, not tag values
 1. [17013](https://github.com/influxdata/influxdb/pull/17013): Scatterplots can once again render the tooltip correctly
 1. [17027](https://github.com/influxdata/influxdb/pull/17027): Drop pkger gauge chart requirement for color threshold type
+1. [17040](https://github.com/influxdata/influxdb/pull/17040): Fixed bug that was preventing the interval status on the dashboard header from refreshing on selections
 
 ## v2.0.0-beta.4 [2020-02-14]
 

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -164,8 +164,19 @@ class DashboardHeader extends Component<Props> {
   }
 
   private handleChooseAutoRefresh = (milliseconds: number) => {
-    const {handleChooseAutoRefresh, dashboard} = this.props
+    const {
+      handleChooseAutoRefresh,
+      onSetAutoRefreshStatus,
+      dashboard,
+    } = this.props
     handleChooseAutoRefresh(dashboard.id, milliseconds)
+
+    if (milliseconds === 0) {
+      onSetAutoRefreshStatus(dashboard.id, AutoRefreshStatus.Paused)
+      return
+    }
+
+    onSetAutoRefreshStatus(dashboard.id, AutoRefreshStatus.Active)
   }
 
   private handleChooseTimeRange = (timeRange: TimeRange) => {


### PR DESCRIPTION
Closes #17037
Closes #17022 

### Problem

Set interval dropdown on the dashboard header wasn't updating the interval

### Solution

Updated the function to set the status correctly - something that had been lost in the refactor

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)