### PR TITLE
fix(ui): fixed yield bug that was caused by race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 1. [17049](https://github.com/influxdata/influxdb/pull/17049): Fixed bug that was preventing the interval status on the dashboard header from refreshing on selections
 1. [17161](https://github.com/influxdata/influxdb/pull/17161): Update table custom decimal feature for tables to update table onFocus
 1. [17168](https://github.com/influxdata/influxdb/pull/17168): Fixed UI bug that was setting Telegraf config buttons off-center and was resizing config selections when filtering through the data
+1. [17208](https://github.com/influxdata/influxdb/pull/17208): Fixed UI bug that was setting causing dashboard cells to error when the a v.bucket was being used and was being configured for the first time
 
 ## v2.0.0-beta.5 [2020-02-27]
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -131,8 +131,11 @@ export const executeQueries = (dashboardID?: string) => async (
     dispatch(setQueryResults(RemoteDataState.Loading, [], null))
 
     await dispatch(refreshTimeMachineVariableValues(dashboardID))
-
-    const variableAssignments = getVariableAssignments(state)
+    // keeping getState() here ensures that the state we are working with
+    // is the most current one. By having this set to state, we were creating a race
+    // condition that was causing the following bug:
+    // https://github.com/influxdata/idpe/issues/6240
+    const variableAssignments = getVariableAssignments(getState())
     const orgID = getOrg(state).id
 
     const startTime = Date.now()


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/6240

### Problem

Race condition was leading to a bug where user was receiving an error due to an undefined variable

### Solution

Replaced the `state` with `getState` to get the most up-to-date version of the state, thereby resolving the race condition error

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)