### PR TITLE
feat(cloud): markdown: do not parse or render images in cloud envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.0.0-beta.9
+
+### Features
+
+### Bug Fixes
+
+### UI Improvements
+
+1. [17714](https://github.com/influxdata/influxdb/pull/17714): Cloud environments no longer render markdown images, for security reasons.
+
 ## v2.0.0-beta.8 [2020-04-10]
 
 ### Features

--- a/ui/src/dashboards/components/NoteEditorPreview.test.tsx
+++ b/ui/src/dashboards/components/NoteEditorPreview.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+jest.mock('honeybadger-js', () => {
+  return {
+    configure: jest.fn(),
+    notify: jest.fn(),
+  }
+})
+
+import {render} from 'react-testing-library'
+
+describe('the NoteEditor markdown renderer', () => {
+  describe('image rendering behavior', () => {
+    const note = '\n![](https://i.imgur.com/k3wIaNU.gif)\n'
+
+    describe('in cloud contexts', () => {
+      it("renders a warning that we can't render images, rather than rendering the image", () => {
+        jest.mock('src/shared/constants', () => ({CLOUD: true}))
+        const NoteEditorPreview = require('src/dashboards/components/NoteEditorPreview.tsx')
+          .default
+
+        const {getByText} = render(
+          <NoteEditorPreview note={note} scrollTop={0} onScroll={() => {}} />
+        )
+        expect(
+          getByText("We don't support images in markdown for security purposes")
+        )
+      })
+    })
+
+    describe('in oss contexts', () => {
+      it('renders the image', () => {
+        jest.mock('src/shared/constants', () => ({CLOUD: false}))
+        const NoteEditorPreview = require('src/dashboards/components/NoteEditorPreview.tsx')
+          .default
+        const {container} = render(
+          <NoteEditorPreview note={note} scrollTop={0} onScroll={() => {}} />
+        )
+        expect(
+          container.querySelector('img[src*="https://i.imgur.com/k3wIaNU.gif"]')
+        )
+      })
+    })
+  })
+})

--- a/ui/src/dashboards/components/NoteEditorPreview.tsx
+++ b/ui/src/dashboards/components/NoteEditorPreview.tsx
@@ -1,13 +1,17 @@
 import React, {SFC, MouseEvent} from 'react'
-import ReactMarkdown from 'react-markdown'
 
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
+
+import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 
 interface Props {
   note: string
   scrollTop: number
   onScroll: (e: MouseEvent) => void
 }
+
+const cloudImageRenderer = (): any =>
+  "We don't support images in markdown for security purposes"
 
 const NoteEditorPreview: SFC<Props> = props => {
   return (
@@ -18,10 +22,13 @@ const NoteEditorPreview: SFC<Props> = props => {
         setScrollTop={props.onScroll}
       >
         <div className="note-editor--markdown-container">
-          <ReactMarkdown
-            source={props.note}
-            escapeHtml={true}
+          <MarkdownRenderer
+            text={props.note}
             className="markdown-format"
+            cloudRenderers={{
+              image: cloudImageRenderer,
+              imageReference: cloudImageRenderer,
+            }}
           />
         </div>
       </FancyScrollbar>

--- a/ui/src/shared/components/EmptyQueryView.tsx
+++ b/ui/src/shared/components/EmptyQueryView.tsx
@@ -5,7 +5,7 @@ import React, {PureComponent} from 'react'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import EmptyGraphErrorTooltip from 'src/shared/components/EmptyGraphErrorTooltip'
 import EmptyGraphError from 'src/shared/components/EmptyGraphError'
-import Markdown from 'src/shared/components/views/Markdown'
+import ScrollableMarkdown from 'src/shared/components/views/ScrollableMarkdown'
 
 // Constants
 import {emptyGraphCopy} from 'src/shared/copy/cell'
@@ -73,7 +73,7 @@ export default class EmptyQueryView extends PureComponent<Props> {
     }
 
     if (!hasResults && fallbackNote) {
-      return <Markdown text={fallbackNote} />
+      return <ScrollableMarkdown text={fallbackNote} />
     }
 
     if (!hasResults) {

--- a/ui/src/shared/components/cells/Cell.tsx
+++ b/ui/src/shared/components/cells/Cell.tsx
@@ -6,7 +6,7 @@ import {get} from 'lodash'
 // Components
 import CellHeader from 'src/shared/components/cells/CellHeader'
 import CellContext from 'src/shared/components/cells/CellContext'
-import Markdown from 'src/shared/components/views/Markdown'
+import ScrollableMarkdown from 'src/shared/components/views/ScrollableMarkdown'
 import RefreshingView from 'src/shared/components/RefreshingView'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
@@ -92,7 +92,7 @@ class CellComponent extends Component<Props, State> {
     }
 
     if (view.properties.type === 'markdown') {
-      return <Markdown text={view.properties.note} />
+      return <ScrollableMarkdown text={view.properties.note} />
     }
 
     return (

--- a/ui/src/shared/components/cells/CellHeaderNote.tsx
+++ b/ui/src/shared/components/cells/CellHeaderNote.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FunctionComponent, useRef, RefObject, useState} from 'react'
-import ReactMarkdown from 'react-markdown'
 import classnames from 'classnames'
 
 // Components
@@ -12,6 +11,8 @@ import {
   Appearance,
   DapperScrollbars,
 } from '@influxdata/clockface'
+
+import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 
 // Constants
 const MAX_POPOVER_WIDTH = 280
@@ -58,7 +59,7 @@ const CellHeaderNote: FunctionComponent<Props> = ({note}) => {
         contents={() => (
           <DapperScrollbars style={contentStyle} autoSize={true}>
             <div className="cell--note-contents markdown-format">
-              <ReactMarkdown source={note} />
+              <MarkdownRenderer text={note} />
             </div>
           </DapperScrollbars>
         )}

--- a/ui/src/shared/components/cells/CellHeaderNoteTooltip.tsx
+++ b/ui/src/shared/components/cells/CellHeaderNoteTooltip.tsx
@@ -1,10 +1,11 @@
 // Libraries
 import React, {SFC, CSSProperties} from 'react'
 import {createPortal} from 'react-dom'
-import ReactMarkdown from 'react-markdown'
 
 // Constants
 import {NOTES_PORTAL_ID} from 'src/portals/NotesPortal'
+
+import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 
 interface Props {
   note: string
@@ -27,7 +28,7 @@ const CellHeaderNoteTooltip: SFC<Props> = props => {
         className="cell-header-note-tooltip--content markdown-format"
         style={style}
       >
-        <ReactMarkdown source={note} />
+        <MarkdownRenderer text={note} />
       </div>
     </div>
   )

--- a/ui/src/shared/components/views/MarkdownRenderer.test.tsx
+++ b/ui/src/shared/components/views/MarkdownRenderer.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import {render} from 'react-testing-library'
+
+describe('the MarkdownRenderer wrapper around ReactMarkdown', () => {
+  describe('image rendering behavior', () => {
+    const text = '\n![](https://i.imgur.com/k3wIaNU.gif)\n'
+
+    describe('in cloud contexts', () => {
+      it('renders the image markdown literal, rather than rendering the image', () => {
+        jest.mock('src/shared/constants', () => ({CLOUD: true}))
+        const {
+          MarkdownRenderer,
+        } = require('src/shared/components/views/MarkdownRenderer.tsx')
+
+        const {getByText} = render(<MarkdownRenderer text={text} />)
+        expect(getByText('![](https://i.imgur.com/k3wIaNU.gif)'))
+      })
+    })
+
+    describe('in oss contexts', () => {
+      it('renders the image', () => {
+        jest.mock('src/shared/constants', () => ({CLOUD: false}))
+        const {
+          MarkdownRenderer,
+        } = require('src/shared/components/views/MarkdownRenderer.tsx')
+
+        const {container} = render(<MarkdownRenderer text={text} />)
+        expect(
+          container.querySelector('img[src*="https://i.imgur.com/k3wIaNU.gif"]')
+        )
+      })
+    })
+  })
+})

--- a/ui/src/shared/components/views/MarkdownRenderer.tsx
+++ b/ui/src/shared/components/views/MarkdownRenderer.tsx
@@ -1,0 +1,40 @@
+// Libraries
+import React, {FC} from 'react'
+import ReactMarkdown, {Renderer, Renderers} from 'react-markdown'
+
+import {CLOUD} from 'src/shared/constants/index'
+
+interface Props {
+  className?: string
+  cloudRenderers?: Renderers
+  text: string
+}
+
+// we don't want to render an image, but Renderer is generic and expects
+// React element wrapping an image to be returned, so we use any
+// https://github.com/rexxars/react-markdown/blob/master/index.d.ts#L101
+const imageRenderer: Renderer<HTMLImageElement> = (props: HTMLImageElement): any => {
+  return `![](${props.src})`
+}
+
+export const MarkdownRenderer: FC<Props> = ({className = '', cloudRenderers = {}, text}) => {
+  // don't parse images in cloud environments to prevent arbitrary script execution via images
+  if (CLOUD) {
+    const renderers = {image: imageRenderer, imageReference: imageRenderer}
+    return (
+      <ReactMarkdown
+        source={text}
+        className={className}
+        renderers={{...renderers, ...cloudRenderers}}
+      />
+    )
+  }
+
+  // load images locally to your heart's content. caveat emptor
+  return (
+    <ReactMarkdown
+      source={text}
+      className={className}
+    />
+  )
+}

--- a/ui/src/shared/components/views/MarkdownRenderer.tsx
+++ b/ui/src/shared/components/views/MarkdownRenderer.tsx
@@ -10,14 +10,21 @@ interface Props {
   text: string
 }
 
-// we don't want to render an image, but Renderer is generic and expects
-// React element wrapping an image to be returned, so we use any
-// https://github.com/rexxars/react-markdown/blob/master/index.d.ts#L101
-const imageRenderer: Renderer<HTMLImageElement> = (props: HTMLImageElement): any => {
+// In cloud environments, we want to render the literal markdown image tag
+// but ReactMarkdown expects a React element wrapping an image to be returned,
+// so we use any
+// see: https://github.com/rexxars/react-markdown/blob/master/index.d.ts#L101
+const imageRenderer: Renderer<HTMLImageElement> = (
+  props: HTMLImageElement
+): any => {
   return `![](${props.src})`
 }
 
-export const MarkdownRenderer: FC<Props> = ({className = '', cloudRenderers = {}, text}) => {
+export const MarkdownRenderer: FC<Props> = ({
+  className = '',
+  cloudRenderers = {},
+  text,
+}) => {
   // don't parse images in cloud environments to prevent arbitrary script execution via images
   if (CLOUD) {
     const renderers = {image: imageRenderer, imageReference: imageRenderer}
@@ -31,10 +38,5 @@ export const MarkdownRenderer: FC<Props> = ({className = '', cloudRenderers = {}
   }
 
   // load images locally to your heart's content. caveat emptor
-  return (
-    <ReactMarkdown
-      source={text}
-      className={className}
-    />
-  )
+  return <ReactMarkdown source={text} className={className} />
 }

--- a/ui/src/shared/components/views/ScrollableMarkdown.tsx
+++ b/ui/src/shared/components/views/ScrollableMarkdown.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import ReactMarkdown from 'react-markdown'
 
 // Components
 import {DapperScrollbars} from '@influxdata/clockface'
@@ -11,20 +10,22 @@ import {humanizeNote} from 'src/dashboards/utils/notes'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
+
 interface Props {
   text: string
 }
 
 @ErrorHandling
-class Markdown extends PureComponent<Props> {
+class ScrollableMarkdown extends PureComponent<Props> {
   public render() {
     const {text} = this.props
 
     return (
       <DapperScrollbars className="markdown-cell" autoHide={true}>
         <div className="markdown-cell--contents">
-          <ReactMarkdown
-            source={humanizeNote(text)}
+          <MarkdownRenderer
+            text={humanizeNote(text)}
             className="markdown-format"
           />
         </div>
@@ -33,4 +34,4 @@ class Markdown extends PureComponent<Props> {
   }
 }
 
-export default Markdown
+export default ScrollableMarkdown


### PR DESCRIPTION
Closes idpe 5288

* Creates a cloud-aware markdown renderer that behaves as it always has on OSS, but blocks image loading on cloud.
* Refactored existing `Markdown` component to use the new `MarkdownRender` and to be renamed `ScrollableMarkdown` (it's wrapped in a `DapperScrollbar`) to avoid future confusion.
* Made all other instances of markdown rendering use the new cloud aware renderer

**Cloud behavior:**
* In editor window, show warning: `We don't support images in markdown for security purposes`
* In note, show literal markdown string

**OSS Behavior:**
* Render the image normally

## Testing Instructions
1. In an OSS Context:
1. Go to a dashboard
1. Click add note
1. In the text editor add a markdown image `![](url.to.image/image.jpg)`
  1. it should render in the preview
1. Click save
1. It should Shown below the cell.

---

1. For a cloud context, change [this line](https://github.com/influxdata/influxdb/pull/17714/files#diff-00a39300b1379f1441c65ba1d56cacafR29) to `if (CLOUD || true)`
1. Reload the dashboard you just edited
1. The note you added should show the literal image markdown
1. In the top right corner of the note, click the gear and click `Edit Note`
1. You should see a warning saying we can't render markdown for security reasons
1. add another markdown image `![](url.image)` to test parsing new text - the same warning should pop up

### Cloud
![Screen Shot 2020-04-10 at 12 27 24 PM](https://user-images.githubusercontent.com/146112/79030058-0cc21b80-7b4c-11ea-894d-39558197c0e1.png)

### Cloud
![Screen Shot 2020-04-10 at 4 58 36 PM](https://user-images.githubusercontent.com/146112/79030193-b4d7e480-7b4c-11ea-990c-35c6cfbef64d.png)

### OSS
![Screen Shot 2020-04-10 at 4 58 04 PM](https://user-images.githubusercontent.com/146112/79030197-bacdc580-7b4c-11ea-9882-ad046624c063.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
