### PR TITLE
fix(kv): update index to use new bucket.GetBatch

### DIFF
--- a/kv/index_test.go
+++ b/kv/index_test.go
@@ -1,10 +1,16 @@
 package kv_test
 
 import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/inmem"
 	influxdbtesting "github.com/influxdata/influxdb/testing"
+	"go.uber.org/zap/zaptest"
 )
 
 func Test_Inmem_Index(t *testing.T) {
@@ -19,4 +25,29 @@ func Test_Bolt_Index(t *testing.T) {
 	defer closeBolt()
 
 	influxdbtesting.TestIndex(t, s)
+}
+
+func Benchmark_Inmem_Index_Walk(b *testing.B) {
+	influxdbtesting.BenchmarkIndexWalk(b, inmem.NewKVStore(), 1000, 200)
+}
+
+func Benchmark_Bolt_Index_Walk(b *testing.B) {
+	f, err := ioutil.TempFile("", "influxdata-bolt-")
+	if err != nil {
+		b.Fatal(errors.New("unable to open temporary boltdb file"))
+	}
+	f.Close()
+
+	path := f.Name()
+	s := bolt.NewKVStore(zaptest.NewLogger(b), path)
+	if err := s.Open(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+
+	defer func() {
+		s.Close()
+		os.Remove(path)
+	}()
+
+	influxdbtesting.BenchmarkIndexWalk(b, s, 1000, 200)
 }


### PR DESCRIPTION
This updates the `index.Walk(fn)` function to use the new `bucket.GetBatch(keys...)` lookup for the keys found in the index.

This reduces index lookups from an N+1 access pattern to just 2 bucket operations per lookup.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
