### PR TITLE
fix(ui): allow mouse cursor inside Script Editor for Safari

### DIFF
--- a/ui/src/shared/components/FluxMonacoEditor.scss
+++ b/ui/src/shared/components/FluxMonacoEditor.scss
@@ -3,6 +3,7 @@
 // the specificity here is important to override the dynamic
 // base theme that monaco loads in at runtime
 .react-monaco-editor-container > .monaco-editor {
+  -webkit-user-select: text;
   font-family: $cf-code-font;
   font-weight: 500;
   font-size: 13px;


### PR DESCRIPTION
Closes https://app.zenhub.com/workspaces/applicationmonitoring-5e3b05772922e316b3a210a4/issues/influxdata/idpe/5962

Allow the cursor inside the Script Editor for Safari.
