### PR TITLE
feat(ui): sort getting started dashboards by modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### UI Improvements
 
 1. [17583](https://github.com/influxdata/influxdb/pull/17583): Update layout of Alerts page to work on all screen sizes
+1. [17657](https://github.com/influxdata/influxdb/pull/17657): Sort dashboards on Getting Started page by recently modified
 
 ## v2.0.0-beta.7 [2020-03-27]
 

--- a/ui/src/me/components/DashboardsList.tsx
+++ b/ui/src/me/components/DashboardsList.tsx
@@ -1,10 +1,11 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FC} from 'react'
 import {Link} from 'react-router'
 import {connect} from 'react-redux'
+import {sortBy} from 'lodash'
 
 // Components
-import {EmptyState} from '@influxdata/clockface'
+import {EmptyState, DapperScrollbars} from '@influxdata/clockface'
 
 // Types
 import {Dashboard, Organization, AppState, ResourceType} from 'src/types'
@@ -22,34 +23,32 @@ interface StateProps {
 
 type Props = StateProps
 
-class DashboardList extends PureComponent<Props> {
-  public render() {
-    const {dashboards, org} = this.props
-
-    if (this.isEmpty) {
-      return (
-        <EmptyState size={ComponentSize.ExtraSmall}>
-          <EmptyState.Text>You don't have any Dashboards</EmptyState.Text>
-        </EmptyState>
-      )
-    }
+const DashboardList: FC<Props> = ({dashboards, org}) => {
+  if (dashboards && dashboards.length) {
+    const sortedDashboards = sortBy(dashboards, ['meta.updatedAt']).reverse()
 
     return (
-      <>
-        <ul className="link-list">
-          {dashboards.map(({id, name}) => (
-            <li key={id}>
-              <Link to={`/orgs/${org.id}/dashboards/${id}`}>{name}</Link>
-            </li>
+      <DapperScrollbars autoSizeHeight={true} style={{maxHeight: '400px'}}>
+        <div className="recent-dashboards">
+          {sortedDashboards.map(({id, name}) => (
+            <Link
+              key={id}
+              to={`/orgs/${org.id}/dashboards/${id}`}
+              className="recent-dashboards--item"
+            >
+              {name}
+            </Link>
           ))}
-        </ul>
-      </>
+        </div>
+      </DapperScrollbars>
     )
   }
 
-  private get isEmpty(): boolean {
-    return !this.props.dashboards.length
-  }
+  return (
+    <EmptyState size={ComponentSize.ExtraSmall}>
+      <EmptyState.Text>You don't have any Dashboards</EmptyState.Text>
+    </EmptyState>
+  )
 }
 
 const mstp = (state: AppState): StateProps => {

--- a/ui/src/me/components/DashboardsList.tsx
+++ b/ui/src/me/components/DashboardsList.tsx
@@ -49,7 +49,8 @@ const DashboardList: FC<Props> = ({dashboards, org}) => {
 
     if (searchTerm.length) {
       recentlyModifiedDashboards = recentlyModifiedDashboards.filter(
-        dashboard => dashboard.name.toLowerCase().includes(searchTerm.toLowerCase())
+        dashboard =>
+          dashboard.name.toLowerCase().includes(searchTerm.toLowerCase())
       )
     }
 

--- a/ui/src/me/components/Docs.tsx
+++ b/ui/src/me/components/Docs.tsx
@@ -31,7 +31,7 @@ export default class SupportLinks extends PureComponent {
           <h4>Some Handy Guides and Tutorials</h4>
         </Panel.Header>
         <Panel.Body>
-          <ul className="link-list tutorials">
+          <ul className="tutorials-list">
             {supportLinks.map(({link, title}) => (
               <li key={title}>
                 <a href={link} target="_blank">

--- a/ui/src/me/components/Resources.tsx
+++ b/ui/src/me/components/Resources.tsx
@@ -39,7 +39,7 @@ class ResourceLists extends PureComponent<Props> {
         </Panel>
         <Panel>
           <Panel.Header>
-            <h4>Dashboards</h4>
+            <h4>Recent Dashboards</h4>
           </Panel.Header>
           <Panel.Body>
             <GetResources resources={[ResourceType.Dashboards]}>

--- a/ui/src/me/components/Support.tsx
+++ b/ui/src/me/components/Support.tsx
@@ -19,7 +19,7 @@ const supportLinks = [
 export default class SupportLinks extends PureComponent {
   public render() {
     return (
-      <ul className="link-list">
+      <ul className="useful-links">
         {supportLinks.map(({link, title}) => (
           <li key={title}>
             <a href={link} target="_blank">

--- a/ui/src/me/containers/MePage.scss
+++ b/ui/src/me/containers/MePage.scss
@@ -5,6 +5,20 @@
 
 @import "../../style/modules";
 
+.recent-dashboards {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  font-size: 1.25em;
+}
+
+.recent-dashboards--item {
+  margin-bottom: $cf-marg-b;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding-right: $cf-marg-c;
+}
+
 .link-list {
   padding: 0;
   list-style: none;

--- a/ui/src/me/containers/MePage.scss
+++ b/ui/src/me/containers/MePage.scss
@@ -19,6 +19,10 @@
   padding-right: $cf-marg-c;
 }
 
+.recent-dashboards--filter {
+  margin-bottom: $cf-marg-b;
+}
+
 .link-list {
   padding: 0;
   list-style: none;

--- a/ui/src/me/containers/MePage.scss
+++ b/ui/src/me/containers/MePage.scss
@@ -23,21 +23,21 @@
   margin-bottom: $cf-marg-b;
 }
 
-.link-list {
+.tutorials-list,
+.useful-links {
   padding: 0;
   list-style: none;
-
-  > li {
-    padding: 0;
-  }
 }
 
-.link-list.tutorials > li {
-  display: flex;
-  align-items: center;
-  height: 50px;
+.tutorials-list > li {
+  font-size: 1.25em;
   background-color: $g2-kevlar;
   border-radius: $radius;
-  padding: 0 $ix-marg-c;
+  padding: $ix-marg-c;
   margin-bottom: $ix-marg-a;
+}
+
+.useful-links > li {
+  margin-bottom: $cf-marg-b;
+  padding: 0;
 }


### PR DESCRIPTION
Closes #17545 

- Make dashboards panel scrollable after a certain height (400px)
- Make long dashboard names wrap
- Sort dashboards by modified date
- Add filter input
- Increase size of dashboard names and handy tutorials

![Screen Shot 2020-04-07 at 11 44 36 AM](https://user-images.githubusercontent.com/2433762/78707402-6a910200-78c5-11ea-99e9-f88540b4a155.png)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
