### PR TITLE
fix(http): fixup logging for http middleware

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -33,7 +33,7 @@ func LoggingMW(log *zap.Logger) kithttp.Middleware {
 
 				errReferenceField := zap.Skip()
 				if errReference := w.Header().Get(kithttp.PlatformErrorCodeHeader); errReference != "" {
-					errReferenceField = zap.String("error_code", kithttp.PlatformErrorCodeHeader)
+					errReferenceField = zap.String("error_code", errReference)
 				}
 
 				fields := []zap.Field{


### PR DESCRIPTION
found this little bugger in integration tests


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass