### PR TITLE
fix(ui): fixed logout functionality so that Logout Component is displayed and used on cloud

### DIFF
--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -4,11 +4,31 @@ import {Link} from 'react-router'
 
 // Components
 import {Button, ComponentSize} from '@influxdata/clockface'
+import CloudExclude from 'src/shared/components/cloud/CloudExclude'
+import CloudOnly from 'src/shared/components/cloud/CloudOnly'
+import {CLOUD_URL, CLOUD_LOGOUT_PATH} from 'src/shared/constants'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 const LogoutButton: SFC = () => (
-  <Link to="/logout">
-    <Button text="Logout" size={ComponentSize.ExtraSmall} />
-  </Link>
+  <>
+    <FeatureFlag name="regionBasedLoginPage">
+      <Link to="/logout">
+        <Button text="Logout" size={ComponentSize.ExtraSmall} />
+      </Link>
+    </FeatureFlag>
+    <FeatureFlag name="regionBasedLoginPage" equals={false}>
+      <CloudExclude>
+        <Link to="/logout">
+          <Button text="Logout" size={ComponentSize.ExtraSmall} />
+        </Link>
+      </CloudExclude>
+      <CloudOnly>
+        <a href={`${CLOUD_URL}${CLOUD_LOGOUT_PATH}`}>
+          <Button text="Logout" size={ComponentSize.ExtraSmall} />
+        </a>
+      </CloudOnly>
+    </FeatureFlag>
+  </>
 )
 
 export default LogoutButton

--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -4,23 +4,11 @@ import {Link} from 'react-router'
 
 // Components
 import {Button, ComponentSize} from '@influxdata/clockface'
-import CloudExclude from 'src/shared/components/cloud/CloudExclude'
-import CloudOnly from 'src/shared/components/cloud/CloudOnly'
-import {CLOUD_URL, CLOUD_LOGOUT_PATH} from 'src/shared/constants'
 
 const LogoutButton: SFC = () => (
-  <>
-    <CloudExclude>
-      <Link to="/logout">
-        <Button text="Logout" size={ComponentSize.ExtraSmall} />
-      </Link>
-    </CloudExclude>
-    <CloudOnly>
-      <a href={`${CLOUD_URL}${CLOUD_LOGOUT_PATH}`}>
-        <Button text="Logout" size={ComponentSize.ExtraSmall} />
-      </a>
-    </CloudOnly>
-  </>
+  <Link to="/logout">
+    <Button text="Logout" size={ComponentSize.ExtraSmall} />
+  </Link>
 )
 
 export default LogoutButton


### PR DESCRIPTION
### Problem

The existing PR addresses the problem that occurs once we integrate auth0 login capabilities into the UI. Since the existing `<LogoutButton />` component conditionally renders the logout button (and it's functionality) based on whether the UI is being displayed in cloud or not. However, since the existing Auth0 logout functionality is wrapped in a `CloudExclude` wrapper, a user is never really logged out of Auth0 on cloud. Instead, they are simply redirected based on the `CloudOnly` logic.

### Solution

Since the existing `Logout` component already contains the appropriate "CloudOnly" logic we had integrated beforehand, this PR aims to reduce the logic down to one component that can work across OSS and Cloud.

### Reservations

Since we know that the current order of things is functioning, would it instead be more valuable to add a featureFlag enabled logout functionality that rendered within the `CloudOnly` wrapper?