### PR TITLE
feat: swallow unselected variable error

### DIFF
--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -259,11 +259,15 @@ export const asAssignment = (variable: Variable): VariableAssignment => {
 
   if (variable.arguments.type === 'query') {
     if (!variable.selected || !variable.selected[0]) {
-      return null
-    }
-    out.init = {
-      type: 'StringLiteral',
-      value: variable.selected[0],
+      out.init = {
+        type: 'StringLiteral',
+        value: '',
+      }
+    } else {
+      out.init = {
+        type: 'StringLiteral',
+        value: variable.selected[0],
+      }
     }
   }
 


### PR DESCRIPTION
while we figure out how to more proactively prevent the user from reaching an error state from unset variables (influxdata/idpe#6675), we can hide the errors from the backend by filling unselected query variables as an empty string.