### PR TITLE
fix(pkger): fixup field misassignment in table view export

### DIFF
--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -647,11 +647,13 @@ func convertCellView(cell influxdb.Cell) chart {
 
 func convertChartToResource(ch chart) Resource {
 	r := Resource{
-		fieldKind:         ch.Kind.title(),
-		fieldName:         ch.Name,
-		fieldChartQueries: ch.Queries,
-		fieldChartHeight:  ch.Height,
-		fieldChartWidth:   ch.Width,
+		fieldKind:        ch.Kind.title(),
+		fieldName:        ch.Name,
+		fieldChartHeight: ch.Height,
+		fieldChartWidth:  ch.Width,
+	}
+	if len(ch.Queries) > 0 {
+		r[fieldChartQueries] = ch.Queries
 	}
 	if len(ch.Colors) > 0 {
 		r[fieldChartColors] = ch.Colors
@@ -671,7 +673,7 @@ func convertChartToResource(ch chart) Resource {
 		tRes := make(Resource)
 		assignNonZeroBools(tRes, map[string]bool{
 			fieldChartTableOptionVerticalTimeAxis: ch.TableOptions.VerticalTimeAxis,
-			fieldChartTableOptionFixFirstColumn:   ch.TableOptions.VerticalTimeAxis,
+			fieldChartTableOptionFixFirstColumn:   ch.TableOptions.FixFirstColumn,
 		})
 		assignNonZeroStrings(tRes, map[string]string{
 			fieldChartTableOptionSortBy:   ch.TableOptions.SortByField,
@@ -787,7 +789,9 @@ func DashboardToObject(name string, dash influxdb.Dashboard) Object {
 	}
 
 	o := newObject(KindDashboard, name)
-	o.Spec[fieldDescription] = dash.Description
+	assignNonZeroStrings(o.Spec, map[string]string{
+		fieldDescription: dash.Description,
+	})
 	o.Spec[fieldDashCharts] = charts
 	return o
 }

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -2656,9 +2656,6 @@ func (c chart) properties() influxdb.ViewProperties {
 				Visible:      fieldOpt.Visible,
 			})
 		}
-		sort.Slice(fieldOptions, func(i, j int) bool {
-			return fieldOptions[i].InternalName < fieldOptions[j].InternalName
-		})
 
 		return influxdb.TableViewProperties{
 			Type:              influxdb.ViewPropertyTypeTable,

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -2259,19 +2259,16 @@ spec:
 					assert.Equal(t, "truncate", tableOpts.Wrapping)
 					assert.True(t, tableOpts.FixFirstColumn)
 
-					require.Len(t, props.FieldOptions, 2)
-					expectedField := influxdb.RenamableField{
-						InternalName: "_time",
-						DisplayName:  "time (ms)",
-						Visible:      true,
-					}
-					assert.Equal(t, expectedField, props.FieldOptions[0])
-					expectedField = influxdb.RenamableField{
+					assert.Contains(t, props.FieldOptions, influxdb.RenamableField{
 						InternalName: "_value",
 						DisplayName:  "MB",
 						Visible:      true,
-					}
-					assert.Equal(t, expectedField, props.FieldOptions[1])
+					})
+					assert.Contains(t, props.FieldOptions, influxdb.RenamableField{
+						InternalName: "_time",
+						DisplayName:  "time (ms)",
+						Visible:      true,
+					})
 				})
 			})
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1941,6 +1941,47 @@ func TestService(t *testing.T) {
 								},
 							},
 						},
+						{
+							// validate implementation resolves: https://github.com/influxdata/influxdb/issues/17708
+							name:    "table converts table options correctly",
+							newName: "new name",
+							expectedView: influxdb.View{
+								ViewContents: influxdb.ViewContents{
+									Name: "view name",
+								},
+								Properties: influxdb.TableViewProperties{
+									Type:              influxdb.ViewPropertyTypeTable,
+									Note:              "a note",
+									ShowNoteWhenEmpty: true,
+									Queries:           []influxdb.DashboardQuery{newQuery()},
+									ViewColors:        []influxdb.ViewColor{{Type: "scale", Hex: "#8F8AF4", Value: 0}, {Type: "scale", Hex: "#8F8AF4", Value: 0}, {Type: "scale", Hex: "#8F8AF4", Value: 0}},
+									TableOptions: influxdb.TableOptions{
+										VerticalTimeAxis: true,
+										SortBy: influxdb.RenamableField{
+											InternalName: "_time",
+										},
+										Wrapping: "truncate",
+									},
+									FieldOptions: []influxdb.RenamableField{
+										{
+											InternalName: "_time",
+											DisplayName:  "time (ms)",
+											Visible:      true,
+										},
+										{
+											InternalName: "_value",
+											DisplayName:  "bytes",
+											Visible:      true,
+										},
+									},
+									TimeFormat: "YYYY:MM:DD",
+									DecimalPlaces: influxdb.DecimalPlaces{
+										IsEnforced: true,
+										Digits:     1,
+									},
+								},
+							},
+						},
 					}
 
 					for _, tt := range tests {


### PR DESCRIPTION
closes: #17708

`influx pkg export --dashboards $ID | influx pkg` results in:
![image](https://user-images.githubusercontent.com/17263167/79149796-87717d80-7d7c-11ea-932e-996d92aa73ae.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass