### PR TITLE
fix: show more

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -111,7 +111,7 @@ export default class DashboardCards extends PureComponent<Props> {
     const frame = this._frame.getBoundingClientRect()
     const win = this._window.getBoundingClientRect()
 
-    if (frame.height == win.height) {
+    if (frame.height <= win.height) {
       this.setState(
         {
           windowSize: this.state.windowSize + 1,


### PR DESCRIPTION
Closes influxdata/EAR#1466

no idea why this kinda sometimes worked if state was already loaded into localstorage, and not if it was fetched from the api, had a lot of red herrings based in state management surrounding this one. The core of the issue came down to firefox not rendering _sometimes_ when there was only a single row of results in the infinite scroll. If this doesn't work for the client, the next step is to address a potential race condition where the window is measured before state is loaded, but this fix made the problem disappear locally.