### PR TITLE
fix(secrets): wrap secrets service in authorizer

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -163,6 +163,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	orgBackend := NewOrgBackend(b.Logger.With(zap.String("handler", "org")), b)
 	orgBackend.OrganizationService = authorizer.NewOrgService(b.OrganizationService)
+	orgBackend.SecretService = authorizer.NewSecretService(b.SecretService)
 	h.Mount(prefixOrganizations, NewOrgHandler(b.Logger, orgBackend))
 
 	scraperBackend := NewScraperBackend(b.Logger.With(zap.String("handler", "scraper")), b)


### PR DESCRIPTION
This PR wraps the `SecretService` on the `OrgBackend` object in an authorizer. This is part of the ongoing work to update pipeline tests for the API.


- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
