### PR TITLE
refactor(tsdb): remove read from unexported field

### DIFF
--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -30,7 +30,7 @@ type seriesIDSetIterator struct {
 }
 
 func NewSeriesIDSetIterator(ss *SeriesIDSet) SeriesIDSetIterator {
-	if ss.IsEmpty() {
+	if ss == nil || ss.IsEmpty() {
 		return nil
 	}
 	return &seriesIDSetIterator{ss: ss, itr: ss.Iterator()}

--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -30,7 +30,7 @@ type seriesIDSetIterator struct {
 }
 
 func NewSeriesIDSetIterator(ss *SeriesIDSet) SeriesIDSetIterator {
-	if ss == nil || ss.bitmap == nil {
+	if ss.IsEmpty() {
 		return nil
 	}
 	return &seriesIDSetIterator{ss: ss, itr: ss.Iterator()}

--- a/tsdb/series_iterators_test.go
+++ b/tsdb/series_iterators_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb/seriesfile"
 	"github.com/influxdata/influxdb/tsdb/tsi1"
 	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/assert"
 )
 
 func toSeriesIDs(ids []uint64) []tsdb.SeriesID {
@@ -354,4 +355,26 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 			})
 		})
 	}
+}
+
+func TestSeriesIDSet_isEmpty(t *testing.T) {
+	sis := tsdb.NewSeriesIDSet(tsdb.NewSeriesID(1))
+	assert.False(t, sis.IsEmpty())
+
+	sis = tsdb.NewSeriesIDSet()
+	assert.True(t, sis.IsEmpty())
+
+	sis = &tsdb.SeriesIDSet{} // sis.bitmap == nil
+	assert.True(t, sis.IsEmpty())
+}
+
+func TestNewSeriesIDSetIterator(t *testing.T) {
+	sisi := tsdb.NewSeriesIDSetIterator(tsdb.NewSeriesIDSet(tsdb.NewSeriesID(1)))
+	assert.NotNil(t, sisi)
+
+	sisi = tsdb.NewSeriesIDSetIterator(tsdb.NewSeriesIDSet())
+	assert.Nil(t, sisi)
+
+	sisi = tsdb.NewSeriesIDSetIterator(nil)
+	assert.Nil(t, sisi)
 }

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -49,7 +49,7 @@ func (s *SeriesIDSet) Bytes() int {
 }
 
 func (s *SeriesIDSet) IsEmpty() bool {
-	return s.bitmap == nil || s.bitmap.IsEmpty()
+	return s == nil || s.bitmap == nil || s.bitmap.IsEmpty()
 }
 
 // Add adds the series id to the set.

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -48,6 +48,10 @@ func (s *SeriesIDSet) Bytes() int {
 	return b
 }
 
+func (s *SeriesIDSet) IsEmpty() bool {
+	return s.bitmap == nil || s.bitmap.IsEmpty()
+}
+
 // Add adds the series id to the set.
 func (s *SeriesIDSet) Add(id SeriesID) {
 	s.Lock()


### PR DESCRIPTION
Small cleanup to reduce complexity.

This PR is [the final commit](https://github.com/influxdata/influxdb/commit/0ffcc29fd9f13ce40629aa2341598ddc0c5d169b) in the reverted #17241, which caused incident inc-aws-error-rate-spi-5e6c1423, plus a failing regression test, and a fix.