### PR TITLE
fix(tsdb): Replace panic with error while de/encoding corrupt data

### DIFF
--- a/tsdb/engine/tsm1/compact.gen.go
+++ b/tsdb/engine/tsm1/compact.gen.go
@@ -76,7 +76,7 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 
 				v, err := DecodeFloatBlock(k.blocks[i].b, &[]FloatValue{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -105,20 +105,25 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
+			}
+
+			if count < k.size {
 				break
 			}
-			i++
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -152,7 +157,7 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 
 			v, err := DecodeFloatBlock(k.blocks[i].b, &[]FloatValue{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -178,7 +183,7 @@ func (k *tsmKeyIterator) chunkFloat(dst blocks) blocks {
 		values := k.mergedFloatValues[:k.size]
 		cb, err := FloatValues(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -196,7 +201,7 @@ func (k *tsmKeyIterator) chunkFloat(dst blocks) blocks {
 	if len(k.mergedFloatValues) > 0 {
 		cb, err := FloatValues(k.mergedFloatValues).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -275,7 +280,7 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 
 				v, err := DecodeIntegerBlock(k.blocks[i].b, &[]IntegerValue{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -304,20 +309,25 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
+			}
+
+			if count < k.size {
 				break
 			}
-			i++
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -351,7 +361,7 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 
 			v, err := DecodeIntegerBlock(k.blocks[i].b, &[]IntegerValue{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -377,7 +387,7 @@ func (k *tsmKeyIterator) chunkInteger(dst blocks) blocks {
 		values := k.mergedIntegerValues[:k.size]
 		cb, err := IntegerValues(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -395,7 +405,7 @@ func (k *tsmKeyIterator) chunkInteger(dst blocks) blocks {
 	if len(k.mergedIntegerValues) > 0 {
 		cb, err := IntegerValues(k.mergedIntegerValues).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -474,7 +484,7 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 
 				v, err := DecodeUnsignedBlock(k.blocks[i].b, &[]UnsignedValue{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -503,20 +513,25 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
+			}
+
+			if count < k.size {
 				break
 			}
-			i++
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -550,7 +565,7 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 
 			v, err := DecodeUnsignedBlock(k.blocks[i].b, &[]UnsignedValue{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -576,7 +591,7 @@ func (k *tsmKeyIterator) chunkUnsigned(dst blocks) blocks {
 		values := k.mergedUnsignedValues[:k.size]
 		cb, err := UnsignedValues(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -594,7 +609,7 @@ func (k *tsmKeyIterator) chunkUnsigned(dst blocks) blocks {
 	if len(k.mergedUnsignedValues) > 0 {
 		cb, err := UnsignedValues(k.mergedUnsignedValues).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -673,7 +688,7 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 
 				v, err := DecodeStringBlock(k.blocks[i].b, &[]StringValue{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -702,20 +717,25 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
+			}
+
+			if count < k.size {
 				break
 			}
-			i++
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -749,7 +769,7 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 
 			v, err := DecodeStringBlock(k.blocks[i].b, &[]StringValue{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -775,7 +795,7 @@ func (k *tsmKeyIterator) chunkString(dst blocks) blocks {
 		values := k.mergedStringValues[:k.size]
 		cb, err := StringValues(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -793,7 +813,7 @@ func (k *tsmKeyIterator) chunkString(dst blocks) blocks {
 	if len(k.mergedStringValues) > 0 {
 		cb, err := StringValues(k.mergedStringValues).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -872,7 +892,7 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 
 				v, err := DecodeBooleanBlock(k.blocks[i].b, &[]BooleanValue{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -901,20 +921,25 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
+			}
+
+			if count < k.size {
 				break
 			}
-			i++
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -948,7 +973,7 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 
 			v, err := DecodeBooleanBlock(k.blocks[i].b, &[]BooleanValue{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -974,7 +999,7 @@ func (k *tsmKeyIterator) chunkBoolean(dst blocks) blocks {
 		values := k.mergedBooleanValues[:k.size]
 		cb, err := BooleanValues(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -992,7 +1017,7 @@ func (k *tsmKeyIterator) chunkBoolean(dst blocks) blocks {
 	if len(k.mergedBooleanValues) > 0 {
 		cb, err := BooleanValues(k.mergedBooleanValues).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -1109,20 +1134,25 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 	}
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+			k.AppendError(err)
+			continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -1138,7 +1168,7 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])
@@ -1328,20 +1358,25 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 	}
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+			k.AppendError(err)
+			continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -1357,7 +1392,7 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])
@@ -1547,20 +1582,25 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 	}
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+			k.AppendError(err)
+			continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -1576,7 +1616,7 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])
@@ -1766,20 +1806,25 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 	}
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+			k.AppendError(err)
+			continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -1795,7 +1840,7 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])
@@ -1985,20 +2030,25 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 	}
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+			k.AppendError(err)
+			continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -2014,7 +2064,7 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])

--- a/tsdb/engine/tsm1/compact.gen.go.tmpl
+++ b/tsdb/engine/tsm1/compact.gen.go.tmpl
@@ -72,7 +72,7 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 
 				v, err := Decode{{.Name}}Block(k.blocks[i].b, &[]{{.Name}}Value{})
 				if err != nil {
-					k.err = err
+					k.AppendError(err)
 					return nil
 				}
 
@@ -101,20 +101,25 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 	} else {
 		var i int
 
-		for i < len(k.blocks) {
-
+		for ; i < len(k.blocks); i++ {
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
-				i++
 				continue
 			}
-			// If we this block is already full, just add it as is
-			if BlockCount(k.blocks[i].b) >= k.size {
-				k.merged = append(k.merged, k.blocks[i])
-			} else {
-				break
+
+			// If this block is already full, just add it as is
+			count, err := BlockCount(k.blocks[i].b)
+			if  err != nil {
+				// accumulate all errors to tsmKeyIterator.err
+				k.AppendError(err)
+				continue
 			}
-			i++
+
+			if count < k.size {
+			    break
+			}
+
+			k.merged = append(k.merged, k.blocks[i])
 		}
 
 		if k.fast {
@@ -148,7 +153,7 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 
 			v, err := Decode{{.Name}}Block(k.blocks[i].b, &[]{{.Name}}Value{})
 			if err != nil {
-				k.err = err
+				k.AppendError(err)
 				return nil
 			}
 
@@ -174,7 +179,7 @@ func (k *tsmKeyIterator) chunk{{.Name}}(dst blocks) blocks {
 		values := k.merged{{.Name}}Values[:k.size]
 		cb, err := {{.Name}}Values(values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -192,7 +197,7 @@ func (k *tsmKeyIterator) chunk{{.Name}}(dst blocks) blocks {
 	if len(k.merged{{.Name}}Values) > 0 {
 		cb, err := {{.Name}}Values(k.merged{{.Name}}Values).Encode(nil)
 		if err != nil {
-			k.err = err
+			k.AppendError(err)
 			return nil
 		}
 
@@ -312,20 +317,25 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 	} 
 	var i int
 
-	for i < len(k.blocks) {
+	for ; i < len(k.blocks); i++ {
 
 		// skip this block if it's values were already read
 		if k.blocks[i].read() {
-			i++
 			continue
 		}
-		// If we this block is already full, just add it as is
-		if BlockCount(k.blocks[i].b) >= k.size {
-			k.merged = append(k.merged, k.blocks[i])
-		} else {
+
+		// if this block is already full, just add it as is
+		count, err := BlockCount(k.blocks[i].b)
+		if err != nil {
+		    k.AppendError(err)
+		    continue
+		}
+
+		if count < k.size {
 			break
 		}
-		i++
+
+		k.merged = append(k.merged, k.blocks[i])
 	}
 
 	if k.fast {
@@ -341,7 +351,7 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 		}
 	}
 
-	// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
+	// if we only have 1 blocks left, just append it as is and avoid decoding/recoding
 	if i == len(k.blocks)-1 {
 		if !k.blocks[i].read() {
 			k.merged = append(k.merged, k.blocks[i])

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -121,7 +121,7 @@ func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
 
 	files, err := compactor.CompactFull([]string{f1, f2})
 	if err != nil {
-		t.Fatalf("unexpected error writing snapshot: %v", err)
+		t.Fatalf("unexpected error writing snapshot: %#v", err)
 	}
 
 	r := MustOpenTSMReader(files[0])

--- a/tsdb/engine/tsm1/digest.go
+++ b/tsdb/engine/tsm1/digest.go
@@ -92,7 +92,11 @@ func DigestWithOptions(dir string, files []string, opts DigestOptions, w io.Writ
 					continue
 				}
 
-				cnt := BlockCount(b)
+				cnt, err := BlockCount(b)
+				if err != nil {
+					return err
+				}
+
 				ts.Add(entry.MinTime, entry.MaxTime, cnt, crc)
 			}
 		}

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -234,28 +234,28 @@ func BlockType(block []byte) (byte, error) {
 }
 
 // BlockCount returns the number of timestamps encoded in block.
-func BlockCount(block []byte) int {
+func BlockCount(block []byte) (int, error) {
 	if len(block) <= encodedBlockHeaderSize {
-		panic(fmt.Sprintf("count of short block: got %v, exp %v", len(block), encodedBlockHeaderSize))
+		return 0, fmt.Errorf("count of short block: got %v, exp %v", len(block), encodedBlockHeaderSize)
 	}
 	// first byte is the block type
 	tb, _, err := unpackBlock(block[1:])
 	if err != nil {
-		panic(fmt.Sprintf("BlockCount: error unpacking block: %s", err.Error()))
+		return 0, fmt.Errorf("BlockCount: error unpacking block: %v", err)
 	}
-	return CountTimestamps(tb)
+	return CountTimestamps(tb), nil
 }
 
 // DecodeBlock takes a byte slice and decodes it into values of the appropriate type
 // based on the block.
 func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 	if len(block) <= encodedBlockHeaderSize {
-		panic(fmt.Sprintf("decode of short block: got %v, exp %v", len(block), encodedBlockHeaderSize))
+		return nil, fmt.Errorf("decode of short block: got %v, exp %v", len(block), encodedBlockHeaderSize)
 	}
 
 	blockType, err := BlockType(block)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding block type: %v", err)
 	}
 
 	switch blockType {
@@ -314,7 +314,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 		return vals[:len(decoded)], err
 
 	default:
-		panic(fmt.Sprintf("unknown block type: %d", blockType))
+		return nil, fmt.Errorf("unknown block type: %d", blockType)
 	}
 }
 

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -313,7 +313,11 @@ func TestEncoding_Count(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if got, exp := tsm1.BlockCount(b), 1; got != exp {
+		cnt, err := tsm1.BlockCount(b)
+		if err != nil {
+			t.Fatalf("Block is corrupted: %v", err)
+		}
+		if got, exp := cnt, 1; got != exp {
 			t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 		}
 	}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -924,7 +924,9 @@ func (f *FileStore) BlockCount(path string, idx int) int {
 				}
 			}
 			_, _, _, _, _, block, _ := iter.Read()
-			return BlockCount(block)
+			// on Error, BlockCount(block) returns 0 for cnt
+			cnt, _ := BlockCount(block)
+			return cnt
 		}
 	}
 	return 0

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -1539,7 +1539,11 @@ func TestCompacted_NotFull(t *testing.T) {
 		t.Fatalf("unexpected error reading block: %v", err)
 	}
 
-	if got, exp := BlockCount(block), 1; got != exp {
+	cnt, err := BlockCount(block)
+	if err != nil {
+		t.Fatalf("Block is corrupted: %v", err)
+	}
+	if got, exp := cnt, 1; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }


### PR DESCRIPTION
fixes #17440
backports https://github.com/influxdata/influxdb/pull/17532 to 1.8

While encoding or decoding corrupt data, the current behaviour is to `panic`.
This commit replaces the `panic` with `error` to be propagated up to the calling `iterator`.
To avoid overwriting other `error`, iterators now wraps a `TSMErrors` which contains ALL the encountered errors.
TSMErrors itself implements `Error()`, the returned string contains all the error msgs, separated by "," delimiter.

