### PR TITLE
fix(ui): update giraffe to fix spacing between ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [17651](https://github.com/influxdata/influxdb/pull/17651): Fix check graph font and lines defaulting to black causing graph to be unreadable
 1. [17660](https://github.com/influxdata/influxdb/pull/17660): Fix text wrapping display issue and popover sizing bug when adding labels to a resource
 1. [17670](https://github.com/influxdata/influxdb/pull/17670): Respect the now-time of the compiled query if it's provided
+1. [17692](https://github.com/influxdata/influxdb/pull/17692): Update giraffe to fix spacing between ticks
 
 ### UI Improvements
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -133,7 +133,7 @@
     "@influxdata/flux": "^0.4.0",
     "@influxdata/flux-lsp-browser": "^0.4.2",
     "@influxdata/flux-parser": "^0.3.0",
-    "@influxdata/giraffe": "0.17.6",
+    "@influxdata/giraffe": "0.18.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1038,10 +1038,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.4.0.tgz#7780f1344175c3dc784fb935e7224c6758d44846"
   integrity sha512-m678aFy2fUMlBFwbZ8dG1yawuLUAzOEJm6jPdZR6ezUW/Z07mLk1XwMEbCMk7vFkx1f7cbZ0Yxe/sDt0uwRcxA==
 
-"@influxdata/giraffe@0.17.6":
-  version "0.17.6"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.17.6.tgz#33e94a98dea81601f2759488605e206493a34555"
-  integrity sha512-7HayQtfHXDVlxus++RXRa8UzwPeYKvMQOIp0sEuGRuQdsT5D/wo6aT8Q17vCj5230UvMYjU60s7xi58wg/AUcw==
+"@influxdata/giraffe@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.18.0.tgz#30345878f2941f432489bdde303ca0ffffa3dcb8"
+  integrity sha512-iBCvYBjlKDh4Ken7rI95BaxX16ypYhvf80tfON/+EXwTEEC74IbJDh2C/P/xBvkpHrua3uzHmTLgmFwr10Fb9Q==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes #17585 

### Update giraffe to:

Separate the generation of vertical and horizontal ticks to allow different spacing. For each direction, ticks can be time ticks or value ticks.

x: time, y: value
<img width="1680" alt="Screen Shot 2020-04-08 at 4 37 32 PM" src="https://user-images.githubusercontent.com/10736577/78843332-5fb69a00-79b7-11ea-9df2-4af42b01c887.png">

y: time, x: value
<img width="1680" alt="Screen Shot 2020-04-08 at 4 38 00 PM" src="https://user-images.githubusercontent.com/10736577/78843356-6fce7980-79b7-11ea-958a-89551434a3f5.png">

