### PR TITLE
refactor(storage): move and remove to help cleanup tsdb package

### DIFF
--- a/storage/config.go
+++ b/storage/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/toml"
-	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/seriesfile"
 	"github.com/influxdata/influxdb/tsdb/tsi1"
 	"github.com/influxdata/influxdb/tsdb/tsm1"
 )
@@ -27,8 +27,8 @@ type Config struct {
 	// Series file config.
 	SeriesFilePath string `toml:"series-file-path"` // Overrides the default path.
 
-	// TSDB config.
-	TSDB tsdb.Config `toml:"tsdb"`
+	// Series file config.
+	SeriesFile seriesfile.Config `toml:"tsdb"`
 
 	// WAL config.
 	WAL     tsm1.WALConfig `toml:"wal"`
@@ -47,7 +47,7 @@ type Config struct {
 func NewConfig() Config {
 	return Config{
 		RetentionInterval: toml.Duration(DefaultRetentionInterval),
-		TSDB:              tsdb.NewConfig(),
+		SeriesFile:        seriesfile.NewConfig(),
 		WAL:               tsm1.NewWALConfig(),
 		Engine:            tsm1.NewConfig(),
 		Index:             tsi1.NewConfig(),

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -168,7 +168,7 @@ func NewEngine(path string, c Config, options ...Option) *Engine {
 
 	// Initialize series file.
 	e.sfile = seriesfile.NewSeriesFile(c.GetSeriesFilePath(path))
-	e.sfile.LargeWriteThreshold = c.TSDB.LargeSeriesWriteThreshold
+	e.sfile.LargeWriteThreshold = c.SeriesFile.LargeSeriesWriteThreshold
 
 	// Initialise index.
 	e.index = tsi1.NewIndex(e.sfile, c.Index,

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -786,17 +786,6 @@ func (e *Engine) Path() string {
 	return e.path
 }
 
-// ApplyFnToSeriesIDSet allows the caller to apply fn to the SeriesIDSet held
-// within the engine's index.
-func (e *Engine) ApplyFnToSeriesIDSet(fn func(*tsdb.SeriesIDSet)) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	if e.closing == nil {
-		return
-	}
-	fn(e.index.SeriesIDSet())
-}
-
 // MeasurementCardinalityStats returns cardinality stats for all measurements.
 func (e *Engine) MeasurementCardinalityStats() (tsi1.MeasurementCardinalityStats, error) {
 	e.mu.RLock()

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -1,28 +1,6 @@
 package tsdb
 
-import (
-	"github.com/influxdata/influxdb/query"
-)
+import "github.com/influxdata/influxdb/query"
 
 // EOF represents a "not found" key returned by a Cursor.
 const EOF = query.ZeroTime
-
-const (
-	// DefaultLargeSeriesWriteThreshold is the number of series per write
-	// that requires the series index be pregrown before insert.
-	DefaultLargeSeriesWriteThreshold = 10000
-)
-
-// Config contains all of the configuration related to tsdb.
-type Config struct {
-	// LargeSeriesWriteThreshold is the threshold before a write requires
-	// preallocation to improve throughput. Currently used in the series file.
-	LargeSeriesWriteThreshold int `toml:"large-series-write-threshold"`
-}
-
-// NewConfig return a new instance of config with default settings.
-func NewConfig() Config {
-	return Config{
-		LargeSeriesWriteThreshold: DefaultLargeSeriesWriteThreshold,
-	}
-}

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -1,6 +1,0 @@
-package tsdb
-
-import "github.com/influxdata/influxdb/query"
-
-// EOF represents a "not found" key returned by a Cursor.
-const EOF = query.ZeroTime

--- a/tsdb/errors.go
+++ b/tsdb/errors.go
@@ -1,16 +1,7 @@
 package tsdb
 
 import (
-	"errors"
 	"fmt"
-)
-
-var (
-	// ErrFieldTypeConflict is returned when a new field already exists with a different type.
-	ErrFieldTypeConflict = errors.New("field type conflict")
-
-	// ErrUnknownFieldType is returned when the type of a field cannot be determined.
-	ErrUnknownFieldType = errors.New("unknown field type")
 )
 
 // PartialWriteError indicates a write request could only write a portion of the

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -480,17 +480,6 @@ type MeasurementIterator interface {
 	Next() ([]byte, error)
 }
 
-type MeasurementIterators []MeasurementIterator
-
-func (a MeasurementIterators) Close() (err error) {
-	for i := range a {
-		if e := a[i].Close(); e != nil && err == nil {
-			err = e
-		}
-	}
-	return err
-}
-
 type measurementSliceIterator struct {
 	names [][]byte
 }

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -480,25 +480,6 @@ type MeasurementIterator interface {
 	Next() ([]byte, error)
 }
 
-type measurementSliceIterator struct {
-	names [][]byte
-}
-
-// NewMeasurementSliceIterator returns an iterator over a slice of in-memory measurement names.
-func NewMeasurementSliceIterator(names [][]byte) *measurementSliceIterator {
-	return &measurementSliceIterator{names: names}
-}
-
-func (itr *measurementSliceIterator) Close() (err error) { return nil }
-
-func (itr *measurementSliceIterator) Next() (name []byte, err error) {
-	if len(itr.names) == 0 {
-		return nil, nil
-	}
-	name, itr.names = itr.names[0], itr.names[1:]
-	return name, nil
-}
-
 // MergeMeasurementIterators returns an iterator that merges a set of iterators.
 // Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -30,7 +30,7 @@ type seriesIDSetIterator struct {
 }
 
 func NewSeriesIDSetIterator(ss *SeriesIDSet) SeriesIDSetIterator {
-	if ss == nil || ss.bitmap == nil {
+	if ss.IsEmpty() {
 		return nil
 	}
 	return &seriesIDSetIterator{ss: ss, itr: ss.Iterator()}

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -556,39 +556,6 @@ type TagKeyIterator interface {
 	Next() ([]byte, error)
 }
 
-type TagKeyIterators []TagKeyIterator
-
-func (a TagKeyIterators) Close() (err error) {
-	for i := range a {
-		if e := a[i].Close(); e != nil && err == nil {
-			err = e
-		}
-	}
-	return err
-}
-
-// NewTagKeySliceIterator returns a TagKeyIterator that iterates over a slice.
-func NewTagKeySliceIterator(keys [][]byte) *tagKeySliceIterator {
-	return &tagKeySliceIterator{keys: keys}
-}
-
-// tagKeySliceIterator iterates over a slice of tag keys.
-type tagKeySliceIterator struct {
-	keys [][]byte
-}
-
-// Next returns the next tag key in the slice.
-func (itr *tagKeySliceIterator) Next() ([]byte, error) {
-	if len(itr.keys) == 0 {
-		return nil, nil
-	}
-	key := itr.keys[0]
-	itr.keys = itr.keys[1:]
-	return key, nil
-}
-
-func (itr *tagKeySliceIterator) Close() error { return nil }
-
 // MergeTagKeyIterators returns an iterator that merges a set of iterators.
 func MergeTagKeyIterators(itrs ...TagKeyIterator) TagKeyIterator {
 	if len(itrs) == 0 {

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -693,17 +693,6 @@ type TagValueIterator interface {
 	Next() ([]byte, error)
 }
 
-type TagValueIterators []TagValueIterator
-
-func (a TagValueIterators) Close() (err error) {
-	for i := range a {
-		if e := a[i].Close(); e != nil && err == nil {
-			err = e
-		}
-	}
-	return err
-}
-
 // MergeTagValueIterators returns an iterator that merges a set of iterators.
 func MergeTagValueIterators(itrs ...TagValueIterator) TagValueIterator {
 	if len(itrs) == 0 {

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -48,6 +48,10 @@ func (s *SeriesIDSet) Bytes() int {
 	return b
 }
 
+func (s *SeriesIDSet) IsEmpty() bool {
+	return s.bitmap == nil || s.bitmap.IsEmpty()
+}
+
 // Add adds the series id to the set.
 func (s *SeriesIDSet) Add(id SeriesID) {
 	s.Lock()

--- a/tsdb/seriesfile/config.go
+++ b/tsdb/seriesfile/config.go
@@ -1,0 +1,21 @@
+package seriesfile
+
+const (
+	// DefaultLargeSeriesWriteThreshold is the number of series per write
+	// that requires the series index be pregrown before insert.
+	DefaultLargeSeriesWriteThreshold = 10000
+)
+
+// Config contains all of the configuration related to tsdb.
+type Config struct {
+	// LargeSeriesWriteThreshold is the threshold before a write requires
+	// preallocation to improve throughput. Currently used in the series file.
+	LargeSeriesWriteThreshold int `toml:"large-series-write-threshold"`
+}
+
+// NewConfig return a new instance of config with default settings.
+func NewConfig() Config {
+	return Config{
+		LargeSeriesWriteThreshold: DefaultLargeSeriesWriteThreshold,
+	}
+}

--- a/tsdb/seriesfile/series_file.go
+++ b/tsdb/seriesfile/series_file.go
@@ -62,7 +62,7 @@ func NewSeriesFile(path string) *SeriesFile {
 		metricsEnabled: true,
 		Logger:         zap.NewNop(),
 
-		LargeWriteThreshold: tsdb.DefaultLargeSeriesWriteThreshold,
+		LargeWriteThreshold: DefaultLargeSeriesWriteThreshold,
 	}
 }
 

--- a/tsdb/seriesfile/series_file.go
+++ b/tsdb/seriesfile/series_file.go
@@ -346,14 +346,15 @@ func (f *SeriesFile) SeriesCount() uint64 {
 	return n
 }
 
-// SeriesIterator returns an iterator over all the series.
-func (f *SeriesFile) SeriesIDIterator() tsdb.SeriesIDIterator {
+// AllSeriesIDs returns a slice of all series IDs, sorted.
+// This may return a lot of data at once, so use sparingly.
+func (f *SeriesFile) AllSeriesIDs() []tsdb.SeriesID {
 	var ids []tsdb.SeriesID
 	for _, p := range f.partitions {
 		ids = p.AppendSeriesIDs(ids)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i].Less(ids[j]) })
-	return tsdb.NewSeriesIDSliceIterator(ids)
+	return ids
 }
 
 func (f *SeriesFile) SeriesIDPartitionID(id tsdb.SeriesID) int {

--- a/tsdb/seriesfile/series_partition.go
+++ b/tsdb/seriesfile/series_partition.go
@@ -62,7 +62,7 @@ func NewSeriesPartition(id int, path string) *SeriesPartition {
 		path:                path,
 		closing:             make(chan struct{}),
 		CompactThreshold:    DefaultSeriesPartitionCompactThreshold,
-		LargeWriteThreshold: tsdb.DefaultLargeSeriesWriteThreshold,
+		LargeWriteThreshold: DefaultLargeSeriesWriteThreshold,
 		tracker:             newSeriesPartitionTracker(newSeriesFileMetrics(nil), prometheus.Labels{"series_file_partition": fmt.Sprint(id)}),
 		Logger:              zap.NewNop(),
 		seq:                 uint64(id) + 1,

--- a/tsdb/tsi1/dump_tsi1.go
+++ b/tsdb/tsi1/dump_tsi1.go
@@ -119,21 +119,18 @@ func (cmd *DumpTSI) printSeries(sfile *seriesfile.SeriesFile) error {
 	fmt.Fprintln(tw, "Series\t")
 
 	// Iterate over each series.
-	itr := sfile.SeriesIDIterator()
-	for {
-		e, err := itr.Next()
-		if err != nil {
-			return err
-		} else if e.SeriesID.ID == 0 {
+	seriesIDs := sfile.AllSeriesIDs()
+	for _, seriesID := range seriesIDs {
+		if seriesID.ID == 0 {
 			break
 		}
-		name, tags := seriesfile.ParseSeriesKey(sfile.SeriesKey(e.SeriesID))
+		name, tags := seriesfile.ParseSeriesKey(sfile.SeriesKey(seriesID))
 
 		if !cmd.matchSeries(name, tags) {
 			continue
 		}
 
-		deleted := sfile.IsDeleted(e.SeriesID)
+		deleted := sfile.IsDeleted(seriesID)
 
 		fmt.Fprintf(tw, "%s%s\t%v\n", name, tags.HashKey(), deletedString(deleted))
 	}

--- a/tsdb/tsi1/file_set_test.go
+++ b/tsdb/tsi1/file_set_test.go
@@ -34,11 +34,8 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 		}
 		defer fs.Release()
 
-		itr := fs.SeriesFile().SeriesIDIterator()
-		if itr == nil {
-			t.Fatal("expected iterator")
-		}
-		if result := mustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		seriesIDs := fs.SeriesFile().AllSeriesIDs()
+		if result := seriesIDsToStrings(fs.SeriesFile(), seriesIDs); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region west}]",
 			"mem,[{region east}]",
@@ -64,12 +61,8 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 		}
 		defer fs.Release()
 
-		itr := fs.SeriesFile().SeriesIDIterator()
-		if itr == nil {
-			t.Fatal("expected iterator")
-		}
-
-		if result := mustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		seriesIDs := fs.SeriesFile().AllSeriesIDs()
+		if result := seriesIDsToStrings(fs.SeriesFile(), seriesIDs); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region north}]",
 			"cpu,[{region west}]",
@@ -307,6 +300,10 @@ func mustReadAllSeriesIDIteratorString(sfile *seriesfile.SeriesFile, itr tsdb.Se
 		ids = append(ids, e.SeriesID)
 	}
 
+	return seriesIDsToStrings(sfile, ids)
+}
+
+func seriesIDsToStrings(sfile *seriesfile.SeriesFile, ids []tsdb.SeriesID) []string {
 	// Convert to keys and sort.
 	keys := sfile.SeriesKeys(ids)
 	sort.Slice(keys, func(i, j int) bool { return seriesfile.CompareSeriesKeys(keys[i], keys[j]) == -1 })

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -528,7 +528,9 @@ func (i *Index) MeasurementIterator() (tsdb.MeasurementIterator, error) {
 	for _, p := range i.partitions {
 		itr, err := p.MeasurementIterator()
 		if err != nil {
-			tsdb.MeasurementIterators(itrs).Close()
+			for _, itr := range itrs {
+				itr.Close()
+			}
 			return nil, err
 		} else if itr != nil {
 			itrs = append(itrs, itr)

--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -308,7 +308,7 @@ func (c *Cache) Type(key []byte) (models.FieldType, error) {
 	if e != nil {
 		typ, err := e.InfluxQLType()
 		if err != nil {
-			return models.Empty, tsdb.ErrUnknownFieldType
+			return models.Empty, errUnknownFieldType
 		}
 
 		switch typ {
@@ -325,7 +325,7 @@ func (c *Cache) Type(key []byte) (models.FieldType, error) {
 		}
 	}
 
-	return models.Empty, tsdb.ErrUnknownFieldType
+	return models.Empty, errUnknownFieldType
 }
 
 // Values returns a copy of all values, deduped and sorted, for the given key.

--- a/tsdb/tsm1/cache_entry.go
+++ b/tsdb/tsm1/cache_entry.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
@@ -39,7 +38,7 @@ func newEntryValues(values []Value) (*entry, error) {
 	for _, v := range values {
 		// Make sure all the values are the same type
 		if et != valueType(v) {
-			return nil, tsdb.ErrFieldTypeConflict
+			return nil, errFieldTypeConflict
 		}
 	}
 
@@ -59,7 +58,7 @@ func (e *entry) add(values []Value) error {
 	if e.vtype != 0 {
 		for _, v := range values {
 			if e.vtype != valueType(v) {
-				return tsdb.ErrFieldTypeConflict
+				return errFieldTypeConflict
 			}
 		}
 	}

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -40,20 +40,14 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 
 	// Collect series IDs.
 	seriesIDMap := map[string]tsdb.SeriesID{}
-	var e tsdb.SeriesIDElem
-	var err error
-
-	itr := engine.sfile.SeriesIDIterator()
-	for e, err = itr.Next(); ; e, err = itr.Next() {
-		if err != nil {
-			t.Fatal(err)
-		} else if e.SeriesID.IsZero() {
+	for _, seriesID := range engine.sfile.AllSeriesIDs() {
+		if seriesID.IsZero() {
 			break
 		}
 
-		name, tags := seriesfile.ParseSeriesKey(engine.sfile.SeriesKey(e.SeriesID))
+		name, tags := seriesfile.ParseSeriesKey(engine.sfile.SeriesKey(seriesID))
 		key := fmt.Sprintf("%s%s", name, tags.HashKey())
-		seriesIDMap[key] = e.SeriesID
+		seriesIDMap[key] = seriesID
 	}
 
 	for _, id := range seriesIDMap {

--- a/tsdb/tsm1/errors.go
+++ b/tsdb/tsm1/errors.go
@@ -1,0 +1,11 @@
+package tsm1
+
+import "errors"
+
+var (
+	// errFieldTypeConflict is returned when a new field already exists with a different type.
+	errFieldTypeConflict = errors.New("field type conflict")
+
+	// errUnknownFieldType is returned when the type of a field cannot be determined.
+	errUnknownFieldType = errors.New("unknown field type")
+)

--- a/tsdb/value/value.go
+++ b/tsdb/value/value.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/query"
 )
 
 // Value represents a TSM-encoded value.
@@ -76,8 +76,8 @@ func NewStringValue(t int64, v string) Value { return NewRawStringValue(t, v) }
 // EmptyValue is used when there is no appropriate other value.
 type EmptyValue struct{}
 
-// UnixNano returns tsdb.EOF.
-func (e EmptyValue) UnixNano() int64 { return tsdb.EOF }
+// UnixNano returns query.ZeroTime.
+func (e EmptyValue) UnixNano() int64 { return query.ZeroTime }
 
 // Value returns nil.
 func (e EmptyValue) Value() interface{} { return nil }


### PR DESCRIPTION
The objective, whether it is possible or not, is to remove all dependencies on the tsdb package from it's children (tsm1, tsi1, seriesfile, etc). This gets us closer to that goal.