### PR TITLE
fix(variables): add nil check for variable arguments

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -123,7 +123,7 @@ func (m *Variable) Valid() error {
 		"query":    true,
 	}
 
-	if !validTypes[m.Arguments.Type] {
+	if m.Arguments == nil || !validTypes[m.Arguments.Type] {
 		return fmt.Errorf("invalid arguments type")
 	}
 


### PR DESCRIPTION
Add a nil check for variable arguments to prevent a panic when checking if a Variable is valid during creation, etc.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
