### PR TITLE
refactor(tasks): auth user id

### DIFF
--- a/jsonweb/token.go
+++ b/jsonweb/token.go
@@ -89,6 +89,8 @@ type Token struct {
 	KeyID string `json:"kid"`
 	// Permissions is the set of authorized permissions for the token
 	Permissions []influxdb.Permission `json:"permissions"`
+	// UserID for the token
+	UserID string `json:"uid,omitempty"`
 }
 
 // Allowed returns whether or not a permission is allowed based
@@ -121,7 +123,11 @@ func (t *Token) Identifier() influxdb.ID {
 // GetUserID returns an invalid id as tokens are generated
 // with permissions rather than for or by a particular user
 func (t *Token) GetUserID() influxdb.ID {
-	return influxdb.InvalidID()
+	id, err := influxdb.IDFromString(t.UserID)
+	if err != nil {
+		return influxdb.InvalidID()
+	}
+	return *id
 }
 
 // Kind returns the string "jwt" which is used for auditing

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -208,6 +208,9 @@ func (e *Executor) createPromise(ctx context.Context, run *influxdb.Run) (*promi
 	if err != nil {
 		return nil, err
 	}
+	if !t.Authorization.GetUserID().Valid() {
+		t.Authorization.UserID = t.OwnerID
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	// create promise


### PR DESCRIPTION
Adds a user ID to the JWT `Token` auth implementation. This implementation is still permission-based; this change just keeps the identity around on the token for reference.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
