### PR TITLE
refactor(kv): when no session length is set, use the default

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -77,7 +77,9 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 
 	if len(configs) > 0 {
 		s.Config = configs[0]
-	} else {
+	}
+
+	if s.Config.SessionLength == 0 {
 		s.Config.SessionLength = influxdb.DefaultSessionLength
 	}
 

--- a/ui/src/onboarding/containers/LoginPage.scss
+++ b/ui/src/onboarding/containers/LoginPage.scss
@@ -99,7 +99,7 @@
   z-index: 100;
 }
 
-@media screen and (min-width: $grid--breakpoint-md) {
+@media screen and (min-width: $cf-grid--breakpoint-md) {
   .sign-up--form-panel {
     max-width: 100%;
   }


### PR DESCRIPTION
In the past, the default was only being set if a service config wasn't
provided. But if a service config was provided and gave a zero value, it
would not fill in the default value. This changes the code so that it
will always set the default value if the session length is set to zero.