### PR TITLE
fix(http): Revert requirement of Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 1. [17028](https://github.com/influxdata/influxdb/pull/17028): Fixed issue where selecting an aggregate function in the script editor was not adding the function to a new line
 1. [17072](https://github.com/influxdata/influxdb/pull/17072): Fixed issue where creating a variable of type map was piping the incorrect value when map variables were used in queries
 1. [17050](https://github.com/influxdata/influxdb/pull/17050): Added missing user names to auth CLI commands
-1. [17091](https://github.com/influxdata/influxdb/pull/17091): Require Content-Type for query endpoint
 1. [17120](https://github.com/influxdata/influxdb/pull/17120): Fixed cell configuration error that was popping up when users create a dashboard and accessed the disk usage cell for the first time
 
 ## v2.0.0-beta.5 [2020-02-27]

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -243,11 +243,7 @@ func TestFluxHandler_postFluxAST(t *testing.T) {
 		{
 			name: "get ast from()",
 			w:    httptest.NewRecorder(),
-			r: func() *http.Request {
-				r := httptest.NewRequest("POST", "/api/v2/query/ast", bytes.NewBufferString(`{"query": "from()"}`))
-				r.Header.Set("Content-Type", "application/json")
-				return r
-			}(),
+			r:    httptest.NewRequest("POST", "/api/v2/query/ast", bytes.NewBufferString(`{"query": "from()"}`)),
 			want: `{"ast":{"type":"Package","package":"main","files":[{"type":"File","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"metadata":"parser-type=rust","package":null,"imports":null,"body":[{"type":"ExpressionStatement","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"expression":{"type":"CallExpression","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":7},"source":"from()"},"callee":{"type":"Identifier","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":5},"source":"from"},"name":"from"}}}]}]}}
 `,
 			status: http.StatusOK,

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -400,11 +400,7 @@ func Test_decodeQueryRequest(t *testing.T) {
 		{
 			name: "valid query request",
 			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`))
-					r.Header.Set("Content-Type", "application/json")
-					return r
-				}(),
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{
@@ -458,40 +454,14 @@ func Test_decodeQueryRequest(t *testing.T) {
 		{
 			name: "error decoding json",
 			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`error`))
-					r.Header.Set("Content-Type", "application/json")
-					return r
-				}(),
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`error`)),
 			},
 			wantErr: true,
 		},
 		{
 			name: "error validating query",
 			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`))
-					r.Header.Set("Content-Type", "application/json")
-					return r
-				}(),
-			},
-			wantErr: true,
-		},
-		{
-			name: "no content-type provided",
-			args: args{
 				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`)),
-			},
-			wantErr: true,
-		},
-		{
-			name: "unsupported content-type",
-			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{}`))
-					r.Header.Set("Content-Type", "plain/text")
-					return r
-				}(),
 			},
 			wantErr: true,
 		},
@@ -526,11 +496,7 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 		{
 			name: "valid post query request",
 			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`))
-					r.Header.Set("Content-Type", "application/json")
-					return r
-				}(),
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`{"query": "from()"}`)),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{
@@ -557,8 +523,7 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 		{
 			name: "valid query including extern definition",
 			args: args{
-				r: func() *http.Request {
-					r := httptest.NewRequest("POST", "/", bytes.NewBufferString(`
+				r: httptest.NewRequest("POST", "/", bytes.NewBufferString(`
 {
 	"extern": {
 		"type": "File",
@@ -581,10 +546,7 @@ func Test_decodeProxyQueryRequest(t *testing.T) {
 	},
 	"query": "from(bucket: \"mybucket\")"
 }
-`))
-					r.Header.Set("Content-Type", "application/json")
-					return r
-				}(),
+`)),
 				svc: &mock.OrganizationService{
 					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
 						return &platform.Organization{


### PR DESCRIPTION
This is causing issues for some clients. We are rolling it back until we can completely assess the situation.