### PR TITLE
fix(ui): updated styling so that telegraf configs maintain their original size when filtering configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [17097](https://github.com/influxdata/influxdb/pull/17097): Listing all the default variables in the VariableTab of the script editor
 1. [17049](https://github.com/influxdata/influxdb/pull/17049): Fixed bug that was preventing the interval status on the dashboard header from refreshing on selections
 1. [17161](https://github.com/influxdata/influxdb/pull/17161): Update table custom decimal feature for tables to update table onFocus
+1. [17168](https://github.com/influxdata/influxdb/pull/17168): Fixed UI bug that was setting Telegraf config buttons off-center and was resizing config selections when filtering through the data
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
@@ -70,7 +70,7 @@ class StreamingSelector extends PureComponent<Props, State> {
     const {buckets} = this.props
     const {searchTerm} = this.state
 
-    const cardSize = `${100 / (this.filteredBundles.length + 1)}%`
+    const cardSize = `${100 / (PLUGIN_BUNDLE_OPTIONS.length + 1)}%`
 
     return (
       <div className="wizard-step--grid-container">

--- a/ui/src/telegrafs/components/Collectors.scss
+++ b/ui/src/telegrafs/components/Collectors.scss
@@ -13,8 +13,6 @@
 
 .telegraf-collectors-button-wrap {
   display: flex;
-  padding-left: 8px;
-  width: 334px;
   box-sizing: border-box;
   text-align: right;
   @media screen and (max-width: 680px) {


### PR DESCRIPTION
Closes #16663 
Closes #17166 

### Problem

1. Telegraf Config buttons were slightly off-center (too far to the right) (#17166)
2. Filtering through telegraf configs were resizing the cells beyond the screen size (#16663)

![telegraf-filter-fix](https://user-images.githubusercontent.com/19984220/76333851-703bfd80-62af-11ea-8765-fdc9398ab047.gif)

### Solution

1. Removed specific css properties to ensure that the buttons are aligned correctly
2. Updated the sizing process so that cells don't update in size as they get filtered

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)