### PR TITLE
fix(query): Respect the now-time of the compiled query if it's provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [17612](https://github.com/influxdata/influxdb/pull/17612): Fix card size and layout jank in dashboards index view
 1. [17651](https://github.com/influxdata/influxdb/pull/17651): Fix check graph font and lines defaulting to black causing graph to be unreadable
+1. [17670](https://github.com/influxdata/influxdb/pull/17670): Respect the now-time of the compiled query if it's provided
 
 ### UI Improvements
 

--- a/http/query.go
+++ b/http/query.go
@@ -37,6 +37,7 @@ type QueryRequest struct {
 	Spec    *flux.Spec   `json:"spec,omitempty"`
 	AST     *ast.Package `json:"ast,omitempty"`
 	Dialect QueryDialect `json:"dialect"`
+	Now     time.Time    `json:"now"`
 
 	// InfluxQL fields
 	Bucket string `json:"bucket,omitempty"`
@@ -252,12 +253,17 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 	if err := r.Validate(); err != nil {
 		return nil, err
 	}
+
+	n := r.Now
+	if n.IsZero() {
+		n = now()
+	}
+
 	// Query is preferred over AST
 	var compiler flux.Compiler
 	if r.Query != "" {
 		switch r.Type {
 		case "influxql":
-			n := now()
 			compiler = &transpiler.Compiler{
 				Now:    &n,
 				Query:  r.Query,
@@ -267,7 +273,7 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 			fallthrough
 		default:
 			compiler = lang.FluxCompiler{
-				Now:    now(),
+				Now:    n,
 				Extern: r.Extern,
 				Query:  r.Query,
 			}
@@ -275,7 +281,7 @@ func (r QueryRequest) proxyRequest(now func() time.Time) (*query.ProxyRequest, e
 	} else if r.AST != nil {
 		c := lang.ASTCompiler{
 			AST: r.AST,
-			Now: now(),
+			Now: n,
 		}
 		if r.Extern != nil {
 			c.PrependFile(r.Extern)
@@ -345,6 +351,7 @@ func QueryRequestFromProxyRequest(req *query.ProxyRequest) (*QueryRequest, error
 	case lang.ASTCompiler:
 		qr.Type = "flux"
 		qr.AST = c.AST
+		qr.Now = c.Now
 	default:
 		return nil, fmt.Errorf("unsupported compiler %T", c)
 	}

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -212,6 +212,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 		Query   string
 		Type    string
 		Dialect QueryDialect
+		Now     time.Time
 		org     *platform.Organization
 	}
 	tests := []struct {
@@ -264,14 +265,42 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 					Delimiter:      ",",
 					DateTimeFormat: "RFC3339",
 				},
+				Now: time.Unix(1, 1),
 				org: &platform.Organization{},
 			},
-			now: func() time.Time { return time.Unix(1, 1) },
+			now: func() time.Time { return time.Unix(2, 2) },
 			want: &query.ProxyRequest{
 				Request: query.Request{
 					Compiler: lang.ASTCompiler{
 						AST: &ast.Package{},
 						Now: time.Unix(1, 1),
+					},
+				},
+				Dialect: &csv.Dialect{
+					ResultEncoderConfig: csv.ResultEncoderConfig{
+						NoHeader:  false,
+						Delimiter: ',',
+					},
+				},
+			},
+		},
+		{
+			name: "valid AST with calculated now",
+			fields: fields{
+				AST:  &ast.Package{},
+				Type: "flux",
+				Dialect: QueryDialect{
+					Delimiter:      ",",
+					DateTimeFormat: "RFC3339",
+				},
+				org: &platform.Organization{},
+			},
+			now: func() time.Time { return time.Unix(2, 2) },
+			want: &query.ProxyRequest{
+				Request: query.Request{
+					Compiler: lang.ASTCompiler{
+						AST: &ast.Package{},
+						Now: time.Unix(2, 2),
 					},
 				},
 				Dialect: &csv.Dialect{
@@ -345,6 +374,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 				},
 				org: &platform.Organization{},
 			},
+			now: func() time.Time { return time.Unix(1, 1) },
 			want: &query.ProxyRequest{
 				Request: query.Request{
 					Compiler: repl.Compiler{
@@ -371,6 +401,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 				Query:   tt.fields.Query,
 				Type:    tt.fields.Type,
 				Dialect: tt.fields.Dialect,
+				Now:     tt.fields.Now,
 				Org:     tt.fields.org,
 			}
 			got, err := r.proxyRequest(tt.now)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6351,6 +6351,10 @@ components:
             - flux
         dialect:
           $ref: "#/components/schemas/Dialect"
+        now:
+          description: Specifies the time that should be reported as "now" in the query. Default is the server's now time.
+          type: string
+          format: date-time
     InfluxQLQuery:
       description: Query influx using the InfluxQL language
       type: object


### PR DESCRIPTION
We are seeing a mismatch between the expected `now()` time of a Task run and what is actually reported at the time the task is executed. Upon further investigation we found that proxied query requests (via HTTP) aren't using the `Now` time provided by the Task Executor.

This teaches the HTTP layer to use the `Now` time provided if it is presented. Otherwise, it falls back to calculating a time with the epoch.