### PR TITLE
fix(ui): fixed single column links bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 1. [17404](https://github.com/influxdata/influxdb/pull/17404): Updated duplicate check error message to be more explicit and actionable
 1. [17515](https://github.com/influxdata/influxdb/pull/17515): Editing a table cell shows the proper values and respects changes
 1. [17521](https://github.com/influxdata/influxdb/pull/17521): Table view scrolling should be slightly smoother
+1. [17601](https://github.com/influxdata/influxdb/pull/17601): URL table values on single columns are being correctly parsed
 
 ### UI Improvements
 

--- a/ui/src/shared/components/tables/TableCell.tsx
+++ b/ui/src/shared/components/tables/TableCell.tsx
@@ -31,12 +31,13 @@ interface Props extends CellRendererProps {
   timeFormatter: (time: string) => string
 }
 
-const URL_REGEXP = /(https?:\/\/[^\s]+)/g
+const URL_REGEXP = /((http|https)?:\/\/[^\s]+)/g
 
 // NOTE: rip this out if you spend time any here as per:
 // https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501
 function asLink(str) {
-  if (!URL_REGEXP.test('' + str)) {
+  const isURL = `${str}`.includes('http://') || `${str}`.includes('https://')
+  if (isURL === false) {
     return str
   }
 


### PR DESCRIPTION
Closes #16924

### Problem

URL parsing for table results with 1 column would apply funky styling to the results.

### Solution

I genuinely can't say why the previous implementation was failing. The regex statement was able to parse a URL correctly when multiple columns were present, but the second only 1 column was present, the regex statement failed to parse the URL correctly. After investigating it for a while, I genuinely couldn't a valid reason why it would be failing to parse the values correctly. As such, I switched the initial validation to use a native JS method to validate whether the value is a URL based on the regex parsing that was previously being used to validate the string.

![table-column-fix](https://user-images.githubusercontent.com/19984220/78376144-bfa9dc80-7582-11ea-9281-ecb5d07d6edf.gif)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)