### PR TITLE
fix(http): make label service authorized by default

### DIFF
--- a/http/check_service.go
+++ b/http/check_service.go
@@ -124,7 +124,7 @@ func NewCheckHandler(log *zap.Logger, b *CheckBackend) *CheckHandler {
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              b.log.With(zap.String("handler", "label")),
 		LabelService:     b.LabelService,
-		ResourceType:     influxdb.TelegrafsResourceType,
+		ResourceType:     influxdb.ChecksResourceType,
 	}
 	h.HandlerFunc("GET", checksIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", checksIDLabelsPath, newPostLabelHandler(labelBackend))

--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -119,7 +119,7 @@ func NewNotificationEndpointHandler(log *zap.Logger, b *NotificationEndpointBack
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              b.log.With(zap.String("handler", "label")),
 		LabelService:     b.LabelService,
-		ResourceType:     influxdb.TelegrafsResourceType,
+		ResourceType:     influxdb.NotificationEndpointResourceType,
 	}
 	h.HandlerFunc("GET", notificationEndpointsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", notificationEndpointsIDLabelsPath, newPostLabelHandler(labelBackend))

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -132,7 +132,7 @@ func NewNotificationRuleHandler(log *zap.Logger, b *NotificationRuleBackend) *No
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              b.log.With(zap.String("handler", "label")),
 		LabelService:     b.LabelService,
-		ResourceType:     influxdb.TelegrafsResourceType,
+		ResourceType:     influxdb.NotificationRuleResourceType,
 	}
 	h.HandlerFunc("GET", notificationRulesIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", notificationRulesIDLabelsPath, newPostLabelHandler(labelBackend))


### PR DESCRIPTION
This PR does 2 things:

 - makes it so that every resource uses an `authorizer.LabelService` by default.
 - fixes resource type for label backends: some of them where mounted on the right endpoint, but with the wrong resource type (bad copy paste?)
