### PR TITLE
fix(ui): add component to route hierarchy to handle org renaming

### DIFF
--- a/ui/cypress/e2e/orgs.test.ts
+++ b/ui/cypress/e2e/orgs.test.ts
@@ -18,4 +18,28 @@ describe('Orgs', () => {
       cy.url().should('contain', 'signin')
     })
   })
+
+  describe('when user wants to rename an org', () => {
+    beforeEach(() => {
+      cy.signin().then(({body}) => {
+        console.log('signed in, body is', body)
+      })
+
+      cy.visit('/')
+    })
+    it('should be able to rename the org', () => {
+      const extraText = '_renamed'
+      cy.getByTestID('nav-item-org').click()
+      cy.get('span:contains("About")').click()
+      cy.get('span:contains("Rename")').click()
+      cy.get('button.cf-button.cf-button-danger').click()
+      cy.getByTestID('create-org-name-input')
+        .click()
+        .type(extraText)
+      cy.get('button.cf-button.cf-button-success').click()
+      cy.get('.cf-tree-nav--team')
+        .contains(extraText)
+        .should('have.length', 1)
+    })
+  })
 })

--- a/ui/cypress/e2e/orgs.test.ts
+++ b/ui/cypress/e2e/orgs.test.ts
@@ -21,14 +21,12 @@ describe('Orgs', () => {
 
   describe('when user wants to rename an org', () => {
     beforeEach(() => {
-      cy.signin().then(({body}) => {
-        console.log('signed in, body is', body)
+      cy.signin().then(() => {
+        cy.visit('/')
       })
-
-      cy.visit('/')
     })
     it('should be able to rename the org', () => {
-      const extraText = '_renamed'
+      const extraText = '_my_renamed_org_in_e2e'
       cy.getByTestID('nav-item-org').click()
       cy.get('span:contains("About")').click()
       cy.get('span:contains("Rename")').click()

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -404,6 +404,12 @@ class Root extends PureComponent {
                               />
                             </Route>
                             <Route path="labels" component={LabelsIndex} />
+                            <Route path="about" component={OrgProfilePage}>
+                              <Route
+                                path="rename"
+                                component={RenameOrgOverlay}
+                              />
+                            </Route>
                           </Route>
                           <Route path="alerting" component={AlertingIndex}>
                             <Route
@@ -443,9 +449,7 @@ class Root extends PureComponent {
                             path="checks/:checkID"
                             component={CheckHistory}
                           />
-                          <Route path="about" component={OrgProfilePage}>
-                            <Route path="rename" component={RenameOrgOverlay} />
-                          </Route>
+                          <Route path="about" component={OrgProfilePage} />
                           {!CLOUD && (
                             <Route path="members" component={MembersIndex} />
                           )}


### PR DESCRIPTION
Closes idpe 6730

Adds the component for renaming orgs to the correct place in the routing hierarchy
