### PR TITLE
feat(query): update buckets and v1.databases calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6
-	github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0
+	github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0 h1:MHbkua9CcRQFt5Atv0o6vLLruRFVaFKoFFAAKYVL61I=
-github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0/go.mod h1:w3sG1aa88CoEWlV//7XvonBz5fMKnuwhZi9ojcfKbmY=
+github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a h1:h4moMMIBlcFJxV8E3UDkSvJ1K6B9Ae7Lp2tC7WV1DVo=
+github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a/go.mod h1:w3sG1aa88CoEWlV//7XvonBz5fMKnuwhZi9ojcfKbmY=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0
+	github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -288,8 +288,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0 h1:MHbkua9CcRQFt5Atv0o6vLLruRFVaFKoFFAAKYVL61I=
-github.com/influxdata/flux v0.64.1-0.20200312214513-8048b2f76be0/go.mod h1:w3sG1aa88CoEWlV//7XvonBz5fMKnuwhZi9ojcfKbmY=
+github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a h1:h4moMMIBlcFJxV8E3UDkSvJ1K6B9Ae7Lp2tC7WV1DVo=
+github.com/influxdata/flux v0.64.1-0.20200316205527-19a6b22ea80a/go.mod h1:w3sG1aa88CoEWlV//7XvonBz5fMKnuwhZi9ojcfKbmY=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=

--- a/query/stdlib/influxdata/influxdb/buckets.go
+++ b/query/stdlib/influxdata/influxdb/buckets.go
@@ -15,8 +15,23 @@ import (
 	"github.com/influxdata/influxdb/query"
 )
 
