### PR TITLE
fix(ui): fixed dashboard cells and check query builder update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1. [17161](https://github.com/influxdata/influxdb/pull/17161): Update table custom decimal feature for tables to update table onFocus
 1. [17168](https://github.com/influxdata/influxdb/pull/17168): Fixed UI bug that was setting Telegraf config buttons off-center and was resizing config selections when filtering through the data
 1. [17208](https://github.com/influxdata/influxdb/pull/17208): Fixed UI bug that was setting causing dashboard cells to error when the a v.bucket was being used and was being configured for the first time
+1. [17202](https://github.com/influxdata/influxdb/pull/17202): Fixed UI bug that was preventing checks created with the query builder from updating. Also fixed a bug that was preventing dashboard cell queries from working properly when creating group queries using the query builder
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -873,8 +873,9 @@ type DashboardQuery struct {
 type BuilderConfig struct {
 	Buckets []string `json:"buckets"`
 	Tags    []struct {
-		Key    string   `json:"key"`
-		Values []string `json:"values"`
+		Key                   string   `json:"key"`
+		Values                []string `json:"values"`
+		AggregateFunctionType string   `json:"aggregateFunctionType"`
 	} `json:"tags"`
 	Functions []struct {
 		Name string `json:"name"`
@@ -895,8 +896,9 @@ func (b BuilderConfig) MarshalJSON() ([]byte, error) {
 	}
 	if copyCfg.Tags == nil {
 		copyCfg.Tags = []struct {
-			Key    string   `json:"key"`
-			Values []string `json:"values"`
+			Key                   string   `json:"key"`
+			Values                []string `json:"values"`
+			AggregateFunctionType string   `json:"aggregateFunctionType"`
 		}{}
 	}
 	if copyCfg.Functions == nil {
@@ -911,16 +913,19 @@ func (b BuilderConfig) MarshalJSON() ([]byte, error) {
 // isn't technically required, but working with struct literals with embedded
 // struct tags is really painful. This is to get around that bit. Would be nicer
 // to have these as actual types maybe.
-func NewBuilderTag(key string, values ...string) struct {
-	Key    string   `json:"key"`
-	Values []string `json:"values"`
+func NewBuilderTag(key string, values []string, functionType string) struct {
+	Key                   string   `json:"key"`
+	Values                []string `json:"values"`
+	AggregateFunctionType string   `json:"aggregateFunctionType"`
 } {
 	return struct {
-		Key    string   `json:"key"`
-		Values []string `json:"values"`
+		Key                   string   `json:"key"`
+		Values                []string `json:"values"`
+		AggregateFunctionType string   `json:"aggregateFunctionType"`
 	}{
-		Key:    key,
-		Values: values,
+		Key:                   key,
+		Values:                values,
+		AggregateFunctionType: functionType,
 	}
 }
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -913,7 +913,7 @@ func (b BuilderConfig) MarshalJSON() ([]byte, error) {
 // isn't technically required, but working with struct literals with embedded
 // struct tags is really painful. This is to get around that bit. Would be nicer
 // to have these as actual types maybe.
-func NewBuilderTag(key string, values []string, functionType string) struct {
+func NewBuilderTag(key string, functionType string, values ...string) struct {
 	Key                   string   `json:"key"`
 	Values                []string `json:"values"`
 	AggregateFunctionType string   `json:"aggregateFunctionType"`

--- a/notification/check/check_test.go
+++ b/notification/check/check_test.go
@@ -191,8 +191,9 @@ func TestJSON(t *testing.T) {
 						BuilderConfig: influxdb.BuilderConfig{
 							Buckets: []string{},
 							Tags: []struct {
-								Key    string   `json:"key"`
-								Values []string `json:"values"`
+								Key                   string   `json:"key"`
+								Values                []string `json:"values"`
+								AggregateFunctionType string   `json:"aggregateFunctionType"`
 							}{},
 							Functions: []struct {
 								Name string `json:"name"`
@@ -232,8 +233,9 @@ func TestJSON(t *testing.T) {
 						BuilderConfig: influxdb.BuilderConfig{
 							Buckets: []string{},
 							Tags: []struct {
-								Key    string   `json:"key"`
-								Values []string `json:"values"`
+								Key                   string   `json:"key"`
+								Values                []string `json:"values"`
+								AggregateFunctionType string   `json:"aggregateFunctionType"`
 							}{},
 							Functions: []struct {
 								Name string `json:"name"`

--- a/notification/check/deadman_test.go
+++ b/notification/check/deadman_test.go
@@ -38,12 +38,14 @@ func TestDeadman_GenerateFlux(t *testing.T) {
 							Text: `from(bucket: "foo") |> range(start: -1d, stop: now()) |> aggregateWindow(fn: mean, every: 1m) |> yield()`,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -99,12 +101,14 @@ data
 							Text: `from(bucket: "foo") |> range(start: -1d, stop: now()) |> yield()`,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2638,7 +2638,7 @@ func (q queries) influxDashQueries() []influxdb.DashboardQuery {
 			EditMode: "advanced",
 		}
 		// TODO: axe this builder configs when issue https://github.com/influxdata/influxdb/issues/15708 is fixed up
-		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", ""))
+		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", []string{""}, "filter"))
 		iQueries = append(iQueries, newQuery)
 	}
 	return iQueries

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2638,7 +2638,7 @@ func (q queries) influxDashQueries() []influxdb.DashboardQuery {
 			EditMode: "advanced",
 		}
 		// TODO: axe this builder configs when issue https://github.com/influxdata/influxdb/issues/15708 is fixed up
-		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", []string{""}, "filter"))
+		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", []string{""}))
 		iQueries = append(iQueries, newQuery)
 	}
 	return iQueries

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2638,7 +2638,7 @@ func (q queries) influxDashQueries() []influxdb.DashboardQuery {
 			EditMode: "advanced",
 		}
 		// TODO: axe this builder configs when issue https://github.com/influxdata/influxdb/issues/15708 is fixed up
-		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", []string{""}))
+		newQuery.BuilderConfig.Tags = append(newQuery.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", ""))
 		iQueries = append(iQueries, newQuery)
 	}
 	return iQueries

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1577,7 +1577,7 @@ func TestService(t *testing.T) {
 					EditMode: "advanced",
 				}
 				// TODO: remove this when issue that forced the builder tag to be here to render in UI.
-				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", ""))
+				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", []string{"usage_user"}, "filter"))
 				return q
 			}
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1577,7 +1577,7 @@ func TestService(t *testing.T) {
 					EditMode: "advanced",
 				}
 				// TODO: remove this when issue that forced the builder tag to be here to render in UI.
-				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", []string{"usage_user"}))
+				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", ""))
 				return q
 			}
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1577,7 +1577,7 @@ func TestService(t *testing.T) {
 					EditMode: "advanced",
 				}
 				// TODO: remove this when issue that forced the builder tag to be here to render in UI.
-				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", []string{"usage_user"}, "filter"))
+				q.BuilderConfig.Tags = append(q.BuilderConfig.Tags, influxdb.NewBuilderTag("_measurement", "filter", []string{"usage_user"}))
 				return q
 			}
 

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -46,12 +46,14 @@ var deadman1 = &check.Deadman{
 			BuilderConfig: influxdb.BuilderConfig{
 				Buckets: []string{},
 				Tags: []struct {
-					Key    string   `json:"key"`
-					Values []string `json:"values"`
+					Key                   string   `json:"key"`
+					Values                []string `json:"values"`
+					AggregateFunctionType string   `json:"aggregateFunctionType"`
 				}{
 					{
-						Key:    "_field",
-						Values: []string{"usage_user"},
+						Key:                   "_field",
+						Values:                []string{"usage_user"},
+						AggregateFunctionType: "filter",
 					},
 				},
 				Functions: []struct {
@@ -91,8 +93,9 @@ var threshold1 = &check.Threshold{
 			BuilderConfig: influxdb.BuilderConfig{
 				Buckets: []string{},
 				Tags: []struct {
-					Key    string   `json:"key"`
-					Values []string `json:"values"`
+					Key                   string   `json:"key"`
+					Values                []string `json:"values"`
+					AggregateFunctionType string   `json:"aggregateFunctionType"`
 				}{},
 				Functions: []struct {
 					Name string `json:"name"`
@@ -270,12 +273,14 @@ func CreateCheck(
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -326,12 +331,14 @@ func CreateCheck(
 								BuilderConfig: influxdb.BuilderConfig{
 									Buckets: []string{},
 									Tags: []struct {
-										Key    string   `json:"key"`
-										Values []string `json:"values"`
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
 									}{
 										{
-											Key:    "_field",
-											Values: []string{"usage_user"},
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
 										},
 									},
 									Functions: []struct {
@@ -519,12 +526,14 @@ func CreateCheck(
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -611,12 +620,14 @@ func CreateCheck(
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -657,12 +668,14 @@ func CreateCheck(
 								BuilderConfig: influxdb.BuilderConfig{
 									Buckets: []string{},
 									Tags: []struct {
-										Key    string   `json:"key"`
-										Values []string `json:"values"`
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
 									}{
 										{
-											Key:    "_field",
-											Values: []string{"usage_user"},
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
 										},
 									},
 									Functions: []struct {
@@ -705,12 +718,14 @@ func CreateCheck(
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -1495,12 +1510,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -1555,12 +1572,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 							Text: script,
 							BuilderConfig: influxdb.BuilderConfig{
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 							},
@@ -1624,12 +1643,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 								Text: script,
 								BuilderConfig: influxdb.BuilderConfig{
 									Tags: []struct {
-										Key    string   `json:"key"`
-										Values []string `json:"values"`
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
 									}{
 										{
-											Key:    "_field",
-											Values: []string{"usage_user"},
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
 										},
 									},
 								},
@@ -1763,12 +1784,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 							BuilderConfig: influxdb.BuilderConfig{
 								Buckets: []string{},
 								Tags: []struct {
-									Key    string   `json:"key"`
-									Values []string `json:"values"`
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
 								}{
 									{
-										Key:    "_field",
-										Values: []string{"usage_user"},
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
 									},
 								},
 								Functions: []struct {
@@ -1816,12 +1839,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 								Text: script,
 								BuilderConfig: influxdb.BuilderConfig{
 									Tags: []struct {
-										Key    string   `json:"key"`
-										Values []string `json:"values"`
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
 									}{
 										{
-											Key:    "_field",
-											Values: []string{"usage_user"},
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
 										},
 									},
 								},

--- a/ui/cypress/fixtures/view.json
+++ b/ui/cypress/fixtures/view.json
@@ -16,7 +16,8 @@
           "tags": [
             {
               "key": "",
-              "values": []
+              "values": [],
+              "aggregateFunctionType": ""
             }
           ],
           "functions": [],

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -926,6 +926,7 @@ export const viewProperties: ViewProperties = {
           {
             key: '_measurement',
             values: [],
+            aggregateFunctionType: 'filter',
           },
         ],
         functions: [],

--- a/ui/src/alerting/utils/customCheck.test.ts
+++ b/ui/src/alerting/utils/customCheck.test.ts
@@ -4,7 +4,10 @@ import {AlertBuilderState} from '../reducers/alertBuilder'
 
 const bc1: BuilderConfig = {
   buckets: ['bestBuck'],
-  tags: [{key: 'k1', values: ['v1']}, {key: '_field', values: ['v2']}],
+  tags: [
+    {key: 'k1', values: ['v1'], aggregateFunctionType: 'filter'},
+    {key: '_field', values: ['v2'], aggregateFunctionType: 'filter'},
+  ],
   functions: [{name: 'mean'}],
 }
 

--- a/ui/src/shared/utils/mocks/resourceToTemplate.ts
+++ b/ui/src/shared/utils/mocks/resourceToTemplate.ts
@@ -43,10 +43,12 @@ export const myView: View = {
             {
               key: '_measurement',
               values: ['cpu'],
+              aggregateFunctionType: 'filter',
             },
             {
               key: '_field',
               values: [],
+              aggregateFunctionType: 'filter',
             },
           ],
           functions: [],

--- a/ui/src/shared/utils/resourceToTemplate.test.ts
+++ b/ui/src/shared/utils/resourceToTemplate.test.ts
@@ -364,6 +364,7 @@ describe('resourceToTemplate', () => {
                           {
                             key: '_measurement',
                             values: [],
+                            aggregateFunctionType: 'filter',
                           },
                         ],
                         functions: [],

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -803,6 +803,7 @@ export const timeMachineReducer = (
 
         tag.key = key
         tag.values = []
+        tag.aggregateFunctionType = 'filter'
       })
     }
 
@@ -812,7 +813,6 @@ export const timeMachineReducer = (
         const draftQuery = draftState.draftQueries[draftState.activeQueryIndex]
 
         draftQuery.builderConfig.tags[index].values = values
-
         buildActiveQuery(draftState)
       })
     }

--- a/ui/src/timeMachine/selectors/index.test.ts
+++ b/ui/src/timeMachine/selectors/index.test.ts
@@ -12,6 +12,7 @@ const custom = 'custom' as 'custom'
 describe('TimeMachine.Selectors.Index', () => {
   const thirty = moment()
     .subtract(30, 'days')
+    .subtract(moment().isDST() ? 1 : 0, 'hours') // added to account for DST
     .valueOf()
   it(`getStartTime should return ${thirty} when lower is now() - 30d`, () => {
     expect(getStartTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(thirty)

--- a/ui/src/views/helpers/index.ts
+++ b/ui/src/views/helpers/index.ts
@@ -52,7 +52,7 @@ export function defaultViewQuery(): DashboardQuery {
 export function defaultBuilderConfig(): BuilderConfig {
   return {
     buckets: [],
-    tags: [{key: '_measurement', values: []}],
+    tags: [{key: '_measurement', values: [], aggregateFunctionType: 'filter'}],
     functions: [],
     aggregateWindow: {period: 'auto'},
   }
@@ -269,7 +269,13 @@ const NEW_VIEW_CREATORS = {
           editMode: 'builder',
           builderConfig: {
             buckets: [],
-            tags: [{key: '_measurement', values: []}],
+            tags: [
+              {
+                key: '_measurement',
+                values: [],
+                aggregateFunctionType: 'filter',
+              },
+            ],
             functions: [{name: 'mean'}],
             aggregateWindow: {period: DEFAULT_CHECK_EVERY},
           },
@@ -291,7 +297,13 @@ const NEW_VIEW_CREATORS = {
           editMode: 'builder',
           builderConfig: {
             buckets: [],
-            tags: [{key: '_measurement', values: []}],
+            tags: [
+              {
+                key: '_measurement',
+                values: [],
+                aggregateFunctionType: 'filter',
+              },
+            ],
             functions: [],
           },
         },


### PR DESCRIPTION
Closes #17130

### Problem

1. Updates made to existing Checks were not registering the changes
2. Creating cells with Group as the aggregate function type were not maintaining the aggregate type

### Solution

Updated the `BuilderConfig tag` struct to account for the `AggregateFunctionType` that had been passed in by the UI but was not being stored on the API. The consequence of this action allows the UI to have access to the `aggregateFunctionType` as a reference for making changes in the query builder. Put simply, the existing query builder is built around the fact that an `aggregateFunctionType` will be passed in as a tag property, but it was not. 

Check Update Fix:
![check_update_fix](https://user-images.githubusercontent.com/19984220/76439231-50710c00-6379-11ea-93e0-b90f35307ff3.gif)

Dashboard Cell Fix:
![dashboard_cell_fix](https://user-images.githubusercontent.com/19984220/76439261-5bc43780-6379-11ea-81db-db9a05fdcc88.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
