### PR TITLE
fix(http): Require Content-Type for query endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Features
 1. [17085](https://github.com/influxdata/influxdb/pull/17085): Clicking on bucket name takes user to Data Explorer with bucket selected
-
 1. [17095](https://github.com/influxdata/influxdb/pull/17095): Extend pkger dashboards with table view support
 
 ### Bug Fixes
@@ -13,6 +12,7 @@
 1. [17028](https://github.com/influxdata/influxdb/pull/17028): Fixed issue where selecting an aggregate function in the script editor was not adding the function to a new line
 1. [17072](https://github.com/influxdata/influxdb/pull/17072): Fixed issue where creating a variable of type map was piping the incorrect value when map variables were used in queries
 1. [17050](https://github.com/influxdata/influxdb/pull/17050): Added missing user names to auth CLI commands
+1. [17091](https://github.com/influxdata/influxdb/pull/17091): Require Content-Type for query endpoint
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/http/query.go
+++ b/http/query.go
@@ -366,15 +366,21 @@ func QueryRequestFromProxyRequest(req *query.ProxyRequest) (*QueryRequest, error
 	return qr, nil
 }
 
+var (
+	errNoContentType          = errors.New("no Content-Type header provided")
+	errUnsupportedContentType = errors.New("unsupported Content-Type header value")
+)
+
 func decodeQueryRequest(ctx context.Context, r *http.Request, svc influxdb.OrganizationService) (*QueryRequest, int, error) {
 	var req QueryRequest
 	body := &countReader{Reader: r.Body}
 
-	var contentType = "application/json"
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		contentType = ct
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return nil, body.bytesRead, errNoContentType
 	}
-	mt, _, err := mime.ParseMediaType(contentType)
+
+	mt, _, err := mime.ParseMediaType(ct)
 	if err != nil {
 		return nil, body.bytesRead, err
 	}
@@ -386,11 +392,11 @@ func decodeQueryRequest(ctx context.Context, r *http.Request, svc influxdb.Organ
 		}
 		req.Query = string(octets)
 	case "application/json":
-		fallthrough
-	default:
 		if err := json.NewDecoder(body).Decode(&req); err != nil {
 			return nil, body.bytesRead, err
 		}
+	default:
+		return nil, body.bytesRead, errUnsupportedContentType
 	}
 
 	switch hv := r.Header.Get(query.PreferHeaderKey); hv {

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -243,7 +243,11 @@ func TestFluxHandler_postFluxAST(t *testing.T) {
 		{
 			name: "get ast from()",
 			w:    httptest.NewRecorder(),
-			r:    httptest.NewRequest("POST", "/api/v2/query/ast", bytes.NewBufferString(`{"query": "from()"}`)),
+			r: func() *http.Request {
+				r := httptest.NewRequest("POST", "/api/v2/query/ast", bytes.NewBufferString(`{"query": "from()"}`))
+				r.Header.Set("Content-Type", "application/json")
+				return r
+			}(),
 			want: `{"ast":{"type":"Package","package":"main","files":[{"type":"File","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"metadata":"parser-type=rust","package":null,"imports":null,"body":[{"type":"ExpressionStatement","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"expression":{"type":"CallExpression","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"callee":{"type":"Identifier","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":5},"source":"from"},"name":"from"}}}]}]}}
 `,
 			status: http.StatusOK,

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -400,7 +400,11 @@ func Test_decodeQueryRequest(t *testing.T) {
 		{
 			name: "valid query request",
 			args: args{
-				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`))
+					r.Header.Set("Content-Type", "application/json")
+					return r
+				}(),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{
@@ -454,14 +458,40 @@ func Test_decodeQueryRequest(t *testing.T) {
 		{
 			name: "error decoding json",
 			args: args{
-				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`error`)),
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`error`))
+					r.Header.Set("Content-Type", "application/json")
+					return r
+				}(),
 			},
 			wantErr: true,
 		},
 		{
 			name: "error validating query",
 			args: args{
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`))
+					r.Header.Set("Content-Type", "application/json")
+					return r
+				}(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "no content-type provided",
+			args: args{
 				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported content-type",
+			args: args{
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`))
+					r.Header.Set("Content-Type", "plain/text")
+					return r
+				}(),
 			},
 			wantErr: true,
 		},
@@ -496,7 +526,11 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 		{
 			name: "valid post query request",
 			args: args{
-				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`))
+					r.Header.Set("Content-Type", "application/json")
+					return r
+				}(),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{
@@ -523,7 +557,8 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 		{
 			name: "valid query including extern definition",
 			args: args{
-				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`
+				r: func() *http.Request {
+					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`
 {
 	"extern": {
 		"type": "File",
@@ -546,7 +581,10 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 	},
 	"query": "from(bucket: \"mybucket\")"
 }
-`)),
+`))
+					r.Header.Set("Content-Type", "application/json")
+					return r
+				}(),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{


### PR DESCRIPTION
Addresses influxdata/idpe#5862.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
