### PR TITLE
fix(models): fix the line breaker

### DIFF
--- a/models/points_parser.go
+++ b/models/points_parser.go
@@ -152,7 +152,7 @@ func (pp *pointsParser) parsePoints(buf []byte) (err error) {
 		}
 
 		// strip the newline if one is present
-		if block[len(block)-1] == '\n' {
+		if lb := block[len(block)-1]; lb == '\n' || lb == '\r' {
 			block = block[:len(block)-1]
 		}
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -832,6 +832,23 @@ func TestParsePointFloatMultipleDecimals(t *testing.T) {
 	}
 }
 
+func TestParseWithLineBreaks(t *testing.T) {
+	ss := []string{
+		"cpu,host=serverA,region=us-west value=1i\ncpu,host=serverA,region=us-west value=2i",
+		"cpu,host=serverA,region=us-west value=1i\n\ncpu,host=serverA,region=us-west value=2i",
+		"cpu,host=serverA,region=us-west value=1i\r\ncpu,host=serverA,region=us-west value=2i",
+	}
+	for _, s := range ss {
+		pp, err := models.ParsePointsString(s, "mm")
+		if err != nil {
+			t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, s, err)
+		}
+		if l := len(pp); l != 2 {
+			t.Errorf(`ParsePoints("%s") mismatch. got %v, exp 2`, s, l)
+		}
+	}
+}
+
 func TestParsePointInteger(t *testing.T) {
 	_, err := models.ParsePointsString(`cpu,host=serverA,region=us-west value=1i`, "mm")
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15829

Turns out the issue @sanderson seeing is not related to the batch writer, but a simple line breaker.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)