### PR TITLE
fix(ui): fixed dashboard cell error for disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-beta.6 [unreleased]
 
 ### Features
+
 1. [17085](https://github.com/influxdata/influxdb/pull/17085): Clicking on bucket name takes user to Data Explorer with bucket selected
 1. [17095](https://github.com/influxdata/influxdb/pull/17095): Extend pkger dashboards with table view support
 
@@ -13,6 +14,7 @@
 1. [17072](https://github.com/influxdata/influxdb/pull/17072): Fixed issue where creating a variable of type map was piping the incorrect value when map variables were used in queries
 1. [17050](https://github.com/influxdata/influxdb/pull/17050): Added missing user names to auth CLI commands
 1. [17091](https://github.com/influxdata/influxdb/pull/17091): Require Content-Type for query endpoint
+1. [17120](https://github.com/influxdata/influxdb/pull/17120): Fixed cell configuration error that was popping up when users create a dashboard and accessed the disk usage cell for the first time
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/src/cells/selectors/index.ts
+++ b/ui/src/cells/selectors/index.ts
@@ -5,12 +5,13 @@ export const getCells = (
   dashboardID: string
 ): Cell[] => {
   const dashboard = resources.dashboards.byID[dashboardID]
-
   if (!dashboard || !dashboard.cells) {
     return []
   }
 
   const cellIDs = dashboard.cells
 
-  return cellIDs.map(id => resources.cells.byID[id])
+  return cellIDs
+    .filter(id => resources.cells.byID[id]) // added filter since it was returning undefined cells
+    .map(id => resources.cells.byID[id])
 }

--- a/ui/src/cells/selectors/index.ts
+++ b/ui/src/cells/selectors/index.ts
@@ -12,6 +12,6 @@ export const getCells = (
   const cellIDs = dashboard.cells
 
   return cellIDs
-    .filter(id => resources.cells.byID[id]) // added filter since it was returning undefined cells
+    .filter(id => !!resources.cells.byID[id]) // added filter since it was returning undefined cells
     .map(id => resources.cells.byID[id])
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/6240

### Problem

The getCells selector function was mapping over undefined values, so the cells were throwing an error when they were being configured

### Solution

Added a filter so that the cells are filtered of falsey values before mapping them. 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)