### PR TITLE
feat(cloud): add user id to and org id to global context

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -150,6 +150,13 @@ const basepath = getBrowserBasepath()
 declare global {
   interface Window {
     basepath: string
+    context: {
+      identity: {
+        userID: string
+        username: string
+        orgID: string
+      }
+    }
   }
 }
 

--- a/ui/src/shared/actions/me.ts
+++ b/ui/src/shared/actions/me.ts
@@ -1,6 +1,8 @@
-import {MeState} from 'src/shared/reducers/me'
-import {client} from 'src/utils/api'
 import HoneyBadger from 'honeybadger-js'
+import {MeState} from 'src/shared/reducers/me'
+import {getOrgIDFromUrl} from 'src/shared/utils/getOrgIDFromUrl'
+import {CLOUD} from 'src/shared/constants'
+import {client} from 'src/utils/api'
 
 export enum ActionTypes {
   SetMe = 'SET_ME',
@@ -25,6 +27,18 @@ export const setMe = me => ({
 export const getMe = () => async dispatch => {
   try {
     const user = await client.users.me()
+
+    if (CLOUD) {
+      const orgID = getOrgIDFromUrl()
+
+      window.context = {
+        identity: {
+          userID: user.id,
+          username: user.name,
+          orgID,
+        },
+      }
+    }
 
     HoneyBadger.setContext({
       user_id: user.id,

--- a/ui/src/shared/utils/getOrgIDFromUrl.test.ts
+++ b/ui/src/shared/utils/getOrgIDFromUrl.test.ts
@@ -1,0 +1,39 @@
+import {getOrgIDFromUrl} from 'src/shared/utils/getOrgIDFromUrl'
+
+const baseUrl = 'http://influx.application/'
+const orgID = 'f440096db5cdb0b1'
+const pathname = `/orgs/${orgID}`
+const location = {
+  ...window.location,
+  href: `${baseUrl}${pathname}`,
+  pathname,
+};
+Object.defineProperty(window, 'location', {
+  writable: true,
+  value: location,
+});
+
+describe('getting an orgId', () => {
+  it('gets the org id from the simplest url', () => {
+    expect(getOrgIDFromUrl()).toEqual(orgID)
+  })
+
+  it ("returns -1 if it can't find the org id", () => {
+    const newPathname = '/'
+    window.location.pathname = newPathname
+    window.location.href = `${baseUrl}${pathname}`
+    expect(getOrgIDFromUrl()).toEqual('-1')
+  })
+
+  it('handles paths with more stuff after the org id', () => {
+    let newPathname = `/orgs/${orgID}/dashboard/1333333333337`
+    window.location.pathname = newPathname
+    window.location.href = `${baseUrl}${pathname}`
+    expect(getOrgIDFromUrl()).toEqual(orgID)
+
+    newPathname = `/orgs/${orgID}/data-explorer`
+    window.location.pathname = newPathname
+    window.location.href = `${baseUrl}${pathname}`
+    expect(getOrgIDFromUrl()).toEqual(orgID)
+  })
+})

--- a/ui/src/shared/utils/getOrgIDFromUrl.test.ts
+++ b/ui/src/shared/utils/getOrgIDFromUrl.test.ts
@@ -7,18 +7,18 @@ const location = {
   ...window.location,
   href: `${baseUrl}${pathname}`,
   pathname,
-};
+}
 Object.defineProperty(window, 'location', {
   writable: true,
   value: location,
-});
+})
 
 describe('getting an orgId', () => {
   it('gets the org id from the simplest url', () => {
     expect(getOrgIDFromUrl()).toEqual(orgID)
   })
 
-  it ("returns -1 if it can't find the org id", () => {
+  it("returns -1 if it can't find the org id", () => {
     const newPathname = '/'
     window.location.pathname = newPathname
     window.location.href = `${baseUrl}${pathname}`

--- a/ui/src/shared/utils/getOrgIdFromUrl.ts
+++ b/ui/src/shared/utils/getOrgIdFromUrl.ts
@@ -1,0 +1,11 @@
+export const getOrgIDFromUrl = function getOrgIDFromUrl() {
+  // split urls like orgs/1337/dashboards
+  const baseOrgID = window.location.pathname.split('orgs/')[1]
+  // baseOrgID might have other paths behind it, like 1337/alerting
+  let orgID = '-1'
+  if (baseOrgID) {
+    [orgID] = baseOrgID.split('/')
+  }
+
+  return orgID
+}

--- a/ui/src/shared/utils/getOrgIdFromUrl.ts
+++ b/ui/src/shared/utils/getOrgIdFromUrl.ts
@@ -2,10 +2,10 @@ export const getOrgIDFromUrl = function getOrgIDFromUrl() {
   // split urls like orgs/1337/dashboards
   const baseOrgID = window.location.pathname.split('orgs/')[1]
   // baseOrgID might have other paths behind it, like 1337/alerting
-  let orgID = '-1'
+
   if (baseOrgID) {
-    [orgID] = baseOrgID.split('/')
+    return baseOrgID.split('/')[0]
   }
 
-  return orgID
+  return '-1'
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/6298

* Adds method to get orgId from the url
* in cloud environments, exposes user id, org id, and username to `window.context` object for use in instrumentation

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass