### PR TITLE
chore: Revert "refactor(tsdb): remove read from unexported field (#17279)

### DIFF
--- a/tsdb/series_iterators.go
+++ b/tsdb/series_iterators.go
@@ -30,7 +30,7 @@ type seriesIDSetIterator struct {
 }
 
 func NewSeriesIDSetIterator(ss *SeriesIDSet) SeriesIDSetIterator {
-	if ss == nil || ss.IsEmpty() {
+	if ss == nil || ss.bitmap == nil {
 		return nil
 	}
 	return &seriesIDSetIterator{ss: ss, itr: ss.Iterator()}

--- a/tsdb/series_iterators_test.go
+++ b/tsdb/series_iterators_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/influxdata/influxdb/tsdb/seriesfile"
 	"github.com/influxdata/influxdb/tsdb/tsi1"
 	"github.com/influxdata/influxql"
-	"github.com/stretchr/testify/assert"
 )
 
 func toSeriesIDs(ids []uint64) []tsdb.SeriesID {
@@ -355,26 +354,4 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 			})
 		})
 	}
-}
-
-func TestSeriesIDSet_isEmpty(t *testing.T) {
-	sis := tsdb.NewSeriesIDSet(tsdb.NewSeriesID(1))
-	assert.False(t, sis.IsEmpty())
-
-	sis = tsdb.NewSeriesIDSet()
-	assert.True(t, sis.IsEmpty())
-
-	sis = &tsdb.SeriesIDSet{} // sis.bitmap == nil
-	assert.True(t, sis.IsEmpty())
-}
-
-func TestNewSeriesIDSetIterator(t *testing.T) {
-	sisi := tsdb.NewSeriesIDSetIterator(tsdb.NewSeriesIDSet(tsdb.NewSeriesID(1)))
-	assert.NotNil(t, sisi)
-
-	sisi = tsdb.NewSeriesIDSetIterator(tsdb.NewSeriesIDSet())
-	assert.Nil(t, sisi)
-
-	sisi = tsdb.NewSeriesIDSetIterator(nil)
-	assert.Nil(t, sisi)
 }

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -48,10 +48,6 @@ func (s *SeriesIDSet) Bytes() int {
 	return b
 }
 
-func (s *SeriesIDSet) IsEmpty() bool {
-	return s == nil || s.bitmap == nil || s.bitmap.IsEmpty()
-}
-
 // Add adds the series id to the set.
 func (s *SeriesIDSet) Add(id SeriesID) {
 	s.Lock()


### PR DESCRIPTION
This reverts commit 0ec2b453b91c3f4102967ce5c73b96a8ac71a851.

Fixes panic.