### PR TITLE
feat(kv): migration types for managing kv buckets and indexes over time

### DIFF
--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -34,6 +34,11 @@ func NewKVStore(log *zap.Logger, path string) *KVStore {
 	}
 }
 
+// AutoMigrate returns true as the bolt KVStore is safe to migrate on initialize.
+func (s *KVStore) AutoMigrate() bool {
+	return true
+}
+
 // Open creates boltDB file it doesn't exists and opens it otherwise.
 func (s *KVStore) Open(ctx context.Context) error {
 	span, _ := tracing.StartSpanFromContext(ctx)

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -61,6 +61,11 @@ func (s *KVStore) Backup(ctx context.Context, w io.Writer) error {
 	panic("not implemented")
 }
 
+// AutoMigrate returns true as inmem KVStore is safe to migrate on initialize.
+func (s *KVStore) AutoMigrate() bool {
+	return true
+}
+
 // Flush removes all data from the buckets.  Used for testing.
 func (s *KVStore) Flush(ctx context.Context) {
 	s.mu.Lock()

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -13,6 +13,18 @@ import (
 var (
 	authBucket = []byte("authorizationsv1")
 	authIndex  = []byte("authorizationindexv1")
+
+	authByUserIndex = NewIndex(NewIndexMapping(
+		authBucket,
+		[]byte("authorizationbyuserindexv1"),
+		func(v []byte) ([]byte, error) {
+			var auth influxdb.Authorization
+			if err := json.Unmarshal(v, &auth); err != nil {
+				return nil, err
+			}
+			return auth.UserID.Encode()
+		},
+	))
 )
 
 var _ influxdb.AuthorizationService = (*Service)(nil)

--- a/kv/index.go
+++ b/kv/index.go
@@ -141,8 +141,7 @@ func NewIndex(mapping IndexMapping, opts ...IndexOption) *Index {
 	return index
 }
 
-// Initialize creates the bucket if it does not already exist.
-func (i *Index) Initialize(ctx context.Context, store Store) error {
+func (i *Index) initialize(ctx context.Context, store Store) error {
 	return store.Update(ctx, func(tx Tx) error {
 		// create bucket if not exist
 		_, err := tx.Bucket(i.IndexBucket())
@@ -178,6 +177,41 @@ func indexKeyParts(indexKey []byte) (fk, pk []byte, err error) {
 	fk, pk = parts[0], parts[1]
 
 	return
+}
+
+// IndexMigration is a migration for adding and removing an index.
+// These are constructed via the Index.Migration function.
+type IndexMigration struct {
+	*Index
+	opts []PopulateOption
+}
+
+// Name returns a readable name for the index migration.
+func (i *IndexMigration) Name() string {
+	return fmt.Sprintf("add index %q", string(i.IndexBucket()))
+}
+
+// Up initializes the index bucket and populates the index.
+func (i *IndexMigration) Up(ctx context.Context, store Store) error {
+	if err := i.initialize(ctx, store); err != nil {
+		return err
+	}
+
+	_, err := i.Populate(ctx, store, i.opts...)
+	return err
+}
+
+// Down deletes all entries from the index.
+func (i *IndexMigration) Down(ctx context.Context, store Store) error {
+	return i.DeleteAll(ctx, store)
+}
+
+// Migration creates an IndexMigration for the underlying Index.
+func (i *Index) Migration(opts ...PopulateOption) *IndexMigration {
+	return &IndexMigration{
+		Index: i,
+		opts:  opts,
+	}
 }
 
 // Insert creates a single index entry for the provided primary key on the foreign key.

--- a/kv/migration.go
+++ b/kv/migration.go
@@ -1,0 +1,337 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb"
+	"go.uber.org/zap"
+)
+
+var (
+	migrationBucket = []byte("migrationsv1")
+
+	ErrMigrationSpecNotFound = errors.New("migration specification not found")
+)
+
+// MigrationState is a type for describing the state of a migration.
+type MigrationState uint
+
+const (
+	// DownMigrationState is for a migration not yet applied.
+	DownMigrationState MigrationState = iota
+	// UpMigration State is for a migration which has been applied.
+	UpMigrationState
+)
+
+// String returns a string representation for a migration state.
+func (s MigrationState) String() string {
+	switch s {
+	case DownMigrationState:
+		return "down"
+	case UpMigrationState:
+		return "up"
+	default:
+		return "unknown"
+	}
+}
+
+// Migration is a record of a particular migration.
+type Migration struct {
+	ID         influxdb.ID    `json:"id"`
+	Name       string         `json:"name"`
+	State      MigrationState `json:"-"`
+	StartedAt  *time.Time     `json:"started_at"`
+	FinishedAt *time.Time     `json:"finished_at,omitempty"`
+}
+
+// MigrationSpec is a specification for a particular migration.
+// It describes the name of the migration and up and down operations
+// needed to fulfill the migration.
+type MigrationSpec interface {
+	Name() string
+	Up(ctx context.Context, store Store) error
+	Down(ctx context.Context, store Store) error
+}
+
+// MigrationFunc is a function which can be used as either an up or down operation.
+type MigrationFunc func(context.Context, Store) error
+
+// AnonymousMigration is a utility type for creating migrations from anonyomous functions.
+type AnonymousMigration struct {
+	name string
+	up   MigrationFunc
+	down MigrationFunc
+}
+
+// NewAnonymousMigration constructs a new migration from a name string and an up and a down function.
+func NewAnonymousMigration(name string, up, down MigrationFunc) AnonymousMigration {
+	return AnonymousMigration{name, up, down}
+}
+
+// Name returns the name of the migration.
+func (a AnonymousMigration) Name() string { return a.name }
+
+// Up calls the underlying up migration func.
+func (a AnonymousMigration) Up(ctx context.Context, store Store) error { return a.up(ctx, store) }
+
+// Down calls the underlying down migration func.
+func (a AnonymousMigration) Down(ctx context.Context, store Store) error { return a.down(ctx, store) }
+
+// AutoMigrationStore is a Store which also describes whether or not automatic
+// application of migrations can be applied on store initialization.
+// Given AutoMigrate() is defined and returns true, the store supports inline automatic
+// application of up migrations.
+type AutoMigrationStore interface {
+	Store
+	AutoMigrate() bool
+}
+
+// Migrator is a type which manages migrations.
+// It takes a list of migration specifications and undo (down) all or apply (up) outstanding migrations.
+// It records the state of the world in store under the migrations bucket.
+type Migrator struct {
+	logger     *zap.Logger
+	Migrations []MigrationSpec
+
+	now func() time.Time
+}
+
+// NewMigrator constructs and configures a new Migrator.
+func NewMigrator(logger *zap.Logger, ms ...MigrationSpec) *Migrator {
+	m := &Migrator{
+		logger: logger,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	m.AddMigrations(ms...)
+	return m
+}
+
+// AddMigrations appends the provided migration specs onto the Migrator.
+func (m *Migrator) AddMigrations(ms ...MigrationSpec) {
+	m.Migrations = append(m.Migrations, ms...)
+}
+
+// Initialize creates the migration bucket if it does not yet exist.
+func (m *Migrator) Initialize(ctx context.Context, store Store) error {
+	return store.Update(ctx, func(tx Tx) error {
+		_, err := tx.Bucket(migrationBucket)
+		return err
+	})
+}
+
+// List returns a list of migrations and their states within the provided store.
+func (m *Migrator) List(ctx context.Context, store Store) (migrations []Migration, _ error) {
+	if err := m.walk(ctx, store, func(id influxdb.ID, m Migration) {
+		migrations = append(migrations, m)
+	}); err != nil {
+		return nil, err
+	}
+
+	migrationsLen := len(migrations)
+	for idx, migration := range m.Migrations[migrationsLen:] {
+		migration := Migration{
+			ID:   influxdb.ID(migrationsLen + idx + 1),
+			Name: migration.Name(),
+		}
+
+		migrations = append(migrations, migration)
+	}
+
+	return
+}
+
+// Up applies each outstanding migration in order from the lowest indexed migration in a down state.
+// For example, given:
+// 0001 add bucket foo         | (up)
+// 0002 add bucket bar         | (down)
+// 0003 add index "foo on baz" | (down)
+//
+// Up would apply migrations 0002 and then 0003.
+func (m *Migrator) Up(ctx context.Context, store Store) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("up: %w", err)
+		}
+	}()
+
+	var lastMigration int
+	if err = m.walk(ctx, store, func(id influxdb.ID, _ Migration) {
+		lastMigration = int(id)
+	}); err != nil {
+		return
+	}
+
+	for idx, mig := range m.Migrations[lastMigration:] {
+		startedAt := m.now()
+		migration := Migration{
+			ID:        influxdb.ID(lastMigration + idx + 1),
+			Name:      mig.Name(),
+			StartedAt: &startedAt,
+		}
+
+		m.logMigrationEvent(UpMigrationState, migration, "started")
+
+		if err := putMigration(ctx, store, migration); err != nil {
+			return err
+		}
+
+		if err := mig.Up(ctx, store); err != nil {
+			return err
+		}
+
+		finishedAt := m.now()
+		migration.FinishedAt = &finishedAt
+		migration.State = UpMigrationState
+
+		if err := putMigration(ctx, store, migration); err != nil {
+			return err
+		}
+
+		m.logMigrationEvent(UpMigrationState, migration, "completed")
+	}
+
+	return nil
+}
+
+// Down call each migrations down function from the highest indexed migration in an up state;
+// all the to the first migration.
+// For example, given:
+// 0001 add bucket foo         | (up)
+// 0002 add bucket bar         | (up)
+// 0003 add index "foo on baz" | (down)
+//
+// Down would call down() on 0002 and the 0001.
+func (m *Migrator) Down(ctx context.Context, store Store) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("down: %w", err)
+		}
+	}()
+
+	var migrations []struct {
+		MigrationSpec
+		Migration
+	}
+
+	if err = m.walk(ctx, store, func(id influxdb.ID, mig Migration) {
+		migrations = append(
+			migrations,
+			struct {
+				MigrationSpec
+				Migration
+			}{
+				m.Migrations[int(id)-1],
+				mig,
+			},
+		)
+	}); err != nil {
+		return
+	}
+
+	for i := len(migrations) - 1; i >= 0; i-- {
+		migration := migrations[i]
+
+		m.logMigrationEvent(DownMigrationState, migration.Migration, "started")
+
+		if err = migration.MigrationSpec.Down(ctx, store); err != nil {
+			return
+		}
+
+		// clear timestamps
+		migration.Migration.StartedAt = nil
+		migration.Migration.FinishedAt = nil
+
+		if err = deleteMigration(ctx, store, migration.Migration); err != nil {
+			return
+		}
+
+		m.logMigrationEvent(DownMigrationState, migration.Migration, "completed")
+	}
+	return
+}
+
+func (m *Migrator) logMigrationEvent(state MigrationState, mig Migration, event string) {
+	m.logger.Info(fmt.Sprintf("(%s): %q %s", state, mig.Name, event))
+}
+
+func (m *Migrator) walk(ctx context.Context, store Store, fn func(id influxdb.ID, m Migration)) error {
+	if err := store.View(ctx, func(tx Tx) error {
+		bkt, err := tx.Bucket(migrationBucket)
+		if err != nil {
+			return err
+		}
+
+		cursor, err := bkt.ForwardCursor(nil)
+		if err != nil {
+			return err
+		}
+
+		return WalkCursor(ctx, cursor, func(k, v []byte) error {
+			var id influxdb.ID
+			if err := id.Decode(k); err != nil {
+				return fmt.Errorf("decoding migration id: %w", err)
+			}
+
+			var migration Migration
+			if err := json.Unmarshal(v, &migration); err != nil {
+				return err
+			}
+
+			idx := int(id) - 1
+			if idx >= len(m.Migrations) {
+				return fmt.Errorf("migration %q: %w", migration.Name, ErrMigrationSpecNotFound)
+			}
+
+			if mig := m.Migrations[idx]; mig.Name() != migration.Name {
+				return fmt.Errorf("expected migration %q, found %q", mig.Name(), migration.Name)
+			}
+
+			if migration.FinishedAt != nil {
+				migration.State = UpMigrationState
+			}
+
+			fn(id, migration)
+
+			return nil
+		})
+	}); err != nil {
+		return fmt.Errorf("reading migrations: %w", err)
+	}
+
+	return nil
+}
+
+func putMigration(ctx context.Context, store Store, m Migration) error {
+	return store.Update(ctx, func(tx Tx) error {
+		bkt, err := tx.Bucket(migrationBucket)
+		if err != nil {
+			return err
+		}
+
+		data, err := json.Marshal(m)
+		if err != nil {
+			return err
+		}
+
+		id, _ := m.ID.Encode()
+		return bkt.Put(id, data)
+	})
+}
+
+func deleteMigration(ctx context.Context, store Store, m Migration) error {
+	return store.Update(ctx, func(tx Tx) error {
+		bkt, err := tx.Bucket(migrationBucket)
+		if err != nil {
+			return err
+		}
+
+		id, _ := m.ID.Encode()
+		return bkt.Delete(id)
+	})
+}

--- a/kv/migration_private_test.go
+++ b/kv/migration_private_test.go
@@ -1,0 +1,12 @@
+package kv
+
+import (
+	"testing"
+	"time"
+)
+
+func MigratorSetNow(t *testing.T, migrator *Migrator, now func() time.Time) {
+	t.Helper()
+
+	migrator.now = now
+}

--- a/kv/migration_test.go
+++ b/kv/migration_test.go
@@ -1,0 +1,359 @@
+package kv_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/inmem"
+	"github.com/influxdata/influxdb/kv"
+	"go.uber.org/zap"
+)
+
+func Test_Migrator(t *testing.T) {
+	var (
+		ctx            = context.TODO()
+		store          = inmem.NewKVStore()
+		logger         = zap.NewNop()
+		migrationOne   = newMigration("migration one")
+		migrationTwo   = newMigration("migration two")
+		migrationThree = newMigration("migration three")
+		migrationFour  = newMigration("migration four")
+		migrator       = kv.NewMigrator(logger,
+			// all migrations excluding number four (for now)
+			migrationOne,
+			migrationTwo,
+			migrationThree,
+		)
+
+		// mocking now time
+		timestamp = int64(0)
+		now       = func() time.Time {
+			timestamp++
+			return time.Unix(timestamp, 0).In(time.UTC)
+		}
+
+		// ts returns a point to a time at N unix seconds.
+		ts = func(n int64) *time.Time {
+			t := time.Unix(n, 0).In(time.UTC)
+			return &t
+		}
+	)
+
+	kv.MigratorSetNow(t, migrator, now)
+
+	if err := migrator.Initialize(ctx, store); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("List() shows all migrations in down state", func(t *testing.T) {
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:    influxdb.ID(1),
+				Name:  "migration one",
+				State: kv.DownMigrationState,
+			},
+			{
+				ID:    influxdb.ID(2),
+				Name:  "migration two",
+				State: kv.DownMigrationState,
+			},
+			{
+				ID:    influxdb.ID(3),
+				Name:  "migration three",
+				State: kv.DownMigrationState,
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+	})
+
+	t.Run("Up() runs each migration in turn", func(t *testing.T) {
+		// apply all migrations
+		if err := migrator.Up(ctx, store); err != nil {
+			t.Fatal(err)
+		}
+
+		// list migration again
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:         influxdb.ID(1),
+				Name:       "migration one",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(1),
+				FinishedAt: ts(2),
+			},
+			{
+				ID:         influxdb.ID(2),
+				Name:       "migration two",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(3),
+				FinishedAt: ts(4),
+			},
+			{
+				ID:         influxdb.ID(3),
+				Name:       "migration three",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(5),
+				FinishedAt: ts(6),
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+
+		// assert each migration was called
+		migrationOne.assertUpCalled(t, 1)
+		migrationTwo.assertUpCalled(t, 1)
+		migrationThree.assertUpCalled(t, 1)
+	})
+
+	t.Run("List() after adding new migration it reports as expected", func(t *testing.T) {
+		migrator.AddMigrations(migrationFour)
+
+		// list migration again
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:         influxdb.ID(1),
+				Name:       "migration one",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(1),
+				FinishedAt: ts(2),
+			},
+			{
+				ID:         influxdb.ID(2),
+				Name:       "migration two",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(3),
+				FinishedAt: ts(4),
+			},
+			{
+				ID:         influxdb.ID(3),
+				Name:       "migration three",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(5),
+				FinishedAt: ts(6),
+			},
+			{
+				ID:    influxdb.ID(4),
+				Name:  "migration four",
+				State: kv.DownMigrationState,
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+	})
+
+	t.Run("Up() only applies the single down migration", func(t *testing.T) {
+		// apply all migrations
+		if err := migrator.Up(ctx, store); err != nil {
+			t.Fatal(err)
+		}
+
+		// list migration again
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:         influxdb.ID(1),
+				Name:       "migration one",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(1),
+				FinishedAt: ts(2),
+			},
+			{
+				ID:         influxdb.ID(2),
+				Name:       "migration two",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(3),
+				FinishedAt: ts(4),
+			},
+			{
+				ID:         influxdb.ID(3),
+				Name:       "migration three",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(5),
+				FinishedAt: ts(6),
+			},
+			{
+				ID:         influxdb.ID(4),
+				Name:       "migration four",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(7),
+				FinishedAt: ts(8),
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+
+		// assert each migration was called only once
+		migrationOne.assertUpCalled(t, 1)
+		migrationTwo.assertUpCalled(t, 1)
+		migrationThree.assertUpCalled(t, 1)
+		migrationFour.assertUpCalled(t, 1)
+	})
+
+	t.Run("Down() calls down for each migration", func(t *testing.T) {
+		// apply all migrations
+		if err := migrator.Down(ctx, store); err != nil {
+			t.Fatal(err)
+		}
+
+		// list migration again
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:    influxdb.ID(1),
+				Name:  "migration one",
+				State: kv.DownMigrationState,
+			},
+			{
+				ID:    influxdb.ID(2),
+				Name:  "migration two",
+				State: kv.DownMigrationState,
+			},
+			{
+				ID:    influxdb.ID(3),
+				Name:  "migration three",
+				State: kv.DownMigrationState,
+			},
+			{
+				ID:    influxdb.ID(4),
+				Name:  "migration four",
+				State: kv.DownMigrationState,
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+
+		// assert each migration was called only once
+		migrationOne.assertDownCalled(t, 1)
+		migrationTwo.assertDownCalled(t, 1)
+		migrationThree.assertDownCalled(t, 1)
+		migrationFour.assertDownCalled(t, 1)
+	})
+
+	t.Run("Up() re-applies all migrations", func(t *testing.T) {
+		// apply all migrations
+		if err := migrator.Up(ctx, store); err != nil {
+			t.Fatal(err)
+		}
+
+		// list migration again
+		migrations, err := migrator.List(ctx, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected := []kv.Migration{
+			{
+				ID:         influxdb.ID(1),
+				Name:       "migration one",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(9),
+				FinishedAt: ts(10),
+			},
+			{
+				ID:         influxdb.ID(2),
+				Name:       "migration two",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(11),
+				FinishedAt: ts(12),
+			},
+			{
+				ID:         influxdb.ID(3),
+				Name:       "migration three",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(13),
+				FinishedAt: ts(14),
+			},
+			{
+				ID:         influxdb.ID(4),
+				Name:       "migration four",
+				State:      kv.UpMigrationState,
+				StartedAt:  ts(15),
+				FinishedAt: ts(16),
+			},
+		}; !reflect.DeepEqual(expected, migrations) {
+			t.Errorf("expected %#v, found %#v", expected, migrations)
+		}
+
+		// assert each migration up was called for a second time
+		migrationOne.assertUpCalled(t, 2)
+		migrationTwo.assertUpCalled(t, 2)
+		migrationThree.assertUpCalled(t, 2)
+		migrationFour.assertUpCalled(t, 2)
+	})
+
+	t.Run("List() missing migration spec errors as expected", func(t *testing.T) {
+		// remove last specification from migration list
+		migrator.Migrations = migrator.Migrations[:len(migrator.Migrations)-1]
+		// list migration again
+		_, err := migrator.List(ctx, store)
+		if !errors.Is(err, kv.ErrMigrationSpecNotFound) {
+			t.Errorf("expected migration spec error, found %v", err)
+		}
+	})
+}
+
+func newMigration(name string) *spyMigrationSpec {
+	return &spyMigrationSpec{name: name}
+}
+
+type spyMigrationSpec struct {
+	name       string
+	upCalled   int
+	downCalled int
+}
+
+func (s *spyMigrationSpec) Name() string {
+	return s.name
+}
+
+func (s *spyMigrationSpec) assertUpCalled(t *testing.T, times int) {
+	t.Helper()
+	if s.upCalled != times {
+		t.Errorf("expected Up() to be called %d times, instead found %d times", times, s.upCalled)
+	}
+}
+
+func (s *spyMigrationSpec) Up(ctx context.Context, store kv.Store) error {
+	s.upCalled++
+	return nil
+}
+
+func (s *spyMigrationSpec) assertDownCalled(t *testing.T, times int) {
+	t.Helper()
+	if s.downCalled != times {
+		t.Errorf("expected Down() to be called %d times, instead found %d times", times, s.downCalled)
+	}
+}
+
+func (s *spyMigrationSpec) Down(ctx context.Context, store kv.Store) error {
+	s.downCalled++
+	return nil
+}

--- a/kv/service.go
+++ b/kv/service.go
@@ -103,6 +103,15 @@ type ServiceConfig struct {
 	Clock         clock.Clock
 }
 
+// AutoMigrationStore is a Store which also describes whether or not
+// migrations can be applied automatically.
+// Given the AutoMigrate method is defined and it returns true then migrations
+// will automatically be applied on Service.Initialize(...).
+type AutoMigrationStore interface {
+	Store
+	AutoMigrate() bool
+}
+
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
 	if store, ok := s.kv.(AutoMigrationStore); ok && store.AutoMigrate() {

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -14,6 +14,18 @@ import (
 var (
 	urmBucket = []byte("userresourcemappingsv1")
 
+	urmByUserIndex = NewIndex(NewIndexMapping(
+		urmBucket,
+		[]byte("userresourcemappingsindexv1"),
+		func(v []byte) ([]byte, error) {
+			var urm influxdb.UserResourceMapping
+			if err := json.Unmarshal(v, &urm); err != nil {
+				return nil, err
+			}
+			return urm.UserID.Encode()
+		},
+	))
+
 	// ErrInvalidURMID is used when the service was provided
 	// an invalid ID format.
 	ErrInvalidURMID = &influxdb.Error{

--- a/testing/index.go
+++ b/testing/index.go
@@ -36,16 +36,11 @@ type someResourceStore struct {
 	ownerIDIndex *kv.Index
 }
 
-func newSomeResourceStore(ctx context.Context, store kv.Store) (*someResourceStore, error) {
-	ownerIDIndex := kv.NewIndex(mapping)
-	if err := ownerIDIndex.Initialize(ctx, store); err != nil {
-		return nil, err
-	}
-
+func newSomeResourceStore(ctx context.Context, store kv.Store) *someResourceStore {
 	return &someResourceStore{
 		store:        store,
-		ownerIDIndex: ownerIDIndex,
-	}, nil
+		ownerIDIndex: kv.NewIndex(mapping),
+	}
 }
 
 func (s *someResourceStore) FindByOwner(ctx context.Context, ownerID string) (resources []someResource, err error) {
@@ -112,9 +107,9 @@ func TestIndex(t *testing.T, store kv.Store) {
 
 func testPopulateAndVerify(t *testing.T, store kv.Store) {
 	var (
-		ctx                = context.TODO()
-		resources          = newNResources(20)
-		resourceStore, err = newSomeResourceStore(ctx, store)
+		ctx           = context.TODO()
+		resources     = newNResources(20)
+		resourceStore = newSomeResourceStore(ctx, store)
 	)
 
 	// insert 20 resources, but only index the first half
@@ -270,7 +265,7 @@ func testWalk(t *testing.T, store kv.Store) {
 		ctx       = context.TODO()
 		resources = newNResources(20)
 		// configure resource store with read disabled
-		resourceStore, err = newSomeResourceStore(ctx, store)
+		resourceStore = newSomeResourceStore(ctx, store)
 
 		cases = []struct {
 			owner     string
@@ -323,10 +318,6 @@ func testWalk(t *testing.T, store kv.Store) {
 			},
 		}
 	)
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// insert all 20 resources with indexing enabled
 	for _, resource := range resources {


### PR DESCRIPTION
This change introduces a new `kv.Migrator` and associated migrations types.
This change sets a new precedent for how we introduce new resource types and indexes into the `kv` package within Influx.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
