### PR TITLE
chore(litmus): run integration tests on master:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,27 @@ jobs:
       - store_test_results:
           path: ~/project
           destination: daily-junit
+  litmus_integration:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
+      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list -e BINARYPATH=/Litmus/result/bin/linux/influxd -e BOLTPATH=/Litmus/result/influxd_test/influxd.bolt -e ENGINEPATH=/Litmus/result/influxd_test --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run:
+          name: Litmus INtegration Tests Success
+          when: on_success
+          command: bash ~/project/etc/litmus_success_notify.sh Integration
+      - run:
+          name: Litmus Integration Tests Failure
+          when: on_fail
+          command: bash ~/project/etc/litmus_fail_notify.sh Integration
+      - store_artifacts:
+          path: ~/project
+          destination: raw-daily-output
+      - store_test_results:
+          path: ~/project
+          destination: daily-junit
   litmus_nightly:
     machine: true
     steps:
@@ -424,6 +445,13 @@ workflows:
           filters:
             branches:
               only: /^(?!pull\/).*$/
+      - litmus_integration:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
   e2e:
     jobs:
       - e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ workflows:
               only: /^(?!pull\/).*$/
       - litmus_integration:
           requires:
-            - build
+            - litmus_daily
           filters:
             branches:
               only:

--- a/etc/litmus_fail_notify.sh
+++ b/etc/litmus_fail_notify.sh
@@ -2,7 +2,7 @@
 
 # SLACK_TOKEN is an env var defined in CircleCI
 # CIRCLE_BRANCH, CIRCLE_JOB, CIRLCE_BUILD_NUM and CIRCLE_BUILD_URL are CircleCI's vars.
-# $1 - name of the litmus test run, either Nightly or Smoke
+# $1 - name of the litmus test run, either Nightly, Smoke or Integration
 
 curl -X POST https://slack.com/api/chat.postMessage \
 -H "Authorization: Bearer $SLACK_TOKEN" \

--- a/etc/litmus_success_notify.sh
+++ b/etc/litmus_success_notify.sh
@@ -2,7 +2,7 @@
 
 # SLACK_TOKEN is an env var defined in CircleCI
 # CIRCLE_BRANCH, CIRCLE_JOB, CIRLCE_BUILD_NUM and CIRCLE_BUILD_URL are CircleCI's vars.
-# $1 - name of the litmus test run, either Nightly or Smoke
+# $1 - name of the litmus test run, either Nightly, Smoke or Integration
 
 curl -X POST https://slack.com/api/chat.postMessage \
 -H "Authorization: Bearer $SLACK_TOKEN" \


### PR DESCRIPTION
- after successful E2E run after master build, run integration tests
Closes # Add OSS (influxdb) litmus extended tests when branch==master. litmus_daily is only running smoke tests now.

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
