### PR TITLE
feat: add support for complex bound parameters

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -442,6 +442,9 @@ type Query struct {
 	Parameters      map[string]interface{}
 }
 
+// Params is a type alias to the query parameters.
+type Params map[string]interface{}
+
 // NewQuery returns a query object.
 // The database and precision arguments can be empty strings if they are not needed for the query.
 func NewQuery(command, database, precision string) Query {

--- a/client/v2/example_test.go
+++ b/client/v2/example_test.go
@@ -263,3 +263,23 @@ func ExampleClient_createDatabase() {
 		fmt.Println(response.Results)
 	}
 }
+
+func ExampleClient_queryWithParams() {
+	// Make client
+	c, err := client.NewHTTPClient(client.HTTPConfig{
+		Addr: "http://localhost:8086",
+	})
+	if err != nil {
+		fmt.Println("Error creating InfluxDB Client: ", err.Error())
+	}
+	defer c.Close()
+
+	q := client.NewQueryWithParameters("SELECT $fn($value) FROM $m", "square_holes", "ns", client.Params{
+		"fn":    client.Identifier("count"),
+		"value": client.Identifier("value"),
+		"m":     client.Identifier("shapes"),
+	})
+	if response, err := c.Query(q); err == nil && response.Error() == nil {
+		fmt.Println(response.Results)
+	}
+}

--- a/client/v2/params.go
+++ b/client/v2/params.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type (
+	// Identifier is an identifier value.
+	Identifier string
+
+	// StringValue is a string literal.
+	StringValue string
+
+	// RegexValue is a regexp literal.
+	RegexValue string
+
+	// NumberValue is a number literal.
+	NumberValue float64
+
+	// IntegerValue is an integer literal.
+	IntegerValue int64
+
+	// BooleanValue is a boolean literal.
+	BooleanValue bool
+
+	// TimeValue is a time literal.
+	TimeValue time.Time
+
+	// DurationValue is a duration literal.
+	DurationValue time.Duration
+)
+
+func (v Identifier) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"identifier": string(v)}
+	return json.Marshal(m)
+}
+
+func (v StringValue) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"string": string(v)}
+	return json.Marshal(m)
+}
+
+func (v RegexValue) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"regex": string(v)}
+	return json.Marshal(m)
+}
+
+func (v NumberValue) MarshalJSON() ([]byte, error) {
+	m := map[string]float64{"number": float64(v)}
+	return json.Marshal(m)
+}
+
+func (v IntegerValue) MarshalJSON() ([]byte, error) {
+	m := map[string]int64{"integer": int64(v)}
+	return json.Marshal(m)
+}
+
+func (v BooleanValue) MarshalJSON() ([]byte, error) {
+	m := map[string]bool{"boolean": bool(v)}
+	return json.Marshal(m)
+}
+
+func (v TimeValue) MarshalJSON() ([]byte, error) {
+	t := time.Time(v)
+	m := map[string]string{"string": t.Format(time.RFC3339Nano)}
+	return json.Marshal(m)
+}
+
+func (v DurationValue) MarshalJSON() ([]byte, error) {
+	m := map[string]int64{"duration": int64(v)}
+	return json.Marshal(m)
+}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/google/go-cmp v0.4.0
 	github.com/influxdata/flux v0.64.0
-	github.com/influxdata/influxql v1.0.1
+	github.com/influxdata/influxql v1.1.0
 	github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jsternberg/zap-logfmt v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.64.0 h1:tQ1ydITwqmLM/Cuf20JRf/1ZMHkpgYv63ZbxIy8Bnvs=
 github.com/influxdata/flux v0.64.0/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
-github.com/influxdata/influxql v1.0.1 h1:6PGG0SunRmptIMIreNRolhQ38Sq4qDfi2dS3BS1YD8Y=
-github.com/influxdata/influxql v1.0.1/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
+github.com/influxdata/influxql v1.1.0 h1:sPsaumLFRPMwR5QtD3Up54HXpNND8Eu7G1vQFmi3quQ=
+github.com/influxdata/influxql v1.1.0/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=


### PR DESCRIPTION
This updates influxql to a newer version that supports complex bound
parameters. This allows bound parameters to be used as identifiers,
regexes, and durations along with the already existing strings, numbers,
and booleans.

This updates the influxdb client to support passing bound parameters as
part of the parameters json and updates the readme to show how to use
this feature.