### PR TITLE
fix(tracing): add support for tracing route annotation when using chi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2 // indirect
 	github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493 // indirect
-	github.com/go-chi/chi v4.0.2+incompatible
+	github.com/go-chi/chi v4.1.0+incompatible
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/gddo v0.0.0-20181116215533-9bd4a3295021
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2 h1:Ujru
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
 github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493 h1:OTanQnFt0bi5iLFSdbEVA/idR6Q2WhCm+deb7ir2CcM=
 github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
-github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
-github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.1.0+incompatible h1:ETj3cggsVIY2Xao5ExCu6YhEh5MD6JTfcBzS37R260w=
+github.com/go-chi/chi v4.1.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uber/jaeger-client-go"
 
@@ -72,6 +73,10 @@ func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.
 func annotateSpan(span opentracing.Span, handlerName string, req *http.Request) {
 	if route := httprouter.MatchedRouteFromContext(req.Context()); route != "" {
 		span.SetTag("route", route)
+	}
+	if ctx := chi.RouteContext(req.Context()); ctx != nil {
+		span.SetTag("route", ctx.RoutePath)
+		span.SetTag("method", ctx.RouteMethod)
 	}
 	span.SetTag("handler", handlerName)
 	span.LogKV("path", req.URL.Path)

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/go-chi/chi"
 	"github.com/influxdata/httprouter"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
@@ -73,6 +74,21 @@ func TestExtractHTTPRequest(t *testing.T) {
 			path:        "/api/v2/buckets/12345",
 			tags: map[string]interface{}{
 				"route":   "/api/v2/buckets/:bucket_id",
+				"handler": "BucketHandler",
+			},
+		},
+		{
+			name:        "happy path bucket handler (chi)",
+			handlerName: "BucketHandler",
+			ctx: context.WithValue(
+				ctx,
+				chi.RouteCtxKey,
+				&chi.Context{RoutePath: "/api/v2/buckets/:bucket_id", RouteMethod: "GET"},
+			),
+			path: "/api/v2/buckets/12345",
+			tags: map[string]interface{}{
+				"route":   "/api/v2/buckets/:bucket_id",
+				"method":  "GET",
 				"handler": "BucketHandler",
 			},
 		},


### PR DESCRIPTION
Since moving to chi in some places. Traces have lost their `route` tags. This makes searching for certain requests impossible.
This adds support for hijacking the route of the chi context and annotating the span.

It also bumps chi version because there was a bug fix for extracting the router context.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
