### PR TITLE
feat(storage): Measurement(Names|TagKeys|TagValues) schema APIs

### DIFF
--- a/storage/engine_measurement_schema.go
+++ b/storage/engine_measurement_schema.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxql"
+)
+
+// MeasurementNames returns an iterator which enumerates the measurements for the given
+// bucket and limited to the time range (start, end].
+//
+// MeasurementNames will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementNames has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementNames(ctx context.Context, orgID, bucketID influxdb.ID, start, end int64) (cursors.StringIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	return e.engine.MeasurementNames(ctx, orgID, bucketID, start, end)
+}
+
+// MeasurementTagValues returns an iterator which enumerates the tag values for the given
+// bucket, measurement and tag key, filtered using the optional the predicate and limited to the
+// time range (start, end].
+//
+// MeasurementTagValues will always return a StringIterator if there is no error.
+//
+// If the context is canceled before TagValues has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementTagValues(ctx context.Context, orgID, bucketID influxdb.ID, measurement, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	return e.engine.MeasurementTagValues(ctx, orgID, bucketID, measurement, tagKey, start, end, predicate)
+}
+
+// MeasurementTagKeys returns an iterator which enumerates the tag keys for the given
+// bucket and measurement, filtered using the optional the predicate and limited to the
+//// time range (start, end].
+//
+// MeasurementTagKeys will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementTagKeys has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxdb.ID, measurement string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	return e.engine.MeasurementTagKeys(ctx, orgID, bucketID, measurement, start, end, predicate)
+}

--- a/tsdb/cursors/schema.go
+++ b/tsdb/cursors/schema.go
@@ -4,16 +4,11 @@ package cursors
 type FieldType int
 
 const (
-	// Float means the data type is a float.
-	Float FieldType = 0
-	// Integer means the data type is an integer.
-	Integer FieldType = 1
-	// Unsigned means the data type is an unsigned integer.
-	Unsigned FieldType = 2
-	// Boolean means the data type is a boolean.
-	Boolean FieldType = 3
-	// String means the data type is a string of text.
-	String FieldType = 4
+	Float    FieldType = iota // means the data type is a float
+	Integer                   // means the data type is an integer
+	Unsigned                  // means the data type is an unsigned integer
+	Boolean                   // means the data type is a boolean
+	String                    // means the data type is a string of text
 )
 
 type MeasurementField struct {

--- a/tsdb/cursors/schema.go
+++ b/tsdb/cursors/schema.go
@@ -1,0 +1,37 @@
+package cursors
+
+// FieldType represents the primitive field data types available in tsm.
+type FieldType int
+
+const (
+	// Float means the data type is a float.
+	Float FieldType = 0
+	// Integer means the data type is an integer.
+	Integer FieldType = 1
+	// Unsigned means the data type is an unsigned integer.
+	Unsigned FieldType = 2
+	// Boolean means the data type is a boolean.
+	Boolean FieldType = 3
+	// String means the data type is a string of text.
+	String FieldType = 4
+)
+
+type MeasurementField struct {
+	Key  string
+	Type FieldType
+}
+
+type MeasurementFields struct {
+	Fields []MeasurementField
+}
+
+type MeasurementFieldsCursor interface {
+	// Next advances the MeasurementFieldsCursor to the next value. It returns false
+	// when there are no more values.
+	Next() bool
+
+	// Value returns the current value.
+	Value() MeasurementFields
+
+	Stats() CursorStats
+}

--- a/tsdb/tsm1/engine_measurement_schema.go
+++ b/tsdb/tsm1/engine_measurement_schema.go
@@ -1,0 +1,175 @@
+package tsm1
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxql"
+)
+
+// MeasurementNames returns an iterator which enumerates the measurements for the given
+// bucket and limited to the time range (start, end].
+//
+// MeasurementNames will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementNames has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementNames(ctx context.Context, orgID, bucketID influxdb.ID, start, end int64) (cursors.StringIterator, error) {
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
+	// TODO(edd): we need to clean up how we're encoding the prefix so that we
+	// don't have to remember to get it right everywhere we need to touch TSM data.
+	prefix := models.EscapeMeasurement(orgBucket[:])
+
+	var (
+		tsmValues = make(map[string]struct{})
+		stats     cursors.CursorStats
+		canceled  bool
+	)
+
+	e.FileStore.ForEachFile(func(f TSMFile) bool {
+		// Check the context before accessing each tsm file
+		select {
+		case <-ctx.Done():
+			canceled = true
+			return false
+		default:
+		}
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+			iter := f.TimeRangeIterator(prefix, start, end)
+			for i := 0; iter.Next(); i++ {
+				sfkey := iter.Key()
+				if !bytes.HasPrefix(sfkey, prefix) {
+					// end of org+bucket
+					break
+				}
+
+				key, _ := SeriesAndFieldFromCompositeKey(sfkey)
+				name := models.ParseMeasurement(key)
+				if len(name) == 0 {
+					// INVARIANT: If key \x00 is missing the invariant is violated; skip key
+					continue
+				}
+
+				if _, ok := tsmValues[string(name)]; ok {
+					continue
+				}
+
+				if iter.HasData() {
+					tsmValues[string(name)] = struct{}{}
+				}
+			}
+			stats.Add(iter.Stats())
+		}
+		return true
+	})
+
+	if canceled {
+		return cursors.NewStringSliceIteratorWithStats(nil, stats), ctx.Err()
+	}
+
+	// With performance in mind, we explicitly do not check the context
+	// while scanning the entries in the cache.
+	prefixStr := string(prefix)
+	_ = e.Cache.ApplyEntryFn(func(sfkey string, entry *entry) error {
+		if !strings.HasPrefix(sfkey, prefixStr) {
+			return nil
+		}
+
+		// TODO(edd): consider the []byte() conversion here.
+		key, _ := SeriesAndFieldFromCompositeKey([]byte(sfkey))
+		name := models.ParseMeasurement(key)
+		if len(name) == 0 {
+			return nil
+		}
+
+		if _, ok := tsmValues[string(name)]; ok {
+			return nil
+		}
+
+		stats.ScannedValues += entry.values.Len()
+		stats.ScannedBytes += entry.values.Len() * 8 // sizeof timestamp
+
+		if entry.values.Contains(start, end) {
+			tsmValues[string(name)] = struct{}{}
+		}
+		return nil
+	})
+
+	vals := make([]string, 0, len(tsmValues))
+	for val := range tsmValues {
+		vals = append(vals, val)
+	}
+	sort.Strings(vals)
+
+	return cursors.NewStringSliceIteratorWithStats(vals, stats), nil
+}
+
+// MeasurementTagValues returns an iterator which enumerates the tag values for the given
+// bucket, measurement and tag key, filtered using the optional the predicate and limited to the
+// time range (start, end].
+//
+// MeasurementTagValues will always return a StringIterator if there is no error.
+//
+// If the context is canceled before TagValues has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementTagValues(ctx context.Context, orgID, bucketID influxdb.ID, measurement, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	if predicate == nil {
+		return e.tagValuesNoPredicate(ctx, orgID, bucketID, []byte(measurement), []byte(tagKey), start, end)
+	}
+
+	predicate = AddMeasurementToExpr(measurement, predicate)
+
+	return e.tagValuesPredicate(ctx, orgID, bucketID, []byte(measurement), []byte(tagKey), start, end, predicate)
+
+}
+
+// MeasurementTagKeys returns an iterator which enumerates the tag keys for the given
+// bucket and measurement, filtered using the optional the predicate and limited to the
+//// time range (start, end].
+//
+// MeasurementTagKeys will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementTagKeys has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxdb.ID, measurement string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	if predicate == nil {
+		return e.tagKeysNoPredicate(ctx, orgID, bucketID, []byte(measurement), start, end)
+	}
+
+	predicate = AddMeasurementToExpr(measurement, predicate)
+
+	return e.tagKeysPredicate(ctx, orgID, bucketID, []byte(measurement), start, end, predicate)
+}
+
+func AddMeasurementToExpr(measurement string, base influxql.Expr) influxql.Expr {
+	// \x00 = '<measurement>'
+	expr := &influxql.BinaryExpr{
+		LHS: &influxql.VarRef{
+			Val:  models.MeasurementTagKey,
+			Type: influxql.Tag,
+		},
+		Op: influxql.EQ,
+		RHS: &influxql.StringLiteral{
+			Val: measurement,
+		},
+	}
+
+	if base != nil {
+		// \x00 = '<measurement>' AND (base)
+		expr = &influxql.BinaryExpr{
+			LHS: expr,
+			Op:  influxql.AND,
+			RHS: &influxql.ParenExpr{
+				Expr: base,
+			},
+		}
+	}
+
+	return expr
+}

--- a/tsdb/tsm1/engine_measurement_schema_test.go
+++ b/tsdb/tsm1/engine_measurement_schema_test.go
@@ -1,0 +1,832 @@
+package tsm1_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEngine_MeasurementCancelContext(t *testing.T) {
+	e, err := NewEngine(tsm1.NewConfig(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	var (
+		org    influxdb.ID = 0x6000
+		bucket influxdb.ID = 0x6100
+	)
+
+	e.MustWritePointsString(org, bucket, `
+cpuB,host=0B,os=linux value=1.1 101
+cpuB,host=AB,os=linux value=1.2 102
+cpuB,host=AB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 105
+cpuB,host=DB,os=macOS value=1.3 106
+memB,host=DB,os=macOS value=1.3 101`)
+
+	// send some points to TSM data
+	e.MustWriteSnapshot()
+
+	e.MustWritePointsString(org, bucket, `
+cpuB,host=0B,os=linux value=1.1 201
+cpuB,host=AB,os=linux value=1.2 202
+cpuB,host=AB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 205
+cpuB,host=EB,os=macOS value=1.3 206
+memB,host=EB,os=macOS value=1.3 201`)
+
+	t.Run("cancel MeasurementNames", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		iter, err := e.MeasurementNames(ctx, org, bucket, 0, math.MaxInt64)
+		if err == nil {
+			t.Fatal("MeasurementNames: expected error but got nothing")
+		} else if err.Error() != "context canceled" {
+			t.Fatalf("MeasurementNames: error %v", err)
+		}
+
+		if got := iter.Stats(); !cmp.Equal(got, cursors.CursorStats{}) {
+			t.Errorf("unexpected Stats: -got/+exp\n%v", cmp.Diff(got, cursors.CursorStats{}))
+		}
+	})
+}
+
+func TestEngine_MeasurementNames(t *testing.T) {
+	e, err := NewEngine(tsm1.NewConfig(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	orgs := []struct {
+		org, bucket influxdb.ID
+	}{
+		{
+			org:    0x5020,
+			bucket: 0x5100,
+		},
+		{
+			org:    0x6000,
+			bucket: 0x6100,
+		},
+	}
+
+	// this org will require escaping the 0x20 byte
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpu,cpu0=v,cpu1=v,cpu2=v f=1 101
+cpu,cpu1=v               f=1 103
+cpu,cpu2=v               f=1 105
+cpu,cpu0=v,cpu2=v        f=1 107
+cpu,cpu2=v,cpu3=v        f=1 109
+mem,mem0=v,mem1=v        f=1 101`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpu,cpu0=v,cpu1=v,cpu2=v f=1 101
+cpu,cpu1=v               f=1 103
+cpu,cpu2=v               f=1 105
+cpu,cpu0=v,cpu2=v        f=1 107
+cpu,cpu2=v,cpu3=v        f=1 109
+mem,mem0=v,mem1=v        f=1 101`)
+
+	// send some points to TSM data
+	e.MustWriteSnapshot()
+
+	// delete some data from the first bucket
+	e.MustDeleteBucketRange(orgs[0].org, orgs[0].bucket, 0, 105)
+
+	// leave some points in the cache
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpu,cpu3=v,cpu4=v,cpu5=v f=1 201
+cpu,cpu4=v               f=1 203
+cpu,cpu3=v               f=1 205
+cpu,cpu3=v,cpu4=v        f=1 207
+cpu,cpu4=v,cpu5=v        f=1 209
+mem,mem1=v,mem2=v        f=1 201`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpu,cpu3=v,cpu4=v,cpu5=v f=1 201
+cpu,cpu4=v               f=1 203
+cpu,cpu3=v               f=1 205
+cpu,cpu3=v,cpu4=v        f=1 207
+cpu,cpu4=v,cpu5=v        f=1 209
+mem,mem1=v,mem2=v        f=1 201`)
+
+	type args struct {
+		org      int
+		min, max int64
+	}
+
+	var tests = []struct {
+		name     string
+		args     args
+		exp      []string
+		expStats cursors.CursorStats
+	}{
+		// ***********************
+		// * queries for the first org, which has some deleted data
+		// ***********************
+
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 0,
+				min: 0,
+				max: 300,
+			},
+			exp:      []string{"cpu", "mem"},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+		{
+			name: "only TSM",
+			args: args{
+				org: 0,
+				min: 0,
+				max: 199,
+			},
+			exp:      []string{"cpu"},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+		{
+			name: "only cache",
+			args: args{
+				org: 0,
+				min: 200,
+				max: 299,
+			},
+			exp:      []string{"cpu", "mem"},
+			expStats: cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16},
+		},
+		{
+			name: "one timestamp TSM/data",
+			args: args{
+				org: 0,
+				min: 107,
+				max: 107,
+			},
+			exp:      []string{"cpu"},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+		{
+			name: "one timestamp cache/data",
+			args: args{
+				org: 0,
+				min: 207,
+				max: 207,
+			},
+			exp:      []string{"cpu"},
+			expStats: cursors.CursorStats{ScannedValues: 3, ScannedBytes: 24},
+		},
+		{
+			name: "one timestamp TSM/nodata",
+			args: args{
+				org: 0,
+				min: 102,
+				max: 102,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "one timestamp cache/nodata",
+			args: args{
+				org: 0,
+				min: 202,
+				max: 202,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+
+		// ***********************
+		// * queries for the second org, which has no deleted data
+		// ***********************
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 1,
+				min: 0,
+				max: 300,
+			},
+			exp:      []string{"cpu", "mem"},
+			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("org%d/%s", tc.args.org, tc.name), func(t *testing.T) {
+			a := tc.args
+
+			iter, err := e.MeasurementNames(context.Background(), orgs[a.org].org, orgs[a.org].bucket, a.min, a.max)
+			if err != nil {
+				t.Fatalf("MeasurementNames: error %v", err)
+			}
+
+			if got := cursors.StringIteratorToSlice(iter); !cmp.Equal(got, tc.exp) {
+				t.Errorf("unexpected MeasurementNames: -got/+exp\n%v", cmp.Diff(got, tc.exp))
+			}
+
+			if got := iter.Stats(); !cmp.Equal(got, tc.expStats) {
+				t.Errorf("unexpected Stats: -got/+exp\n%v", cmp.Diff(got, tc.expStats))
+			}
+		})
+	}
+}
+
+func TestEngine_MeasurementTagValues(t *testing.T) {
+	e, err := NewEngine(tsm1.NewConfig(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	orgs := []struct {
+		org, bucket influxdb.ID
+	}{
+		{
+			org:    0x5020,
+			bucket: 0x5100,
+		},
+		{
+			org:    0x6000,
+			bucket: 0x6100,
+		},
+	}
+
+	// this org will require escaping the 0x20 byte
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpuA,host=0A,os=linux value=1.1 101
+cpuA,host=AA,os=linux value=1.2 102
+cpuA,host=AA,os=linux value=1.3 104
+cpuA,host=CA,os=linux value=1.3 104
+cpuA,host=CA,os=linux value=1.3 105
+cpuA,host=DA,os=macOS value=1.3 106
+memA,host=DA,os=macOS value=1.3 101`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpuB,host=0B,os=linux value=1.1 101
+cpuB,host=AB,os=linux value=1.2 102
+cpuB,host=AB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 105
+cpuB,host=DB,os=macOS value=1.3 106
+memB,host=DB,os=macOS value=1.3 101`)
+
+	// send some points to TSM data
+	e.MustWriteSnapshot()
+
+	// delete some data from the first bucket
+	e.MustDeleteBucketRange(orgs[0].org, orgs[0].bucket, 0, 105)
+
+	// leave some points in the cache
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpuA,host=0A,os=linux value=1.1 201
+cpuA,host=AA,os=linux value=1.2 202
+cpuA,host=AA,os=linux value=1.3 204
+cpuA,host=BA,os=macOS value=1.3 204
+cpuA,host=BA,os=macOS value=1.3 205
+cpuA,host=EA,os=linux value=1.3 206
+memA,host=EA,os=linux value=1.3 201`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpuB,host=0B,os=linux value=1.1 201
+cpuB,host=AB,os=linux value=1.2 202
+cpuB,host=AB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 205
+cpuB,host=EB,os=macOS value=1.3 206
+memB,host=EB,os=macOS value=1.3 201`)
+
+	type args struct {
+		org      int
+		m        string
+		key      string
+		min, max int64
+		expr     string
+	}
+
+	var tests = []struct {
+		name     string
+		args     args
+		exp      []string
+		expStats cursors.CursorStats
+	}{
+		// ***********************
+		// * queries for the first org, which has some deleted data
+		// ***********************
+
+		// host tag
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 0,
+				max: 300,
+			},
+			exp:      []string{"0A", "AA", "BA", "DA", "EA"},
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "cpuA only TSM",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 0,
+				max: 199,
+			},
+			exp:      []string{"DA"},
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "memA all time",
+			args: args{
+				org: 0,
+				m:   "memA",
+				key: "host",
+				min: 0,
+				max: 1000,
+			},
+			exp:      []string{"EA"},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+		{
+			name: "cpuB only TSM",
+			args: args{
+				org: 1,
+				m:   "cpuB",
+				key: "host",
+				min: 0,
+				max: 199,
+			},
+			exp:      []string{"0B", "AB", "CB", "DB"},
+			expStats: cursors.CursorStats{ScannedValues: 3, ScannedBytes: 24},
+		},
+		{
+			name: "only cache",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 200,
+				max: 299,
+			},
+			exp:      []string{"0A", "AA", "BA", "EA"},
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "one timestamp TSM/data",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 106,
+				max: 106,
+			},
+			exp:      []string{"DA"},
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "one timestamp cache/data",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 201,
+				max: 201,
+			},
+			exp:      []string{"0A"},
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "one timestamp TSM/nodata",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 103,
+				max: 103,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+		{
+			name: "one timestamp cache/nodata",
+			args: args{
+				org: 0,
+				m:   "cpuA",
+				key: "host",
+				min: 203,
+				max: 203,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 6, ScannedBytes: 48},
+		},
+
+		// queries with predicates
+		{
+			name: "predicate/macOS",
+			args: args{
+				org:  0,
+				m:    "cpuA",
+				key:  "host",
+				min:  0,
+				max:  300,
+				expr: `os = 'macOS'`,
+			},
+			exp:      []string{"BA", "DA"},
+			expStats: cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16},
+		},
+		{
+			name: "predicate/linux",
+			args: args{
+				org:  0,
+				m:    "cpuA",
+				key:  "host",
+				min:  0,
+				max:  300,
+				expr: `os = 'linux'`,
+			},
+			exp:      []string{"0A", "AA", "EA"},
+			expStats: cursors.CursorStats{ScannedValues: 4, ScannedBytes: 32},
+		},
+
+		// ***********************
+		// * queries for the second org, which has no deleted data
+		// ***********************
+		{
+			name: "all data",
+			args: args{
+				org: 1,
+				m:   "cpuB",
+				key: "host",
+				min: 0,
+				max: 1000,
+			},
+			exp:      []string{"0B", "AB", "BB", "CB", "DB", "EB"},
+			expStats: cursors.CursorStats{ScannedValues: 3, ScannedBytes: 24},
+		},
+
+		// ***********************
+		// * other scenarios
+		// ***********************
+		{
+			// ensure StringIterator is never nil
+			name: "predicate/no candidate series",
+			args: args{
+				org:  1,
+				m:    "cpuB",
+				key:  "host",
+				min:  0,
+				max:  1000,
+				expr: `foo = 'bar'`,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tc.args
+			var expr influxql.Expr
+			if len(a.expr) > 0 {
+				expr = influxql.MustParseExpr(a.expr)
+			}
+
+			iter, err := e.MeasurementTagValues(context.Background(), orgs[a.org].org, orgs[a.org].bucket, a.m, a.key, a.min, a.max, expr)
+			if err != nil {
+				t.Fatalf("TagValues: error %v", err)
+			}
+
+			if got := cursors.StringIteratorToSlice(iter); !cmp.Equal(got, tc.exp) {
+				t.Errorf("unexpected TagValues: -got/+exp\n%v", cmp.Diff(got, tc.exp))
+			}
+
+			if got := iter.Stats(); !cmp.Equal(got, tc.expStats) {
+				t.Errorf("unexpected Stats: -got/+exp\n%v", cmp.Diff(got, tc.expStats))
+			}
+		})
+	}
+}
+
+func TestEngine_MeasurementTagKeys(t *testing.T) {
+	e, err := NewEngine(tsm1.NewConfig(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	orgs := []struct {
+		org, bucket influxdb.ID
+	}{
+		{
+			org:    0x5020,
+			bucket: 0x5100,
+		},
+		{
+			org:    0x6000,
+			bucket: 0x6100,
+		},
+	}
+
+	// this org will require escaping the 0x20 byte
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpu,cpu0=v,cpu1=v,cpu2=v f=1 101
+cpu,cpu1=v               f=1 103
+cpu,cpu2=v               f=1 105
+cpu,cpu0=v,cpu2=v        f=1 107
+cpu,cpu2=v,cpu3=v        f=1 109
+mem,mem0=v,mem1=v        f=1 101`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpu,cpu0=v,cpu1=v,cpu2=v f=1 101
+cpu,cpu1=v               f=1 103
+cpu,cpu2=v               f=1 105
+cpu,cpu0=v,cpu2=v        f=1 107
+cpu,cpu2=v,cpu3=v        f=1 109
+mem,mem0=v,mem1=v        f=1 101`)
+
+	// send some points to TSM data
+	e.MustWriteSnapshot()
+
+	// delete some data from the first bucket
+	e.MustDeleteBucketRange(orgs[0].org, orgs[0].bucket, 0, 105)
+
+	// leave some points in the cache
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpu,cpu3=v,cpu4=v,cpu5=v f=1 201
+cpu,cpu4=v               f=1 203
+cpu,cpu3=v               f=1 205
+cpu,cpu3=v,cpu4=v        f=1 207
+cpu,cpu4=v,cpu5=v        f=1 209
+mem,mem1=v,mem2=v        f=1 201`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpu,cpu3=v,cpu4=v,cpu5=v f=1 201
+cpu,cpu4=v               f=1 203
+cpu,cpu3=v               f=1 205
+cpu,cpu3=v,cpu4=v        f=1 207
+cpu,cpu4=v,cpu5=v        f=1 209
+mem,mem1=v,mem2=v        f=1 201`)
+
+	type args struct {
+		org      int
+		m        string
+		min, max int64
+		expr     string
+	}
+
+	var tests = []struct {
+		name     string
+		args     args
+		exp      []string
+		expStats cursors.CursorStats
+	}{
+		// ***********************
+		// * queries for the first org, which has some deleted data
+		// ***********************
+
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 0,
+				max: 300,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu0", "cpu2", "cpu3", "cpu4", "cpu5", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16},
+		},
+		{
+			name: "only TSM",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 0,
+				max: 199,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu0", "cpu2", "cpu3", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 4, ScannedBytes: 32},
+		},
+		{
+			name: "only cache",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 200,
+				max: 299,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu3", "cpu4", "cpu5", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 3, ScannedBytes: 24},
+		},
+		{
+			name: "one timestamp TSM/data",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 107,
+				max: 107,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu0", "cpu2", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 5, ScannedBytes: 40},
+		},
+		{
+			name: "one timestamp cache/data",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 207,
+				max: 207,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu3", "cpu4", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 4, ScannedBytes: 32},
+		},
+		{
+			name: "one timestamp TSM/nodata",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 102,
+				max: 102,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 5, ScannedBytes: 40},
+		},
+		{
+			name: "one timestamp cache/nodata",
+			args: args{
+				org: 0,
+				m:   "cpu",
+				min: 202,
+				max: 202,
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 5, ScannedBytes: 40},
+		},
+
+		// queries with predicates
+		{
+			name: "predicate/all time/cpu",
+			args: args{
+				org:  0,
+				m:    "cpu",
+				min:  0,
+				max:  300,
+				expr: `cpu0 = 'v' OR cpu4 = 'v'`,
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu0", "cpu2", "cpu3", "cpu4", "cpu5", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16},
+		},
+		{
+			name: "predicate/all time/mem",
+			args: args{
+				org:  0,
+				m:    "mem",
+				min:  0,
+				max:  300,
+				expr: `mem1 = 'v'`,
+			},
+			exp:      []string{models.MeasurementTagKey, "mem1", "mem2", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+		{
+			name: "predicate/all time/cpu0",
+			args: args{
+				org:  0,
+				m:    "cpu",
+				min:  0,
+				max:  300,
+				expr: "cpu0 = 'v'",
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu0", "cpu2", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
+		},
+		{
+			name: "predicate/all time/cpu3",
+			args: args{
+				org:  0,
+				m:    "cpu",
+				min:  0,
+				max:  300,
+				expr: "cpu3 = 'v'",
+			},
+			exp:      []string{models.MeasurementTagKey, "cpu2", "cpu3", "cpu4", "cpu5", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16},
+		},
+
+		// ***********************
+		// * queries for the second org, which has no deleted data
+		// ***********************
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 1,
+				m:   "mem",
+				min: 0,
+				max: 300,
+			},
+			exp:      []string{models.MeasurementTagKey, "mem0", "mem1", "mem2", models.FieldKeyTagKey},
+			expStats: cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8},
+		},
+
+		// ***********************
+		// * other scenarios
+		// ***********************
+		{
+			// ensure StringIterator is never nil
+			name: "predicate/no candidate series",
+			args: args{
+				org:  0,
+				min:  0,
+				max:  300,
+				expr: "foo = 'bar'",
+			},
+			exp:      nil,
+			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("org%d/%s", tc.args.org, tc.name), func(t *testing.T) {
+			a := tc.args
+			var expr influxql.Expr
+			if len(a.expr) > 0 {
+				expr = influxql.MustParseExpr(a.expr)
+			}
+
+			iter, err := e.MeasurementTagKeys(context.Background(), orgs[a.org].org, orgs[a.org].bucket, a.m, a.min, a.max, expr)
+			if err != nil {
+				t.Fatalf("TagKeys: error %v", err)
+			}
+
+			if got := cursors.StringIteratorToSlice(iter); !cmp.Equal(got, tc.exp) {
+				t.Errorf("unexpected TagKeys: -got/+exp\n%v", cmp.Diff(got, tc.exp))
+			}
+
+			if got := iter.Stats(); !cmp.Equal(got, tc.expStats) {
+				t.Errorf("unexpected Stats: -got/+exp\n%v", cmp.Diff(got, tc.expStats))
+			}
+		})
+	}
+}
+
+// Verifies AddMeasurementToExpr amends the given influxql.Expr
+// with a predicate to restrict results to a single measurement
+func TestAddMeasurementToExpr(t *testing.T) {
+	tests := []struct {
+		name        string
+		measurement string
+		expr        influxql.Expr
+		exp         string
+	}{
+		{
+			name:        "no expression",
+			measurement: "foo",
+			expr:        nil,
+			exp:         "\"\x00\"::tag = 'foo'",
+		},
+		{
+			name:        "simple expression",
+			measurement: "foo",
+			expr:        influxql.MustParseExpr(`bar::tag = 'v1'`),
+			exp:         "\"\x00\"::tag = 'foo' AND (bar::tag = 'v1')",
+		},
+		{
+			name:        "regex expression",
+			measurement: "foo",
+			expr:        influxql.MustParseExpr(`bar::tag =~ /v1/`),
+			exp:         "\"\x00\"::tag = 'foo' AND (bar::tag =~ /v1/)",
+		},
+		{
+			name:        "multiple binary expressions",
+			measurement: "foo",
+			expr:        influxql.MustParseExpr(`(bar = 'a1' OR bar = 'a2') AND cpu = 'cpu0'`),
+			exp:         "\"\x00\"::tag = 'foo' AND ((bar = 'a1' OR bar = 'a2') AND cpu = 'cpu0')",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tsm1.AddMeasurementToExpr(tt.measurement, tt.expr).String()
+			assert.Equal(t, tt.exp, got, "unexpected value for expression")
+		})
+	}
+}

--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -31,22 +31,29 @@ const cancelCheckInterval = 64
 // If the context is canceled before TagValues has finished processing, a non-nil
 // error will be returned along with a partial result of the already scanned values.
 func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
-	encoded := tsdb.EncodeName(orgID, bucketID)
-
 	if predicate == nil {
-		return e.tagValuesNoPredicate(ctx, encoded[:], []byte(tagKey), start, end)
+		return e.tagValuesNoPredicate(ctx, orgID, bucketID, nil, []byte(tagKey), start, end)
 	}
 
-	return e.tagValuesPredicate(ctx, encoded[:], []byte(tagKey), start, end, predicate)
+	return e.tagValuesPredicate(ctx, orgID, bucketID, nil, []byte(tagKey), start, end, predicate)
 }
 
-func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyBytes []byte, start, end int64) (cursors.StringIterator, error) {
+func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgID, bucketID influxdb.ID, measurement, tagKeyBytes []byte, start, end int64) (cursors.StringIterator, error) {
 	tsmValues := make(map[string]struct{})
 	var tags models.Tags
 
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
+
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.
-	prefix := models.EscapeMeasurement(orgBucket)
+	orgBucketEsc := models.EscapeMeasurement(orgBucket[:])
+
+	tsmKeyPrefix := orgBucketEsc
+	if len(measurement) > 0 {
+		// append the measurement tag key to the prefix
+		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
+		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+	}
 
 	// TODO(sgc): extend prefix when filtering by \x00 == <measurement>
 
@@ -61,13 +68,13 @@ func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyByte
 			return false
 		default:
 		}
-		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(tsmKeyPrefix, tsmKeyPrefix) {
 			// TODO(sgc): create f.TimeRangeIterator(minKey, maxKey, start, end)
-			iter := f.TimeRangeIterator(prefix, start, end)
+			iter := f.TimeRangeIterator(tsmKeyPrefix, start, end)
 			for i := 0; iter.Next(); i++ {
 				sfkey := iter.Key()
-				if !bytes.HasPrefix(sfkey, prefix) {
-					// end of org+bucket
+				if !bytes.HasPrefix(sfkey, tsmKeyPrefix) {
+					// end of prefix
 					break
 				}
 
@@ -97,9 +104,9 @@ func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyByte
 
 	// With performance in mind, we explicitly do not check the context
 	// while scanning the entries in the cache.
-	prefixStr := string(prefix)
+	tsmKeyprefixStr := string(tsmKeyPrefix)
 	_ = e.Cache.ApplyEntryFn(func(sfkey string, entry *entry) error {
-		if !strings.HasPrefix(sfkey, prefixStr) {
+		if !strings.HasPrefix(sfkey, tsmKeyprefixStr) {
 			return nil
 		}
 
@@ -133,12 +140,14 @@ func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyByte
 	return cursors.NewStringSliceIteratorWithStats(vals, stats), nil
 }
 
-func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes []byte, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+func (e *Engine) tagValuesPredicate(ctx context.Context, orgID, bucketID influxdb.ID, measurement, tagKeyBytes []byte, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
 	if err := ValidateTagPredicate(predicate); err != nil {
 		return nil, err
 	}
 
-	keys, err := e.findCandidateKeys(ctx, orgBucket, predicate)
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
+
+	keys, err := e.findCandidateKeys(ctx, orgBucket[:], predicate)
 	if err != nil {
 		return cursors.EmptyStringIterator, err
 	}
@@ -157,7 +166,15 @@ func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes 
 
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.
-	prefix := models.EscapeMeasurement(orgBucket)
+	orgBucketEsc := models.EscapeMeasurement(orgBucket[:])
+
+	tsmKeyPrefix := orgBucketEsc
+	if len(measurement) > 0 {
+		// append the measurement tag key to the prefix
+		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
+		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+	}
+
 	var canceled bool
 
 	e.FileStore.ForEachFile(func(f TSMFile) bool {
@@ -168,10 +185,10 @@ func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes 
 			return false
 		default:
 		}
-		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(tsmKeyPrefix, tsmKeyPrefix) {
 			f.Ref()
 			files = append(files, f)
-			iters = append(iters, f.TimeRangeIterator(prefix, start, end))
+			iters = append(iters, f.TimeRangeIterator(tsmKeyPrefix, start, end))
 		}
 		return true
 	})
@@ -213,7 +230,7 @@ func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes 
 			continue
 		}
 
-		keybuf = models.AppendMakeKey(keybuf[:0], prefix, tags)
+		keybuf = models.AppendMakeKey(keybuf[:0], orgBucketEsc, tags)
 		sfkey = AppendSeriesFieldKeyBytes(sfkey[:0], keybuf, tags.Get(models.FieldKeyTagKeyBytes))
 
 		values := e.Cache.Values(sfkey)
@@ -226,7 +243,6 @@ func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes 
 		}
 
 		for _, iter := range iters {
-
 			if exact, _ := iter.Seek(sfkey); !exact {
 				continue
 			}
@@ -295,21 +311,28 @@ func (e *Engine) findCandidateKeys(ctx context.Context, orgBucket []byte, predic
 // If the context is canceled before TagKeys has finished processing, a non-nil
 // error will be returned along with a partial result of the already scanned keys.
 func (e *Engine) TagKeys(ctx context.Context, orgID, bucketID influxdb.ID, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
-	encoded := tsdb.EncodeName(orgID, bucketID)
-
 	if predicate == nil {
-		return e.tagKeysNoPredicate(ctx, encoded[:], start, end)
+		return e.tagKeysNoPredicate(ctx, orgID, bucketID, nil, start, end)
 	}
 
-	return e.tagKeysPredicate(ctx, encoded[:], start, end, predicate)
+	return e.tagKeysPredicate(ctx, orgID, bucketID, nil, start, end, predicate)
 }
 
-func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgBucket []byte, start, end int64) (cursors.StringIterator, error) {
+func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgID, bucketID influxdb.ID, measurement []byte, start, end int64) (cursors.StringIterator, error) {
 	var tags models.Tags
+
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
 
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.
-	prefix := models.EscapeMeasurement(orgBucket)
+	orgBucketEsc := models.EscapeMeasurement(orgBucket[:])
+
+	tsmKeyPrefix := orgBucketEsc
+	if len(measurement) > 0 {
+		// append the measurement tag key to the prefix
+		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
+		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+	}
 
 	var keyset models.TagKeysSet
 
@@ -326,13 +349,13 @@ func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgBucket []byte, start
 			return false
 		default:
 		}
-		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(tsmKeyPrefix, tsmKeyPrefix) {
 			// TODO(sgc): create f.TimeRangeIterator(minKey, maxKey, start, end)
-			iter := f.TimeRangeIterator(prefix, start, end)
+			iter := f.TimeRangeIterator(tsmKeyPrefix, start, end)
 			for i := 0; iter.Next(); i++ {
 				sfkey := iter.Key()
-				if !bytes.HasPrefix(sfkey, prefix) {
-					// end of org+bucket
+				if !bytes.HasPrefix(sfkey, tsmKeyPrefix) {
+					// end of prefix
 					break
 				}
 
@@ -357,8 +380,9 @@ func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgBucket []byte, start
 
 	// With performance in mind, we explicitly do not check the context
 	// while scanning the entries in the cache.
+	tsmKeyprefixStr := string(tsmKeyPrefix)
 	_ = e.Cache.ApplyEntryFn(func(sfkey string, entry *entry) error {
-		if !strings.HasPrefix(sfkey, string(prefix)) {
+		if !strings.HasPrefix(sfkey, tsmKeyprefixStr) {
 			return nil
 		}
 
@@ -381,12 +405,14 @@ func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgBucket []byte, start
 	return cursors.NewStringSliceIteratorWithStats(keyset.Keys(), stats), nil
 }
 
-func (e *Engine) tagKeysPredicate(ctx context.Context, orgBucket []byte, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+func (e *Engine) tagKeysPredicate(ctx context.Context, orgID, bucketID influxdb.ID, measurement []byte, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
 	if err := ValidateTagPredicate(predicate); err != nil {
 		return nil, err
 	}
 
-	keys, err := e.findCandidateKeys(ctx, orgBucket, predicate)
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
+
+	keys, err := e.findCandidateKeys(ctx, orgBucket[:], predicate)
 	if err != nil {
 		return cursors.EmptyStringIterator, err
 	}
@@ -405,7 +431,15 @@ func (e *Engine) tagKeysPredicate(ctx context.Context, orgBucket []byte, start, 
 
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.
-	prefix := models.EscapeMeasurement(orgBucket)
+	orgBucketEsc := models.EscapeMeasurement(orgBucket[:])
+
+	tsmKeyPrefix := orgBucketEsc
+	if len(measurement) > 0 {
+		// append the measurement tag key to the prefix
+		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
+		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+	}
+
 	var canceled bool
 
 	e.FileStore.ForEachFile(func(f TSMFile) bool {
@@ -416,10 +450,10 @@ func (e *Engine) tagKeysPredicate(ctx context.Context, orgBucket []byte, start, 
 			return false
 		default:
 		}
-		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(tsmKeyPrefix, tsmKeyPrefix) {
 			f.Ref()
 			files = append(files, f)
-			iters = append(iters, f.TimeRangeIterator(prefix, start, end))
+			iters = append(iters, f.TimeRangeIterator(tsmKeyPrefix, start, end))
 		}
 		return true
 	})
@@ -456,7 +490,7 @@ func (e *Engine) tagKeysPredicate(ctx context.Context, orgBucket []byte, start, 
 			continue
 		}
 
-		keybuf = models.AppendMakeKey(keybuf[:0], prefix, tags)
+		keybuf = models.AppendMakeKey(keybuf[:0], orgBucketEsc, tags)
 		sfkey = AppendSeriesFieldKeyBytes(sfkey[:0], keybuf, tags.Get(models.FieldKeyTagKeyBytes))
 
 		values := e.Cache.Values(sfkey)
@@ -469,7 +503,6 @@ func (e *Engine) tagKeysPredicate(ctx context.Context, orgBucket []byte, start, 
 		}
 
 		for _, iter := range iters {
-
 			if exact, _ := iter.Seek(sfkey); !exact {
 				continue
 			}
@@ -519,6 +552,7 @@ func ValidateTagPredicate(expr influxql.Expr) (err error) {
 			case *influxql.StringLiteral:
 			case *influxql.RegexLiteral:
 			case *influxql.BinaryExpr:
+			case *influxql.ParenExpr:
 			default:
 				err = fmt.Errorf("binary expression: RHS must be string or regex, got: %T", r)
 			}


### PR DESCRIPTION
This PR provides implementations of the `MeasurementNames`, `MeasurementTagKeys` and `MeasurementTagValues` schema APIs.

These schema APIs require a measurement, permitting additional optimization to reduce the search space against the TSM index. Specifically, the TSM search key prefix is extended from `org+bucket` to `org+bucket,\x00=<measurement>`.

In addition the `models` package provides a new API, `ParseMeasurement` to efficiently extract the value of the `models.MeasurementTagKey` tag key (`\x00`), with no allocations if the value does not require escaping.

Closes #17446
