### PR TITLE
fix(pkger): fix issue with imports causing option task to be injected at wrong point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 1. [17039](https://github.com/influxdata/influxdb/pull/17039): Fixed issue where tasks are exported for notification rules
-1. [17042](https://github.com/influxdata/influxdb/pull/17039): Fixed issue where tasks are not exported when exporting by org id
+1. [17042](https://github.com/influxdata/influxdb/pull/17042): Fixed issue where tasks are not exported when exporting by org id
+1. [17070](https://github.com/influxdata/influxdb/pull/17070): Fixed issue where tasks with imports in query break in pkger
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -635,6 +635,60 @@ spec:
 		})
 	})
 
+	t.Run("apply a task pkg with a complex query", func(t *testing.T) {
+		// validates bug: https://github.com/influxdata/influxdb/issues/17069
+
+		pkgStr := fmt.Sprintf(`
+apiVersion: %[1]s
+kind: Task
+metadata:
+    name: Http.POST Synthetic (POST)
+spec:
+    every: 5m
+    query: |-
+        import "strings"
+        import "csv"
+        import "http"
+        import "system"
+
+        timeDiff = (t1, t2) => {
+        	return duration(v: uint(v: t2) - uint(v: t1))
+        }
+        timeDiffNum = (t1, t2) => {
+        	return uint(v: t2) - uint(v: t1)
+        }
+        urlToPost = "http://www.duckduckgo.com"
+        timeBeforeCall = system.time()
+        responseCode = http.post(url: urlToPost, data: bytes(v: "influxdata"))
+        timeAfterCall = system.time()
+        responseTime = timeDiff(t1: timeBeforeCall, t2: timeAfterCall)
+        responseTimeNum = timeDiffNum(t1: timeBeforeCall, t2: timeAfterCall)
+        data = "#group,false,false,true,true,true,true,true,true
+        #datatype,string,long,string,string,string,string,string,string
+        #default,mean,,,,,,,
+        ,result,table,service,response_code,time_before,time_after,response_time_duration,response_time_ns
+        ,,0,http_post_ping,${string(v: responseCode)},${string(v: timeBeforeCall)},${string(v: timeAfterCall)},${string(v: responseTime)},${string(v: responseTimeNum)}"
+        theTable = csv.from(csv: data)
+
+        theTable
+        	|> map(fn: (r) =>
+        		({r with _time: now()}))
+        	|> map(fn: (r) =>
+        		({r with _measurement: "PingService", url: urlToPost, method: "POST"}))
+        	|> drop(columns: ["time_before", "time_after", "response_time_duration"])
+        	|> to(bucket: "Pingpire", orgID: "039346c3777a1000", fieldFn: (r) =>
+        		({"responseCode": r.response_code, "responseTime": int(v: r.response_time_ns)}))
+`, pkger.APIVersion)
+
+		pkg, err := pkger.Parse(pkger.EncodingYAML, pkger.FromString(pkgStr))
+		require.NoError(t, err)
+
+		sum, err := svc.Apply(timedCtx(time.Second), l.Org.ID, l.User.ID, pkg)
+		require.NoError(t, err)
+
+		require.Len(t, sum.Tasks, 1)
+	})
+
 	t.Run("apply a package with env refs", func(t *testing.T) {
 		pkgStr := fmt.Sprintf(`
 apiVersion: %[1]s


### PR DESCRIPTION
this is super painful, its a symptom of working with the task API. It requires the task be inlined in the query today. Painful b/c ordering matters, especially with `imports` as it turns out.

closes: #17069

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
