### PR TITLE
fix: read only errors

### DIFF
--- a/ui/src/client/index.ts
+++ b/ui/src/client/index.ts
@@ -14,7 +14,9 @@ setRequestHandler((url, query, init) => {
 })
 
 setResponseHandler((status, headers, data) => {
-  if (status === 403) {
+  // if the user is inactive log them out
+  // influxdb/http/authentication_middleware.go
+  if (status === 403 && data.message === 'User is inactive') {
     postSignout({})
     window.location.href = '/signin'
   }

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -478,7 +478,7 @@ export const saveVEOView = (dashboardID: string) => async (
     }
   } catch (error) {
     console.error(error)
-    dispatch(notify(copy.cellAddFailed()))
+    dispatch(notify(copy.cellAddFailed(error.message)))
     throw error
   }
 }

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -13,8 +13,6 @@ import {Form, Input, Button, Grid} from '@influxdata/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import DashboardsDropdown from 'src/dataExplorer/components/DashboardsDropdown'
 
-// Constants
-import {cellAddFailed, cellAdded} from 'src/shared/copy/notifications'
 import {
   DashboardTemplate,
   DEFAULT_DASHBOARD_NAME,
@@ -173,7 +171,6 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       dashboards,
       view,
       dismiss,
-      notify,
       orgID,
     } = this.props
     const {targetDashboardIDs} = this.state
@@ -186,21 +183,16 @@ class SaveAsCellForm extends PureComponent<Props, State> {
 
     try {
       targetDashboardIDs.forEach(dashID => {
-        let targetDashboardName = ''
-        try {
-          if (dashID === DashboardTemplate.id) {
-            targetDashboardName = newDashboardName || DEFAULT_DASHBOARD_NAME
-            onCreateDashboardWithView(orgID, newDashboardName, viewWithProps)
-          } else {
-            const selectedDashboard = dashboards.find(d => d.id === dashID)
-            targetDashboardName = selectedDashboard.name
-            onCreateCellWithView(selectedDashboard.id, viewWithProps)
-          }
-          notify(cellAdded(cellName, targetDashboardName))
-        } catch {
-          notify(cellAddFailed(cellName, targetDashboardName))
+        if (dashID === DashboardTemplate.id) {
+          onCreateDashboardWithView(orgID, newDashboardName, viewWithProps)
+          return
         }
+
+        const selectedDashboard = dashboards.find(d => d.id === dashID)
+        onCreateCellWithView(selectedDashboard.id, viewWithProps)
       })
+    } catch (error) {
+      console.error(error)
     } finally {
       this.resetForm()
       dismiss()

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -621,12 +621,14 @@ export const writeLineProtocolAction = (
     } else if (resp.status === 429) {
       dispatch(notify(readWriteCardinalityLimitReached(resp.data.message)))
       dispatch(setLPStatus(RemoteDataState.Error))
+    } else if (resp.status === 403) {
+      dispatch(setLPStatus(RemoteDataState.Error, resp.data.message))
     } else {
+      dispatch(setLPStatus(RemoteDataState.Error, 'failed to write data'))
       throw new Error(get(resp, 'data.message', 'Failed to write data'))
     }
   } catch (error) {
     console.error(error)
-    dispatch(setLPStatus(RemoteDataState.Error, error.message))
   }
 }
 

--- a/ui/src/notifications/endpoints/actions/thunks.ts
+++ b/ui/src/notifications/endpoints/actions/thunks.ts
@@ -107,6 +107,7 @@ export const createEndpoint = (endpoint: NotificationEndpoint) => async (
     dispatch(checkEndpointsLimits())
   } catch (error) {
     console.error(error)
+    dispatch(notify(copy.createEndpointFailed(error.message)))
   }
 }
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -166,6 +166,11 @@ export const dashboardCreateFailed = () => ({
   message: 'Failed to create dashboard.',
 })
 
+export const dashboardCreateSuccess = () => ({
+  ...defaultSuccessNotification,
+  message: 'Created dashboard successfully',
+})
+
 export const dashboardDeleteFailed = (
   name: string,
   errorMessage: string
@@ -194,11 +199,15 @@ export const cellAdded = (
 })
 
 export const cellAddFailed = (
-  cellName?: string,
-  dashboardName?: string
+  message: string = 'unknown error'
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to add cell ${cellName + ' '}to dashboard ${dashboardName}`,
+  message: `Failed to add cell: ${message}`,
+})
+
+export const cellCopyFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Cell copy failed',
 })
 
 export const cellUpdateFailed = (): Notification => ({


### PR DESCRIPTION
Closes https://github.com/influxdata/quartz/issues/2373
Closes https://github.com/influxdata/quartz/issues/2370
Closes https://github.com/influxdata/quartz/issues/2375

### Errors and not logged out!
![Kapture 2020-04-07 at 16 23 00](https://user-images.githubusercontent.com/7582765/78728478-4d235e80-78ec-11ea-8d82-2c3fdb0aa1c7.gif)

### You can't create that
![Kapture 2020-04-07 at 16 23 36](https://user-images.githubusercontent.com/7582765/78728487-514f7c00-78ec-11ea-9e1c-1aed5ed92199.gif)

### You can't create that either
![Kapture 2020-04-07 at 16 24 21](https://user-images.githubusercontent.com/7582765/78728489-5280a900-78ec-11ea-8e8c-652e73d69d37.gif)

### Notes
I understand that string comparison in 992f13a is a bit weak.  Should that error message change so would this guard clause.  However, this string is unlikely to change in the near future.  It's certainly better than logging the user out on _all_ 403s.  Good enough for government. 
