### PR TITLE
chore(pkger): refactor influx pkg cmd to not validate in CLI and have server validate

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -327,6 +327,7 @@ func checkSetupRunEMiddleware(f *globalFlags) cobraRunEMiddleware {
 			}
 
 			if setupErr := checkSetup(f.Host, f.skipVerify); setupErr != nil && influxdb.EUnauthorized != influxdb.ErrorCode(setupErr) {
+				cmd.OutOrStderr().Write([]byte(fmt.Sprintf("Error: %s\n", internal.ErrorFmt(err).Error())))
 				return internal.ErrorFmt(setupErr)
 			}
 

--- a/pkger/http_server.go
+++ b/pkger/http_server.go
@@ -213,7 +213,7 @@ func (r ReqApplyPkg) Pkgs(encoding Encoding) (*Pkg, error) {
 		rawPkgs = append(rawPkgs, pkg)
 	}
 
-	return Combine(rawPkgs...)
+	return Combine(rawPkgs)
 }
 
 // RespApplyPkg is the response body for the apply pkg endpoint.

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -370,13 +370,13 @@ func (p *Pkg) applySecrets(secrets map[string]string) {
 
 // Combine combines pkgs together. Is useful when you want to take multiple disparate pkgs
 // and compile them into one to take advantage of the parser and service guarantees.
-func Combine(pkgs ...*Pkg) (*Pkg, error) {
+func Combine(pkgs []*Pkg, validationOpts ...ValidateOptFn) (*Pkg, error) {
 	newPkg := new(Pkg)
 	for _, p := range pkgs {
 		newPkg.Objects = append(newPkg.Objects, p.Objects...)
 	}
 
-	return newPkg, newPkg.Validate()
+	return newPkg, newPkg.Validate(validationOpts...)
 }
 
 type (

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -4038,7 +4038,7 @@ spec:
       name: label_2
 `, APIVersion)))
 
-		combinedPkg, err := Combine(pkgs...)
+		combinedPkg, err := Combine(pkgs)
 		require.NoError(t, err)
 
 		sum := combinedPkg.Summary()


### PR DESCRIPTION
the `pkger.ValidSkipParseError` option allows our server to be the one to validate the
the pkg is accurate. If a user has an older version of the UI and our cloud gets updated
with new validation rules,they'll get immediate access to that change without having to
role their CLI build.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
