### PR TITLE
refactor(query): add stack trace to query controller execution

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -395,6 +395,7 @@ func (c *Controller) executeQuery(q *Query) {
 			err, ok := e.(error)
 			if !ok {
 				err = fmt.Errorf("panic: %v", e)
+				c.log.Error(err.Error(), zap.Error(err))
 			}
 			q.setErr(err)
 			if entry := c.log.With(influxlogger.TraceFields(q.parentCtx)...).


### PR DESCRIPTION
This PR adds more error logging to the query execution function in the query controller to track down the source of this issue: https://github.com/influxdata/EAR/issues/1449

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
