### PR TITLE
feat(kv): add user resource mapping by user index

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -109,13 +109,18 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		s.clock = clock.New()
 	}
 
+	if s.Config.URMByUserIndexReadPathEnabled {
+		WithIndexReadPathEnabled(s.urmByUserIndex)
+	}
+
 	return s
 }
 
 // ServiceConfig allows us to configure Services
 type ServiceConfig struct {
-	SessionLength time.Duration
-	Clock         clock.Clock
+	SessionLength                 time.Duration
+	Clock                         clock.Clock
+	URMByUserIndexReadPathEnabled bool
 }
 
 // AutoMigrationStore is a Store which also describes whether or not

--- a/kv/urm_test.go
+++ b/kv/urm_test.go
@@ -5,10 +5,24 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kv"
+	"github.com/influxdata/influxdb/snowflake"
 	influxdbtesting "github.com/influxdata/influxdb/testing"
 	"go.uber.org/zap/zaptest"
 )
+
+type testable interface {
+	Logf(string, ...interface{})
+	Error(args ...interface{})
+	Errorf(string, ...interface{})
+	Fail()
+	Failed() bool
+	Name() string
+	FailNow()
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+}
 
 func TestBoltUserResourceMappingService(t *testing.T) {
 	influxdbtesting.UserResourceMappingService(initBoltUserResourceMappingService, t)
@@ -27,7 +41,7 @@ func initBoltUserResourceMappingService(f influxdbtesting.UserResourceFields, t 
 	}
 }
 
-func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
+func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFields, t testable) (influxdb.UserResourceMappingService, func()) {
 	svc := kv.NewService(zaptest.NewLogger(t), s)
 
 	ctx := context.Background()
@@ -35,9 +49,27 @@ func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFi
 		t.Fatalf("error initializing urm service: %v", err)
 	}
 
+	for _, o := range f.Organizations {
+		if err := svc.CreateOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to create org %q", err)
+		}
+	}
+
+	for _, u := range f.Users {
+		if err := svc.CreateUser(ctx, u); err != nil {
+			t.Fatalf("failed to create user %q", err)
+		}
+	}
+
+	for _, b := range f.Buckets {
+		if err := svc.PutBucket(ctx, b); err != nil {
+			t.Fatalf("failed to create bucket %q", err)
+		}
+	}
+
 	for _, m := range f.UserResourceMappings {
 		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
-			t.Fatalf("failed to populate mappings")
+			t.Fatalf("failed to populate mappings %q", err)
 		}
 	}
 
@@ -47,5 +79,52 @@ func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFi
 				t.Logf("failed to remove user resource mapping: %v", err)
 			}
 		}
+
+		for _, b := range f.Buckets {
+			if err := svc.DeleteBucket(ctx, b.ID); err != nil {
+				t.Logf("failed to delete org", err)
+			}
+		}
+
+		for _, u := range f.Users {
+			if err := svc.DeleteUser(ctx, u.ID); err != nil {
+				t.Fatalf("failed to delete user %q", err)
+			}
+		}
+
+		for _, o := range f.Organizations {
+			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {
+				t.Logf("failed to delete org", err)
+			}
+		}
+	}
+}
+
+func BenchmarkReadURMs(b *testing.B) {
+	urms := influxdbtesting.UserResourceFields{
+		UserResourceMappings: make([]*influxdb.UserResourceMapping, 10000),
+	}
+	idgen := snowflake.NewDefaultIDGenerator()
+	users := make([]influxdb.ID, 10)
+	for i := 0; i < 10; i++ {
+		users[i] = idgen.ID()
+	}
+
+	for i := 0; i < 10000; i++ {
+		urms.UserResourceMappings[i] = &influxdb.UserResourceMapping{
+			ResourceID:   idgen.ID(),
+			UserID:       users[i%len(users)],
+			UserType:     influxdb.Member,
+			ResourceType: influxdb.BucketsResourceType,
+		}
+	}
+	st := inmem.NewKVStore()
+	initUserResourceMappingService(st, urms, b)
+	svc := kv.NewService(zaptest.NewLogger(b), st)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		svc.FindUserResourceMappings(context.Background(), influxdb.UserResourceMappingFilter{
+			UserID: users[0],
+		})
 	}
 }

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -39,6 +39,9 @@ var mappingCmpOptions = cmp.Options{
 
 // UserResourceFields includes prepopulated data for mapping tests
 type UserResourceFields struct {
+	Organizations        []*platform.Organization
+	Users                []*platform.User
+	Buckets              []*platform.Bucket
 	UserResourceMappings []*platform.UserResourceMapping
 }
 
@@ -241,6 +244,46 @@ func DeleteUserResourceMapping(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{},
 				err:      fmt.Errorf("user to resource mapping not found"),
+			},
+		},
+		{
+			name: "delete user resource mapping for org",
+			fields: UserResourceFields{
+				Organizations: []*platform.Organization{
+					{
+						ID:   MustIDBase16(orgOneID),
+						Name: "organization1",
+					},
+				},
+				Users: []*platform.User{
+					{
+						ID:   MustIDBase16(userOneID),
+						Name: "user1",
+					},
+				},
+				Buckets: []*platform.Bucket{
+					{
+						ID:    MustIDBase16(bucketOneID),
+						Name:  "bucket1",
+						OrgID: MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: platform.OrgsResourceType,
+						MappingType:  platform.UserMappingType,
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+					},
+				},
+			},
+			args: args{
+				resourceID: MustIDBase16(orgOneID),
+				userID:     MustIDBase16(userOneID),
+			},
+			wants: wants{
+				mappings: []*platform.UserResourceMapping{},
 			},
 		},
 	}


### PR DESCRIPTION
This adds the user resource mapping by user ID index.
It currently just integrates the write paths (insert, delete) and adds the migrations necessary to intialize the index and populate it with existing source contents.

A subsequent change is necessary to enable the read-path. This does however add configuration to enable it when ready and it runs the test suites against this code with the read-path enabled.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
