### PR TITLE
fix(CORS): added User-Agent to allowed CORS headers

### DIFF
--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -20,7 +20,7 @@ func SetCORS(next http.Handler) http.Handler {
 		if origin := r.Header.Get("Origin"); origin != "" {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent")
 		}
 		next.ServeHTTP(w, r)
 	}

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -77,6 +77,7 @@ func TestCors(t *testing.T) {
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE",
 				"Access-Control-Allow-Origin":  "http://anotherapp.com",
+				"Access-Control-Allow-Headers": "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent",
 			},
 		},
 	}


### PR DESCRIPTION
`Access-Control-Allow-Headers` header should also contains a `User-Agent` because we want to monitor version of clients - see https://github.com/influxdata/influxdb-client-js/issues/152

cc https://github.com/influxdata/influxdb-client-js/issues/160

![Screenshot 2020-04-01 at 09 30 54](https://user-images.githubusercontent.com/455137/78126943-96b70980-7413-11ea-8afa-6a253abf2fa9.png)
![Screenshot 2020-04-01 at 09 30 18](https://user-images.githubusercontent.com/455137/78126944-974fa000-7413-11ea-9b4d-0a3f1418a521.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
