### PR TITLE
feat(ui): redesign alerting index to be responsive

### DIFF
--- a/ui/src/alerting/components/AlertingIndex.scss
+++ b/ui/src/alerting/components/AlertingIndex.scss
@@ -1,30 +1,68 @@
-.alerting-index,
-.alerting-index > .cf-grid--row,
-.alerting-index > .cf-grid--row > .cf-grid--column {
-  height: 100%;
+/*
+  Small Screen Layout
+  ------------------------------------------------------------------------------
+*/
+
+.alerting-index .cf-page-contents__fluid {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.alerting-index--selector {
+  width: 100%;
+  margin-bottom: $cf-marg-b;
+}
+
+.alerting-index--columns {
+  display: flex;
+  align-items: stretch;
+  flex: 1 0 0;
 }
 
 .alerting-index--column {
-  height: calc(100% - #{$ix-marg-d});
+  display: none;
+  flex-direction: column;
+  flex: 1 0 0;
   overflow: hidden;
+  margin-bottom: $cf-marg-c;
 }
 
-.alert-column--empty {
-  min-height: 160px;
-  justify-content: center;
+.alerting-index__checks .alerting-index--checks,
+.alerting-index__endpoints .alerting-index--notification-endpoints,
+.alerting-index__rules .alerting-index--notification-rules {
+  display: flex;
 }
 
 .alerting-index--column-body {
   flex: 1 0 0;
-  position: relative;
-  height: 90%;
-  padding-bottom: $ix-marg-d;
 }
 
 .alerting-index--list,
 .alerting-index--search {
-  padding: 18px;
+  padding: 20px;
   padding-top: 0;
+}
+
+/*
+  Large Screen Layout
+  ------------------------------------------------------------------------------
+*/
+
+@media screen and (min-width: $cf-grid--breakpoint-lg) {
+  .alerting-index--selector {
+    display: none;
+  }
+
+  .alerting-index--column {
+    display: flex;
+    margin-bottom: $cf-marg-d;
+    margin-right: $cf-marg-b;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 }
 
 /*

--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -1,9 +1,9 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, useState} from 'react'
 import {connect} from 'react-redux'
 
 //Components
-import {Grid, GridRow, GridColumn, Page} from '@influxdata/clockface'
+import {Page, SelectGroup, ButtonShape} from '@influxdata/clockface'
 import ChecksColumn from 'src/checks/components/ChecksColumn'
 import RulesColumn from 'src/notifications/rules/components/RulesColumn'
 import EndpointsColumn from 'src/notifications/endpoints/components/EndpointsColumn'
@@ -28,19 +28,33 @@ interface StateProps {
   limitedResources: string
 }
 
+type ActiveColumn = 'checks' | 'endpoints' | 'rules'
+
 const AlertingIndex: FunctionComponent<StateProps> = ({
   children,
   limitStatus,
   limitedResources,
 }) => {
+  const [activeColumn, setActiveColumn] = useState<ActiveColumn>('checks')
+
+  const pageContentsClassName = `alerting-index alerting-index__${activeColumn}`
+
+  const handleTabClick = (selectGroupOptionID: ActiveColumn): void => {
+    setActiveColumn(selectGroupOptionID)
+  }
+
   return (
     <>
       <Page titleTag={pageTitleSuffixer(['Alerts'])}>
-        <Page.Header fullWidth={false}>
+        <Page.Header fullWidth={true}>
           <Page.Title title="Alerts" />
           <CloudUpgradeButton />
         </Page.Header>
-        <Page.Contents fullWidth={false} scrollable={false}>
+        <Page.Contents
+          fullWidth={true}
+          scrollable={false}
+          className={pageContentsClassName}
+        >
           <GetResources resources={[ResourceType.Labels]}>
             <GetAssetLimits>
               <AssetLimitAlert
@@ -48,27 +62,49 @@ const AlertingIndex: FunctionComponent<StateProps> = ({
                 limitStatus={limitStatus}
                 className="load-data--asset-alert"
               />
-              <Grid className="alerting-index">
-                <GridRow testID="grid--row">
-                  <GridColumn widthLG={4} widthMD={4} widthSM={4} widthXS={12}>
-                    <GetResources resources={[ResourceType.Checks]}>
-                      <ChecksColumn />
-                    </GetResources>
-                  </GridColumn>
-                  <GridColumn widthLG={4} widthMD={4} widthSM={4} widthXS={12}>
-                    <GetResources
-                      resources={[ResourceType.NotificationEndpoints]}
-                    >
-                      <EndpointsColumn />
-                    </GetResources>
-                  </GridColumn>
-                  <GridColumn widthLG={4} widthMD={4} widthSM={4} widthXS={12}>
-                    <GetResources resources={[ResourceType.NotificationRules]}>
-                      <RulesColumn />
-                    </GetResources>
-                  </GridColumn>
-                </GridRow>
-              </Grid>
+              <SelectGroup
+                className="alerting-index--selector"
+                shape={ButtonShape.StretchToFit}
+              >
+                <SelectGroup.Option
+                  value="checks"
+                  id="checks"
+                  onClick={handleTabClick}
+                  name="alerting-active-tab"
+                  active={activeColumn === 'checks'}
+                >
+                  Checks
+                </SelectGroup.Option>
+                <SelectGroup.Option
+                  value="endpoints"
+                  id="endpoints"
+                  onClick={handleTabClick}
+                  name="alerting-active-tab"
+                  active={activeColumn === 'endpoints'}
+                >
+                  Notification Endpoints
+                </SelectGroup.Option>
+                <SelectGroup.Option
+                  value="rules"
+                  id="rules"
+                  onClick={handleTabClick}
+                  name="alerting-active-tab"
+                  active={activeColumn === 'rules'}
+                >
+                  Notification Rules
+                </SelectGroup.Option>
+              </SelectGroup>
+              <div className="alerting-index--columns">
+                <GetResources resources={[ResourceType.Checks]}>
+                  <ChecksColumn />
+                </GetResources>
+                <GetResources resources={[ResourceType.NotificationEndpoints]}>
+                  <EndpointsColumn />
+                </GetResources>
+                <GetResources resources={[ResourceType.NotificationRules]}>
+                  <RulesColumn />
+                </GetResources>
+              </div>
             </GetAssetLimits>
           </GetResources>
         </Page.Contents>

--- a/ui/src/alerting/components/AlertsColumn.tsx
+++ b/ui/src/alerting/components/AlertsColumn.tsx
@@ -39,10 +39,14 @@ const AlertsColumnHeader: FC<Props> = ({
   questionMarkTooltipContents,
 }) => {
   const [searchTerm, onChangeSearchTerm] = useState('')
+
+  const formattedTitle = title.toLowerCase().replace(' ', '-')
+  const panelClassName = `alerting-index--column alerting-index--${formattedTitle}`
+
   return (
     <Panel
       backgroundColor={InfluxColors.Kevlar}
-      className="alerting-index--column"
+      className={panelClassName}
       testID={`${type}--column`}
     >
       <Panel.Header>


### PR DESCRIPTION
Goal is to allow the `TreeNav` to be in `expanded` state by default, which we previously couldn't do because this page became so squished that the e2e tests broke.

On most displays the page will only show 1 column at a time, but on larger displays it will show all 3 side by side.

![Screen Shot 2020-04-02 at 11 31 14 AM](https://user-images.githubusercontent.com/2433762/78285739-8a938080-74d5-11ea-8c03-7c2498c5ae90.png)
![Screen Shot 2020-04-02 at 11 31 25 AM](https://user-images.githubusercontent.com/2433762/78285783-8e270780-74d5-11ea-8ee0-01a2da760488.png)
![Screen Shot 2020-04-02 at 11 31 32 AM](https://user-images.githubusercontent.com/2433762/78285839-9121f800-74d5-11ea-826f-1b149d3273a8.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
