### PR TITLE
fix(ui): displaying variable list default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [17091](https://github.com/influxdata/influxdb/pull/17091): Require Content-Type for query endpoint
 1. [17113](https://github.com/influxdata/influxdb/pull/17113): Disabled group functionality for check query builder
 1. [17120](https://github.com/influxdata/influxdb/pull/17120): Fixed cell configuration error that was popping up when users create a dashboard and accessed the disk usage cell for the first time
+1. [17097](https://github.com/influxdata/influxdb/pull/17097): Listing all the default variables in the VariableTab of the script editor
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/cypress/e2e/dashboardsView.test.ts
+++ b/ui/cypress/e2e/dashboardsView.test.ts
@@ -106,7 +106,12 @@ describe('Dashboard', () => {
           cy.getByTestID('add-cell--button').click()
           cy.getByTestID('switch-to-script-editor').click()
           cy.getByTestID('toolbar-tab').click()
-          cy.get('.variables-toolbar--label').click()
+          // check to see if the default timeRange variables are available
+          cy.get('.variables-toolbar--label').contains('timeRangeStart')
+          cy.get('.variables-toolbar--label').contains('timeRangeStop')
+          cy.get('.variables-toolbar--label')
+            .first()
+            .click()
           cy.getByTestID('save-cell--button').click()
 
           // selected value in dashboard is 1st value
@@ -135,7 +140,9 @@ describe('Dashboard', () => {
             .should('equal', secondKey)
 
           cy.getByTestID('toolbar-tab').click()
-          cy.get('.variables-toolbar--label').trigger('mouseover')
+          cy.get('.variables-toolbar--label')
+            .first()
+            .trigger('mouseover')
           // toggle the variable dropdown in the VEO cell dashboard
           cy.getByTestID('toolbar-popover--contents').within(() => {
             cy.getByTestID('dropdown--button').click()

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -535,8 +535,14 @@ describe('DataExplorer', () => {
       })
 
       cy.getByTestID('toolbar-tab').click()
+      // checks to see if the default variables exist
+      cy.get('.variables-toolbar--label').contains('timeRangeStart')
+      cy.get('.variables-toolbar--label').contains('timeRangeStop')
+      cy.get('.variables-toolbar--label').contains('windowPeriod')
       //insert variable name by clicking on variable
-      cy.get('.variables-toolbar--label').click()
+      cy.get('.variables-toolbar--label')
+        .first()
+        .click()
 
       cy.getByTestID('save-query-as').click()
       cy.getByTestID('task--radio-button').click()

--- a/ui/cypress/e2e/variables.test.ts
+++ b/ui/cypress/e2e/variables.test.ts
@@ -13,6 +13,10 @@ describe('Variables', () => {
 
   it('can create a variable', () => {
     cy.getByTestID('resource-card').should('have.length', 1)
+    // ensure that the default variables are not accessible on the Variables Tab
+    cy.getByTestID('resource-card').should('not.contain', 'timeRangeStart')
+    cy.getByTestID('resource-card').should('not.contain', 'timeRangeStop')
+    cy.getByTestID('resource-card').should('not.contain', 'windowPeriod')
 
     cy.getByTestID('add-resource-dropdown--button').click()
 

--- a/ui/src/timeMachine/components/variableToolbar/VariableItem.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableItem.tsx
@@ -33,7 +33,12 @@ const VariableItem: FC<Props> = ({variable, onClickVariable}) => {
         hideEvent={PopoverInteraction.Hover}
         distanceFromTrigger={8}
         testID="toolbar-popover"
-        contents={() => <VariableTooltipContents variableID={variable.id} />}
+        contents={() => (
+          <VariableTooltipContents
+            variable={variable}
+            variableID={variable.id}
+          />
+        )}
       />
     </div>
   )

--- a/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
@@ -8,7 +8,7 @@ import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar
 import VariableItem from 'src/timeMachine/components/variableToolbar/VariableItem'
 
 // Utils
-import {extractVariablesList} from 'src/variables/selectors'
+import {extractVariablesListWithDefaults} from 'src/variables/selectors'
 
 // Types
 import {AppState, Variable} from 'src/types'
@@ -48,7 +48,7 @@ const VariableToolbar: FunctionComponent<OwnProps & StateProps> = ({
 }
 
 const mstp = (state: AppState): StateProps => {
-  const variables = extractVariablesList(state)
+  const variables = extractVariablesListWithDefaults(state)
 
   return {variables}
 }

--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -25,7 +25,7 @@ import {
 import {toComponentStatus} from 'src/shared/utils/toComponentStatus'
 
 // Types
-import {RemoteDataState, VariableValues} from 'src/types'
+import {RemoteDataState, Variable, VariableValues} from 'src/types'
 import {AppState} from 'src/types'
 
 interface StateProps {
@@ -39,6 +39,7 @@ interface DispatchProps {
 }
 
 interface OwnProps {
+  variable?: Variable
   variableID: string
 }
 
@@ -105,7 +106,21 @@ const VariableTooltipContents: FunctionComponent<Props> = ({
 
 const mstp = (state: AppState, ownProps: OwnProps) => {
   const valuesStatus = getTimeMachineValuesStatus(state)
-  const values = getTimeMachineValues(state, ownProps.variableID)
+  const {variableID} = ownProps
+  let values: VariableValues
+  if (variableID.includes('timeRange') || variableID.includes('windowPeriod')) {
+    const vals = ownProps.variable.arguments.values
+    const selectedValue = Object.values(vals).join('')
+    const selectedKey = Object.keys(vals).join('')
+    values = {
+      valueType: 'string',
+      values: vals,
+      selectedValue,
+      selectedKey,
+    }
+  } else {
+    values = getTimeMachineValues(state, variableID)
+  }
   return {values, valuesStatus}
 }
 

--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -8,6 +8,7 @@ import {
   Form,
   SelectDropdown,
   IconFont,
+  Dropdown,
   ComponentStatus,
 } from '@influxdata/clockface'
 
@@ -87,18 +88,36 @@ const VariableTooltipContents: FunctionComponent<Props> = ({
     selectedOption = get(values, 'selectedKey', 'None Selected')
   }
 
+  const button = () => (
+    <Dropdown.Button status={ComponentStatus.Disabled} onClick={() => {}}>
+      {selectedOption}
+    </Dropdown.Button>
+  )
+
+  const menu = () => null
+
   return (
     <div onMouseEnter={handleMouseEnter}>
       <Form.Element label="Value">
-        <SelectDropdown
-          buttonIcon={icon}
-          options={dropdownItems as string[]}
-          selectedOption={selectedOption}
-          testID="variable--tooltip-dropdown"
-          buttonStatus={status}
-          style={{width: '200px'}}
-          onSelect={value => onSelectVariableValue(variableID, value)}
-        />
+        {dropdownItems.length === 1 && (
+          <Dropdown
+            button={button}
+            style={{width: '200px'}}
+            menu={menu}
+            testID="variable--tooltip-dropdown"
+          />
+        )}
+        {dropdownItems.length !== 1 && (
+          <SelectDropdown
+            buttonIcon={icon}
+            options={dropdownItems as string[]}
+            selectedOption={selectedOption}
+            testID="variable--tooltip-dropdown"
+            buttonStatus={status}
+            style={{width: '200px'}}
+            onSelect={value => onSelectVariableValue(variableID, value)}
+          />
+        )}
       </Form.Element>
     </div>
   )

--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -99,15 +99,14 @@ const VariableTooltipContents: FunctionComponent<Props> = ({
   return (
     <div onMouseEnter={handleMouseEnter}>
       <Form.Element label="Value">
-        {dropdownItems.length === 1 && (
+        {dropdownItems.length === 1 ? (
           <Dropdown
             button={button}
             style={{width: '200px'}}
             menu={menu}
             testID="variable--tooltip-dropdown"
           />
-        )}
-        {dropdownItems.length !== 1 && (
+        ) : (
           <SelectDropdown
             buttonIcon={icon}
             options={dropdownItems as string[]}

--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -107,20 +107,7 @@ const VariableTooltipContents: FunctionComponent<Props> = ({
 const mstp = (state: AppState, ownProps: OwnProps) => {
   const valuesStatus = getTimeMachineValuesStatus(state)
   const {variableID} = ownProps
-  let values: VariableValues
-  if (variableID.includes('timeRange') || variableID.includes('windowPeriod')) {
-    const vals = ownProps.variable.arguments.values
-    const selectedValue = Object.values(vals).join('')
-    const selectedKey = Object.keys(vals).join('')
-    values = {
-      valueType: 'string',
-      values: vals,
-      selectedValue,
-      selectedKey,
-    }
-  } else {
-    values = getTimeMachineValues(state, variableID)
-  }
+  const values = getTimeMachineValues(state, variableID, ownProps.variable)
   return {values, valuesStatus}
 }
 

--- a/ui/src/variables/mocks/index.ts
+++ b/ui/src/variables/mocks/index.ts
@@ -1,5 +1,46 @@
 // Types
 import {Variable, RemoteDataState} from 'src/types'
+import {VariableAssignment} from 'src/types/ast'
+
+export const defaultVariableAssignments: VariableAssignment[] = [
+  {
+    type: 'VariableAssignment',
+    id: {
+      type: 'Identifier',
+      name: 'timeRangeStart',
+    },
+    init: {
+      type: 'UnaryExpression',
+      operator: '-',
+      argument: {
+        type: 'DurationLiteral',
+        values: [{magnitude: 1, unit: 'h'}],
+      },
+    },
+  },
+  {
+    type: 'VariableAssignment',
+    id: {
+      type: 'Identifier',
+      name: 'timeRangeStop',
+    },
+    init: {
+      type: 'CallExpression',
+      callee: {type: 'Identifier', name: 'now'},
+    },
+  },
+  {
+    type: 'VariableAssignment',
+    id: {
+      type: 'Identifier',
+      name: 'createdVariable',
+    },
+    init: {
+      type: 'StringLiteral',
+      value: 'randomValue',
+    },
+  },
+]
 
 export const createVariable = (
   name: string,

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -4,6 +4,13 @@ import {get} from 'lodash'
 
 // Utils
 import {getVarAssignment} from 'src/variables/utils/getVarAssignment'
+import {
+  getActiveQuery,
+  getVariableAssignments as getTimeMachineVarAssignment,
+} from 'src/timeMachine/selectors'
+import {getTimeRangeAsVariable} from 'src/variables/utils/getTimeRangeVars'
+import {getTimeRange} from 'src/timeMachine/selectors'
+import {getWindowPeriodVariable} from 'src/variables/utils/getWindowVars'
 
 // Types
 import {
@@ -35,8 +42,24 @@ const extractVariablesListMemoized = memoizeOne(
   }
 )
 
+const extractWindowPeriodVariableMemoized = memoizeOne(
+  (state: AppState): Variable[] => {
+    const {text} = getActiveQuery(state)
+    const variables = getTimeMachineVarAssignment(state)
+    return getWindowPeriodVariable(text, variables) || []
+  }
+)
+
+export const extractTimeRangeVariablesMemoized = memoizeOne(
+  (state: AppState): Variable[] => getTimeRangeAsVariable(getTimeRange(state))
+)
+
 export const extractVariablesList = (state: AppState): Variable[] => {
-  return extractVariablesListMemoized(state.resources.variables.byID)
+  return [
+    ...extractVariablesListMemoized(state.resources.variables.byID),
+    ...extractWindowPeriodVariableMemoized(state),
+    ...extractTimeRangeVariablesMemoized(state),
+  ]
 }
 
 export const extractVariableEditorName = (state: AppState): string => {

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -232,8 +232,20 @@ export const getVariableAssignments = (
 
 export const getTimeMachineValues = (
   state: AppState,
-  variableID: string
+  variableID: string,
+  variable?: Variable
 ): VariableValues => {
+  if (variableID.includes('timeRange') || variableID.includes('windowPeriod')) {
+    const vals = get(variable, 'arguments.values', {})
+    const selectedValue = Object.values(vals).join('')
+    const selectedKey = Object.keys(vals).join('')
+    return {
+      valueType: 'string',
+      values: vals,
+      selectedValue,
+      selectedKey,
+    }
+  }
   const activeTimeMachineID = state.timeMachines.activeTimeMachineID
   const values = get(
     state,

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -55,6 +55,12 @@ export const extractTimeRangeVariablesMemoized = memoizeOne(
 )
 
 export const extractVariablesList = (state: AppState): Variable[] => {
+  return [...extractVariablesListMemoized(state.resources.variables.byID)]
+}
+
+export const extractVariablesListWithDefaults = (
+  state: AppState
+): Variable[] => {
   return [
     ...extractVariablesListMemoized(state.resources.variables.byID),
     ...extractWindowPeriodVariableMemoized(state),

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -55,7 +55,7 @@ export const extractTimeRangeVariablesMemoized = memoizeOne(
 )
 
 export const extractVariablesList = (state: AppState): Variable[] => {
-  return [...extractVariablesListMemoized(state.resources.variables.byID)]
+  return extractVariablesListMemoized(state.resources.variables.byID)
 }
 
 export const extractVariablesListWithDefaults = (

--- a/ui/src/variables/utils/getTimeRangeVars.test.ts
+++ b/ui/src/variables/utils/getTimeRangeVars.test.ts
@@ -1,4 +1,7 @@
-import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
+import {
+  getTimeRangeVars,
+  getTimeRangeAsVariable,
+} from 'src/variables/utils/getTimeRangeVars'
 import {pastHourTimeRange} from 'src/shared/constants/timeRanges'
 
 const custom = 'custom' as 'custom'
@@ -51,5 +54,26 @@ describe('getTimeRangeVars', () => {
         name: 'now',
       },
     })
+  })
+})
+
+describe('getTimeRangeAsVariable', () => {
+  test('should handle relative dates', () => {
+    const [start, stop] = getTimeRangeAsVariable(pastHourTimeRange)
+    expect(start.name).toEqual('timeRangeStart')
+    expect(stop.name).toEqual('timeRangeStop')
+    expect(start.arguments.values).toEqual({'1h': '1h'})
+    expect(stop.arguments.values).toEqual({'now()': 'now()'})
+  })
+
+  test('should return an empty array when handling custom dates', () => {
+    const timeRange = {
+      type: custom,
+      lower: '2019-02-28T15:00:00Z',
+      upper: '2019-03-28T15:00:00Z',
+    }
+
+    const actual = getTimeRangeAsVariable(timeRange)
+    expect(actual).toEqual([])
   })
 })

--- a/ui/src/variables/utils/getTimeRangeVars.ts
+++ b/ui/src/variables/utils/getTimeRangeVars.ts
@@ -5,7 +5,7 @@ import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 
 // Types
-import {TimeRange} from 'src/types'
+import {RemoteDataState, TimeRange, Variable} from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
 
 export const getTimeRangeVars = (
@@ -54,6 +54,55 @@ export const getTimeRangeVars = (
     }
   }
   return [startValue, stopValue]
+}
+
+export const getTimeRangeAsVariable = (timeRange: TimeRange): Variable[] => {
+  let startValue: Variable
+
+  if (!isDateParseable(timeRange.lower)) {
+    const [{magnitude, unit}] = parseDuration(timeRangeToDuration(timeRange))
+    const start = `${magnitude}${unit}`
+    startValue = {
+      orgID: '',
+      id: TIME_RANGE_START,
+      name: TIME_RANGE_START,
+      arguments: {
+        type: 'map',
+        values: {
+          [start]: start,
+        },
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+    }
+  }
+
+  let stopValue: Variable
+
+  if (!timeRange.upper) {
+    const now = 'now()'
+    stopValue = {
+      orgID: '',
+      id: TIME_RANGE_STOP,
+      name: TIME_RANGE_STOP,
+      arguments: {
+        type: 'map',
+        values: {
+          [now]: now,
+        },
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+    }
+  }
+  const range = []
+  if (startValue) {
+    range[0] = startValue
+  }
+  if (stopValue) {
+    range[1] = stopValue
+  }
+  return range
 }
 
 const generateDateTimeLiteral = (

--- a/ui/src/variables/utils/getWindowVars.test.ts
+++ b/ui/src/variables/utils/getWindowVars.test.ts
@@ -1,0 +1,74 @@
+import {getWindowPeriodVariable} from 'src/variables/utils/getWindowVars'
+import {defaultVariableAssignments} from 'src/variables/mocks'
+
+describe('getWindowPeriodVariable', () => {
+  beforeEach(() => {
+    // NOTE: as long as you mock children like below, before importing your
+    // component by using a require().default pattern, this will reset your
+    // mocks between tests (alex)
+    jest.resetModules()
+  })
+  test('should return null when passed an empty query string', () => {
+    const actual = getWindowPeriodVariable('', [])
+    expect(actual).toEqual(null)
+  })
+
+  test('should return null when no timeRange is input', () => {
+    const query = `from(bucket: "Cool Story")
+    |> filter(fn: (r) => r._measurement == "cpu")
+    |> filter(fn: (r) => r._field == "usage_user")`
+    const actual = getWindowPeriodVariable(query, defaultVariableAssignments)
+    expect(actual).toEqual(null)
+  })
+
+  test('should return a dynamic windowPeriod depending on the timeRange that is input', () => {
+    jest.mock('@influxdata/flux-parser', () => {
+      return {
+        parse: jest.fn(() => ({
+          type: 'File',
+          package: null,
+          imports: [],
+          body: [
+            {
+              type: 'ExpressionStatement',
+              expression: {
+                type: 'PipeExpression',
+                argument: {type: 'PipeExpression', argument: {}, call: {}},
+                call: {type: 'CallExpression', callee: {}, arguments: [{}]},
+              },
+            },
+          ],
+        })),
+      }
+    })
+    jest.mock('src/shared/utils/getMinDurationFromAST', () => {
+      return {
+        getMinDurationFromAST: jest.fn(() => 86400000),
+      }
+    })
+    const getWindowVars = require('src/variables/utils/getWindowVars')
+    const query = `from(bucket: "Phil Collins")
+    |> range(start: time(v: "2020-03-03T12:00:00Z"), stop: time(v: "2020-03-04T12:00:00Z"))
+    |> filter(fn: (r) => r._measurement == "cpu")
+    |> filter(fn: (r) => r._field == "usage_user")`
+
+    const actual = getWindowVars.getWindowPeriodVariable(
+      query,
+      defaultVariableAssignments
+    )
+    const expected = [
+      {
+        orgID: '',
+        id: 'windowPeriod',
+        name: 'windowPeriod',
+        arguments: {
+          type: 'map',
+          values: {'240000': 240000},
+        },
+        status: 'Done',
+        labels: [],
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -10,6 +10,7 @@ import {WINDOW_PERIOD} from 'src/variables/constants'
 
 // Types
 import {VariableAssignment, Package} from 'src/types/ast'
+import {RemoteDataState, Variable} from 'src/types'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 
 const DESIRED_POINTS_PER_GRAPH = 360
@@ -80,6 +81,61 @@ export const getWindowPeriod = (
     reportError(error, {
       context: {query},
       name: 'getWindowPeriod function',
+    })
+    return null
+  }
+}
+
+export const getWindowPeriodVariable = (
+  query: string,
+  variables: VariableAssignment[]
+): Variable[] | null => {
+  if (query.length === 0) {
+    return null
+  }
+  try {
+    const ast = parse(query)
+
+    const substitutedAST: Package = {
+      package: '',
+      type: 'Package',
+      files: [ast, buildVarsOption(variables)],
+    }
+
+    const queryDuration = getMinDurationFromAST(substitutedAST) // in ms
+
+    const foundDuration = SELECTABLE_TIME_RANGES.find(
+      tr => tr.seconds * 1000 === queryDuration
+    )
+
+    let total: number = null
+
+    if (foundDuration) {
+      total = foundDuration.windowPeriod
+    }
+
+    total = Math.round(queryDuration / DESIRED_POINTS_PER_GRAPH)
+
+    const windowPeriodVariable: Variable = {
+      orgID: '',
+      id: 'windowPeriod',
+      name: 'windowPeriod',
+      arguments: {
+        type: 'map',
+        values: {
+          [total]: total,
+        },
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+    }
+
+    return [windowPeriodVariable]
+  } catch (error) {
+    console.error(error)
+    reportError(error, {
+      context: {query},
+      name: 'getWindowPeriodVariable function',
     })
     return null
   }

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -132,7 +132,6 @@ export const getWindowPeriodVariable = (
 
     return [windowPeriodVariable]
   } catch (error) {
-    console.error(error)
     reportError(error, {
       context: {query},
       name: 'getWindowPeriodVariable function',


### PR DESCRIPTION
Closes #16058

### Problem

Variable list was showing only created variables and not showing default variables

### Solution

Default variables are populated whenever the query runs, so the solution involved calculating the default variables whenever the variable list was rendered & whenever the variable tooltip was being toggled. Here's how it looks like in action:

![defaultVariables](https://user-images.githubusercontent.com/19984220/75934626-db11b280-5e31-11ea-855f-6759e62f35c4.gif)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)