### PR TITLE
fix(go.mod): Update go version in mod file to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go/bigtable v1.2.0 // indirect


### PR DESCRIPTION
This PR updates the version of go required in our `go.mod` file to 1.13.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
