### PR TITLE
fix: escaping tags in flux queries

### DIFF
--- a/ui/src/timeMachine/reducers/index.test.ts
+++ b/ui/src/timeMachine/reducers/index.test.ts
@@ -52,7 +52,7 @@ describe('the Time Machine reducer', () => {
 
     it('builds the query if the query builder config is valid', () => {
       const expectedText =
-        'from(bucket: "metrics")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == "mem")\n  |> filter(fn: (r) => r._field == "active")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean)\n  |> yield(name: "mean")'
+        'from(bucket: "metrics")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "mem")\n  |> filter(fn: (r) => r["_field"] == "active")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean)\n  |> yield(name: "mean")'
       const validDraftQuery = {
         text: '',
         editMode: 'advanced',
@@ -127,7 +127,7 @@ describe('the Time Machine reducer', () => {
     it("retains text of valid queries that weren't built with the query builder", () => {
       const invalidDraftQueryWithText = {
         text:
-          'from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart)\n  |> filter(fn: (r) => r._measurement == "system")\n  |> filter(fn: (r) => r._field == "load1" or r._field == "load5" or r._field == "load15")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")',
+          'from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart)\n  |> filter(fn: (r) => r["_measurement"] == "system")\n  |> filter(fn: (r) => r["_field"] == "load1" or r["_field"] == "load5" or r["_field"] == "load15")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")',
         editMode: 'advanced',
         name: '',
         builderConfig: {

--- a/ui/src/timeMachine/utils/queryBuilder.test.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.test.ts
@@ -15,7 +15,7 @@ describe('buildQuery', () => {
 
     const expected = `from(bucket: "b0")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  |> filter(fn: (r) => r._measurement == "m0")`
+  |> filter(fn: (r) => r["_measurement"] == "m0")`
 
     const actual = buildQuery(config)
     expect(actual).toEqual(expected)
@@ -38,8 +38,8 @@ describe('buildQuery', () => {
 
     const expected = `from(bucket: "b0")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  |> filter(fn: (r) => r._measurement == "m0" or r._measurement == "m1")
-  |> filter(fn: (r) => r._field == "f0" or r._field == "f1")`
+  |> filter(fn: (r) => r["_measurement"] == "m0" or r["_measurement"] == "m1")
+  |> filter(fn: (r) => r["_field"] == "f0" or r["_field"] == "f1")`
 
     const actual = buildQuery(config)
 
@@ -58,13 +58,13 @@ describe('buildQuery', () => {
 
     const expected = `from(bucket: "b0")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  |> filter(fn: (r) => r._measurement == "m0")
+  |> filter(fn: (r) => r["_measurement"] == "m0")
   |> aggregateWindow(every: v.windowPeriod, fn: mean)
   |> yield(name: "mean")
 
 from(bucket: "b0")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  |> filter(fn: (r) => r._measurement == "m0")
+  |> filter(fn: (r) => r["_measurement"] == "m0")
   |> aggregateWindow(every: v.windowPeriod, fn: median)
   |> yield(name: "median")`
 

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -174,7 +174,7 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
 
 export const tagToFlux = function tagToFlux(tag: BuilderTagsType) {
   return tag.values
-    .map(value => `r.${tag.key} == "${value.replace(/\\/g, '\\\\')}"`)
+    .map(value => `r["${tag.key}"] == "${value.replace(/\\/g, '\\\\')}"`)
     .join(' or ')
 }
 


### PR DESCRIPTION
Closes #17529

instead of using the dot notation, lets just wrap the fields so that we get some escaping for free