### PR TITLE
perf(tsi1): batch write tombstone entries when dropping/deleting

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1634,6 +1634,9 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 		ids := tsdb.NewSeriesIDSet()
 		measurements := make(map[string]struct{}, 1)
 
+		deleteIDList := make([]uint64, 0, 10000)
+		deleteKeyList := make([][]byte, 0, 10000)
+
 		for _, k := range seriesKeys {
 			if len(k) == 0 {
 				continue // This key was wiped because it shouldn't be removed from index.
@@ -1663,14 +1666,17 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 				continue
 			}
 
+			// Insert deleting series info into queue
 			measurements[string(name)] = struct{}{}
-			// Remove the series from the local index.
-			if err := e.index.DropSeries(sid, k, false); err != nil {
-				return err
-			}
+			deleteIDList = append(deleteIDList, sid)
+			deleteKeyList = append(deleteKeyList, k)
 
 			// Add the id to the set of delete ids.
 			ids.Add(sid)
+		}
+		// Remove the series from the local index.
+		if err := e.index.DropSeriesList(deleteIDList, deleteKeyList, false); err != nil {
+			return err
 		}
 
 		fielsetChanged := false

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -42,6 +42,7 @@ type Index interface {
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
 	DropSeries(seriesID uint64, key []byte, cascade bool) error
+	DropSeriesList(seriesID []uint64, key [][]byte, cascade bool) error
 	DropMeasurementIfSeriesNotExist(name []byte) (bool, error)
 
 	// Used to clean up series in inmem index that were dropped with a shard.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -824,6 +824,64 @@ func (i *Index) DropSeries(seriesID uint64, key []byte, cascade bool) error {
 	return nil
 }
 
+// DropSeries drops the provided series from the index.  If cascade is true
+// and this is the last series to the measurement, the measurment will also be dropped.
+func (i *Index) DropSeriesList(seriesIDs []uint64, keys [][]byte, _ bool) error {
+	// All slices must be of equal length.
+	if len(seriesIDs) != len(keys) {
+		return errors.New("seriesIDs/keys length mismatch in index")
+	}
+
+	// We need to move different series into collections for each partition
+	// to process.
+	pSeriesIDs := make([][]uint64, i.PartitionN)
+	pKeys := make([][][]byte, i.PartitionN)
+
+	for idx, key := range keys {
+		pidx := i.partitionIdx(key)
+		pSeriesIDs[pidx] = append(pSeriesIDs[pidx], seriesIDs[idx])
+		pKeys[pidx] = append(pKeys[pidx], key)
+	}
+
+	// Process each subset of series on each partition.
+	n := i.availableThreads()
+
+	// Store errors.
+	errC := make(chan error, i.PartitionN)
+
+	var pidx uint32 // Index of maximum Partition being worked on.
+	for k := 0; k < n; k++ {
+		go func() {
+			for {
+				idx := int(atomic.AddUint32(&pidx, 1) - 1) // Get next partition to work on.
+				if idx >= len(i.partitions) {
+					return // No more work.
+				}
+
+				// Drop from partition.
+				err := i.partitions[idx].DropSeriesList(pSeriesIDs[idx])
+				errC <- err
+			}
+		}()
+	}
+
+	// Check for error
+	for i := 0; i < cap(errC); i++ {
+		if err := <-errC; err != nil {
+			return err
+		}
+	}
+
+	// Add sketch tombstone.
+	i.mu.Lock()
+	for _, key := range keys {
+		i.sTSketch.Add(key)
+	}
+	i.mu.Unlock()
+
+	return nil
+}
+
 // DropSeriesGlobal is a no-op on the tsi1 index.
 func (i *Index) DropSeriesGlobal(key []byte) error { return nil }
 


### PR DESCRIPTION
Closes #9636

Describe your proposed changes here.
Profile shows that fsync costs a lot if dropping the series id one by one. We can write the tombstones in batch to utilize disk io.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
