### PR TITLE
fix: load dashboard before accessing

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "yarn install && yarn generate && cross-env TS_NODE_PROJECT=\"webpack.tsconfig.json\" && yarn run build:vendor && yarn run start:dev",
     "start:cloud": "yarn install && yarn generate && cross-env TS_NODE_PROJECT=\"webpack.tsconfig.json\" && yarn run build:vendor && yarn run start:dev-cloud",
-    "start:dev": "webpack-dev-server --config ./webpack.dev.ts",
+    "start:dev": "webpack-dev-server --config ./webpack.dev.ts --progress false",
     "start:dev-cloud": "cross-env CLOUD_LOGOUT_URL=http://localhost:8080/api/v2/signout CLOUD_URL=http://localhost:9999 webpack-dev-server --config ./webpack.dev.ts",
     "start:docker": "yarn generate && yarn build:vendor && yarn run start:dev",
     "build": "yarn install --silent && yarn build:ci",

--- a/ui/src/authorizations/apis/index.ts
+++ b/ui/src/authorizations/apis/index.ts
@@ -21,7 +21,9 @@ export const createAuthorization = async (
 
 export const getAuth0Config = async (): Promise<Auth0Config> => {
   try {
-    const response = await fetch(`${getAPIBasepath()}/api/v2private/oauth/clientConfig`)
+    const response = await fetch(
+      `${getAPIBasepath()}/api/v2private/oauth/clientConfig`
+    )
     const data = await response.json()
     return data
   } catch (error) {

--- a/ui/src/authorizations/apis/index.ts
+++ b/ui/src/authorizations/apis/index.ts
@@ -1,5 +1,6 @@
 import AJAX from 'src/utils/ajax'
 import {Authorization, Auth0Config} from 'src/types'
+import {getAPIBasepath} from 'src/utils/basepath'
 
 export const createAuthorization = async (
   authorization
@@ -20,7 +21,7 @@ export const createAuthorization = async (
 
 export const getAuth0Config = async (): Promise<Auth0Config> => {
   try {
-    const response = await fetch('/api/v2private/oauth/clientConfig')
+    const response = await fetch(`${getAPIBasepath()}/api/v2private/oauth/clientConfig`)
     const data = await response.json()
     return data
   } catch (error) {

--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -148,11 +148,7 @@ export const createDashboardWithView = (
       dashboardSchema
     )
 
-    await dispatch(setDashboard(
-        resp.data.id,
-        RemoteDataState.Done,
-        normDash
-    ))
+    await dispatch(setDashboard(resp.data.id, RemoteDataState.Done, normDash))
 
     await dispatch(createCellWithView(resp.data.id, view))
     dispatch(notify(copy.dashboardCreateSuccess()))

--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -143,6 +143,17 @@ export const createDashboardWithView = (
       throw new Error(resp.data.message)
     }
 
+    const normDash = normalize<Dashboard, DashboardEntities, string>(
+      resp.data,
+      dashboardSchema
+    )
+
+    await dispatch(setDashboard(
+        resp.data.id,
+        RemoteDataState.Done,
+        normDash
+    ))
+
     await dispatch(createCellWithView(resp.data.id, view))
     dispatch(notify(copy.dashboardCreateSuccess()))
   } catch (error) {

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -90,6 +90,17 @@ export const createDashboard = () => async (
       throw new Error(resp.data.message)
     }
 
+    const normDash = normalize<Dashboard, DashboardEntities, string>(
+      resp.data,
+      dashboardSchema
+    )
+
+    await dispatch(setDashboard(
+        resp.data.id,
+        RemoteDataState.Done,
+        normDash
+    ))
+
     dispatch(push(`/orgs/${org.id}/dashboards/${resp.data.id}`))
     dispatch(checkDashboardLimits())
   } catch (error) {
@@ -143,6 +154,17 @@ export const cloneDashboard = (
     if (postResp.status !== 201) {
       throw new Error(postResp.data.message)
     }
+
+    const normDash = normalize<Dashboard, DashboardEntities, string>(
+      postResp.data,
+      dashboardSchema
+    )
+
+    await dispatch(setDashboard(
+        postResp.data.id,
+        RemoteDataState.Done,
+        normDash
+    ))
 
     const pendingLabels = getResp.data.labels.map(l =>
       api.postDashboardsLabel({

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -95,11 +95,9 @@ export const createDashboard = () => async (
       dashboardSchema
     )
 
-    await dispatch(setDashboard(
-        resp.data.id,
-        RemoteDataState.Done,
-        normDash
-    ))
+    await dispatch(
+      creators.setDashboard(resp.data.id, RemoteDataState.Done, normDash)
+    )
 
     dispatch(push(`/orgs/${org.id}/dashboards/${resp.data.id}`))
     dispatch(checkDashboardLimits())
@@ -160,11 +158,9 @@ export const cloneDashboard = (
       dashboardSchema
     )
 
-    await dispatch(setDashboard(
-        postResp.data.id,
-        RemoteDataState.Done,
-        normDash
-    ))
+    await dispatch(
+      creators.setDashboard(postResp.data.id, RemoteDataState.Done, normDash)
+    )
 
     const pendingLabels = getResp.data.labels.map(l =>
       api.postDashboardsLabel({


### PR DESCRIPTION
Closes #17505

while the dashboard was getting created, it wasn't being added to the local resources. the cell would then error when it tried to access the dashboard, as it didn't exist until a hard refresh