### PR TITLE
fix(kv): add test to ensure skip first item behaviour handles single item

### DIFF
--- a/testing/kv.go
+++ b/testing/kv.go
@@ -757,6 +757,23 @@ func KVForwardCursor(
 			exp: []string{"aaa/01", "aaa/02", "aaa/03"},
 		},
 		{
+			name: "prefix - skip first (one item)",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek: "bbb/02",
+				opts: []kv.CursorOption{
+					kv.WithCursorSkipFirstItem(),
+				},
+			},
+			exp: nil,
+		},
+		{
 			name: "prefix - does not prefix seek",
 			fields: KVStoreFields{
 				Bucket: []byte("bucket"),


### PR DESCRIPTION
This adds an edge case to the kv tests ensuring that forward cursor configured using `WithSkipFirstItem` handles a single item cursor properly.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