+const BucketsKind = "influxdata/influxdb.localBuckets"
+
 func init() {
-	execute.RegisterSource(influxdb.BucketsKind, createBucketsSource)
+	execute.RegisterSource(BucketsKind, createBucketsSource)
+	plan.RegisterPhysicalRules(LocalBucketsRule{})
+}
+
+type LocalBucketsProcedureSpec struct {
+	plan.DefaultCost
+}
+
+func (s *LocalBucketsProcedureSpec) Kind() plan.ProcedureKind {
+	return BucketsKind
+}
+
+func (s *LocalBucketsProcedureSpec) Copy() plan.ProcedureSpec {
+	return new(LocalBucketsProcedureSpec)
 }
 
 type BucketsDecoder struct {
@@ -99,7 +114,7 @@ func (bd *BucketsDecoder) Close() error {
 }
 
 func createBucketsSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
-	_, ok := prSpec.(*influxdb.BucketsProcedureSpec)
+	_, ok := prSpec.(*LocalBucketsProcedureSpec)
 	if !ok {
 		return nil, &flux.Error{
 			Code: codes.Internal,
@@ -128,3 +143,27 @@ type AllBucketLookup interface {
 	FindAllBuckets(ctx context.Context, orgID platform.ID) ([]*platform.Bucket, int)
 }
 type BucketDependencies AllBucketLookup
+
+type LocalBucketsRule struct{}
+
+func (rule LocalBucketsRule) Name() string {
+	return "influxdata/influxdb.LocalBucketsRule"
+}
+
+func (rule LocalBucketsRule) Pattern() plan.Pattern {
+	return plan.Pat(influxdb.BucketsKind)
+}
+
+func (rule LocalBucketsRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+	fromSpec := node.ProcedureSpec().(*influxdb.BucketsProcedureSpec)
+	if fromSpec.Host != nil {
+		return node, false, nil
+	} else if fromSpec.Org != nil {
+		return node, false, &flux.Error{
+			Code: codes.Unimplemented,
+			Msg:  "buckets cannot list from a separate organization; please specify a host or remove the organization",
+		}
+	}
+
+	return plan.CreateLogicalNode("localBuckets", &LocalBucketsProcedureSpec{}), true, nil
+}

--- a/query/stdlib/influxdata/influxdb/v1/databases.go
+++ b/query/stdlib/influxdata/influxdb/v1/databases.go
@@ -6,66 +6,35 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
-	"github.com/influxdata/flux/runtime"
-	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
+	v1 "github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
 	"github.com/influxdata/flux/values"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/query"
 	"github.com/pkg/errors"
 )
 
-const DatabasesKind = v1.DatabasesKind
-
-type DatabasesOpSpec struct {
-}
-
-func init() {
-	databasesSignature := runtime.MustLookupBuiltinType("influxdata/influxdb/v1", DatabasesKind)
-	runtime.ReplacePackageValue("influxdata/influxdb/v1", DatabasesKind, flux.MustValue(flux.FunctionValue(DatabasesKind, createDatabasesOpSpec, databasesSignature)))
-	flux.RegisterOpSpec(DatabasesKind, newDatabasesOp)
-	plan.RegisterProcedureSpec(DatabasesKind, newDatabasesProcedure, DatabasesKind)
-}
-
-func createDatabasesOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
-	spec := new(DatabasesOpSpec)
-	return spec, nil
-}
-
-func newDatabasesOp() flux.OperationSpec {
-	return new(DatabasesOpSpec)
-}
-
-func (s *DatabasesOpSpec) Kind() flux.OperationKind {
-	return DatabasesKind
-}
-
-type DatabasesProcedureSpec struct {
-	plan.DefaultCost
-}
-
-func newDatabasesProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
-	_, ok := qs.(*DatabasesOpSpec)
-	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
-	}
-
-	return &DatabasesProcedureSpec{}, nil
-}
-
-func (s *DatabasesProcedureSpec) Kind() plan.ProcedureKind {
-	return DatabasesKind
-}
-
-func (s *DatabasesProcedureSpec) Copy() plan.ProcedureSpec {
-	ns := new(DatabasesProcedureSpec)
-	return ns
-}
+const DatabasesKind = "influxdata/influxdb/v1.localDatabases"
 
 func init() {
 	execute.RegisterSource(DatabasesKind, createDatabasesSource)
+	plan.RegisterPhysicalRules(LocalDatabasesRule{})
+}
+
+type LocalDatabasesProcedureSpec struct {
+	plan.DefaultCost
+}
+
+func (s *LocalDatabasesProcedureSpec) Kind() plan.ProcedureKind {
+	return DatabasesKind
+}
+
+func (s *LocalDatabasesProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(LocalDatabasesProcedureSpec)
+	return ns
 }
 
 type DatabasesDecoder struct {
@@ -179,7 +148,7 @@ func (bd *DatabasesDecoder) Close() error {
 }
 
 func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
-	_, ok := prSpec.(*DatabasesProcedureSpec)
+	_, ok := prSpec.(*LocalDatabasesProcedureSpec)
 	if !ok {
 		return nil, fmt.Errorf("invalid spec type %T", prSpec)
 	}
@@ -220,4 +189,28 @@ func (d DatabasesDependencies) Validate() error {
 		return errors.New("missing buckets lookup dependency")
 	}
 	return nil
+}
+
+type LocalDatabasesRule struct{}
+
+func (rule LocalDatabasesRule) Name() string {
+	return "influxdata/influxdb.LocalDatabasesRule"
+}
+
+func (rule LocalDatabasesRule) Pattern() plan.Pattern {
+	return plan.Pat(v1.DatabasesKind)
+}
+
+func (rule LocalDatabasesRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+	fromSpec := node.ProcedureSpec().(*v1.DatabasesProcedureSpec)
+	if fromSpec.Host != nil {
+		return node, false, nil
+	} else if fromSpec.Org != nil {
+		return node, false, &flux.Error{
+			Code: codes.Unimplemented,
+			Msg:  "buckets cannot list from a separate organization; please specify a host or remove the organization",
+		}
+	}
+
+	return plan.CreateLogicalNode("localDatabases", &LocalDatabasesProcedureSpec{}), true, nil
 }


### PR DESCRIPTION
The `buckets()` and `v1.databases()` functions have been updated to
support their remote counterparts that were added to flux. These
functions now do the same thing as the `from()` call where they will
default to the current organization when run against the server and will
use the remote versions from the repl.

Fixes #17205.