### PR TITLE
fix(regression): function inserts now happen on new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 1. [17515](https://github.com/influxdata/influxdb/pull/17515): Editing a table cell shows the proper values and respects changes
 1. [17521](https://github.com/influxdata/influxdb/pull/17521): Table view scrolling should be slightly smoother
 1. [17601](https://github.com/influxdata/influxdb/pull/17601): URL table values on single columns are being correctly parsed
+1. [17552](https://github.com/influxdata/influxdb/pull/17552): Fixed a regression bug that insert aggregate functions where the cursor is rather than a new line
 
 ### UI Improvements
 

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -75,7 +75,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
     const p = editorInstance.getPosition()
     const scriptLines = activeQueryText.split('\n')
 
-    let insertLineNumber = getInsertLineNumber(p.lineNumber, scriptLines)
+    const insertLineNumber = getInsertLineNumber(p.lineNumber, scriptLines)
 
     // sets the range based on the current position
     let range = new window.monaco.Range(

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -77,21 +77,23 @@ const TimeMachineFluxEditor: FC<Props> = ({
 
     const insertLineNumber = getInsertLineNumber(p.lineNumber, scriptLines)
 
+    const defaultColumnPosition = 1 // beginning column of the row
+
     // sets the range based on the current position
     let range = new window.monaco.Range(
       insertLineNumber, // the row beneath the cursor
-      1, // beginning column of the row
+      defaultColumnPosition,
       insertLineNumber,
-      1
+      defaultColumnPosition
     )
     // edge case for when user toggles to the script editor
     // this defaults the cursor to the initial position (top-left, 1:1 position)
     const [currentRange] = editorInstance.getVisibleRanges()
     // Determines whether the new insert line is beyond the current range
-    let insertOnLastLine = insertLineNumber > currentRange.endLineNumber
-    if (p.lineNumber === 1 && p.column === 1) {
+    let shouldInsertOnLastLine = insertLineNumber > currentRange.endLineNumber
+    if (p.lineNumber === 1 && p.column === defaultColumnPosition) {
       // adds the function to the end of the query
-      insertOnLastLine = true
+      shouldInsertOnLastLine = true
       range = new window.monaco.Range(
         currentRange.endLineNumber + 1,
         p.column,
@@ -106,7 +108,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
         text: formatFunctionForInsert(
           func.name,
           func.example,
-          insertOnLastLine
+          shouldInsertOnLastLine
         ),
       },
     ]

--- a/ui/src/timeMachine/utils/insertFunction.test.ts
+++ b/ui/src/timeMachine/utils/insertFunction.test.ts
@@ -18,10 +18,10 @@ describe('insertFunction', () => {
   test('formatFunctionForInsert', () => {
     const fluxFunc = 'funky'
     const union = 'union'
-    const requiresNewLine = formatFunctionForInsert(union, fluxFunc)
-    expect(requiresNewLine).toEqual(`\n${fluxFunc}`)
+    const requiresNewLine = formatFunctionForInsert(union, fluxFunc, false)
+    expect(requiresNewLine).toEqual(`\n${fluxFunc}\n`)
     const to = 'to'
-    const fluxNewLine = formatFunctionForInsert(to, fluxFunc)
-    expect(fluxNewLine).toEqual(`\n  |> ${fluxFunc}`)
+    const fluxNewLine = formatFunctionForInsert(to, fluxFunc, true)
+    expect(fluxNewLine).toEqual(`\n  |> ${fluxFunc}\n`)
   })
 })

--- a/ui/src/timeMachine/utils/insertFunction.test.ts
+++ b/ui/src/timeMachine/utils/insertFunction.test.ts
@@ -1,7 +1,4 @@
-import {
-  generateImport,
-  formatFunctionForInsert,
-} from 'src/timeMachine/utils/insertFunction'
+import {generateImport} from 'src/timeMachine/utils/insertFunction'
 
 describe('insertFunction', () => {
   test('generateImport should generate an import statement', () => {
@@ -13,15 +10,5 @@ describe('insertFunction', () => {
     |> filter(fn: (r) => r._measurement == "m0")`
     const actual = generateImport(func, script)
     expect(actual).toEqual(`import "${func}"`)
-  })
-
-  test('formatFunctionForInsert should insert a function formatted based on the type of function', () => {
-    const fluxFunc = 'funky'
-    const union = 'union'
-    const requiresNewLine = formatFunctionForInsert(union, fluxFunc, false)
-    expect(requiresNewLine).toEqual(`\n${fluxFunc}\n`)
-    const to = 'to'
-    const fluxNewLine = formatFunctionForInsert(to, fluxFunc, true)
-    expect(fluxNewLine).toEqual(`\n  |> ${fluxFunc}`)
   })
 })

--- a/ui/src/timeMachine/utils/insertFunction.test.ts
+++ b/ui/src/timeMachine/utils/insertFunction.test.ts
@@ -22,6 +22,6 @@ describe('insertFunction', () => {
     expect(requiresNewLine).toEqual(`\n${fluxFunc}\n`)
     const to = 'to'
     const fluxNewLine = formatFunctionForInsert(to, fluxFunc, true)
-    expect(fluxNewLine).toEqual(`\n  |> ${fluxFunc}\n`)
+    expect(fluxNewLine).toEqual(`\n  |> ${fluxFunc}`)
   })
 })

--- a/ui/src/timeMachine/utils/insertFunction.test.ts
+++ b/ui/src/timeMachine/utils/insertFunction.test.ts
@@ -4,7 +4,7 @@ import {
 } from 'src/timeMachine/utils/insertFunction'
 
 describe('insertFunction', () => {
-  test('generateImport', () => {
+  test('generateImport should generate an import statement', () => {
     const emptyImport = generateImport('', '')
     expect(emptyImport).toEqual(false)
     const func = 'aggregateWindow'
@@ -15,7 +15,7 @@ describe('insertFunction', () => {
     expect(actual).toEqual(`import "${func}"`)
   })
 
-  test('formatFunctionForInsert', () => {
+  test('formatFunctionForInsert should insert a function formatted based on the type of function', () => {
     const fluxFunc = 'funky'
     const union = 'union'
     const requiresNewLine = formatFunctionForInsert(union, fluxFunc, false)

--- a/ui/src/timeMachine/utils/insertFunction.ts
+++ b/ui/src/timeMachine/utils/insertFunction.ts
@@ -14,13 +14,14 @@ const functionRequiresNewLine = (funcName: string): boolean => {
 
 export const formatFunctionForInsert = (
   funcName: string,
-  fluxFunction: string
-) => {
+  fluxFunction: string,
+  newLine: boolean
+): string => {
   if (functionRequiresNewLine(funcName)) {
-    return `\n${fluxFunction}`
+    return `\n${fluxFunction}\n`
   }
 
-  return `\n  |> ${fluxFunction}`
+  return `${newLine ? '\n' : ''}  |> ${fluxFunction}\n`
 }
 
 export const generateImport = (

--- a/ui/src/timeMachine/utils/insertFunction.ts
+++ b/ui/src/timeMachine/utils/insertFunction.ts
@@ -1,6 +1,5 @@
 // Constants
 import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
-import {FluxToolbarFunction, Position} from 'src/types'
 
 const functionRequiresNewLine = (funcName: string): boolean => {
   switch (funcName) {

--- a/ui/src/timeMachine/utils/insertFunction.ts
+++ b/ui/src/timeMachine/utils/insertFunction.ts
@@ -1,5 +1,6 @@
 // Constants
 import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
+import {FluxToolbarFunction, Position} from 'src/types'
 
 const functionRequiresNewLine = (funcName: string): boolean => {
   switch (funcName) {
@@ -21,7 +22,11 @@ export const formatFunctionForInsert = (
     return `\n${fluxFunction}\n`
   }
 
-  return `${newLine ? '\n' : ''}  |> ${fluxFunction}\n`
+  if (newLine) {
+    return `\n  |> ${fluxFunction}`
+  }
+
+  return `  |> ${fluxFunction}\n`
 }
 
 export const generateImport = (

--- a/ui/src/timeMachine/utils/insertFunction.ts
+++ b/ui/src/timeMachine/utils/insertFunction.ts
@@ -1,7 +1,7 @@
 // Constants
 import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
 
-const functionRequiresNewLine = (funcName: string): boolean => {
+export const functionRequiresNewLine = (funcName: string): boolean => {
   switch (funcName) {
     case FROM.name:
     case UNION.name: {
@@ -10,22 +10,6 @@ const functionRequiresNewLine = (funcName: string): boolean => {
     default:
       return false
   }
-}
-
-export const formatFunctionForInsert = (
-  funcName: string,
-  fluxFunction: string,
-  newLine: boolean
-): string => {
-  if (functionRequiresNewLine(funcName)) {
-    return `\n${fluxFunction}\n`
-  }
-
-  if (newLine) {
-    return `\n  |> ${fluxFunction}`
-  }
-
-  return `  |> ${fluxFunction}\n`
 }
 
 export const generateImport = (


### PR DESCRIPTION
Closes #17282

### Problem

This bug is a regression that stemmed from our earlier transition from codemirror to monaco. In particular, the issue was that some of the logic that had previously been used to determine the insert line of a function was not integrated into the monaco functionality.

### Solution

Integrated a few logical steps to calculate where a function should be placed when selecting an aggregate function.

![func-insert-regression-fix](https://user-images.githubusercontent.com/19984220/78179813-a97f0d80-7416-11ea-9e55-e7d412a557c4.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable