### PR TITLE
fix: bubble template create permission error

### DIFF
--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -105,6 +105,7 @@ export const createDashboardFromTemplate = async (
     }
   } catch (error) {
     console.error(error)
+    throw new Error(error.message)
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/quartz/issues/2371

### The Problem
The `createDashboardTemplate` function swallowed the http error in its own `catch`. 

### The Solution
Throw the error from `catch` so consuming functions can respond to said error.

![Kapture 2020-04-06 at 10 56 57](https://user-images.githubusercontent.com/7582765/78589745-8a58f500-77f5-11ea-87db-27fa06479ccb.gif)
