### PR TITLE
refactor(tasks): Task scheduler refactor.

### DIFF
--- a/task/backend/schedulerv2/scheduler.go
+++ b/task/backend/schedulerv2/scheduler.go
@@ -1,0 +1,143 @@
+package schedulerv2
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/influxdata/cron"
+	"github.com/influxdata/influxdb/task/options"
+)
+
+// ID duplicates the influxdb ID so users of the scheduler don't have to
+// import influxdb for the ID.
+type ID uint64
+
+// Executor is a system used by the scheduler to actually execute the scheduleable item.
+type Executor interface {
+	// Execute is used to execute run's for any schedulable object.
+	// the executor can go through manual runs, clean currently running, and then create a new run based on `now`.
+	// if Now is zero we can just do the first 2 steps (This is how we would trigger manual runs).
+	// Errors returned from the execute request imply that this attempt has failed and
+	// should be put back in scheduler and re executed at a alter time. We will add scheduler specific errors
+	// so the time can be configurable.
+	Execute(ctx context.Context, id ID, scheduledFor time.Time, runAt time.Time) error
+}
+
+// Schedulable is the interface that encapsulates work that
+// is to be executed on a specified schedule.
+type Schedulable interface {
+	// ID is the unique identifier for this Schedulable
+	ID() ID
+
+	// Schedule defines the frequency for which this Schedulable should be
+	// queued for execution.
+	Schedule() Schedule
+
+	// Offset defines a negative or positive duration that should be added
+	// to the scheduled time, resulting in the instance running earlier or later
+	// than the scheduled time.
+	Offset() time.Duration
+
+	// LastScheduled specifies last time this Schedulable was queued
+	// for execution.
+	LastScheduled() time.Time
+}
+
+// SchedulableService encapsulates the work necessary to schedule a job
+type SchedulableService interface {
+
+	// UpdateLastScheduled notifies the instance that it was scheduled for
+	// execution at the specified time
+	UpdateLastScheduled(ctx context.Context, id ID, t time.Time) error
+}
+
+type SchedulerState int
+
+const (
+	SchedulerStateUnknown SchedulerState = iota
+	SchedulerStateReady
+	SchedulerStateProcessing
+	SchedulerStateWaiting
+	SchedulerStateStopping
+	SchedulerStateStopped
+)
+
+func NewSchedule(unparsed string, lastScheduledAt time.Time) (Schedule, time.Time, error) {
+	lastScheduledAt = lastScheduledAt.UTC().Truncate(time.Second)
+	c, err := cron.ParseUTC(unparsed)
+	if err != nil {
+		return Schedule{}, lastScheduledAt, err
+	}
+
+	unparsed = strings.TrimSpace(unparsed)
+
+	// Align create to the hour/minute
+	if strings.HasPrefix(unparsed, "@every ") {
+		everyString := strings.TrimSpace(strings.TrimPrefix(unparsed, "@every "))
+		every := options.Duration{}
+		err := every.Parse(everyString)
+		if err != nil {
+			// We cannot align a invalid time
+			return Schedule{c}, lastScheduledAt, nil
+		}
+
+		// drop nanoseconds
+		lastScheduledAt = time.Unix(lastScheduledAt.UTC().Unix(), 0).UTC()
+		everyDur, err := every.DurationFrom(lastScheduledAt)
+		if err != nil {
+			return Schedule{c}, lastScheduledAt, nil
+		}
+
+		// and align
+		lastScheduledAt = lastScheduledAt.Truncate(everyDur).Truncate(time.Second)
+	}
+
+	return Schedule{c}, lastScheduledAt, err
+}
+
+// Schedule is an object a valid schedule of runs
+type Schedule struct {
+	cron cron.Parsed
+}
+
+// Next returns the next time after from that a schedule should trigger on.
+func (s Schedule) Next(from time.Time) (time.Time, error) {
+	return cron.Parsed(s.cron).Next(from)
+}
+
+// ValidSchedule returns an error if the cron string is invalid.
+func ValidateSchedule(c string) error {
+	_, err := cron.ParseUTC(c)
+	return err
+}
+
+// Scheduler is a example interface of a Scheduler.
+// // todo(lh): remove this once we start building the actual scheduler
+type Scheduler interface {
+
+	// Schedule adds the specified task to the scheduler.
+	Schedule(task Schedulable) error
+
+	// Release removes the specified task from the scheduler.
+	Release(taskID ID) error
+
+	Process(ctx context.Context)
+
+	State() SchedulerState
+}
+
+type ErrUnrecoverable struct {
+	error
+}
+
+func (e *ErrUnrecoverable) Error() string {
+	if e.error != nil {
+		return "error unrecoverable error on task run " + e.error.Error()
+	}
+	return "error unrecoverable error on task run"
+}
+
+func (e *ErrUnrecoverable) Unwrap() error {
+	return e.error
+}

