### PR TITLE
feat(storageflux): move flux components out to separate package

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -42,7 +42,7 @@ import (
 	"github.com/influxdata/influxdb/snowflake"
 	"github.com/influxdata/influxdb/source"
 	"github.com/influxdata/influxdb/storage"
-	"github.com/influxdata/influxdb/storage/reads"
+	storageflux "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/storage/readservice"
 	taskbackend "github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/backend/coordinator"
@@ -594,7 +594,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	)
 
 	deps, err := influxdb.NewDependencies(
-		reads.NewReader(readservice.NewStore(m.engine)),
+		storageflux.NewReader(readservice.NewStore(m.engine)),
 		m.engine,
 		authorizer.NewBucketService(bucketSvc),
 		authorizer.NewOrgService(orgSvc),

--- a/storage/Makefile
+++ b/storage/Makefile
@@ -3,7 +3,7 @@ TARGETS =
 # List any source files used to generate the targets here
 SOURCES =
 # List any directories that have their own Makefile here
-SUBDIRS = reads
+SUBDIRS = reads flux
 
 # Default target
 all: $(SUBDIRS) $(TARGETS)

--- a/storage/flux/Makefile
+++ b/storage/flux/Makefile
@@ -1,14 +1,11 @@
 # List any generated files here
-TARGETS = array_cursor.gen.go
+TARGETS = table.gen.go
 
 # List any source files used to generate the targets here
-SOURCES = gen.go \
-	array_cursor.gen.go.tmpl \
-	array_cursor.gen.go.tmpldata \
-	types.tmpldata
+SOURCES = table.gen.go.tmpl
 
 # List any directories that have their own Makefile here
-SUBDIRS = datatypes
+SUBDIRS = 
 
 # Default target
 all: $(SUBDIRS) $(TARGETS)

--- a/storage/flux/predicate.go
+++ b/storage/flux/predicate.go
@@ -1,4 +1,4 @@
-package reads
+package storageflux
 
 import (
 	"fmt"
@@ -8,12 +8,6 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/pkg/errors"
-)
-
-const (
-	fieldKey       = "_field"
-	measurementKey = "_measurement"
-	valueKey       = "_value"
 )
 
 func toStoragePredicate(f *semantic.FunctionExpression) (*datatypes.Predicate, error) {
@@ -119,25 +113,25 @@ func toStoragePredicateHelper(n semantic.Expression, objectName string) (*dataty
 			return nil, fmt.Errorf("unknown object %q", n.Object)
 		}
 		switch n.Property {
-		case fieldKey:
+		case datatypes.FieldKey:
 			return &datatypes.Node{
 				NodeType: datatypes.NodeTypeTagRef,
 				Value: &datatypes.Node_TagRefValue{
 					TagRefValue: models.FieldKeyTagKey,
 				},
 			}, nil
-		case measurementKey:
+		case datatypes.MeasurementKey:
 			return &datatypes.Node{
 				NodeType: datatypes.NodeTypeTagRef,
 				Value: &datatypes.Node_TagRefValue{
 					TagRefValue: models.MeasurementTagKey,
 				},
 			}, nil
-		case valueKey:
+		case datatypes.ValueKey:
 			return &datatypes.Node{
 				NodeType: datatypes.NodeTypeFieldRef,
 				Value: &datatypes.Node_FieldRefValue{
-					FieldRefValue: valueKey,
+					FieldRefValue: datatypes.ValueKey,
 				},
 			}, nil
 

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -2,9 +2,9 @@
 // https://github.com/benbjohnson/tmpl
 //
 // DO NOT EDIT!
-// Source: flux_table.gen.go.tmpl
+// Source: table.gen.go.tmpl
 
-package reads
+package storageflux
 
 import (
 	"sync"
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/influxdb/models"
+	storage "github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 	"github.com/pkg/errors"
 )
@@ -101,13 +102,13 @@ func (t *floatTable) advance() bool {
 type floatGroupTable struct {
 	table
 	mu  sync.Mutex
-	gc  GroupCursor
+	gc  storage.GroupCursor
 	cur cursors.FloatArrayCursor
 }
 
 func newFloatGroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.FloatArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,
@@ -286,13 +287,13 @@ func (t *integerTable) advance() bool {
 type integerGroupTable struct {
 	table
 	mu  sync.Mutex
-	gc  GroupCursor
+	gc  storage.GroupCursor
 	cur cursors.IntegerArrayCursor
 }
 
 func newIntegerGroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.IntegerArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,
@@ -471,13 +472,13 @@ func (t *unsignedTable) advance() bool {
 type unsignedGroupTable struct {
 	table
 	mu  sync.Mutex
-	gc  GroupCursor
+	gc  storage.GroupCursor
 	cur cursors.UnsignedArrayCursor
 }
 
 func newUnsignedGroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.UnsignedArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,
@@ -656,13 +657,13 @@ func (t *stringTable) advance() bool {
 type stringGroupTable struct {
 	table
 	mu  sync.Mutex
-	gc  GroupCursor
+	gc  storage.GroupCursor
 	cur cursors.StringArrayCursor
 }
 
 func newStringGroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.StringArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,
@@ -841,13 +842,13 @@ func (t *booleanTable) advance() bool {
 type booleanGroupTable struct {
 	table
 	mu  sync.Mutex
-	gc  GroupCursor
+	gc  storage.GroupCursor
 	cur cursors.BooleanArrayCursor
 }
 
 func newBooleanGroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.BooleanArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -1,4 +1,4 @@
-package reads
+package storageflux 
 
 import (
 	"sync"
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/influxdb/models"
+	storage "github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 	"github.com/pkg/errors"
 )
@@ -95,13 +96,13 @@ func (t *{{.name}}Table) advance() bool {
 type {{.name}}GroupTable struct {
 	table
 	mu     sync.Mutex
-	gc     GroupCursor
+	gc     storage.GroupCursor
 	cur    cursors.{{.Name}}ArrayCursor
 }
 
 func new{{.Name}}GroupTable(
 	done chan struct{},
-	gc GroupCursor,
+	gc storage.GroupCursor,
 	cur cursors.{{.Name}}ArrayCursor,
 	bounds execute.Bounds,
 	key flux.GroupKey,

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -1,6 +1,6 @@
-package reads
+package storageflux
 
-//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@types.tmpldata flux_table.gen.go.tmpl
+//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@types.tmpldata table.gen.go.tmpl
 
 import (
 	"errors"

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/data/gen"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage"
+	storageflux "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/storage/readservice"
 	"go.uber.org/zap/zaptest"
 )
@@ -153,7 +154,7 @@ func benchmarkRead(b *testing.B, sg gen.SeriesGenerator, f func(r influxdb.Reade
 	if err := engine.Open(context.Background()); err != nil {
 		b.Fatal(err)
 	}
-	reader := NewReader(readservice.NewStore(engine))
+	reader := storageflux.NewReader(readservice.NewStore(engine))
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -1,4 +1,4 @@
-package reads_test
+package storageflux_test
 
 import (
 	"context"
@@ -20,7 +20,6 @@ import (
 	"github.com/influxdata/influxdb/pkg/data/gen"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage"
-	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/readservice"
 	"go.uber.org/zap/zaptest"
 )
@@ -154,7 +153,7 @@ func benchmarkRead(b *testing.B, sg gen.SeriesGenerator, f func(r influxdb.Reade
 	if err := engine.Open(context.Background()); err != nil {
 		b.Fatal(err)
 	}
-	reader := reads.NewReader(readservice.NewStore(engine))
+	reader := NewReader(readservice.NewStore(engine))
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/storage/flux/tags_cache.go
+++ b/storage/flux/tags_cache.go
@@ -1,4 +1,4 @@
-package reads
+package storageflux
 
 import (
 	"container/list"

--- a/storage/flux/types.tmpldata
+++ b/storage/flux/types.tmpldata
@@ -1,0 +1,27 @@
+[
+	{
+		"Name":"Float",
+		"name":"float",
+		"Type":"float64"
+	},
+	{
+		"Name":"Integer",
+		"name":"integer",
+		"Type":"int64"
+	},
+	{
+		"Name":"Unsigned",
+		"name":"unsigned",
+		"Type":"uint64"
+	},
+	{
+		"Name":"String",
+		"name":"string",
+		"Type":"string"
+	},
+	{
+		"Name":"Boolean",
+		"name":"boolean",
+		"Type":"bool"
+	}
+]

--- a/storage/reads/datatypes/key_types.go
+++ b/storage/reads/datatypes/key_types.go
@@ -1,0 +1,7 @@
+package datatypes
+
+const (
+	FieldKey       = "_field"
+	MeasurementKey = "_measurement"
+	ValueKey       = "_value"
+)

--- a/storage/reads/series_cursor.go
+++ b/storage/reads/series_cursor.go
@@ -31,8 +31,8 @@ type SeriesRow struct {
 }
 
 var (
-	fieldKeyBytes       = []byte(fieldKey)
-	measurementKeyBytes = []byte(measurementKey)
+	fieldKeyBytes       = []byte(datatypes.FieldKey)
+	measurementKeyBytes = []byte(datatypes.MeasurementKey)
 )
 
 type indexSeriesCursor struct {

--- a/storage/reads/series_cursor_test.go
+++ b/storage/reads/series_cursor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxql"
 )
 
@@ -31,7 +32,7 @@ func TestPlannerCondition(t *testing.T) {
 		},
 	}
 
-	expr := fmt.Sprintf(`(%[1]s = 'cpu' AND (%[2]s = 'user' OR %[2]s = 'system')) OR (%[1]s = 'mem' AND "_value" = 0)`, measurementKey, fieldKey)
+	expr := fmt.Sprintf(`(%[1]s = 'cpu' AND (%[2]s = 'user' OR %[2]s = 'system')) OR (%[1]s = 'mem' AND "_value" = 0)`, datatypes.MeasurementKey, datatypes.FieldKey)
 	cond, err := parseExpr(expr)
 	if err != nil {
 		t.Fatal("ParseExpr", err)
@@ -61,7 +62,7 @@ func TestPlannerCondition(t *testing.T) {
 	expr = `org_bucket,%[2]s=system,%[1]s=cpu,host=host1
 org_bucket,%[2]s=user,%[1]s=mem,host=host1`
 
-	expr = fmt.Sprintf(expr, measurementKey, fieldKey)
+	expr = fmt.Sprintf(expr, datatypes.MeasurementKey, datatypes.FieldKey)
 
 	exp := strings.Split(expr, "\n")
 	if !cmp.Equal(exp, keys) {
@@ -80,9 +81,9 @@ func parseExpr(expr string) (influxql.Expr, error) {
 	e = influxql.RewriteExpr(e, func(expr influxql.Expr) influxql.Expr {
 		if vr, ok := expr.(*influxql.VarRef); ok {
 			switch vr.Val {
-			case measurementKey:
+			case datatypes.MeasurementKey:
 				vr.Val = models.MeasurementTagKey
-			case fieldKey:
+			case datatypes.FieldKey:
 				vr.Val = models.FieldKeyTagKey
 			}
 		}

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/influxdata/influxdb/query/control"
 	stdlib "github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage"
-	"github.com/influxdata/influxdb/storage/reads"
+	storageflux "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/storage/readservice"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/servicetest"
@@ -165,7 +165,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	)
 
 	// TODO(adam): do we need a proper secret service here?
-	reader := reads.NewReader(readservice.NewStore(engine))
+	reader := storageflux.NewReader(readservice.NewStore(engine))
 	deps, err := stdlib.NewDependencies(reader, engine, bucketSvc, orgSvc, nil, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR separates out the `flux` pieces from the main `reads` package within the storage libs. As the code is largely unrelated to the rest of reads, and the reads service uses components within the storage `flux` reference, we should pull this into a new package.