### PR TITLE
fix(flux): buckets call no longer panics

### DIFF
--- a/flux/stdlib/influxdata/influxdb/buckets.go
+++ b/flux/stdlib/influxdata/influxdb/buckets.go
@@ -82,10 +82,9 @@ func (bd *BucketsDecoder) Decode(ctx context.Context) (flux.Table, error) {
 			for _, rp := range db.RetentionPolicies {
 				_ = b.AppendString(0, db.Name+"/"+rp.Name)
 				_ = b.AppendString(1, "")
-				_ = b.AppendString(2, "influxdb")
-				_ = b.AppendString(3, "")
-				_ = b.AppendString(4, rp.Name)
-				_ = b.AppendInt(5, rp.Duration.Nanoseconds())
+				_ = b.AppendString(2, "")
+				_ = b.AppendString(3, rp.Name)
+				_ = b.AppendInt(4, rp.Duration.Nanoseconds())
 			}
 		}
 	}

--- a/patches/flux.patch
+++ b/patches/flux.patch
@@ -124,10 +124,9 @@ index 4fd36f948d..9ecbe49234 100644
 +			for _, rp := range db.RetentionPolicies {
 +				_ = b.AppendString(0, db.Name+"/"+rp.Name)
 +				_ = b.AppendString(1, "")
-+				_ = b.AppendString(2, "influxdb")
-+				_ = b.AppendString(3, "")
-+				_ = b.AppendString(4, rp.Name)
-+				_ = b.AppendInt(5, rp.Duration.Nanoseconds())
++				_ = b.AppendString(2, "")
++				_ = b.AppendString(3, rp.Name)
++				_ = b.AppendInt(4, rp.Duration.Nanoseconds())
 +			}
 +		}
  	}


### PR DESCRIPTION
The buckets call had a column removed and the backport did not remove
that line. This modifies the buckets command to not append a row to a
column that no longer exists.

Fixes #17317.