### PR TITLE
feat: include user ID with web token

### DIFF
--- a/jsonweb/token.go
+++ b/jsonweb/token.go
@@ -89,6 +89,8 @@ type Token struct {
 	KeyID string `json:"kid"`
 	// Permissions is the set of authorized permissions for the token
 	Permissions []influxdb.Permission `json:"permissions"`
+	// UserID for the token
+	UserID influxdb.ID `json:"uid,omitempty"`
 }
 
 // Allowed returns whether or not a permission is allowed based
@@ -118,10 +120,9 @@ func (t *Token) Identifier() influxdb.ID {
 	return *id
 }
 
-// GetUserID returns an invalid id as tokens are generated
-// with permissions rather than for or by a particular user
+// GetUserID returns the user ID for the token
 func (t *Token) GetUserID() influxdb.ID {
-	return influxdb.InvalidID()
+	return t.UserID
 }
 
 // Kind returns the string "jwt" which is used for auditing


### PR DESCRIPTION
Adds a user ID to the JWT `Token` auth implementation. This implementation is still permission-based; this change just keeps the identity around on the token for reference.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
