### PR TITLE
feat(pkger): extend DiffBucket with name for existing and new bucket values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/nats-io/nats-streaming-server v0.11.2
 	github.com/nats-io/nkeys v0.0.2 // indirect
 	github.com/nats-io/nuid v1.0.0 // indirect
-	github.com/olekukonko/tablewriter v0.0.1
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,8 @@ github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=
@@ -351,8 +353,8 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nuid v1.0.0 h1:44QGdhbiANq8ZCbUkdn6W5bqtg+mHuDE4wOUuxxndFs=
 github.com/nats-io/nuid v1.0.0/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
-github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7504,11 +7504,13 @@ components:
                 properties:
                   id:
                     type: string
-                  name:
+                  pkgName:
                     type: string
                   new:
                     type: object
                     properties:
+                      name:
+                        type: string
                       description:
                         type: string
                       retentionRules:
@@ -7516,6 +7518,8 @@ components:
                   old:
                     type: object
                     properties:
+                      name:
+                        type: string
                       description:
                         type: string
                       retentionRules:

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -157,7 +157,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 							var diff pkger.Diff
 							for _, b := range sum.Buckets {
 								diff.Buckets = append(diff.Buckets, pkger.DiffBucket{
-									Name: b.Name,
+									PkgName: b.Name,
 								})
 							}
 							return sum, diff, nil
@@ -211,7 +211,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 							var diff pkger.Diff
 							for _, b := range sum.Buckets {
 								diff.Buckets = append(diff.Buckets, pkger.DiffBucket{
-									Name: b.Name,
+									PkgName: b.Name,
 								})
 							}
 							return sum, diff, nil
@@ -313,7 +313,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 							var diff pkger.Diff
 							for _, b := range sum.Buckets {
 								diff.Buckets = append(diff.Buckets, pkger.DiffBucket{
-									Name: b.Name,
+									PkgName: b.Name,
 								})
 							}
 							return sum, diff, nil
@@ -353,7 +353,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 				var diff pkger.Diff
 				for _, b := range sum.Buckets {
 					diff.Buckets = append(diff.Buckets, pkger.DiffBucket{
-						Name: b.Name,
+						PkgName: b.Name,
 					})
 				}
 				return sum, diff, nil

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -136,7 +136,7 @@ func TestPkg(t *testing.T) {
 				{
 					name: "new bucket",
 					resource: DiffBucket{
-						Name: "new bucket",
+						PkgName: "new bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 						},
@@ -146,8 +146,8 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing bucket with no changes",
 					resource: DiffBucket{
-						ID:   3,
-						Name: "new bucket",
+						ID:      3,
+						PkgName: "new bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 							RetentionRules: retentionRules{{
@@ -168,8 +168,8 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing bucket with desc changes",
 					resource: DiffBucket{
-						ID:   3,
-						Name: "existing bucket",
+						ID:      3,
+						PkgName: "existing bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 							RetentionRules: retentionRules{{
@@ -190,8 +190,8 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing bucket with retention changes",
 					resource: DiffBucket{
-						ID:   3,
-						Name: "existing bucket",
+						ID:      3,
+						PkgName: "existing bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 							RetentionRules: retentionRules{{
@@ -208,8 +208,8 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing bucket with retention changes",
 					resource: DiffBucket{
-						ID:   3,
-						Name: "existing bucket",
+						ID:      3,
+						PkgName: "existing bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 							RetentionRules: retentionRules{{
@@ -230,8 +230,8 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing bucket with retention changes",
 					resource: DiffBucket{
-						ID:   3,
-						Name: "existing bucket",
+						ID:      3,
+						PkgName: "existing bucket",
 						New: DiffBucketValues{
 							Description: "new desc",
 							RetentionRules: retentionRules{{

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -725,7 +725,7 @@ func (s *Service) dryRunBuckets(ctx context.Context, orgID influxdb.ID, pkg *Pkg
 		diffs = append(diffs, diff)
 	}
 	sort.Slice(diffs, func(i, j int) bool {
-		return diffs[i].Name < diffs[j].Name
+		return diffs[i].PkgName < diffs[j].PkgName
 	})
 
 	return diffs

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -83,13 +83,15 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Buckets, 2)
 
 					expected := DiffBucket{
-						ID:   SafeID(1),
-						Name: "rucket_11",
+						ID:      SafeID(1),
+						PkgName: "rucket_11",
 						Old: &DiffBucketValues{
+							Name:           "rucket_11",
 							Description:    "old desc",
 							RetentionRules: retentionRules{newRetentionRule(30 * time.Hour)},
 						},
 						New: DiffBucketValues{
+							Name:           "rucket_11",
 							Description:    "bucket 1 description",
 							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 						},
@@ -112,8 +114,9 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Buckets, 2)
 
 					expected := DiffBucket{
-						Name: "rucket_11",
+						PkgName: "rucket_11",
 						New: DiffBucketValues{
+							Name:           "rucket_11",
 							Description:    "bucket 1 description",
 							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 						},


### PR DESCRIPTION
provides mapping between pkgName and resource the diff represents. Now that
stacks are in place, the existing bucket may change names.

references: #17434 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)

example of the CLI updates. We have new an addiotional state that resources can be in (Removed) this new CLI design addresses:

![image](https://user-images.githubusercontent.com/17263167/78069316-bdf7d300-734e-11ea-8e38-750959287c2e.png)

