### PR TITLE
feat(sampledata): Request buckets with demodata orgID

### DIFF
--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -35,6 +35,7 @@ import {
 } from 'src/buckets/actions/creators'
 import {notify, Action as NotifyAction} from 'src/shared/actions/notifications'
 import {checkBucketLimits} from 'src/cloud/actions/limits'
+import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
 
 // Constants
 import {
@@ -49,7 +50,6 @@ import {
   removeBucketLabelFailed,
 } from 'src/shared/copy/notifications'
 import {LIMIT} from 'src/resources/constants'
-import {getDemoDataBucketsFromAll} from 'src/cloud/apis/demodata'
 
 type Action = BucketAction | NotifyAction
 
@@ -72,7 +72,7 @@ export const getBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
-    const demoDataBuckets = await getDemoDataBucketsFromAll()
+    const demoDataBuckets = await fetchDemoDataBuckets()
 
     const buckets = normalize<Bucket, BucketEntities, string[]>(
       [...resp.data.buckets, ...demoDataBuckets],

--- a/ui/src/cloud/apis/demodata.ts
+++ b/ui/src/cloud/apis/demodata.ts
@@ -5,7 +5,6 @@ import AJAX from 'src/utils/ajax'
 
 //Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {isDemoData} from 'src/cloud/utils/filterDemoData'
 
 //Types
 import {Bucket} from 'src/types'
@@ -75,17 +74,30 @@ export const deleteDemoDataBucketMembership = async (
   }
 }
 
-export const getDemoDataBucketsFromAll = async (): Promise<Bucket[]> => {
+export const fetchDemoDataBuckets = async (): Promise<Bucket[]> => {
   if (!isFlagEnabled('demodata')) return []
   try {
-    const resp = await api.getBuckets({query: {limit: LIMIT}})
+    // FindBuckets paginates before filtering for authed buckets until #6591 is resolved,
+    // so UI needs to make getBuckets request with demodata orgID parameter
+    const buckets = await getDemoDataBuckets()
+    const demodataOrgID = get(buckets, '[0].orgID')
+    if (!demodataOrgID) {
+      throw new Error('Could not get demodata orgID')
+    }
+
+    const resp = await api.getBuckets({
+      query: {orgID: demodataOrgID, limit: LIMIT},
+    })
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
-    return resp.data.buckets
-      .filter(isDemoData)
-      .map(b => ({...b, type: 'system' as 'system', labels: []}))
+
+    return resp.data.buckets.map(b => ({
+      ...b,
+      type: 'system' as 'system',
+      labels: [],
+    }))
   } catch (error) {
     console.error(error)
     // demodata bucket fetching errors should not effect regular bucket fetching

--- a/ui/src/cloud/utils/filterDemoData.ts
+++ b/ui/src/cloud/utils/filterDemoData.ts
@@ -1,9 +1,0 @@
-const DemoDataBucketNames = ['Website Monitoring Bucket']
-
-export const isDemoData = (bucket): boolean => {
-  if (DemoDataBucketNames.includes(bucket.name)) {
-    //bucket is demo data bucket
-    return true
-  }
-  return false
-}

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -2,6 +2,7 @@
 import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import * as api from 'src/client'
 import {get} from 'lodash'
+import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
 
 // Utils
 import {
@@ -31,7 +32,6 @@ import {getAll} from 'src/resources/selectors'
 
 // Constants
 import {LIMIT} from 'src/resources/constants'
-import {getDemoDataBucketsFromAll} from 'src/cloud/apis/demodata'
 
 export type Action =
   | ReturnType<typeof setBuilderAggregateFunctionType>
@@ -161,7 +161,7 @@ export const loadBuckets = () => async (
       throw new Error(resp.data.message)
     }
 
-    const demoDataBuckets = await getDemoDataBucketsFromAll()
+    const demoDataBuckets = await fetchDemoDataBuckets()
 
     const allBuckets = [...resp.data.buckets, ...demoDataBuckets].map(
       b => b.name


### PR DESCRIPTION
As per 6591, 
FindBuckets filters by orgID, limits the number of responses, and then filters by authorization. 
So if there is no filtering by orgID query parameter the limit may not return enough buckets to find one that user is authorized to read. 

In this PR we query demodata buckets, and peel off the orgID parameter if it exists, from the first returned bucket and supply the demodata orgID as a query parameter to the second getBuckets request to fetch demodata buckets user is authorized to read. 