### PR TITLE
fix: storage read service should not return a nil cursor

### DIFF
--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -207,8 +207,8 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 	if err != nil {
 		return nil, err
 	}
-	if len(shardIDs) == 0 { // TODO(jeff): this was a typed nil
-		return nil, nil
+	if len(shardIDs) == 0 {
+		return cursors.NewStringSliceIterator(nil), nil
 	}
 
 	var expr influxql.Expr
@@ -282,8 +282,8 @@ func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if len(shardIDs) == 0 { // TODO(jeff): this was a typed nil
-		return nil, nil
+	if len(shardIDs) == 0 {
+		return cursors.NewStringSliceIterator(nil), nil
 	}
 
 	var expr influxql.Expr


### PR DESCRIPTION
The storage read service would return a nil cursor if there was no data
and no shards to read from. This modifies it to return an empty cursor
instead.

Fixes influxdata/flux#2641.