### PR TITLE
refactor(http): simplify authorizer

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -111,6 +111,9 @@ func (a openAuthorizer) AuthorizeQuery(_ string, _ *influxql.Query) error { retu
 // function should be preferred over directly checking if an Authorizer is nil
 // or not.
 func AuthorizerIsOpen(a Authorizer) bool {
+	if u, ok := a.(interface{ AuthorizeUnrestricted() bool }); ok {
+		return u.AuthorizeUnrestricted()
+	}
 	return a == nil || a == OpenAuthorizer
 }
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -585,12 +585,8 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 	}
 
 	if h.Config.AuthEnabled {
-		if user != nil && user.AuthorizeUnrestricted() {
-			opts.Authorizer = query.OpenAuthorizer
-		} else {
-			// The current user determines the authorized actions.
-			opts.Authorizer = user
-		}
+		// The current user determines the authorized actions.
+		opts.Authorizer = user
 	} else {
 		// Auth is disabled, so allow everything.
 		opts.Authorizer = query.OpenAuthorizer


### PR DESCRIPTION
AuthorizeUnrestricted() method and if so, call that to provide the result of AuthorizerIsOpen().

Otherwise we check if the supplied Authorizer is nil.

This preserves the fast-path for checking tag-level (and other) tsdb operations.

This also simplifies how we perform authorization by handling these cases in only one place.

There is no associated bug.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
