### PR TITLE
feat(sampledata): Add demo data dropdown and membership request to buckets

### DIFF
--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -49,6 +49,7 @@ import {
   removeBucketLabelFailed,
 } from 'src/shared/copy/notifications'
 import {LIMIT} from 'src/resources/constants'
+import {getDemoDataBucketsFromAll} from 'src/cloud/apis/demodata'
 
 type Action = BucketAction | NotifyAction
 
@@ -71,8 +72,10 @@ export const getBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
+    let demoDataBuckets = await getDemoDataBucketsFromAll()
+
     const buckets = normalize<Bucket, BucketEntities, string[]>(
-      resp.data.buckets,
+      [...resp.data.buckets, ...demoDataBuckets],
       arrayOfBuckets
     )
 

--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -72,7 +72,7 @@ export const getBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
-    let demoDataBuckets = await getDemoDataBucketsFromAll()
+    const demoDataBuckets = await getDemoDataBucketsFromAll()
 
     const buckets = normalize<Bucket, BucketEntities, string[]>(
       [...resp.data.buckets, ...demoDataBuckets],

--- a/ui/src/buckets/components/BucketAddDataButton.scss
+++ b/ui/src/buckets/components/BucketAddDataButton.scss
@@ -54,3 +54,12 @@
 .system-bucket {
   color: mix($c-honeydew, $g13-mist);
 }
+
+.buckets-buttons-wrap {
+  display: flex;
+  box-sizing: border-box;
+  text-align: right;
+  @media screen and (max-width: 680px) {
+    margin: 8px auto 0;
+  }
+}

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -21,10 +21,10 @@ import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
 import FilterList from 'src/shared/components/FilterList'
 import BucketList from 'src/buckets/components/BucketList'
-import {PrettyBucket} from 'src/buckets/components/BucketCard'
 import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
 import BucketExplainer from 'src/buckets/components/BucketExplainer'
+import DemoDataDropdown from 'src/buckets/components/DemoDataDropdown'
 
 // Actions
 import {
@@ -42,8 +42,10 @@ import {prettyBuckets} from 'src/shared/utils/prettyBucket'
 import {extractBucketLimits} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Types
+import {PrettyBucket} from 'src/buckets/components/BucketCard'
 import {
   OverlayState,
   AppState,
@@ -121,15 +123,20 @@ class BucketsTab extends PureComponent<Props, State> {
             searchTerm={searchTerm}
             onSearch={this.handleFilterChange}
           />
-          <Button
-            text="Create Bucket"
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-            onClick={this.handleOpenModal}
-            testID="Create Bucket"
-            status={this.createButtonStatus}
-            titleText={this.createButtonTitleText}
-          />
+          <div className="buckets-buttons-wrap">
+            <FeatureFlag name="demodata">
+              <DemoDataDropdown />
+            </FeatureFlag>
+            <Button
+              text="Create Bucket"
+              icon={IconFont.Plus}
+              color={ComponentColor.Primary}
+              onClick={this.handleOpenModal}
+              testID="Create Bucket"
+              status={this.createButtonStatus}
+              titleText={this.createButtonTitleText}
+            />
+          </div>
         </SettingsTabbedPageHeader>
         <Grid>
           <Grid.Row>

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -36,7 +36,10 @@ import {
   checkBucketLimits as checkBucketLimitsAction,
   LimitStatus,
 } from 'src/cloud/actions/limits'
-import {getDemoDataBuckets} from 'src/cloud/actions/demodata'
+import {
+  getDemoDataBuckets as getDemoDataBucketsAction,
+  getDemoDataBucketMembership as getDemoDataBucketMembershipAction,
+} from 'src/cloud/actions/demodata'
 
 // Utils
 import {prettyBuckets} from 'src/shared/utils/prettyBucket'
@@ -68,7 +71,8 @@ interface DispatchProps {
   updateBucket: typeof updateBucket
   deleteBucket: typeof deleteBucket
   checkBucketLimits: typeof checkBucketLimitsAction
-  getDemoDataBuckets: typeof getDemoDataBuckets
+  getDemoDataBuckets: typeof getDemoDataBucketsAction
+  getDemoDataBucketMembership: typeof getDemoDataBucketMembershipAction
 }
 
 interface State {
@@ -107,7 +111,13 @@ class BucketsTab extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {org, buckets, limitStatus, demoDataBuckets} = this.props
+    const {
+      org,
+      buckets,
+      limitStatus,
+      demoDataBuckets,
+      getDemoDataBucketMembership,
+    } = this.props
     const {
       searchTerm,
       overlayState,
@@ -132,7 +142,10 @@ class BucketsTab extends PureComponent<Props, State> {
           <div className="buckets-buttons-wrap">
             <FeatureFlag name="demodata">
               {demoDataBuckets.length > 0 && (
-                <DemoDataDropdown buckets={demoDataBuckets} />
+                <DemoDataDropdown
+                  buckets={demoDataBuckets}
+                  getMembership={getDemoDataBucketMembership}
+                />
               )}
             </FeatureFlag>
             <Button
@@ -277,12 +290,13 @@ const mstp = (state: AppState): StateProps => ({
   demoDataBuckets: get(state, 'cloud.demoData.buckets', []),
 })
 
-const mdtp = {
+const mdtp: DispatchProps = {
   createBucket,
   updateBucket,
   deleteBucket,
   checkBucketLimits: checkBucketLimitsAction,
-  getDemoDataBuckets: getDemoDataBuckets,
+  getDemoDataBuckets: getDemoDataBucketsAction,
+  getDemoDataBucketMembership: getDemoDataBucketMembershipAction,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -46,7 +46,7 @@ import {prettyBuckets} from 'src/shared/utils/prettyBucket'
 import {extractBucketLimits} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
-import {FeatureFlag, isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {PrettyBucket} from 'src/buckets/components/BucketCard'
@@ -140,14 +140,12 @@ class BucketsTab extends PureComponent<Props, State> {
             onSearch={this.handleFilterChange}
           />
           <div className="buckets-buttons-wrap">
-            <FeatureFlag name="demodata">
-              {demoDataBuckets.length > 0 && (
-                <DemoDataDropdown
-                  buckets={demoDataBuckets}
-                  getMembership={getDemoDataBucketMembership}
-                />
-              )}
-            </FeatureFlag>
+            {isFlagEnabled('demodata') && demoDataBuckets.length > 0 && (
+              <DemoDataDropdown
+                buckets={demoDataBuckets}
+                getMembership={getDemoDataBucketMembership}
+              />
+            )}
             <Button
               text="Create Bucket"
               icon={IconFont.Plus}

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {isEmpty} from 'lodash'
+import {isEmpty, get} from 'lodash'
 import {connect} from 'react-redux'
 
 // Components
@@ -36,6 +36,7 @@ import {
   checkBucketLimits as checkBucketLimitsAction,
   LimitStatus,
 } from 'src/cloud/actions/limits'
+import {getDemoDataBuckets} from 'src/cloud/actions/demodata'
 
 // Utils
 import {prettyBuckets} from 'src/shared/utils/prettyBucket'
@@ -59,6 +60,7 @@ interface StateProps {
   org: Organization
   buckets: Bucket[]
   limitStatus: LimitStatus
+  demoDataBuckets: Bucket[]
 }
 
 interface DispatchProps {
@@ -66,6 +68,7 @@ interface DispatchProps {
   updateBucket: typeof updateBucket
   deleteBucket: typeof deleteBucket
   checkBucketLimits: typeof checkBucketLimitsAction
+  getDemoDataBuckets: typeof getDemoDataBuckets
 }
 
 interface State {
@@ -98,10 +101,11 @@ class BucketsTab extends PureComponent<Props, State> {
 
   public componentDidMount() {
     this.props.checkBucketLimits()
+    this.props.getDemoDataBuckets()
   }
 
   public render() {
-    const {org, buckets, limitStatus} = this.props
+    const {org, buckets, limitStatus, demoDataBuckets} = this.props
     const {
       searchTerm,
       overlayState,
@@ -125,7 +129,9 @@ class BucketsTab extends PureComponent<Props, State> {
           />
           <div className="buckets-buttons-wrap">
             <FeatureFlag name="demodata">
-              <DemoDataDropdown />
+              {demoDataBuckets.length > 0 && (
+                <DemoDataDropdown buckets={demoDataBuckets} />
+              )}
             </FeatureFlag>
             <Button
               text="Create Bucket"
@@ -266,6 +272,7 @@ const mstp = (state: AppState): StateProps => ({
   org: getOrg(state),
   buckets: getAll<Bucket>(state, ResourceType.Buckets),
   limitStatus: extractBucketLimits(state.cloud.limits),
+  demoDataBuckets: get(state, 'cloud.demoData.buckets', []),
 })
 
 const mdtp = {
@@ -273,6 +280,7 @@ const mdtp = {
   updateBucket,
   deleteBucket,
   checkBucketLimits: checkBucketLimitsAction,
+  getDemoDataBuckets: getDemoDataBuckets,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -43,7 +43,7 @@ import {prettyBuckets} from 'src/shared/utils/prettyBucket'
 import {extractBucketLimits} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
+import {FeatureFlag, isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {PrettyBucket} from 'src/buckets/components/BucketCard'
@@ -101,7 +101,9 @@ class BucketsTab extends PureComponent<Props, State> {
 
   public componentDidMount() {
     this.props.checkBucketLimits()
-    this.props.getDemoDataBuckets()
+    if (isFlagEnabled('demodata')) {
+      this.props.getDemoDataBuckets()
+    }
   }
 
   public render() {

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -1,0 +1,46 @@
+// Libraries
+import React, {FC} from 'react'
+import _ from 'lodash'
+
+// Components
+import {Dropdown} from '@influxdata/clockface'
+
+// Types
+import {IconFont, ComponentColor} from '@influxdata/clockface'
+
+const DemoDataDropdown: FC = () => {
+  const demoDataItems = [
+    <Dropdown.Item
+      testID="dropdown-item demodata--1"
+      id={'1'}
+      key={'1'}
+      value={'1'}
+      onClick={v => console.log(v)}
+    >
+      {'DemoData1'}
+    </Dropdown.Item>,
+  ]
+
+  return (
+    <Dropdown
+      testID="dropdown--demodata"
+      style={{width: '160px', marginRight: '8px'}}
+      button={(active, onClick) => (
+        <Dropdown.Button
+          active={active}
+          onClick={onClick}
+          icon={IconFont.Plus}
+          color={ComponentColor.Secondary}
+          testID="dropdown-button--demodata"
+        >
+          Add Demo Data
+        </Dropdown.Button>
+      )}
+      menu={onCollapse => (
+        <Dropdown.Menu onCollapse={onCollapse}>{demoDataItems}</Dropdown.Menu>
+      )}
+    />
+  )
+}
+
+export default DemoDataDropdown

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -4,22 +4,27 @@ import _ from 'lodash'
 
 // Components
 import {Dropdown} from '@influxdata/clockface'
-
-// Types
 import {IconFont, ComponentColor} from '@influxdata/clockface'
 
-const DemoDataDropdown: FC = () => {
-  const demoDataItems = [
+// Types
+import {Bucket} from 'src/types'
+
+interface Props {
+  buckets: Bucket[]
+}
+
+const DemoDataDropdown: FC<Props> = ({buckets}) => {
+  const demoDataItems = buckets.map(b => (
     <Dropdown.Item
       testID="dropdown-item demodata--1"
-      id={'1'}
-      key={'1'}
-      value={'1'}
+      id={b.name}
+      key={b.name}
+      value={b.name}
       onClick={v => console.log(v)}
     >
-      {'DemoData1'}
-    </Dropdown.Item>,
-  ]
+      {b.name}
+    </Dropdown.Item>
+  ))
 
   return (
     <Dropdown

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -7,19 +7,21 @@ import {IconFont, ComponentColor, Dropdown} from '@influxdata/clockface'
 
 // Types
 import {Bucket} from 'src/types'
+import {getDemoDataBucketMembership as getDemoDataBucketMembershipAction} from 'src/cloud/actions/demodata'
 
 interface Props {
   buckets: Bucket[]
+  getMembership: typeof getDemoDataBucketMembershipAction
 }
 
-const DemoDataDropdown: FC<Props> = ({buckets}) => {
+const DemoDataDropdown: FC<Props> = ({buckets, getMembership}) => {
   const demoDataItems = buckets.map(b => (
     <Dropdown.Item
-      testID="dropdown-item demodata--1"
-      id={b.name}
-      key={b.name}
-      value={b.name}
-      onClick={v => console.log(v)}
+      testID={`dropdown-item ${b.name}`}
+      id={b.id}
+      key={b.id}
+      value={b.id}
+      onClick={getMembership}
     >
       {b.name}
     </Dropdown.Item>

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -3,8 +3,7 @@ import React, {FC} from 'react'
 import _ from 'lodash'
 
 // Components
-import {Dropdown} from '@influxdata/clockface'
-import {IconFont, ComponentColor} from '@influxdata/clockface'
+import {IconFont, ComponentColor, Dropdown} from '@influxdata/clockface'
 
 // Types
 import {Bucket} from 'src/types'

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -17,7 +17,7 @@ interface Props {
 const DemoDataDropdown: FC<Props> = ({buckets, getMembership}) => {
   const demoDataItems = buckets.map(b => (
     <Dropdown.Item
-      testID={`dropdown-item ${b.name}`}
+      testID={`dropdown-item--demodata-${b.name}`}
       id={b.id}
       key={b.id}
       value={b.id}

--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -1,5 +1,7 @@
 // API
-import {getDemoDataBuckets as getDemoDataBucketsAJAX} from 'src/cloud/apis/demodata'
+import {
+  getDemoDataBuckets as getDemoDataBucketsAJAX,
+} from 'src/cloud/apis/demodata'
 
 // Types
 import {Bucket, RemoteDataState, GetState} from 'src/types'
@@ -32,10 +34,7 @@ export const getDemoDataBuckets = () => async (
   }
   try {
     const buckets = await getDemoDataBucketsAJAX()
-    if (!Array.isArray(buckets)) {
-      dispatch(setDemoDataStatus(RemoteDataState.Error))
-      return
-    }
+
     dispatch(setDemoDataStatus(RemoteDataState.Done))
     dispatch(setDemoDataBuckets(buckets))
   } catch (error) {

--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -1,0 +1,45 @@
+// API
+import {getDemoDataBuckets as getDemoDataBucketsAJAX} from 'src/cloud/apis/demodata'
+
+// Types
+import {Bucket, RemoteDataState, GetState} from 'src/types'
+
+export type Actions =
+  | ReturnType<typeof setDemoDataStatus>
+  | ReturnType<typeof setDemoDataBuckets>
+
+export const setDemoDataStatus = (status: RemoteDataState) => ({
+  type: 'SET_DEMODATA_STATUS' as 'SET_DEMODATA_STATUS',
+  payload: {status},
+})
+
+export const setDemoDataBuckets = (buckets: Bucket[]) => ({
+  type: 'SET_DEMODATA_BUCKETS' as 'SET_DEMODATA_BUCKETS',
+  payload: {buckets},
+})
+
+export const getDemoDataBuckets = () => async (
+  dispatch,
+  getState: GetState
+) => {
+  const {
+    cloud: {
+      demoData: {status},
+    },
+  } = getState()
+  if (status === RemoteDataState.NotStarted) {
+    dispatch(setDemoDataStatus(RemoteDataState.Loading))
+  }
+  try {
+    const buckets = await getDemoDataBucketsAJAX()
+    if (!Array.isArray(buckets)) {
+      dispatch(setDemoDataStatus(RemoteDataState.Error))
+      return
+    }
+    dispatch(setDemoDataStatus(RemoteDataState.Done))
+    dispatch(setDemoDataBuckets(buckets))
+  } catch (error) {
+    console.error(error)
+    dispatch(setDemoDataStatus(RemoteDataState.Error))
+  }
+}

--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -1,10 +1,13 @@
 // API
 import {
   getDemoDataBuckets as getDemoDataBucketsAJAX,
+  getDemoDataBucketMembership as getDemoDataBucketMembershipAJAX,
+  deleteDemoDataBucketMembership as deleteDemoDataBucketMembershipAJAX,
 } from 'src/cloud/apis/demodata'
 
 // Types
 import {Bucket, RemoteDataState, GetState} from 'src/types'
+import {getBuckets} from 'src/buckets/actions/thunks'
 
 export type Actions =
   | ReturnType<typeof setDemoDataStatus>
@@ -40,5 +43,43 @@ export const getDemoDataBuckets = () => async (
   } catch (error) {
     console.error(error)
     dispatch(setDemoDataStatus(RemoteDataState.Error))
+  }
+}
+
+export const getDemoDataBucketMembership = (bucketID: string) => async (
+  dispatch,
+  getState: GetState
+) => {
+  const {
+    me: {id: userID},
+  } = getState()
+
+  try {
+    await getDemoDataBucketMembershipAJAX(bucketID, userID)
+
+    dispatch(getBuckets())
+    // TODO: check for success and error appropriately
+    // TODO: instantiate dashboard template
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const deleteDemoDataBucketMembership = (bucketID: string) => async (
+  dispatch,
+  getState: GetState
+) => {
+  const {
+    me: {id: userID},
+  } = getState()
+
+  try {
+    await deleteDemoDataBucketMembershipAJAX(bucketID, userID)
+    dispatch(getBuckets())
+
+    // TODO: check for success and error appropriately
+    // TODO: delete associated dashboard
+  } catch (error) {
+    console.error(error)
   }
 }

--- a/ui/src/cloud/apis/demodata.ts
+++ b/ui/src/cloud/apis/demodata.ts
@@ -18,9 +18,7 @@ export const getDemoDataBuckets = async (): Promise<Bucket[]> => {
       throw new Error('Could not reach demodata endpoint')
     }
 
-    return buckets
-      .filter(b => b.type == 'user') // remove returned _tasks and _monitoring buckets
-      .map(b => ({...b, type: 'system'})) as Bucket[] // treat sampledata buckets as system buckets
+    return buckets.filter(b => b.type == 'user') as Bucket[] // remove returned _tasks and _monitoring buckets
   } catch (error) {
     console.error(error)
     throw error

--- a/ui/src/cloud/apis/demodata.ts
+++ b/ui/src/cloud/apis/demodata.ts
@@ -1,13 +1,67 @@
 import AJAX from 'src/utils/ajax'
+import {get} from 'lodash'
+import {Bucket} from 'src/types'
 
-export const getDemoDataBuckets = async () => {
+const baseURL = '/api/v2/experimental/sampledata'
+
+export const getDemoDataBuckets = async (): Promise<Bucket[]> => {
   try {
     const {data} = await AJAX({
       method: 'GET',
-      url: `/api/v2/experimental/sampledata/buckets`,
+      url: `${baseURL}/buckets`,
     })
-    // filter out the 'system buckets'
-    return data
+
+    // if sampledata endpoints are not available in a cluster
+    // gateway responds with a list of links where 'buckets' field is a string
+    const buckets = get(data, 'buckets', false)
+    if (!buckets || !Array.isArray(buckets)) {
+      throw new Error('Could not reach demodata endpoint')
+    }
+
+    return buckets
+      .filter(b => b.type == 'user') // remove returned _tasks and _monitoring buckets
+      .map(b => ({...b, type: 'system'})) as Bucket[] // treat sampledata buckets as system buckets
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+export const getDemoDataBucketMembership = async (
+  bucketID: string,
+  userID: string
+) => {
+  try {
+    const response = await AJAX({
+      method: 'POST',
+      url: `${baseURL}/buckets/${bucketID}/members`,
+      data: {userID},
+    })
+
+    if (response.status === '200') {
+      // a failed or successful membership POST to sampledata should return 204
+      throw new Error('Could not reach demodata endpoint')
+    }
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+export const deleteDemoDataBucketMembership = async (
+  bucketID: string,
+  userID: string
+) => {
+  try {
+    const response = await AJAX({
+      method: 'DELETE',
+      url: `${baseURL}/buckets/${bucketID}/members/${userID}`,
+    })
+
+    if (response.status === '200') {
+      // a failed or successful membership DELETE to sampledata should return 204
+      throw new Error('Could not reach demodata endpoint')
+    }
   } catch (error) {
     console.error(error)
     throw error

--- a/ui/src/cloud/apis/demodata.ts
+++ b/ui/src/cloud/apis/demodata.ts
@@ -1,0 +1,15 @@
+import AJAX from 'src/utils/ajax'
+
+export const getDemoDataBuckets = async () => {
+  try {
+    const {data} = await AJAX({
+      method: 'GET',
+      url: `/api/v2/experimental/sampledata/buckets`,
+    })
+    // filter out the 'system buckets'
+    return data
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/ui/src/cloud/apis/demodata.ts
+++ b/ui/src/cloud/apis/demodata.ts
@@ -23,7 +23,7 @@ export const getDemoDataBuckets = async (): Promise<Bucket[]> => {
     // if sampledata endpoints are not available in a cluster
     // gateway responds with a list of links where 'buckets' field is a string
     const buckets = get(data, 'buckets', false)
-    if (!buckets || !Array.isArray(buckets)) {
+    if (!Array.isArray(buckets)) {
       throw new Error('Could not reach demodata endpoint')
     }
 

--- a/ui/src/cloud/reducers/demodata.ts
+++ b/ui/src/cloud/reducers/demodata.ts
@@ -1,0 +1,35 @@
+//Types
+import {Actions} from 'src/cloud/actions/demodata'
+import {RemoteDataState, Bucket} from 'src/types'
+
+export interface DemoDataState {
+  buckets: Bucket[]
+  status: RemoteDataState
+}
+
+export const defaultState: DemoDataState = {
+  buckets: [],
+  status: RemoteDataState.NotStarted,
+}
+
+export const demoDataReducer = (
+  state = defaultState,
+  action: Actions
+): DemoDataState => {
+  switch (action.type) {
+    case 'SET_DEMODATA_STATUS': {
+      return {...state, status: action.payload.status}
+    }
+    case 'SET_DEMODATA_BUCKETS': {
+      return {
+        ...state,
+        status: RemoteDataState.Done,
+        buckets: action.payload.buckets,
+      }
+    }
+    default:
+      return state
+  }
+}
+
+export default demoDataReducer

--- a/ui/src/cloud/utils/filterDemoData.ts
+++ b/ui/src/cloud/utils/filterDemoData.ts
@@ -1,0 +1,9 @@
+const DemoDataBucketNames = ['Website Monitoring Bucket']
+
+export const isDemoData = (bucket): boolean => {
+  if (DemoDataBucketNames.includes(bucket.name)) {
+    //bucket is demo data bucket
+    return true
+  }
+  return false
+}

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -9,6 +9,7 @@ export const OSS_FLAGS = {
   matchingNotificationRules: false,
   regionBasedLoginPage: false,
   treeNav: false,
+  demodata: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -21,6 +22,7 @@ export const CLOUD_FLAGS = {
   matchingNotificationRules: false,
   regionBasedLoginPage: false,
   treeNav: false,
+  demodata: false,
 }
 
 export const isFlagEnabled = (flagName: string, equals?: string | boolean) => {

--- a/ui/src/store/configureStore.ts
+++ b/ui/src/store/configureStore.ts
@@ -35,6 +35,7 @@ import {userSettingsReducer} from 'src/userSettings/reducers'
 import {membersReducer} from 'src/members/reducers'
 import {autoRefreshReducer} from 'src/shared/reducers/autoRefresh'
 import {limitsReducer, LimitsState} from 'src/cloud/reducers/limits'
+import {demoDataReducer, DemoDataState} from 'src/cloud/reducers/demodata'
 import checksReducer from 'src/checks/reducers'
 import rulesReducer from 'src/notifications/rules/reducers'
 import endpointsReducer from 'src/notifications/endpoints/reducers'
@@ -56,7 +57,10 @@ export const rootReducer = combineReducers<ReducerState>({
   ...sharedReducers,
   autoRefresh: autoRefreshReducer,
   alertBuilder: alertBuilderReducer,
-  cloud: combineReducers<{limits: LimitsState}>({limits: limitsReducer}),
+  cloud: combineReducers<{limits: LimitsState; demoData: DemoDataState}>({
+    limits: limitsReducer,
+    demoData: demoDataReducer,
+  }),
   currentPage: currentPageReducer,
   currentDashboard: currentDashboardReducer,
   dataLoading: dataLoadingReducer,

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -161,7 +161,7 @@ export const loadBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
-    let demoDataBuckets = await getDemoDataBucketsFromAll()
+    const demoDataBuckets = await getDemoDataBucketsFromAll()
 
     const allBuckets = [...resp.data.buckets, ...demoDataBuckets].map(
       b => b.name

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -31,6 +31,7 @@ import {getAll} from 'src/resources/selectors'
 
 // Constants
 import {LIMIT} from 'src/resources/constants'
+import {getDemoDataBucketsFromAll} from 'src/cloud/apis/demodata'
 
 export type Action =
   | ReturnType<typeof setBuilderAggregateFunctionType>
@@ -160,7 +161,11 @@ export const loadBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
-    const allBuckets = resp.data.buckets.map(b => b.name)
+    let demoDataBuckets = await getDemoDataBucketsFromAll()
+
+    const allBuckets = [...resp.data.buckets, ...demoDataBuckets].map(
+      b => b.name
+    )
 
     const systemBuckets = allBuckets.filter(b => b.startsWith('_'))
     const userBuckets = allBuckets.filter(b => !b.startsWith('_'))

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -23,6 +23,7 @@ import {AutoRefreshState} from 'src/shared/reducers/autoRefresh'
 import {LimitsState} from 'src/cloud/reducers/limits'
 import {AlertBuilderState} from 'src/alerting/reducers/alertBuilder'
 import {CurrentPage} from 'src/shared/reducers/currentPage'
+import {DemoDataState} from 'src/cloud/reducers/demodata'
 
 import {ResourceState} from 'src/types'
 
@@ -30,7 +31,7 @@ export interface AppState {
   alertBuilder: AlertBuilderState
   app: AppPresentationState
   autoRefresh: AutoRefreshState
-  cloud: {limits: LimitsState}
+  cloud: {limits: LimitsState; demoData: DemoDataState}
   currentPage: CurrentPage
   currentDashboard: CurrentDashboardState
   dataLoading: DataLoadingState


### PR DESCRIPTION
Partially Closes #6097

Query sampledata `/buckets` endpoint to get available demodata buckets for `Add demo data` dropdown
Request membership to a demodata bucket on click to demodata bucket dropdown item.
Query for demodata buckets user is member to on fetch buckets. 
All behind feature flag

![Screen Shot 2020-03-26 at 4 01 36 PM](https://user-images.githubusercontent.com/10937678/77704806-2b84b780-6f7b-11ea-9853-df7039c23928.png)

![Screen Shot 2020-03-26 at 4 01 52 PM](https://user-images.githubusercontent.com/10937678/77704811-317a9880-6f7b-11ea-9e58-e805eb139fb5.png)



