### PR TITLE
fix(http/write_handler): propagate context to http request

### DIFF
--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -410,7 +410,7 @@ func (s *WriteService) Write(ctx context.Context, orgID, bucketID influxdb.ID, r
 		return err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), r)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
_http.NewRequestWithContext_ (available since golang 1.13) ensures that the supplied context also controls the entire lifetime of a request and its response. Before this PR, the supplied context was not used at all.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
