### PR TITLE
feat: moved parser

### DIFF
--- a/ui/src/shared/utils/fromFlux.test.ts
+++ b/ui/src/shared/utils/fromFlux.test.ts
@@ -203,4 +203,10 @@ there",5
       '[576] query terminated: reached maximum allowed memory limits'
     )
   })
+
+  test('does nothing with nothing', () => {
+    expect(() => fromFlux('')).not.toThrow()
+    expect(() => fromFlux('\n\n\n\nyolo\ntrash\n\n\n\n')).not.toThrow()
+    expect(fromFlux('\n\n\n\nyolo\ntrash\n\n\n\n').table.length).toEqual(0)
+  })
 })

--- a/ui/src/shared/utils/fromFlux.test.ts
+++ b/ui/src/shared/utils/fromFlux.test.ts
@@ -1,4 +1,4 @@
-import {fromFlux} from './fromFlux'
+import fromFlux from './fromFlux'
 
 describe('fromFlux', () => {
   test('can parse a Flux CSV with mismatched schemas', () => {
@@ -18,83 +18,81 @@ describe('fromFlux', () => {
 
     const actual = fromFlux(CSV)
 
-    console.log('neat', actual)
-
-    expect(actual.table.getColumn('result', 'string')).toEqual([
+    expect(actual.table.columns['result'].data).toEqual([
       '_result',
       '_result',
       '_result',
       '_result',
     ])
 
-    expect(actual.table.getColumn('_start', 'time')).toEqual([
+    expect(actual.table.columns['_start'].data).toEqual([
       1549064312524,
       1549064312524,
       1549064312524,
       1549064312524,
     ])
 
-    expect(actual.table.getColumn('_stop', 'time')).toEqual([
+    expect(actual.table.columns['_stop'].data).toEqual([
       1549064342524,
       1549064342524,
       1549064342524,
       1549064342524,
     ])
 
-    expect(actual.table.getColumn('_time', 'time')).toEqual([
+    expect(actual.table.columns['_time'].data).toEqual([
       1549064313000,
       1549064323000,
       1549064313000,
       1549064323000,
     ])
 
-    expect(actual.table.getColumn('_value (number)', 'number')).toEqual([
+    expect(actual.table.columns['_value (number)'].data).toEqual([
       10,
       20,
       undefined,
       undefined,
     ])
 
-    expect(actual.table.getColumn('_value (string)', 'string')).toEqual([
+    expect(actual.table.columns['_value (string)'].data).toEqual([
       undefined,
       undefined,
       'thirty',
       'fourty',
     ])
 
-    expect(actual.table.getColumn('_field', 'string')).toEqual([
+    expect(actual.table.columns['_field'].data).toEqual([
       'usage_guest',
       'usage_guest',
       'usage_guest',
       'usage_guest',
     ])
 
-    expect(actual.table.getColumn('_measurement', 'string')).toEqual([
+    expect(actual.table.columns['_measurement'].data).toEqual([
       'cpu',
       'cpu',
       'cpu',
       'cpu',
     ])
 
-    expect(actual.table.getColumn('cpu', 'string')).toEqual([
+    expect(actual.table.columns['cpu'].data).toEqual([
       'cpu-total',
       'cpu-total',
       'cpu0',
       'cpu0',
     ])
 
-    expect(actual.table.getColumn('host', 'string')).toEqual([
+    expect(actual.table.columns['host'].data).toEqual([
       'oox4k.local',
       'oox4k.local',
       'oox4k.local',
       'oox4k.local',
     ])
 
-    expect(actual.table.getColumn('table', 'number')).toEqual([0, 1, 2, 3])
+    expect(actual.table.columns['table'].data).toEqual([0, 1, 2, 3])
 
-    expect(actual.table.getColumnName('_value (number)')).toEqual('_value')
+    //expect(actual.table.getColumnName('_value (number)')).toEqual('_value')
 
-    expect(actual.table.getColumnName('_value (string)')).toEqual('_value')
+    //expect(actual.table.getColumnName('_value (string)')).toEqual('_value')
 
     expect(actual.fluxGroupKeyUnion).toEqual([
       '_value (number)',
@@ -118,11 +116,11 @@ describe('fromFlux', () => {
 
     const actual = fromFlux(CSV).table
 
-    expect(actual.getColumn('result')).toEqual(['_result', '_result'])
-    expect(actual.getColumn('a')).toEqual(['usage_guest', 'usage_guest'])
-    expect(actual.getColumn('b')).toEqual(['cpu', 'cpu'])
-    expect(actual.getColumn('c')).toEqual([4, 5])
-    expect(actual.getColumn('d')).toEqual([6, 6])
+    expect(actual.columns['result'].data).toEqual(['_result', '_result'])
+    expect(actual.columns['a'].data).toEqual(['usage_guest', 'usage_guest'])
+    expect(actual.columns['b'].data).toEqual(['cpu', 'cpu'])
+    expect(actual.columns['c'].data).toEqual([4, 5])
+    expect(actual.columns['d'].data).toEqual([6, 6])
   })
 
   test('returns a group key union', () => {
@@ -151,7 +149,7 @@ describe('fromFlux', () => {
 
     const {table} = fromFlux(CSV)
 
-    expect(table.getColumn('_value')).toEqual([10, null])
+    expect(table.columns['_value'].data).toEqual([10, null])
   })
 
   test('handles newlines inside string values', () => {
@@ -177,9 +175,9 @@ there",5
 
     const {table} = fromFlux(CSV)
 
-    expect(table.getColumn('value')).toEqual([5, 5, 6, 5, 5, 6])
+    expect(table.columns['value'].data).toEqual([5, 5, 6, 5, 5, 6])
 
-    expect(table.getColumn('message')).toEqual([
+    expect(table.columns['message'].data).toEqual([
       'howdy',
       'hello\n\nthere',
       'hi',
@@ -187,5 +185,20 @@ there",5
       'hello\n\nthere',
       'hi',
     ])
+  })
+
+  test('handles errors that show up on any page', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,,,
+,a,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,,,
+,error,reference
+,query terminated: reached maximum allowed memory limits,576`
+
+    expect(() => fromFlux(CSV)).toThrowError('[576] query terminated: reached maximum allowed memory limits')
   })
 })

--- a/ui/src/shared/utils/fromFlux.test.ts
+++ b/ui/src/shared/utils/fromFlux.test.ts
@@ -199,6 +199,8 @@ there",5
 ,error,reference
 ,query terminated: reached maximum allowed memory limits,576`
 
-    expect(() => fromFlux(CSV)).toThrowError('[576] query terminated: reached maximum allowed memory limits')
+    expect(() => fromFlux(CSV)).toThrowError(
+      '[576] query terminated: reached maximum allowed memory limits'
+    )
   })
 })

--- a/ui/src/shared/utils/fromFlux.test.ts
+++ b/ui/src/shared/utils/fromFlux.test.ts
@@ -1,0 +1,191 @@
+import {fromFlux} from './fromFlux'
+
+describe('fromFlux', () => {
+  test('can parse a Flux CSV with mismatched schemas', () => {
+    const CSV = `#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,10,usage_guest,cpu,cpu-total,oox4k.local
+,,1,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,20,usage_guest,cpu,cpu-total,oox4k.local
+
+#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,2,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,thirty,usage_guest,cpu,cpu0,oox4k.local
+,,3,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,fourty,usage_guest,cpu,cpu0,oox4k.local`
+
+    const actual = fromFlux(CSV)
+
+    console.log('neat', actual)
+
+    expect(actual.table.getColumn('result', 'string')).toEqual([
+      '_result',
+      '_result',
+      '_result',
+      '_result',
+    ])
+
+    expect(actual.table.getColumn('_start', 'time')).toEqual([
+      1549064312524,
+      1549064312524,
+      1549064312524,
+      1549064312524,
+    ])
+
+    expect(actual.table.getColumn('_stop', 'time')).toEqual([
+      1549064342524,
+      1549064342524,
+      1549064342524,
+      1549064342524,
+    ])
+
+    expect(actual.table.getColumn('_time', 'time')).toEqual([
+      1549064313000,
+      1549064323000,
+      1549064313000,
+      1549064323000,
+    ])
+
+    expect(actual.table.getColumn('_value (number)', 'number')).toEqual([
+      10,
+      20,
+      undefined,
+      undefined,
+    ])
+
+    expect(actual.table.getColumn('_value (string)', 'string')).toEqual([
+      undefined,
+      undefined,
+      'thirty',
+      'fourty',
+    ])
+
+    expect(actual.table.getColumn('_field', 'string')).toEqual([
+      'usage_guest',
+      'usage_guest',
+      'usage_guest',
+      'usage_guest',
+    ])
+
+    expect(actual.table.getColumn('_measurement', 'string')).toEqual([
+      'cpu',
+      'cpu',
+      'cpu',
+      'cpu',
+    ])
+
+    expect(actual.table.getColumn('cpu', 'string')).toEqual([
+      'cpu-total',
+      'cpu-total',
+      'cpu0',
+      'cpu0',
+    ])
+
+    expect(actual.table.getColumn('host', 'string')).toEqual([
+      'oox4k.local',
+      'oox4k.local',
+      'oox4k.local',
+      'oox4k.local',
+    ])
+
+    expect(actual.table.getColumn('table', 'number')).toEqual([0, 1, 2, 3])
+
+    expect(actual.table.getColumnName('_value (number)')).toEqual('_value')
+
+    expect(actual.table.getColumnName('_value (string)')).toEqual('_value')
+
+    expect(actual.fluxGroupKeyUnion).toEqual([
+      '_value (number)',
+      '_value (string)',
+      '_start',
+      '_stop',
+      '_field',
+      '_measurement',
+      'cpu',
+      'host',
+    ])
+  })
+
+  test('uses the default annotation to fill in empty values', () => {
+    const CSV = `#group,false,false,true,true,true,true
+#datatype,string,long,string,string,long,long
+#default,_result,,,cpu,,6
+,result,table,a,b,c,d
+,,1,usage_guest,,4,
+,,1,usage_guest,,5,`
+
+    const actual = fromFlux(CSV).table
+
+    expect(actual.getColumn('result')).toEqual(['_result', '_result'])
+    expect(actual.getColumn('a')).toEqual(['usage_guest', 'usage_guest'])
+    expect(actual.getColumn('b')).toEqual(['cpu', 'cpu'])
+    expect(actual.getColumn('c')).toEqual([4, 5])
+    expect(actual.getColumn('d')).toEqual([6, 6])
+  })
+
+  test('returns a group key union', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,,,
+,a,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,,,
+,a,b,c,d`
+
+    const {fluxGroupKeyUnion} = fromFlux(CSV)
+
+    expect(fluxGroupKeyUnion).toEqual(['a', 'c', 'd'])
+  })
+
+  test('parses empty numeric values as null', () => {
+    const CSV = `#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,10,usage_guest,cpu,cpu-total,oox4k.local
+,,1,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,,usage_guest,cpu,cpu-total,oox4k.local`
+
+    const {table} = fromFlux(CSV)
+
+    expect(table.getColumn('_value')).toEqual([10, null])
+  })
+
+  test('handles newlines inside string values', () => {
+    const CSV = `#group,false,false,false,false
+#datatype,string,long,string,long
+#default,_result,,,
+,result,table,message,value
+,,0,howdy,5
+,,0,"hello
+
+there",5
+,,0,hi,6
+
+#group,false,false,false,false
+#datatype,string,long,string,long
+#default,_result,,,
+,result,table,message,value
+,,1,howdy,5
+,,1,"hello
+
+there",5
+,,1,hi,6`
+
+    const {table} = fromFlux(CSV)
+
+    expect(table.getColumn('value')).toEqual([5, 5, 6, 5, 5, 6])
+
+    expect(table.getColumn('message')).toEqual([
+      'howdy',
+      'hello\n\nthere',
+      'hi',
+      'howdy',
+      'hello\n\nthere',
+      'hi',
+    ])
+  })
+})

--- a/ui/src/shared/utils/fromFlux.ts
+++ b/ui/src/shared/utils/fromFlux.ts
@@ -104,7 +104,7 @@ function parseValue(
     in the input Flux CSV.
     Values are coerced into appropriate JavaScript types based on the Flux
     `#datatype` annotation for the table
-    The `Table` stores a `key` for each column which is seperate from the column
+    The `Table` stores a `key` for each column which is separate from the column
     `name`. If multiple Flux tables have the same column but with different
     types, they will be distinguished by different keys in the resulting `Table`;
     otherwise the `key` and `name` for each column in the result table will be

--- a/ui/src/shared/utils/fromFlux.ts
+++ b/ui/src/shared/utils/fromFlux.ts
@@ -1,0 +1,230 @@
+import Papa from 'papaparse';
+
+const TO_COLUMN_TYPE = {
+    boolean: 'boolean',
+    unsignedLong: 'number',
+    long: 'number',
+    double: 'number',
+    string: 'string',
+    'dateTime:RFC3339': 'time'
+};
+
+function parseValue(value, columnType) {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (value === 'null') {
+        return null;
+    }
+
+    if (value === 'NaN') {
+        return NaN;
+    }
+
+    if (columnType === 'boolean' && value === 'true') {
+        return true;
+    }
+
+    if (columnType === 'boolean' && value === 'false') {
+        return false;
+    }
+
+    if (columnType === 'string') {
+        return value;
+    }
+
+    if (columnType === 'time') {
+        return Date.parse(value);
+    }
+
+    if (columnType === 'number' && value === '') {
+        return null;
+    }
+
+    if (columnType === 'number') {
+        return Number(value);
+    }
+
+    return null;
+}
+
+/*
+    Convert a [Flux CSV response][0] to a `Table`.
+    For example, given a series of Flux tables that look like this:
+        column_a | column_b | column_c  <-- name
+        long     | string   | long      <-- type
+        ------------------------------
+               1 |      "g" |       34
+               2 |      "f" |       58
+               3 |      "c" |       21
+        column_b | column_d   <-- name
+        double   | boolean    <-- type
+        -------------------
+             1.0 |     true
+             2.0 |     true
+             3.0 |     true
+
+    This function will spread them out to a single wide table that looks like
+    this instead:
+        column_a | column_b (string) | column_c | column_b (number) | column_d  <-- key
+        column_a | column_b          | column_c | column_b          | column_d  <-- name
+        number   | string            | number   | number            | bool      <-- type
+        ---------------------------------------------------------------------
+               1 |               "g" |       34 |                   |
+               2 |               "f" |       58 |                   |
+               3 |                   |       21 |                   |
+                 |                   |          |               1.0 |     true
+                 |                   |          |               2.0 |     true
+                 |                   |          |               3.0 |     true
+
+    The `#group`, `#datatype`, and `#default` [annotations][1] are expected to be
+    in the input Flux CSV.
+    Values are coerced into appropriate JavaScript types based on the Flux
+    `#datatype` annotation for the table
+    The `Table` stores a `key` for each column which is seperate from the column
+    `name`. If multiple Flux tables have the same column but with different
+    types, they will be distinguished by different keys in the resulting `Table`;
+    otherwise the `key` and `name` for each column in the result table will be
+    identical.
+
+    [0]: https://github.com/influxdata/flux/blob/master/docs/SPEC.md#csv
+    [1]: https://github.com/influxdata/flux/blob/master/docs/SPEC.md#annotations
+    */
+
+export default function fromFlux(csv) {
+    /*
+         A Flux CSV response can contain multiple CSV files each joined by a newline.
+         See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
+
+         Split the response into separate chunks whenever we encounter:
+             1. A newline
+             2. Followed by any amount of whitespace
+             3. Followed by a newline
+             4. Followed by a `#` character
+         The last condition is [necessary][0] for handling CSV responses with
+         values containing newlines.
+
+         [0]: https://github.com/influxdata/influxdb/issues/15017
+     */
+    const output = {},
+        groupKey = {};
+    let startIdx = 0;
+
+    const chunks = [],
+        regerz = /\n\s*\n#/g;
+    let match, lastRange = 0;
+
+    while ((match = regerz.exec(csv)) !== null) {
+        chunks.push({
+            start: lastRange,
+            stop: match.index,
+        });
+        lastRange = match.index + match[0].length - 1;
+    }
+    chunks.push({
+        start: lastRange,
+        stop: csv.length,
+    });
+
+    let runningTotal = 0,
+        ni,
+        headerLocation,
+        no,
+        na,
+        colName, colType, colKey,
+        annotations, parsed;
+
+    for(ni = 0; ni < chunks.length; ni++) {
+        annotations = {};
+        parsed = Papa.parse(csv.substring(chunks[ni].start, chunks[ni].stop)).data;
+
+        headerLocation = 0;
+        while (/^\s*#/.test(parsed[headerLocation][0])) {
+            headerLocation++;
+        }
+
+        for (no = 0; no < headerLocation; no++) {
+            annotations[parsed[no][0]] = parsed[no].reduce((p, c, i) => {
+                p[parsed[headerLocation][i]] = c;
+                return p;
+            }, {});
+        }
+
+        for (no = 1; no < parsed[headerLocation].length; no++) {
+            colName = parsed[headerLocation][no];
+            colType = annotations['#datatype'][colName];
+            colKey = `${colName} ${colType}`;
+
+            if (!output.hasOwnProperty(colKey)) {
+                output[colKey] = {
+                    name: colName,
+                    group: annotations['#group'][colName],
+                    type: TO_COLUMN_TYPE[colType],
+                    default: annotations['#default'][colName],
+                    data: []
+                };
+            }
+
+            for (na = headerLocation + 1; na < parsed.length; na++) {
+                output[colKey].data[runningTotal + na - headerLocation - 1] = parseValue(
+                    parsed[na][no] || output[colKey].default,
+                    output[colKey].type
+                );
+            }
+        }
+
+        runningTotal += parsed.length - headerLocation;
+    }
+
+    annotations = [];
+
+    /*
+        Each column in a parsed `Table` can only have a single type, but because we
+        combine columns from multiple Flux tables into a single table, we may
+        encounter conflicting types for a given column during parsing.
+        To avoid this issue, we seperate the concept of the column _key_ and column
+        _name_ in the `Table` object, where each key is unique but each name is not
+        necessarily unique. We name the keys something like "foo (int)", where "foo"
+        is the name and "int" is the type.
+        But since type conflicts are rare and the public API requires referencing
+        columns by key, we want to avoid unwieldy keys whenever possible. So the last
+        stage of parsing is to rename all column keys from the `$NAME ($TYPE)` format
+        to just `$NAME` if we can do so safely. That is what this function does.
+    */
+    const colNameCounts = Object.values(output)
+        .map(c => {
+            c.data.length = runningTotal;
+            return c.name;
+        })
+        .reduce((prev, curr) => {
+            if (!prev.hasOwnProperty(curr)) {
+                prev[curr] = 0;
+            }
+
+            prev[curr]++;
+
+            return prev;
+        }, {});
+
+    Object.keys(colNameCounts)
+        .filter(name => colNameCounts[name] === 1)
+        .forEach(uniqueName => {
+            const [columnKey, column] = Object.entries(output).find(
+                ([_, col]) => col.name === uniqueName
+            );
+
+            output[uniqueName] = column;
+
+            delete output[columnKey];
+        });
+
+    return {
+        table: {
+            columnKeys: Object.keys(output),
+            columns: output,
+            length: runningTotal
+        },
+        fluxGroupKeyUnion: Object.keys(groupKey)
+    };
+}

--- a/ui/src/shared/utils/fromFlux.ts
+++ b/ui/src/shared/utils/fromFlux.ts
@@ -225,13 +225,13 @@ export default function fromFlux(csv) {
     */
   Object.entries(names)
     .map(([k, v]) => {
-      const colNames = Object.keys(v) as string[]
+      const colNames = Object.keys(v)
 
       colNames.forEach(n => {
         output[n].data.length = runningTotal
       })
 
-      return [k as string, colNames]
+      return [k, colNames]
     })
     .filter(([_, v]) => v.length === 1)
     .map(([k, v]) => [k, v[0]])


### PR DESCRIPTION
we have to make some weird jumps through spaghetti hoops to get the csv routed from an api response, to timemachine and giraffe for parsing, then back out to display meta data that then goes back into giraffe to choose how to display it.

this can get fixed by just moving the parser out of giraffe

i'm also hoping to get a couple of perf points by using array pointers to build the results table and not cloning of the results for parsing.

existing tests work, but the interface is a little different and readability has been sacrificed for reducing memory footprint where possible

possibly a prereq for #16474