### PR TITLE
unskip flux end-to-end tests

### DIFF
--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -33,7 +33,6 @@ func init() {
 }
 
 func TestFluxEndToEnd(t *testing.T) {
-	t.Skip("timing out on algo-w branch: https://github.com/influxdata/influxdb/issues/16812")
 	runEndToEnd(t, stdlib.FluxTestPackages)
 }
 func BenchmarkFluxEndToEnd(b *testing.B) {

--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -90,6 +90,7 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 		"to_uint": "dateTime conversion issue: https://github.com/influxdata/influxdb/issues/14575",
 
 		"holt_winters_panic": "Expected output is an empty table which breaks the testing framework (https://github.com/influxdata/influxdb/issues/14749)",
+		"fill_previous":      "algo-w: https://github.com/influxdata/influxdb/issues/17065",
 	},
 	"experimental": {
 		"set": "Reason TBD",
@@ -106,7 +107,8 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 		"show_tag_keys":     "flaky test (https://github.com/influxdata/influxdb/issues/15450)",
 	},
 	"influxdata/influxdb/monitor": {
-		"check": "Cannot see overridden options from inside stdlib functions (https://github.com/influxdata/flux/issues/1720)",
+		"check":         "Cannot see overridden options from inside stdlib functions (https://github.com/influxdata/flux/issues/1720)",
+		"state_changes": "algo-w: https://github.com/influxdata/influxdb/issues/17064",
 	},
 	"influxdata/influxdb/secrets": {
 		"secrets": "Cannot inject custom deps into the test framework so the secrets don't lookup correctly",
@@ -127,5 +129,11 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 	"testing/promql": {
 		"emptyTable": "tests a source",
 		"year":       "flakey test: https://github.com/influxdata/influxdb/issues/15667",
+	},
+	"testing/usage": {
+		"storage": "algo-w: https://github.com/influxdata/flux/issues/2570",
+	},
+	"testing/influxql": {
+		"aggregate_group_by_time": "algo-w: https://github.com/influxdata/influxdb/issues/17064",
 	},
 }


### PR DESCRIPTION
The PR updates the flux dependency to point to the tip of the `feat/use-algo-w` branch. Afterwards I had change occurrences of `semantic.MustLookupBuiltinType` to `runtime.MustLookupBuiltinType`.

The flux end to end tests no longer hang in influxdb. However there were 3 end to end test failures that had to be skipped. Issues were created and linked for each one. They are:

* https://github.com/influxdata/influxdb/issues/17064
* https://github.com/influxdata/influxdb/issues/17065
* https://github.com/influxdata/flux/issues/2570