### PR TITLE
fix: test suite to account for internal go 1.14 API change

### DIFF
--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -746,9 +746,9 @@ func TestClient_Timeout(t *testing.T) {
 	_, err = c.Query(query)
 	if err == nil {
 		t.Fatalf("unexpected success. expected timeout error")
-	} else if !strings.Contains(err.Error(), "request canceled") &&
+	} else if !strings.Contains(err.Error(), "context deadline exceeded") &&
 		!strings.Contains(err.Error(), "use of closed network connection") {
-		t.Fatalf("unexpected error. expected 'request canceled' error, got %v", err)
+		t.Fatalf("unexpected error. expected 'context deadline exceeded' error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Seems like there was some subtle changes in the go 1.14 http/client API
regarding context timeout changes. This changes the resulting error
string.

https://github.com/golang/go/commit/7fc2625ef16c9e271ca3016f761157ec082cc45a
https://github.com/golang/go/commit/19e0799ba049bf26e770d150d4c296f247e1de5c

Signed-off-by: Morten Linderud <morten@linderud.pw>

Closes #17222

Describe your proposed changes here.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
