### PR TITLE
fix(tsdb): Revert "fix: remove some unsafe marshalling to reduce risk of segfault"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ v1.8.0 [unreleased]
 -	[#16762](https://github.com/influxdata/influxdb/pull/16762): Fix bugs in -compact-series-file.
 -	[#16944](https://github.com/influxdata/influxdb/pull/16944): Update to Go 1.13.8 and Go modules.
 -	[#17032](https://github.com/influxdata/influxdb/pull/17032): Fix a SIGSEGV when accessing tsi active log.
--	[#17204](https://github.com/influxdata/influxdb/pull/17204): Remove unsafe marshalling.
 
 v1.7.0 [unreleased]
 -------------------

--- a/cmd/influxd/backup_util/backup_util.go
+++ b/cmd/influxd/backup_util/backup_util.go
@@ -6,15 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	internal "github.com/influxdata/influxdb/cmd/influxd/backup_util/internal"
 	"github.com/influxdata/influxdb/services/snapshotter"
+	"io/ioutil"
+	"path/filepath"
 )
 
 //go:generate protoc --gogo_out=. internal/data.proto

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -1,18 +1,19 @@
 package tests
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
+
+	"fmt"
 
 	"github.com/influxdata/influxdb/cmd/influxd/backup"
 	"github.com/influxdata/influxdb/cmd/influxd/restore"
 	"github.com/influxdata/influxdb/toml"
+	"strings"
 )
 
 func TestServer_BackupAndRestore(t *testing.T) {

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -229,7 +229,7 @@ func (f *IndexFile) SeriesIDSet() (*tsdb.SeriesIDSet, error) {
 
 func (f *IndexFile) TombstoneSeriesIDSet() (*tsdb.SeriesIDSet, error) {
 	ss := tsdb.NewSeriesIDSet()
-	if err := ss.UnmarshalBinary(f.tombstoneSeriesIDSetData); err != nil {
+	if err := ss.UnmarshalBinaryUnsafe(f.tombstoneSeriesIDSetData); err != nil {
 		return nil, err
 	}
 	return ss, nil

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -464,7 +464,7 @@ func (e *MeasurementBlockElem) UnmarshalBinary(data []byte) error {
 	} else {
 		// data = memalign(data)
 		e.seriesIDSet = tsdb.NewSeriesIDSet()
-		if err = e.seriesIDSet.UnmarshalBinary(data[:sz]); err != nil {
+		if err = e.seriesIDSet.UnmarshalBinaryUnsafe(data[:sz]); err != nil {
 			return err
 		}
 		data = data[sz:]

--- a/tsdb/index/tsi1/tag_block.go
+++ b/tsdb/index/tsi1/tag_block.go
@@ -377,7 +377,7 @@ func (e *TagBlockValueElem) SeriesIDSet() (*tsdb.SeriesIDSet, error) {
 
 	// Read bitmap data directly from mmap, if available.
 	if e.seriesIDSetData != nil {
-		if err := ss.UnmarshalBinary(e.seriesIDSetData); err != nil {
+		if err := ss.UnmarshalBinaryUnsafe(e.seriesIDSetData); err != nil {
 			return nil, err
 		}
 		return ss, nil

--- a/tsdb/series_set_test.go
+++ b/tsdb/series_set_test.go
@@ -406,7 +406,7 @@ func BenchmarkSeriesIDSet_Clone(b *testing.B) {
 			ssResult = init()
 			for i := 0; i < b.N; i++ {
 				other.WriteTo(&buf)
-				ssResult.UnmarshalBinary(buf.Bytes())
+				ssResult.UnmarshalBinaryUnsafe(buf.Bytes())
 				b.StopTimer()
 				ssResult = init()
 				buf.Reset()


### PR DESCRIPTION
This reverts commit 30dab0331033af22472df89852247b72e4074e32.

This is to test whether this commit causes a doubling of heap memory.