### PR TITLE
feat(metrics): add metrics middleware to tenant service

### DIFF
--- a/tenant/middleware_bucket_metrics.go
+++ b/tenant/middleware_bucket_metrics.go
@@ -1,0 +1,75 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/metric"
+	"github.com/influxdata/influxdb/kit/prom"
+)
+
+type BucketMetrics struct {
+	// RED metrics
+	rec *metric.REDClient
+
+	bucketService influxdb.BucketService
+}
+
+var _ influxdb.BucketService = (*BucketMetrics)(nil)
+
+// NewBucketMetrics returns a metrics service middleware for the Bucket Service.
+func NewBucketMetrics(reg *prom.Registry, s influxdb.BucketService) *BucketMetrics {
+	return &BucketMetrics{
+		rec:           metric.New(reg, "bucket"),
+		bucketService: s,
+	}
+}
+
+// Returns a single bucket by ID.
+func (m *BucketMetrics) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+	rec := m.rec.Record("find_bucket_by_id")
+	bucket, err := m.bucketService.FindBucketByID(ctx, id)
+	return bucket, rec(err)
+}
+
+// Returns the first bucket that matches filter.
+func (m *BucketMetrics) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+	rec := m.rec.Record("find_bucket")
+	bucket, err := m.bucketService.FindBucket(ctx, filter)
+	return bucket, rec(err)
+}
+
+// FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
+func (m *BucketMetrics) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+	rec := m.rec.Record("find_buckets")
+	buckets, n, err := m.bucketService.FindBuckets(ctx, filter, opt...)
+	return buckets, n, rec(err)
+}
+
+// Creates a new bucket and sets b.ID with the new identifier.
+func (m *BucketMetrics) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
+	rec := m.rec.Record("create_bucket")
+	err := m.bucketService.CreateBucket(ctx, b)
+	return rec(err)
+}
+
+// Updates a single bucket with changeset and returns the new bucket state after update.
+func (m *BucketMetrics) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
+	rec := m.rec.Record("update_bucket")
+	updatedBucket, err := m.bucketService.UpdateBucket(ctx, id, upd)
+	return updatedBucket, rec(err)
+}
+
+// Removes a bucket by ID.
+func (m *BucketMetrics) DeleteBucket(ctx context.Context, id influxdb.ID) error {
+	rec := m.rec.Record("delete_bucket")
+	err := m.bucketService.DeleteBucket(ctx, id)
+	return rec(err)
+}
+
+// FindBucketByName finds a Bucket given its name and Organization ID
+func (m *BucketMetrics) FindBucketByName(ctx context.Context, orgID influxdb.ID, name string) (*influxdb.Bucket, error) {
+	rec := m.rec.Record("find_bucket_by_name")
+	bucket, err := m.bucketService.FindBucketByName(ctx, orgID, name)
+	return bucket, rec(err)
+}

--- a/tenant/middleware_org_metrics.go
+++ b/tenant/middleware_org_metrics.go
@@ -1,0 +1,70 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/metric"
+	"github.com/influxdata/influxdb/kit/prom"
+)
+
+type OrgMetrics struct {
+	// RED metrics
+	rec *metric.REDClient
+
+	orgService influxdb.OrganizationService
+}
+
+var _ influxdb.OrganizationService = (*OrgMetrics)(nil)
+
+// NewOrgMetrics returns a metrics service middleware for the Organization Service.
+func NewOrgMetrics(reg *prom.Registry, s influxdb.OrganizationService) *OrgMetrics {
+	return &OrgMetrics{
+		rec:        metric.New(reg, "org"),
+		orgService: s,
+	}
+}
+
+// Returns a single organization by ID.
+func (m *OrgMetrics) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+	rec := m.rec.Record("find_org_by_id")
+	org, err := m.orgService.FindOrganizationByID(ctx, id)
+	return org, rec(err)
+}
+
+// Returns the first organization that matches filter.
+func (m *OrgMetrics) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+	rec := m.rec.Record("find_org")
+	org, err := m.orgService.FindOrganization(ctx, filter)
+	return org, rec(err)
+}
+
+// Returns a list of organizations that match filter and the total count of matching organizations.
+// Additional options provide pagination & sorting.
+func (m *OrgMetrics) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+	rec := m.rec.Record("find_orgs")
+	orgs, n, err := m.orgService.FindOrganizations(ctx, filter, opt...)
+	return orgs, n, rec(err)
+}
+
+// Creates a new organization and sets b.ID with the new identifier.
+func (m *OrgMetrics) CreateOrganization(ctx context.Context, b *influxdb.Organization) error {
+	rec := m.rec.Record("create_org")
+	err := m.orgService.CreateOrganization(ctx, b)
+	return rec(err)
+}
+
+// Updates a single organization with changeset.
+// Returns the new organization state after update.
+func (m *OrgMetrics) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+	rec := m.rec.Record("update_org")
+	updatedOrg, err := m.orgService.UpdateOrganization(ctx, id, upd)
+	return updatedOrg, rec(err)
+}
+
+// Removes a organization by ID.
+func (m *OrgMetrics) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
+	rec := m.rec.Record("delete_org")
+	err := m.orgService.DeleteOrganization(ctx, id)
+	return rec(err)
+}

