### PR TITLE
feat(cloud): add userid and org id to gtm

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -150,6 +150,7 @@ const basepath = getBrowserBasepath()
 declare global {
   interface Window {
     basepath: string
+    dataLayer: any[]
   }
 }
 

--- a/ui/src/organizations/actions/thunks.ts
+++ b/ui/src/organizations/actions/thunks.ts
@@ -18,6 +18,8 @@ import {
 } from 'src/organizations/actions/creators'
 
 // Constants
+import {CLOUD} from 'src/shared/constants'
+
 import {
   orgCreateSuccess,
   orgCreateFailed,
@@ -28,6 +30,8 @@ import {
   orgRenameSuccess,
   orgRenameFailed,
 } from 'src/shared/copy/notifications'
+
+import {fireOrgIdReady} from 'src/shared/utils/analytics'
 
 // Schemas
 import {orgSchema, arrayOfOrgs} from 'src/schemas'
@@ -60,6 +64,10 @@ export const getOrganizations = () => async (
       orgs,
       arrayOfOrgs
     )
+
+    if (CLOUD) {
+      fireOrgIdReady(organizations.result)
+    }
 
     dispatch(setOrgs(RemoteDataState.Done, organizations))
 

--- a/ui/src/shared/actions/me.ts
+++ b/ui/src/shared/actions/me.ts
@@ -1,6 +1,8 @@
 import {MeState} from 'src/shared/reducers/me'
 import {client} from 'src/utils/api'
+import {CLOUD} from 'src/shared/constants'
 import HoneyBadger from 'honeybadger-js'
+import {fireUserDataReady} from 'src/shared/utils/analytics'
 
 export enum ActionTypes {
   SetMe = 'SET_ME',
@@ -25,6 +27,10 @@ export const setMe = me => ({
 export const getMe = () => async dispatch => {
   try {
     const user = await client.users.me()
+
+    if (CLOUD) {
+      fireUserDataReady(user.id, user.name)
+    }
 
     HoneyBadger.setContext({
       user_id: user.id,

--- a/ui/src/shared/utils/analytics.ts
+++ b/ui/src/shared/utils/analytics.ts
@@ -1,0 +1,25 @@
+export const fireOrgIdReady = function fireOrgIdReady(
+  organizationIds: string[]
+) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({
+    event: 'cloudAppOrgIdReady',
+    identity: {
+      organizationIds,
+    },
+  })
+}
+
+export const fireUserDataReady = function fireUserDataReady(
+  id: string,
+  email: string
+) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({
+    event: 'cloudAppUserDataReady',
+    identity: {
+      email,
+      id,
+    },
+  })
+}


### PR DESCRIPTION
Closes https://github.com/influxdata/growth/issues/41

(Private repo):
#### add dataLayer indentifiers to idpe

* adds a couple of helper methods to initialize the user in google tag manager
* calls those methods when user data and organization data are loaded

### Testing Instructions
* fire up app
* open your console and look for `window.dataLayer`. it shouldn't exist
* without a lot of config to make cloud work locally, change [this](https://github.com/influxdata/influxdb/pull/17302/files#diff-8c33463caf3e87edc906ec5715cb6eabR68) and [this](https://github.com/influxdata/influxdb/pull/17302/files#diff-023642cbf29399507646a13659e14d24R31) line to say `if (CLOUD || true)`
* open up your console and look for `window.dataLayer` it should be there.
  * if you prefer to just see an object with values, you can do something cutesy like:
    ```ts
      console.log(dataLayer.reduce((identity, item) => {
       return {...identity, ...item.identity}
      }, {}))
    ```

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass