### PR TITLE
fix: Invariant violated: mixed block types for a single series

### DIFF
--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -701,17 +701,43 @@ func (t *cacheTracker) SetAge(d time.Duration) {
 	t.metrics.Age.With(labels).Set(d.Seconds())
 }
 
+const (
+	valueTypeUndefined = 0
+	valueTypeFloat64   = 1
+	valueTypeInteger   = 2
+	valueTypeString    = 3
+	valueTypeBoolean   = 4
+	valueTypeUnsigned  = 5
+)
+
 func valueType(v Value) byte {
 	switch v.(type) {
 	case FloatValue:
-		return 1
+		return valueTypeFloat64
 	case IntegerValue:
-		return 2
+		return valueTypeInteger
 	case StringValue:
-		return 3
+		return valueTypeString
 	case BooleanValue:
-		return 4
+		return valueTypeBoolean
+	case UnsignedValue:
+		return valueTypeUnsigned
 	default:
-		return 0
+		return valueTypeUndefined
 	}
 }
+
+var (
+	valueTypeBlockType = [8]byte{
+		valueTypeUndefined: blockUndefined,
+		valueTypeFloat64:   BlockFloat64,
+		valueTypeInteger:   BlockInteger,
+		valueTypeString:    BlockString,
+		valueTypeBoolean:   BlockBoolean,
+		valueTypeUnsigned:  BlockUnsigned,
+		6:                  blockUndefined,
+		7:                  blockUndefined,
+	}
+)
+
+func valueTypeToBlockType(typ byte) byte { return valueTypeBlockType[typ&7] }

--- a/tsdb/tsm1/cache_entry.go
+++ b/tsdb/tsm1/cache_entry.go
@@ -123,3 +123,10 @@ func (e *entry) InfluxQLType() (influxql.DataType, error) {
 	defer e.mu.RUnlock()
 	return e.values.InfluxQLType()
 }
+
+// BlockType returns the data type for the entry as a block type.
+func (e *entry) BlockType() byte {
+	// This value is mutated on create and does not need to be
+	// protected by a mutex.
+	return valueTypeToBlockType(e.vtype)
+}

--- a/tsdb/tsm1/encoding.go
+++ b/tsdb/tsm1/encoding.go
@@ -25,6 +25,9 @@ const (
 	// BlockUnsigned designates a block encodes uint64 values.
 	BlockUnsigned = byte(4)
 
+	// blockUndefined represents an undefined block type value.
+	blockUndefined = BlockUnsigned + 1
+
 	// encodedBlockHeaderSize is the size of the header for an encoded block.  There is one
 	// byte encoding the type of the block.
 	encodedBlockHeaderSize = 1

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1455,14 +1455,14 @@ func AppendSeriesFieldKeyBytes(dst, seriesKey, field []byte) []byte {
 
 var (
 	blockToFieldType = [8]influxql.DataType{
-		BlockFloat64:  influxql.Float,
-		BlockInteger:  influxql.Integer,
-		BlockBoolean:  influxql.Boolean,
-		BlockString:   influxql.String,
-		BlockUnsigned: influxql.Unsigned,
-		5:             influxql.Unknown,
-		6:             influxql.Unknown,
-		7:             influxql.Unknown,
+		BlockFloat64:   influxql.Float,
+		BlockInteger:   influxql.Integer,
+		BlockBoolean:   influxql.Boolean,
+		BlockString:    influxql.String,
+		BlockUnsigned:  influxql.Unsigned,
+		blockUndefined: influxql.Unknown,
+		6:              influxql.Unknown,
+		7:              influxql.Unknown,
 	}
 )
 


### PR DESCRIPTION
The root cause is that the `Unsigned` data type has no representation in the `valueType` function in the cache and falls back to the default case of 0.

0 is also a sentinel value in the `entry#add` function that will result in skipping the value type check.

It therefore is possible that unsigned values followed by some other data type is stored in the cache.

It is suspected that the write may be rejected before reaching the cache, and therefore may not occur in practice. Specifically, the series file stores the data types on a per-series basis and would
reject the write.

This commit turns the value types into explicit constants and ensures all existing block types are represented. In addition, it adds a mapping function to convert these to a known Block type,
which will be used by the `MeasurementFields` schema request to determine the type of a series in the cache.
