### PR TITLE
fix(ui): resolved telegraf bucket dropdown bug and undefined token issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 1. [17232](https://github.com/influxdata/influxdb/pull/17232): Allow dashboards to optionally be displayed in light mode
 1. [17273](https://github.com/influxdata/influxdb/pull/17273): Add shell completions command for the influx cli
 1. [17353](https://github.com/influxdata/influxdb/pull/17353): Make all pkg resources unique by metadata.name field
+1. [17363](https://github.com/influxdata/influxdb/pull/17363): Telegraf config tokens can no longer be retrieved after creation, but new tokens can be created after a telegraf has been setup
 
 ### Bug Fixes
 
 1. [17240](https://github.com/influxdata/influxdb/pull/17240): NodeJS logo displays properly in Firefox
+1. [17363](https://github.com/influxdata/influxdb/pull/17363): Fixed telegraf configuration bugs where system buckets were appearing in the buckets dropdown
 
 ### UI Improvements
 

--- a/ui/src/buckets/selectors/index.ts
+++ b/ui/src/buckets/selectors/index.ts
@@ -1,7 +1,19 @@
 // Types
-import {Bucket} from 'src/types'
+import {AppState, Bucket, ResourceType} from 'src/types'
+
+// Selectors
+import {getAll} from 'src/resources/selectors'
 
 export const SYSTEM = 'system'
+
+export const getBucketByName = (
+  state: AppState,
+  bucketName: string
+): Bucket => {
+  const buckets = getAll<Bucket>(state, ResourceType.Buckets)
+  const bucket = buckets.find(b => b.name === bucketName)
+  return bucket
+}
 
 export const isSystemBucket = (type: string): boolean => type === SYSTEM
 

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -497,8 +497,6 @@ const createTelegraf = async (dispatch, getState: GetState, plugins) => {
       permissions,
     }
 
-    console.log('token on create: ', token)
-
     // create token
     const createdToken = await createAuthorization(token)
 

--- a/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -50,7 +50,9 @@ import {AppState, Bucket, Organization, ResourceType} from 'src/types'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 import {getOrg} from 'src/organizations/selectors'
-import {isSystemBucket} from 'src/buckets/selectors'
+
+// Utils
+import {isSystemBucket} from 'src/buckets/constants/index'
 
 export interface CollectorsStepProps {
   currentStepIndex: number

--- a/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -52,7 +52,7 @@ import {getAll} from 'src/resources/selectors'
 import {getOrg} from 'src/organizations/selectors'
 
 // Utils
-import {isSystemBucket} from 'src/buckets/constants/index'
+import {isSystemBucket} from 'src/buckets/constants'
 
 export interface CollectorsStepProps {
   currentStepIndex: number

--- a/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {Alert, ComponentColor, IconFont} from '@influxdata/clockface'
 import _ from 'lodash'
 
 // Decorator
@@ -7,6 +8,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Components
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+import TokenCodeSnippet from 'src/shared/components/TokenCodeSnippet'
 
 export interface Props {
   token: string
@@ -17,7 +19,6 @@ export interface Props {
 class TelegrafInstructions extends PureComponent<Props> {
   public render() {
     const {token, configID} = this.props
-    const exportToken = `export INFLUX_TOKEN=${token || ''}`
     const configScript = `telegraf --config ${
       this.origin
     }/api/v2/telegrafs/${configID || ''}`
@@ -42,7 +43,13 @@ class TelegrafInstructions extends PureComponent<Props> {
           copy the following command to your terminal window to set an
           environment variable with your token.
         </p>
-        <CodeSnippet copyText={exportToken} label="CLI" />
+        {token && (
+          <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
+            Make sure to copy your new personal access token now. You won’t be
+            able to see it again!
+          </Alert>
+        )}
+        <TokenCodeSnippet copyText={token} configID={configID} label="CLI" />
         <h6>3. Start Telegraf</h6>
         <p>
           Finally, you can run the following command to start the Telegraf agent

--- a/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -49,7 +49,7 @@ class TelegrafInstructions extends PureComponent<Props> {
             able to see it again!
           </Alert>
         )}
-        <TokenCodeSnippet copyText={token} configID={configID} label="CLI" />
+        <TokenCodeSnippet token={token} configID={configID} label="CLI" />
         <h6>3. Start Telegraf</h6>
         <p>
           Finally, you can run the following command to start the Telegraf agent

--- a/ui/src/dataLoaders/selectors/index.ts
+++ b/ui/src/dataLoaders/selectors/index.ts
@@ -1,4 +1,7 @@
-import {AppState} from 'src/types'
+// Libraries
+import {filter} from 'lodash'
+// Types
+import {AppState, Bucket} from 'src/types'
 
 export const getDataLoaders = (state: AppState) => {
   return state.dataLoading.dataLoaders
@@ -6,4 +9,15 @@ export const getDataLoaders = (state: AppState) => {
 
 export const getSteps = (state: AppState) => {
   return state.dataLoading.steps
+}
+
+export const getBucketByName = (
+  state: AppState,
+  bucketName: string
+): Bucket => {
+  const buckets = state.resources.buckets.byID
+  const [bucket] = filter(buckets, b => {
+    return b.name === bucketName
+  })
+  return bucket
 }

--- a/ui/src/dataLoaders/selectors/index.ts
+++ b/ui/src/dataLoaders/selectors/index.ts
@@ -1,7 +1,4 @@
-// Libraries
-import {filter} from 'lodash'
-// Types
-import {AppState, Bucket} from 'src/types'
+import {AppState} from 'src/types'
 
 export const getDataLoaders = (state: AppState) => {
   return state.dataLoading.dataLoaders
@@ -9,15 +6,4 @@ export const getDataLoaders = (state: AppState) => {
 
 export const getSteps = (state: AppState) => {
   return state.dataLoading.steps
-}
-
-export const getBucketByName = (
-  state: AppState,
-  bucketName: string
-): Bucket => {
-  const buckets = state.resources.buckets.byID
-  const [bucket] = filter(buckets, b => {
-    return b.name === bucketName
-  })
-  return bucket
 }

--- a/ui/src/resources/selectors/index.ts
+++ b/ui/src/resources/selectors/index.ts
@@ -20,6 +20,9 @@ export const getAll = <R>(
   return allIDs.map(id => byID[id])
 }
 
+export const getToken = (state: AppState): string =>
+  get(state, 'dataLoading.dataLoaders.token', '') || ''
+
 export const getByID = <R>(
   {resources}: AppState,
   type: ResourceType,

--- a/ui/src/shared/components/CodeSnippet.scss
+++ b/ui/src/shared/components/CodeSnippet.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.new-token--btn {
+  margin: $ix-marg-a $ix-marg-c;
+}
+
 .code-snippet--footer {
   background-color: rgba($g4-onyx, 0.5);
   display: flex;

--- a/ui/src/shared/components/TokenCodeSnippet.tsx
+++ b/ui/src/shared/components/TokenCodeSnippet.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FC} from 'react'
 import {connect} from 'react-redux'
 import {
   Button,
@@ -10,7 +10,6 @@ import {
 } from '@influxdata/clockface'
 
 // Decorator
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Notification} from 'src/types'
 
 // Components
@@ -22,7 +21,7 @@ import {generateTelegrafToken} from 'src/dataLoaders/actions/dataLoaders'
 
 export interface Props {
   configID: string
-  copyText: string
+  token: string
   onCopyText?: (text: string, status: boolean) => Notification
   testID?: string
   label: string
@@ -32,62 +31,55 @@ interface DispatchProps {
   onGenerateTelegrafToken: typeof generateTelegrafToken
 }
 
-@ErrorHandling
-class TokenCodeSnippet extends PureComponent<Props & DispatchProps> {
-  public static defaultProps = {
-    label: 'Code Snippet',
-  }
-
-  public handleRefreshClick = () => {
+const TokenCodeSnippet: FC<Props & DispatchProps> = ({
+  token,
+  onCopyText,
+  testID,
+  label = 'Code Snippet',
+}) => {
+  const handleRefreshClick = () => {
     const {configID, onGenerateTelegrafToken} = this.props
     onGenerateTelegrafToken(configID)
   }
 
-  public render() {
-    const {copyText, label, onCopyText} = this.props
-    const testID = this.props.testID || 'code-snippet'
-
-    return (
-      <div className="code-snippet" data-testid={testID}>
-        <FancyScrollbar
-          autoHide={false}
-          autoHeight={true}
-          maxHeight={400}
-          className="code-snippet--scroll"
-        >
-          <div className="code-snippet--text">
-            <pre>
-              export INFLUX_TOKEN=<i>{copyText || '<INFLUX_TOKEN>'}</i>
-            </pre>
-          </div>
-        </FancyScrollbar>
-        <div className="code-snippet--footer">
-          <div>
-            <CopyButton
-              textToCopy={copyText}
-              onCopyText={onCopyText}
-              contentName="Script"
-            />
-            <Button
-              size={ComponentSize.ExtraSmall}
-              status={
-                copyText === ''
-                  ? ComponentStatus.Default
-                  : ComponentStatus.Disabled
-              }
-              text="Generate New Token"
-              titleText="Generate New Token"
-              icon={IconFont.Refresh}
-              color={ComponentColor.Success}
-              onClick={this.handleRefreshClick}
-              className="new-token--btn"
-            />
-          </div>
-          <label className="code-snippet--label">{label}</label>
+  return (
+    <div className="code-snippet" data-testid={testID}>
+      <FancyScrollbar
+        autoHide={false}
+        autoHeight={true}
+        maxHeight={400}
+        className="code-snippet--scroll"
+      >
+        <div className="code-snippet--text">
+          <pre>
+            export INFLUX_TOKEN=<i>{token || '<INFLUX_TOKEN>'}</i>
+          </pre>
         </div>
+      </FancyScrollbar>
+      <div className="code-snippet--footer">
+        <div>
+          <CopyButton
+            textToCopy={token}
+            onCopyText={onCopyText}
+            contentName="Script"
+          />
+          <Button
+            size={ComponentSize.ExtraSmall}
+            status={
+              token === '' ? ComponentStatus.Default : ComponentStatus.Disabled
+            }
+            text="Generate New Token"
+            titleText="Generate New Token"
+            icon={IconFont.Refresh}
+            color={ComponentColor.Success}
+            onClick={handleRefreshClick}
+            className="new-token--btn"
+          />
+        </div>
+        <label className="code-snippet--label">{label}</label>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 const mdtp: DispatchProps = {

--- a/ui/src/shared/components/TokenCodeSnippet.tsx
+++ b/ui/src/shared/components/TokenCodeSnippet.tsx
@@ -1,0 +1,100 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+import {
+  Button,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  IconFont,
+} from '@influxdata/clockface'
+
+// Decorator
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {Notification} from 'src/types'
+
+// Components
+import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
+import CopyButton from 'src/shared/components/CopyButton'
+
+// Actions
+import {generateTelegrafToken} from 'src/dataLoaders/actions/dataLoaders'
+
+export interface Props {
+  configID: string
+  copyText: string
+  onCopyText?: (text: string, status: boolean) => Notification
+  testID?: string
+  label: string
+}
+
+interface DispatchProps {
+  onGenerateTelegrafToken: typeof generateTelegrafToken
+}
+
+@ErrorHandling
+class TokenCodeSnippet extends PureComponent<Props & DispatchProps> {
+  public static defaultProps = {
+    label: 'Code Snippet',
+  }
+
+  public handleRefreshClick = () => {
+    const {configID, onGenerateTelegrafToken} = this.props
+    onGenerateTelegrafToken(configID)
+  }
+
+  public render() {
+    const {copyText, label, onCopyText} = this.props
+    const testID = this.props.testID || 'code-snippet'
+
+    return (
+      <div className="code-snippet" data-testid={testID}>
+        <FancyScrollbar
+          autoHide={false}
+          autoHeight={true}
+          maxHeight={400}
+          className="code-snippet--scroll"
+        >
+          <div className="code-snippet--text">
+            <pre>
+              export INFLUX_TOKEN=<i>{copyText || '<INFLUX_TOKEN>'}</i>
+            </pre>
+          </div>
+        </FancyScrollbar>
+        <div className="code-snippet--footer">
+          <div>
+            <CopyButton
+              textToCopy={copyText}
+              onCopyText={onCopyText}
+              contentName="Script"
+            />
+            <Button
+              size={ComponentSize.ExtraSmall}
+              status={
+                copyText === ''
+                  ? ComponentStatus.Default
+                  : ComponentStatus.Disabled
+              }
+              text="Generate New Token"
+              titleText="Generate New Token"
+              icon={IconFont.Refresh}
+              color={ComponentColor.Success}
+              onClick={this.handleRefreshClick}
+              className="new-token--btn"
+            />
+          </div>
+          <label className="code-snippet--label">{label}</label>
+        </div>
+      </div>
+    )
+  }
+}
+
+const mdtp: DispatchProps = {
+  onGenerateTelegrafToken: generateTelegrafToken,
+}
+
+export default connect<{}, DispatchProps>(
+  null,
+  mdtp
+)(TokenCodeSnippet)

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -121,6 +121,11 @@ export const TelegrafConfigCreationError: Notification = {
   message: `Failed to save configurations`,
 }
 
+export const TokenCreationError: Notification = {
+  ...defaultErrorNotification,
+  message: `Failed to create a new Telegraf Token`,
+}
+
 //  Task Notifications
 //  ----------------------------------------------------------------------------
 export const addTaskLabelFailed = (): Notification => ({


### PR DESCRIPTION
Closes #17118

### Problem

1. The default buckets that were being passed were passing the system buckets in when they should've been filtering them out
2. Fetching tokens were broken in the normalization process due to a tenuous connection that existed between Telegraf Configs, Telegrafs, Labels, and Tokens

### Solution

1. Passed in the correct selector to filter out the buckets to remove system buckets from the dropdown
2. After speaking with @russorat and @121watts, it became clear that tokens should be more in line with other conventions that are currently used by Apple, Github, etc... in that tokens that are generated should never be retrieved. That is to say that a token that is created should be stored by the user. If they lose their token, we should give them an opportunity to generate a new token. 

After speaking with @alexpaxton, it became clear that having a button underneath the code snippet made more sense to include rather than having a small button on the same line as the code

![telegraf-token-fix](https://user-images.githubusercontent.com/19984220/77119967-e1d52380-69f4-11ea-8e8e-38ca45f18449.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable