### PR TITLE
refactor(authorizer): auth micro framework

### DIFF
--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -3,24 +3,11 @@ package authorizer
 import (
 	"context"
 	"fmt"
-
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 )
 
-// IsAllowed checks to see if an action is authorized by retrieving the authorizer
-// off of context and authorizing the action appropriately.
-func IsAllowed(ctx context.Context, p influxdb.Permission) error {
-	return IsAllowedAll(ctx, []influxdb.Permission{p})
-}
-
-// IsAllowedAll checks to see if an action is authorized by ALL permissions.
-// Also see IsAllowed.
-func IsAllowedAll(ctx context.Context, permissions []influxdb.Permission) error {
-	a, err := icontext.GetAuthorizer(ctx)
-	if err != nil {
-		return err
-	}
+func isAllowedAll(a influxdb.Authorizer, permissions []influxdb.Permission) error {
 	for _, p := range permissions {
 		if !a.Allowed(p) {
 			return &influxdb.Error{
@@ -30,6 +17,26 @@ func IsAllowedAll(ctx context.Context, permissions []influxdb.Permission) error 
 		}
 	}
 	return nil
+}
+
+func isAllowed(a influxdb.Authorizer, p influxdb.Permission) error {
+	return isAllowedAll(a, []influxdb.Permission{p})
+}
+
+// IsAllowedAll checks to see if an action is authorized by ALL permissions.
+// Also see IsAllowed.
+func IsAllowedAll(ctx context.Context, permissions []influxdb.Permission) error {
+	a, err := icontext.GetAuthorizer(ctx)
+	if err != nil {
+		return err
+	}
+	return isAllowedAll(a, permissions)
+}
+
+// IsAllowed checks to see if an action is authorized by retrieving the authorizer
+// off of context and authorizing the action appropriately.
+func IsAllowed(ctx context.Context, p influxdb.Permission) error {
+	return IsAllowedAll(ctx, []influxdb.Permission{p})
 }
 
 // IsAllowedAll checks to see if an action is authorized by ALL permissions.
@@ -48,4 +55,112 @@ func IsAllowedAny(ctx context.Context, permissions []influxdb.Permission) error 
 		Code: influxdb.EUnauthorized,
 		Msg:  fmt.Sprintf("none of %v is authorized", permissions),
 	}
+}
+
+func authorize(ctx context.Context, a influxdb.Action, rt influxdb.ResourceType, rid, oid *influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	var p *influxdb.Permission
+	var err error
+	if rid != nil && oid != nil {
+		p, err = influxdb.NewPermissionAtID(*rid, a, rt, *oid)
+	} else if rid != nil {
+		p, err = influxdb.NewResourcePermission(a, rt, *rid)
+	} else if oid != nil {
+		p, err = influxdb.NewPermission(a, rt, *oid)
+	} else {
+		p, err = influxdb.NewGlobalPermission(a, rt)
+	}
+	if err != nil {
+		return nil, influxdb.Permission{}, err
+	}
+	auth, err := icontext.GetAuthorizer(ctx)
+	if err != nil {
+		return nil, influxdb.Permission{}, err
+	}
+	return auth, *p, isAllowed(auth, *p)
+}
+
+func authorizeReadSystemBucket(ctx context.Context, bid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	// HACK: remove once system buckets are migrated away from hard coded values
+	if !oid.Valid() && (bid == influxdb.TasksSystemBucketID || bid == influxdb.MonitoringSystemBucketID) {
+		a, _ := icontext.GetAuthorizer(ctx)
+		return a, influxdb.Permission{}, nil
+	}
+	return AuthorizeReadOrg(ctx, oid)
+}
+
+// AuthorizeReadBucket exists because buckets are a special case and should use this method.
+// I.e., instead of:
+//  AuthorizeRead(crx, influxdb.BucketsResourceType, b.ID, b.OrgID)
+// use:
+//  AuthorizeReadBucket(crx, b.Type, b.ID, b.OrgID)
+func AuthorizeReadBucket(ctx context.Context, bt influxdb.BucketType, bid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	switch bt {
+	case influxdb.BucketTypeSystem:
+		return authorizeReadSystemBucket(ctx, bid, oid)
+	default:
+		return AuthorizeRead(ctx, influxdb.BucketsResourceType, bid, oid)
+	}
+}
+
+// AuthorizeRead authorizes the user in the context to read the specified resource (identified by its type, ID, and orgID).
+// NOTE: authorization will pass even if the user only has permissions for the resource type and organization ID only.
+func AuthorizeRead(ctx context.Context, rt influxdb.ResourceType, rid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, rt, &rid, &oid)
+}
+
+// AuthorizeRead authorizes the user in the context to write the specified resource (identified by its type, ID, and orgID).
+// NOTE: authorization will pass even if the user only has permissions for the resource type and organization ID only.
+func AuthorizeWrite(ctx context.Context, rt influxdb.ResourceType, rid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, rt, &rid, &oid)
+}
+
+// AuthorizeRead authorizes the user in the context to read the specified resource (identified by its type, ID).
+// NOTE: authorization will pass only if the user has a specific permission for the given resource.
+func AuthorizeReadResource(ctx context.Context, rt influxdb.ResourceType, rid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, rt, &rid, nil)
+}
+
+// AuthorizeWrite authorizes the user in the context to write the specified resource (identified by its type, ID).
+// NOTE: authorization will pass only if the user has a specific permission for the given resource.
+func AuthorizeWriteResource(ctx context.Context, rt influxdb.ResourceType, rid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, rt, &rid, nil)
+}
+
+// AuthorizeOrgReadResource authorizes the given org to read the resources of the given type.
+// NOTE: this is pretty much the same as AuthorizeRead, in the case that the resource ID is ignored.
+// Use it in the case that you do not know which resource in particular you want to give access to.
+func AuthorizeOrgReadResource(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, rt, nil, &oid)
+}
+
+// AuthorizeOrgWriteResource authorizes the given org to write the resources of the given type.
+// NOTE: this is pretty much the same as AuthorizeWrite, in the case that the resource ID is ignored.
+// Use it in the case that you do not know which resource in particular you want to give access to.
+func AuthorizeOrgWriteResource(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, rt, nil, &oid)
+}
+
+// AuthorizeCreate authorizes a user to create a resource of the given type for the given org.
+func AuthorizeCreate(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return AuthorizeOrgWriteResource(ctx, rt, oid)
+}
+
+// AuthorizeOrg authorizes the user to read the given org.
+func AuthorizeReadOrg(ctx context.Context, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, influxdb.OrgsResourceType, &oid, nil)
+}
+
+// AuthorizeOrg authorizes the user to write the given org.
+func AuthorizeWriteOrg(ctx context.Context, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, influxdb.OrgsResourceType, &oid, nil)
+}
+
+// AuthorizeReadGlobal authorizes to read resources of the given type.
+func AuthorizeReadGlobal(ctx context.Context, rt influxdb.ResourceType) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, rt, nil, nil)
+}
+
+// AuthorizeWriteGlobal authorizes to write resources of the given type.
+func AuthorizeWriteGlobal(ctx context.Context, rt influxdb.ResourceType) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, rt, nil, nil)
 }

