### PR TITLE
feat(cmd/influx): add delete bucket by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [17273](https://github.com/influxdata/influxdb/pull/17273): Add shell completions command for the influx cli
 1. [17353](https://github.com/influxdata/influxdb/pull/17353): Make all pkg resources unique by metadata.name field
 1. [17363](https://github.com/influxdata/influxdb/pull/17363): Telegraf config tokens can no longer be retrieved after creation, but new tokens can be created after a telegraf has been setup
+1. [17400](https://github.com/influxdata/influxdb/pull/17400): Be able to delete bucket by name via cli
 
 ### Bug Fixes
 

--- a/cmd/influx/bucket_test.go
+++ b/cmd/influx/bucket_test.go
@@ -128,17 +128,32 @@ func TestCmdBucket(t *testing.T) {
 		tests := []struct {
 			name       string
 			expectedID influxdb.ID
-			flag       string
+			flags      []string
 		}{
 			{
 				name:       "with description and retention period",
 				expectedID: influxdb.ID(1),
-				flag:       "--id=",
+				flags:      []string{"--id=" + influxdb.ID(1).String()},
 			},
 			{
 				name:       "shorts",
 				expectedID: influxdb.ID(1),
-				flag:       "-i=",
+				flags:      []string{"-i=" + influxdb.ID(1).String()},
+			},
+			{
+				name:       "with name and org name",
+				expectedID: influxdb.ID(1),
+				flags:      []string{"--name=n1", "--org=org1"},
+			},
+			{
+				name:       "with name and org name short",
+				expectedID: influxdb.ID(1),
+				flags:      []string{"-n=n1", "-o=org1"},
+			},
+			{
+				name:       "with name and org id",
+				expectedID: influxdb.ID(1),
+				flags:      []string{"--name=n1", "--org-id=" + influxdb.ID(3).String()},
 			},
 		}
 
@@ -146,6 +161,15 @@ func TestCmdBucket(t *testing.T) {
 			svc := mock.NewBucketService()
 			svc.FindBucketByIDFn = func(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
 				return &influxdb.Bucket{ID: id}, nil
+			}
+			svc.FindBucketFn = func(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+				if filter.ID != nil {
+					return &influxdb.Bucket{ID: *filter.ID}, nil
+				}
+				if filter.Name != nil {
+					return &influxdb.Bucket{ID: expectedID}, nil
+				}
+				return nil, nil
 			}
 			svc.DeleteBucketFn = func(ctx context.Context, id influxdb.ID) error {
 				if expectedID != id {
@@ -167,8 +191,7 @@ func TestCmdBucket(t *testing.T) {
 				)
 
 				cmd := builder.cmd(cmdFn(tt.expectedID))
-				idFlag := tt.flag + tt.expectedID.String()
-				cmd.SetArgs([]string{"bucket", "delete", idFlag})
+				cmd.SetArgs(append([]string{"bucket", "delete"}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
 			}


### PR DESCRIPTION
Closes #17277

Be able to delete bucket by name.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
