### PR TITLE
feat(kv): add ability to configure a max permissions using auth filter function

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -48,6 +48,8 @@ type Service struct {
 	Migrator *Migrator
 
 	urmByUserIndex *Index
+
+	disableAuthorizationsForMaxPermissions func(context.Context) bool
 }
 
 // NewService returns an instance of a Service.
@@ -79,6 +81,9 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 				return id, nil
 			},
 		)),
+		disableAuthorizationsForMaxPermissions: func(context.Context) bool {
+			return false
+		},
 	}
 
 	// kv service migrations
@@ -267,4 +272,11 @@ func (s *Service) WithStore(store Store) {
 // Should only be used in tests for mocking.
 func (s *Service) WithSpecialOrgBucketIDs(gen influxdb.IDGenerator) {
 	s.OrgBucketIDs = gen
+}
+
+// WithMaxPermissionFunc sets the useAuthorizationsForMaxPermissions function
+// which can trigger whether or not max permissions uses the users authorizations
+// to derive maximum permissions.
+func (s *Service) WithMaxPermissionFunc(fn func(context.Context) bool) {
+	s.disableAuthorizationsForMaxPermissions = fn
 }

--- a/kv/session.go
+++ b/kv/session.go
@@ -124,15 +124,17 @@ func (s *Service) maxPermissions(ctx context.Context, tx Tx, userID influxdb.ID)
 	}
 	ps = append(ps, influxdb.MePermissions(userID)...)
 
-	// TODO(desa): this is super expensive, we should keep a list of a users maximal privileges somewhere
-	// we did this so that the oper token would be used in a users permissions.
-	af := influxdb.AuthorizationFilter{UserID: &userID}
-	as, err := s.findAuthorizations(ctx, tx, af)
-	if err != nil {
-		return nil, err
-	}
-	for _, a := range as {
-		ps = append(ps, a.Permissions...)
+	if !s.disableAuthorizationsForMaxPermissions(ctx) {
+		// TODO(desa): this is super expensive, we should keep a list of a users maximal privileges somewhere
+		// we did this so that the oper token would be used in a users permissions.
+		af := influxdb.AuthorizationFilter{UserID: &userID}
+		as, err := s.findAuthorizations(ctx, tx, af)
+		if err != nil {
+			return nil, err
+		}
+		for _, a := range as {
+			ps = append(ps, a.Permissions...)
+		}
 	}
 
 	return ps, nil

--- a/kv/task.go
+++ b/kv/task.go
@@ -131,9 +131,11 @@ func (s *Service) findTaskByIDWithAuth(ctx context.Context, tx Tx, id influxdb.I
 		Status: influxdb.Active,
 		ID:     influxdb.ID(1),
 		OrgID:  t.OrganizationID,
+		UserID: t.OwnerID,
 	}
 
 	if t.OwnerID.Valid() {
+		ctx = icontext.SetAuthorizer(ctx, t.Authorization)
 		// populate task Auth
 		ps, err := s.maxPermissions(ctx, tx, t.OwnerID)
 		if err != nil {

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -280,10 +280,15 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		Flux:            fmt.Sprintf(scriptFmt, 0),
 		Type:            influxdb.TaskSystemType,
 	}
+
+	// tasks sets user id on authorization to that
+	// of the tasks owner
+	want.Authorization.UserID = tsk.OwnerID
+
 	for fn, f := range found {
 		if diff := cmp.Diff(f, want); diff != "" {
 			t.Logf("got: %+#v", f)
-			t.Fatalf("expected %s task to be consistant: -got/+want: %s", fn, diff)
+			t.Errorf("expected %s task to be consistant: -got/+want: %s", fn, diff)
 		}
 	}
 


### PR DESCRIPTION
Add ability to configure disabling max permissions using auth lookup via a `useAuthorizationsForMaxPermissions` filter function.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
