### PR TITLE
fix: allow the addition of variables

### DIFF
--- a/ui/src/variables/selectors/index.test.tsx
+++ b/ui/src/variables/selectors/index.test.tsx
@@ -1,5 +1,5 @@
 import {
-    getUserVariableNames,
+  getUserVariableNames,
   getVariables,
   getAllVariables,
   getVariable,
@@ -118,24 +118,26 @@ describe('VariableSelectors', () => {
     })
 
     it('should respect chaos', () => {
-        const vars = getUserVariableNames(({
-            resources: {
-                variables: {
-                    allIDs: ['5678', '1234', 'abc'],
-                    values: {
-                        qwerty: {
-                            order: ['ghi', '1234', '5678', 'def'],
-                        },
-                    },
+      const vars = getUserVariableNames(
+        ({
+          resources: {
+            variables: {
+              allIDs: ['5678', '1234', 'abc'],
+              values: {
+                qwerty: {
+                  order: ['ghi', '1234', '5678', 'def'],
                 },
+              },
             },
+          },
         } as any) as AppState,
-        'qwerty')
+        'qwerty'
+      )
 
-        expect(vars.length).toEqual(3)
-        expect(vars[0]).toEqual('1234')
-        expect(vars[1]).toEqual('5678')
-        expect(vars[2]).toEqual('abc')
+      expect(vars.length).toEqual(3)
+      expect(vars[0]).toEqual('1234')
+      expect(vars[1]).toEqual('5678')
+      expect(vars[2]).toEqual('abc')
     })
 
     // skipping this one as it requires some weird mocking

--- a/ui/src/variables/selectors/index.test.tsx
+++ b/ui/src/variables/selectors/index.test.tsx
@@ -1,4 +1,5 @@
 import {
+    getUserVariableNames,
   getVariables,
   getAllVariables,
   getVariable,
@@ -114,6 +115,27 @@ describe('VariableSelectors', () => {
       expect(vars.length).toEqual(4)
       expect(vars[0].name).toEqual('1234')
       expect(vars[1].name).toEqual('5678')
+    })
+
+    it('should respect chaos', () => {
+        const vars = getUserVariableNames(({
+            resources: {
+                variables: {
+                    allIDs: ['5678', '1234', 'abc'],
+                    values: {
+                        qwerty: {
+                            order: ['ghi', '1234', '5678', 'def'],
+                        },
+                    },
+                },
+            },
+        } as any) as AppState,
+        'qwerty')
+
+        expect(vars.length).toEqual(3)
+        expect(vars[0]).toEqual('1234')
+        expect(vars[1]).toEqual('5678')
+        expect(vars[2]).toEqual('abc')
     })
 
     // skipping this one as it requires some weird mocking

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -64,19 +64,29 @@ export const extractVariableEditorConstant = (
   )
 }
 
+export const getUserVariableNames = (
+  state: AppState,
+  contextID?: string | null
+): string[] => {
+  const allIDs = get(state, ['resources', 'variables', 'allIDs'], [])
+  const contextIDs = get(
+    state,
+    ['resources', 'variables', 'values', contextID, 'order'],
+    []
+  )
+
+  return contextIDs
+    .filter(v => allIDs.includes(v))
+    .concat(allIDs.filter(v => !contextIDs.includes(v)))
+}
+
 // this function grabs all user defined variables
 // and hydrates them based on their context
 export const getVariables = (
   state: AppState,
   contextID?: string | null
 ): Variable[] => {
-  const variableIDs = get(
-    state,
-    ['resources', 'variables', 'values', contextID, 'order'],
-    get(state, ['resources', 'variables', 'allIDs'], [])
-  )
-
-  return variableIDs
+  return getUserVariableNames(state, contextID)
     .reduce((prev, curr) => {
       prev.push(getVariable(state, contextID, curr))
 
@@ -91,13 +101,8 @@ export const getAllVariables = (
   state: AppState,
   contextID?: string | null
 ): Variable[] => {
-  const variableIDs = get(
-    state,
-    ['resources', 'variables', 'values', contextID, 'order'],
-    get(state, ['resources', 'variables', 'allIDs'], [])
-  ).concat([TIME_RANGE_START, TIME_RANGE_STOP, WINDOW_PERIOD])
-
-  return variableIDs
+  return getUserVariableNames(state, contextID)
+    .concat([TIME_RANGE_START, TIME_RANGE_STOP, WINDOW_PERIOD])
     .reduce((prev, curr) => {
       prev.push(getVariable(state, contextID, curr))
 


### PR DESCRIPTION
this solves part 2 of #17513

summary of the problem is that when a value is loaded for a variable, it inherits an order from the resource. when you add or removing something, the order isn't being updated.

instead of chasing around all of the places where order might be manipulated, i kept the behavior as "use the order that is explicitly created by the user, and fill in anything else". as soon as they reorder something, it should fix itself