### PR TITLE
refactor: remove labels from bucket api

### DIFF
--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -125,16 +125,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "orgID": "50f7ba1150f7ba11",
 			"type": "user",
       "name": "hello",
-      "retentionRules": [{"type": "expire", "everySeconds": 2}],
-			"labels": [
-        {
-          "id": "fc3dc670a4be9b9a",
-          "name": "label",
-          "properties": {
-            "color": "fff000"
-          }
-        }
-      ]
+      "retentionRules": [{"type": "expire", "everySeconds": 2}]
     },
     {
       "links": {
@@ -152,16 +143,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "orgID": "7e55e118dbabb1ed",
 			"type": "user",
       "name": "example",
-      "retentionRules": [{"type": "expire", "everySeconds": 86400}],
-      "labels": [
-        {
-          "id": "fc3dc670a4be9b9a",
-          "name": "label",
-          "properties": {
-            "color": "fff000"
-          }
-        }
-      ]
+      "retentionRules": [{"type": "expire", "everySeconds": 86400}]
     }
   ]
 }
@@ -295,8 +277,7 @@ func TestService_handleGetBucket(t *testing.T) {
 		  "orgID": "020f755c3c082000",
 			"type": "user",
 		  "name": "hello",
-		  "retentionRules": [{"type": "expire", "everySeconds": 30}],
-      "labels": []
+		  "retentionRules": [{"type": "expire", "everySeconds": 30}]
 		}
 		`,
 			},
@@ -428,8 +409,7 @@ func TestService_handlePostBucket(t *testing.T) {
   "orgID": "6f626f7274697320",
 	"type": "user",
   "name": "hello",
-  "retentionRules": [],
-  "labels": []
+  "retentionRules": []
 }
 `,
 			},
@@ -684,8 +664,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "orgID": "020f755c3c082000",
 	"type": "user",
   "name": "example",
-  "retentionRules": [{"type": "expire", "everySeconds": 2}],
-  "labels": []
+  "retentionRules": [{"type": "expire", "everySeconds": 2}]
 }
 `,
 			},
@@ -813,8 +792,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "orgID": "020f755c3c082000",
 	"type": "user",
   "name": "bucket with no retention",
-  "retentionRules": [],
-  "labels": []
+  "retentionRules": []
 }
 `,
 			},
@@ -873,8 +851,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "orgID": "020f755c3c082000",
 	"type": "user",
   "name": "b1",
-  "retentionRules": [],
-  "labels": []
+  "retentionRules": []
 }
 `,
 			},

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -119,7 +119,7 @@ func newOnboardingResponse(results *platform.OnboardingResults) *onboardingRespo
 	}
 	return &onboardingResponse{
 		User:         newUserResponse(results.User),
-		Bucket:       NewBucketResponse(results.Bucket, []*platform.Label{}),
+		Bucket:       NewBucketResponse(results.Bucket),
 		Organization: newOrgResponse(*results.Org),
 		Auth:         newAuthResponse(results.Auth, results.Org, results.User, ps),
 	}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7039,8 +7039,6 @@ components:
           readOnly: true
         retentionRules:
           $ref: "#/components/schemas/RetentionRules"
-        labels:
-          $ref: "#/components/schemas/Labels"
       required: [name, retentionRules]
     Buckets:
       type: object

--- a/ui/src/types/buckets.ts
+++ b/ui/src/types/buckets.ts
@@ -1,14 +1,18 @@
 export {Bucket as GenBucket} from 'src/client'
 
-import {Bucket as GenBucket} from 'src/client'
+import {Bucket as GenBucket, Labels} from 'src/client'
 
-export interface OwnBucket extends Omit<GenBucket, 'labels'> {
+export interface OwnBucket extends GenBucket {
   labels?: string[]
   readableRetention: string
 }
 
 export interface DemoBucket extends Omit<OwnBucket, 'type'> {
   type: 'demodata'
+}
+
+export interface BucketWithLabel extends GenBucket {
+  labels?: Labels
 }
 
 export type Bucket = DemoBucket | OwnBucket


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17689

This PR removes the `Labels` property from the `Buckets` object in the API, and updates the thunks to reflect this change.

This change is being implemented because the "get" routes each resource should be separate, rather than having Labels embedded in the Buckets routes.  This is a part of the Gateway API Refactor epic (epic can be seen on the above issue) and the ongoing work to compartmentalize each API so that teams can more easily make changes to the APIs they work with.

Users will still be able to get Labels for a Bucket using the `bucket/[id]/labels` route, and the behavior on the frontend should not change.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
