### PR TITLE
fix(task/scheduler): Reuse slices built by iterator to reduce allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [17240](https://github.com/influxdata/influxdb/pull/17240): NodeJS logo displays properly in Firefox
 1. [17363](https://github.com/influxdata/influxdb/pull/17363): Fixed telegraf configuration bugs where system buckets were appearing in the buckets dropdown
 1. [17391](https://github.com/influxdata/influxdb/pull/17391): Fixed threshold check bug where checks could not be created when a field had a space in the name
+1. [17384](https://github.com/influxdata/influxdb/pull/17384): Reuse slices built by iterator to reduce allocations
 
 ### UI Improvements
 


### PR DESCRIPTION
Reuse the the `toDelete` and `toInsert` slices within the `TreeScheduler` to reduce the allocation churn when creating iterators for the B-Tree ascension.

This is an intermediate step to relieve some of the memory usage. We will be going farther than this in how we handle this iterator in the upcoming `TreeScheduler` refactor.

📎 influxdata/idpe#6479

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
