### PR TITLE
fix(tracing): set method to trace

### DIFF
--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -74,9 +74,9 @@ func annotateSpan(span opentracing.Span, handlerName string, req *http.Request) 
 	if route := httprouter.MatchedRouteFromContext(req.Context()); route != "" {
 		span.SetTag("route", route)
 	}
+	span.SetTag("method", req.Method)
 	if ctx := chi.RouteContext(req.Context()); ctx != nil {
 		span.SetTag("route", ctx.RoutePath)
-		span.SetTag("method", ctx.RouteMethod)
 	}
 	span.SetTag("handler", handlerName)
 	span.LogKV("path", req.URL.Path)

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -56,11 +56,13 @@ func TestExtractHTTPRequest(t *testing.T) {
 		path        string
 		ctx         context.Context
 		tags        map[string]interface{}
+		method      string
 	}{
 		{
 			name:        "happy path",
 			handlerName: "WriteHandler",
 			ctx:         context.WithValue(ctx, httprouter.MatchedRouteKey, "/api/v2/write"),
+			method:      http.MethodGet,
 			path:        "/api/v2/write",
 			tags: map[string]interface{}{
 				"route":   "/api/v2/write",
@@ -72,6 +74,7 @@ func TestExtractHTTPRequest(t *testing.T) {
 			handlerName: "BucketHandler",
 			ctx:         context.WithValue(ctx, httprouter.MatchedRouteKey, "/api/v2/buckets/:bucket_id"),
 			path:        "/api/v2/buckets/12345",
+			method:      http.MethodGet,
 			tags: map[string]interface{}{
 				"route":   "/api/v2/buckets/:bucket_id",
 				"handler": "BucketHandler",
@@ -85,7 +88,8 @@ func TestExtractHTTPRequest(t *testing.T) {
 				chi.RouteCtxKey,
 				&chi.Context{RoutePath: "/api/v2/buckets/:bucket_id", RouteMethod: "GET"},
 			),
-			path: "/api/v2/buckets/12345",
+			path:   "/api/v2/buckets/12345",
+			method: http.MethodGet,
 			tags: map[string]interface{}{
 				"route":   "/api/v2/buckets/:bucket_id",
 				"method":  "GET",
@@ -96,13 +100,14 @@ func TestExtractHTTPRequest(t *testing.T) {
 			name:        "empty path",
 			handlerName: "Home",
 			ctx:         ctx,
+			method:      http.MethodGet,
 			tags: map[string]interface{}{
 				"handler": "Home",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodPost, "http://localhost"+test.path, nil)
+			request, err := http.NewRequest(test.method, "http://localhost"+test.path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
It is solid to use retrieve the method directly from the request.

Co-authored-by: George MacRorie <gmacrorie@influxdata.com>
Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>