### PR TITLE
feat(tracing): add userID to lookup traces

### DIFF
--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -11,6 +11,7 @@ import (
 	platform "github.com/influxdata/influxdb/v2"
 	platcontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/jsonweb"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 )
 
@@ -116,6 +117,10 @@ func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	ctx = platcontext.SetAuthorizer(ctx, auth)
+
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span.SetTag("user_id", auth.GetUserID().String())
+	}
 
 	h.Handler.ServeHTTP(w, r.WithContext(ctx))
 }


### PR DESCRIPTION
This commit adds `user_id` as a tag for traces. It helps to lookup and
filter traces we need by userID.

OrgID is harder to get right, so I will open an issue, but it will be
nice to have it in as well.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>
Co-authored-by: George MacRorie <gmacrorie@influxdata.com>