--- a/task/backend/schedulerv2/scheduler_metrics.go
+++ b/task/backend/schedulerv2/scheduler_metrics.go
@@ -1,0 +1,111 @@
+package schedulerv2
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SchedulerMetrics struct {
+	totalExecuteCalls   prometheus.Counter
+	totalExecuteFailure prometheus.Counter
+	scheduleCalls       prometheus.Counter
+	scheduleFails       prometheus.Counter
+	releaseCalls        prometheus.Counter
+
+	scheduleDelay prometheus.Summary
+	executeDelta  prometheus.Summary
+}
+
+func NewSchedulerMetrics() *SchedulerMetrics {
+	const namespace = "task"
+	const subsystem = "scheduler"
+
+	return &SchedulerMetrics{
+		totalExecuteCalls: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_execution_calls",
+			Help:      "Total number of executions across all tasks.",
+		}),
+		scheduleCalls: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_schedule_calls",
+			Help:      "Total number of schedule requests.",
+		}),
+		scheduleFails: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_schedule_fails",
+			Help:      "Total number of schedule requests that fail to schedule.",
+		}),
+
+		totalExecuteFailure: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_execute_failure",
+			Help:      "Total number of times an execution has failed.",
+		}),
+
+		releaseCalls: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_release_calls",
+			Help:      "Total number of release requests.",
+		}),
+		// executingTasks: newExecutingTasks(te),
+		scheduleDelay: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "schedule_delay",
+			Help:       "The duration between when a Item should be scheduled and when it is told to execute.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+
+		executeDelta: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "execute_delta",
+			Help:       "The duration in seconds between a run starting and finishing.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+	}
+}
+
+// PrometheusCollectors satisfies the prom.PrometheusCollector interface.
+func (em *SchedulerMetrics) PrometheusCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		em.totalExecuteCalls,
+		em.totalExecuteFailure,
+		em.scheduleCalls,
+		em.scheduleFails,
+		em.releaseCalls,
+		em.scheduleDelay,
+		em.executeDelta,
+	}
+}
+
+func (em *SchedulerMetrics) schedule(taskID ID) {
+	em.scheduleCalls.Inc()
+}
+
+func (em *SchedulerMetrics) scheduleFail(taskID ID) {
+	em.scheduleFails.Inc()
+}
+
+func (em *SchedulerMetrics) release(taskID ID) {
+	em.releaseCalls.Inc()
+}
+
+func (em *SchedulerMetrics) reportScheduleDelay(d time.Duration) {
+	em.scheduleDelay.Observe(d.Seconds())
+}
+
+func (em *SchedulerMetrics) reportExecution(err error, d time.Duration) {
+	em.totalExecuteCalls.Inc()
+	em.executeDelta.Observe(d.Seconds())
+	if err != nil {
+		em.totalExecuteFailure.Inc()
+	}
+}

