### PR TITLE
fix(TelegrafInstructions): Updated the TelegrafInstructions to remove the warning to tell users to keep the token

### DIFF
--- a/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -1,7 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {Alert, ComponentColor, IconFont} from '@influxdata/clockface'
-import _ from 'lodash'
 
 // Decorator
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -44,12 +42,6 @@ class TelegrafInstructions extends PureComponent<Props> {
           copy the following command to your terminal window to set an
           environment variable with your token.
         </p>
-        {token && (
-          <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
-            Make sure to copy your new personal access token now. You won’t be
-            able to see it again!
-          </Alert>
-        )}
         <TokenCodeSnippet token={exportToken} configID={configID} label="CLI" />
         <h6>3. Start Telegraf</h6>
         <p>


### PR DESCRIPTION
This PR is a minor UI tweak to address a warning that was displaying when users were creating a telegraf config for the first time. The original intent of the warning was to align token creation and retrievability to conventions that exist in other platforms (that tokens are unique and cannot be retrieved after creation). This PR removes that warning since:

- Users can still access their tokens in the `tokens` tab
- Tokens can regenerate tokens if they lose their token