### PR TITLE
feat(ui): parsing domain on the UI to keep particular logic encompassed

### DIFF
--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -15,13 +15,15 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {parseUrl} from 'src/shared/utils/parseUrl'
 
 const Logout: FC<WithRouterProps> = ({router}) => {
   const handleSignOut = async () => {
     if (CLOUD && isFlagEnabled('regionBasedLoginPage')) {
       const config = await getAuth0Config()
+      const domain = parseUrl(config.domain)
       const auth0 = new auth0js.WebAuth({
-        domain: config.domain,
+        domain,
         clientID: config.clientID,
       })
       auth0.logout({})

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -35,6 +35,9 @@ import {notify} from 'src/shared/actions/notifications'
 import {passwordResetSuccessfully} from 'src/shared/copy/notifications'
 import {getAuth0Config} from 'src/authorizations/apis'
 
+// Utils
+import {parseUrl} from 'src/shared/utils/parseUrl'
+
 interface ErrorObject {
   [key: string]: string | undefined
 }
@@ -84,8 +87,9 @@ class LoginPageContents extends PureComponent<DispatchProps> {
   public async componentDidMount() {
     try {
       const config = await getAuth0Config()
+      const domain = parseUrl(config.domain)
       this.auth0 = new auth0js.WebAuth({
-        domain: config.domain,
+        domain,
         clientID: config.clientID,
         redirectUri: config.redirectURL,
         responseType: 'code',

--- a/ui/src/shared/utils/parseUrl.test.ts
+++ b/ui/src/shared/utils/parseUrl.test.ts
@@ -1,0 +1,23 @@
+import {parseUrl} from 'src/shared/utils/parseUrl'
+
+describe('Shared.utils.parseUrl', () => {
+  it('should return the current domain if none is provided', () => {
+    const actual = parseUrl(undefined)
+    expect(actual).toEqual('localhost/')
+  })
+
+  it('should return the current domain if an empty string is provided', () => {
+    const actual = parseUrl('')
+    expect(actual).toEqual('localhost/')
+  })
+
+  it('Should return the url stripped of the query and protocol', () => {
+    const actual = parseUrl('https://www.influxdata.com/developers?random')
+    expect(actual).toEqual('www.influxdata.com/developers')
+  })
+
+  it('Should return the url when no protocol has been provided', () => {
+    const actual = parseUrl('www.influxdata.com/developers')
+    expect(actual).toEqual('www.influxdata.com/developers')
+  })
+})

--- a/ui/src/shared/utils/parseUrl.ts
+++ b/ui/src/shared/utils/parseUrl.ts
@@ -1,0 +1,19 @@
+export const urlIsValid = (url: string) => {
+  try {
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const parseUrl = (url: string) => {
+  if (!url) {
+    url = window.location.href
+  }
+  if (urlIsValid(url)) {
+    const uri = new URL(url)
+    return `${uri.host}${uri.pathname}`
+  }
+  return url
+}


### PR DESCRIPTION
Implementing a UI-based solution in favor of an API solution (https://github.com/influxdata/idpe/pull/6392) due to the fact that we want to keep logic that is particular to the UI in the UI. That is to say, that since the UI expects the domain to be constructed in a particular way, we want the related logic to be conveniently located near the code where it is being used rather than abstracting it to the API and making it hard to understand both on the API and the UI.
