### PR TITLE
chore(github): change CODEOWNERS for tools-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 #
 http/swagger.yml @influxdata/monitoring-team
 
+# dev tools
+/pkger/ @influxdata/tools-team
+
 # Storage code
 /storage/ @influxdata/storage-team-assigner
 /tsdb/ @influxdata/storage-team-assigner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # Here is information about how to configure this file:
 # https://help.github.com/en/articles/about-code-owners
 
-# API and monitoring team will help to review swagger.yml changes.
+# monitoring team will help to review swagger.yml changes.
 #
-http/swagger.yml @influxdata/api @influxdata/monitoring-team
+http/swagger.yml @influxdata/monitoring-team
 
 # Storage code
 /storage/ @influxdata/storage-team-assigner


### PR DESCRIPTION
We own the pkger tool, so adding that to CODEOWNERS.

Removing api-team, as that team no longer exists.