### PR TITLE
refactor(http): change *ast.Package to json.RawMessage in query requests

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -122,7 +122,7 @@ func TestPipeline_QueryMemoryLimits(t *testing.T) {
 
 	// compile a from query and get the spec
 	qs := fmt.Sprintf(`from(bucket:"%s") |> range(start:-5m)`, l.Bucket.Name)
-	pkg, err := runtime.Parse(qs)
+	pkg, err := runtime.ParseToJSON(qs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6
-	github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e
+	github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e h1:TVXzrBQKFuXfTF0pwHE4BVEoQIyW4Fs8C5to8R7lk/k=
-github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e/go.mod h1:RumtF2WhfdihnXNa5jJ77X65t3aDR0txvu+5TLIi0aQ=
+github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229 h1:xNYfjzeco9qzoF+lZQlYNRlOYXATdnT9zT0inAZSWMg=
+github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229/go.mod h1:X3qfF/kqGSKF6kDJbDwFBl58/Gxm/NVd0hgk2jaVuNI=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
@@ -252,7 +252,7 @@ github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/q
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
-github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.1.1/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwONTxrlEc=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=

--- a/http/document_test.go
+++ b/http/document_test.go
@@ -93,7 +93,7 @@ var (
 		},
 		Content: "content5",
 	}
-	doc6        = influxdb.Document{
+	doc6 = influxdb.Document{
 		ID: doc6ID,
 		Meta: influxdb.DocumentMeta{
 			Name: "doc6",

--- a/http/query.go
+++ b/http/query.go
@@ -31,9 +31,9 @@ type QueryRequest struct {
 	Query string `json:"query"`
 
 	// Flux fields
-	Extern  *ast.File    `json:"extern,omitempty"`
-	AST     *ast.Package `json:"ast,omitempty"`
-	Dialect QueryDialect `json:"dialect"`
+	Extern  json.RawMessage `json:"extern,omitempty"`
+	AST     json.RawMessage `json:"ast,omitempty"`
+	Dialect QueryDialect    `json:"dialect"`
 
 	// InfluxQL fields
 	Bucket string `json:"bucket,omitempty"`
@@ -263,13 +263,11 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 				Query:  r.Query,
 			}
 		}
-	} else if r.AST != nil {
+	} else if len(r.AST) > 0 {
 		c := lang.ASTCompiler{
-			AST: r.AST,
-			Now: now(),
-		}
-		if r.Extern != nil {
-			c.PrependFile(r.Extern)
+			Extern: r.Extern,
+			AST:    r.AST,
+			Now:    now(),
 		}
 		compiler = c
 	}

--- a/query/influxql/compiler.go
+++ b/query/influxql/compiler.go
@@ -2,6 +2,7 @@ package influxql
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/influxdata/flux"
@@ -64,7 +65,15 @@ func (c *Compiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Prog
 		return nil, err
 	}
 	compileOptions := lang.WithLogPlanOpts(c.logicalPlannerOptions...)
-	return lang.CompileAST(astPkg, runtime, now, compileOptions), nil
+	bs, err := json.Marshal(astPkg)
+	if err != nil {
+		return nil, err
+	}
+	hdl, err := runtime.JSONToHandle(bs)
+	if err != nil {
+		return nil, err
+	}
+	return lang.CompileAST(hdl, runtime, now, compileOptions), nil
 }
 
 func (c *Compiler) CompilerType() flux.CompilerType {

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e
+	github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229
 	github.com/influxdata/influxdb v0.0.0-20190925213338-8af36d5aaedd
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -288,8 +288,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e h1:TVXzrBQKFuXfTF0pwHE4BVEoQIyW4Fs8C5to8R7lk/k=
-github.com/influxdata/flux v0.64.1-0.20200319160451-5d0dbfe33a7e/go.mod h1:RumtF2WhfdihnXNa5jJ77X65t3aDR0txvu+5TLIi0aQ=
+github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229 h1:xNYfjzeco9qzoF+lZQlYNRlOYXATdnT9zT0inAZSWMg=
+github.com/influxdata/flux v0.64.1-0.20200323190316-80120e492229/go.mod h1:X3qfF/kqGSKF6kDJbDwFBl58/Gxm/NVd0hgk2jaVuNI=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
@@ -297,7 +297,7 @@ github.com/influxdata/influxql v1.0.1 h1:6PGG0SunRmptIMIreNRolhQ38Sq4qDfi2dS3BS1
 github.com/influxdata/influxql v1.0.1/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
-github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.1.1/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwONTxrlEc=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -160,9 +161,14 @@ func testFlux(t testing.TB, l *launcher.TestLauncher, file *ast.File) {
 	inspectCalls := stdlib.TestingInspectCalls(pkg)
 	pkg.Files = append(pkg.Files, inspectCalls)
 
+	bs, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	req := &query.Request{
 		OrganizationID: l.Org.ID,
-		Compiler:       lang.ASTCompiler{AST: pkg},
+		Compiler:       lang.ASTCompiler{AST: bs},
 	}
 	if r, err := l.FluxQueryService().Query(ctx, req); err != nil {
 		t.Fatal(err)

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -364,7 +364,7 @@ func (w *worker) executeQuery(p *promise) {
 	// start
 	w.start(p)
 
-	pkg, err := runtime.Parse(p.task.Flux)
+	pkg, err := runtime.ParseToJSON(p.task.Flux)
 	if err != nil {
 		w.finish(p, influxdb.RunFail, influxdb.ErrFluxParseError(err))
 		return

--- a/task/backend/executor/support_test.go
+++ b/task/backend/executor/support_test.go
@@ -32,7 +32,7 @@ type fakeQueryService struct {
 var _ query.AsyncQueryService = (*fakeQueryService)(nil)
 
 func makeAST(q string) lang.ASTCompiler {
-	pkg, err := runtime.Parse(q)
+	pkg, err := runtime.ParseToJSON(q)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This makes some changes to the `Compiler` interface used to issue Flux queries. In order to delay deserialization as long as possible, in order to do the deserialization in Rust, fields in serialized data structures like `FluxCompiler`, `ASTCompiler`, and `http.QueryRequest` have been changed to be typed as `json.RawMessage` instead of `*ast.Package`.