### PR TITLE
fix: set bucket limit to 100

### DIFF
--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -62,7 +62,7 @@ export const getBuckets = () => async (
     }
     const org = getOrg(state)
 
-    const resp = await api.getBuckets({query: {orgID: org.id}})
+    const resp = await api.getBuckets({query: {orgID: org.id, limit: 100}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -48,6 +48,7 @@ import {
   addBucketLabelFailed,
   removeBucketLabelFailed,
 } from 'src/shared/copy/notifications'
+import {LIMIT} from 'src/resources/constants'
 
 type Action = BucketAction | NotifyAction
 
@@ -62,7 +63,9 @@ export const getBuckets = () => async (
     }
     const org = getOrg(state)
 
-    const resp = await api.getBuckets({query: {orgID: org.id, limit: 100}})
+    const resp = await api.getBuckets({
+      query: {orgID: org.id, limit: LIMIT},
+    })
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/resources/constants/index.ts
+++ b/ui/src/resources/constants/index.ts
@@ -1,0 +1,2 @@
+// TODO: temporary fix until we implement pagination https://github.com/influxdata/influxdb/pull/17336
+export const LIMIT = 100

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -29,6 +29,9 @@ import {
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
 
+// Constants
+import {LIMIT} from 'src/resources/constants'
+
 export type Action =
   | ReturnType<typeof setBuilderAggregateFunctionType>
   | ReturnType<typeof setBuilderBucket>
@@ -151,7 +154,7 @@ export const loadBuckets = () => async (
   dispatch(setBuilderBucketsStatus(RemoteDataState.Loading))
 
   try {
-    const resp = await api.getBuckets({query: {orgID, limit: 100}})
+    const resp = await api.getBuckets({query: {orgID, limit: LIMIT}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -151,7 +151,7 @@ export const loadBuckets = () => async (
   dispatch(setBuilderBucketsStatus(RemoteDataState.Loading))
 
   try {
-    const resp = await api.getBuckets({query: {orgID}})
+    const resp = await api.getBuckets({query: {orgID, limit: 100}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)


### PR DESCRIPTION
Closes #17068 

### The Problem
Users with more than 20 buckets could not see all their buckets

### The (Temporary) Solution
Increase the `limit` query parameter to 100.  

### The Real Solution
Implement an app wide pagination / filtering / infiniscroll solution for all resources.  