--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -1,0 +1,259 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+// AuthorizeFindBuckets takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindBuckets(ctx context.Context, rs []*influxdb.Bucket) ([]*influxdb.Bucket, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeReadBucket(ctx, r.Type, r.ID, r.OrgID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindDashboards takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindDashboards(ctx context.Context, rs []*influxdb.Dashboard) ([]*influxdb.Dashboard, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.DashboardsResourceType, r.ID, r.OrganizationID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindOrganizations takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindOrganizations(ctx context.Context, rs []*influxdb.Organization) ([]*influxdb.Organization, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeReadOrg(ctx, r.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindSources takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindSources(ctx context.Context, rs []*influxdb.Source) ([]*influxdb.Source, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.SourcesResourceType, r.ID, r.OrganizationID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindTasks takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindTasks(ctx context.Context, rs []*influxdb.Task) ([]*influxdb.Task, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.TasksResourceType, r.ID, r.OrganizationID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindTelegrafs takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindTelegrafs(ctx context.Context, rs []*influxdb.TelegrafConfig) ([]*influxdb.TelegrafConfig, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.TelegrafsResourceType, r.ID, r.OrgID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindUsers takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindUsers(ctx context.Context, rs []*influxdb.User) ([]*influxdb.User, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeReadResource(ctx, influxdb.UsersResourceType, r.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindVariables takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindVariables(ctx context.Context, rs []*influxdb.Variable) ([]*influxdb.Variable, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.VariablesResourceType, r.ID, r.OrganizationID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindScrapers takes the given items and returns only the ones that the user is authorize to read.
+func AuthorizeFindScrapers(ctx context.Context, rs []influxdb.ScraperTarget) ([]influxdb.ScraperTarget, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.ScraperResourceType, r.ID, r.OrgID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindLabels takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindLabels(ctx context.Context, rs []*influxdb.Label) ([]*influxdb.Label, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.LabelsResourceType, r.ID, r.OrgID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindNotificationRules takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindNotificationRules(ctx context.Context, rs []influxdb.NotificationRule) ([]influxdb.NotificationRule, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.NotificationRuleResourceType, r.GetID(), r.GetOrgID())
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindNotificationEndpoints takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindNotificationEndpoints(ctx context.Context, rs []influxdb.NotificationEndpoint) ([]influxdb.NotificationEndpoint, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.NotificationEndpointResourceType, r.GetID(), r.GetOrgID())
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindChecks takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindChecks(ctx context.Context, rs []influxdb.Check) ([]influxdb.Check, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.ChecksResourceType, r.GetID(), r.GetOrgID())
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
+// AuthorizeFindUserResourceMappings takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindUserResourceMappings(ctx context.Context, os OrganizationService, rs []*influxdb.UserResourceMapping) ([]*influxdb.UserResourceMapping, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		orgID, err := os.FindResourceOrganizationID(ctx, r.ResourceType, r.ResourceID)
+		if err != nil {
+			return nil, 0, err
+		}
+		if _, _, err := AuthorizeRead(ctx, r.ResourceType, r.ResourceID, orgID); err != nil {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}

--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -2,10 +2,6 @@ package authorizer
 
 import (
 	"context"
-	"fmt"
-
-	icontext "github.com/influxdata/influxdb/context"
-
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 )
@@ -27,83 +23,6 @@ func NewBucketService(s influxdb.BucketService, u influxdb.UserResourceMappingSe
 	}
 }
 
-func newBucketPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.BucketsResourceType, orgID)
-}
-
-func authorizeWriteBucket(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newBucketPermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeReadBucket(ctx context.Context, b *influxdb.Bucket, u influxdb.UserResourceMappingService) error {
-	switch b.Type {
-	case influxdb.BucketTypeSystem:
-		return authorizeReadSystemBucket(ctx, b, u)
-	default:
-		return authorizeReadUserBucket(ctx, b)
-	}
-}
-
-func authorizeReadUserBucket(ctx context.Context, b *influxdb.Bucket) error {
-	span, ctx := tracing.StartSpanFromContext(ctx)
-	defer span.Finish()
-
-	p, err := newBucketPermission(influxdb.ReadAction, b.OrgID, b.ID)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeReadSystemBucket(ctx context.Context, b *influxdb.Bucket, u influxdb.UserResourceMappingService) error {
-	// HACK: remove once system buckets are migrated away from hard coded values
-	if !b.OrgID.Valid() && (b.ID == influxdb.TasksSystemBucketID || b.ID == influxdb.MonitoringSystemBucketID) {
-		return nil
-	}
-
-	userID, err := icontext.GetUserID(ctx)
-	if err != nil {
-		return &influxdb.Error{
-			Code: influxdb.EUnauthorized,
-			Msg:  fmt.Sprintf("unauthorized"),
-			Err:  err,
-		}
-	}
-
-	ms, _, err := u.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
-		UserID:       userID,
-		ResourceType: influxdb.OrgsResourceType,
-	})
-	if err != nil {
-		return fmt.Errorf("finding organization mapping for user %s: %v", b.ID, err)
-	}
-
-	for _, m := range ms {
-		if m.ResourceID == b.OrgID {
-			return nil
-		}
-	}
-
-	return &influxdb.Error{
-		Code: influxdb.EUnauthorized,
-		Msg:  "unauthorized",
-	}
-}
-
 // FindBucketByID checks to see if the authorizer on context has read access to the id provided.
 func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
@@ -113,11 +32,9 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*in
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadBucket(ctx, b, s.u); err != nil {
+	if _, _, err := AuthorizeReadBucket(ctx, b.Type, b.ID, b.OrgID); err != nil {
 		return nil, err
 	}
-
 	return b, nil
 }
 
@@ -130,11 +47,9 @@ func (s *BucketService) FindBucketByName(ctx context.Context, orgID influxdb.ID,
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadBucket(ctx, b, s.u); err != nil {
+	if _, _, err := AuthorizeReadBucket(ctx, b.Type, b.ID, b.OrgID); err != nil {
 		return nil, err
 	}
-
 	return b, nil
 }
 
@@ -147,11 +62,9 @@ func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFi
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadBucket(ctx, b, s.u); err != nil {
+	if _, _, err := AuthorizeReadBucket(ctx, b.Type, b.ID, b.OrgID); err != nil {
 		return nil, err
 	}
-
 	return b, nil
 }
 
@@ -166,24 +79,7 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	buckets := bs[:0]
-	for _, b := range bs {
-		err := authorizeReadBucket(ctx, b, s.u)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		buckets = append(buckets, b)
-	}
-
-	return buckets, len(buckets), nil
+	return AuthorizeFindBuckets(ctx, bs)
 }
 
 // CreateBucket checks to see if the authorizer on context has write access to the global buckets resource.
@@ -191,15 +87,9 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) er
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.BucketsResourceType, b.OrgID)
-	if err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.BucketsResourceType, b.OrgID); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
 	return s.s.CreateBucket(ctx, b)
 }
 
@@ -209,11 +99,9 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id influxdb.ID, upd in
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteBucket(ctx, b.OrgID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.BucketsResourceType, id, b.OrgID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateBucket(ctx, id, upd)
 }
 
@@ -223,10 +111,8 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id influxdb.ID) error 
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteBucket(ctx, b.OrgID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.BucketsResourceType, id, b.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteBucket(ctx, id)
 }

--- a/authorizer/check.go
+++ b/authorizer/check.go
@@ -32,11 +32,9 @@ func (s *CheckService) FindCheckByID(ctx context.Context, id influxdb.ID) (influ
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.ChecksResourceType, chk.GetID(), chk.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return chk, nil
 }
 
@@ -48,17 +46,7 @@ func (s *CheckService) FindChecks(ctx context.Context, filter influxdb.CheckFilt
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	rules := chks[:0]
-	for _, chk := range chks {
-		if err := authorizeReadOrg(ctx, chk.GetOrgID()); err == nil {
-			rules = append(rules, chk)
-		}
-	}
-
-	return rules, len(rules), nil
+	return AuthorizeFindChecks(ctx, chks)
 }
 
 // FindCheck will return the check.
@@ -67,20 +55,17 @@ func (s *CheckService) FindCheck(ctx context.Context, filter influxdb.CheckFilte
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.ChecksResourceType, chk.GetID(), chk.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return chk, nil
 }
 
 // CreateCheck checks to see if the authorizer on context has write access to the global check resource.
 func (s *CheckService) CreateCheck(ctx context.Context, chk influxdb.CheckCreate, userID influxdb.ID) error {
-	if err := authorizeWriteOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.ChecksResourceType, chk.GetOrgID()); err != nil {
 		return err
 	}
-
 	return s.s.CreateCheck(ctx, chk, userID)
 }
 
@@ -90,11 +75,9 @@ func (s *CheckService) UpdateCheck(ctx context.Context, id influxdb.ID, upd infl
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.ChecksResourceType, chk.GetID(), chk.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateCheck(ctx, id, upd)
 }
 
@@ -104,11 +87,9 @@ func (s *CheckService) PatchCheck(ctx context.Context, id influxdb.ID, upd influ
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.ChecksResourceType, chk.GetID(), chk.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.PatchCheck(ctx, id, upd)
 }
 
@@ -118,10 +99,8 @@ func (s *CheckService) DeleteCheck(ctx context.Context, id influxdb.ID) error {
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteOrg(ctx, chk.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.ChecksResourceType, chk.GetID(), chk.GetOrgID()); err != nil {
 		return err
 	}
-
 	return s.s.DeleteCheck(ctx, id)
 }

--- a/authorizer/check_test.go
+++ b/authorizer/check_test.go
@@ -63,10 +63,10 @@ func TestCheckService_FindCheckByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.ChecksResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 				id: 1,
@@ -91,17 +91,17 @@ func TestCheckService_FindCheckByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(2),
+						Type:  influxdb.ChecksResourceType,
+						OrgID: influxdbtesting.IDPtr(2),
 					},
 				},
 				id: 1,
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:orgs/000000000000000a is unauthorized",
+					Msg:  "read:orgs/000000000000000a/checks/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -169,9 +169,9 @@ func TestCheckService_FindChecks(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
+						Type: influxdb.ChecksResourceType,
 					},
 				},
 			},
