### PR TITLE
refactor(query): update semantic graph usage for function expression refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6
-	github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481
+	github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/pkg-config v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481 h1:S1bKQ0VSDEGPezUfW5hsaDSPkWEZLGNMc0zLGM8yvfg=
-github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481/go.mod h1:4PVm7oUSOMJgXbEsEZgHmWZRjIPtB6gF0F9et2i3+3w=
+github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b h1:AJmLp073BKI7PWqfaGdN8AyEpiSd1CADvSQqfSZmRZw=
+github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b/go.mod h1:4PVm7oUSOMJgXbEsEZgHmWZRjIPtB6gF0F9et2i3+3w=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/promql/internal/promqltests/go.mod
+++ b/query/promql/internal/promqltests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1
-	github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481
+	github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b
 	github.com/influxdata/influxdb/v2 v2.0.1-alpha.10.0.20200406212829-84386b884ac5
 	github.com/influxdata/influxql v1.0.1 // indirect
 	github.com/influxdata/promql/v2 v2.12.0

--- a/query/promql/internal/promqltests/go.sum
+++ b/query/promql/internal/promqltests/go.sum
@@ -289,8 +289,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481 h1:S1bKQ0VSDEGPezUfW5hsaDSPkWEZLGNMc0zLGM8yvfg=
-github.com/influxdata/flux v0.64.1-0.20200406183908-833eea1d2481/go.mod h1:4PVm7oUSOMJgXbEsEZgHmWZRjIPtB6gF0F9et2i3+3w=
+github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b h1:AJmLp073BKI7PWqfaGdN8AyEpiSd1CADvSQqfSZmRZw=
+github.com/influxdata/flux v0.64.1-0.20200407154536-5c3014df244b/go.mod h1:4PVm7oUSOMJgXbEsEZgHmWZRjIPtB6gF0F9et2i3+3w=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxdb v0.0.0-20170331210902-15e594fc09f1 h1:O08dwjOwv9CYlJJEUZKAazSoQDKlsN34Bq3dnhqhyVI=

--- a/query/promql/query_test.go
+++ b/query/promql/query_test.go
@@ -375,49 +375,53 @@ func TestBuild(t *testing.T) {
 							Fn: interpreter.ResolvedFunction{
 								Scope: nil,
 								Fn: &semantic.FunctionExpression{
-									Block: &semantic.FunctionBlock{
-										Parameters: &semantic.FunctionParameters{
-											List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
-										},
-										Body: &semantic.LogicalExpression{
-											Operator: ast.AndOperator,
-											Left: &semantic.LogicalExpression{
-												Operator: ast.AndOperator,
-												Left: &semantic.BinaryExpression{
-													Operator: ast.EqualOperator,
-													Left: &semantic.MemberExpression{
-														Object: &semantic.IdentifierExpression{
-															Name: "r",
+									Parameters: &semantic.FunctionParameters{
+										List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+									},
+									Block: &semantic.Block{
+										Body: []semantic.Statement{
+											&semantic.ReturnStatement{
+												Argument: &semantic.LogicalExpression{
+													Operator: ast.AndOperator,
+													Left: &semantic.LogicalExpression{
+														Operator: ast.AndOperator,
+														Left: &semantic.BinaryExpression{
+															Operator: ast.EqualOperator,
+															Left: &semantic.MemberExpression{
+																Object: &semantic.IdentifierExpression{
+																	Name: "r",
+																},
+																Property: "_metric",
+															},
+															Right: &semantic.StringLiteral{
+																Value: "node_cpu",
+															},
 														},
-														Property: "_metric",
-													},
-													Right: &semantic.StringLiteral{
-														Value: "node_cpu",
-													},
-												},
-												Right: &semantic.BinaryExpression{
-													Operator: ast.EqualOperator,
-													Left: &semantic.MemberExpression{
-														Object: &semantic.IdentifierExpression{
-															Name: "r",
+														Right: &semantic.BinaryExpression{
+															Operator: ast.EqualOperator,
+															Left: &semantic.MemberExpression{
+																Object: &semantic.IdentifierExpression{
+																	Name: "r",
+																},
+																Property: "mode",
+															},
+															Right: &semantic.StringLiteral{
+																Value: "user",
+															},
 														},
-														Property: "mode",
 													},
-													Right: &semantic.StringLiteral{
-														Value: "user",
+													Right: &semantic.BinaryExpression{
+														Operator: ast.EqualOperator,
+														Left: &semantic.MemberExpression{
+															Object: &semantic.IdentifierExpression{
+																Name: "r",
+															},
+															Property: "cpu",
+														},
+														Right: &semantic.StringLiteral{
+															Value: "cpu2",
+														},
 													},
-												},
-											},
-											Right: &semantic.BinaryExpression{
-												Operator: ast.EqualOperator,
-												Left: &semantic.MemberExpression{
-													Object: &semantic.IdentifierExpression{
-														Name: "r",
-													},
-													Property: "cpu",
-												},
-												Right: &semantic.StringLiteral{
-													Value: "cpu2",
 												},
 											},
 										},
@@ -465,34 +469,38 @@ func TestBuild(t *testing.T) {
 							Fn: interpreter.ResolvedFunction{
 								Scope: nil,
 								Fn: &semantic.FunctionExpression{
-									Block: &semantic.FunctionBlock{
-										Parameters: &semantic.FunctionParameters{
-											List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
-										},
-										Body: &semantic.LogicalExpression{
-											Operator: ast.AndOperator,
-											Left: &semantic.BinaryExpression{
-												Operator: ast.EqualOperator,
-												Left: &semantic.MemberExpression{
-													Object: &semantic.IdentifierExpression{
-														Name: "r",
+									Parameters: &semantic.FunctionParameters{
+										List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+									},
+									Block: &semantic.Block{
+										Body: []semantic.Statement{
+											&semantic.ReturnStatement{
+												Argument: &semantic.LogicalExpression{
+													Operator: ast.AndOperator,
+													Left: &semantic.BinaryExpression{
+														Operator: ast.EqualOperator,
+														Left: &semantic.MemberExpression{
+															Object: &semantic.IdentifierExpression{
+																Name: "r",
+															},
+															Property: "_metric",
+														},
+														Right: &semantic.StringLiteral{
+															Value: "node_cpu",
+														},
 													},
-													Property: "_metric",
-												},
-												Right: &semantic.StringLiteral{
-													Value: "node_cpu",
-												},
-											},
-											Right: &semantic.BinaryExpression{
-												Operator: ast.EqualOperator,
-												Left: &semantic.MemberExpression{
-													Object: &semantic.IdentifierExpression{
-														Name: "r",
+													Right: &semantic.BinaryExpression{
+														Operator: ast.EqualOperator,
+														Left: &semantic.MemberExpression{
+															Object: &semantic.IdentifierExpression{
+																Name: "r",
+															},
+															Property: "mode",
+														},
+														Right: &semantic.StringLiteral{
+															Value: "user",
+														},
 													},
-													Property: "mode",
-												},
-												Right: &semantic.StringLiteral{
-													Value: "user",
 												},
 											},
 										},
@@ -538,34 +546,38 @@ func TestBuild(t *testing.T) {
 							Fn: interpreter.ResolvedFunction{
 								Scope: nil,
 								Fn: &semantic.FunctionExpression{
-									Block: &semantic.FunctionBlock{
-										Parameters: &semantic.FunctionParameters{
-											List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
-										},
-										Body: &semantic.LogicalExpression{
-											Operator: ast.AndOperator,
-											Left: &semantic.BinaryExpression{
-												Operator: ast.EqualOperator,
-												Left: &semantic.MemberExpression{
-													Object: &semantic.IdentifierExpression{
-														Name: "r",
+									Parameters: &semantic.FunctionParameters{
+										List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+									},
+									Block: &semantic.Block{
+										Body: []semantic.Statement{
+											&semantic.ReturnStatement{
+												Argument: &semantic.LogicalExpression{
+													Operator: ast.AndOperator,
+													Left: &semantic.BinaryExpression{
+														Operator: ast.EqualOperator,
+														Left: &semantic.MemberExpression{
+															Object: &semantic.IdentifierExpression{
+																Name: "r",
+															},
+															Property: "_metric",
+														},
+														Right: &semantic.StringLiteral{
+															Value: "node_cpu",
+														},
 													},
-													Property: "_metric",
-												},
-												Right: &semantic.StringLiteral{
-													Value: "node_cpu",
-												},
-											},
-											Right: &semantic.BinaryExpression{
-												Operator: ast.EqualOperator,
-												Left: &semantic.MemberExpression{
-													Object: &semantic.IdentifierExpression{
-														Name: "r",
+													Right: &semantic.BinaryExpression{
+														Operator: ast.EqualOperator,
+														Left: &semantic.MemberExpression{
+															Object: &semantic.IdentifierExpression{
+																Name: "r",
+															},
+															Property: "_measurement",
+														},
+														Right: &semantic.StringLiteral{
+															Value: "m0",
+														},
 													},
-													Property: "_measurement",
-												},
-												Right: &semantic.StringLiteral{
-													Value: "m0",
 												},
 											},
 										},

--- a/query/promql/types.go
+++ b/query/promql/types.go
@@ -260,11 +260,15 @@ func NewWhereOperation(metricName string, labels []*LabelMatcher) (*flux.Operati
 			Fn: interpreter.ResolvedFunction{
 				Scope: nil,
 				Fn: &semantic.FunctionExpression{
-					Block: &semantic.FunctionBlock{
-						Parameters: &semantic.FunctionParameters{
-							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+					Parameters: &semantic.FunctionParameters{
+						List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+					},
+					Block: &semantic.Block{
+						Body: []semantic.Statement{
+							&semantic.ReturnStatement{
+								Argument: node,
+							},
 						},
-						Body: node,
 					},
 				},
 			},

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -139,12 +139,12 @@ func (PushDownFilterRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
 		return pn, false, nil
 	}
 
-	if len(filterSpec.Fn.Fn.Block.Parameters.List) != 1 {
+	if len(filterSpec.Fn.Fn.Parameters.List) != 1 {
 		// I would expect that type checking would catch this, but just to be safe...
 		return pn, false, nil
 	}
 
-	paramName := filterSpec.Fn.Fn.Block.Parameters.List[0].Key.Name
+	paramName := filterSpec.Fn.Fn.Parameters.List[0].Key.Name
 
 	pushable, notPushable, err := semantic.PartitionPredicates(bodyExpr, func(e semantic.Expression) (bool, error) {
 		return isPushableExpr(paramName, e)
@@ -194,7 +194,7 @@ func (PushDownFilterRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
 	}
 
 	newFilterSpec := filterSpec.Copy().(*universe.FilterProcedureSpec)
-	newFilterSpec.Fn.Fn.Block.Body = &semantic.Block{
+	newFilterSpec.Fn.Fn.Block = &semantic.Block{
 		Body: []semantic.Statement{
 			&semantic.ReturnStatement{Argument: notPushable},
 		},

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -689,24 +689,28 @@ func TestReadTagKeysRule(t *testing.T) {
 		Fn: interpreter.ResolvedFunction{
 			Scope: nil,
 			Fn: &semantic.FunctionExpression{
-				Block: &semantic.FunctionBlock{
-					Parameters: &semantic.FunctionParameters{
-						List: []*semantic.FunctionParameter{{
-							Key: &semantic.Identifier{
-								Name: "r",
-							},
-						}},
-					},
-					Body: &semantic.BinaryExpression{
-						Operator: ast.EqualOperator,
-						Left: &semantic.MemberExpression{
-							Object: &semantic.IdentifierExpression{
-								Name: "r",
-							},
-							Property: "_measurement",
+				Parameters: &semantic.FunctionParameters{
+					List: []*semantic.FunctionParameter{{
+						Key: &semantic.Identifier{
+							Name: "r",
 						},
-						Right: &semantic.StringLiteral{
-							Value: "cpu",
+					}},
+				},
+				Block: &semantic.Block{
+					Body: []semantic.Statement{
+						&semantic.ReturnStatement{
+							Argument: &semantic.BinaryExpression{
+								Operator: ast.EqualOperator,
+								Left: &semantic.MemberExpression{
+									Object: &semantic.IdentifierExpression{
+										Name: "r",
+									},
+									Property: "_measurement",
+								},
+								Right: &semantic.StringLiteral{
+									Value: "cpu",
+								},
+							},
 						},
 					},
 				},
@@ -904,24 +908,28 @@ func TestReadTagValuesRule(t *testing.T) {
 		Fn: interpreter.ResolvedFunction{
 			Scope: nil,
 			Fn: &semantic.FunctionExpression{
-				Block: &semantic.FunctionBlock{
-					Parameters: &semantic.FunctionParameters{
-						List: []*semantic.FunctionParameter{{
-							Key: &semantic.Identifier{
-								Name: "r",
-							},
-						}},
-					},
-					Body: &semantic.BinaryExpression{
-						Operator: ast.EqualOperator,
-						Left: &semantic.MemberExpression{
-							Object: &semantic.IdentifierExpression{
-								Name: "r",
-							},
-							Property: "_measurement",
+				Parameters: &semantic.FunctionParameters{
+					List: []*semantic.FunctionParameter{{
+						Key: &semantic.Identifier{
+							Name: "r",
 						},
-						Right: &semantic.StringLiteral{
-							Value: "cpu",
+					}},
+				},
+				Block: &semantic.Block{
+					Body: []semantic.Statement{
+						&semantic.ReturnStatement{
+							Argument: &semantic.BinaryExpression{
+								Operator: ast.EqualOperator,
+								Left: &semantic.MemberExpression{
+									Object: &semantic.IdentifierExpression{
+										Name: "r",
+									},
+									Property: "_measurement",
+								},
+								Right: &semantic.StringLiteral{
+									Value: "cpu",
+								},
+							},
 						},
 					},
 				},

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -350,7 +350,7 @@ func (t *ToTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 		// If a field function is specified then we exclude any column that
 		// is referenced in the function expression from being a tag column.
 		if t.spec.Spec.FieldFn.Fn != nil {
-			recordParam := t.spec.Spec.FieldFn.Fn.Block.Parameters.List[0].Key.Name
+			recordParam := t.spec.Spec.FieldFn.Fn.Parameters.List[0].Key.Name
 			exprNode := t.spec.Spec.FieldFn.Fn
 			colVisitor := newFieldFunctionVisitor(recordParam, tbl.Cols())
 


### PR DESCRIPTION
This updates the semantic graph usage to accomodate the change to the
semantic graph that removed the ambiguity of the body so now it is
always a block instead of being a block or an expression.