### PR TITLE
fix(ui): treating headers with an error the same as any other value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [17240](https://github.com/influxdata/influxdb/pull/17240): NodeJS logo displays properly in Firefox
+1. [17350](https://github.com/influxdata/influxdb/pull/17350): Query Columns with the name "error" should no longer throw an Error
 
 ### UI Improvements
 

--- a/ui/src/shared/utils/checkQueryResult.test.ts
+++ b/ui/src/shared/utils/checkQueryResult.test.ts
@@ -1,7 +1,7 @@
 import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 
 describe('checkQueryResult', () => {
-  test('throws an error when the response has an error table', () => {
+  test('should not throw an error when the response has an error table', () => {
     const RESPONSE = `#group,true,true
 #datatype,string,string
 #default,,
@@ -10,7 +10,7 @@ describe('checkQueryResult', () => {
 
     expect(() => {
       checkQueryResult(RESPONSE)
-    }).toThrow('function references unknown column')
+    }).not.toThrow()
   })
 
   test('does not throw an error when the response is valid', () => {

--- a/ui/src/shared/utils/checkQueryResult.ts
+++ b/ui/src/shared/utils/checkQueryResult.ts
@@ -1,7 +1,7 @@
 /*
   Given Flux query response as a CSV, check if the CSV contains an error table
   as the first result. If it does, throw the error message contained within
-  that table. 
+  that table.
 
   For example, given the following response:
 
@@ -24,18 +24,7 @@ export const checkQueryResult = (file: string): void => {
     return
   }
 
-  const header = lines[0].split(',').map(s => s.trim())
-  const row = lines[1].split(',').map(s => s.trim())
-  const index = header.indexOf('error')
-
-  if (index === -1 || !row[index]) {
-    return
-  }
-
-  // Trim off extra quotes at start and end of message
-  const errorMessage = row[index].replace(/^"/, '').replace(/"$/, '')
-
-  throw new Error(errorMessage)
+  return
 }
 
 const findNthIndex = (s: string, c: string, n: number) => {


### PR DESCRIPTION
Closes #16474 

After speaking with @russorat and checking out the previous issue regarding a similar matter (https://app.zenhub.com/workspaces/applicationmonitoring-5e3b05772922e316b3a210a4/issues/influxdata/idpe/5152) it seems clear that the intent of the issue is to treat `error` headers the same as all other columns. As such, this PR removes the logic that dealt with throwing an error whenever a `header` returned an `error`. Below is an example of how this looks:

![Screen Shot 2020-03-19 at 08 26 21](https://user-images.githubusercontent.com/19984220/77084044-a407d900-69bb-11ea-8b2d-58b5319bf821.png)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)