--- a/tenant/middleware_urm_metrics.go
+++ b/tenant/middleware_urm_metrics.go
@@ -1,0 +1,47 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/metric"
+	"github.com/influxdata/influxdb/kit/prom"
+)
+
+type UrmMetrics struct {
+	// RED metrics
+	rec *metric.REDClient
+
+	urmService influxdb.UserResourceMappingService
+}
+
+var _ influxdb.UserResourceMappingService = (*UrmMetrics)(nil)
+
+// NewUrmMetrics returns a metrics service middleware for the URM Service.
+func NewUrmMetrics(reg *prom.Registry, s influxdb.UserResourceMappingService) *UrmMetrics {
+	return &UrmMetrics{
+		rec:        metric.New(reg, "urm"),
+		urmService: s,
+	}
+}
+
+// FindUserResourceMappings returns a list of UserResourceMappings that match filter and the total count of matching mappings.
+func (m *UrmMetrics) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
+	rec := m.rec.Record("find_urms")
+	urms, n, err := m.urmService.FindUserResourceMappings(ctx, filter, opt...)
+	return urms, n, rec(err)
+}
+
+// CreateUserResourceMapping creates a user resource mapping.
+func (m *UrmMetrics) CreateUserResourceMapping(ctx context.Context, urm *influxdb.UserResourceMapping) error {
+	rec := m.rec.Record("create_urm")
+	err := m.urmService.CreateUserResourceMapping(ctx, urm)
+	return rec(err)
+}
+
+// DeleteUserResourceMapping deletes a user resource mapping.
+func (m *UrmMetrics) DeleteUserResourceMapping(ctx context.Context, resourceID, userID influxdb.ID) error {
+	rec := m.rec.Record("delete_urm")
+	err := m.urmService.DeleteUserResourceMapping(ctx, resourceID, userID)
+	return rec(err)
+}

--- a/tenant/middleware_user_metrics.go
+++ b/tenant/middleware_user_metrics.go
@@ -1,0 +1,70 @@
+package tenant
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/metric"
+	"github.com/influxdata/influxdb/kit/prom"
+)
+
+type UserMetrics struct {
+	// RED metrics
+	rec *metric.REDClient
+
+	userService influxdb.UserService
+}
+
+var _ influxdb.UserService = (*UserMetrics)(nil)
+
+// NewUserMetrics returns a metrics service middleware for the User Service.
+func NewUserMetrics(reg *prom.Registry, s influxdb.UserService) *UserMetrics {
+	return &UserMetrics{
+		rec:         metric.New(reg, "user"),
+		userService: s,
+	}
+}
+
+// Returns a single user by ID.
+func (m *UserMetrics) FindUserByID(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
+	rec := m.rec.Record("find_user_by_id")
+	user, err := m.userService.FindUserByID(ctx, id)
+	return user, rec(err)
+}
+
+// Returns the first user that matches filter.
+func (m *UserMetrics) FindUser(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
+	rec := m.rec.Record("find_user")
+	user, err := m.userService.FindUser(ctx, filter)
+	return user, rec(err)
+}
+
+// Returns a list of users that match filter and the total count of matching users.
+// Additional options provide pagination & sorting.
+func (m *UserMetrics) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {
+	rec := m.rec.Record("find_users")
+	users, n, err := m.userService.FindUsers(ctx, filter, opt...)
+	return users, n, rec(err)
+}
+
+// Creates a new user and sets u.ID with the new identifier.
+func (m *UserMetrics) CreateUser(ctx context.Context, u *influxdb.User) error {
+	rec := m.rec.Record("create_user")
+	err := m.userService.CreateUser(ctx, u)
+	return rec(err)
+}
+
+// Updates a single user with changeset.
+// Returns the new user state after update.
+func (m *UserMetrics) UpdateUser(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
+	rec := m.rec.Record("update_user")
+	updatedUser, err := m.userService.UpdateUser(ctx, id, upd)
+	return updatedUser, rec(err)
+}
+
+// Removes a user by ID.
+func (m *UserMetrics) DeleteUser(ctx context.Context, id influxdb.ID) error {
+	rec := m.rec.Record("delete_user")
+	err := m.userService.DeleteUser(ctx, id)
+	return rec(err)
+}


### PR DESCRIPTION
This PR adds a metrics middleware wrapping the services that comprise the Tenant Service: User, URM, Bucket, and Org. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
