### PR TITLE
feat(tsdb): Bulk delete series performance improvement

### DIFF
--- a/tsdb/seriesfile/series_file_test.go
+++ b/tsdb/seriesfile/series_file_test.go
@@ -218,7 +218,7 @@ func TestSeriesFile_DeleteSeriesID(t *testing.T) {
 	}
 
 	// Delete and ensure deletion.
-	if err := sfile.DeleteSeriesID(id); err != nil {
+	if err := sfile.DeleteSeriesIDs([]tsdb.SeriesID{id}); err != nil {
 		t.Fatal(err)
 	} else if !sfile.IsDeleted(id) {
 		t.Fatal("expected deletion before compaction")
@@ -301,7 +301,7 @@ func TestSeriesFile_Compaction(t *testing.T) {
 
 		if id := sfile.SeriesID(collection.Names[i], collection.Tags[i], nil); id.IsZero() {
 			t.Fatal("expected series id")
-		} else if err := sfile.DeleteSeriesID(id); err != nil {
+		} else if err := sfile.DeleteSeriesIDs([]tsdb.SeriesID{id}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -387,7 +387,7 @@ func BenchmarkSeriesFile_Compaction(b *testing.B) {
 
 		// Delete a subset of keys.
 		for i := 0; i < len(ids); i += 10 {
-			if err := sfile.DeleteSeriesID(ids[i]); err != nil {
+			if err := sfile.DeleteSeriesIDs([]tsdb.SeriesID{ids[i]}); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/tsdb/seriesfile/series_partition.go
+++ b/tsdb/seriesfile/series_partition.go
@@ -368,9 +368,9 @@ func (p *SeriesPartition) Compacting() bool {
 	return p.compacting
 }
 
-// DeleteSeriesID flags a series as permanently deleted.
-// If the series is reintroduced later then it must create a new id.
-func (p *SeriesPartition) DeleteSeriesID(id tsdb.SeriesID) error {
+// DeleteSeriesID flags a list of series as permanently deleted.
+// If a series is reintroduced later then it must create a new id.
+func (p *SeriesPartition) DeleteSeriesIDs(ids []tsdb.SeriesID) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -378,15 +378,19 @@ func (p *SeriesPartition) DeleteSeriesID(id tsdb.SeriesID) error {
 		return ErrSeriesPartitionClosed
 	}
 
-	// Already tombstoned, ignore.
-	if p.index.IsDeleted(id) {
-		return nil
-	}
+	var n uint64
+	for _, id := range ids {
+		// Already tombstoned, ignore.
+		if p.index.IsDeleted(id) {
+			continue
+		}
 
-	// Write tombstone entry. The type is ignored in tombstones.
-	_, err := p.writeLogEntry(AppendSeriesEntry(nil, SeriesEntryTombstoneFlag, id.WithType(models.Empty), nil))
-	if err != nil {
-		return err
+		// Write tombstone entries. The type is ignored in tombstones.
+		_, err := p.writeLogEntry(AppendSeriesEntry(nil, SeriesEntryTombstoneFlag, id.WithType(models.Empty), nil))
+		if err != nil {
+			return err
+		}
+		n++
 	}
 
 	// Flush active segment write.
@@ -397,8 +401,11 @@ func (p *SeriesPartition) DeleteSeriesID(id tsdb.SeriesID) error {
 	}
 
 	// Mark tombstone in memory.
-	p.index.Delete(id)
-	p.tracker.SubSeries(1)
+	for _, id := range ids {
+		p.index.Delete(id)
+	}
+	p.tracker.SubSeries(n)
+
 	return nil
 }
 

--- a/tsdb/seriesfile/series_verify_test.go
+++ b/tsdb/seriesfile/series_verify_test.go
@@ -113,7 +113,7 @@ func NewTest(t *testing.T) *Test {
 		}
 
 		// delete one series
-		if err := seriesFile.DeleteSeriesID(tsdb.NewSeriesID(ids[0])); err != nil {
+		if err := seriesFile.DeleteSeriesIDs([]tsdb.SeriesID{tsdb.NewSeriesID(ids[0])}); err != nil {
 			return err
 		}
 

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxql"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // ErrCompactionInterrupted is returned if compactions are disabled or
@@ -371,11 +372,6 @@ func (i *Index) Path() string { return i.path }
 // PartitionAt returns the partition by index.
 func (i *Index) PartitionAt(index int) *Partition {
 	return i.partitions[index]
-}
-
-// partition returns the appropriate Partition for a provided series key.
-func (i *Index) partition(key []byte) *Partition {
-	return i.partitions[int(xxhash.Sum64(key)&(i.PartitionN-1))]
 }
 
 // partitionIdx returns the index of the partition that key belongs in.
@@ -732,11 +728,23 @@ func (i *Index) InitializeSeries(*tsdb.SeriesCollection) error {
 	return nil
 }
 
-// DropSeries drops the provided series from the index.  If cascade is true
+// DropSeries drops the provided set of series from the index.  If cascade is true
 // and this is the last series to the measurement, the measurment will also be dropped.
-func (i *Index) DropSeries(seriesID tsdb.SeriesID, key []byte, cascade bool) error {
-	// Remove from partition.
-	if err := i.partition(key).DropSeries(seriesID); err != nil {
+func (i *Index) DropSeries(items []DropSeriesItem, cascade bool) error {
+	// Split into batches for each partition.
+	m := make(map[int][]tsdb.SeriesID)
+	for _, item := range items {
+		partitionID := i.partitionIdx(item.Key)
+		m[partitionID] = append(m[partitionID], item.SeriesID)
+	}
+
+	// Remove from all partitions in parallel.
+	var g errgroup.Group
+	for partitionID, ids := range m {
+		partitionID, ids := partitionID, ids
+		g.Go(func() error { return i.partitions[partitionID].DropSeries(ids) })
+	}
+	if err := g.Wait(); err != nil {
 		return err
 	}
 
@@ -744,29 +752,38 @@ func (i *Index) DropSeries(seriesID tsdb.SeriesID, key []byte, cascade bool) err
 		return nil
 	}
 
-	// Extract measurement name & tags.
-	name, tags := models.ParseKeyBytes(key)
+	// Clear tag value cache & determine unique set of measurement names.
+	nameSet := make(map[string]struct{})
+	for _, item := range items {
+		// Extract measurement name & tags.
+		name, tags := models.ParseKeyBytes(item.Key)
+		nameSet[string(name)] = struct{}{}
 
-	// If there are cached sets for any of the tag pairs, they will need to be
-	// updated with the series id.
-	i.tagValueCache.RLock()
-	if i.tagValueCache.measurementContainsSets(name) {
-		for _, pair := range tags {
-			i.tagValueCache.delete(name, pair.Key, pair.Value, seriesID) // Takes a lock on the series id set
+		// If there are cached sets for any of the tag pairs, they will need to be
+		// updated with the series id.
+		i.tagValueCache.RLock()
+		if i.tagValueCache.measurementContainsSets(name) {
+			for _, pair := range tags {
+				i.tagValueCache.delete(name, pair.Key, pair.Value, item.SeriesID) // Takes a lock on the series id set
+			}
 		}
-	}
-	i.tagValueCache.RUnlock()
-
-	// Check if that was the last series for the measurement in the entire index.
-	if ok, err := i.MeasurementHasSeries(name); err != nil {
-		return err
-	} else if ok {
-		return nil
+		i.tagValueCache.RUnlock()
 	}
 
-	// If no more series exist in the measurement then delete the measurement.
-	if err := i.DropMeasurement(name); err != nil {
-		return err
+	for name := range nameSet {
+		namebytes := []byte(name)
+
+		// Check if that was the last series for the measurement in the entire index.
+		if ok, err := i.MeasurementHasSeries(namebytes); err != nil {
+			return err
+		} else if ok {
+			continue
+		}
+
+		// If no more series exist in the measurement then delete the measurement.
+		if err := i.DropMeasurement(namebytes); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1663,4 +1680,9 @@ func (itr *filterUndeletedSeriesIDIterator) Next() (tsdb.SeriesIDElem, error) {
 		}
 		return e, nil
 	}
+}
+
+type DropSeriesItem struct {
+	SeriesID tsdb.SeriesID
+	Key      []byte
 }

--- a/tsdb/tsi1/index_test.go
+++ b/tsdb/tsi1/index_test.go
@@ -109,7 +109,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	}
 
 	// Delete one series.
-	if err := idx.DropSeries(sid, models.MakeKey(name, tags), true); err != nil {
+	if err := idx.DropSeries([]tsi1.DropSeriesItem{{SeriesID: sid, Key: models.MakeKey(name, tags)}}, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	if sid.IsZero() {
 		t.Fatalf("got 0 series id for %s/%v", name, tags)
 	}
-	if err := idx.DropSeries(sid, models.MakeKey(name, tags), true); err != nil {
+	if err := idx.DropSeries([]tsi1.DropSeriesItem{{SeriesID: sid, Key: models.MakeKey(name, tags)}}, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -378,7 +378,7 @@ func TestIndex_MeasurementCardinalityStats(t *testing.T) {
 		}
 
 		seriesID := idx.SeriesFile.SeriesID([]byte("cpu"), models.NewTags(map[string]string{"region": "west"}), nil)
-		if err := idx.DropSeries(seriesID, idx.SeriesFile.SeriesKey(seriesID), true); err != nil {
+		if err := idx.DropSeries([]tsi1.DropSeriesItem{{SeriesID: seriesID, Key: idx.SeriesFile.SeriesKey(seriesID)}}, true); err != nil {
 			t.Fatal(err)
 		} else if stats, err := idx.MeasurementCardinalityStats(); err != nil {
 			t.Fatal(err)
@@ -387,7 +387,7 @@ func TestIndex_MeasurementCardinalityStats(t *testing.T) {
 		}
 
 		seriesID = idx.SeriesFile.SeriesID([]byte("mem"), models.NewTags(map[string]string{"region": "east"}), nil)
-		if err := idx.DropSeries(seriesID, idx.SeriesFile.SeriesKey(seriesID), true); err != nil {
+		if err := idx.DropSeries([]tsi1.DropSeriesItem{{SeriesID: seriesID, Key: idx.SeriesFile.SeriesKey(seriesID)}}, true); err != nil {
 			t.Fatal(err)
 		} else if stats, err := idx.MeasurementCardinalityStats(); err != nil {
 			t.Fatal(err)

--- a/tsdb/tsi1/log_file.go
+++ b/tsdb/tsi1/log_file.go
@@ -456,19 +456,31 @@ func (f *LogFile) TagValueIterator(name, key []byte) TagValueIterator {
 	return tk.TagValueIterator()
 }
 
-// DeleteTagKey adds a tombstone for a tag key to the log file.
-func (f *LogFile) DeleteTagKey(name, key []byte) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
+// deleteTagKey adds a tombstone for a tag key to the log file without a lock.
+func (f *LogFile) deleteTagKey(name, key []byte) error {
 	e := LogEntry{Flag: LogEntryTagKeyTombstoneFlag, Name: name, Key: key}
 	if err := f.appendEntry(&e); err != nil {
 		return err
 	}
 	f.execEntry(&e)
+	return nil
+}
 
-	// Flush buffer and sync to disk.
+// DeleteTagKey adds a tombstone for a tag key to the log file.
+func (f *LogFile) DeleteTagKey(name, key []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.deleteTagKey(name, key); err != nil {
+		return err
+	}
 	return f.FlushAndSync()
+}
+
+// DeleteTagKeyNoSync adds a tombstone for a tag key to the log file without a sync.
+func (f *LogFile) DeleteTagKeyNoSync(name, key []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deleteTagKey(name, key)
 }
 
 // TagValueSeriesIDSet returns a series iterator for a tag value.
@@ -525,19 +537,32 @@ func (f *LogFile) TagValueN() (n uint64) {
 	return n
 }
 
-// DeleteTagValue adds a tombstone for a tag value to the log file.
-func (f *LogFile) DeleteTagValue(name, key, value []byte) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
+// deleteTagValue adds a tombstone for a tag value to the log file without a lock.
+func (f *LogFile) deleteTagValue(name, key, value []byte) error {
 	e := LogEntry{Flag: LogEntryTagValueTombstoneFlag, Name: name, Key: key, Value: value}
 	if err := f.appendEntry(&e); err != nil {
 		return err
 	}
 	f.execEntry(&e)
+	return nil
+}
 
-	// Flush buffer and sync to disk.
+// DeleteTagValue adds a tombstone for a tag value to the log file.
+func (f *LogFile) DeleteTagValue(name, key, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.deleteTagValue(name, key, value); err != nil {
+		return err
+	}
 	return f.FlushAndSync()
+}
+
+// DeleteTagValueNoSync adds a tombstone for a tag value to the log file.
+// Caller must call FlushAndSync().
+func (f *LogFile) DeleteTagValueNoSync(name, key, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deleteTagValue(name, key, value)
 }
 
 // AddSeriesList adds a list of series to the log file in bulk.
@@ -608,16 +633,18 @@ func (f *LogFile) AddSeriesList(seriesSet *tsdb.SeriesIDSet, collection *tsdb.Se
 	return seriesIDs, nil
 }
 
-// DeleteSeriesID adds a tombstone for a series id.
-func (f *LogFile) DeleteSeriesID(id tsdb.SeriesID) error {
+// DeleteSeriesIDs adds a tombstone for a list of series ids.
+func (f *LogFile) DeleteSeriesIDs(ids []tsdb.SeriesID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	e := LogEntry{Flag: LogEntrySeriesTombstoneFlag, SeriesID: id}
-	if err := f.appendEntry(&e); err != nil {
-		return err
+	for _, id := range ids {
+		e := LogEntry{Flag: LogEntrySeriesTombstoneFlag, SeriesID: id}
+		if err := f.appendEntry(&e); err != nil {
+			return err
+		}
+		f.execEntry(&e)
 	}
-	f.execEntry(&e)
 
 	// Flush buffer and sync to disk.
 	return f.FlushAndSync()

--- a/tsdb/tsi1/partition.go
+++ b/tsdb/tsi1/partition.go
@@ -621,7 +621,7 @@ func (p *Partition) DropMeasurement(name []byte) error {
 				if err := func() error {
 					p.mu.RLock()
 					defer p.mu.RUnlock()
-					return p.activeLogFile.DeleteTagKey(name, k.Key())
+					return p.activeLogFile.DeleteTagKeyNoSync(name, k.Key())
 				}(); err != nil {
 					return err
 				}
@@ -634,7 +634,7 @@ func (p *Partition) DropMeasurement(name []byte) error {
 						if err := func() error {
 							p.mu.RLock()
 							defer p.mu.RUnlock()
-							return p.activeLogFile.DeleteTagValue(name, k.Key(), v.Value())
+							return p.activeLogFile.DeleteTagValueNoSync(name, k.Key(), v.Value())
 						}(); err != nil {
 							return err
 						}
@@ -683,6 +683,15 @@ func (p *Partition) DropMeasurement(name []byte) error {
 		p.mu.RLock()
 		defer p.mu.RUnlock()
 		return p.activeLogFile.DeleteMeasurement(name)
+	}(); err != nil {
+		return err
+	}
+
+	// Ensure log is flushed & synced.
+	if err := func() error {
+		p.mu.RLock()
+		defer p.mu.RUnlock()
+		return p.activeLogFile.FlushAndSync()
 	}(); err != nil {
 		return err
 	}
@@ -750,24 +759,27 @@ func (p *Partition) createSeriesListIfNotExists(collection *tsdb.SeriesCollectio
 	return ids, nil
 }
 
-// DropSeries removes the provided series id from the index.
-//
-// TODO(edd): We should support a bulk drop here.
-func (p *Partition) DropSeries(seriesID tsdb.SeriesID) error {
-	// Ignore if the series is already deleted.
-	if !p.seriesIDSet.Contains(seriesID) {
-		return nil
+// DropSeries removes the provided set of series id from the index.
+func (p *Partition) DropSeries(ids []tsdb.SeriesID) error {
+	// Count total affected series.
+	var n uint64
+	for _, id := range ids {
+		if p.seriesIDSet.Contains(id) {
+			n++
+		}
 	}
 
 	// Delete series from index.
-	if err := p.activeLogFile.DeleteSeriesID(seriesID); err != nil {
+	if err := p.activeLogFile.DeleteSeriesIDs(ids); err != nil {
 		return err
 	}
 
 	// Update series set.
-	p.seriesIDSet.Remove(seriesID)
-	p.tracker.AddSeriesDropped(1)
-	p.tracker.SubSeries(1)
+	for _, id := range ids {
+		p.seriesIDSet.Remove(id)
+	}
+	p.tracker.AddSeriesDropped(n)
+	p.tracker.SubSeries(n)
 
 	// Swap log file, if necessary.
 	return p.CheckLogFile()


### PR DESCRIPTION
## Overview

This pull request significantly improves the performance of deleting with predicate. Local tests show a delete of 1m points going from 20m+ to subsecond. The primary change is batching `Sync()` calls when deleting series & tag values from the index and deleting series from the series file.