### PR TITLE
refactor: rename Generate to OnboardInitialUser

### DIFF
--- a/authorizer/task_test.go
+++ b/authorizer/task_test.go
@@ -21,7 +21,7 @@ func TestOnboardingValidation(t *testing.T) {
 	svc := newKVSVC(t)
 	ts := authorizer.NewTaskService(zaptest.NewLogger(t), mockTaskService(3, 2, 1))
 
-	r, err := svc.Generate(context.Background(), &influxdb.OnboardingRequest{
+	r, err := svc.OnboardInitalUser(context.Background(), &influxdb.OnboardingRequest{
 		User:            "Setec Astronomy",
 		Password:        "too many secrets",
 		Org:             "thing",
@@ -121,7 +121,7 @@ func TestValidations(t *testing.T) {
 
 	svc := newKVSVC(t)
 
-	r, err := svc.Generate(context.Background(), &influxdb.OnboardingRequest{
+	r, err := svc.OnboardInitalUser(context.Background(), &influxdb.OnboardingRequest{
 		User:            "Setec Astronomy",
 		Password:        "too many secrets",
 		Org:             "thing",

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -91,7 +91,7 @@ func setupF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to retrieve data to setup instance: %v", err)
 	}
 
-	result, err := s.Generate(context.Background(), req)
+	result, err := s.OnboardInitalUser(context.Background(), req)
 	if err != nil {
 		return fmt.Errorf("failed to setup instance: %v", err)
 	}

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -131,7 +131,7 @@ func (tl *TestLauncher) SetupOrFail(tb testing.TB) {
 // OnBoard attempts an on-boarding request.
 // The on-boarding status is also reset to allow multiple user/org/buckets to be created.
 func (tl *TestLauncher) OnBoard(req *platform.OnboardingRequest) (*platform.OnboardingResults, error) {
-	res, err := tl.KeyValueService().Generate(context.Background(), req)
+	res, err := tl.KeyValueService().OnboardInitalUser(context.Background(), req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -24,7 +24,7 @@ func TestLauncher_Setup(t *testing.T) {
 	defer l.Shutdown(ctx)
 
 	svc := &http.SetupService{Addr: l.URL()}
-	if results, err := svc.Generate(ctx, &platform.OnboardingRequest{
+	if results, err := svc.OnboardInitalUser(ctx, &platform.OnboardingRequest{
 		User:     "USER",
 		Password: "PASSWORD",
 		Org:      "ORG",

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -83,7 +83,7 @@ func (h *SetupHandler) handlePostSetup(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	results, err := h.OnboardingService.Generate(ctx, req)
+	results, err := h.OnboardingService.OnboardInitalUser(ctx, req)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
@@ -166,8 +166,8 @@ func (s *SetupService) IsOnboarding(ctx context.Context) (bool, error) {
 	return ir.Allowed, nil
 }
 
-// Generate OnboardingResults.
-func (s *SetupService) Generate(ctx context.Context, or *platform.OnboardingRequest) (*platform.OnboardingResults, error) {
+// OnboardInitalUser OnboardingResults.
+func (s *SetupService) OnboardInitalUser(ctx context.Context, or *platform.OnboardingRequest) (*platform.OnboardingResults, error) {
 	u, err := NewURL(s.Addr, prefixSetup)
 	if err != nil {
 		return nil, err

--- a/http/onboarding_test.go
+++ b/http/onboarding_test.go
@@ -62,5 +62,5 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	return client, done
 }
 func TestOnboardingService(t *testing.T) {
-	platformtesting.Generate(initOnboardingService, t)
+	platformtesting.OnboardInitalUser(initOnboardingService, t)
 }

--- a/kv/onboarding.go
+++ b/kv/onboarding.go
@@ -94,9 +94,9 @@ func (s *Service) setOnboarded(ctx context.Context, tx Tx) error {
 	return nil
 }
 
-// Generate OnboardingResults from onboarding request,
+// OnboardInitalUser OnboardingResults from onboarding request,
 // update db so this request will be disabled for the second run.
-func (s *Service) Generate(ctx context.Context, req *influxdb.OnboardingRequest) (*influxdb.OnboardingResults, error) {
+func (s *Service) OnboardInitalUser(ctx context.Context, req *influxdb.OnboardingRequest) (*influxdb.OnboardingResults, error) {
 	isOnboarding, err := s.IsOnboarding(ctx)
 	if err != nil {
 		return nil, err

--- a/kv/onboarding_test.go
+++ b/kv/onboarding_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBoltOnboardingService(t *testing.T) {
-	influxdbtesting.Generate(initBoltOnboardingService, t)
+	influxdbtesting.OnboardInitalUser(initBoltOnboardingService, t)
 }
 
 func initBoltOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {

--- a/mock/onboarding_service.go
+++ b/mock/onboarding_service.go
@@ -35,7 +35,7 @@ func (s *OnboardingService) IsOnboarding(ctx context.Context) (bool, error) {
 	return s.IsOnboardingFn(ctx)
 }
 
-// Generate OnboardingResults.
-func (s *OnboardingService) Generate(ctx context.Context, req *platform.OnboardingRequest) (*platform.OnboardingResults, error) {
+// OnboardInitalUser OnboardingResults.
+func (s *OnboardingService) OnboardInitalUser(ctx context.Context, req *platform.OnboardingRequest) (*platform.OnboardingResults, error) {
 	return s.GenerateFn(ctx, req)
 }

--- a/onboarding.go
+++ b/onboarding.go
@@ -12,8 +12,8 @@ type OnboardingService interface {
 
 	// IsOnboarding determine if onboarding request is allowed.
 	IsOnboarding(ctx context.Context) (bool, error)
-	// Generate OnboardingResults.
-	Generate(ctx context.Context, req *OnboardingRequest) (*OnboardingResults, error)
+	// OnboardInitalUser OnboardingResults.
+	OnboardInitalUser(ctx context.Context, req *OnboardingRequest) (*OnboardingResults, error)
 }
 
 // OnboardingResults is a group of elements required for first run.

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -19,8 +19,8 @@ type OnboardingFields struct {
 	IsOnboarding   bool
 }
 
-// Generate testing
-func Generate(
+// OnboardInitalUser testing
+func OnboardInitalUser(
 	init func(OnboardingFields, *testing.T) (platform.OnboardingService, func()),
 	t *testing.T,
 ) {
@@ -195,7 +195,7 @@ func Generate(
 			s, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			results, err := s.Generate(ctx, tt.args.request)
+			results, err := s.OnboardInitalUser(ctx, tt.args.request)
 			if (err != nil) != (tt.wants.errCode != "") {
 				t.Logf("Error: %v", err)
 				t.Fatalf("expected error code '%s' got '%v'", tt.wants.errCode, err)


### PR DESCRIPTION
Renaming Generate in anticipation of a new method that will onboard
users other than the initial user. The intent is to simplify multi-user
setups.

Co-authored-by: Chris Goller <goller@gmail.com>

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