@@ -228,10 +228,10 @@ func TestCheckService_FindChecks(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.ChecksResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -315,17 +315,17 @@ func TestCheckService_UpdateCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -360,17 +360,17 @@ func TestCheckService_UpdateCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/checks/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -439,17 +439,17 @@ func TestCheckService_PatchCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -484,17 +484,17 @@ func TestCheckService_PatchCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/checks/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -553,17 +553,17 @@ func TestCheckService_DeleteCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -593,17 +593,17 @@ func TestCheckService_DeleteCheck(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.ChecksResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/checks/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -653,10 +653,10 @@ func TestCheckService_CreateCheck(t *testing.T) {
 			args: args{
 				orgID: 10,
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.ChecksResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -676,16 +676,16 @@ func TestCheckService_CreateCheck(t *testing.T) {
 			args: args{
 				orgID: 10,
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(1),
+						Type:  influxdb.ChecksResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/checks is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},

--- a/authorizer/dashboard.go
+++ b/authorizer/dashboard.go
@@ -21,47 +21,15 @@ func NewDashboardService(s influxdb.DashboardService) *DashboardService {
 	}
 }
 
-func newDashboardPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.DashboardsResourceType, orgID)
-}
-
-func authorizeReadDashboard(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newDashboardPermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteDashboard(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newDashboardPermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindDashboardByID checks to see if the authorizer on context has read access to the id provided.
 func (s *DashboardService) FindDashboardByID(ctx context.Context, id influxdb.ID) (*influxdb.Dashboard, error) {
 	b, err := s.s.FindDashboardByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadDashboard(ctx, b.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.DashboardsResourceType, id, b.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return b, nil
 }
 
@@ -69,41 +37,18 @@ func (s *DashboardService) FindDashboardByID(ctx context.Context, id influxdb.ID
 func (s *DashboardService) FindDashboards(ctx context.Context, filter influxdb.DashboardFilter, opt influxdb.FindOptions) ([]*influxdb.Dashboard, int, error) {
 	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
 	// will likely be expensive.
-	bs, _, err := s.s.FindDashboards(ctx, filter, opt)
+	ds, _, err := s.s.FindDashboards(ctx, filter, opt)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	dashboards := bs[:0]
-	for _, b := range bs {
-		err := authorizeReadDashboard(ctx, b.OrganizationID, b.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		dashboards = append(dashboards, b)
-	}
-
-	return dashboards, len(dashboards), nil
+	return AuthorizeFindDashboards(ctx, ds)
 }
 
 // CreateDashboard checks to see if the authorizer on context has write access to the global dashboards resource.
 func (s *DashboardService) CreateDashboard(ctx context.Context, b *influxdb.Dashboard) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.DashboardsResourceType, b.OrganizationID)
-	if err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.DashboardsResourceType, b.OrganizationID); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
 	return s.s.CreateDashboard(ctx, b)
 }
 
@@ -113,11 +58,9 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, id influxdb.ID, 
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, id, b.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateDashboard(ctx, id, upd)
 }
 
@@ -127,11 +70,9 @@ func (s *DashboardService) DeleteDashboard(ctx context.Context, id influxdb.ID) 
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, id, b.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteDashboard(ctx, id)
 }
 
@@ -140,11 +81,9 @@ func (s *DashboardService) AddDashboardCell(ctx context.Context, id influxdb.ID,
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, id, b.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.AddDashboardCell(ctx, id, c, opts)
 }
 
@@ -153,11 +92,9 @@ func (s *DashboardService) RemoveDashboardCell(ctx context.Context, dashboardID 
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, dashboardID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, dashboardID, b.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.RemoveDashboardCell(ctx, dashboardID, cellID)
 }
 
@@ -166,11 +103,9 @@ func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID 
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, dashboardID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, dashboardID, b.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateDashboardCell(ctx, dashboardID, cellID, upd)
 }
 
@@ -179,11 +114,9 @@ func (s *DashboardService) GetDashboardCellView(ctx context.Context, dashboardID
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadDashboard(ctx, b.OrganizationID, dashboardID); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.DashboardsResourceType, dashboardID, b.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.GetDashboardCellView(ctx, dashboardID, cellID)
 }
 
@@ -192,11 +125,9 @@ func (s *DashboardService) UpdateDashboardCellView(ctx context.Context, dashboar
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, dashboardID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, dashboardID, b.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateDashboardCellView(ctx, dashboardID, cellID, upd)
 }
 
@@ -205,10 +136,8 @@ func (s *DashboardService) ReplaceDashboardCells(ctx context.Context, id influxd
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteDashboard(ctx, b.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.DashboardsResourceType, id, b.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.ReplaceDashboardCells(ctx, id, c)
 }

--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -25,77 +25,15 @@ func NewLabelServiceWithOrg(s influxdb.LabelService, orgSvc OrganizationService)
 	}
 }
 
