### PR TITLE
fix: editing a table cell shows the proper values and respects changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [17391](https://github.com/influxdata/influxdb/pull/17391): Fixed threshold check bug where checks could not be created when a field had a space in the name
 1. [17384](https://github.com/influxdata/influxdb/pull/17384): Reuse slices built by iterator to reduce allocations
 1. [17404](https://github.com/influxdata/influxdb/pull/17404): Updated duplicate check error message to be more explicit and actionable
+1. [17515](https://github.com/influxdata/influxdb/pull/17515): Editing a table cell shows the proper values and respects changes
 
 ### UI Improvements
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -173,7 +173,7 @@ export const executeQueries = (dashboardID?: string) => async (
     // https://github.com/influxdata/idpe/issues/6240
     const variableAssignments = getVariableAssignments(getState())
 
-    const startTime = Date.now()
+    const startTime = window.performance.now()
 
     pendingResults.forEach(({cancel}) => cancel())
 
@@ -186,7 +186,7 @@ export const executeQueries = (dashboardID?: string) => async (
     })
 
     const results = await Promise.all(pendingResults.map(r => r.promise))
-    const duration = Date.now() - startTime
+    const duration = window.performance.now() - startTime
 
     let statuses = [[]] as StatusRow[][]
     if (checkID) {

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -281,7 +281,7 @@ export const timeMachineReducer = (
         draftState.queryResults.status = status
         draftState.queryResults.errorMessage = errorMessage
 
-        if (files) {
+        if (files && files.length) {
           if (
             state.view &&
             state.view.properties &&


### PR DESCRIPTION
Closes #17364

Due to a confusing `falsy` check in a reducer, editing a dashboard cell showed the defaults or the query results for any changed properties. This fixes that.

### Steps to Reproduce
1. Create a dashboard cell that is a `table` visualization
1. Add custom names to the columns in the `Customize` section
1. Save the cell
1. Observe the correct cell name in dashboard
1. Edit the cell again
1. Observe the incorrect cell names in the overlay

This fix changes it so that the final step shows the correct value.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass