### PR TITLE
fix(ui): updated trigger to be onFocus as well as onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [17120](https://github.com/influxdata/influxdb/pull/17120): Fixed cell configuration error that was popping up when users create a dashboard and accessed the disk usage cell for the first time
 1. [17097](https://github.com/influxdata/influxdb/pull/17097): Listing all the default variables in the VariableTab of the script editor
 1. [17049](https://github.com/influxdata/influxdb/pull/17049): Fixed bug that was preventing the interval status on the dashboard header from refreshing on selections
+1. [17161](https://github.com/influxdata/influxdb/pull/17161): Update table custom decimal feature for tables to update table onFocus
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/src/timeMachine/components/view_options/DecimalPlaces.tsx
+++ b/ui/src/timeMachine/components/view_options/DecimalPlaces.tsx
@@ -56,6 +56,7 @@ class DecimalPlacesOption extends PureComponent<Props, State> {
               <Input
                 name="decimal-places"
                 placeholder="Enter a number"
+                onFocus={this.handleSetValue}
                 onChange={this.handleSetValue}
                 value={this.state.value}
                 min={MIN_DECIMAL_PLACES}
@@ -69,8 +70,8 @@ class DecimalPlacesOption extends PureComponent<Props, State> {
     )
   }
 
-  public handleSetValue = (e: ChangeEvent<HTMLInputElement>): void => {
-    const value = convertUserInputToNumOrNaN(e)
+  public handleSetValue = (event: ChangeEvent<HTMLInputElement>): void => {
+    const value = convertUserInputToNumOrNaN(event)
     const {digits, onDecimalPlacesChange} = this.props
 
     if (value === value && value >= MIN_DECIMAL_PLACES) {


### PR DESCRIPTION
Closes #16277

### Problem

The default option for customizing a table's values would not be updated even when the input was selected.

### Solution

Added an onFocus listener to trim values based on the custom input field

![decimal_bug](https://user-images.githubusercontent.com/19984220/76261296-eccecd80-6216-11ea-8803-b5692605a503.gif)


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)