### PR TITLE
refactor(kv): set the default session length when not specified

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -100,7 +100,9 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 
 	if len(configs) > 0 {
 		s.Config = configs[0]
-	} else {
+	}
+
+	if s.Config.SessionLength == 0 {
 		s.Config.SessionLength = influxdb.DefaultSessionLength
 	}
 


### PR DESCRIPTION
At the moment, the default session length only gets set to the default
when no service config is specified. So if a service config is used and
it does not set a value for the session length, then the session length
will be zero.

This modifies the creation of the kv service so that it will set the
default session length if the session length is set to zero (the default
value) instead of only doing it when no service config is specified.