### PR TITLE
fix(ui): ensure all dashboard cards render the same size

### DIFF
--- a/ui/src/dashboards/components/DashboardsCardGrid.scss
+++ b/ui/src/dashboards/components/DashboardsCardGrid.scss
@@ -16,21 +16,22 @@
 }
 
 .dashboards-card-grid {
-   display: grid;
-   grid-template-columns: 1fr;
-   grid-template-rows: 150px 150px 150px;
-   grid-column-gap: $ix-marg-a;
-   grid-row-gap: $ix-marg-a;
-   height: 100%;
+  padding-bottom: $cf-marg-d;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: 152px;
+  grid-column-gap: $cf-marg-a;
+  grid-row-gap: $cf-marg-a;
+  height: 100%;
 
-   .cf-resource-card {
-      margin-bottom: 0;
-   }
+  .cf-resource-card {
+    margin-bottom: 0;
+  }
 
-   .cf-resource-description {
-      height: 60px;
-      overflow: hidden;
-   }
+  .cf-resource-description {
+    height: 60px;
+    overflow: hidden;
+  }
 }
 
 @media screen and (min-width: $cf-grid--breakpoint-sm) {


### PR DESCRIPTION
Closes #16966

![Screen Shot 2020-04-03 at 12 54 02 PM](https://user-images.githubusercontent.com/2433762/78401519-c4d05100-75ad-11ea-9a2a-9a4a0d0f9602.png)
All cards are the same height regardless of contents or position

![Screen Shot 2020-04-03 at 1 19 29 PM](https://user-images.githubusercontent.com/2433762/78401537-cf8ae600-75ad-11ea-8277-17768c470a68.png)
Cards with a long name don't change width and truncate the name

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
