### PR TITLE
fix: dont wait for query hydration

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -28,7 +28,7 @@ import {
   updateTimeRangeFromQueryParams,
 } from 'src/dashboards/actions/ranges'
 import {setViews} from 'src/views/actions/creators'
-import {getVariables} from 'src/variables/actions/thunks'
+import {getVariables, hydrateVariables} from 'src/variables/actions/thunks'
 import {setExportTemplate} from 'src/templates/actions/creators'
 import {checkDashboardLimits} from 'src/cloud/actions/limits'
 import {updateViewAndVariables} from 'src/views/actions/thunks'
@@ -285,6 +285,8 @@ export const getDashboard = (dashboardID: string) => async (
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
+
+    dispatch(hydrateVariables())
 
     const normDash = normalize<Dashboard, DashboardEntities, string>(
       resp.data,

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -90,40 +90,47 @@ export const getVariables = () => async (
       })
 
     await dispatch(setVariables(RemoteDataState.Done, variables))
-
-    const _state = getState()
-    const vars = getVariablesFromState(_state)
-    const vals = await hydrateVars(vars, getAllVariablesFromState(_state), {
-      orgID: org.id,
-      url: _state.links.query.self,
-    }).promise
-
-    vars
-      .filter(v => {
-        return vals[v.id] && v.arguments.type === 'query'
-      })
-      .forEach(v => {
-        v.arguments.values.results = vals[v.id].values
-        v.selected = vals[v.id].selected
-      })
-
-    await dispatch(
-      setVariables(RemoteDataState.Done, {
-        result: vars.map(v => v.id),
-        entities: {
-          variables: vars.reduce((prev, curr) => {
-            prev[curr.id] = curr
-
-            return prev
-          }, {}),
-        },
-      })
-    )
   } catch (error) {
     console.error(error)
     dispatch(setVariables(RemoteDataState.Error))
     dispatch(notify(copy.getVariablesFailed()))
   }
+}
+
+export const hydrateVariables = () => async (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  const state = getState()
+  const org = getOrg(state)
+  const vars = getVariablesFromState(state)
+  const vals = await hydrateVars(vars, getAllVariablesFromState(state), {
+    orgID: org.id,
+    url: state.links.query.self,
+    skipCache: true,
+  }).promise
+
+  vars
+    .filter(v => {
+      return vals[v.id] && v.arguments.type === 'query'
+    })
+    .forEach(v => {
+      v.arguments.values.results = vals[v.id].values
+      v.selected = vals[v.id].selected
+    })
+
+  await dispatch(
+    setVariables(RemoteDataState.Done, {
+      result: vars.map(v => v.id),
+      entities: {
+        variables: vars.reduce((prev, curr) => {
+          prev[curr.id] = curr
+
+          return prev
+        }, {}),
+      },
+    })
+  )
 }
 
 export const getVariable = (id: string) => async (

--- a/ui/src/variables/utils/ValueFetcher.ts
+++ b/ui/src/variables/utils/ValueFetcher.ts
@@ -66,7 +66,8 @@ export interface ValueFetcher {
     query: string,
     variables: VariableAssignment[],
     prevSelection: string,
-    defaultSelection: string
+    defaultSelection: string,
+    skipCache: boolean
   ) => CancelBox<VariableValues>
 }
 

--- a/ui/src/variables/utils/ValueFetcher.ts
+++ b/ui/src/variables/utils/ValueFetcher.ts
@@ -73,12 +73,26 @@ export interface ValueFetcher {
 export class DefaultValueFetcher implements ValueFetcher {
   private cache: {[cacheKey: string]: VariableValues} = {}
 
-  public fetch(url, orgID, query, variables, prevSelection, defaultSelection) {
+  public fetch(
+    url,
+    orgID,
+    query,
+    variables,
+    prevSelection,
+    defaultSelection,
+    skipCache
+  ) {
     const key = cacheKey(url, orgID, query, variables)
-    const cachedValues = this.cachedValues(key, prevSelection, defaultSelection)
+    if (!skipCache) {
+      const cachedValues = this.cachedValues(
+        key,
+        prevSelection,
+        defaultSelection
+      )
 
-    if (cachedValues) {
-      return {promise: Promise.resolve(cachedValues), cancel: () => {}}
+      if (cachedValues) {
+        return {promise: Promise.resolve(cachedValues), cancel: () => {}}
+      }
     }
 
     const extern = buildVarsOption(variables)

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -30,6 +30,7 @@ interface HydrateVarsOptions {
   orgID: string
   selections?: ValueSelections
   fetcher?: ValueFetcher
+  skipCache?: boolean
 }
 
 export const createVariableGraph = (

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -211,7 +211,15 @@ const hydrateVarsHelper = async (
   const {query} = node.variable.arguments.values
   const fetcher = options.fetcher || valueFetcher
 
-  const request = fetcher.fetch(url, orgID, query, assignments, null, '')
+  const request = fetcher.fetch(
+    url,
+    orgID,
+    query,
+    assignments,
+    null,
+    '',
+    options.skipCache
+  )
 
   node.cancel = request.cancel
 


### PR DESCRIPTION
Closes #17576
Closes #17209

We were waiting for all query variables to return their results before rendering the dashboard. Most users should not have seen this, but the tools cluster was real slow. Some copy pasta later to reorder the execution to not include hydration on a Promise.all, and we are back in business.

While poking around the hydration code, i also found where query variable requests were cached! overriding that fixed the bucket problem and means that navigating away, and then back to, a dashboard refreshes all your variables