### PR TITLE
refactor(http): modify query handler to use a language service

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -38,6 +38,7 @@ import (
 	infprom "github.com/influxdata/influxdb/prometheus"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/fluxlang"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/snowflake"
 	"github.com/influxdata/influxdb/source"
@@ -795,6 +796,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		OnboardingService:               onboardingSvc,
 		InfluxQLService:                 nil, // No InfluxQL support
 		FluxService:                     storageQueryService,
+		FluxLanguageService:             fluxlang.DefaultService,
 		TaskService:                     taskSvc,
 		TelegrafService:                 telegrafSvc,
 		NotificationRuleStore:           notificationRuleSvc,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -72,6 +72,7 @@ type APIBackend struct {
 	OnboardingService               influxdb.OnboardingService
 	InfluxQLService                 query.ProxyQueryService
 	FluxService                     query.ProxyQueryService
+	FluxLanguageService             influxdb.FluxLanguageService
 	TaskService                     influxdb.TaskService
 	CheckService                    influxdb.CheckService
 	TelegrafService                 influxdb.TelegrafConfigStore

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -28,6 +28,7 @@ import (
 	kithttp "github.com/influxdata/influxdb/kit/transport/http"
 	influxmock "github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/query/fluxlang"
 	"github.com/influxdata/influxdb/query/mock"
 	"go.uber.org/zap/zaptest"
 )
@@ -260,6 +261,7 @@ func TestFluxHandler_postFluxAST(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &FluxHandler{
 				HTTPErrorHandler: kithttp.ErrorHandler(0),
+				LanguageService:  fluxlang.DefaultService,
 			}
 			h.postFluxAST(tt.w, tt.r)
 			if got := tt.w.Body.String(); got != tt.want {
@@ -338,6 +340,7 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 				}
 			},
 		},
+		FluxLanguageService: fluxlang.DefaultService,
 	}
 	h := NewFluxHandler(zaptest.NewLogger(t), b)
 
@@ -497,6 +500,7 @@ func TestFluxService_Query_gzip(t *testing.T) {
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: orgService,
 		ProxyQueryService:   queryService,
+		FluxLanguageService: fluxlang.DefaultService,
 	}
 
 	fluxHandler := NewFluxHandler(zaptest.NewLogger(t), fluxBackend)
@@ -633,6 +637,7 @@ func benchmarkQuery(b *testing.B, disableCompression bool) {
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: orgService,
 		ProxyQueryService:   queryService,
+		FluxLanguageService: fluxlang.DefaultService,
 	}
 
 	fluxHandler := NewFluxHandler(zaptest.NewLogger(b), fluxBackend)

--- a/query.go
+++ b/query.go
@@ -1,5 +1,7 @@
 package influxdb
 
+import "github.com/influxdata/flux/ast"
+
 // TODO(desa): These files are possibly a temporary. This is needed
 // as a part of the source work that is being done.
 // See https://github.com/influxdata/platform/issues/594 for more info.
@@ -8,4 +10,13 @@ package influxdb
 type SourceQuery struct {
 	Query string `json:"query"`
 	Type  string `json:"type"`
+}
+
+// FluxLanguageService is a service for interacting with flux code.
+type FluxLanguageService interface {
+	// Parse will take flux source code and produce a package.
+	// If there are errors when parsing, the first error is returned.
+	// An ast.Package may be returned when a parsing error occurs,
+	// but it may be null if parsing didn't even occur.
+	Parse(source string) (*ast.Package, error)
 }

--- a/query/fluxlang/service.go
+++ b/query/fluxlang/service.go
@@ -1,0 +1,21 @@
+// Package language exposes the flux parser as an interface.
+package fluxlang
+
+import (
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/parser"
+	"github.com/influxdata/influxdb"
+)
+
+// DefaultService is the default language service.
+var DefaultService influxdb.FluxLanguageService = defaultService{}
+
+type defaultService struct{}
+
+func (d defaultService) Parse(source string) (pkg *ast.Package, err error) {
+	pkg = parser.ParseSource(source)
+	if ast.Check(pkg) > 0 {
+		err = ast.GetError(pkg)
+	}
+	return pkg, err
+}


### PR DESCRIPTION
The language service abstracts away the parse source which breaks the
dependency without moving any of the code.

Fixes #16846.