### PR TITLE
fix: adding contextual time

### DIFF
--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -9,10 +9,11 @@ import {
   Action as QueryBuilderAction,
 } from 'src/timeMachine/actions/queryBuilder'
 import {convertCheckToCustom} from 'src/alerting/actions/alertBuilder'
+import {setDashboardTimeRange} from 'src/dashboards/actions/ranges'
 
 // Selectors
 import {getTimeRange} from 'src/dashboards/selectors'
-import {getActiveQuery} from 'src/timeMachine/selectors'
+import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Utils
 import {createView} from 'src/views/helpers'
@@ -45,7 +46,6 @@ export type Action =
   | SetActiveTimeMachineAction
   | SetActiveTabAction
   | SetNameAction
-  | SetTimeRangeAction
   | SetAutoRefreshAction
   | SetTypeAction
   | SetActiveQueryText
@@ -139,18 +139,14 @@ export const setName = (name: string): SetNameAction => ({
   payload: {name},
 })
 
-interface SetTimeRangeAction {
-  type: 'SET_TIME_RANGE'
-  payload: {timeRange: TimeRange}
-}
+export const setTimeRange = (timeRange: TimeRange) => (dispatch, getState) => {
+  //TODO: replace with activeContext selector
+  const state = getState()
+  const activeTimeMachine = getActiveTimeMachine(state)
+  const contextID =
+    activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
 
-const setTimeRangeSync = (timeRange: TimeRange): SetTimeRangeAction => ({
-  type: 'SET_TIME_RANGE',
-  payload: {timeRange},
-})
-
-export const setTimeRange = (timeRange: TimeRange) => dispatch => {
-  dispatch(setTimeRangeSync(timeRange))
+  dispatch(setDashboardTimeRange(contextID, timeRange))
   dispatch(saveAndExecuteQueries())
   dispatch(reloadTagSelectors())
 }

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -100,8 +100,10 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
 
   const allBuckets = getAll<Bucket>(state, ResourceType.Buckets)
 
-  const {view} = getActiveTimeMachine(state)
-  const queries = view.properties.queries.filter(({text}) => !!text.trim())
+  const activeTimeMachine = getActiveTimeMachine(state)
+  const queries = activeTimeMachine.view.properties.queries.filter(
+    ({text}) => !!text.trim()
+  )
   const {
     alertBuilder: {id: checkID},
   } = state
@@ -113,10 +115,12 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
   try {
     dispatch(setQueryResults(RemoteDataState.Loading, [], null))
 
-    const variableAssignments = getAllVariables(
-      state,
-      state.timeMachines.activeTimeMachineID
-    ).map(v => asAssignment(v))
+    //TODO: replace with activeContext selector
+    const contextID =
+      activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
+    const variableAssignments = getAllVariables(state, contextID).map(v =>
+      asAssignment(v)
+    )
 
     // keeping getState() here ensures that the state we are working with
     // is the most current one. By having this set to state, we were creating a race

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -218,10 +218,11 @@ export const loadTagSelector = (index: number) => async (
   const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
 
   try {
-    const timeRange = getTimeRange(
-      state,
-      state.timeMachines.activeTimeMachineID
-    )
+    //TODO: replace with activeContext selector
+    const activeTimeMachine = getActiveTimeMachine(state)
+    const contextID =
+      activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
+    const timeRange = getTimeRange(state, contextID)
     const searchTerm = getActiveTimeMachine(state).queryBuilder.tags[index]
       .keysSearchTerm
 
@@ -286,7 +287,10 @@ const loadTagSelectorValues = (index: number) => async (
   dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
 
   try {
-    const contextID = state.timeMachines.activeTimeMachineID
+    //TODO: replace with activeContext selector
+    const activeTimeMachine = getActiveTimeMachine(state)
+    const contextID =
+      activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
     const timeRange = getTimeRange(state, contextID)
     const key = getActiveQuery(getState()).builderConfig.tags[index].key
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]

--- a/ui/src/timeMachine/components/Queries.tsx
+++ b/ui/src/timeMachine/components/Queries.tsx
@@ -30,6 +30,7 @@ import {
   getIsInCheckOverlay,
   getActiveQuery,
 } from 'src/timeMachine/selectors'
+import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -123,14 +124,18 @@ class TimeMachineQueries extends PureComponent<Props> {
 }
 
 const mstp = (state: AppState) => {
-  const {timeRange, autoRefresh} = getActiveTimeMachine(state)
+  //TODO: replace with activeContext selector
+  const activeTimeMachine = getActiveTimeMachine(state)
+  const contextID =
+    activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
+  const timeRange = getTimeRange(state, contextID)
 
   const activeQuery = getActiveQuery(state)
 
   return {
     timeRange,
     activeQuery,
-    autoRefresh,
+    autoRefresh: activeTimeMachine.autoRefresh,
     isInCheckOverlay: getIsInCheckOverlay(state),
   }
 }

--- a/ui/src/timeMachine/components/Vis.tsx
+++ b/ui/src/timeMachine/components/Vis.tsx
@@ -21,6 +21,7 @@ import {
   getFillColumnsSelection,
   getSymbolColumnsSelection,
 } from 'src/timeMachine/selectors'
+import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -140,6 +141,7 @@ const TimeMachineVis: SFC<Props> = ({
 }
 
 const mstp = (state: AppState): StateProps => {
+  const activeTimeMachine = getActiveTimeMachine(state)
   const {
     isViewingRawData,
     view: {properties: viewProperties},
@@ -150,8 +152,11 @@ const mstp = (state: AppState): StateProps => {
       files,
       statuses,
     },
-    timeRange,
-  } = getActiveTimeMachine(state)
+  } = activeTimeMachine
+  //TODO: replace with activeContext selector
+  const contextID =
+    activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
+  const timeRange = getTimeRange(state, contextID)
   const {
     alertBuilder: {type: checkType, thresholds: checkThresholds},
   } = state

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -234,14 +234,6 @@ export const timeMachineReducer = (
       return {...state, view}
     }
 
-    case 'SET_TIME_RANGE': {
-      return produce(state, draftState => {
-        draftState.timeRange = action.payload.timeRange
-
-        buildAllQueries(draftState)
-      })
-    }
-
     case 'SET_AUTO_REFRESH': {
       return produce(state, draftState => {
         draftState.autoRefresh = action.payload.autoRefresh

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -65,10 +65,11 @@ export const getActiveQuery = (state: AppState): DashboardDraftQuery => {
 // TODO kill this function
 export const getActiveWindowPeriod = (state: AppState) => {
   const {text} = getActiveQuery(state)
-  const variables = getAllVariables(
-    state,
-    state.timeMachines.activeTimeMachineID
-  ).map(v => asAssignment(v))
+  //TODO: replace with activeContext selector
+  const activeTimeMachine = getActiveTimeMachine(state)
+  const contextID =
+    activeTimeMachine.contextID || state.timeMachines.activeTimeMachineID
+  const variables = getAllVariables(state, contextID).map(v => asAssignment(v))
 
   return getWindowPeriod(text, variables)
 }


### PR DESCRIPTION
Closes #17527 

when refactoring how variables are used in the system, a concept of "context" was added to share state between dashboards and time machine instances so that a time machine could sync it's variable selection state with the dashboard it was operating on. seems like this concept needs to be extended to include time as well, because the visualization of the time could be represented by a variable.

a follow up task is to go through and add a `currentContext` selector to reduce some of the copy pasta going on, but it's currently broken in production, so lets stop the bleeding first