### PR TITLE
fix(storage/reads): update sortKey sorting method to use null byte as delimiter, not comma

### DIFF
--- a/storage/reads/group_resultset.go
+++ b/storage/reads/group_resultset.go
@@ -247,7 +247,8 @@ func (g *groupResultSet) groupBySort() (int, error) {
 			nr.SortKey = make([]byte, 0, l)
 			for _, v := range vals {
 				nr.SortKey = append(nr.SortKey, v...)
-				nr.SortKey = append(nr.SortKey, ',')
+				// separate sort key values with ascii null character
+				nr.SortKey = append(nr.SortKey, '\000')
 			}
 
 			seriesRows = append(seriesRows, &nr)

--- a/storage/reads/group_resultset_test.go
+++ b/storage/reads/group_resultset_test.go
@@ -86,6 +86,49 @@ group:
 `,
 		},
 		{
+			name: "group by tags key sort collision",
+			cur: &sliceSeriesCursor{
+				rows: newSeriesRows(
+					"cpu,tag0=a,tag1=b",
+					"cpu,tag0=a*,tag1=b",
+					"cpu,tag0=a*",
+				)},
+			group: datatypes.GroupBy,
+			keys:  []string{"tag0", "tag1"},
+			exp: `group:
+  tag key      : _m,tag0,tag1
+  partition key: a,b
+    series: _m=cpu,tag0=a,tag1=b
+group:
+  tag key      : _m,tag0,tag1
+  partition key: a*,b
+    series: _m=cpu,tag0=a*,tag1=b
+group:
+  tag key      : _m,tag0
+  partition key: a*,<nil>
+    series: _m=cpu,tag0=a*
+`,
+		},
+		{
+			name: "group by tags missing tag",
+			cur: &sliceSeriesCursor{
+				rows: newSeriesRows(
+					"cpu,tag0=a,tag1=b",
+					"cpu,tag1=b",
+				)},
+			group: datatypes.GroupBy,
+			keys:  []string{"tag0", "tag1"},
+			exp: `group:
+  tag key      : _m,tag0,tag1
+  partition key: a,b
+    series: _m=cpu,tag0=a,tag1=b
+group:
+  tag key      : _m,tag1
+  partition key: <nil>,b
+    series: _m=cpu,tag1=b
+`,
+		},
+		{
 			name: "group by tag1 in partial series",
 			cur: &sliceSeriesCursor{
 				rows: newSeriesRows(


### PR DESCRIPTION
Currently, the comparison function for sorting in `group_resultset.go` `groupBySort` just sorts sortKeys as a contiguous byte array, using commas to separate values.
[](url)
https://github.com/influxdata/influxdb/blob/636a27e77f00f0faeff186c8b6b005d79da7c424/storage/reads/group_resultset.go#L217-L265

This causes an issue whenever there is an ascii character in the byte array that would be sorted before a `,` character.

For example:
`a*,b` would sort before `a,b` because `*` is less than `,`.

This PR resolves that issue. 