### PR TITLE
feat(sampledata): Return bucket resources that user has member access to

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -396,3 +396,8 @@ func MemberPermissions(orgID ID) []Permission {
 
 	return ps
 }
+
+// MemberPermissions are the default permissions for those who can see a resource.
+func MemberBucketPermission(bucketID ID) Permission {
+	return Permission{Action: ReadAction, Resource: Resource{Type: BucketsResourceType, ID: &bucketID}}
+}

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -161,6 +161,10 @@ func (m *UserResourceMapping) memberPerms() ([]Permission, error) {
 		ps = append(ps, MemberPermissions(m.ResourceID)...)
 	}
 
+	if m.ResourceType == BucketsResourceType {
+		ps = append(ps, MemberBucketPermission(m.ResourceID))
+	}
+
 	return ps, nil
 }
 

--- a/user_resource_mapping_test.go
+++ b/user_resource_mapping_test.go
@@ -3,8 +3,10 @@ package influxdb_test
 import (
 	"testing"
 
+	"github.com/influxdata/influxdb"
 	platform "github.com/influxdata/influxdb"
 	platformtesting "github.com/influxdata/influxdb/testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOwnerMappingValidate(t *testing.T) {
@@ -96,6 +98,78 @@ func TestOwnerMappingValidate(t *testing.T) {
 			if err := m.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("OwnerMapping.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestOwnerMappingToPermissions(t *testing.T) {
+	type wants struct {
+		perms platform.Permission
+		err   bool
+	}
+
+	ResourceID, _ := platform.IDFromString("020f755c3c082000")
+
+	tests := []struct {
+		name  string
+		urm   platform.UserResourceMapping
+		wants wants
+	}{
+		{
+			name: "Org Member Has Permission To Read Org",
+			urm: platform.UserResourceMapping{
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Member,
+				ResourceType: platform.OrgsResourceType,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+			},
+			wants: wants{
+				err:   false,
+				perms: influxdb.Permission{Action: "read", Resource: influxdb.Resource{Type: "orgs", ID: ResourceID}}},
+		},
+		{
+			name: "Org Owner Has Permission To Write Org",
+			urm: platform.UserResourceMapping{
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Owner,
+				ResourceType: platform.OrgsResourceType,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+			},
+			wants: wants{
+				err:   false,
+				perms: influxdb.Permission{Action: "write", Resource: influxdb.Resource{Type: "orgs", ID: ResourceID}}},
+		},
+		{
+			name: "Org Owner Has Permission To Read Org",
+			urm: platform.UserResourceMapping{
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Owner,
+				ResourceType: platform.OrgsResourceType,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+			},
+			wants: wants{
+				err:   false,
+				perms: influxdb.Permission{Action: "read", Resource: influxdb.Resource{Type: "orgs", ID: ResourceID}}},
+		},
+		{
+			name: "Bucket Member User Has Permission To Read Bucket",
+			urm: platform.UserResourceMapping{
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Member,
+				ResourceType: platform.BucketsResourceType,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+			},
+			wants: wants{
+				err:   false,
+				perms: influxdb.Permission{Action: "read", Resource: influxdb.Resource{Type: "buckets", ID: ResourceID}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perms, err := tt.urm.ToPermissions()
+
+			require.Contains(t, perms, tt.wants.perms)
+			require.Equal(t, tt.wants.err, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
Partially addresses #https://github.com/influxdata/idpe/issues/6341

Authorizes buckets resource that a user has member access to. 