### PR TITLE
fix: force a server redirect to /upgrade

### DIFF
--- a/ui/src/shared/components/CloudUpgradeButton.tsx
+++ b/ui/src/shared/components/CloudUpgradeButton.tsx
@@ -14,6 +14,7 @@ const CloudUpgradeButton: FC = () => {
       <Link
         className="cf-button cf-button-sm cf-button-success upgrade-payg--button"
         to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+        target="_self"
       >
         Upgrade Now
       </Link>


### PR DESCRIPTION
Closes 6679

apparently, [adding `_target`](https://github.com/ReactTraining/react-router/issues/3109#issuecomment-189782650) to `Link`s skips state transitions and sends the request directly to the server.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
