### PR TITLE
feat(pkger): add auth for pkger stack CRUDing

### DIFF
--- a/authorizer/agent.go
+++ b/authorizer/agent.go
@@ -1,0 +1,44 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+// AuthAgent provides a means to authenticate users with resource and their associate actions. It
+// makes for a clear dependency, to an auth middleware for instance.
+type AuthAgent struct{}
+
+// OrgPermissions identifies if a user has access to the org by the specified action.
+func (a *AuthAgent) OrgPermissions(ctx context.Context, orgID influxdb.ID, action influxdb.Action, rest ...influxdb.Action) error {
+	for _, action := range append(rest, action) {
+		var err error
+		switch action {
+		case influxdb.ReadAction:
+			_, _, err = AuthorizeReadOrg(ctx, orgID)
+		case influxdb.WriteAction:
+			_, _, err = AuthorizeWriteOrg(ctx, orgID)
+		default:
+			err = &influxdb.Error{Code: influxdb.EInvalid, Msg: "invalid action provided: " + string(action)}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *AuthAgent) IsWritable(ctx context.Context, orgID influxdb.ID, resType influxdb.ResourceType) error {
+	_, _, resTypeErr := AuthorizeOrgWriteResource(ctx, resType, orgID)
+	_, _, orgErr := AuthorizeWriteOrg(ctx, orgID)
+
+	if resTypeErr != nil && orgErr != nil {
+		return &influxdb.Error{
+			Code: influxdb.EUnauthorized,
+			Msg:  "not authorized to create " + string(resType),
+		}
+	}
+
+	return nil
+}

--- a/authorizer/agent_test.go
+++ b/authorizer/agent_test.go
@@ -1,0 +1,297 @@
+package authorizer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	icontext "github.com/influxdata/influxdb/context"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Agent(t *testing.T) {
+	t.Run("OrgPermissions", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			action      influxdb.Action
+			orgID       influxdb.ID
+			permissions []influxdb.Permission
+			shouldErr   bool
+		}{
+			{
+				name:   "read valid org  is successful",
+				action: influxdb.ReadAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+			},
+			{
+				name:   "write from valid org is successful",
+				action: influxdb.WriteAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+			},
+			{
+				name:   "read from org with only both privileges is successful",
+				action: influxdb.ReadAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+			},
+			{
+				name:   "write from org with only both privileges is successful",
+				action: influxdb.WriteAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+			},
+			{
+				name:   "read from invalid org errors",
+				action: influxdb.ReadAction,
+				orgID:  3333,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+				shouldErr: true,
+			},
+			{
+				name:   "write from invalid org errors",
+				action: influxdb.WriteAction,
+				orgID:  3333,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+				shouldErr: true,
+			},
+			{
+				name:   "read from org with only write privileges should errors",
+				action: influxdb.ReadAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+				shouldErr: true,
+			},
+			{
+				name:   "write from org with only read privileges should errors",
+				action: influxdb.WriteAction,
+				orgID:  3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+				shouldErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			fn := func(t *testing.T) {
+				ctx := icontext.SetAuthorizer(context.TODO(), &Authorizer{tt.permissions})
+
+				agent := new(authorizer.AuthAgent)
+
+				err := agent.OrgPermissions(ctx, tt.orgID, tt.action)
+				if tt.shouldErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			t.Run(tt.name, fn)
+		}
+	})
+
+	t.Run("IsWritable", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			resourceType influxdb.ResourceType
+			orgID        influxdb.ID
+			permissions  []influxdb.Permission
+			shouldErr    bool
+		}{
+			{
+				name:         "valid org write perms is always successful",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+				},
+			},
+			{
+				name:         "valid resource write perm is always successful",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+						},
+					},
+				},
+			},
+			{
+				name:         "valid org and resource write perm is always successful",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(3),
+						},
+					},
+					{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+						},
+					},
+				},
+			},
+			{
+				name:         "read only org perm errors",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   idPtr(3),
+						},
+					},
+				},
+				shouldErr: true,
+			},
+			{
+				name:         "read only resource perms errors",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+						},
+					},
+				},
+				shouldErr: true,
+			},
+			{
+				name:         "read only org and resource resource perms errors",
+				resourceType: influxdb.LabelsResourceType,
+				orgID:        3,
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   idPtr(3),
+						},
+					},
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+						},
+					},
+				},
+				shouldErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			fn := func(t *testing.T) {
+				ctx := icontext.SetAuthorizer(context.TODO(), &Authorizer{tt.permissions})
+
+				agent := new(authorizer.AuthAgent)
+
+				err := agent.IsWritable(ctx, tt.orgID, tt.resourceType)
+				if tt.shouldErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			t.Run(tt.name, fn)
+		}
+	})
+}

