### PR TITLE
fix(ui): make cell cloning more predictable

### DIFF
--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -25,9 +25,6 @@ import {notify} from 'src/shared/actions/notifications'
 import {setDashboard} from 'src/dashboards/actions/creators'
 import {setCells, setCell, removeCell} from 'src/cells/actions/creators'
 
-// Utils
-import {getClonedDashboardCell} from 'src/dashboards/utils/cellGetters'
-
 // Constants
 import * as copy from 'src/shared/copy/notifications'
 
@@ -182,23 +179,6 @@ export const updateCells = (dashboardID: string, cells: Cell[]) => async (
     dispatch(setCells(dashboardID, RemoteDataState.Done, normCells))
   } catch (error) {
     dispatch(notify(copy.cellUpdateFailed()))
-    console.error(error)
-  }
-}
-
-export const copyCell = (dashboard: Dashboard, cell: Cell) => dispatch => {
-  try {
-    const clonedCell = getClonedDashboardCell(dashboard, cell)
-
-    const normCell = normalize<Dashboard, DashboardEntities, string>(
-      clonedCell,
-      cellSchema
-    )
-
-    dispatch(setCell(cell.id, RemoteDataState.Done, normCell))
-    dispatch(notify(copy.cellAdded()))
-  } catch (error) {
-    dispatch(notify(copy.cellCopyFailed()))
     console.error(error)
   }
 }

--- a/ui/src/cells/actions/thunks.ts
+++ b/ui/src/cells/actions/thunks.ts
@@ -68,6 +68,7 @@ export const createCellWithView = (
   clonedCell?: Cell
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
+  let workingView = view
 
   let dashboard = getByID<Dashboard>(
     state,
@@ -103,8 +104,12 @@ export const createCellWithView = (
 
     const cellID = cellResp.data.id
 
+    if (clonedCell) {
+      workingView = {...workingView, name: `${view.name} (Clone)`}
+    }
+
     // Create the view and associate it with the cell
-    const newView = await updateView(dashboardID, cellID, view)
+    const newView = await updateView(dashboardID, cellID, workingView)
 
     const normCell = normalize<Cell, CellEntities, string>(
       {...cellResp.data, dashboardID},

--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -31,33 +31,6 @@ export const isCellUntitled = (cellName: string): boolean => {
   return cellName === UNTITLED_GRAPH
 }
 
-const numColumns = 12
-
-const getNextAvailablePosition = (dashboard, newCell) => {
-  const farthestY = dashboard.cells
-    .map(cell => cell.y)
-    .reduce((a, b) => (a > b ? a : b))
-
-  const bottomCells = dashboard.cells.filter(cell => cell.y === farthestY)
-  const farthestX = bottomCells
-    .map(cell => cell.x)
-    .reduce((a, b) => (a > b ? a : b))
-  const lastCell = bottomCells.find(cell => cell.x === farthestX)
-
-  const availableSpace = numColumns - (lastCell.x + lastCell.w)
-  const newCellFits = availableSpace >= newCell.w
-
-  return newCellFits
-    ? {
-        x: lastCell.x + lastCell.w,
-        y: farthestY,
-      }
-    : {
-        x: 0,
-        y: lastCell.y + lastCell.h,
-      }
-}
-
 export const getNewDashboardCell = (
   state: AppState,
   dashboard: Dashboard,
@@ -102,23 +75,10 @@ export const getNewDashboardCell = (
       ...defaultCell,
       w: clonedCell.w,
       h: clonedCell.h,
+      x: clonedCell.x,
+      y: clonedCell.y,
     }
   }
 
-  const {x, y} = getNextAvailablePosition(dashboard, newCell)
-
-  return {
-    ...newCell,
-    x,
-    y,
-  }
-}
-
-export const getClonedDashboardCell = (
-  dashboard: Dashboard,
-  cloneCell: Cell
-): Cell => {
-  const {x, y} = getNextAvailablePosition(dashboard, cloneCell)
-
-  return {...cloneCell, x, y}
+  return newCell
 }


### PR DESCRIPTION
Closes #17630

- Assign cloned cells the same `x`, and `y` as their target cell
  - This results in the cloned cell getting created right below the target cell
  - react grid layout handles this out of the box
- Append `(Clone)` to the end of a new view name if it was created via cloning

### Testing

Initially I wrote an e2e test for cloning that asserts the cloned cell is placed next to its target. I spent a non-trivial amount of time setting up the test itself before making the assertion and it started to feel like overkill. I took a step back and concluded there is no point in testing the behavior that comes out of the box from a library.

### Preview

![clone-fix-example](https://user-images.githubusercontent.com/2433762/79014738-5dbc1a80-7b20-11ea-9c50-d48e26f1b8dd.gif)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
