### PR TITLE
fix(logger): Ensure default level value is info

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -15,5 +15,6 @@ type Config struct {
 func NewConfig() Config {
 	return Config{
 		Format: "auto",
+		Level:  zapcore.InfoLevel,
 	}
 }


### PR DESCRIPTION
Though the comments in the sample configuration file say that the default value for the level key in the logging section should be info, this doesn't appear to be so.

We should either update the documentation or update the code to ensure the default log level meets users' expectations.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
