### PR TITLE
fix(CORS): stop processing in pre-flight CORS requests

### DIFF
--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -18,13 +18,18 @@ type Middleware func(http.Handler) http.Handler
 func SetCORS(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if origin := r.Header.Get("Origin"); origin != "" {
+			// Access-Control-Allow-Origin must be present in every response
 			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
+		if r.Method == http.MethodOptions {
+			// allow and stop processing in pre-flight requests
 			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent")
+			w.WriteHeader(http.StatusNoContent)
+			return
 		}
 		next.ServeHTTP(w, r)
 	}
-
 	return http.HandlerFunc(fn)
 }
 

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -67,7 +67,7 @@ func TestCors(t *testing.T) {
 			name:           "OPTIONS with Origin",
 			method:         "OPTIONS",
 			headers:        []string{"Origin", "http://myapp.com"},
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusNoContent,
 		},
 		{
 			name:           "GET with Origin",
@@ -75,9 +75,7 @@ func TestCors(t *testing.T) {
 			headers:        []string{"Origin", "http://anotherapp.com"},
 			expectedStatus: http.StatusOK,
 			expectedHeaders: map[string]string{
-				"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE",
-				"Access-Control-Allow-Origin":  "http://anotherapp.com",
-				"Access-Control-Allow-Headers": "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent",
+				"Access-Control-Allow-Origin": "http://anotherapp.com",
 			},
 		},
 	}


### PR DESCRIPTION
In CORS (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS),
- the server stops processing when satisfying pre-flight requests
- Access-Control-Allow-Origin header is included in CORS-allowed responses

This fix is required for any browser client (including influxdb-client-js) to work fine against influxdb OSS. 

cc influxdata/influxdb-client-js#164 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
