### PR TITLE
feat(ui): add dashboard empty state graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### UI Improvements
 
 1. [17291](https://github.com/influxdata/influxdb/pull/17291): Redesign OSS Login page
+1. [17297](https://github.com/influxdata/influxdb/pull/17297): Display graphic when a dashboard has no cells
 
 ## v2.0.0-beta.6 [2020-03-12]
 

--- a/ui/assets/images/dashboard-empty--dark.svg
+++ b/ui/assets/images/dashboard-empty--dark.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 820 470" style="enable-background:new 0 0 820 470;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.14;fill:url(#SVGID_1_);}
+	.st1{opacity:0.63;}
+	.st2{fill:url(#SVGID_2_);}
+	.st3{fill:url(#SVGID_3_);}
+	.st4{opacity:0.6;}
+	.st5{fill:url(#SVGID_4_);}
+	.st6{fill:url(#SVGID_5_);}
+	.st7{opacity:0.21;}
+	.st8{fill:url(#SVGID_6_);}
+	.st9{opacity:0.17;}
+	.st10{fill:url(#SVGID_7_);}
+	.st11{fill:url(#SVGID_8_);}
+	.st12{opacity:0.65;fill:url(#SVGID_9_);}
+	.st13{opacity:0.34;fill:url(#SVGID_10_);}
+	.st14{opacity:0.65;fill:url(#SVGID_11_);}
+	.st15{opacity:0.7;}
+	.st16{fill:url(#SVGID_12_);}
+	.st17{opacity:0.18;}
+	.st18{fill:url(#SVGID_13_);}
+	.st19{fill:url(#SVGID_14_);}
+	.st20{opacity:0.34;fill:url(#SVGID_15_);}
+	.st21{fill:url(#SVGID_16_);}
+	.st22{fill:url(#SVGID_17_);}
+	.st23{fill:url(#SVGID_18_);}
+	.st24{fill:url(#SVGID_19_);}
+	.st25{fill:url(#SVGID_20_);}
+	.st26{fill:url(#SVGID_21_);}
+	.st27{fill:url(#SVGID_22_);}
+	.st28{fill:url(#SVGID_23_);}
+	.st29{fill:#FFFFFF;}
+	.st30{fill:url(#SVGID_24_);}
+	.st31{opacity:0.1;fill:#31A1F4;}
+	.st32{fill:#31A1F4;}
+	.st33{opacity:0.5;fill:#31A1F4;}
+	.st34{opacity:0.65;fill:url(#SVGID_25_);}
+	.st35{fill:url(#SVGID_26_);}
+	.st36{opacity:0.65;fill:url(#SVGID_27_);}
+	.st37{fill:url(#SVGID_28_);}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="459.6685" y1="269.1053" x2="744.5178" y2="234.4615">
+	<stop  offset="0" style="stop-color:#22ADF6"/>
+	<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+	<stop  offset="0.6283" style="stop-color:#9154EA"/>
+	<stop  offset="0.8689" style="stop-color:#B239E6"/>
+	<stop  offset="1" style="stop-color:#BF2FE5"/>
+</linearGradient>
+<path class="st0" d="M481.5,247.3l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0L481.5,260C476.7,257.2,476.7,250.2,481.5,247.3z"/>
+<g class="st1">
+	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="680.8183" y1="253.6697" x2="695.4383" y2="251.8916">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st2" d="M682.7,265.6c-0.2,0-0.4-0.1-0.5-0.3c-0.1-0.2-0.1-0.6,0.2-0.7l8.7-5c2.1-1.2,3.4-3.4,3.4-5.9
+		c0-2.5-1.3-4.7-3.4-5.9l-9.4-5.4c-0.3-0.1-0.3-0.5-0.2-0.7c0.1-0.3,0.5-0.3,0.7-0.2l9.4,5.4c2.5,1.4,3.9,4,3.9,6.8
+		c0,2.8-1.5,5.4-3.9,6.8l-8.7,5C682.9,265.5,682.8,265.6,682.7,265.6z"/>
+</g>
+<g class="st1">
+	<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="477.4974" y1="255.3506" x2="491.9907" y2="253.5879">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st3" d="M490.5,265.7c-0.1,0-0.2,0-0.3-0.1l-8.9-5.2c-2.5-1.4-3.9-4-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8l8.6-4.9
+		c0.2-0.1,0.6-0.1,0.7,0.2c0.1,0.2,0.1,0.6-0.2,0.7l-8.6,4.9c-2.1,1.2-3.4,3.4-3.4,5.9c0,2.5,1.3,4.7,3.4,5.9l8.9,5.2
+		c0.3,0.1,0.3,0.5,0.2,0.7C490.8,265.6,490.7,265.7,490.5,265.7z"/>
+</g>
+<g class="st4">
+	<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="304.5968" y1="455.1901" x2="363.0546" y2="353.9382">
+		<stop  offset="0" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st5" d="M439,397.8l-96.1-55.5c-5.6-3.2-12.6-3.2-18.2,0l-96.1,55.5c-2.5,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8
+		l84.3,48.7h2l-85.8-49.5c-2.1-1.2-3.4-3.4-3.4-5.9c0-2.5,1.3-4.7,3.4-5.9l96.1-55.5c5.3-3.1,11.9-3.1,17.2,0l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9c0,2.5-1.3,4.7-3.4,5.9L352.7,460h2l84.3-48.7c2.5-1.4,3.9-3.9,3.9-6.8C442.9,401.7,441.5,399.2,439,397.8
+		z"/>
+</g>
+<g class="st4">
+	<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="174.4898" y1="379.0534" x2="232.9459" y2="277.8045">
+		<stop  offset="0" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st6" d="M203.7,393.1c-3.2,0-6.3-0.8-9.1-2.4l-96.1-55.5c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8l96.1-55.5
+		c5.6-3.2,12.6-3.2,18.2,0l96.1,55.5c2.4,1.4,3.9,3.9,3.9,6.8c0,2.8-1.5,5.4-3.9,6.8l-96.1,55.5C210,392.3,206.9,393.1,203.7,393.1z
+		 M203.7,264.7c-3,0-6,0.8-8.6,2.3L99,322.5c-2.1,1.2-3.4,3.4-3.4,5.9c0,2.5,1.3,4.7,3.4,5.9l96.1,55.5c5.3,3.1,11.9,3.1,17.3,0
+		l96.1-55.5c2.1-1.2,3.4-3.4,3.4-5.9c0-2.5-1.3-4.7-3.4-5.9L212.3,267C209.7,265.5,206.7,264.7,203.7,264.7z"/>
+</g>
+<g class="st7">
+	<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="466.0864" y1="455.1333" x2="466.0864" y2="413.6295">
+		<stop  offset="0" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st8" d="M536.7,455.1l-66.2-38.2c-5.3-3.1-11.9-3.1-17.3,0l-57.7,33.3l-0.5-0.9l57.7-33.3c5.6-3.2,12.6-3.2,18.2,0
+		l66.2,38.2L536.7,455.1z"/>
+</g>
+<g class="st9">
+	<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="720.3909" y1="455.1333" x2="720.3909" y2="413.6299">
+		<stop  offset="0" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st10" d="M791,455.1l-66.2-38.2c-5.3-3.1-11.9-3.1-17.3,0l-57.7,33.3l-0.5-0.9l57.7-33.3c5.6-3.2,12.6-3.2,18.2,0
+		l66.2,38.2L791,455.1z"/>
+</g>
+<g class="st4">
+	<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="54.8538" y1="310.7675" x2="113.3047" y2="209.5275">
+		<stop  offset="0" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st11" d="M178.3,247l-96.1-55.5c-5.6-3.2-12.6-3.2-18.2,0l-54,31.2v1.1l54.5-31.4c5.3-3.1,11.9-3.1,17.2,0l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9l-96.1,55.5c-5.3,3.1-11.9,3.1-17.2,0L10,283.7v1.1L64,316c2.8,1.6,6,2.4,9.1,2.4
+		c3.1,0,6.3-0.8,9.1-2.4l96.1-55.5c2.5-1.4,3.9-3.9,3.9-6.8C182.2,251,180.7,248.4,178.3,247z"/>
+</g>
+<linearGradient id="SVGID_9_" gradientUnits="userSpaceOnUse" x1="519.2421" y1="365.774" x2="291.974" y2="230.1707">
+	<stop  offset="0" style="stop-color:#383846"/>
+	<stop  offset="1" style="stop-color:#292933"/>
+</linearGradient>
+<path class="st12" d="M563,321.7L339.2,192.5c-5.5-3.2-12.3-3.2-17.7,0L225.4,248c-4.9,2.8-4.9,9.9,0,12.7l223.8,129.1
+	c5.5,3.2,12.3,3.2,17.7,0l96.1-55.5C567.9,331.5,567.9,324.5,563,321.7z"/>
+<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="91.2954" y1="179.442" x2="308.4898" y2="179.442">
+	<stop  offset="0" style="stop-color:#292933"/>
+	<stop  offset="1" style="stop-color:#383846"/>
+</linearGradient>
+<path class="st13" d="M95,173.1l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0L95,185.8C90.1,183,90.1,175.9,95,173.1z"/>
+<linearGradient id="SVGID_11_" gradientUnits="userSpaceOnUse" x1="580.1917" y1="251.7263" x2="418.8313" y2="157.7888">
+	<stop  offset="0" style="stop-color:#383846"/>
+	<stop  offset="1" style="stop-color:#292933"/>
+</linearGradient>
+<path class="st14" d="M352.7,174l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0l-96.1-55.5C347.8,183.9,347.8,176.9,352.7,174z"/>
+<g class="st15">
+	<linearGradient id="SVGID_12_" gradientUnits="userSpaceOnUse" x1="809.9969" y1="326.5455" x2="606.257" y2="326.5455">
+		<stop  offset="0.2067" style="stop-color:#736CED;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#736CED"/>
+	</linearGradient>
+	<path class="st16" d="M610.7,320.6l96.1-55.5c2.7-1.5,5.6-2.3,8.6-2.3c3,0,6,0.8,8.6,2.3l86,49.7v-1.1l-85.5-49.4
+		c-5.6-3.2-12.6-3.2-18.2,0l-96.1,55.5c-2.4,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4
+		c3.2,0,6.3-0.8,9.1-2.4l85.5-49.4v-1.1l-86,49.7c-5.3,3.1-11.9,3.1-17.2,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9
+		C607.2,324.1,608.5,321.9,610.7,320.6z"/>
+</g>
+<g class="st17">
+	<linearGradient id="SVGID_13_" gradientUnits="userSpaceOnUse" x1="809.9969" y1="399.6244" x2="735.107" y2="399.6244">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st18" d="M736.1,399.6c0,2.5,1.3,4.7,3.4,5.9l70.5,40.7v1.1l-71-41c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8
+		l71-41v1.2l-70.5,40.7C737.4,394.9,736.1,397.1,736.1,399.6z"/>
+</g>
+<g class="st17">
+	<linearGradient id="SVGID_14_" gradientUnits="userSpaceOnUse" x1="809.9969" y1="250.7644" x2="735.107" y2="250.7644">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st19" d="M736.1,250.8c0,2.5,1.3,4.7,3.4,5.9l70.5,40.7v1.2l-71-41c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8
+		l71-41v1.1l-70.5,40.7C737.4,246.1,736.1,248.3,736.1,250.8z"/>
+</g>
+<linearGradient id="SVGID_15_" gradientUnits="userSpaceOnUse" x1="219.1337" y1="105.0116" x2="436.3281" y2="105.0116">
+	<stop  offset="0" style="stop-color:#292933"/>
+	<stop  offset="1" style="stop-color:#383846"/>
+</linearGradient>
+<path class="st20" d="M222.8,98.7l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0l-96.1-55.5C217.9,108.5,217.9,101.5,222.8,98.7z"/>
+<g class="st15">
+	<linearGradient id="SVGID_16_" gradientUnits="userSpaceOnUse" x1="52.2256" y1="45.4634" x2="110.6785" y2="146.7068">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st21" d="M174.8,96.2L78.7,40.7c-5.6-3.2-12.6-3.2-18.2,0L10,69.8V71l51-29.4c5.3-3.1,11.9-3.1,17.3,0L174.3,97
+		c2.1,1.2,3.4,3.5,3.4,5.9s-1.3,4.7-3.4,5.9l-96.1,55.5c-5.3,3.1-11.9,3.1-17.3,0l-51-29.4v1.1l50.5,29.2c2.8,1.6,6,2.4,9.1,2.4
+		c3.2,0,6.3-0.8,9.1-2.4l96.1-55.5c2.4-1.4,3.9-3.9,3.9-6.8C178.7,100.1,177.2,97.6,174.8,96.2z"/>
+</g>
+<g class="st15">
+	<linearGradient id="SVGID_17_" gradientUnits="userSpaceOnUse" x1="189.4912" y1="-25.2686" x2="208.7761" y2="105.3895">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st22" d="M302.6,21.7L282.3,10h-2l21.8,12.6c2.1,1.2,3.4,3.4,3.4,5.9c0,2.5-1.3,4.7-3.4,5.9l-96.1,55.5
+		c-5.3,3.1-11.9,3.1-17.2,0L92.7,34.4c-2.1-1.2-3.4-3.5-3.4-5.9c0-2.5,1.3-4.7,3.4-5.9L114.5,10h-2L92.2,21.7
+		c-2.4,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4c3.2,0,6.3-0.8,9.1-2.4l96.1-55.5
+		c2.5-1.4,3.9-3.9,3.9-6.8C306.5,25.7,305.1,23.1,302.6,21.7z"/>
+</g>
+<g class="st15">
+	<linearGradient id="SVGID_18_" gradientUnits="userSpaceOnUse" x1="766.4109" y1="123.4933" x2="656.0267" y2="233.8776">
+		<stop  offset="0.2067" style="stop-color:#9B4CE9;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#9B4CE9"/>
+	</linearGradient>
+	<path class="st23" d="M608.5,172.8l96.1-55.5c5.3-3.1,11.9-3.1,17.3,0l88.2,50.9v-1.1l-87.7-50.6c-5.6-3.2-12.6-3.2-18.2,0
+		L608,171.9c-2.5,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4c3.1,0,6.3-0.8,9.1-2.4l87.7-50.6v-1.1
+		l-88.2,50.9c-5.3,3.1-11.9,3.1-17.3,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9C605.1,176.2,606.3,174,608.5,172.8z"/>
+</g>
+<g class="st15">
+	<linearGradient id="SVGID_19_" gradientUnits="userSpaceOnUse" x1="640.5245" y1="49.2203" x2="528.1845" y2="161.5603">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st24" d="M584.4,170.1c-3.2,0-6.3-0.8-9.1-2.4l-96.1-55.5c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8l96.1-55.5
+		c5.6-3.2,12.6-3.2,18.2,0l96.1,55.5c2.4,1.4,3.9,3.9,3.9,6.8c0,2.8-1.5,5.4-3.9,6.8l-96.1,55.5
+		C590.7,169.2,587.5,170.1,584.4,170.1z M479.7,99.5c-2.1,1.2-3.4,3.4-3.4,5.9c0,2.5,1.3,4.7,3.4,5.9l96.1,55.5
+		c5.3,3.1,11.9,3.1,17.3,0l96.1-55.5c2.1-1.2,3.4-3.4,3.4-5.9c0-2.5-1.3-4.7-3.4-5.9L593,44c-5.3-3.1-11.9-3.1-17.3,0L479.7,99.5z"
+		/>
+</g>
+<g class="st15">
+	<linearGradient id="SVGID_20_" gradientUnits="userSpaceOnUse" x1="483.6637" y1="-20.6135" x2="425.2059" y2="80.6384">
+		<stop  offset="0.2067" style="stop-color:#383846;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#383846"/>
+	</linearGradient>
+	<path class="st25" d="M559.6,23.2L536.7,10h-2l24.4,14.1c2.1,1.2,3.4,3.4,3.4,5.9c0,2.5-1.3,4.7-3.4,5.9l-96.1,55.5
+		c-5.3,3.1-11.9,3.1-17.2,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9c0-2.5,1.3-4.7,3.4-5.9L374.2,10h-2l-22.9,13.2
+		c-2.4,1.4-3.9,4-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4c3.1,0,6.3-0.8,9.1-2.4l96.1-55.5
+		c2.4-1.4,3.9-3.9,3.9-6.8C563.5,27.2,562.1,24.6,559.6,23.2z"/>
+</g>
+<g class="st15">
+	<linearGradient id="SVGID_21_" gradientUnits="userSpaceOnUse" x1="585.867" y1="459.9995" x2="585.867" y2="337.1118">
+		<stop  offset="0.2067" style="stop-color:#5F7CEF;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#5F7CEF"/>
+	</linearGradient>
+	<path class="st26" d="M691,395L595,339.5c-5.6-3.2-12.6-3.2-18.2,0L480.7,395c-2.5,1.4-3.9,4-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8
+		l89.1,51.4h2l-90.6-52.3c-2.1-1.2-3.4-3.5-3.4-5.9s1.3-4.7,3.4-5.9l96.1-55.5c2.7-1.5,5.6-2.3,8.6-2.3c3,0,6,0.8,8.6,2.3l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9L600,460h2l89.1-51.4c2.4-1.4,3.9-3.9,3.9-6.8C695,399,693.5,396.4,691,395z"/>
+</g>
+<g class="st1">
+	<linearGradient id="SVGID_22_" gradientUnits="userSpaceOnUse" x1="477.9163" y1="244.1453" x2="695.034" y2="217.7391">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st27" d="M586.5,296.6c-3.3,0-6.7-0.9-9.6-2.6l-96-55.4c-2.8-1.6-4.4-4.5-4.4-7.6c0-3.2,1.7-6,4.4-7.6l96-55.4
+		c6-3.4,13.3-3.4,19.3,0l96,55.4c2.8,1.6,4.4,4.5,4.4,7.6c0,3.2-1.6,6.1-4.4,7.6l-96,55.4C593.1,295.8,589.8,296.6,586.5,296.6z
+		 M586.5,168.3c-2.8,0-5.6,0.7-8.1,2.2l-96,55.4c-1.8,1.1-2.9,2.9-2.9,5c0,2.1,1.1,4,2.9,5l96,55.4c5,2.9,11.3,2.9,16.3,0l96-55.4
+		c1.8-1.1,2.9-2.9,2.9-5c0-2.1-1.1-4-2.9-5l-96-55.4C592.1,169,589.3,168.3,586.5,168.3z M481.5,224.6L481.5,224.6L481.5,224.6z"/>
+</g>
+<linearGradient id="SVGID_23_" gradientUnits="userSpaceOnUse" x1="484.8282" y1="218.3951" x2="769.6774" y2="183.7513">
+	<stop  offset="0" style="stop-color:#22ADF6"/>
+	<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+	<stop  offset="0.6283" style="stop-color:#9154EA"/>
+	<stop  offset="0.8689" style="stop-color:#B239E6"/>
+	<stop  offset="1" style="stop-color:#BF2FE5"/>
+</linearGradient>
+<path class="st28" d="M481.5,199.7l96-55.4c5.5-3.2,12.3-3.2,17.8,0l96,55.4c4.9,2.8,4.9,9.9,0,12.7l-96,55.4
+	c-5.5,3.2-12.3,3.2-17.8,0l-96-55.4C476.7,209.6,476.7,202.5,481.5,199.7z"/>
+<path class="st29" d="M607.4,189.2c-2.3-1.3-5.9-1.3-8.2,0l-12.5,7.2l-12.5-7.2c-2.3-1.3-5.9-1.3-8.2,0c-2.3,1.3-2.2,3.4,0,4.7
+	l12.5,7.2l-12.5,7.2c-2.3,1.3-2.2,3.4,0,4.7c2.3,1.3,5.9,1.3,8.2,0l12.5-7.2l12.5,7.2c2.3,1.3,5.9,1.3,8.2,0c2.3-1.3,2.2-3.4,0-4.7
+	l-12.5-7.2l12.5-7.2C609.7,192.6,609.7,190.5,607.4,189.2L607.4,189.2z"/>
+<g class="st1">
+	<linearGradient id="SVGID_24_" gradientUnits="userSpaceOnUse" x1="565.6533" y1="314.4857" x2="607.0245" y2="309.454">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st30" d="M586.5,318.4c-3.2,0-6.3-0.8-9.1-2.4l-12.2-7c-0.3-0.1-0.3-0.5-0.2-0.7c0.1-0.3,0.5-0.3,0.7-0.2l12.2,7
+		c5.3,3.1,11.9,3.1,17.2,0l11.1-6.4c0.3-0.1,0.6-0.1,0.7,0.2c0.1,0.2,0.1,0.6-0.2,0.7l-11.1,6.4
+		C592.8,317.6,589.6,318.4,586.5,318.4z"/>
+</g>
+<path class="st31" d="M718.9,270c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6c1.7,1,4.5,1,6.1,0C720.6,272.6,720.6,271,718.9,270
+	L718.9,270z"/>
+<path class="st32" d="M333.6,200.1c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6c1.7,1,4.5,1,6.1,0C335.4,202.6,335.3,201.1,333.6,200.1
+	L333.6,200.1z"/>
+<path class="st33" d="M202.8,129.1c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0C204.5,131.7,204.5,130.1,202.8,129.1
+	L202.8,129.1z"/>
+<path class="st33" d="M330,51.8c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6c1.7,1,4.5,1,6.1,0C331.7,54.4,331.7,52.8,330,51.8
+	L330,51.8z"/>
+<path class="st32" d="M462.5,125.8c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6c1.7,1,4.5,1,6.1,0S464.2,126.8,462.5,125.8L462.5,125.8
+	z"/>
+<g>
+	<linearGradient id="SVGID_25_" gradientUnits="userSpaceOnUse" x1="176.0747" y1="162.0554" x2="150.4638" y2="177.0472">
+		<stop  offset="0" style="stop-color:#383846"/>
+		<stop  offset="1" style="stop-color:#292933"/>
+	</linearGradient>
+	<polygon class="st34" points="179.5,165.9 169.5,160.1 142.6,175.7 152.7,181.5 179.5,165.9 	"/>
+	<linearGradient id="SVGID_26_" gradientUnits="userSpaceOnUse" x1="217.4698" y1="157.7266" x2="173.4727" y2="182.3955">
+		<stop  offset="0" style="stop-color:#3C98F3;stop-opacity:0.7"/>
+		<stop  offset="1.811739e-02" style="stop-color:#3B94EC;stop-opacity:0.6991"/>
+		<stop  offset="0.1509" style="stop-color:#3576BA;stop-opacity:0.6924"/>
+		<stop  offset="0.2869" style="stop-color:#2F5D8F;stop-opacity:0.6856"/>
+		<stop  offset="0.4238" style="stop-color:#2B486D;stop-opacity:0.6787"/>
+		<stop  offset="0.562" style="stop-color:#273852;stop-opacity:0.6717"/>
+		<stop  offset="0.7019" style="stop-color:#252D3E;stop-opacity:0.6647"/>
+		<stop  offset="0.8446" style="stop-color:#232633;stop-opacity:0.6575"/>
+		<stop  offset="0.9944" style="stop-color:#23242F;stop-opacity:0.65"/>
+	</linearGradient>
+	<polygon class="st35" points="213.6,165.2 203.5,159.4 159,185.2 169.1,191 213.6,165.2 	"/>
+	<linearGradient id="SVGID_27_" gradientUnits="userSpaceOnUse" x1="208.8969" y1="180.118" x2="182.6535" y2="195.48">
+		<stop  offset="0" style="stop-color:#383846"/>
+		<stop  offset="1" style="stop-color:#292933"/>
+	</linearGradient>
+	<polygon class="st36" points="212.4,184 202.3,178.2 174.7,194.2 184.7,200 212.4,184 	"/>
+	<linearGradient id="SVGID_28_" gradientUnits="userSpaceOnUse" x1="250.853" y1="173.5665" x2="196.8203" y2="203.8624">
+		<stop  offset="0" style="stop-color:#3C98F3;stop-opacity:0.7"/>
+		<stop  offset="0.2193" style="stop-color:#3578BC;stop-opacity:0.689"/>
+		<stop  offset="0.4867" style="stop-color:#2D5480;stop-opacity:0.6755"/>
+		<stop  offset="0.7146" style="stop-color:#283A54;stop-opacity:0.6641"/>
+		<stop  offset="0.8909" style="stop-color:#242A39;stop-opacity:0.6552"/>
+		<stop  offset="0.9944" style="stop-color:#23242F;stop-opacity:0.65"/>
+	</linearGradient>
+	<polygon class="st37" points="255.4,176.2 245.3,170.4 189.5,202.8 199.6,208.6 255.4,176.2 	"/>
+</g>
+</svg>

--- a/ui/assets/images/dashboard-empty--light.svg
+++ b/ui/assets/images/dashboard-empty--light.svg
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 820 470" style="enable-background:new 0 0 820 470;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.14;fill:url(#SVGID_1_);enable-background:new    ;}
+	.st1{opacity:0.63;}
+	.st2{fill:url(#SVGID_2_);}
+	.st3{fill:url(#SVGID_3_);}
+	.st4{opacity:0.6;}
+	.st5{fill:url(#SVGID_4_);}
+	.st6{fill:url(#SVGID_5_);}
+	.st7{opacity:0.21;}
+	.st8{fill:url(#SVGID_6_);}
+	.st9{opacity:0.17;}
+	.st10{fill:url(#SVGID_7_);}
+	.st11{fill:url(#SVGID_8_);}
+	.st12{opacity:0.65;fill:#FFFFFF;stroke:#D4D7DD;stroke-miterlimit:10;enable-background:new    ;}
+	.st13{fill:#FFFFFF;stroke:#D4D7DD;stroke-miterlimit:10;enable-background:new    ;}
+	.st14{opacity:0.7;}
+	.st15{fill:url(#SVGID_9_);}
+	.st16{opacity:0.18;}
+	.st17{fill:url(#SVGID_10_);}
+	.st18{fill:url(#SVGID_11_);}
+	.st19{fill:url(#SVGID_12_);}
+	.st20{fill:url(#SVGID_13_);}
+	.st21{fill:url(#SVGID_14_);}
+	.st22{fill:url(#SVGID_15_);}
+	.st23{fill:url(#SVGID_16_);}
+	.st24{fill:url(#SVGID_17_);}
+	.st25{fill:url(#SVGID_18_);}
+	.st26{fill:url(#SVGID_19_);}
+	.st27{fill:#FFFFFF;}
+	.st28{fill:url(#SVGID_20_);}
+	.st29{opacity:0.1;fill:#31A1F4;enable-background:new    ;}
+	.st30{fill:#31A1F4;}
+	.st31{opacity:0.5;fill:#31A1F4;enable-background:new    ;}
+	.st32{fill:url(#SVGID_21_);}
+	.st33{fill:url(#SVGID_22_);}
+	.st34{fill:url(#SVGID_23_);}
+	.st35{fill:url(#SVGID_24_);}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="459.6642" y1="200.9301" x2="744.5135" y2="235.5739" gradientTransform="matrix(1 0 0 -1 0 470)">
+	<stop  offset="0" style="stop-color:#22ADF6"/>
+	<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+	<stop  offset="0.6283" style="stop-color:#9154EA"/>
+	<stop  offset="0.8689" style="stop-color:#B239E6"/>
+	<stop  offset="1" style="stop-color:#BF2FE5"/>
+</linearGradient>
+<path class="st0" d="M481.5,247.3l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0L481.5,260C476.7,257.2,476.7,250.2,481.5,247.3z"/>
+<g class="st1">
+	
+		<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="680.8219" y1="216.3005" x2="695.4419" y2="218.0786" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st2" d="M682.7,265.6c-0.2,0-0.4-0.1-0.5-0.3c-0.1-0.2-0.1-0.6,0.2-0.7l8.7-5c2.1-1.2,3.4-3.4,3.4-5.9
+		s-1.3-4.7-3.4-5.9l-9.4-5.4c-0.3-0.1-0.3-0.5-0.2-0.7c0.1-0.3,0.5-0.3,0.7-0.2l9.4,5.4c2.5,1.4,3.9,4,3.9,6.8s-1.5,5.4-3.9,6.8
+		l-8.7,5C682.9,265.5,682.8,265.6,682.7,265.6z"/>
+</g>
+<g class="st1">
+	
+		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="477.4951" y1="214.6685" x2="491.9884" y2="216.4312" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st3" d="M490.5,265.7c-0.1,0-0.2,0-0.3-0.1l-8.9-5.2c-2.5-1.4-3.9-4-3.9-6.8s1.5-5.4,3.9-6.8l8.6-4.9
+		c0.2-0.1,0.6-0.1,0.7,0.2c0.1,0.2,0.1,0.6-0.2,0.7l-8.6,4.9c-2.1,1.2-3.4,3.4-3.4,5.9s1.3,4.7,3.4,5.9l8.9,5.2
+		c0.3,0.1,0.3,0.5,0.2,0.7C490.8,265.6,490.7,265.7,490.5,265.7z"/>
+</g>
+<g class="st4">
+	
+		<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="304.5211" y1="14.7375" x2="363.03" y2="116.0779" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st5" d="M439,397.8l-96.1-55.5c-5.6-3.2-12.6-3.2-18.2,0l-96.1,55.5c-2.5,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8
+		l84.3,48.7h2l-85.8-49.5c-2.1-1.2-3.4-3.4-3.4-5.9s1.3-4.7,3.4-5.9l96.1-55.5c5.3-3.1,11.9-3.1,17.2,0l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9L352.7,460h2l84.3-48.7c2.5-1.4,3.9-3.9,3.9-6.8C442.9,401.7,441.5,399.2,439,397.8z"/>
+</g>
+<g class="st4">
+	
+		<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="174.4483" y1="90.9346" x2="232.9517" y2="192.2654" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st6" d="M203.7,393.1c-3.2,0-6.3-0.8-9.1-2.4l-96.1-55.5c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8l96.1-55.5
+		c5.6-3.2,12.6-3.2,18.2,0l96.1,55.5c2.4,1.4,3.9,3.9,3.9,6.8c0,2.8-1.5,5.4-3.9,6.8l-96.1,55.5C210,392.3,206.9,393.1,203.7,393.1z
+		 M203.7,264.7c-3,0-6,0.8-8.6,2.3L99,322.5c-2.1,1.2-3.4,3.4-3.4,5.9s1.3,4.7,3.4,5.9l96.1,55.5c5.3,3.1,11.9,3.1,17.3,0l96.1-55.5
+		c2.1-1.2,3.4-3.4,3.4-5.9s-1.3-4.7-3.4-5.9L212.3,267C209.7,265.5,206.7,264.7,203.7,264.7z"/>
+</g>
+<g class="st7">
+	
+		<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="466.05" y1="14.9" x2="466.05" y2="56.4" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st8" d="M536.7,455.1l-66.2-38.2c-5.3-3.1-11.9-3.1-17.3,0l-57.7,33.3l-0.5-0.9l57.7-33.3c5.6-3.2,12.6-3.2,18.2,0
+		l66.2,38.2L536.7,455.1z"/>
+</g>
+<g class="st9">
+	
+		<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="720.35" y1="14.9" x2="720.35" y2="56.4" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st10" d="M791,455.1l-66.2-38.2c-5.3-3.1-11.9-3.1-17.3,0l-57.7,33.3l-0.5-0.9L707,416c5.6-3.2,12.6-3.2,18.2,0
+		l66.2,38.2L791,455.1z"/>
+</g>
+<g class="st4">
+	
+		<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="54.8649" y1="159.2742" x2="113.325" y2="260.53" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st11" d="M178.3,247l-96.1-55.5c-5.6-3.2-12.6-3.2-18.2,0l-54,31.2v1.1l54.5-31.4c5.3-3.1,11.9-3.1,17.2,0l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9c0,2.5-1.3,4.7-3.4,5.9l-96.1,55.5c-5.3,3.1-11.9,3.1-17.2,0L10,283.7v1.1L64,316c2.8,1.6,6,2.4,9.1,2.4
+		s6.3-0.8,9.1-2.4l96.1-55.5c2.5-1.4,3.9-3.9,3.9-6.8C182.2,251,180.7,248.4,178.3,247z"/>
+</g>
+<path class="st12" d="M563,321.7L339.2,192.5c-5.5-3.2-12.3-3.2-17.7,0L225.4,248c-4.9,2.8-4.9,9.9,0,12.7l223.8,129.1
+	c5.5,3.2,12.3,3.2,17.7,0l96.1-55.5C567.9,331.5,567.9,324.5,563,321.7z"/>
+<path class="st13" d="M95,173.1l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0L95,185.8C90.1,183,90.1,175.9,95,173.1z"/>
+<path class="st12" d="M352.7,174l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0l-96.1-55.5C347.8,183.9,347.8,176.9,352.7,174z"/>
+<g class="st14">
+	
+		<linearGradient id="SVGID_9_" gradientUnits="userSpaceOnUse" x1="809.9999" y1="143.4" x2="606.2999" y2="143.4" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#736CED;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#736CED"/>
+	</linearGradient>
+	<path class="st15" d="M610.7,320.6l96.1-55.5c2.7-1.5,5.6-2.3,8.6-2.3s6,0.8,8.6,2.3l86,49.7v-1.1l-85.5-49.4
+		c-5.6-3.2-12.6-3.2-18.2,0l-96.1,55.5c-2.4,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4
+		c3.2,0,6.3-0.8,9.1-2.4l85.5-49.4v-1.1l-86,49.7c-5.3,3.1-11.9,3.1-17.2,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9
+		C607.2,324.1,608.5,321.9,610.7,320.6z"/>
+</g>
+<g class="st16">
+	
+		<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="810" y1="70.5" x2="735.1" y2="70.5" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st17" d="M736.1,399.6c0,2.5,1.3,4.7,3.4,5.9l70.5,40.7v1.1l-71-41c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8
+		l71-41v1.2l-70.5,40.7C737.4,394.9,736.1,397.1,736.1,399.6z"/>
+</g>
+<g class="st16">
+	
+		<linearGradient id="SVGID_11_" gradientUnits="userSpaceOnUse" x1="810" y1="219.2" x2="735.1" y2="219.2" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st18" d="M736.1,250.8c0,2.5,1.3,4.7,3.4,5.9l70.5,40.7v1.2l-71-41c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8
+		l71-41v1.1l-70.5,40.7C737.4,246.1,736.1,248.3,736.1,250.8z"/>
+</g>
+<path class="st13" d="M222.8,98.7l96.1-55.5c5.5-3.2,12.3-3.2,17.7,0l96.1,55.5c4.9,2.8,4.9,9.9,0,12.7l-96.1,55.5
+	c-5.5,3.2-12.3,3.2-17.7,0l-96.1-55.5C217.9,108.5,217.9,101.5,222.8,98.7z"/>
+<g class="st14">
+	
+		<linearGradient id="SVGID_12_" gradientUnits="userSpaceOnUse" x1="52.1665" y1="424.5448" x2="110.6259" y2="323.2901" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st19" d="M174.8,96.2L78.7,40.7c-5.6-3.2-12.6-3.2-18.2,0L10,69.8V71l51-29.4c5.3-3.1,11.9-3.1,17.3,0l96,55.4
+		c2.1,1.2,3.4,3.5,3.4,5.9s-1.3,4.7-3.4,5.9l-96.1,55.5c-5.3,3.1-11.9,3.1-17.3,0l-51-29.4v1.1l50.5,29.2c2.8,1.6,6,2.4,9.1,2.4
+		c3.2,0,6.3-0.8,9.1-2.4l96.1-55.5c2.4-1.4,3.9-3.9,3.9-6.8C178.7,100.1,177.2,97.6,174.8,96.2z"/>
+</g>
+<g class="st14">
+	
+		<linearGradient id="SVGID_13_" gradientUnits="userSpaceOnUse" x1="189.467" y1="495.265" x2="208.7519" y2="364.6069" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st20" d="M302.6,21.7L282.3,10h-2l21.8,12.6c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9L206,89.9
+		c-5.3,3.1-11.9,3.1-17.2,0L92.7,34.4c-2.1-1.2-3.4-3.5-3.4-5.9c0-2.5,1.3-4.7,3.4-5.9L114.5,10h-2L92.2,21.7
+		c-2.4,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4c3.2,0,6.3-0.8,9.1-2.4l96.1-55.5
+		c2.5-1.4,3.9-3.9,3.9-6.8C306.5,25.7,305.1,23.1,302.6,21.7z"/>
+</g>
+<g class="st14">
+	
+		<linearGradient id="SVGID_14_" gradientUnits="userSpaceOnUse" x1="766.4702" y1="346.5298" x2="656.0389" y2="236.0984" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#9B4CE9;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#9B4CE9"/>
+	</linearGradient>
+	<path class="st21" d="M608.5,172.8l96.1-55.5c5.3-3.1,11.9-3.1,17.3,0l88.2,50.9v-1.1l-87.7-50.6c-5.6-3.2-12.6-3.2-18.2,0
+		L608,171.9c-2.5,1.4-3.9,3.9-3.9,6.8c0,2.8,1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4s6.3-0.8,9.1-2.4l87.7-50.6v-1.1
+		l-88.2,50.9c-5.3,3.1-11.9,3.1-17.3,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9C605.1,176.2,606.3,174,608.5,172.8z"/>
+</g>
+<g class="st14">
+	
+		<linearGradient id="SVGID_15_" gradientUnits="userSpaceOnUse" x1="640.5883" y1="420.7883" x2="528.2118" y2="308.4117" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st22" d="M584.4,170.1c-3.2,0-6.3-0.8-9.1-2.4l-96.1-55.5c-2.4-1.4-3.9-3.9-3.9-6.8c0-2.8,1.5-5.4,3.9-6.8l96.1-55.5
+		c5.6-3.2,12.6-3.2,18.2,0l96.1,55.5c2.4,1.4,3.9,3.9,3.9,6.8c0,2.8-1.5,5.4-3.9,6.8l-96.1,55.5
+		C590.7,169.2,587.5,170.1,584.4,170.1z M479.7,99.5c-2.1,1.2-3.4,3.4-3.4,5.9s1.3,4.7,3.4,5.9l96.1,55.5c5.3,3.1,11.9,3.1,17.3,0
+		l96.1-55.5c2.1-1.2,3.4-3.4,3.4-5.9s-1.3-4.7-3.4-5.9L593,44c-5.3-3.1-11.9-3.1-17.3,0L479.7,99.5z"/>
+</g>
+<g class="st14">
+	
+		<linearGradient id="SVGID_16_" gradientUnits="userSpaceOnUse" x1="483.7279" y1="490.6055" x2="425.2565" y2="389.3299" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.451" style="stop-color:#D4D7DD;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#D4D7DD"/>
+	</linearGradient>
+	<path class="st23" d="M559.6,23.2L536.7,10h-2l24.4,14.1c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9L463,91.4
+		c-5.3,3.1-11.9,3.1-17.2,0l-96.1-55.5c-2.1-1.2-3.4-3.4-3.4-5.9s1.3-4.7,3.4-5.9L374.2,10h-2l-22.9,13.2c-2.4,1.4-3.9,4-3.9,6.8
+		s1.5,5.4,3.9,6.8l96.1,55.5c2.8,1.6,6,2.4,9.1,2.4s6.3-0.8,9.1-2.4l96.1-55.5c2.4-1.4,3.9-3.9,3.9-6.8
+		C563.5,27.2,562.1,24.6,559.6,23.2z"/>
+</g>
+<g class="st14">
+	
+		<linearGradient id="SVGID_17_" gradientUnits="userSpaceOnUse" x1="585.9" y1="10" x2="585.9" y2="132.9" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0.2067" style="stop-color:#5F7CEF;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#5F7CEF"/>
+	</linearGradient>
+	<path class="st24" d="M691,395l-96-55.5c-5.6-3.2-12.6-3.2-18.2,0L480.7,395c-2.5,1.4-3.9,4-3.9,6.8s1.5,5.4,3.9,6.8l89.1,51.4h2
+		l-90.6-52.3c-2.1-1.2-3.4-3.5-3.4-5.9s1.3-4.7,3.4-5.9l96.1-55.5c2.7-1.5,5.6-2.3,8.6-2.3s6,0.8,8.6,2.3l96.1,55.5
+		c2.1,1.2,3.4,3.4,3.4,5.9s-1.3,4.7-3.4,5.9L600,460h2l89.1-51.4c2.4-1.4,3.9-3.9,3.9-6.8C695,399,693.5,396.4,691,395z"/>
+</g>
+<g class="st1">
+	
+		<linearGradient id="SVGID_18_" gradientUnits="userSpaceOnUse" x1="478.0419" y1="225.7792" x2="695.0639" y2="252.1737" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st25" d="M586.5,296.6c-3.3,0-6.7-0.9-9.6-2.6l-96-55.4c-2.8-1.6-4.4-4.5-4.4-7.6c0-3.2,1.7-6,4.4-7.6l96-55.4
+		c6-3.4,13.3-3.4,19.3,0l96,55.4c2.8,1.6,4.4,4.5,4.4,7.6c0,3.2-1.6,6.1-4.4,7.6l-96,55.4C593.1,295.8,589.8,296.6,586.5,296.6z
+		 M586.5,168.3c-2.8,0-5.6,0.7-8.1,2.2l-96,55.4c-1.8,1.1-2.9,2.9-2.9,5s1.1,4,2.9,5l96,55.4c5,2.9,11.3,2.9,16.3,0l96-55.4
+		c1.8-1.1,2.9-2.9,2.9-5s-1.1-4-2.9-5l-96-55.4C592.1,169,589.3,168.3,586.5,168.3z M481.5,224.6L481.5,224.6L481.5,224.6z"/>
+</g>
+<linearGradient id="SVGID_19_" gradientUnits="userSpaceOnUse" x1="484.8292" y1="251.5968" x2="769.6784" y2="286.2406" gradientTransform="matrix(1 0 0 -1 0 470)">
+	<stop  offset="0" style="stop-color:#22ADF6"/>
+	<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+	<stop  offset="0.6283" style="stop-color:#9154EA"/>
+	<stop  offset="0.8689" style="stop-color:#B239E6"/>
+	<stop  offset="1" style="stop-color:#BF2FE5"/>
+</linearGradient>
+<path class="st26" d="M481.5,199.7l96-55.4c5.5-3.2,12.3-3.2,17.8,0l96,55.4c4.9,2.8,4.9,9.9,0,12.7l-96,55.4
+	c-5.5,3.2-12.3,3.2-17.8,0l-96-55.4C476.7,209.6,476.7,202.5,481.5,199.7z"/>
+<path class="st27" d="M607.4,189.2c-2.3-1.3-5.9-1.3-8.2,0l-12.5,7.2l-12.5-7.2c-2.3-1.3-5.9-1.3-8.2,0s-2.2,3.4,0,4.7l12.5,7.2
+	l-12.5,7.2c-2.3,1.3-2.2,3.4,0,4.7c2.3,1.3,5.9,1.3,8.2,0l12.5-7.2l12.5,7.2c2.3,1.3,5.9,1.3,8.2,0s2.2-3.4,0-4.7l-12.5-7.2
+	l12.5-7.2C609.7,192.6,609.7,190.5,607.4,189.2L607.4,189.2z"/>
+<g class="st1">
+	
+		<linearGradient id="SVGID_20_" gradientUnits="userSpaceOnUse" x1="565.6605" y1="155.4621" x2="607.0055" y2="160.4906" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#22ADF6"/>
+		<stop  offset="0.308" style="stop-color:#5C7FF0"/>
+		<stop  offset="0.6283" style="stop-color:#9154EA"/>
+		<stop  offset="0.8689" style="stop-color:#B239E6"/>
+		<stop  offset="1" style="stop-color:#BF2FE5"/>
+	</linearGradient>
+	<path class="st28" d="M586.5,318.4c-3.2,0-6.3-0.8-9.1-2.4l-12.2-7c-0.3-0.1-0.3-0.5-0.2-0.7c0.1-0.3,0.5-0.3,0.7-0.2l12.2,7
+		c5.3,3.1,11.9,3.1,17.2,0l11.1-6.4c0.3-0.1,0.6-0.1,0.7,0.2c0.1,0.2,0.1,0.6-0.2,0.7l-11.1,6.4
+		C592.8,317.6,589.6,318.4,586.5,318.4z"/>
+</g>
+<path class="st29" d="M718.9,270c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0C720.6,272.6,720.6,271,718.9,270L718.9,270z"
+	/>
+<path class="st30" d="M333.6,200.1c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0C335.4,202.6,335.3,201.1,333.6,200.1
+	L333.6,200.1z"/>
+<path class="st31" d="M202.8,129.1c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0C204.5,131.7,204.5,130.1,202.8,129.1
+	L202.8,129.1z"/>
+<path class="st31" d="M330,51.8c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0C331.7,54.4,331.7,52.8,330,51.8L330,51.8z"/>
+<path class="st30" d="M462.5,125.8c-1.7-1-4.5-1-6.1,0c-1.7,1-1.7,2.6,0,3.6s4.5,1,6.1,0S464.2,126.8,462.5,125.8L462.5,125.8z"/>
+<g>
+	<linearGradient id="SVGID_21_" gradientUnits="userSpaceOnUse" x1="174.407" y1="148.5384" x2="155.251" y2="180.4649">
+		<stop  offset="0" style="stop-color:#31A1F4;stop-opacity:0.71"/>
+		<stop  offset="1" style="stop-color:#F3FFD6"/>
+	</linearGradient>
+	<polygon class="st32" points="179.5,165.9 169.5,160.1 142.6,175.7 152.7,181.5 	"/>
+	
+		<linearGradient id="SVGID_22_" gradientUnits="userSpaceOnUse" x1="217.4684" y1="312.2759" x2="173.4713" y2="287.607" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#3C98F3;stop-opacity:0.7"/>
+		<stop  offset="1" style="stop-color:#FAD9FF"/>
+	</linearGradient>
+	<polygon class="st33" points="213.6,165.2 203.5,159.4 159,185.2 169.1,191 	"/>
+	<linearGradient id="SVGID_23_" gradientUnits="userSpaceOnUse" x1="206.1701" y1="171.9152" x2="185.4729" y2="200.0986">
+		<stop  offset="0" style="stop-color:#31A1F4;stop-opacity:0.71"/>
+		<stop  offset="1" style="stop-color:#F3FFD6"/>
+	</linearGradient>
+	<polygon class="st34" points="212.4,184 202.3,178.2 174.7,194.2 184.7,200 	"/>
+	
+		<linearGradient id="SVGID_24_" gradientUnits="userSpaceOnUse" x1="250.8564" y1="296.4274" x2="196.8237" y2="266.1315" gradientTransform="matrix(1 0 0 -1 0 470)">
+		<stop  offset="0" style="stop-color:#3C98F3;stop-opacity:0.7"/>
+		<stop  offset="2.623671e-02" style="stop-color:#419AF3;stop-opacity:0.7079"/>
+		<stop  offset="1" style="stop-color:#FAD9FF"/>
+	</linearGradient>
+	<polygon class="st35" points="255.4,176.2 245.3,170.4 189.5,202.8 199.6,208.6 	"/>
+</g>
+</svg>

--- a/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.scss
+++ b/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.scss
@@ -3,8 +3,6 @@
     ----------------------------------------------------------------------------
 */
 
-$empty-menu--gutter: 4px;
-
 .dashboard-empty {
   position: absolute;
   top: 0;
@@ -16,99 +14,44 @@ $empty-menu--gutter: 4px;
   justify-content: center;
   align-items: center;
   text-align: center;
-
-  p {
-    color: $g11-sidewalk;
-    font-size: 18px;
-    margin: 0 0 20px 0;
-    @include no-user-select();
-
-    strong {
-      color: $g15-platinum;
-    }
-  }
 }
 
-.dashboard-empty--menu {
-  width: 70%;
-  max-width: 800px;
-  margin-bottom: 65px;
-}
-
-.dashboard-empty--menu-option {
-  float: left;
-  width: 25%;
-  padding-bottom: 25%;
+.dashboard-empty--graphic {
+  display: inline-flex;
   position: relative;
+  width: 50%;
+  max-width: 720px;
+}
 
-  > div > p {
-    margin: 0;
-    font-size: 14px;
-    font-weight: 900;
-    position: absolute;
-    bottom: 18px;
-    left: 10px;
-    width: calc(100% - 20px);
-    text-align: center;
-    display: inline-block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.dashboard-empty--graphic:after {
+  content: '';
+  display: inline-block;
+  // This % ensures proper aspect ratio for the image without using
+  // the <img /> element
+  padding-bottom: 57.3170731707317%;
+}
+
+.dashbpard-empty--graphic-content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-position: center center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-image: url('../../assets/images/dashboard-empty--dark.svg');
+}
+
+.clockface--app-wrapper.dashboard-light-mode {
+  .dashbpard-empty--graphic-content {
+    background-image: url('../../assets/images/dashboard-empty--light.svg');
   }
-
-  // Actual "card"
-  > div {
-    background-color: $g2-kevlar;
+  .dashboard-empty .cf-empty-state--text {
     color: $g11-sidewalk;
-    border-radius: 4px;
-    width: calc(100% - #{$empty-menu--gutter});
-    height: calc(100% - #{$empty-menu--gutter});
-    position: absolute;
-    top: $empty-menu--gutter / 2;
-    left: $empty-menu--gutter / 2;
-    transition: color 0.25s ease, border-color 0.25s ease,
-      background-color 0.25s ease;
   }
-}
-
-// Hover state "card"
-.dashboard-empty--menu-option:hover {
-  cursor: pointer;
-}
-.dashboard-empty--menu-option:hover > div {
-  background-color: $g5-pepper;
-  color: $g18-cloud;
-
-  .viz-type-selector--graphic {
-    .viz-type-selector--graphic-line.graphic-line-a {
-      stroke: $c-pool;
-    }
-    .viz-type-selector--graphic-line.graphic-line-b {
-      stroke: $c-dreamsicle;
-    }
-    .viz-type-selector--graphic-line.graphic-line-c {
-      stroke: $c-rainforest;
-    }
-    .viz-type-selector--graphic-line.graphic-line-d {
-      stroke: $g17-whisper;
-    }
-    .viz-type-selector--graphic-fill.graphic-fill-a {
-      fill: $c-pool;
-    }
-    .viz-type-selector--graphic-fill.graphic-fill-b {
-      fill: $c-dreamsicle;
-    }
-    .viz-type-selector--graphic-fill.graphic-fill-c {
-      fill: $c-rainforest;
-    }
-    .viz-type-selector--graphic-fill.graphic-fill-a,
-    .viz-type-selector--graphic-fill.graphic-fill-b,
-    .viz-type-selector--graphic-fill.graphic-fill-c {
-      opacity: 0.22;
-    }
-    .viz-type-selector--graphic-fill.graphic-fill-d {
-      fill: $g17-whisper;
-      opacity: 1;
-    }
+  .dashboard-empty .cf-empty-state--text strong,
+  .dashboard-empty .cf-empty-state--text b {
+    color: $g7-graphite;
   }
 }

--- a/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
+++ b/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
@@ -29,6 +29,9 @@ class DashboardEmpty extends Component<Props> {
     return (
       <div className="dashboard-empty">
         <EmptyState size={ComponentSize.Large}>
+          <div className="dashboard-empty--graphic">
+            <div className="dashbpard-empty--graphic-content" />
+          </div>
           <EmptyState.Text>
             This Dashboard doesn't have any <b>Cells</b>, why not add one?
           </EmptyState.Text>


### PR DESCRIPTION
Closes #17150 

- Add empty state image assets for both light and dark modes
- Implement graphics in empty state
- Cleanup some old styles

![Screen Shot 2020-03-16 at 3 15 46 PM](https://user-images.githubusercontent.com/2433762/76804511-aee32380-6799-11ea-9798-76b770b24599.png)
![Screen Shot 2020-03-16 at 3 15 39 PM](https://user-images.githubusercontent.com/2433762/76804517-b1de1400-6799-11ea-8ba6-bbd7ec592708.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