-func newLabelPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.LabelsResourceType, orgID)
-}
-
-func newResourcePermission(a influxdb.Action, orgID, id influxdb.ID, resourceType influxdb.ResourceType) (*influxdb.Permission, error) {
-	if err := resourceType.Valid(); err != nil {
-		return nil, err
-	}
-
-	p := &influxdb.Permission{
-		Action: a,
-		Resource: influxdb.Resource{
-			Type:  resourceType,
-			ID:    &id,
-			OrgID: &orgID,
-		},
-	}
-
-	return p, p.Valid()
-}
-
-func authorizeLabelMappingAction(ctx context.Context, action influxdb.Action, orgID, id influxdb.ID, resourceType influxdb.ResourceType) error {
-	p, err := newResourcePermission(action, orgID, id, resourceType)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeReadLabel(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newLabelPermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteLabel(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newLabelPermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindLabelByID checks to see if the authorizer on context has read access to the label id provided.
 func (s *LabelService) FindLabelByID(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
 	l, err := s.s.FindLabelByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadLabel(ctx, l.OrgID, id); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.LabelsResourceType, id, l.OrgID); err != nil {
 		return nil, err
 	}
-
 	return l, nil
 }
 
@@ -107,27 +45,8 @@ func (s *LabelService) FindLabels(ctx context.Context, filter influxdb.LabelFilt
 	if err != nil {
 		return nil, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	labels := ls[:0]
-	for _, l := range ls {
-		err := authorizeReadLabel(ctx, l.OrgID, l.ID)
-		if err != nil &&
-			influxdb.ErrorCode(err) != influxdb.EUnauthorized &&
-			influxdb.ErrorCode(err) != influxdb.EInvalid {
-			return nil, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized ||
-			influxdb.ErrorCode(err) == influxdb.EInvalid {
-			continue
-		}
-
-		labels = append(labels, l)
-	}
-
-	return labels, nil
+	ls, _, err = AuthorizeFindLabels(ctx, ls)
+	return ls, err
 }
 
 // FindResourceLabels retrieves all labels belonging to the filtering resource if the authorizer on context has read access to it.
@@ -136,7 +55,6 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 	if err := filter.ResourceType.Valid(); err != nil {
 		return nil, err
 	}
-
 	if s.orgSvc == nil {
 		return nil, errors.New("failed to find orgSvc")
 	}
@@ -144,8 +62,7 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeLabelMappingAction(ctx, influxdb.ReadAction, orgID, filter.ResourceID, filter.ResourceType); err != nil {
+	if _, _, err := AuthorizeRead(ctx, filter.ResourceType, filter.ResourceID, orgID); err != nil {
 		return nil, err
 	}
 
@@ -153,30 +70,15 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 	if err != nil {
 		return nil, err
 	}
-
-	labels := ls[:0]
-	for _, l := range ls {
-		err := authorizeReadLabel(ctx, l.OrgID, l.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		labels = append(labels, l)
-	}
-
-	return labels, nil
+	ls, _, err = AuthorizeFindLabels(ctx, ls)
+	return ls, err
 }
 
 // CreateLabel checks to see if the authorizer on context has write access to the new label's org.
 func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error {
-	if err := authorizeWriteOrg(ctx, l.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.LabelsResourceType, l.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.CreateLabel(ctx, l)
 }
 
@@ -186,16 +88,12 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *influxdb.Label
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteLabel(ctx, l.OrgID, m.LabelID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.LabelsResourceType, m.LabelID, l.OrgID); err != nil {
 		return err
 	}
-
-	// if err := authorizeLabelMappingAction(ctx, influxdb.WriteAction, m.ResourceID, m.ResourceType); err != nil {
-	if err := authorizeLabelMappingAction(ctx, influxdb.WriteAction, l.OrgID, m.ResourceID, m.ResourceType); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, m.ResourceType, m.ResourceID, l.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.CreateLabelMapping(ctx, m)
 }
 
@@ -205,11 +103,9 @@ func (s *LabelService) UpdateLabel(ctx context.Context, id influxdb.ID, upd infl
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteLabel(ctx, l.OrgID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.LabelsResourceType, l.ID, l.OrgID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateLabel(ctx, id, upd)
 }
 
@@ -219,11 +115,9 @@ func (s *LabelService) DeleteLabel(ctx context.Context, id influxdb.ID) error {
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteLabel(ctx, l.OrgID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.LabelsResourceType, l.ID, l.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteLabel(ctx, id)
 }
 
@@ -233,14 +127,11 @@ func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *influxdb.Label
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteLabel(ctx, l.OrgID, m.LabelID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.LabelsResourceType, m.LabelID, l.OrgID); err != nil {
 		return err
 	}
-
-	if err := authorizeLabelMappingAction(ctx, influxdb.WriteAction, l.OrgID, m.ResourceID, m.ResourceType); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, m.ResourceType, m.ResourceID, l.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteLabelMapping(ctx, m)
 }

--- a/authorizer/label_test.go
+++ b/authorizer/label_test.go
@@ -72,7 +72,7 @@ func TestLabelService_FindLabelByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.LabelsResourceType,
 						ID:   influxdbtesting.IDPtr(1),
@@ -98,7 +98,7 @@ func TestLabelService_FindLabelByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.LabelsResourceType,
 						ID:   influxdbtesting.IDPtr(2),
@@ -170,7 +170,7 @@ func TestLabelService_FindLabels(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.LabelsResourceType,
 					},
@@ -217,7 +217,7 @@ func TestLabelService_FindLabels(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.LabelsResourceType,
 						ID:   influxdbtesting.IDPtr(1),
@@ -257,7 +257,7 @@ func TestLabelService_FindLabels(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.LabelsResourceType,
 						ID:   influxdbtesting.IDPtr(10),
@@ -327,7 +327,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -361,7 +361,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -428,7 +428,7 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.LabelsResourceType,
 							ID:    influxdbtesting.IDPtr(1),
@@ -460,7 +460,7 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.LabelsResourceType,
 							ID:    influxdbtesting.IDPtr(1),
@@ -519,7 +519,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						ID:   influxdbtesting.IDPtr(orgOneInfluxID),
 						Type: influxdb.OrgsResourceType,
@@ -528,13 +528,13 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/020f755c3c083000 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
 		},
 		{
-			name: "unauthorized to create label with incomplete write permission",
+			name: "unauthorized to create label with wrong write permission",
 			fields: fields{
 				LabelService: &mock.LabelService{
 					CreateLabelFn: func(ctx context.Context, b *influxdb.Label) error {
@@ -544,15 +544,15 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.LabelsResourceType,
+						Type: influxdb.OrgsResourceType,
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/020f755c3c083000 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -569,10 +569,10 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						ID:   influxdbtesting.IDPtr(orgOneInfluxID),
-						Type: influxdb.OrgsResourceType,
+						OrgID: influxdbtesting.IDPtr(orgOneInfluxID),
+						Type:  influxdb.LabelsResourceType,
 					},
 				},
 			},
@@ -642,13 +642,13 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(10),
@@ -703,14 +703,14 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 							ID:   influxdbtesting.IDPtr(3),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(10),
@@ -757,7 +757,7 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(10),
@@ -798,7 +798,7 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
@@ -872,13 +872,13 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(2),
@@ -913,7 +913,7 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
@@ -950,7 +950,7 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
@@ -1020,13 +1020,13 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(2),
@@ -1061,7 +1061,7 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},
@@ -1098,7 +1098,7 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				},
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.LabelsResourceType,
 						},

--- a/authorizer/notification_endpoint.go
+++ b/authorizer/notification_endpoint.go
@@ -29,47 +29,15 @@ func NewNotificationEndpointService(
 	}
 }
 
-func newNotificationEndpointPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.NotificationEndpointResourceType, orgID)
-}
-
-func authorizeReadNotificationEndpoint(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newNotificationEndpointPermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteNotificationEndpoint(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newNotificationEndpointPermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindNotificationEndpointByID checks to see if the authorizer on context has read access to the id provided.
 func (s *NotificationEndpointService) FindNotificationEndpointByID(ctx context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error) {
 	edp, err := s.s.FindNotificationEndpointByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadNotificationEndpoint(ctx, edp.GetOrgID(), edp.GetID()); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.NotificationEndpointResourceType, edp.GetID(), edp.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return edp, nil
 }
 
@@ -89,33 +57,12 @@ func (s *NotificationEndpointService) FindNotificationEndpoints(ctx context.Cont
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	endpoints := edps[:0]
-	for _, edp := range edps {
-		err := authorizeReadNotificationEndpoint(ctx, edp.GetOrgID(), edp.GetID())
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		endpoints = append(endpoints, edp)
-	}
-
-	return endpoints, len(endpoints), nil
+	return AuthorizeFindNotificationEndpoints(ctx, edps)
 }
 
 // CreateNotificationEndpoint checks to see if the authorizer on context has write access to the global notification endpoint resource.
 func (s *NotificationEndpointService) CreateNotificationEndpoint(ctx context.Context, edp influxdb.NotificationEndpoint, userID influxdb.ID) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.NotificationEndpointResourceType, edp.GetOrgID())
-	if err != nil {
-		return err
-	}
-	if err := IsAllowed(ctx, *p); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationEndpointResourceType, edp.GetOrgID()); err != nil {
 		return err
 	}
 	return s.s.CreateNotificationEndpoint(ctx, edp, userID)
@@ -127,11 +74,9 @@ func (s *NotificationEndpointService) UpdateNotificationEndpoint(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteNotificationEndpoint(ctx, edp.GetOrgID(), edp.GetID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationEndpointResourceType, edp.GetID(), edp.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateNotificationEndpoint(ctx, id, upd, userID)
 }
 
@@ -141,11 +86,9 @@ func (s *NotificationEndpointService) PatchNotificationEndpoint(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteNotificationEndpoint(ctx, edp.GetOrgID(), edp.GetID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationEndpointResourceType, edp.GetID(), edp.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.PatchNotificationEndpoint(ctx, id, upd)
 }
 
@@ -155,10 +98,8 @@ func (s *NotificationEndpointService) DeleteNotificationEndpoint(ctx context.Con
 	if err != nil {
 		return nil, 0, err
 	}
-
-	if err := authorizeWriteNotificationEndpoint(ctx, edp.GetOrgID(), edp.GetID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationEndpointResourceType, edp.GetID(), edp.GetOrgID()); err != nil {
 		return nil, 0, err
 	}
-
 	return s.s.DeleteNotificationEndpoint(ctx, id)
 }

--- a/authorizer/notification_rule.go
+++ b/authorizer/notification_rule.go
@@ -31,11 +31,9 @@ func (s *NotificationRuleStore) FindNotificationRuleByID(ctx context.Context, id
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadOrg(ctx, nr.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.NotificationRuleResourceType, nr.GetID(), nr.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return nr, nil
 }
 
@@ -47,22 +45,12 @@ func (s *NotificationRuleStore) FindNotificationRules(ctx context.Context, filte
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	rules := nrs[:0]
-	for _, nr := range nrs {
-		if err := authorizeReadOrg(ctx, nr.GetOrgID()); err == nil {
-			rules = append(rules, nr)
-		}
-	}
-
-	return rules, len(rules), nil
+	return AuthorizeFindNotificationRules(ctx, nrs)
 }
 
 // CreateNotificationRule checks to see if the authorizer on context has write access to the global notification rule resource.
 func (s *NotificationRuleStore) CreateNotificationRule(ctx context.Context, nr influxdb.NotificationRuleCreate, userID influxdb.ID) error {
-	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationRuleResourceType, nr.GetOrgID()); err != nil {
 		return err
 	}
 	return s.s.CreateNotificationRule(ctx, nr, userID)
@@ -74,11 +62,9 @@ func (s *NotificationRuleStore) UpdateNotificationRule(ctx context.Context, id i
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationRuleResourceType, nr.GetID(), nr.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateNotificationRule(ctx, id, upd, userID)
 }
 
@@ -88,11 +74,9 @@ func (s *NotificationRuleStore) PatchNotificationRule(ctx context.Context, id in
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationRuleResourceType, nr.GetID(), nr.GetOrgID()); err != nil {
 		return nil, err
 	}
-
 	return s.s.PatchNotificationRule(ctx, id, upd)
 }
 
@@ -102,10 +86,8 @@ func (s *NotificationRuleStore) DeleteNotificationRule(ctx context.Context, id i
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.NotificationRuleResourceType, nr.GetID(), nr.GetOrgID()); err != nil {
 		return err
 	}
-
 	return s.s.DeleteNotificationRule(ctx, id)
 }

--- a/authorizer/notification_rule_test.go
+++ b/authorizer/notification_rule_test.go
@@ -63,10 +63,10 @@ func TestNotificationRuleStore_FindNotificationRuleByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.NotificationRuleResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 				id: 1,
@@ -91,17 +91,17 @@ func TestNotificationRuleStore_FindNotificationRuleByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(2),
+						Type:  influxdb.NotificationRuleResourceType,
+						OrgID: influxdbtesting.IDPtr(2),
 					},
 				},
 				id: 1,
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:orgs/000000000000000a is unauthorized",
+					Msg:  "read:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -169,9 +169,9 @@ func TestNotificationRuleStore_FindNotificationRules(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
+						Type: influxdb.NotificationRuleResourceType,
 					},
 				},
 			},
