### PR TITLE
fix: tech-debt workaround - add limit of 100 to checks fetches

### DIFF
--- a/ui/src/checks/actions/thunks.ts
+++ b/ui/src/checks/actions/thunks.ts
@@ -59,6 +59,8 @@ import {
 } from 'src/types'
 import {labelSchema} from 'src/schemas/labels'
 
+import {LIMIT} from 'src/resources/constants'
+
 export const getChecks = () => async (
   dispatch: Dispatch<
     Action | NotificationAction | ReturnType<typeof checkChecksLimits>
@@ -72,7 +74,9 @@ export const getChecks = () => async (
     }
     const {id: orgID} = getOrg(state)
 
-    const resp = await api.getChecks({query: {orgID}})
+    // bump the limit up to the max. see idpe 6592
+    // TODO: https://github.com/influxdata/influxdb/issues/17541
+    const resp = await api.getChecks({query: {orgID, limit: LIMIT}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)


### PR DESCRIPTION
Closes idpe 6592

Checks in tools are hamstrung because there are more than 20 that need to be shown, but we currently only show 20. This bumps that limit up to `100` the API's hard cap.

#### Testing Instructions
1. go to monitoring and alerting
1. create new check
1. clone that check 20 or so times (I know)
1. on `master`, you should only see the 20 items (check 1 and its 19 clones)
1. on this branch, you should see more than 20.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass