### PR TITLE
feat(pkger): add support for exporting all and filter by resource types

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -277,7 +277,10 @@ func (b *cmdPkgBuilder) pkgExportAllRunEFn(cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	return b.writePkg(cmd.OutOrStdout(), pkgSVC, b.file, pkger.CreateWithAllOrgResources(orgID))
+	orgOpt := pkger.CreateWithAllOrgResources(pkger.CreateByOrgIDOpt{
+		OrgID: orgID,
+	})
+	return b.writePkg(cmd.OutOrStdout(), pkgSVC, b.file, orgOpt)
 }
 
 func (b *cmdPkgBuilder) cmdPkgSummary() *cobra.Command {

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -83,7 +83,7 @@ func TestCmdPkg(t *testing.T) {
 							return nil, err
 						}
 					}
-					if !opt.OrgIDs[expectedOrgID] {
+					if opt.OrgIDs[0].OrgID != expectedOrgID {
 						return nil, errors.New("did not provide expected orgID")
 					}
 

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -384,10 +384,32 @@ spec:
 		)
 
 		t.Run("exporting all resources for an org", func(t *testing.T) {
-			newPkg, err := svc.CreatePkg(timedCtx(2*time.Second), pkger.CreateWithAllOrgResources(l.Org.ID))
+			newPkg, err := svc.CreatePkg(timedCtx(2*time.Second), pkger.CreateWithAllOrgResources(
+				pkger.CreateByOrgIDOpt{
+					OrgID: l.Org.ID,
+				},
+			))
 			require.NoError(t, err)
 
 			verifyCompleteSummary(t, newPkg.Summary(), true)
+
+			bucketsOnlyPkg, err := svc.CreatePkg(timedCtx(2*time.Second), pkger.CreateWithAllOrgResources(
+				pkger.CreateByOrgIDOpt{
+					OrgID:         l.Org.ID,
+					ResourceKinds: []pkger.Kind{pkger.KindBucket, pkger.KindTask},
+				},
+			))
+			require.NoError(t, err)
+
+			bktsOnlySum := bucketsOnlyPkg.Summary()
+			assert.NotEmpty(t, bktsOnlySum.Buckets)
+			assert.NotEmpty(t, bktsOnlySum.Labels)
+			assert.NotEmpty(t, bktsOnlySum.Tasks)
+			assert.Empty(t, bktsOnlySum.Checks)
+			assert.Empty(t, bktsOnlySum.Dashboards)
+			assert.Empty(t, bktsOnlySum.NotificationEndpoints)
+			assert.Empty(t, bktsOnlySum.NotificationRules)
+			assert.Empty(t, bktsOnlySum.Variables)
 		})
 
 		t.Run("pkg with same bkt-var-label does nto create new resources for them", func(t *testing.T) {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7171,30 +7171,46 @@ components:
               contentType:
                 type: string
             required: ["url"]
+    PkgCreateKind:
+      type: string
+      enum:
+        - bucket
+        - check
+        - dashboard
+        - label
+        - notification_endpoint
+        - notification_rule
+        - task
+        - telegraf
+        - variable
     PkgCreate:
       type: object
       properties:
         orgIDs:
           type: array
           items:
-            type: string
+            type: object
+            properties:
+              orgID:
+                type: string
+              resourceFilters:
+                type: object
+                properties:
+                  byLabel:
+                    type: array
+                    items:
+                      type: string
+                  byResourceKind:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PkgCreateKind"
         resources:
           type: object
           properties:
             id:
               type: string
             kind:
-              type: string
-              enum:
-                - bucket
-                - check
-                - dashboard
-                - label
-                - notification_endpoint
-                - notification_rule
-                - task
-                - telegraf
-                - variable
+              $ref: "#/components/schemas/PkgCreateKind"
             name:
               type: string
           required: [id, kind]
@@ -7217,7 +7233,6 @@ components:
               - NotificationEndpointPagerDuty
               - NotificationEndpointSlack
               - NotificationRule
-              - NotificationEndpointHTTP
               - Task
               - Telegraf
               - Variable

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -23,9 +23,19 @@ func (s *HTTPRemoteService) CreatePkg(ctx context.Context, setters ...CreatePkgS
 			return nil, err
 		}
 	}
-	var orgIDs []string
-	for orgID := range opt.OrgIDs {
-		orgIDs = append(orgIDs, orgID.String())
+
+	var orgIDs []ReqCreateOrgIDOpt
+	for _, org := range opt.OrgIDs {
+		orgIDs = append(orgIDs, ReqCreateOrgIDOpt{
+			OrgID: org.OrgID.String(),
+			Filters: struct {
+				ByLabel        []string `json:"byLabel"`
+				ByResourceKind []Kind   `json:"byResourceKind"`
+			}{
+				ByLabel:        org.LabelNames,
+				ByResourceKind: org.ResourceKinds,
+			},
+		})
 	}
 
 	reqBody := ReqCreatePkg{

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -171,14 +171,24 @@ func NewService(opts ...ServiceSetterFn) *Service {
 	}
 }
 
-// CreatePkgSetFn is a functional input for setting the pkg fields.
-type CreatePkgSetFn func(opt *CreateOpt) error
+type (
+	// CreatePkgSetFn is a functional input for setting the pkg fields.
+	CreatePkgSetFn func(opt *CreateOpt) error
 
-// CreateOpt are the options for creating a new package.
-type CreateOpt struct {
-	OrgIDs    map[influxdb.ID]bool
-	Resources []ResourceToClone
-}
+	// CreateOpt are the options for creating a new package.
+	CreateOpt struct {
+		OrgIDs    []CreateByOrgIDOpt
+		Resources []ResourceToClone
+	}
+
+	// CreateByOrgIDOpt identifies an org to export resources for and provides
+	// multiple filtering options.
+	CreateByOrgIDOpt struct {
+		OrgID         influxdb.ID
+		LabelNames    []string
+		ResourceKinds []Kind
+	}
+)
 
 // CreateWithExistingResources allows the create method to clone existing resources.
 func CreateWithExistingResources(resources ...ResourceToClone) CreatePkgSetFn {
@@ -195,15 +205,17 @@ func CreateWithExistingResources(resources ...ResourceToClone) CreatePkgSetFn {
 
 // CreateWithAllOrgResources allows the create method to clone all existing resources
 // for the given organization.
-func CreateWithAllOrgResources(orgID influxdb.ID) CreatePkgSetFn {
+func CreateWithAllOrgResources(orgIDOpt CreateByOrgIDOpt) CreatePkgSetFn {
 	return func(opt *CreateOpt) error {
-		if orgID == 0 {
+		if orgIDOpt.OrgID == 0 {
 			return errors.New("orgID provided must not be zero")
 		}
-		if opt.OrgIDs == nil {
-			opt.OrgIDs = make(map[influxdb.ID]bool)
+		for _, k := range orgIDOpt.ResourceKinds {
+			if err := k.OK(); err != nil {
+				return err
+			}
 		}
-		opt.OrgIDs[orgID] = true
+		opt.OrgIDs = append(opt.OrgIDs, orgIDOpt)
 		return nil
 	}
 }
@@ -221,15 +233,15 @@ func (s *Service) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pk
 		Objects: make([]Object, 0, len(opt.Resources)),
 	}
 
-	cloneAssFn := s.resourceCloneAssociationsGen()
-	for orgID := range opt.OrgIDs {
-		resourcesToClone, err := s.cloneOrgResources(ctx, orgID)
+	for _, orgIDOpt := range opt.OrgIDs {
+		resourcesToClone, err := s.cloneOrgResources(ctx, orgIDOpt.OrgID, orgIDOpt.ResourceKinds)
 		if err != nil {
 			return nil, internalErr(err)
 		}
 		opt.Resources = append(opt.Resources, resourcesToClone...)
 	}
 
+	cloneAssFn := s.resourceCloneAssociationsGen()
 	for _, r := range uniqResourcesToClone(opt.Resources) {
 		newKinds, err := s.resourceCloneToKind(ctx, r, cloneAssFn)
 		if err != nil {
@@ -271,51 +283,9 @@ func (s *Service) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pk
 	return pkg, nil
 }
 
-func (s *Service) cloneOrgResources(ctx context.Context, orgID influxdb.ID) ([]ResourceToClone, error) {
-	resourceTypeGens := []struct {
-		resType influxdb.ResourceType
-		cloneFn func(context.Context, influxdb.ID) ([]ResourceToClone, error)
-	}{
-		{
-			resType: KindBucket.ResourceType(),
-			cloneFn: s.cloneOrgBuckets,
-		},
-		{
-			resType: KindCheck.ResourceType(),
-			cloneFn: s.cloneOrgChecks,
-		},
-		{
-			resType: KindDashboard.ResourceType(),
-			cloneFn: s.cloneOrgDashboards,
-		},
-		{
-			resType: KindLabel.ResourceType(),
-			cloneFn: s.cloneOrgLabels,
-		},
-		{
-			resType: KindNotificationEndpoint.ResourceType(),
-			cloneFn: s.cloneOrgNotificationEndpoints,
-		},
-		{
-			resType: KindNotificationRule.ResourceType(),
-			cloneFn: s.cloneOrgNotificationRules,
-		},
-		{
-			resType: KindTask.ResourceType(),
-			cloneFn: s.cloneOrgTasks,
-		},
-		{
-			resType: KindTelegraf.ResourceType(),
-			cloneFn: s.cloneOrgTelegrafs,
-		},
-		{
-			resType: KindVariable.ResourceType(),
-			cloneFn: s.cloneOrgVariables,
-		},
-	}
-
+func (s *Service) cloneOrgResources(ctx context.Context, orgID influxdb.ID, resourceKinds []Kind) ([]ResourceToClone, error) {
 	var resources []ResourceToClone
-	for _, resGen := range resourceTypeGens {
+	for _, resGen := range s.filterOrgResourceKinds(resourceKinds) {
 		existingResources, err := resGen.cloneFn(ctx, orgID)
 		if err != nil {
 			return nil, ierrors.Wrap(err, "finding "+string(resGen.resType))
@@ -619,6 +589,61 @@ func (s *Service) exportNotificationRule(ctx context.Context, r ResourceToClone)
 	}
 
 	return ruleToObject(rule, ruleEndpoint.GetName(), r.Name), endpointKind(ruleEndpoint, ""), nil
+}
+
+type cloneResFn func(context.Context, influxdb.ID) ([]ResourceToClone, error)
+
+func (s *Service) filterOrgResourceKinds(resourceKindFilters []Kind) []struct {
+	resType influxdb.ResourceType
+	cloneFn cloneResFn
+} {
+	mKinds := map[Kind]cloneResFn{
+		KindBucket:               s.cloneOrgBuckets,
+		KindCheck:                s.cloneOrgChecks,
+		KindDashboard:            s.cloneOrgDashboards,
+		KindLabel:                s.cloneOrgLabels,
+		KindNotificationEndpoint: s.cloneOrgNotificationEndpoints,
+		KindNotificationRule:     s.cloneOrgNotificationRules,
+		KindTask:                 s.cloneOrgTasks,
+		KindTelegraf:             s.cloneOrgTelegrafs,
+		KindVariable:             s.cloneOrgVariables,
+	}
+
+	newResGen := func(resType influxdb.ResourceType, cloneFn cloneResFn) struct {
+		resType influxdb.ResourceType
+		cloneFn cloneResFn
+	} {
+		return struct {
+			resType influxdb.ResourceType
+			cloneFn cloneResFn
+		}{
+			resType: resType,
+			cloneFn: cloneFn,
+		}
+	}
+
+	var resourceTypeGens []struct {
+		resType influxdb.ResourceType
+		cloneFn cloneResFn
+	}
+	if len(resourceKindFilters) == 0 {
+		for k, cloneFn := range mKinds {
+			resourceTypeGens = append(resourceTypeGens, newResGen(k.ResourceType(), cloneFn))
+		}
+		return resourceTypeGens
+	}
+
+	seenKinds := make(map[Kind]bool)
+	for _, k := range resourceKindFilters {
+		cloneFn, ok := mKinds[k]
+		if !ok || seenKinds[k] {
+			continue
+		}
+		seenKinds[k] = true
+		resourceTypeGens = append(resourceTypeGens, newResGen(k.ResourceType(), cloneFn))
+	}
+
+	return resourceTypeGens
 }
 
 type (

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -2750,7 +2750,12 @@ func TestService(t *testing.T) {
 				WithVariableSVC(varSVC),
 			)
 
-			pkg, err := svc.CreatePkg(context.TODO(), CreateWithAllOrgResources(orgID))
+			pkg, err := svc.CreatePkg(
+				context.TODO(),
+				CreateWithAllOrgResources(CreateByOrgIDOpt{
+					OrgID: orgID,
+				}),
+			)
 			require.NoError(t, err)
 
 			summary := pkg.Summary()


### PR DESCRIPTION
note: all associations are still included for resources that match the filter criteria.

this is work towards exporting by label(#17029)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)