### PR TITLE
feat(sampledata): Allow users to query buckets in 'other' org

### DIFF
--- a/ui/src/authorizations/actions/thunks.ts
+++ b/ui/src/authorizations/actions/thunks.ts
@@ -36,10 +36,12 @@ import {
   NotificationAction,
   Authorization,
   AuthEntities,
+  ResourceType,
 } from 'src/types'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
+import {getStatus} from 'src/resources/selectors'
 
 type GetAuthorizations = (
   dispatch: Dispatch<Action | NotificationAction>,
@@ -50,8 +52,15 @@ export const getAuthorizations = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setAuthorizations(RemoteDataState.Loading))
-    const org = getOrg(getState())
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.Authorizations) ===
+      RemoteDataState.NotStarted
+    ) {
+      dispatch(setAuthorizations(RemoteDataState.Loading))
+    }
+
+    const org = getOrg(state)
     const resp = await api.getAuthorizations({query: {orgID: org.id}})
 
     if (resp.status !== 200) {

--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -17,11 +17,13 @@ import {
   Bucket,
   BucketEntities,
   Label,
+  ResourceType,
 } from 'src/types'
 
 // Utils
 import {getErrorMessage} from 'src/utils/api'
 import {getOrg} from 'src/organizations/selectors'
+import {getLabels, getStatus} from 'src/resources/selectors'
 
 // Actions
 import {
@@ -46,7 +48,6 @@ import {
   addBucketLabelFailed,
   removeBucketLabelFailed,
 } from 'src/shared/copy/notifications'
-import {getLabels} from 'src/resources/selectors'
 
 type Action = BucketAction | NotifyAction
 
@@ -55,8 +56,11 @@ export const getBuckets = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setBuckets(RemoteDataState.Loading))
-    const org = getOrg(getState())
+    const state = getState()
+    if (getStatus(state, ResourceType.Buckets) === RemoteDataState.NotStarted) {
+      dispatch(setBuckets(RemoteDataState.Loading))
+    }
+    const org = getOrg(state)
 
     const resp = await api.getBuckets({query: {orgID: org.id}})
 

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -41,6 +41,7 @@ import {
 import {prettyBuckets} from 'src/shared/utils/prettyBucket'
 import {extractBucketLimits} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
+import {getAll} from 'src/resources/selectors'
 
 // Types
 import {
@@ -51,7 +52,6 @@ import {
   ResourceType,
 } from 'src/types'
 import {SortTypes} from 'src/shared/utils/sort'
-import {getAll} from 'src/resources/selectors'
 
 interface StateProps {
   org: Organization

--- a/ui/src/checks/actions/thunks.ts
+++ b/ui/src/checks/actions/thunks.ts
@@ -18,7 +18,7 @@ import {reportError} from 'src/shared/utils/errors'
 import {createView} from 'src/views/helpers'
 import {getOrg} from 'src/organizations/selectors'
 import {toPostCheck, builderToPostCheck} from 'src/checks/utils'
-import {getAll} from 'src/resources/selectors'
+import {getAll, getStatus} from 'src/resources/selectors'
 
 // Actions
 import {
@@ -66,8 +66,11 @@ export const getChecks = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setChecks(RemoteDataState.Loading))
-    const {id: orgID} = getOrg(getState())
+    const state = getState()
+    if (getStatus(state, ResourceType.Checks) === RemoteDataState.NotStarted) {
+      dispatch(setChecks(RemoteDataState.Loading))
+    }
+    const {id: orgID} = getOrg(state)
 
     const resp = await api.getChecks({query: {orgID}})
 

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -48,7 +48,7 @@ import {getSaveableView} from 'src/timeMachine/selectors'
 import {incrementCloneName} from 'src/utils/naming'
 import {isLimitError} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll, getByID} from 'src/resources/selectors'
+import {getAll, getByID, getStatus} from 'src/resources/selectors'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -193,10 +193,17 @@ export const getDashboards = () => async (
   getState: GetState
 ): Promise<void> => {
   try {
-    const org = getOrg(getState())
     const {setDashboards} = creators
 
-    dispatch(setDashboards(RemoteDataState.Loading))
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.Dashboards) === RemoteDataState.NotStarted
+    ) {
+      dispatch(setDashboards(RemoteDataState.Loading))
+    }
+
+    const org = getOrg(state)
+
     const resp = await api.getDashboards({query: {orgID: org.id}})
 
     if (resp.status !== 200) {

--- a/ui/src/dashboards/components/DashboardContainer.tsx
+++ b/ui/src/dashboards/components/DashboardContainer.tsx
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 
 // Components
 import GetResource from 'src/resources/components/GetResource'
+import GetResources from 'src/resources/components/GetResources'
 import DashboardPage from 'src/dashboards/components/DashboardPage'
 import GetTimeRange from 'src/dashboards/components/GetTimeRange'
 import DashboardRoute from 'src/shared/components/DashboardRoute'
@@ -43,9 +44,11 @@ const DashboardContainer: FC<Props> = ({autoRefresh, dashboard, children}) => {
   return (
     <DashboardRoute>
       <GetResource resources={[{type: ResourceType.Dashboards, id: dashboard}]}>
-        <GetTimeRange />
-        <DashboardPage autoRefresh={autoRefresh} />
-        {children}
+        <GetResources resources={[ResourceType.Buckets]}>
+          <GetTimeRange />
+          <DashboardPage autoRefresh={autoRefresh} />
+          {children}
+        </GetResources>
       </GetResource>
     </DashboardRoute>
   )

--- a/ui/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/ui/src/dataExplorer/components/DataExplorerPage.tsx
@@ -21,7 +21,7 @@ const DataExplorerPage: SFC = ({children}) => {
   return (
     <Page titleTag={pageTitleSuffixer(['Data Explorer'])}>
       {children}
-      <GetResources resources={[ResourceType.Variables]}>
+      <GetResources resources={[ResourceType.Variables, ResourceType.Buckets]}>
         <Page.Header fullWidth={true}>
           <Page.Title title="Data Explorer" />
         </Page.Header>

--- a/ui/src/dataLoaders/actions/telegrafEditor.ts
+++ b/ui/src/dataLoaders/actions/telegrafEditor.ts
@@ -1,20 +1,32 @@
-import {Bucket} from 'src/types'
-import {getTelegrafPlugins} from 'src/client'
-import {RemoteDataState} from 'src/types'
 import {Dispatch} from 'react'
+
+import {getTelegrafPlugins} from 'src/client'
+
 import {
   TelegrafEditorPluginState,
   TelegrafEditorActivePluginState,
   TelegrafEditorBasicPlugin,
 } from 'src/dataLoaders/reducers/telegrafEditor'
 
+// Utils
+
+// Types
+import {Bucket, RemoteDataState, ResourceType, GetState} from 'src/types'
+import {getStatus} from 'src/resources/selectors'
+
 export type PluginResourceAction =
   | ReturnType<typeof setPlugins>
   | ReturnType<typeof setPluginLoadingState>
 
 export const getPlugins = () => async (
-  dispatch: Dispatch<PluginResourceAction>
+  dispatch: Dispatch<PluginResourceAction>,
+  getState: GetState
 ) => {
+  const state = getState()
+  if (getStatus(state, ResourceType.Plugins) === RemoteDataState.NotStarted) {
+    dispatch(setPluginLoadingState(RemoteDataState.Loading))
+  }
+
   dispatch(setPluginLoadingState(RemoteDataState.Loading))
 
   const result = await getTelegrafPlugins({}, {})

--- a/ui/src/labels/actions/thunks.ts
+++ b/ui/src/labels/actions/thunks.ts
@@ -20,6 +20,7 @@ import {
   GetState,
   Label,
   LabelEntities,
+  ResourceType,
 } from 'src/types'
 
 // Actions
@@ -40,14 +41,19 @@ import {
 // Utils
 import {getOrg} from 'src/organizations/selectors'
 import {viewableLabels} from 'src/labels/selectors'
+import {getStatus} from 'src/resources/selectors'
 
 export const getLabels = () => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
   try {
-    const org = getOrg(getState())
-    dispatch(setLabels(RemoteDataState.Loading))
+    const state = getState()
+    if (getStatus(state, ResourceType.Labels) === RemoteDataState.NotStarted) {
+      dispatch(setLabels(RemoteDataState.Loading))
+    }
+
+    const org = getOrg(state)
 
     const resp = await apiGetLabels({query: {orgID: org.id}})
 

--- a/ui/src/members/actions/thunks.ts
+++ b/ui/src/members/actions/thunks.ts
@@ -1,4 +1,5 @@
 // Libraries
+import {Dispatch} from 'react'
 import {get} from 'lodash'
 import {normalize} from 'normalizr'
 
@@ -7,10 +8,14 @@ import * as api from 'src/client'
 import {memberSchema, arrayOfMembers} from 'src/schemas'
 
 // Types
-import {RemoteDataState, GetState} from 'src/types'
+import {
+  RemoteDataState,
+  GetState,
+  Member,
+  MemberEntities,
+  ResourceType,
+} from 'src/types'
 import {AddResourceMemberRequestBody} from '@influxdata/influx'
-import {Dispatch} from 'react'
-import {Member, MemberEntities} from 'src/types'
 
 // Actions
 import {
@@ -29,14 +34,19 @@ import {
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
+import {getStatus} from 'src/resources/selectors'
 
 export const getMembers = () => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
   try {
-    const {id} = getOrg(getState())
-    dispatch(setMembers(RemoteDataState.Loading))
+    const state = getState()
+    if (getStatus(state, ResourceType.Members) === RemoteDataState.NotStarted) {
+      dispatch(setMembers(RemoteDataState.Loading))
+    }
+
+    const {id} = getOrg(state)
 
     const [ownersResp, membersResp] = await Promise.all([
       api.getOrgsOwners({orgID: id}),

--- a/ui/src/notifications/endpoints/actions/thunks.ts
+++ b/ui/src/notifications/endpoints/actions/thunks.ts
@@ -27,7 +27,7 @@ import * as api from 'src/client'
 // Utils
 import {incrementCloneName} from 'src/utils/naming'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll} from 'src/resources/selectors'
+import {getAll, getStatus} from 'src/resources/selectors'
 import {toPostNotificationEndpoint} from 'src/notifications/endpoints/utils'
 import * as copy from 'src/shared/copy/notifications'
 
@@ -50,9 +50,15 @@ export const getEndpoints = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setEndpoints(RemoteDataState.Loading))
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.NotificationEndpoints) ===
+      RemoteDataState.NotStarted
+    ) {
+      dispatch(setEndpoints(RemoteDataState.Loading))
+    }
 
-    const {id: orgID} = getOrg(getState())
+    const {id: orgID} = getOrg(state)
 
     const resp = await api.getNotificationEndpoints({
       query: {orgID},

--- a/ui/src/notifications/rules/actions/thunks.ts
+++ b/ui/src/notifications/rules/actions/thunks.ts
@@ -31,7 +31,7 @@ import {setLabelOnResource} from 'src/labels/actions/creators'
 // Utils
 import {draftRuleToPostRule} from 'src/notifications/rules/utils'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll} from 'src/resources/selectors'
+import {getAll, getStatus} from 'src/resources/selectors'
 
 // Types
 import {
@@ -54,8 +54,16 @@ export const getNotificationRules = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setRules(RemoteDataState.Loading))
-    const {id: orgID} = getOrg(getState())
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.NotificationRules) ===
+      RemoteDataState.NotStarted
+    ) {
+      dispatch(setRules(RemoteDataState.Loading))
+    }
+
+    const {id: orgID} = getOrg(state)
+
     const resp = await api.getNotificationRules({query: {orgID}})
 
     if (resp.status !== 200) {

--- a/ui/src/scrapers/actions/thunks.ts
+++ b/ui/src/scrapers/actions/thunks.ts
@@ -8,7 +8,13 @@ import {client} from 'src/utils/api'
 import {arrayOfScrapers, scraperSchema} from 'src/schemas'
 
 // Types
-import {RemoteDataState, GetState, Scraper, ScraperEntities} from 'src/types'
+import {
+  RemoteDataState,
+  GetState,
+  Scraper,
+  ScraperEntities,
+  ResourceType,
+} from 'src/types'
 import {Dispatch} from 'react'
 
 // Actions
@@ -32,6 +38,7 @@ import {
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
+import {getStatus} from 'src/resources/selectors'
 
 type Action = ScraperAction | NotifyAction
 
@@ -40,7 +47,13 @@ export const getScrapers = () => async (
   getState: GetState
 ) => {
   try {
-    const org = getOrg(getState())
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.Scrapers) === RemoteDataState.NotStarted
+    ) {
+      dispatch(setScrapers(RemoteDataState.Loading))
+    }
+    const org = getOrg(state)
 
     dispatch(setScrapers(RemoteDataState.Loading))
 

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -18,6 +18,8 @@ import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import 'intersection-observer'
+import {getAll} from 'src/resources/selectors'
+import {getOrgIDFromBuckets} from 'src/timeMachine/actions/queries'
 
 // Constants
 import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
@@ -26,11 +28,17 @@ import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Types
-import {RemoteDataState, Check, StatusRow} from 'src/types'
-import {DashboardQuery} from 'src/types/dashboards'
-import {AppState} from 'src/types'
-import {CancelBox} from 'src/types/promises'
-import {VariableAssignment} from 'src/types/ast'
+import {
+  RemoteDataState,
+  Check,
+  StatusRow,
+  Bucket,
+  ResourceType,
+  DashboardQuery,
+  VariableAssignment,
+  AppState,
+  CancelBox,
+} from 'src/types'
 
 interface QueriesState {
   files: string[] | null
@@ -44,6 +52,7 @@ interface QueriesState {
 
 interface StateProps {
   queryLink: string
+  buckets: Bucket[]
 }
 
 interface OwnProps {
@@ -153,9 +162,8 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
   }
 
   private reload = async () => {
-    const {variables, notify, check} = this.props
+    const {variables, notify, check, buckets} = this.props
     const queries = this.props.queries.filter(({text}) => !!text.trim())
-    const orgID = this.props.params.orgID
 
     if (!queries.length) {
       this.setState(defaultState())
@@ -177,6 +185,9 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
       // Issue new queries
       this.pendingResults = queries.map(({text}) => {
+        const orgID =
+          getOrgIDFromBuckets(text, buckets) || this.props.params.orgID
+
         const windowVars = getWindowVars(text, variables)
         const extern = buildVarsOption([...variables, ...windowVars])
 
@@ -189,7 +200,11 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
       let statuses = [] as StatusRow[][]
       if (check) {
         const extern = buildVarsOption(variables)
-        this.pendingCheckStatuses = runStatusesQuery(orgID, check.id, extern)
+        this.pendingCheckStatuses = runStatusesQuery(
+          this.props.params.orgID,
+          check.id,
+          extern
+        )
         statuses = await this.pendingCheckStatuses.promise // TODO handle errors
       }
 
@@ -263,10 +278,13 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
   }
 }
 
-const mstp = (state: AppState) => {
+const mstp = (state: AppState): StateProps => {
   const {links} = state
 
-  return {queryLink: links.query.self}
+  return {
+    queryLink: links.query.self,
+    buckets: getAll<Bucket>(state, ResourceType.Buckets),
+  }
 }
 
 const mdtp: DispatchProps = {

--- a/ui/src/tasks/actions/thunks.ts
+++ b/ui/src/tasks/actions/thunks.ts
@@ -40,6 +40,7 @@ import {
   TaskSchedule,
   RemoteDataState,
   TaskEntities,
+  ResourceType,
 } from 'src/types'
 
 // Utils
@@ -49,6 +50,7 @@ import {taskToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {isLimitError} from 'src/cloud/utils/limits'
 import {checkTaskLimits} from 'src/cloud/actions/limits'
 import {getOrg} from 'src/organizations/selectors'
+import {getStatus} from 'src/resources/selectors'
 
 type Action = TaskAction | ExternalActions | ReturnType<typeof getTasks>
 type ExternalActions = NotifyAction | ReturnType<typeof checkTaskLimits>
@@ -59,9 +61,13 @@ export const getTasks = () => async (
   getState: GetState
 ): Promise<void> => {
   try {
-    dispatch(setTasks(RemoteDataState.Loading))
+    const state = getState()
+    if (getStatus(state, ResourceType.Tasks) === RemoteDataState.NotStarted) {
+      dispatch(setTasks(RemoteDataState.Loading))
+    }
 
-    const org = getOrg(getState())
+    const org = getOrg(state)
+
     const resp = await api.getTasks({query: {orgID: org.id}})
 
     if (resp.status !== 200) {

--- a/ui/src/telegrafs/actions/thunks.ts
+++ b/ui/src/telegrafs/actions/thunks.ts
@@ -1,23 +1,12 @@
 // Libraries
 import {normalize} from 'normalizr'
+import {Dispatch} from 'react'
 
 // API
 import {client} from 'src/utils/api'
 
 // Schemas
 import {telegrafSchema, arrayOfTelegrafs} from 'src/schemas/telegrafs'
-
-// Types
-import {ILabel} from '@influxdata/influx'
-import {
-  AppThunk,
-  RemoteDataState,
-  GetState,
-  Telegraf,
-  Label,
-  TelegrafEntities,
-} from 'src/types'
-import {Dispatch} from 'react'
 
 // Actions
 import {notify} from 'src/shared/actions/notifications'
@@ -30,7 +19,7 @@ import {
   setCurrentConfig,
 } from 'src/telegrafs/actions/creators'
 
-// Utils
+// Constants
 import {
   telegrafGetFailed,
   telegrafCreateFailed,
@@ -40,17 +29,35 @@ import {
   removeTelegrafLabelFailed,
   getTelegrafConfigFailed,
 } from 'src/shared/copy/notifications'
+
+// Utils
 import {getOrg} from 'src/organizations/selectors'
-import {getLabels} from 'src/resources/selectors'
+import {getLabels, getStatus} from 'src/resources/selectors'
+
+// Types
+import {ILabel} from '@influxdata/influx'
+import {
+  AppThunk,
+  RemoteDataState,
+  GetState,
+  Telegraf,
+  Label,
+  TelegrafEntities,
+  ResourceType,
+} from 'src/types'
 
 export const getTelegrafs = () => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
-  const org = getOrg(getState())
-
   try {
-    dispatch(setTelegrafs(RemoteDataState.Loading))
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.Telegrafs) === RemoteDataState.NotStarted
+    ) {
+      dispatch(setTelegrafs(RemoteDataState.Loading))
+    }
+    const org = getOrg(state)
 
     const telegrafs = await client.telegrafConfigs.getAll(org.id)
 

--- a/ui/src/templates/actions/thunks.ts
+++ b/ui/src/templates/actions/thunks.ts
@@ -39,12 +39,13 @@ import {
   Label,
   Template,
   TaskTemplate,
+  ResourceType,
 } from 'src/types'
 
 // Utils
 import {templateToExport} from 'src/shared/utils/resourceToTemplate'
 import {getOrg} from 'src/organizations/selectors'
-import {getLabels} from 'src/resources/selectors'
+import {getLabels, getStatus} from 'src/resources/selectors'
 
 type Action = TemplateAction | NotifyAction
 
@@ -57,8 +58,13 @@ export const getTemplates = () => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ): Promise<void> => {
-  const org = getOrg(getState())
-  dispatch(setTemplatesStatus(RemoteDataState.Loading))
+  const state = getState()
+  if (getStatus(state, ResourceType.Templates) === RemoteDataState.NotStarted) {
+    dispatch(setTemplatesStatus(RemoteDataState.Loading))
+  }
+
+  const org = getOrg(state)
+
   const items = await client.templates.getAll(org.id)
   const templateSummaries = normalize<
     TemplateSummary,

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -126,16 +126,18 @@ export const getOrgIDFromBuckets = (
   allBuckets: Bucket[]
 ): string | null => {
   const ast = parse(text)
-  const bucketsInQuery = findNodes(ast, isFromBucket).map(node =>
+  const bucketsInQuery: string[] = findNodes(ast, isFromBucket).map(node =>
     get(node, 'arguments.0.properties.0.value.value', '')
   )
-  if (bucketsInQuery.length == 0) {
+
+  // if there are buckets from multiple orgs in a query, query will error, and user will receive error from query
+  const bucketMatch = allBuckets.find(a => bucketsInQuery.includes(a.name))
+
+  if (!bucketMatch) {
     return null
   }
 
-  const buckets = bucketsInQuery.map(b => allBuckets.find(a => a.name === b))
-  // if there are buckets from multiple orgs ina query, query will error, and user will receive error from query
-  return buckets[0].orgID
+  return bucketMatch.orgID
 }
 
 const isFromBucket = (node: Node) => {

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -133,11 +133,7 @@ export const getOrgIDFromBuckets = (
   // if there are buckets from multiple orgs in a query, query will error, and user will receive error from query
   const bucketMatch = allBuckets.find(a => bucketsInQuery.includes(a.name))
 
-  if (!bucketMatch) {
-    return null
-  }
-
-  return bucketMatch.orgID
+  return get(bucketMatch, 'orgID', null)
 }
 
 const isFromBucket = (node: Node) => {

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -1,6 +1,7 @@
 // APIs
 import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import * as api from 'src/client'
+import {get} from 'lodash'
 
 // Utils
 import {
@@ -198,12 +199,17 @@ export const loadTagSelector = (index: number) => async (
   if (!tags[index] || !buckets[0]) {
     return
   }
+  dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Loading))
 
   const tagsSelections = tags.slice(0, index)
   const queryURL = getState().links.query.self
-  const orgID = getOrg(getState()).id
 
-  dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Loading))
+  const bucket = buckets[0]
+
+  const allBuckets = getAll<Bucket>(getState(), ResourceType.Buckets)
+  const foundBucket = allBuckets.find(b => b.name === bucket)
+
+  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
 
   try {
     const timeRange = getTimeRange(getState())
@@ -213,7 +219,7 @@ export const loadTagSelector = (index: number) => async (
     const keys = await queryBuilderFetcher.findKeys(index, {
       url: queryURL,
       orgID,
-      bucket: buckets[0],
+      bucket,
       tagsSelections,
       searchTerm,
       timeRange,
@@ -257,11 +263,16 @@ const loadTagSelectorValues = (index: number) => async (
   const {buckets, tags} = getActiveQuery(state).builderConfig
   const tagsSelections = tags.slice(0, index)
   const queryURL = state.links.query.self
-  const orgID = getOrg(getState()).id
 
   if (!buckets[0]) {
     return
   }
+
+  const bucket = buckets[0]
+
+  const allBuckets = getAll<Bucket>(state, ResourceType.Buckets)
+  const foundBucket = allBuckets.find(b => b.name === bucket)
+  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
 
   dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
 
@@ -274,7 +285,7 @@ const loadTagSelectorValues = (index: number) => async (
     const values = await queryBuilderFetcher.findValues(index, {
       url: queryURL,
       orgID,
-      bucket: buckets[0],
+      bucket,
       tagsSelections,
       key,
       searchTerm,

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -25,7 +25,7 @@ import {CancelBox} from 'src/types/promises'
 import {variableToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {findDependentVariables} from 'src/variables/utils/exportVariables'
 import {getOrg} from 'src/organizations/selectors'
-import {getLabels} from 'src/resources/selectors'
+import {getLabels, getStatus} from 'src/resources/selectors'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -40,6 +40,7 @@ import {
   Variable,
   VariableEntities,
   VariableValuesByID,
+  ResourceType,
 } from 'src/types'
 import {Action as NotifyAction} from 'src/shared/actions/notifications'
 import {
@@ -54,8 +55,14 @@ export const getVariables = () => async (
   getState: GetState
 ) => {
   try {
-    dispatch(setVariables(RemoteDataState.Loading))
-    const org = getOrg(getState())
+    const state = getState()
+    if (
+      getStatus(state, ResourceType.Variables) === RemoteDataState.NotStarted
+    ) {
+      dispatch(setVariables(RemoteDataState.Loading))
+    }
+
+    const org = getOrg(state)
     const resp = await api.getVariables({query: {orgID: org.id}})
     if (resp.status !== 200) {
       throw new Error(resp.data.message)


### PR DESCRIPTION
Closes #16803

- Dashboard Queries search query string for bucket name, and make the query to the org bucket belongs to instead of users current org. 
- Buckets are filtered by org at the UI level instead of the buckets request containing orgID in query parameter
- Fix getResources bug which would cause unmount on refetch of resources. 
- Query builder uses api call to get buckets instead of creating a buckets query. 

Will add bucket type filtering to get sampledata buckets, after extending bucket type. 

