### PR TITLE
feat(kv): add support for WithCursorLimit to ForwardCursor

### DIFF
--- a/kv/store.go
+++ b/kv/store.go
@@ -172,6 +172,7 @@ type CursorConfig struct {
 	Hints     CursorHints
 	Prefix    []byte
 	SkipFirst bool
+	Limit     *int
 }
 
 // NewCursorConfig constructs and configures a CursorConfig used to configure
@@ -220,6 +221,14 @@ func WithCursorPrefix(prefix []byte) CursorOption {
 func WithCursorSkipFirstItem() CursorOption {
 	return func(c *CursorConfig) {
 		c.SkipFirst = true
+	}
+}
+
+// WithCursorLimit restricts the number of key values return by the cursor
+// to the provided limit count.
+func WithCursorLimit(limit int) CursorOption {
+	return func(c *CursorConfig) {
+		c.Limit = &limit
 	}
 }
 

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -839,6 +839,23 @@ func KVForwardCursor(
 			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03", "bbb/00"},
 		},
 		{
+			name: "limit",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek: "aaa",
+				opts: []kv.CursorOption{
+					kv.WithCursorLimit(4),
+				},
+			},
+			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03"},
+		},
+		{
 			name: "prefix - no hints",
 			fields: KVStoreFields{
 				Bucket: []byte("bucket"),
@@ -855,6 +872,26 @@ func KVForwardCursor(
 				},
 			},
 			exp: []string{"aaa/00", "aaa/01", "aaa/02", "aaa/03"},
+		},
+
+		{
+			name: "prefix with limit",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa/00",
+				until: "bbb/02",
+				opts: []kv.CursorOption{
+					kv.WithCursorPrefix([]byte("aaa")),
+					kv.WithCursorLimit(2),
+				},
+			},
+			exp: []string{"aaa/00", "aaa/01"},
 		},
 		{
 			name: "prefix - skip first",
@@ -874,6 +911,26 @@ func KVForwardCursor(
 				},
 			},
 			exp: []string{"aaa/01", "aaa/02", "aaa/03"},
+		},
+		{
+			name: "prefix - skip first with limit",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa/00",
+				until: "bbb/02",
+				opts: []kv.CursorOption{
+					kv.WithCursorPrefix([]byte("aaa")),
+					kv.WithCursorSkipFirstItem(),
+					kv.WithCursorLimit(2),
+				},
+			},
+			exp: []string{"aaa/01", "aaa/02"},
 		},
 		{
 			name: "prefix - skip first (one item)",
@@ -1003,6 +1060,25 @@ func KVForwardCursor(
 			exp: []string{"bbb/00", "aaa/03", "aaa/02", "aaa/01", "aaa/00"},
 		},
 		{
+			name: "no hints - descending - with limit",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "bbb/00",
+				until: "aaa/00",
+				opts: []kv.CursorOption{
+					kv.WithCursorDirection(kv.CursorDescending),
+					kv.WithCursorLimit(3),
+				},
+			},
+			exp: []string{"bbb/00", "aaa/03", "aaa/02"},
+		},
+		{
 			name: "prefixed - no hints - descending",
 			fields: KVStoreFields{
 				Bucket: []byte("bucket"),
@@ -1020,6 +1096,26 @@ func KVForwardCursor(
 				},
 			},
 			exp: []string{"aaa/02", "aaa/01", "aaa/00"},
+		},
+		{
+			name: "prefixed - no hints - descending - with limit",
+			fields: KVStoreFields{
+				Bucket: []byte("bucket"),
+				Pairs: pairs(
+					"aa/00", "aa/01",
+					"aaa/00", "aaa/01", "aaa/02", "aaa/03",
+					"bbb/00", "bbb/01", "bbb/02"),
+			},
+			args: args{
+				seek:  "aaa/02",
+				until: "aa/",
+				opts: []kv.CursorOption{
+					kv.WithCursorPrefix([]byte("aaa/")),
+					kv.WithCursorDirection(kv.CursorDescending),
+					kv.WithCursorLimit(2),
+				},
+			},
+			exp: []string{"aaa/02", "aaa/01"},
 		},
 		{
 			name: "start hint - descending",


### PR DESCRIPTION
This introduces the ability to push down a limit for the number of keys returned for a ForwardCursor via the `WithCursorLimit(n)` option.

Update:

Bringing this back from the dead as it will be crucial for efficient pagination across system wide lookups of resources.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
