### PR TITLE
feat(cloud): add some ids to the global context

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -150,11 +150,28 @@ const basepath = getBrowserBasepath()
 declare global {
   interface Window {
     basepath: string
+    context: {
+      identity: {
+        userID: string
+        username: string
+        orgIDs: string[]
+      }
+    }
   }
 }
 
 // Older method used for pre-IE 11 compatibility
 window.basepath = basepath
+
+if (CLOUD) {
+  window.context = {
+    identity: {
+      userID: '',
+      username: '',
+      orgIDs: [''],
+    },
+  }
+}
 
 const history: History = useRouterHistory(createHistory)({
   basename: basepath, // this is written in when available by the URL prefixer middleware

--- a/ui/src/organizations/actions/thunks.ts
+++ b/ui/src/organizations/actions/thunks.ts
@@ -2,6 +2,7 @@
 import {Dispatch} from 'redux'
 import {push, RouterAction} from 'react-router-redux'
 import {normalize} from 'normalizr'
+import {CLOUD} from 'src/shared/constants'
 
 // APIs
 import {getErrorMessage} from 'src/utils/api'
@@ -60,6 +61,10 @@ export const getOrganizations = () => async (
       orgs,
       arrayOfOrgs
     )
+
+    if (CLOUD) {
+      window.context.identity.orgIDs = organizations.result
+    }
 
     dispatch(setOrgs(RemoteDataState.Done, organizations))
 

--- a/ui/src/shared/actions/me.ts
+++ b/ui/src/shared/actions/me.ts
@@ -1,6 +1,7 @@
-import {MeState} from 'src/shared/reducers/me'
-import {client} from 'src/utils/api'
 import HoneyBadger from 'honeybadger-js'
+import {MeState} from 'src/shared/reducers/me'
+import {CLOUD} from 'src/shared/constants'
+import {client} from 'src/utils/api'
 
 export enum ActionTypes {
   SetMe = 'SET_ME',
@@ -25,6 +26,11 @@ export const setMe = me => ({
 export const getMe = () => async dispatch => {
   try {
     const user = await client.users.me()
+
+    if (CLOUD) {
+      window.context.identity.userID = user.id
+      window.context.identity.username = user.name
+    }
 
     HoneyBadger.setContext({
       user_id: user.id,


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/6298

* in cloud environments, exposes user id, org id, and username to `window.context` object for use in instrumentation

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass