### PR TITLE
feat(handler): Add 2.0 compatible health endpoint

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -985,7 +985,14 @@ func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
 
 // serveHealth maps v2 health endpoint to ping endpoint
 func (h *Handler) serveHealth(w http.ResponseWriter, r *http.Request) {
-	b, _ := json.Marshal(map[string]interface{}{"name": "influxdb", "message": "ready for queries and writes", "status": "pass", "checks": []string{}, "version": h.Version})
+	resp := map[string]interface{}{
+		"name":    "influxdb",
+		"message": "ready for queries and writes",
+		"status":  "pass",
+		"checks":  []string{},
+		"version": h.Version,
+	}
+	b, _ := json.Marshal(resp)
 	h.writeHeader(w, http.StatusOK)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if _, err := w.Write(b); err != nil {

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/influxdata/influxdb/internal"
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/testing/assert"
 	"github.com/influxdata/influxdb/prometheus/remote"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/services/httpd"
@@ -1470,6 +1471,29 @@ func TestHandler_Ping(t *testing.T) {
 	h.ServeHTTP(w, MustNewRequest("HEAD", "/ping", nil))
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("unexpected status: %d", w.Code)
+	}
+}
+
+// Ensure the handler handles health requests correctly.
+func TestHandler_Health(t *testing.T) {
+	h := NewHandler(false)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, MustNewRequest("GET", "/health", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, got["name"], "influxdb", "invalid name")
+	assert.Equal(t, got["message"], "ready for queries and writes", "invalid message")
+	assert.Equal(t, got["status"], "pass", "invalid status")
+	assert.Equal(t, got["version"], "0.0.0", "invalid version")
+	if _, present := got["checks"]; !present {
+		t.Fatal("missing checks")
 	}
 }
 


### PR DESCRIPTION
Closes #17248

Make 1.x support the 2.0 health API.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
