### PR TITLE
feat(pkger): extend notification rules with ability to define and rename it

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -312,13 +312,11 @@ spec:
 			}
 			assert.Equal(t, "rule_0", rule.Name)
 			assert.Equal(t, pkger.SafeID(endpoints[0].NotificationEndpoint.GetID()), rule.EndpointID)
-			endpointName := "http_none_auth_notification_endpoint"
-			if exportAllSum {
-				endpointName = "no auth endpoint"
-			}
-			assert.Equal(t, endpointName, rule.EndpointName)
 			if !exportAllSum {
+				assert.Equal(t, "http_none_auth_notification_endpoint", rule.EndpointName)
 				assert.Equalf(t, "http", rule.EndpointType, "rule: %+v", rule)
+			} else {
+				assert.Len(t, rule.EndpointName, influxdb.IDLength)
 			}
 
 			require.Len(t, sum1.Tasks, 1)
@@ -652,7 +650,7 @@ spec:
 			newRule := newSum.NotificationRules[0]
 			assert.Equal(t, "new rule name", newRule.Name)
 			assert.Zero(t, newRule.EndpointID)
-			assert.Equal(t, "no auth endpoint", newRule.EndpointName)
+			assert.Len(t, newRule.EndpointName, influxdb.IDLength)
 			hasLabelAssociations(t, newRule.LabelAssociations, 1, "label_1")
 
 			require.Len(t, newSum.Tasks, 1)
@@ -1066,7 +1064,7 @@ spec:
 apiVersion: %[1]s
 kind: NotificationEndpointHTTP
 metadata:
-  name:  http_none_auth_notification_endpoint
+  name:  http_none_auth_notification_endpoint # on export of resource created from this, will not be same name as this
 spec:
   name: no auth endpoint
   type: none
@@ -1142,8 +1140,9 @@ spec:
 apiVersion: %[1]s
 kind: NotificationRule
 metadata:
-  name:  rule_0
+  name:  rule_UUID
 spec:
+  name:  rule_0
   description: desc_0
   endpointName: http_none_auth_notification_endpoint
   every: 10m

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -1616,9 +1616,10 @@ const (
 )
 
 type notificationRule struct {
-	id    influxdb.ID
-	orgID influxdb.ID
-	name  *references
+	id          influxdb.ID
+	orgID       influxdb.ID
+	name        *references
+	displayName *references
 
 	channel     string
 	description string
@@ -1649,6 +1650,13 @@ func (r *notificationRule) Labels() []*label {
 }
 
 func (r *notificationRule) Name() string {
+	if displayName := r.displayName.String(); displayName != "" {
+		return displayName
+	}
+	return r.name.String()
+}
+
+func (r *notificationRule) PkgName() string {
 	return r.name.String()
 }
 
@@ -1799,7 +1807,13 @@ func (r *notificationRule) valid() []validationErr {
 		})
 	}
 
-	return vErrs
+	if len(vErrs) > 0 {
+		return []validationErr{
+			objectValidationErr(fieldSpec, vErrs...),
+		}
+	}
+
+	return nil
 }
 
 func toSummaryStatusRules(statusRules []struct{ curLvl, prevLvl string }) []SummaryStatusRule {

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3100,7 +3100,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "missing endpoint name",
 						validationErrs: 1,
-						valFields:      []string{fieldNotificationRuleEndpointName},
+						valFields:      []string{fieldSpec, fieldNotificationRuleEndpointName},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3118,7 +3118,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "missing every",
 						validationErrs: 1,
-						valFields:      []string{fieldEvery},
+						valFields:      []string{fieldSpec, fieldEvery},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3136,7 +3136,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "missing status rules",
 						validationErrs: 1,
-						valFields:      []string{fieldNotificationRuleStatusRules},
+						valFields:      []string{fieldSpec, fieldNotificationRuleStatusRules},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3153,7 +3153,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "bad current status rule level",
 						validationErrs: 1,
-						valFields:      []string{fieldNotificationRuleStatusRules},
+						valFields:      []string{fieldSpec, fieldNotificationRuleStatusRules},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3172,7 +3172,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "bad previous status rule level",
 						validationErrs: 1,
-						valFields:      []string{fieldNotificationRuleStatusRules},
+						valFields:      []string{fieldSpec, fieldNotificationRuleStatusRules},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3192,7 +3192,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "bad tag rule operator",
 						validationErrs: 1,
-						valFields:      []string{fieldNotificationRuleTagRules},
+						valFields:      []string{fieldSpec, fieldNotificationRuleTagRules},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3215,7 +3215,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "bad status provided",
 						validationErrs: 1,
-						valFields:      []string{fieldStatus},
+						valFields:      []string{fieldSpec, fieldStatus},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3235,7 +3235,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "label association does not exist",
 						validationErrs: 1,
-						valFields:      []string{fieldAssociations},
+						valFields:      []string{fieldSpec, fieldAssociations},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
@@ -3257,7 +3257,7 @@ spec:
 					resErr: testPkgResourceError{
 						name:           "label association dupe",
 						validationErrs: 1,
-						valFields:      []string{fieldAssociations},
+						valFields:      []string{fieldSpec, fieldAssociations},
 						pkgStr: `apiVersion: influxdata.com/v2alpha1
 kind: Label
 metadata:
@@ -3278,6 +3278,37 @@ spec:
       name: label_1
     - kind: Label
       name: label_1
+`,
+					},
+				},
+				{
+					kind: KindNotificationRule,
+					resErr: testPkgResourceError{
+						name:           "duplicate meta names",
+						validationErrs: 1,
+						valFields:      []string{fieldMetadata, fieldName},
+						pkgStr: `
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationRule
+metadata:
+  name: rule_0
+spec:
+  endpointName: endpoint_0
+  every: 10m
+  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
+  statusRules:
+    - currentLevel: WARN
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationRule
+metadata:
+  name: rule_0
+spec:
+  endpointName: endpoint_0
+  every: 10m
+  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
+  statusRules:
+    - currentLevel: WARN
 `,
 					},
 				},

--- a/pkger/testdata/notification_rule.json
+++ b/pkger/testdata/notification_rule.json
@@ -10,9 +10,10 @@
     "apiVersion": "influxdata.com/v2alpha1",
     "kind": "NotificationRule",
     "metadata": {
-      "name": "rule_0"
+      "name": "rule_UUID"
     },
     "spec": {
+      "name": "rule_0",
       "description": "desc_0",
       "channel": "#two-fer-one",
       "endpointName": "endpoint_0",

--- a/pkger/testdata/notification_rule.yml
+++ b/pkger/testdata/notification_rule.yml
@@ -7,8 +7,9 @@ metadata:
 apiVersion: influxdata.com/v2alpha1
 kind: NotificationRule
 metadata:
-  name: rule_0
+  name: rule_UUID
 spec:
+  name: rule_0
   description: desc_0
   channel: "#two-fer-one"
   endpointName: endpoint_0


### PR DESCRIPTION
this PR makes notification rules unique by name within a pkg. A user can have notification rules within a pkg that have the same `spec.name` still. The `metadata.name` field must be unique.

references #17233 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass