### PR TITLE
fix: add missing flag register to org cmd for json out and hide header flags

### DIFF
--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -322,6 +322,7 @@ func (b *cmdOrgBuilder) cmdMemberList() *cobra.Command {
 		},
 	}
 	opts.mustRegister(cmd)
+	b.registerPrintFlags(cmd)
 	return cmd
 }
 


### PR DESCRIPTION
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass