### PR TITLE
fix(ui): fixes issue where submit btn was only loading onClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [17120](https://github.com/influxdata/influxdb/pull/17120): Fixed cell configuration error that was popping up when users create a dashboard and accessed the disk usage cell for the first time
 1. [17097](https://github.com/influxdata/influxdb/pull/17097): Listing all the default variables in the VariableTab of the script editor
 1. [17049](https://github.com/influxdata/influxdb/pull/17049): Fixed bug that was preventing the interval status on the dashboard header from refreshing on selections
+1. [17154](https://github.com/influxdata/influxdb/pull/17154): Fixed styling bug that preventing button loading state when using hot keys to submit queries
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -31,22 +31,7 @@ interface DispatchProps {
 
 type Props = StateProps & DispatchProps
 
-interface State {
-  didClick: boolean
-}
-
-class SubmitQueryButton extends PureComponent<Props, State> {
-  public state: State = {didClick: false}
-
-  public componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.queryStatus === RemoteDataState.Loading &&
-      this.props.queryStatus === RemoteDataState.Done
-    ) {
-      this.setState({didClick: false})
-    }
-  }
-
+class SubmitQueryButton extends PureComponent<Props> {
   public render() {
     return (
       <Button
@@ -62,14 +47,12 @@ class SubmitQueryButton extends PureComponent<Props, State> {
 
   private get buttonStatus(): ComponentStatus {
     const {queryStatus, submitButtonDisabled} = this.props
-    const {didClick} = this.state
 
     if (submitButtonDisabled) {
       return ComponentStatus.Disabled
     }
 
-    if (queryStatus === RemoteDataState.Loading && didClick) {
-      // Only show loading state for button if it was just clicked
+    if (queryStatus === RemoteDataState.Loading) {
       return ComponentStatus.Loading
     }
 
@@ -78,7 +61,6 @@ class SubmitQueryButton extends PureComponent<Props, State> {
 
   private handleClick = (): void => {
     this.props.onSubmit()
-    this.setState({didClick: true})
   }
 }
 


### PR DESCRIPTION
Closes #15668

### Problem

Hitting `ctrl + enter` in the script editor would submit the query without enabling the loading state of the button

### Solution

Removed property that was only enabling the loading state of the button when the button was clicked. It seems like this was set by design so I'd love another opinion on why this was originally introduced and to see if there's a more correct solution.

![submit-btn-load](https://user-images.githubusercontent.com/19984220/76247437-c7cd6100-61fc-11ea-89d6-e5ebb7479789.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)