--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -3,6 +3,7 @@ package authorizer
 import (
 	"context"
 	"fmt"
+
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 )
@@ -90,9 +91,9 @@ func authorizeReadSystemBucket(ctx context.Context, bid, oid influxdb.ID) (influ
 
 // AuthorizeReadBucket exists because buckets are a special case and should use this method.
 // I.e., instead of:
-//  AuthorizeRead(crx, influxdb.BucketsResourceType, b.ID, b.OrgID)
+//  AuthorizeRead(ctx, influxdb.BucketsResourceType, b.ID, b.OrgID)
 // use:
-//  AuthorizeReadBucket(crx, b.Type, b.ID, b.OrgID)
+//  AuthorizeReadBucket(ctx, b.Type, b.ID, b.OrgID)
 func AuthorizeReadBucket(ctx context.Context, bt influxdb.BucketType, bid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
 	switch bt {
 	case influxdb.BucketTypeSystem:
@@ -108,7 +109,7 @@ func AuthorizeRead(ctx context.Context, rt influxdb.ResourceType, rid, oid influ
 	return authorize(ctx, influxdb.ReadAction, rt, &rid, &oid)
 }
 
-// AuthorizeRead authorizes the user in the context to write the specified resource (identified by its type, ID, and orgID).
+// AuthorizeWrite authorizes the user in the context to write the specified resource (identified by its type, ID, and orgID).
 // NOTE: authorization will pass even if the user only has permissions for the resource type and organization ID only.
 func AuthorizeWrite(ctx context.Context, rt influxdb.ResourceType, rid, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
 	return authorize(ctx, influxdb.WriteAction, rt, &rid, &oid)
@@ -145,12 +146,12 @@ func AuthorizeCreate(ctx context.Context, rt influxdb.ResourceType, oid influxdb
 	return AuthorizeOrgWriteResource(ctx, rt, oid)
 }
 
-// AuthorizeOrg authorizes the user to read the given org.
+// AuthorizeReadOrg authorizes the user to read the given org.
 func AuthorizeReadOrg(ctx context.Context, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
 	return authorize(ctx, influxdb.ReadAction, influxdb.OrgsResourceType, &oid, nil)
 }
 
-// AuthorizeOrg authorizes the user to write the given org.
+// AuthorizeWriteOrg authorizes the user to write the given org.
 func AuthorizeWriteOrg(ctx context.Context, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
 	return authorize(ctx, influxdb.WriteAction, influxdb.OrgsResourceType, &oid, nil)
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -857,6 +857,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	m.reg.MustRegister(m.apibackend.PrometheusCollectors()...)
 
+	authAgent := new(authorizer.AuthAgent)
+
 	var pkgSVC pkger.SVC
 	{
 		b := m.apibackend
@@ -879,6 +881,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		pkgSVC = pkger.MWTracing()(pkgSVC)
 		pkgSVC = pkger.MWMetrics(m.reg)(pkgSVC)
 		pkgSVC = pkger.MWLogging(pkgerLogger)(pkgSVC)
+		pkgSVC = pkger.MWAuth(authAgent)(pkgSVC)
 	}
 
 	var pkgHTTPServer *pkger.HTTPServer

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -44,6 +44,8 @@ type (
 	}
 )
 
+const ResourceTypeStack influxdb.ResourceType = "stack"
+
 // SVC is the packages service interface.
 type SVC interface {
 	InitStack(ctx context.Context, userID influxdb.ID, stack Stack) (Stack, error)

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -1,0 +1,49 @@
+package pkger
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+type AuthAgent interface {
+	IsWritable(ctx context.Context, orgID influxdb.ID, resType influxdb.ResourceType) error
+	OrgPermissions(ctx context.Context, orgID influxdb.ID, action influxdb.Action, rest ...influxdb.Action) error
+}
+
+type authMW struct {
+	authAgent AuthAgent
+	next      SVC
+}
+
+var _ SVC = (*authMW)(nil)
+
+// MWAuth is an auth service middleware for the packager domain.
+func MWAuth(authAgent AuthAgent) SVCMiddleware {
+	return func(svc SVC) SVC {
+		return &authMW{
+			authAgent: authAgent,
+			next:      svc,
+		}
+	}
+}
+
+func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (Stack, error) {
+	err := s.authAgent.IsWritable(ctx, newStack.OrgID, ResourceTypeStack)
+	if err != nil {
+		return Stack{}, err
+	}
+	return s.next.InitStack(ctx, userID, newStack)
+}
+
+func (s *authMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error) {
+	return s.next.CreatePkg(ctx, setters...)
+}
+
+func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+}
+
+func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, error) {
+	return s.next.Apply(ctx, orgID, userID, pkg, opts...)
+}


### PR DESCRIPTION
adds new AuthAgent type that can be reused across service middleware. is added to pkger for stack CRUD calls here.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass