### PR TITLE
fix(ui): change index.html <title> to InfluxDB Cloud

### DIFF
--- a/ui/assets/index.html
+++ b/ui/assets/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>InfluxDB 2.0</title>
+    <title>InfluxDB Cloud</title>
     <base href="/" />
     <%= htmlWebpackPlugin.options.header  %>
   </head>


### PR DESCRIPTION
fix: minor text change for name of product from InfluxDB 2.0 to InfluxDB Cloud in index.html

Trying to change so the name of the product aligns between the page and browser tab <title>
![image](https://user-images.githubusercontent.com/56005508/78182097-64f57100-741a-11ea-9282-d246f47517aa.png)
