### PR TITLE
test(query/stdlib/influxdata/influxdb): update rules_test to use algo-w

### DIFF
--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -471,7 +471,6 @@ func TestPushDownFilterRule(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 			plantest.PhysicalRuleTestHelper(t, &tc)
 		})
 	}


### PR DESCRIPTION
This updates our rules test to create function expressions using the Rust parser and analysis, so that we are testing our rules against the kinds of things we'll actually see in production.