### PR TITLE
fix(documents): prevent adding duplicate labels to documents

### DIFF
--- a/http/document_service_test.go
+++ b/http/document_service_test.go
@@ -647,16 +647,19 @@ func AddLabels(t *testing.T) {
 	})
 
 	t.Run("add same twice", func(t *testing.T) {
-		// TODO(affo)
-		t.Skip("see https://github.com/influxdata/influxdb/issues/17092")
-
 		serverFn, clientFn, fx := setup(t)
-		server := serverFn(fx.auth(influxdb.WriteAction))
+		server := serverFn(func() influxdb.Authorizer {
+			a := fx.auth(influxdb.WriteAction)
+			// The LabelService uses a "standard auth" mode.
+			// That's  why we need to add further permissions and the org ones are not enough.
+			fx.addLabelPermission(a, influxdb.WriteAction, fx.Labels[0].ID)
+			return a
+		}())
 		defer server.Close()
 		client := clientFn(server.URL)
 		if _, err := client.AddDocumentLabel(context.Background(), namespace, fx.Document.ID, fx.Labels[0].ID); err != nil {
-			if !strings.Contains(err.Error(), "???") {
-				t.Errorf("unexpected error: %v", err)
+			if !strings.Contains(err.Error(), influxdb.ErrLabelExistsOnResource.Msg) {
+				t.Errorf("unexpected error: %v", err.Error())
 			}
 		} else {
 			t.Error("expected error got none")

--- a/kv/label.go
+++ b/kv/label.go
@@ -209,6 +209,17 @@ func (s *Service) createLabelMapping(ctx context.Context, tx Tx, m *influxdb.Lab
 		return err
 	}
 
+	ls := []*influxdb.Label{}
+	err := s.findResourceLabels(ctx, tx, influxdb.LabelMappingFilter{ResourceID: m.ResourceID, ResourceType: m.ResourceType}, &ls)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(ls); i++ {
+		if ls[i].ID == m.LabelID {
+			return influxdb.ErrLabelExistsOnResource
+		}
+	}
+
 	if err := s.putLabelMapping(ctx, tx, m); err != nil {
 		return err
 	}

--- a/label.go
+++ b/label.go
@@ -25,6 +25,13 @@ var (
 		Code: EInvalid,
 		Msg:  "label name is empty",
 	}
+
+	// ErrLabelExistsOnResource is used when attempting to add a label to a resource
+	// when that label already exists on the resource
+	ErrLabelExistsOnResource = &Error{
+		Code: EConflict,
+		Msg:  "Cannot add label, label already exists on resource",
+	}
 )
 
 // LabelService represents a service for managing resource labels


### PR DESCRIPTION
Closes #17092

This PR adds a check for existing labels on a Document before adding a Label Mapping, to prevent duplicate Label Mappings from being created for a given Document.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
