### PR TITLE
feat(pkger): extend buckets to be able to define a bucket and rename it

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -155,7 +155,7 @@ func TestLauncher_Pkger(t *testing.T) {
 
 		bkts := sum.Buckets
 		require.Len(t, bkts, 1)
-		assert.Equal(t, "rucket_1", bkts[0].Name)
+		assert.Equal(t, "rucketeer", bkts[0].Name)
 		hasLabelAssociations(t, bkts[0].LabelAssociations, 2, "label_1", "label_2")
 
 		checks := sum.Checks
@@ -269,7 +269,7 @@ spec:
 			if !exportAllSum {
 				assert.NotZero(t, bkts[0].ID)
 			}
-			assert.Equal(t, "rucket_1", bkts[0].Name)
+			assert.Equal(t, "rucketeer", bkts[0].Name)
 			hasLabelAssociations(t, bkts[0].LabelAssociations, 2, "label_1", "label_2")
 
 			checks := sum1.Checks
@@ -617,7 +617,7 @@ spec:
 			bkts := newSum.Buckets
 			require.Len(t, bkts, 1)
 			assert.Zero(t, bkts[0].ID)
-			assert.Equal(t, "rucket_1", bkts[0].Name)
+			assert.Equal(t, "rucketeer", bkts[0].Name)
 			hasLabelAssociations(t, bkts[0].LabelAssociations, 2, "label_1", "label_2")
 
 			checks := newSum.Checks
@@ -995,6 +995,7 @@ kind: Bucket
 metadata:
   name: rucket_1
 spec:
+  name: rucketeer
   associations:
     - kind: Label
       name: label_1

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -22,10 +22,18 @@ func TestParse(t *testing.T) {
 		t.Run("with valid bucket pkg should be valid", func(t *testing.T) {
 			testfileRunner(t, "testdata/bucket", func(t *testing.T, pkg *Pkg) {
 				buckets := pkg.Summary().Buckets
-				require.Len(t, buckets, 1)
+				require.Len(t, buckets, 2)
 
 				actual := buckets[0]
 				expectedBucket := SummaryBucket{
+					Name:              "display name",
+					Description:       "bucket 2 description",
+					LabelAssociations: []SummaryLabel{},
+				}
+				assert.Equal(t, expectedBucket, actual)
+
+				actual = buckets[1]
+				expectedBucket = SummaryBucket{
 					Name:              "rucket_11",
 					Description:       "bucket 1 description",
 					RetentionPeriod:   time.Hour,
@@ -40,7 +48,7 @@ func TestParse(t *testing.T) {
 				{
 					name:           "missing name",
 					validationErrs: 1,
-					valFields:      []string{fieldName},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
@@ -50,7 +58,7 @@ spec:
 				{
 					name:           "mixed valid and missing name",
 					validationErrs: 1,
-					valFields:      []string{fieldName},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
@@ -66,7 +74,7 @@ spec:
 					name:           "mixed valid and multiple bad names",
 					resourceErrs:   2,
 					validationErrs: 1,
-					valFields:      []string{fieldName},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
@@ -87,7 +95,7 @@ spec:
 					name:           "duplicate bucket names",
 					resourceErrs:   1,
 					validationErrs: 1,
-					valFields:      []string{fieldName},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
@@ -97,6 +105,42 @@ apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 metadata:
   name:  valid name
+`,
+				},
+				{
+					name:           "duplicate bucket meta name and display name",
+					resourceErrs:   1,
+					validationErrs: 1,
+					valFields:      []string{fieldSpec, fieldName},
+					pkgStr: `apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:  rucket_1
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:  valid name
+spec:
+  name:  rucket_1
+`,
+				},
+				{
+					name:           "display name too short",
+					resourceErrs:   1,
+					validationErrs: 1,
+					valFields:      []string{fieldSpec, fieldName},
+					pkgStr: `apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:  rucket_1
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:  invalid name
+spec:
+  name:  f
 `,
 				},
 			}
@@ -134,7 +178,7 @@ metadata:
 				{
 					name:           "missing name",
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
@@ -144,7 +188,7 @@ spec:
 				{
 					name:           "mixed valid and missing name",
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
@@ -162,7 +206,7 @@ spec:
 					name:           "multiple labels with missing name",
 					resourceErrs:   2,
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Label
 ---
@@ -2873,7 +2917,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "missing name",
 						validationErrs: 1,
-						valFields:      []string{fieldName},
+						valFields:      []string{fieldMetadata, fieldName},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3124,7 +3168,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "missing name",
 						validationErrs: 1,
-						valFields:      []string{fieldName},
+						valFields:      []string{fieldMetadata, fieldName},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Task
 metadata:
@@ -3348,7 +3392,7 @@ spec:
 				{
 					name:           "name missing",
 					validationErrs: 1,
-					valFields:      []string{"name"},
+					valFields:      []string{fieldMetadata, fieldName},
 					pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Variable
 metadata:

--- a/pkger/testdata/bucket.json
+++ b/pkger/testdata/bucket.json
@@ -14,5 +14,16 @@
         }
       ]
     }
+  },
+  {
+    "apiVersion": "influxdata.com/v2alpha1",
+    "kind": "Bucket",
+    "metadata": {
+      "name": "rucket_22"
+    },
+    "spec": {
+      "name": "display name",
+      "description": "bucket 2 description"
+    }
   }
 ]

--- a/pkger/testdata/bucket.yml
+++ b/pkger/testdata/bucket.yml
@@ -7,3 +7,11 @@ spec:
   retentionRules:
     - type: expire
       everySeconds: 3600
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:  rucket_222
+spec:
+  name: display name
+  description: bucket 2 description


### PR DESCRIPTION
this work is the first of making resources ALL unique by `metadata.name`. The
`spec.name` is a means to rename an existing resource. This is all to support
pkger idempotency. The metadata.name field will be the unique identifier within
a pkg.

with this new `name` field, the errors are now necessary to improve. The nesting of a field that does not pass validation needs to be nested in the specific object it is from `metadata` or `spec`. This PR adds this additional error handling.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass