### PR TITLE
feat(pkger): extend labels diff and summary types to include PkgName and Remove

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7561,11 +7561,13 @@ components:
                 properties:
                   id:
                     type: string
-                  name:
+                  pkgName:
                     type: string
                   new:
                     type: object
                     properties:
+                      name:
+                        type: string
                       color:
                         type: string
                       description:
@@ -7573,6 +7575,8 @@ components:
                   old:
                     type: object
                     properties:
+                      name:
+                        type: string
                       color:
                         type: string
                       description:
@@ -7719,6 +7723,8 @@ components:
         id:
           type: string
         orgID:
+          type: string
+        pkgName:
           type: string
         name:
           type: string

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -258,8 +258,9 @@ func TestPkg(t *testing.T) {
 				{
 					name: "new label",
 					resource: DiffLabel{
-						Name: "new label",
+						PkgName: "new label",
 						New: DiffLabelValues{
+							Name:        "new label",
 							Color:       "new color",
 							Description: "new desc",
 						},
@@ -269,13 +270,15 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing label with no changes",
 					resource: DiffLabel{
-						ID:   1,
-						Name: "existing label",
+						ID:      1,
+						PkgName: "existing label",
 						New: DiffLabelValues{
+							Name:        "existing label",
 							Color:       "color",
 							Description: "desc",
 						},
 						Old: &DiffLabelValues{
+							Name:        "existing label",
 							Color:       "color",
 							Description: "desc",
 						},
@@ -285,13 +288,15 @@ func TestPkg(t *testing.T) {
 				{
 					name: "existing label with changes",
 					resource: DiffLabel{
-						ID:   1,
-						Name: "existing label",
+						ID:      1,
+						PkgName: "existing label",
 						New: DiffLabelValues{
+							Name:        "existing label",
 							Color:       "color",
 							Description: "desc",
 						},
 						Old: &DiffLabelValues{
+							Name:        "existing label",
 							Color:       "new color",
 							Description: "new desc",
 						},

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -160,7 +160,8 @@ spec:
 				require.Len(t, labels, 3)
 
 				expectedLabel0 := SummaryLabel{
-					Name: "display name",
+					PkgName: "label_3",
+					Name:    "display name",
 					Properties: struct {
 						Color       string `json:"color"`
 						Description string `json:"description"`
@@ -171,7 +172,8 @@ spec:
 				assert.Equal(t, expectedLabel0, labels[0])
 
 				expectedLabel1 := SummaryLabel{
-					Name: "label_1",
+					PkgName: "label_1",
+					Name:    "label_1",
 					Properties: struct {
 						Color       string `json:"color"`
 						Description string `json:"description"`
@@ -183,7 +185,8 @@ spec:
 				assert.Equal(t, expectedLabel1, labels[1])
 
 				expectedLabel2 := SummaryLabel{
-					Name: "label_2",
+					PkgName: "label_2",
+					Name:    "label_2",
 					Properties: struct {
 						Color       string `json:"color"`
 						Description string `json:"description"`
@@ -3927,7 +3930,8 @@ spec:
 
 		labels := []SummaryLabel{
 			{
-				Name: "label_1",
+				PkgName: "label_1",
+				Name:    "label_1",
 				Properties: struct {
 					Color       string `json:"color"`
 					Description string `json:"description"`

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -791,7 +791,7 @@ func (s *Service) dryRunLabels(ctx context.Context, orgID influxdb.ID, pkg *Pkg)
 		diffs = append(diffs, diff)
 	}
 	sort.Slice(diffs, func(i, j int) bool {
-		return diffs[i].Name < diffs[j].Name
+		return diffs[i].PkgName < diffs[j].PkgName
 	})
 
 	return diffs

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -189,22 +189,26 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Labels, 3)
 
 					expected := DiffLabel{
-						ID:   SafeID(1),
-						Name: "label_1",
+						ID:      SafeID(1),
+						PkgName: "label_1",
 						Old: &DiffLabelValues{
+							Name:        "label_1",
 							Color:       "old color",
 							Description: "old description",
 						},
 						New: DiffLabelValues{
+							Name:        "label_1",
 							Color:       "#FFFFFF",
 							Description: "label 1 description",
 						},
 					}
 					assert.Contains(t, diff.Labels, expected)
 
-					expected.Name = "label_2"
+					expected.PkgName = "label_2"
+					expected.New.Name = "label_2"
 					expected.New.Color = "#000000"
 					expected.New.Description = "label 2 description"
+					expected.Old.Name = "label_2"
 					assert.Contains(t, diff.Labels, expected)
 				})
 			})
@@ -223,15 +227,17 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Labels, 3)
 
 					expected := DiffLabel{
-						Name: "label_1",
+						PkgName: "label_1",
 						New: DiffLabelValues{
+							Name:        "label_1",
 							Color:       "#FFFFFF",
 							Description: "label 1 description",
 						},
 					}
 					assert.Contains(t, diff.Labels, expected)
 
-					expected.Name = "label_2"
+					expected.PkgName = "label_2"
+					expected.New.Name = "label_2"
 					expected.New.Color = "#000000"
 					expected.New.Description = "label 2 description"
 					assert.Contains(t, diff.Labels, expected)
@@ -633,9 +639,10 @@ func TestService(t *testing.T) {
 					require.Len(t, sum.Labels, 3)
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:    1,
-						OrgID: SafeID(orgID),
-						Name:  "label_1",
+						ID:      1,
+						OrgID:   SafeID(orgID),
+						PkgName: "label_1",
+						Name:    "label_1",
 						Properties: struct {
 							Color       string `json:"color"`
 							Description string `json:"description"`
@@ -646,9 +653,10 @@ func TestService(t *testing.T) {
 					})
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:    2,
-						OrgID: SafeID(orgID),
-						Name:  "label_2",
+						ID:      2,
+						OrgID:   SafeID(orgID),
+						PkgName: "label_2",
+						Name:    "label_2",
 						Properties: struct {
 							Color       string `json:"color"`
 							Description string `json:"description"`
@@ -728,9 +736,10 @@ func TestService(t *testing.T) {
 					require.Len(t, sum.Labels, 3)
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:    1,
-						OrgID: SafeID(orgID),
-						Name:  "label_1",
+						ID:      1,
+						OrgID:   SafeID(orgID),
+						PkgName: "label_1",
+						Name:    "label_1",
 						Properties: struct {
 							Color       string `json:"color"`
 							Description string `json:"description"`
@@ -741,9 +750,10 @@ func TestService(t *testing.T) {
 					})
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:    2,
-						OrgID: SafeID(orgID),
-						Name:  "label_2",
+						ID:      2,
+						OrgID:   SafeID(orgID),
+						PkgName: "label_2",
+						Name:    "label_2",
 						Properties: struct {
 							Color       string `json:"color"`
 							Description string `json:"description"`


### PR DESCRIPTION
the pkgName refers to the unqiue label resource within the pkg and the
Remove field indicates the label will be removed when applying the pkg

references: #17434 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
