### PR TITLE
feat(demodata): Pass bucket to removeBucket function

### DIFF
--- a/ui/src/buckets/components/DemoDataBucketCard.tsx
+++ b/ui/src/buckets/components/DemoDataBucketCard.tsx
@@ -62,7 +62,7 @@ const DemoDataBucketCard: FC<Props & WithRouterProps & DispatchProps> = ({
               <Context.Item
                 label="Confirm"
                 action={removeBucket}
-                value={bucket.id}
+                value={bucket}
                 testID={`context-delete-bucket ${bucket.name}`}
               />
             </Context.Menu>


### PR DESCRIPTION
Was passing the bucket.id instead of the entire bucket value to the removeBucket function. 