### PR TITLE
fix: filter out empty nodes on the ast

### DIFF
--- a/ui/src/external/monaco.flux.server.ts
+++ b/ui/src/external/monaco.flux.server.ts
@@ -202,7 +202,7 @@ export class LSPServer {
     // drift between the parser and the internal representation
     const variables = getAllVariables(state, contextID)
       .map(v => asAssignment(v))
-      .filter(v => !!v.init.value)
+      .filter(v => !(v.init.type === 'StringLiteral' && !v.init.value))
 
     const file = buildVarsOption(variables)
 

--- a/ui/src/external/monaco.flux.server.ts
+++ b/ui/src/external/monaco.flux.server.ts
@@ -202,7 +202,8 @@ export class LSPServer {
     // drift between the parser and the internal representation
     const variables = getAllVariables(state, contextID).map(v =>
       asAssignment(v)
-    )
+    ).filter(v => !!v.init.value)
+
     const file = buildVarsOption(variables)
 
     const parts = uri.split('/')

--- a/ui/src/external/monaco.flux.server.ts
+++ b/ui/src/external/monaco.flux.server.ts
@@ -200,9 +200,9 @@ export class LSPServer {
 
     // NOTE: we use the AST intermediate format as a means of reducing
     // drift between the parser and the internal representation
-    const variables = getAllVariables(state, contextID).map(v =>
-      asAssignment(v)
-    ).filter(v => !!v.init.value)
+    const variables = getAllVariables(state, contextID)
+      .map(v => asAssignment(v))
+      .filter(v => !!v.init.value)
 
     const file = buildVarsOption(variables)
 

--- a/ui/src/timeMachine/components/variableToolbar/VariableItem.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableItem.tsx
@@ -47,6 +47,14 @@ function shouldShowTooltip(variable: Variable): boolean {
     return false
   }
 
+  if (
+    variable.arguments.type === 'query' &&
+    (!(variable.arguments.values as any).results ||
+      (variable.arguments.values as any).results.length <= 1)
+  ) {
+    return false
+  }
+
   return true
 }
 


### PR DESCRIPTION
the lsp breaks with a malformed ast, and an empty value is a malformed ast.