### PR TITLE
fix(query): use query dialect annotations specified in request

### DIFF
--- a/flux/client/request.go
+++ b/flux/client/request.go
@@ -126,6 +126,9 @@ func (r QueryRequest) ProxyRequest() *ProxyRequest {
 	cfg := csv.DefaultEncoderConfig()
 	cfg.NoHeader = noHeader
 	cfg.Delimiter = delimiter
+	if r.Dialect.Annotations != nil {
+		cfg.Annotations = r.Dialect.Annotations
+	}
 
 	return &ProxyRequest{
 		Compiler: compiler,

--- a/flux/client/request_test.go
+++ b/flux/client/request_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/influxdb/pkg/testing/assert"
+)
+
+func TestRequest_ProxyRequest_Annotations(t *testing.T) {
+
+	for _, tt := range []struct {
+		qr          *QueryRequest
+		annotations []string
+	}{
+		{
+			qr:          &QueryRequest{Query: "from"},
+			annotations: []string{"datatype", "group", "default"},
+		},
+		{
+			qr:          &QueryRequest{Query: "from", Dialect: QueryDialect{Annotations: []string{"datatype", "group", "default"}}},
+			annotations: []string{"datatype", "group", "default"},
+		},
+		{
+			qr:          &QueryRequest{Query: "from", Dialect: QueryDialect{Annotations: []string{"datatype", "group"}}},
+			annotations: []string{"datatype", "group"},
+		},
+		{
+			qr:          &QueryRequest{Query: "from", Dialect: QueryDialect{Annotations: nil}},
+			annotations: []string{"datatype", "group", "default"},
+		},
+		{
+			qr:          &QueryRequest{Query: "from", Dialect: QueryDialect{Annotations: []string{}}},
+			annotations: []string{},
+		},
+	} {
+		dialect := tt.qr.ProxyRequest().Dialect.(csv.Dialect)
+		assert.Equal(t, dialect.ResultEncoderConfig.Annotations, tt.annotations, "invalid annotations")
+	}
+}


### PR DESCRIPTION
Closes #17195

Fixed ignoring dialect annotations.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
