### PR TITLE
fix(tls): Enable configuration of TLS 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ v1.8.0 [unreleased]
 -	[#16944](https://github.com/influxdata/influxdb/pull/16944): Update to Go 1.13.8 and Go modules.
 -	[#17032](https://github.com/influxdata/influxdb/pull/17032): Fix a SIGSEGV when accessing tsi active log.
 -	[#17656](https://github.com/influxdata/influxdb/pull/17656): Verify precision in write requests.
+-	[#17698](https://github.com/influxdata/influxdb/pull/17698): Enable configuration of TLS 1.3.
 
 v1.7.0 [unreleased]
 -------------------

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -574,7 +574,7 @@
   # the default settings from Go's crypto/tls package.
   # ciphers = [
   #   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-  #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+  #   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
   # ]
 
   # Minimum version of the tls protocol that will be negotiated. If not specified, uses the
@@ -583,4 +583,4 @@
 
   # Maximum version of the tls protocol that will be negotiated. If not specified, uses the
   # default settings from Go's crypto/tls package.
-  # max-version = "tls1.2"
+  # max-version = "tls1.3"

--- a/pkg/tlsconfig/tls_config.go
+++ b/pkg/tlsconfig/tls_config.go
@@ -87,6 +87,13 @@ var ciphersMap = map[string]uint16{
 	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	// TLS 1.3 cipher suites.
+	"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+	// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
+	// that the client is doing version fallback. See RFC 7507.
+	"TLS_FALLBACK_SCSV": tls.TLS_FALLBACK_SCSV,
 }
 
 func unknownCipher(name string) error {
@@ -108,6 +115,8 @@ var versionsMap = map[string]uint16{
 	"1.1":    tls.VersionTLS11,
 	"TLS1.2": tls.VersionTLS12,
 	"1.2":    tls.VersionTLS12,
+	"TLS1.3": tls.VersionTLS13,
+	"1.3":    tls.VersionTLS13,
 }
 
 func unknownVersion(name string) error {


### PR DESCRIPTION
TLS 1.3 is currently supported with the default configuration. However, the `[tls]` configuration block does yet support TLS 1.3 as an option.

This PR adds TLS 1.3 as an option for `min-version` and `max-version`. The ciphers list was also updated to the [current list of Go ciphers](https://golang.org/pkg/crypto/tls/#pkg-constants). The sample configuration file is also updated to the latest ciphers and `max-version` of 1.3.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
