### PR TITLE
fix: stops variables from crashing

### DIFF
--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -51,7 +51,7 @@ const VariableTooltipContents: FunctionComponent<Props> = ({
   onAddVariableToTimeMachine,
   onSelectVariableValue,
 }) => {
-  let dropdownItems = get(values, 'values', [])
+  let dropdownItems = get(values, 'values', []) || []
 
   if (Object.keys(dropdownItems).length > 0) {
     dropdownItems = Object.keys(dropdownItems)


### PR DESCRIPTION
variables crash in the data explorer when they are not type Map because lodash is... weird