### PR TITLE
feat(pkger): extend stack with name and description fields

### DIFF
--- a/pkger/service.go
+++ b/pkger/service.go
@@ -25,6 +25,8 @@ type (
 	// If the pkg is applied, and no changes are had, then the stack is not updated.
 	Stack struct {
 		ID        influxdb.ID
+		Name      string
+		Desc      string
 		URLS      []url.URL
 		Resources []StackResource
 

--- a/pkger/store.go
+++ b/pkger/store.go
@@ -15,8 +15,10 @@ type (
 		ID    []byte `json:"id"`
 		OrgID []byte `json:"orgID"`
 
-		URLs      []string           `json:"urls,omitempty"`
-		Resources []entStackResource `json:"resources,omitempty"`
+		Name        string             `json:"name"`
+		Description string             `json:"description"`
+		URLs        []string           `json:"urls,omitempty"`
+		Resources   []entStackResource `json:"resources,omitempty"`
 
 		CreatedAt time.Time `json:"createdAt"`
 		UpdatedAt time.Time `json:"updatedAt"`
@@ -167,11 +169,13 @@ func convertStackToEnt(orgID influxdb.ID, stack Stack) (kv.Entity, error) {
 	}
 
 	stEnt := entStack{
-		ID:        idBytes,
-		OrgID:     orgIDBytes,
-		CreatedAt: stack.CreatedAt,
-		UpdatedAt: stack.UpdatedAt,
-		URLs:      urlStrs,
+		ID:          idBytes,
+		OrgID:       orgIDBytes,
+		Name:        stack.Name,
+		Description: stack.Desc,
+		CreatedAt:   stack.CreatedAt,
+		UpdatedAt:   stack.UpdatedAt,
+		URLs:        urlStrs,
 	}
 
 	for _, res := range stack.Resources {
@@ -192,6 +196,8 @@ func convertStackToEnt(orgID influxdb.ID, stack Stack) (kv.Entity, error) {
 
 func convertStackEntToStack(ent *entStack) (Stack, error) {
 	stack := Stack{
+		Name: ent.Name,
+		Desc: ent.Description,
 		CRUDLog: influxdb.CRUDLog{
 			CreatedAt: ent.CreatedAt,
 			UpdatedAt: ent.UpdatedAt,

--- a/pkger/store_test.go
+++ b/pkger/store_test.go
@@ -19,7 +19,9 @@ func TestStoreKv(t *testing.T) {
 	stackStub := func(id influxdb.ID) pkger.Stack {
 		now := time.Time{}.Add(10 * 365 * 24 * time.Hour)
 		return pkger.Stack{
-			ID: id,
+			ID:   id,
+			Name: "threeve",
+			Desc: "desc",
 			CRUDLog: influxdb.CRUDLog{
 				CreatedAt: now,
 				UpdatedAt: now.Add(time.Hour),


### PR DESCRIPTION
updates stacks with a human readable/settable name and description. This is just to decorate the stack object with data that is meaningful to the user.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
