### PR TITLE
refactor(query): change log level to record panic stack traces

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -395,11 +395,10 @@ func (c *Controller) executeQuery(q *Query) {
 			err, ok := e.(error)
 			if !ok {
 				err = fmt.Errorf("panic: %v", e)
-				c.log.Error(err.Error(), zap.Error(err))
 			}
 			q.setErr(err)
 			if entry := c.log.With(influxlogger.TraceFields(q.parentCtx)...).
-				Check(zapcore.InfoLevel, "panic during program start"); entry != nil {
+				Check(zapcore.ErrorLevel, "panic during program start"); entry != nil {
 				entry.Stack = string(debug.Stack())
 				entry.Write(zap.Error(err))
 			}
@@ -412,12 +411,10 @@ func (c *Controller) executeQuery(q *Query) {
 		// client cancelled it, or because the controller is shutting down)
 		// In the case of cancellation, SetErr() should reset the error to an
 		// appropriate message.
-		err := &flux.Error{
+		q.setErr(&flux.Error{
 			Code: codes.Internal,
 			Msg:  "impossible state transition",
-		}
-		q.setErr(err)
-		c.log.Error(err.Msg, zap.Error(err))
+		})
 
 		return
 	}


### PR DESCRIPTION
This PR reverts the changes in https://github.com/influxdata/influxdb/pull/17377 and https://github.com/influxdata/influxdb/pull/17392 and updates the log level for logging a stack trace for recovered panics in the `executeQuery` function

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
