### PR TITLE
fix(alerting): ensure that status fields exist before renaming them

### DIFF
--- a/ui/src/alerting/utils/history.ts
+++ b/ui/src/alerting/utils/history.ts
@@ -43,6 +43,7 @@ export const loadStatuses = (
 from(bucket: "${MONITORING_BUCKET}")
   |> range(start: ${start}, stop: ${Math.round(until / 1000)})
   |> filter(fn: (r) => r._measurement == "statuses" and r._field == "_message")
+  |> filter(fn: (r) => exists r._check_id and exists r._value and exists r._check_name and exists r._level)
   |> keep(columns: ["_time", "_value", "_check_id", "_check_name", "_level"])
   |> rename(columns: {"_time": "time",
                       "_value": "message",
@@ -69,6 +70,7 @@ from(bucket: "${MONITORING_BUCKET}")
   |> range(start: ${start}, stop: ${Math.round(until / 1000)})
   |> filter(fn: (r) => r._measurement == "notifications")
   |> filter(fn: (r) => r._field !~ /^_/)
+  |> filter(fn: (r) => exists r._check_id and exists r._check_name and exists r._notification_rule_id and exists r._notification_rule_name and exists r._notification_endpoint_id and exists r._notification_endpoint_name and exists r._level and exists r._sent)
   |> keep(columns: ["_time",
                     "_check_id",
                     "_check_name",

--- a/ui/src/alerting/utils/statusEvents.ts
+++ b/ui/src/alerting/utils/statusEvents.ts
@@ -19,13 +19,11 @@ export const runStatusesQuery = (
 from(bucket: "${MONITORING_BUCKET}")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r._measurement == "statuses" and r._field == "_message")
-  |> filter(fn: (r) => exists r._check_id)
-  |> filter(fn: (r) => exists r._check_name)
-  |> filter(fn: (r) => exists r._level)
+  |> filter(fn: (r) => r._check_id == "${checkID}")
+  |> filter(fn: (r) => exists r._value and exists r._check_id and exists r._check_name and exists r._level)
   |> keep(columns: ["_time", "_value", "_check_id", "_check_name", "_level"])
   |> window(every: 1s, timeColumn: "_time", startColumn: "_start", stopColumn: "_stop")
   |> group(columns: ["_start", "_stop"])
-  |> filter(fn: (r) => r["_check_id"] == "${checkID}")
   |> rename(columns: {"_time": "time",
                       "_value": "message",
                       "_check_id": "checkID",


### PR DESCRIPTION
Closes #17516

It looks like... if any statuses have been written to the monitoring bucket with no `_check_id` field in the past 60days, they are picked up by the history query, and the rename flux function errors.
Fixed by adding a filter to filter out statuses where a `_check_id` field does not exist. 