@@ -228,10 +228,10 @@ func TestNotificationRuleStore_FindNotificationRules(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.NotificationRuleResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -315,17 +315,17 @@ func TestNotificationRuleStore_UpdateNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -360,17 +360,17 @@ func TestNotificationRuleStore_UpdateNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -439,17 +439,17 @@ func TestNotificationRuleStore_PatchNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -484,17 +484,17 @@ func TestNotificationRuleStore_PatchNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(1),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -553,17 +553,17 @@ func TestNotificationRuleStore_DeleteNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(10),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(1),
 						},
 					},
 				},
@@ -593,17 +593,17 @@ func TestNotificationRuleStore_DeleteNotificationRule(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
-							Type: influxdb.OrgsResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type:  influxdb.NotificationRuleResourceType,
+							OrgID: influxdbtesting.IDPtr(1),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -653,10 +653,10 @@ func TestNotificationRuleStore_CreateNotificationRule(t *testing.T) {
 			args: args{
 				orgID: 10,
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(10),
+						Type:  influxdb.NotificationRuleResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -676,16 +676,16 @@ func TestNotificationRuleStore_CreateNotificationRule(t *testing.T) {
 			args: args{
 				orgID: 10,
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
-						Type: influxdb.OrgsResourceType,
-						ID:   influxdbtesting.IDPtr(1),
+						Type:  influxdb.NotificationRuleResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a is unauthorized",
+					Msg:  "write:orgs/000000000000000a/notificationRules is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},

--- a/authorizer/org.go
+++ b/authorizer/org.go
@@ -21,50 +21,11 @@ func NewOrgService(s influxdb.OrganizationService) *OrgService {
 	}
 }
 
-func newOrgPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
-	p := &influxdb.Permission{
-		Action: a,
-		Resource: influxdb.Resource{
-			Type: influxdb.OrgsResourceType,
-			ID:   &id,
-		},
-	}
-
-	return p, p.Valid()
-}
-
-func authorizeReadOrg(ctx context.Context, id influxdb.ID) error {
-	p, err := newOrgPermission(influxdb.ReadAction, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteOrg(ctx context.Context, id influxdb.ID) error {
-	p, err := newOrgPermission(influxdb.WriteAction, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindOrganizationByID checks to see if the authorizer on context has read access to the id provided.
 func (s *OrgService) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
-	if err := authorizeReadOrg(ctx, id); err != nil {
+	if _, _, err := AuthorizeReadOrg(ctx, id); err != nil {
 		return nil, err
 	}
-
 	return s.s.FindOrganizationByID(ctx, id)
 }
 
@@ -74,11 +35,9 @@ func (s *OrgService) FindOrganization(ctx context.Context, filter influxdb.Organ
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadOrg(ctx, o.ID); err != nil {
+	if _, _, err := AuthorizeReadOrg(ctx, o.ID); err != nil {
 		return nil, err
 	}
-
 	return o, nil
 }
 
@@ -90,54 +49,29 @@ func (s *OrgService) FindOrganizations(ctx context.Context, filter influxdb.Orga
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	orgs := os[:0]
-	for _, o := range os {
-		err := authorizeReadOrg(ctx, o.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		orgs = append(orgs, o)
-	}
-
-	return orgs, len(orgs), nil
+	return AuthorizeFindOrganizations(ctx, os)
 }
 
 // CreateOrganization checks to see if the authorizer on context has write access to the global orgs resource.
 func (s *OrgService) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
-	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.OrgsResourceType)
-	if err != nil {
+	if _, _, err := AuthorizeWriteGlobal(ctx, influxdb.OrgsResourceType); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
 	return s.s.CreateOrganization(ctx, o)
 }
 
 // UpdateOrganization checks to see if the authorizer on context has write access to the organization provided.
 func (s *OrgService) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
-	if err := authorizeWriteOrg(ctx, id); err != nil {
+	if _, _, err := AuthorizeWriteOrg(ctx, id); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateOrganization(ctx, id, upd)
 }
 
 // DeleteOrganization checks to see if the authorizer on context has write access to the organization provided.
 func (s *OrgService) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
-	if err := authorizeWriteOrg(ctx, id); err != nil {
+	if _, _, err := AuthorizeWriteOrg(ctx, id); err != nil {
 		return err
 	}
-
 	return s.s.DeleteOrganization(ctx, id)
 }

--- a/authorizer/password.go
+++ b/authorizer/password.go
@@ -18,10 +18,9 @@ func NewPasswordService(svc influxdb.PasswordsService) *PasswordService {
 
 // SetPassword overrides the password of a known user.
 func (s *PasswordService) SetPassword(ctx context.Context, userID influxdb.ID, password string) error {
-	if err := authorizeWriteUser(ctx, userID); err != nil {
+	if _, _, err := AuthorizeWriteResource(ctx, influxdb.UsersResourceType, userID); err != nil {
 		return err
 	}
-
 	return s.next.SetPassword(ctx, userID, password)
 }
 

--- a/authorizer/scraper.go
+++ b/authorizer/scraper.go
@@ -27,47 +27,15 @@ func NewScraperTargetStoreService(s influxdb.ScraperTargetStoreService,
 	}
 }
 
-func newScraperPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.ScraperResourceType, orgID)
-}
-
-func authorizeReadScraper(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newScraperPermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteScraper(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newScraperPermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetTargetByID checks to see if the authorizer on context has read access to the id provided.
 func (s *ScraperTargetStoreService) GetTargetByID(ctx context.Context, id influxdb.ID) (*influxdb.ScraperTarget, error) {
 	st, err := s.s.GetTargetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadScraper(ctx, st.OrgID, id); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.ScraperResourceType, id, st.OrgID); err != nil {
 		return nil, err
 	}
-
 	return st, nil
 }
 
@@ -79,41 +47,18 @@ func (s *ScraperTargetStoreService) ListTargets(ctx context.Context, filter infl
 	if err != nil {
 		return nil, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	scrapers := ss[:0]
-	for _, st := range ss {
-		err := authorizeReadScraper(ctx, st.OrgID, st.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		scrapers = append(scrapers, st)
-	}
-
-	return scrapers, nil
+	ss, _, err = AuthorizeFindScrapers(ctx, ss)
+	return ss, err
 }
 
 // AddTarget checks to see if the authorizer on context has write access to the global scraper target resource.
 func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, st *influxdb.ScraperTarget, userID influxdb.ID) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.ScraperResourceType, st.OrgID)
-	if err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.ScraperResourceType, st.OrgID); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.BucketsResourceType, st.BucketID, st.OrgID); err != nil {
 		return err
 	}
-
-	if err := authorizeWriteBucket(ctx, st.OrgID, st.BucketID); err != nil {
-		return err
-	}
-
 	return s.s.AddTarget(ctx, st, userID)
 }
 
@@ -123,15 +68,12 @@ func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, upd *influ
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteScraper(ctx, st.OrgID, upd.ID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.ScraperResourceType, upd.ID, st.OrgID); err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteBucket(ctx, st.OrgID, st.BucketID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.BucketsResourceType, st.BucketID, st.OrgID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateTarget(ctx, upd, userID)
 }
 
@@ -141,10 +83,8 @@ func (s *ScraperTargetStoreService) RemoveTarget(ctx context.Context, id influxd
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteScraper(ctx, st.OrgID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.ScraperResourceType, st.ID, st.OrgID); err != nil {
 		return err
 	}
-
 	return s.s.RemoveTarget(ctx, id)
 }

--- a/authorizer/scraper_test.go
+++ b/authorizer/scraper_test.go
@@ -59,7 +59,7 @@ func TestScraperTargetStoreService_GetTargetByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.ScraperResourceType,
 						ID:   influxdbtesting.IDPtr(1),
@@ -85,7 +85,7 @@ func TestScraperTargetStoreService_GetTargetByID(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.ScraperResourceType,
 						ID:   influxdbtesting.IDPtr(2),
@@ -157,7 +157,7 @@ func TestScraperTargetStoreService_ListTargets(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.ScraperResourceType,
 					},
@@ -204,7 +204,7 @@ func TestScraperTargetStoreService_ListTargets(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.ScraperResourceType,
 						OrgID: influxdbtesting.IDPtr(10),
@@ -288,21 +288,21 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(100),
@@ -339,7 +339,7 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -379,7 +379,7 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -447,14 +447,14 @@ func TestScraperTargetStoreService_RemoveTarget(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -485,7 +485,7 @@ func TestScraperTargetStoreService_RemoveTarget(t *testing.T) {
 				id: 1,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
@@ -549,14 +549,14 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.ScraperResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(100),
@@ -582,14 +582,14 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.ScraperResourceType,
 							ID:   influxdbtesting.IDPtr(1),
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(100),
@@ -618,14 +618,14 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 				bucketID: 100,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.ScraperResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							ID:   influxdbtesting.IDPtr(1),

--- a/authorizer/secret.go
+++ b/authorizer/secret.go
@@ -21,75 +21,39 @@ func NewSecretService(s influxdb.SecretService) *SecretService {
 	}
 }
 
-func newSecretPermission(a influxdb.Action, orgID influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermission(a, influxdb.SecretsResourceType, orgID)
-}
-
-func authorizeReadSecret(ctx context.Context, orgID influxdb.ID) error {
-	p, err := newSecretPermission(influxdb.ReadAction, orgID)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteSecret(ctx context.Context, orgID influxdb.ID) error {
-	p, err := newSecretPermission(influxdb.WriteAction, orgID)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // LoadSecret checks to see if the authorizer on context has read access to the secret key provided.
 func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key string) (string, error) {
-	if err := authorizeReadSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return "", err
 	}
-
 	secret, err := s.s.LoadSecret(ctx, orgID, key)
 	if err != nil {
 		return "", err
 	}
-
 	return secret, nil
 }
 
 // GetSecretKeys checks to see if the authorizer on context has read access to all the secrets belonging to orgID.
 func (s *SecretService) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
-	if err := authorizeReadSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return []string{}, err
 	}
-
 	secrets, err := s.s.GetSecretKeys(ctx, orgID)
 	if err != nil {
 		return []string{}, err
 	}
-
 	return secrets, nil
 }
 
 // PutSecret checks to see if the authorizer on context has write access to the secret key provided.
 func (s *SecretService) PutSecret(ctx context.Context, orgID influxdb.ID, key string, val string) error {
-	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return err
 	}
-
 	err := s.s.PutSecret(ctx, orgID, key, val)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -97,46 +61,39 @@ func (s *SecretService) PutSecret(ctx context.Context, orgID influxdb.ID, key st
 func (s *SecretService) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
 	// PutSecrets operates on intersection between m and keys beloging to orgID.
 	// We need to have read access to those secrets since it deletes the secrets (within the intersection) that have not be overridden.
-	if err := authorizeReadSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return err
 	}
-
-	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return err
 	}
-
 	err := s.s.PutSecrets(ctx, orgID, m)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
 // PatchSecrets checks to see if the authorizer on context has write access to the secret keys provided.
 func (s *SecretService) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
-	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return err
 	}
-
 	err := s.s.PatchSecrets(ctx, orgID, m)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
 // DeleteSecret checks to see if the authorizer on context has write access to the secret keys provided.
 func (s *SecretService) DeleteSecret(ctx context.Context, orgID influxdb.ID, keys ...string) error {
-	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
 		return err
 	}
-
 	err := s.s.DeleteSecret(ctx, orgID, keys...)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/authorizer/secret_test.go
+++ b/authorizer/secret_test.go
@@ -55,7 +55,7 @@ func TestSecretService_LoadSecret(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(10),
@@ -85,7 +85,7 @@ func TestSecretService_LoadSecret(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(10),
@@ -118,7 +118,7 @@ func TestSecretService_LoadSecret(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.SecretsResourceType,
 						ID:   influxdbtesting.IDPtr(10),
@@ -183,7 +183,7 @@ func TestSecretService_GetSecretKeys(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
@@ -214,7 +214,7 @@ func TestSecretService_GetSecretKeys(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
@@ -244,7 +244,7 @@ func TestSecretService_GetSecretKeys(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "read",
+					Action: influxdb.ReadAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(10),
@@ -310,7 +310,7 @@ func TestSecretService_PatchSecrets(t *testing.T) {
 				org: influxdb.ID(1),
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(1),
@@ -335,7 +335,7 @@ func TestSecretService_PatchSecrets(t *testing.T) {
 				org: influxdb.ID(1),
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
@@ -397,7 +397,7 @@ func TestSecretService_DeleteSecret(t *testing.T) {
 				org: influxdb.ID(1),
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(1),
@@ -422,7 +422,7 @@ func TestSecretService_DeleteSecret(t *testing.T) {
 				org: 10,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(1),
@@ -482,7 +482,7 @@ func TestSecretService_PutSecret(t *testing.T) {
 			args: args{
 				orgID: influxdb.ID(10),
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
 						Type:  influxdb.SecretsResourceType,
 						OrgID: influxdbtesting.IDPtr(10),
@@ -505,7 +505,7 @@ func TestSecretService_PutSecret(t *testing.T) {
 			args: args{
 				orgID: 10,
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: influxdb.WriteAction,
 					Resource: influxdb.Resource{
 						Type: influxdb.SecretsResourceType,
 						ID:   influxdbtesting.IDPtr(1),
@@ -565,14 +565,14 @@ func TestSecretService_PutSecrets(t *testing.T) {
 				orgID: influxdb.ID(10),
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
@@ -597,14 +597,14 @@ func TestSecretService_PutSecrets(t *testing.T) {
 				orgID: influxdb.ID(2),
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(1),
 						},
 					},
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(2),
@@ -635,7 +635,7 @@ func TestSecretService_PutSecrets(t *testing.T) {
 				orgID: 10,
 				permissions: []influxdb.Permission{
 					{
-						Action: "write",
+						Action: influxdb.WriteAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(10),
@@ -666,7 +666,7 @@ func TestSecretService_PutSecrets(t *testing.T) {
 				orgID: 10,
 				permissions: []influxdb.Permission{
 					{
-						Action: "read",
+						Action: influxdb.ReadAction,
 						Resource: influxdb.Resource{
 							Type:  influxdb.SecretsResourceType,
 							OrgID: influxdbtesting.IDPtr(10),

--- a/authorizer/source.go
+++ b/authorizer/source.go
@@ -21,47 +21,15 @@ func NewSourceService(s influxdb.SourceService) *SourceService {
 	}
 }
 
-func newSourcePermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.SourcesResourceType, orgID)
-}
-
-func authorizeReadSource(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newSourcePermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteSource(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newSourcePermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // DefaultSource checks to see if the authorizer on context has read access to the default source.
 func (s *SourceService) DefaultSource(ctx context.Context) (*influxdb.Source, error) {
 	src, err := s.s.DefaultSource(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadSource(ctx, src.OrganizationID, src.ID); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.SourcesResourceType, src.ID, src.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return src, nil
 }
 
@@ -71,11 +39,9 @@ func (s *SourceService) FindSourceByID(ctx context.Context, id influxdb.ID) (*in
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadSource(ctx, src.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.SourcesResourceType, src.ID, src.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return src, nil
 }
 
@@ -86,37 +52,14 @@ func (s *SourceService) FindSources(ctx context.Context, opts influxdb.FindOptio
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	sources := ss[:0]
-	for _, src := range ss {
-		err := authorizeReadSource(ctx, src.OrganizationID, src.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		sources = append(sources, src)
-	}
-
-	return sources, len(sources), nil
+	return AuthorizeFindSources(ctx, ss)
 }
 
 // CreateSource checks to see if the authorizer on context has write access to the global source resource.
 func (s *SourceService) CreateSource(ctx context.Context, src *influxdb.Source) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.SourcesResourceType, src.OrganizationID)
-	if err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.SourcesResourceType, src.OrganizationID); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
 	return s.s.CreateSource(ctx, src)
 }
 
@@ -126,24 +69,20 @@ func (s *SourceService) UpdateSource(ctx context.Context, id influxdb.ID, upd in
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteSource(ctx, src.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.SourcesResourceType, src.ID, src.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateSource(ctx, id, upd)
 }
 
 // DeleteSource checks to see if the authorizer on context has write access to the source provided.
 func (s *SourceService) DeleteSource(ctx context.Context, id influxdb.ID) error {
-	m, err := s.s.FindSourceByID(ctx, id)
+	src, err := s.s.FindSourceByID(ctx, id)
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteSource(ctx, m.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.SourcesResourceType, src.ID, src.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteSource(ctx, id)
 }

--- a/authorizer/task.go
+++ b/authorizer/task.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/influxdb"
-	platcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"go.uber.org/zap"
 )
@@ -46,6 +45,19 @@ func NewTaskService(log *zap.Logger, ts influxdb.TaskService) influxdb.TaskServi
 	}
 }
 
+func (ts *taskServiceValidator) processPermissionError(a influxdb.Authorizer, p influxdb.Permission, err error, loggerFields ...zap.Field) error {
+	if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+		ts.log.With(loggerFields...).Info("Authorization failed",
+			zap.String("user_id", a.GetUserID().String()),
+			zap.String("auth_kind", a.Kind()),
+			zap.String("auth_id", a.Identifier().String()),
+			zap.String("disallowed_permission", p.String()),
+		)
+		return authError{error: ErrFailedPermission, perm: p, auth: a}
+	}
+	return err
+}
+
 func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id influxdb.ID) (*influxdb.Task, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
@@ -56,56 +68,23 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id influxdb.ID
 		return nil, err
 	}
 
-	perm, err := influxdb.NewPermissionAtID(id, influxdb.ReadAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeRead(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "FindTaskByID"), zap.Stringer("task_id", id)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
-	if err := ts.validatePermission(ctx, *perm,
-		zap.String("method", "FindTaskByID"), zap.Stringer("task_id", id),
-	); err != nil {
-		return nil, err
-	}
-
 	return task, nil
 }
 
 func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
-
-	// Get the authorizer first.
-	// We are getting a list of tasks that may be a superset of what the user is allowed to view.
-	auth, err := platcontext.GetAuthorizer(ctx)
-	if err != nil {
-		ts.log.Info("Failed to retrieve authorizer from context", zap.String("method", "FindTasks"))
-		return nil, 0, err
-	}
-
 	// Get the tasks in the organization, without authentication.
 	unauthenticatedTasks, _, err := ts.TaskService.FindTasks(ctx, filter)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// Then, filter down to what the user is allowed to see.
-	tasks := make([]*influxdb.Task, 0, len(unauthenticatedTasks))
-	for _, t := range unauthenticatedTasks {
-		perm, err := influxdb.NewPermissionAtID(t.ID, influxdb.ReadAction, influxdb.TasksResourceType, t.OrganizationID)
-		if err != nil {
-			continue
-		}
-
-		// We don't want to log authorization errors on this one.
-		if !auth.Allowed(*perm) {
-			continue
-		}
-
-		// Allowed to read it.
-		tasks = append(tasks, t)
-	}
-
-	return tasks, len(tasks), nil
+	return AuthorizeFindTasks(ctx, unauthenticatedTasks)
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t influxdb.TaskCreate) (*influxdb.Task, error) {
@@ -116,16 +95,11 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t influxdb.TaskC
 		return nil, influxdb.ErrInvalidOwnerID
 	}
 
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.TasksResourceType, t.OrganizationID)
-	if err != nil {
-		return nil, err
-	}
-
+	a, p, err := AuthorizeCreate(ctx, influxdb.TasksResourceType, t.OrganizationID)
 	loggerFields := []zap.Field{zap.String("method", "CreateTask")}
-	if err := ts.validatePermission(ctx, *p, loggerFields...); err != nil {
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
 	return ts.TaskService.CreateTask(ctx, t)
 }
 
@@ -139,16 +113,11 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id influxdb.ID, 
 		return nil, err
 	}
 
-	p, err := influxdb.NewPermissionAtID(id, influxdb.WriteAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
-		return nil, err
-	}
-
+	a, p, err := AuthorizeWrite(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
 	loggerFields := []zap.Field{zap.String("method", "UpdateTask"), zap.Stringer("task_id", id)}
-	if err := ts.validatePermission(ctx, *p, loggerFields...); err != nil {
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
 	return ts.TaskService.UpdateTask(ctx, id, upd)
 }
 
@@ -162,17 +131,11 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id influxdb.ID) 
 		return err
 	}
 
-	p, err := influxdb.NewPermissionAtID(id, influxdb.WriteAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeWrite(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "DeleteTask"), zap.Stringer("task_id", id)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return err
 	}
-
-	if err := ts.validatePermission(ctx, *p,
-		zap.String("method", "DeleteTask"), zap.Stringer("task_id", id),
-	); err != nil {
-		return err
-	}
-
 	return ts.TaskService.DeleteTask(ctx, id)
 }
 
@@ -199,17 +162,11 @@ func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter influxdb.Ru
 		return nil, -1, err
 	}
 
-	perm, err := influxdb.NewPermissionAtID(task.ID, influxdb.ReadAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeRead(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "FindRuns"), zap.Stringer("task_id", task.ID)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, -1, err
 	}
-
-	if err := ts.validatePermission(ctx, *perm,
-		zap.String("method", "FindRuns"), zap.Stringer("task_id", task.ID),
-	); err != nil {
-		return nil, -1, err
-	}
-
 	// TODO(lyon): If the user no longer has permission to the organization we might fail or filter here?
 	return ts.TaskService.FindRuns(ctx, filter)
 }
@@ -224,17 +181,11 @@ func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID i
 		return nil, err
 	}
 
-	p, err := influxdb.NewPermissionAtID(taskID, influxdb.ReadAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeRead(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "FindRunByID"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
-	if err := ts.validatePermission(ctx, *p,
-		zap.String("method", "FindRunByID"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID),
-	); err != nil {
-		return nil, err
-	}
-
 	return ts.TaskService.FindRunByID(ctx, taskID, runID)
 }
 
@@ -248,17 +199,11 @@ func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID inf
 		return err
 	}
 
-	p, err := influxdb.NewPermissionAtID(taskID, influxdb.WriteAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeWrite(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "CancelRun"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return err
 	}
-
-	if err := ts.validatePermission(ctx, *p,
-		zap.String("method", "CancelRun"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID),
-	); err != nil {
-		return err
-	}
-
 	return ts.TaskService.CancelRun(ctx, taskID, runID)
 }
 
@@ -276,17 +221,11 @@ func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID infl
 		return nil, ErrInactiveTask
 	}
 
-	p, err := influxdb.NewPermissionAtID(taskID, influxdb.WriteAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeWrite(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "RetryRun"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
-	if err := ts.validatePermission(ctx, *p,
-		zap.String("method", "RetryRun"), zap.Stringer("task_id", taskID), zap.Stringer("run_id", runID),
-	); err != nil {
-		return nil, err
-	}
-
 	return ts.TaskService.RetryRun(ctx, taskID, runID)
 }
 
@@ -304,36 +243,10 @@ func (ts *taskServiceValidator) ForceRun(ctx context.Context, taskID influxdb.ID
 		return nil, ErrInactiveTask
 	}
 
-	p, err := influxdb.NewPermissionAtID(taskID, influxdb.WriteAction, influxdb.TasksResourceType, task.OrganizationID)
-	if err != nil {
+	a, p, err := AuthorizeWrite(ctx, influxdb.TasksResourceType, task.ID, task.OrganizationID)
+	loggerFields := []zap.Field{zap.String("method", "ForceRun"), zap.Stringer("task_id", taskID)}
+	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err
 	}
-
-	if err := ts.validatePermission(ctx, *p,
-		zap.String("method", "ForceRun"), zap.Stringer("task_id", taskID),
-	); err != nil {
-		return nil, err
-	}
-
 	return ts.TaskService.ForceRun(ctx, taskID, scheduledFor)
-}
-
-func (ts *taskServiceValidator) validatePermission(ctx context.Context, perm influxdb.Permission, loggerFields ...zap.Field) error {
-	auth, err := platcontext.GetAuthorizer(ctx)
-	if err != nil {
-		ts.log.With(loggerFields...).Info("Failed to retrieve authorizer from context")
-		return err
-	}
-
-	if !auth.Allowed(perm) {
-		ts.log.With(loggerFields...).Info("Authorization failed",
-			zap.String("user_id", auth.GetUserID().String()),
-			zap.String("auth_kind", auth.Kind()),
-			zap.String("auth_id", auth.Identifier().String()),
-			zap.String("disallowed_permission", perm.String()),
-		)
-		return authError{error: ErrFailedPermission, perm: perm, auth: auth}
-	}
-
-	return nil
 }

--- a/authorizer/user.go
+++ b/authorizer/user.go
@@ -21,123 +21,57 @@ func NewUserService(s influxdb.UserService) *UserService {
 	}
 }
 
-func newUserPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
-	p := &influxdb.Permission{
-		Action: a,
-		Resource: influxdb.Resource{
-			Type: influxdb.UsersResourceType,
-			ID:   &id,
-		},
-	}
-
-	return p, p.Valid()
-}
-
-func authorizeReadUser(ctx context.Context, id influxdb.ID) error {
-	p, err := newUserPermission(influxdb.ReadAction, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteUser(ctx context.Context, id influxdb.ID) error {
-	p, err := newUserPermission(influxdb.WriteAction, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindUserByID checks to see if the authorizer on context has read access to the id provided.
 func (s *UserService) FindUserByID(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
-	if err := authorizeReadUser(ctx, id); err != nil {
+	if _, _, err := AuthorizeReadResource(ctx, influxdb.UsersResourceType, id); err != nil {
 		return nil, err
 	}
-
 	return s.s.FindUserByID(ctx, id)
 }
 
 // FindUser retrieves the user and checks to see if the authorizer on context has read access to the user.
 func (s *UserService) FindUser(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
-	o, err := s.s.FindUser(ctx, filter)
+	u, err := s.s.FindUser(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadUser(ctx, o.ID); err != nil {
+	if _, _, err := AuthorizeReadResource(ctx, influxdb.UsersResourceType, u.ID); err != nil {
 		return nil, err
 	}
-
-	return o, nil
+	return u, nil
 }
 
 // FindUsers retrieves all users that match the provided filter and then filters the list down to only the resources that are authorized.
 func (s *UserService) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {
 	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
 	// will likely be expensive.
-	os, _, err := s.s.FindUsers(ctx, filter, opt...)
+	us, _, err := s.s.FindUsers(ctx, filter, opt...)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	users := os[:0]
-	for _, o := range os {
-		err := authorizeReadUser(ctx, o.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		users = append(users, o)
-	}
-
-	return users, len(users), nil
+	return AuthorizeFindUsers(ctx, us)
 }
 
 // CreateUser checks to see if the authorizer on context has write access to the global users resource.
 func (s *UserService) CreateUser(ctx context.Context, o *influxdb.User) error {
-	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.UsersResourceType)
-	if err != nil {
+	if _, _, err := AuthorizeWriteGlobal(ctx, influxdb.UsersResourceType); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
 	return s.s.CreateUser(ctx, o)
 }
 
 // UpdateUser checks to see if the authorizer on context has write access to the user provided.
 func (s *UserService) UpdateUser(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
-	if err := authorizeWriteUser(ctx, id); err != nil {
+	if _, _, err := AuthorizeWriteResource(ctx, influxdb.UsersResourceType, id); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateUser(ctx, id, upd)
 }
 
 // DeleteUser checks to see if the authorizer on context has write access to the user provided.
 func (s *UserService) DeleteUser(ctx context.Context, id influxdb.ID) error {
-	if err := authorizeWriteUser(ctx, id); err != nil {
+	if _, _, err := AuthorizeWriteResource(ctx, influxdb.UsersResourceType, id); err != nil {
 		return err
 	}
-
 	return s.s.DeleteUser(ctx, id)
 }

--- a/authorizer/variable.go
+++ b/authorizer/variable.go
@@ -21,129 +21,69 @@ func NewVariableService(s influxdb.VariableService) *VariableService {
 	}
 }
 
-func newVariablePermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.VariablesResourceType, orgID)
-}
-
-func authorizeReadVariable(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newVariablePermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteVariable(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newVariablePermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindVariableByID checks to see if the authorizer on context has read access to the id provided.
 func (s *VariableService) FindVariableByID(ctx context.Context, id influxdb.ID) (*influxdb.Variable, error) {
-	m, err := s.s.FindVariableByID(ctx, id)
+	v, err := s.s.FindVariableByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeReadVariable(ctx, m.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeRead(ctx, influxdb.VariablesResourceType, v.ID, v.OrganizationID); err != nil {
 		return nil, err
 	}
-
-	return m, nil
+	return v, nil
 }
 
 // FindVariables retrieves all variables that match the provided filter and then filters the list down to only the resources that are authorized.
 func (s *VariableService) FindVariables(ctx context.Context, filter influxdb.VariableFilter, opt ...influxdb.FindOptions) ([]*influxdb.Variable, error) {
 	// TODO: we'll likely want to push this operation into the database since fetching the whole list of data will likely be expensive.
-	ms, err := s.s.FindVariables(ctx, filter, opt...)
+	vs, err := s.s.FindVariables(ctx, filter, opt...)
 	if err != nil {
 		return nil, err
 	}
-
-	// This filters without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	variables := ms[:0]
-	for _, m := range ms {
-		err := authorizeReadVariable(ctx, m.OrganizationID, m.ID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, err
-		}
-
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
-
-		variables = append(variables, m)
-	}
-
-	return variables, nil
+	vs, _, err = AuthorizeFindVariables(ctx, vs)
+	return vs, err
 }
 
 // CreateVariable checks to see if the authorizer on context has write access to the global variable resource.
-func (s *VariableService) CreateVariable(ctx context.Context, m *influxdb.Variable) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.VariablesResourceType, m.OrganizationID)
-	if err != nil {
+func (s *VariableService) CreateVariable(ctx context.Context, v *influxdb.Variable) error {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.VariablesResourceType, v.OrganizationID); err != nil {
 		return err
 	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return s.s.CreateVariable(ctx, m)
+	return s.s.CreateVariable(ctx, v)
 }
 
 // UpdateVariable checks to see if the authorizer on context has write access to the variable provided.
 func (s *VariableService) UpdateVariable(ctx context.Context, id influxdb.ID, upd *influxdb.VariableUpdate) (*influxdb.Variable, error) {
-	m, err := s.FindVariableByID(ctx, id)
+	v, err := s.FindVariableByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := authorizeWriteVariable(ctx, m.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.VariablesResourceType, v.ID, v.OrganizationID); err != nil {
 		return nil, err
 	}
-
 	return s.s.UpdateVariable(ctx, id, upd)
 }
 
 // ReplaceVariable checks to see if the authorizer on context has write access to the variable provided.
 func (s *VariableService) ReplaceVariable(ctx context.Context, m *influxdb.Variable) error {
-	m, err := s.FindVariableByID(ctx, m.ID)
+	v, err := s.FindVariableByID(ctx, m.ID)
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteVariable(ctx, m.OrganizationID, m.ID); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.VariablesResourceType, v.ID, v.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.ReplaceVariable(ctx, m)
 }
 
 // DeleteVariable checks to see if the authorizer on context has write access to the variable provided.
 func (s *VariableService) DeleteVariable(ctx context.Context, id influxdb.ID) error {
-	m, err := s.FindVariableByID(ctx, id)
+	v, err := s.FindVariableByID(ctx, id)
 	if err != nil {
 		return err
 	}
-
-	if err := authorizeWriteVariable(ctx, m.OrganizationID, id); err != nil {
+	if _, _, err := AuthorizeWrite(ctx, influxdb.VariablesResourceType, v.ID, v.OrganizationID); err != nil {
 		return err
 	}
-
 	return s.s.DeleteVariable(ctx, id)
 }

--- a/authz.go
+++ b/authz.go
@@ -298,6 +298,19 @@ func NewPermission(a Action, rt ResourceType, orgID ID) (*Permission, error) {
 	return p, p.Valid()
 }
 
+// NewResourcePermission returns a permission with provided arguments.
+func NewResourcePermission(a Action, rt ResourceType, rid ID) (*Permission, error) {
+	p := &Permission{
+		Action: a,
+		Resource: Resource{
+			Type: rt,
+			ID:   &rid,
+		},
+	}
+
+	return p, p.Valid()
+}
+
 // NewGlobalPermission constructs a global permission capable of accessing any resource of type rt.
 func NewGlobalPermission(a Action, rt ResourceType) (*Permission, error) {
 	p := &Permission{


### PR DESCRIPTION
This PR tries to lay out foundations for an auth mini framework.

The idea is that every resource will use the same methods exposed in `authorize.go`.

`authorize_find.go` was generated and edited by hand to avoid repeating that logic in every service.

As a PoC, the changes have been introduced in `bucket` and `dashboard`.

The whole point of this is to:
 - clean up the code
- make every resource (almost) authorize in the same way