--- a/task/backend/schedulerv2/scheduler_test.go
+++ b/task/backend/schedulerv2/scheduler_test.go
@@ -1,0 +1,686 @@
+package schedulerv2
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/influxdata/cron"
+)
+
+type mockExecutor struct {
+	sync.Mutex
+	fn  func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time)
+	Err error
+}
+
+type mockSchedulable struct {
+	id            ID
+	schedule      Schedule
+	offset        time.Duration
+	lastScheduled time.Time
+}
+
+func (s mockSchedulable) ID() ID {
+	return s.id
+}
+
+func (s mockSchedulable) Schedule() Schedule {
+	return s.schedule
+}
+func (s mockSchedulable) Offset() time.Duration {
+	return s.offset
+}
+func (s mockSchedulable) LastScheduled() time.Time {
+	return s.lastScheduled
+}
+
+func (e *mockExecutor) Execute(ctx context.Context, id ID, scheduledFor time.Time, runAt time.Time) error {
+	done := make(chan struct{}, 1)
+	select {
+	case <-ctx.Done():
+	default:
+		e.fn(&sync.Mutex{}, ctx, id, scheduledFor)
+		done <- struct{}{}
+	}
+	return nil
+}
+
+type mockSchedulableService struct {
+}
+
+func (m *mockSchedulableService) UpdateLastScheduled(ctx context.Context, id ID, t time.Time) error {
+	return nil
+}
+
+func TestSchedule(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func(exe Executor, checkpointer SchedulableService, opts ...treeSchedulerOptFunc) (Scheduler, error)
+	}{{
+		name: "TreeScheduler",
+		fn: func(exe Executor, checkpointer SchedulableService, opts ...treeSchedulerOptFunc) (Scheduler, error) {
+			sch, _, err := NewTreeScheduler(exe, checkpointer, opts...)
+			return sch, err
+		},
+	}, {
+		name: "ShardedTreeScheduler",
+		fn: func(exe Executor, checkpointer SchedulableService, opts ...treeSchedulerOptFunc) (Scheduler, error) {
+			sch, _, err := NewShardedTreeScheduler(16, exe, checkpointer, opts...)
+			return sch, err
+		},
+	},
+	}
+	for i := range cases {
+		t.Run(cases[i].name, func(t *testing.T) {
+			testSchedule(
+				t,
+				func(exe *mockExecutor, opts ...treeSchedulerOptFunc) (Scheduler, error) {
+					return cases[i].fn(
+						exe,
+						&mockSchedulableService{},
+						opts...,
+					)
+				},
+			)
+		})
+	}
+}
+
+func testSchedule(t *testing.T, newSch func(exe *mockExecutor, opts ...treeSchedulerOptFunc) (Scheduler, error)) {
+	t.Helper()
+	t.Run("@every fires on appropriate boundaries", func(t *testing.T) {
+		cases := []struct {
+			cron      string
+			boundary  time.Duration
+			skipAhead time.Duration
+		}{
+			{
+				cron:      "@every 1m",
+				boundary:  time.Minute,
+				skipAhead: 17 * time.Minute,
+			}, {
+				cron:      "@every 1h",
+				boundary:  time.Hour,
+				skipAhead: 17 * time.Hour,
+			},
+		}
+
+		for _, testCase := range cases {
+			t.Run(testCase.cron, func(t *testing.T) {
+				mockTime := clock.NewMock()
+				mockTime.Set(time.Now())
+
+				c := make(chan time.Time, 100)
+				exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledAt time.Time) {
+					select {
+					case <-ctx.Done():
+						t.Log("ctx done")
+					case c <- scheduledAt:
+					}
+				}}
+				sch, err := newSch(exe, WithTime(mockTime))
+				if err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := context.WithCancel(context.Background())
+				wg := sync.WaitGroup{}
+				wg.Add(1)
+				go func() {
+					sch.Process(ctx)
+					wg.Done()
+				}()
+				defer func() {
+					cancel()
+					wg.Wait()
+				}()
+
+				schedule, ts, err := NewSchedule(testCase.cron, mockTime.Now().UTC())
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: ts})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				mockTime.Set(mockTime.Now().UTC().Add(testCase.skipAhead))
+
+				after := time.After(6 * time.Second)
+				oldCheckC := ts
+				for i := 0; i < 16; i++ {
+					select {
+					case checkC := <-c:
+						if checkC.Sub(oldCheckC) != testCase.boundary {
+							t.Fatalf("task didn't fire on correct interval fired on %s interval, expected on %s, with cron %s %s %s", checkC.Sub(oldCheckC), testCase.boundary, testCase.cron, checkC, oldCheckC)
+						}
+						if !checkC.Truncate(testCase.boundary).Equal(checkC) {
+							t.Fatalf("task didn't fire at the correct time boundary")
+						}
+						oldCheckC = checkC
+					case <-after:
+						t.Fatalf("test timed out, only fired %d times but should have fired 16 times", i)
+					}
+				}
+			})
+		}
+
+	})
+	t.Run("fires properly with non-mocked time", func(t *testing.T) {
+		theClock := clock.New()
+		c := make(chan time.Time, 100)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			select {
+			case <-ctx.Done():
+				t.Log("ctx done")
+			case c <- scheduledFor:
+			default:
+				t.Errorf("called the executor too many times")
+			}
+		}}
+		schedule, ts, err := NewSchedule("* * * * * * *", theClock.Now().UTC())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sch, err := newSch(exe, WithTime(theClock))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: ts})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+
+		select {
+		case <-c:
+		case <-time.After(10 * time.Second):
+			t.Fatal("test timed out")
+		}
+	})
+	t.Run("doesn't fire when the task isn't ready", func(t *testing.T) {
+		mockTime := clock.NewMock()
+		mockTime.Set(time.Now())
+		c := make(chan time.Time, 100)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			select {
+			case <-ctx.Done():
+				t.Log("ctx done")
+			case c <- scheduledFor:
+			default:
+				t.Errorf("called the executor too many times")
+			}
+		}}
+		sch, err := newSch(exe, WithTime(mockTime))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+		schedule, _, err := NewSchedule("* * * * * * *", time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: mockTime.Now().UTC().Add(time.Second)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mockTime.Set(mockTime.Now().Add(2 * time.Second))
+
+		select {
+		case <-c:
+			t.Fatal("test timed out")
+		case <-time.After(2 * time.Second):
+		}
+	})
+	t.Run("fires the correct number of times for the interval with a single schedulable", func(t *testing.T) {
+		c := make(chan time.Time, 100)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			select {
+			case <-ctx.Done():
+				t.Log("ctx done")
+			case c <- scheduledFor:
+			}
+		}}
+		mockTime := clock.NewMock()
+		mockTime.Set(time.Now().UTC())
+		sch, err := newSch(exe, WithTime(mockTime))
+		if err != nil {
+			t.Fatal(err)
+		}
+		schedule, _, err := NewSchedule("* * * * * * *", time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: mockTime.Now().UTC()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mockTime.Set(mockTime.Now().UTC().Add(17 * time.Second))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+
+		after := time.After(6 * time.Second)
+		for i := 0; i < 16; i++ {
+			select {
+			case <-c:
+			case <-after:
+				t.Fatalf("test timed out, only fired %d times but should have fired 16 times", i)
+			}
+		}
+		mockTime.Set(mockTime.Now().UTC().Add(2 * time.Second))
+
+		after = time.After(6 * time.Second)
+
+		for i := 0; i < 2; i++ {
+			select {
+			case <-c:
+			case <-after:
+				t.Fatalf("test timed out, only fired %d times but should have fired 2 times", i)
+			}
+		}
+
+		select {
+		case <-c:
+			t.Fatalf("test scheduler fired too many times")
+		case <-time.After(2 * time.Second):
+		}
+	})
+	t.Run("fires the correct number of times for the interval with multiple schedulables", func(t *testing.T) {
+		now := time.Date(2016, 0, 0, 0, 1, 1, 0, time.UTC)
+		c := make(chan struct {
+			ts time.Time
+			id ID
+		}, 100)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			select {
+			case <-ctx.Done():
+				t.Log("ctx done")
+			case c <- struct {
+				ts time.Time
+				id ID
+			}{
+				ts: scheduledFor,
+				id: id,
+			}:
+			}
+		}}
+		mockTime := clock.NewMock()
+		mockTime.Set(now)
+		sch, err := newSch(exe, WithTime(mockTime))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+
+		schedule, _, err := NewSchedule("* * * * * * *", time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: now})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		schedule2, _, err := NewSchedule("*/2 * * * * * *", time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 2, schedule: schedule2, offset: time.Second, lastScheduled: now})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mockTime.Set(mockTime.Now().Add(17 * time.Second))
+
+		after := time.After(6 * time.Second)
+		for i := 0; i < 24; i++ {
+			select {
+			case <-c:
+			case <-after:
+				t.Fatalf("test timed out, only fired %d times but should have fired 24 times", i)
+			}
+		}
+
+		mockTime.Set(mockTime.Now().Add(2 * time.Second))
+
+		after = time.After(6 * time.Second)
+
+		for i := 0; i < 3; i++ {
+			select {
+			case <-c:
+			case <-after:
+				t.Fatalf("test timed out, only fired %d times but should have fired 3 times", i)
+			}
+		}
+
+		select {
+		case <-c:
+			t.Fatalf("test scheduler fired too many times")
+		case <-time.After(2 * time.Second):
+		}
+	})
+	t.Run("stops properly when processing context is cancled", func(t *testing.T) {
+		now := time.Now().Add(-20 * time.Second)
+		mockTime := clock.NewMock()
+		mockTime.Set(now)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {}}
+		ctx, cancel := context.WithCancel(context.Background())
+		sch, err := newSch(exe, WithTime(mockTime))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+		cancel()
+	})
+
+	t.Run("panics in the executor are treated as errors", func(t *testing.T) {
+		// panics in the executor should be treated as errors
+		mockTime := clock.NewMock()
+		mockTime.Set(time.Now())
+		c := make(chan struct {
+			ts  time.Time
+			err error
+		}, 1000)
+
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			panic("yikes oh no!")
+		}}
+
+		sch, err := newSch(exe, WithTime(mockTime), WithOnErrorFn(
+			func(ctx context.Context, taskID ID, scheduledFor time.Time, err error) {
+				c <- struct {
+					ts  time.Time
+					err error
+				}{
+					ts:  scheduledFor,
+					err: err,
+				}
+			}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+
+		schedule, ts, err := NewSchedule("* * * * * * *", time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: ts})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mockTime.Set(mockTime.Now().UTC().Add(6 * time.Second))
+		select {
+		case <-c: // panic was caught and error handler used
+
+		case <-time.After(4 * time.Second):
+			t.Fatal("test timed out")
+		}
+	})
+	t.Run("release should remove items from being scheduled", func(t *testing.T) {
+		c := make(chan time.Time, 100)
+		exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledFor time.Time) {
+			select {
+			case <-ctx.Done():
+				t.Log("ctx done")
+			case c <- scheduledFor:
+			}
+		}}
+		mockTime := clock.NewMock()
+		mockTime.Set(time.Now())
+		ctx, cancel := context.WithCancel(context.Background())
+		sch, err := newSch(exe, WithTime(mockTime))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg := sync.WaitGroup{}
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+		wg.Add(1)
+		go func() {
+			sch.Process(ctx)
+			wg.Done()
+		}()
+
+		schedule, ts, err := NewSchedule("* * * * * * *", mockTime.Now().UTC())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: ts.UTC()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mockTime.Set(mockTime.Now().UTC().Add(2 * time.Second))
+
+		select {
+		case <-c:
+		case <-time.After(6 * time.Second):
+			t.Fatalf("test timed out, it should have fired but didn't")
+		}
+		if err := sch.Release(1); err != nil {
+			t.Error(err)
+		}
+
+		mockTime.Set(mockTime.Now().UTC().Add(6 * time.Second))
+
+		select {
+		case <-c:
+			t.Fatal("expected test not to fire here, because task was released, but it did anyway")
+		case <-time.After(2 * time.Second):
+		}
+	})
+	t.Run("working with different local TZs", func(t *testing.T) {
+		timeZ := []string{
+			"America/Chicago",
+			"America/New_York",
+			"UTC",
+			"America/Los_Angeles",
+			"Asia/Kolkata",
+		}
+		for _, tzStr := range timeZ {
+			loc, err := time.LoadLocation(tzStr)
+			if err != nil {
+				t.Fatalf("Cannot load %s location, the underlying system needs updated timezones, %s", loc, err)
+			}
+			oldLocal := time.Local
+			time.Local = loc
+			defer func() { time.Local = oldLocal }()
+			mockTime := clock.NewMock()
+			currentMockTime := time.Date(2020, time.December, 11, 11, 11, 3, 22, time.UTC)
+			mockTime.Set(currentMockTime)
+
+			c := make(chan time.Time, 100)
+			exe := &mockExecutor{fn: func(l *sync.Mutex, ctx context.Context, id ID, scheduledAt time.Time) {
+				select {
+				case <-ctx.Done():
+					t.Log("ctx done")
+				case c <- scheduledAt:
+				}
+			}}
+			sch, err := newSch(exe, WithTime(mockTime))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				sch.Process(ctx)
+				wg.Done()
+			}()
+			defer func() {
+				cancel()
+				wg.Wait()
+			}()
+
+			schedule, ts, err := NewSchedule("0 * * * *", mockTime.Now().UTC())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = sch.Schedule(mockSchedulable{id: 1, schedule: schedule, offset: time.Second, lastScheduled: ts})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mockTime.Set(mockTime.Now().UTC().Add(time.Hour))
+
+			after := time.After(6 * time.Second)
+			select {
+			case checkC := <-c:
+				if !checkC.Equal(ts.UTC().Truncate(time.Hour).Add(time.Hour)) {
+					t.Fatalf("scheduled at was incorrect expected %s, got %s", ts.UTC().Truncate(time.Hour).Add(time.Hour), checkC)
+				}
+			case <-after:
+				t.Fatalf("test timed out")
+			}
+		}
+	})
+
+}
+
+func mustCron(s string) Schedule {
+	cr, err := cron.ParseUTC(s)
+	if err != nil {
+		panic(err)
+	}
+	return Schedule{cron: cr}
+}
+
+func TestNewSchedule(t *testing.T) {
+	tests := []struct {
+		name            string
+		unparsed        string
+		lastScheduledAt time.Time
+		want            Schedule
+		want1           time.Time
+		wantErr         bool
+	}{
+		{
+			name:            "bad cron",
+			unparsed:        "this is not a cron string",
+			lastScheduledAt: time.Now(),
+			wantErr:         true,
+		},
+		{
+			name:            "align to minute",
+			unparsed:        "@every 1m",
+			lastScheduledAt: time.Date(2016, 01, 01, 01, 10, 23, 1234567, time.UTC),
+			want:            mustCron("@every 1m"),
+			want1:           time.Date(2016, 01, 01, 01, 10, 0, 0, time.UTC),
+		},
+		{
+			name:            "align to minute with @every 7m",
+			unparsed:        "@every 7m",
+			lastScheduledAt: time.Date(2016, 01, 01, 01, 10, 23, 1234567, time.UTC),
+			want:            mustCron("@every 7m"),
+			want1:           time.Date(2016, 01, 01, 01, 4, 0, 0, time.UTC),
+		},
+
+		{
+			name:            "align to hour",
+			unparsed:        "@every 1h",
+			lastScheduledAt: time.Date(2016, 01, 01, 01, 10, 23, 1234567, time.UTC),
+			want:            mustCron("@every 1h"),
+			want1:           time.Date(2016, 01, 01, 01, 0, 0, 0, time.UTC),
+		},
+		{
+			name:            "align to hour @every 3h",
+			unparsed:        "@every 3h",
+			lastScheduledAt: time.Date(2016, 01, 01, 01, 10, 23, 1234567, time.UTC),
+			want:            mustCron("@every 3h"),
+			want1:           time.Date(2016, 01, 01, 00, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := NewSchedule(tt.unparsed, tt.lastScheduledAt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewSchedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewSchedule() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("NewSchedule() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/task/backend/schedulerv2/shard_scheduler.go
+++ b/task/backend/schedulerv2/shard_scheduler.go
@@ -1,0 +1,84 @@
+package schedulerv2
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+
+	"github.com/cespare/xxhash"
+)
+
+type ShardScheduler struct {
+	schedulers []Scheduler
+	wg         sync.WaitGroup
+	sm         *SchedulerMetrics
+}
+
+// NewShardedScheduler creates a new ShardScheduler. To ensure even
+// distribution, a power of two should be selected for the shard count.
+func NewShardedTreeScheduler(count int, executor Executor, checkpointer SchedulableService, opts ...treeSchedulerOptFunc) (*ShardScheduler, *SchedulerMetrics, error) {
+	metrics := NewSchedulerMetrics()
+
+	s := &ShardScheduler{
+		schedulers: make([]Scheduler, count),
+		sm:         metrics,
+	}
+
+	opts = append(append([]treeSchedulerOptFunc(nil), WithScheduleMetrics(metrics)), opts...)
+
+	for i := range s.schedulers {
+		scheduler, _, err := NewTreeScheduler(executor, checkpointer, opts...)
+		if err != nil {
+			return nil, nil, err
+		}
+		s.schedulers[i] = scheduler
+	}
+
+	return s, metrics, nil
+}
+
+func (s *ShardScheduler) Schedule(task Schedulable) error {
+	return s.schedulers[s.hash(task.ID())].Schedule(task)
+}
+
+func (s *ShardScheduler) Release(taskID ID) error {
+	return s.schedulers[s.hash(taskID)].Release(taskID)
+}
+
+func (s *ShardScheduler) hash(taskID ID) uint64 {
+	buf := [8]byte{}
+	binary.LittleEndian.PutUint64(buf[:], uint64(taskID))
+	return xxhash.Sum64(buf[:]) % uint64(len(s.schedulers)) // we just hash so that the number is uniformly distributed
+}
+
+func (s *ShardScheduler) Process(ctx context.Context) {
+	s.wg.Add(len(s.schedulers))
+	for _, shard := range s.schedulers {
+		go func(shard Scheduler) {
+			shard.Process(ctx)
+			s.wg.Done()
+		}(shard)
+	}
+	s.wg.Wait()
+}
+
+func (s *ShardScheduler) State() SchedulerState {
+	states := [6]int{}
+	for _, s := range s.schedulers {
+		states[s.State()]++
+	}
+
+	// Rules for calculating state. Ordering matters.
+	switch {
+	case states[SchedulerStateStopped] == len(s.schedulers):
+		return SchedulerStateStopped
+	case states[SchedulerStateStopping] > 0 || states[SchedulerStateStopped] > 0:
+		return SchedulerStateStopping
+	case states[SchedulerStateProcessing] > 0:
+		return SchedulerStateProcessing
+	case states[SchedulerStateWaiting] == len(s.schedulers):
+		return SchedulerStateWaiting
+	}
+
+	return SchedulerStateReady
+}

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -183,7 +183,10 @@ func grabTaskOptionAST(p *ast.Package, keys ...string) map[string]ast.Expression
 			}
 			for k := range ae.Properties {
 				prop := ae.Properties[k]
-				if key := prop.Key.Key(); prop != nil && contains(keys, key) {
+				if prop == nil {
+					continue
+				}
+				if key := prop.Key.Key(); contains(keys, key) {
 					res[key] = prop.Value
 				}
 			}


### PR DESCRIPTION
This refactored scheduler also:
1) Adds state transition rules
2) Reduces CPU use by reducing spinning
3) Adds a test for time zone, to make sure that things work correctly
regardless of the time zone the computer is set to.
4) Reduces allocations by reusing a task buffer
5) Doesn't actually use the new scheduler yet, that will undergo more testing first

Co-authored-by: J. Emrys Landivar <landivar@gmail.com>
