### PR TITLE
fix: v2.0.0 needs a /v2 on the go.mod module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/influxdb
+module github.com/influxdata/influxdb/v2
 
 go 1.13
 


### PR DESCRIPTION
Version 2.x requires a /v2 at the end of the module in go.mod.

When trying to import
```github.com/influxdata/influxdb/v2 v2.0.0-beta.7```
The error message
```go: github.com/influxdata/influxdb/v2@v2.0.0-beta.7: go.mod has non-.../v2 module path "github.com/influxdata/influxdb" (and .../v2/go.mod does not exist) at revision v2.0.0-beta.7```
is received.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
