### PR TITLE
fix: sidebar upgrade now should now redirect properly

### DIFF
--- a/ui/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/ui/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -38,6 +38,7 @@ const CloudUpgradeNavBanner: FC = () => {
             <Link
               className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button"
               to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+              target="_self"
             >
               Upgrade Now
             </Link>
@@ -46,6 +47,7 @@ const CloudUpgradeNavBanner: FC = () => {
         <Link
           className="cloud-upgrade-banner__collapsed"
           to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+          target="_self"
         >
           <Icon glyph={IconFont.Star} />
           <Heading element={HeadingElement.H5}>Upgrade Now</Heading>


### PR DESCRIPTION
Closes # idpe 6679

Fixes the Upgrade Now links on the sidebar to do hard server redirects

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass