### PR TITLE
fix(ui/src/alerting): reduce points per check from 300 to 100

### DIFF
--- a/ui/src/alerting/utils/vis.test.ts
+++ b/ui/src/alerting/utils/vis.test.ts
@@ -2,13 +2,13 @@ import {getCheckVisTimeRange} from 'src/alerting/utils/vis'
 
 const duration = 'duration' as 'duration'
 const TESTS = [
-  ['5s', {type: duration, lower: 'now() - 1500s', upper: null}],
-  ['1m', {type: duration, lower: 'now() - 300m', upper: null}],
+  ['5s', {type: duration, lower: 'now() - 500s', upper: null}],
+  ['1m', {type: duration, lower: 'now() - 100m', upper: null}],
   [
     '1m5s',
     {
       type: duration,
-      lower: 'now() - 300m1500s',
+      lower: 'now() - 100m500s',
       upper: null,
     },
   ],

--- a/ui/src/alerting/utils/vis.ts
+++ b/ui/src/alerting/utils/vis.ts
@@ -11,7 +11,7 @@ import {flatMap} from 'lodash'
 // Types
 import {Threshold, DurationTimeRange} from 'src/types'
 
-const POINTS_PER_CHECK_PLOT = 300
+const POINTS_PER_CHECK_PLOT = 100
 
 /*
   Given the duration in a check's `every` field, return a `TimeRange` suitable


### PR DESCRIPTION
This was done to reduce amount of data returned to the client. This is
problematic when there are a large number of series that get returned
from a query. Long term we will want to limit the topN tables so that
this is not an issue.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
