### PR TITLE
feat(ui): added transition effects between form toggling

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -182,6 +182,7 @@
     "react-router": "^3.0.2",
     "react-router-redux": "^4.0.8",
     "react-scrollbars-custom": "^4.0.0-alpha.8",
+    "react-spring": "^8.0.27",
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.0",
     "redux-auth-wrapper": "^1.0.0",

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -21,6 +21,7 @@ import {LoginForm} from 'src/onboarding/components/LoginForm'
 import {SignUpForm} from 'src/onboarding/components/SignUpForm'
 import {SocialButton} from 'src/shared/components/SocialButton'
 import {GoogleLogo, GithubLogo} from 'src/clientLibraries/graphics'
+import {Transition, animated} from 'react-spring/renderprops'
 
 // Types
 import {Auth0Connection, FormFieldValidation} from 'src/types'
@@ -174,35 +175,85 @@ class LoginPageContents extends PureComponent<DispatchProps> {
                 </SelectGroup>
               </FlexBox>
             </div>
-            {loginTabActive && (
-              <LoginForm
-                buttonStatus={buttonStatus}
-                email={email}
-                emailValidation={this.formFieldTypeFactory(emailError)}
-                password={password}
-                passwordValidation={this.formFieldTypeFactory(passwordError)}
-                handleInputChange={this.handleInputChange}
-                handleForgotPasswordClick={this.handleForgotPasswordClick}
-              />
-            )}
-            {loginTabActive === false && (
-              <SignUpForm
-                buttonStatus={buttonStatus}
-                confirmPassword={confirmPassword}
-                confirmPasswordValidation={this.formFieldTypeFactory(
-                  confirmPasswordError
-                )}
-                email={email}
-                emailValidation={this.formFieldTypeFactory(emailError)}
-                firstName={firstName}
-                firstNameValidation={this.formFieldTypeFactory(firstNameError)}
-                lastName={lastName}
-                lastNameValidation={this.formFieldTypeFactory(lastNameError)}
-                password={password}
-                passwordValidation={this.formFieldTypeFactory(passwordError)}
-                handleInputChange={this.handleInputChange}
-              />
-            )}
+            <Transition
+              native
+              reset
+              unique
+              items={loginTabActive}
+              from={{height: 0}}
+              enter={[
+                {
+                  position: 'relative',
+                  overflow: 'hidden',
+                  height: 'auto',
+                },
+              ]}
+              leave={{height: 0}}
+            >
+              {show =>
+                show &&
+                (props => (
+                  <animated.div style={props}>
+                    <LoginForm
+                      buttonStatus={buttonStatus}
+                      email={email}
+                      emailValidation={this.formFieldTypeFactory(emailError)}
+                      password={password}
+                      passwordValidation={this.formFieldTypeFactory(
+                        passwordError
+                      )}
+                      handleInputChange={this.handleInputChange}
+                      handleForgotPasswordClick={this.handleForgotPasswordClick}
+                    />
+                  </animated.div>
+                ))
+              }
+            </Transition>
+            <Transition
+              native
+              reset
+              unique
+              items={loginTabActive === false}
+              from={{height: 0}}
+              enter={[
+                {
+                  position: 'relative',
+                  overflow: 'hidden',
+                  height: 'auto',
+                },
+              ]}
+              leave={{height: 0}}
+            >
+              {show =>
+                show &&
+                (props => (
+                  <animated.div style={props}>
+                    <SignUpForm
+                      buttonStatus={buttonStatus}
+                      confirmPassword={confirmPassword}
+                      confirmPasswordValidation={this.formFieldTypeFactory(
+                        confirmPasswordError
+                      )}
+                      email={email}
+                      emailValidation={this.formFieldTypeFactory(emailError)}
+                      firstName={firstName}
+                      firstNameValidation={this.formFieldTypeFactory(
+                        firstNameError
+                      )}
+                      lastName={lastName}
+                      lastNameValidation={this.formFieldTypeFactory(
+                        lastNameError
+                      )}
+                      password={password}
+                      passwordValidation={this.formFieldTypeFactory(
+                        passwordError
+                      )}
+                      handleInputChange={this.handleInputChange}
+                    />
+                  </animated.div>
+                ))
+              }
+            </Transition>
           </Panel.Body>
         </Panel>
       </form>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -915,6 +915,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -9911,6 +9918,14 @@ react-scrollbars-custom@^4.0.0-alpha.8:
   dependencies:
     cnbuilder "^1.0.8"
     react-draggable "^3.2.1"
+
+react-spring@^8.0.27:
+  version "8.0.27"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
+  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    prop-types "^15.5.8"
 
 react-test-renderer@^16.0.0-0:
   version "16.5.2"


### PR DESCRIPTION
This PR is part of a larger PR to add the sign-in functionality to IDPE. This particular PR is intended to add transitioning effects when users toggle between the sign-up and log-in form so that the transition is a bit smoother. Added react-spring as a dependency to keep with existing transition libraries that are used


![login_transition](https://user-images.githubusercontent.com/19984220/75570714-92f72800-5a0c-11ea-9540-d5805a35c63f.gif)
