### PR TITLE
feat(storage): Provide public MeasurementFields API

### DIFF
--- a/storage/engine_measurement_schema.go
+++ b/storage/engine_measurement_schema.go
@@ -60,3 +60,21 @@ func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxd
 
 	return e.engine.MeasurementTagKeys(ctx, orgID, bucketID, measurement, start, end, predicate)
 }
+
+// MeasurementFields returns an iterator which enumerates the field schema for the given
+// bucket and measurement, filtered using the optional the predicate and limited to the
+//// time range (start, end].
+//
+// MeasurementFields will always return a MeasurementFieldsIterator if there is no error.
+//
+// If the context is canceled before MeasurementFields has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementFields(ctx context.Context, orgID, bucketID influxdb.ID, measurement string, start, end int64, predicate influxql.Expr) (cursors.MeasurementFieldsIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyMeasurementFieldsIterator, nil
+	}
+
+	return e.engine.MeasurementFields(ctx, orgID, bucketID, measurement, start, end, predicate)
+}

--- a/storage/engine_measurement_schema.go
+++ b/storage/engine_measurement_schema.go
@@ -9,7 +9,7 @@ import (
 )
 
 // MeasurementNames returns an iterator which enumerates the measurements for the given
-// bucket and limited to the time range (start, end].
+// bucket and limited to the time range [start, end].
 //
 // MeasurementNames will always return a StringIterator if there is no error.
 //
@@ -27,7 +27,7 @@ func (e *Engine) MeasurementNames(ctx context.Context, orgID, bucketID influxdb.
 
 // MeasurementTagValues returns an iterator which enumerates the tag values for the given
 // bucket, measurement and tag key, filtered using the optional the predicate and limited to the
-// time range (start, end].
+// time range [start, end].
 //
 // MeasurementTagValues will always return a StringIterator if there is no error.
 //
@@ -45,7 +45,7 @@ func (e *Engine) MeasurementTagValues(ctx context.Context, orgID, bucketID influ
 
 // MeasurementTagKeys returns an iterator which enumerates the tag keys for the given
 // bucket and measurement, filtered using the optional the predicate and limited to the
-//// time range (start, end].
+//// time range [start, end].
 //
 // MeasurementTagKeys will always return a StringIterator if there is no error.
 //
@@ -63,7 +63,7 @@ func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxd
 
 // MeasurementFields returns an iterator which enumerates the field schema for the given
 // bucket and measurement, filtered using the optional the predicate and limited to the
-//// time range (start, end].
+//// time range [start, end].
 //
 // MeasurementFields will always return a MeasurementFieldsIterator if there is no error.
 //

--- a/storage/engine_schema.go
+++ b/storage/engine_schema.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TagKeys returns an iterator where the values are tag keys for the bucket
-// matching the predicate within the time range (start, end].
+// matching the predicate within the time range [start, end].
 //
 // TagKeys will always return a StringIterator if there is no error.
 func (e *Engine) TagKeys(ctx context.Context, orgID, bucketID influxdb.ID, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
@@ -24,7 +24,7 @@ func (e *Engine) TagKeys(ctx context.Context, orgID, bucketID influxdb.ID, start
 
 // TagValues returns an iterator which enumerates the values for the specific
 // tagKey in the given bucket matching the predicate within the
-// time range (start, end].
+// time range [start, end].
 //
 // TagValues will always return a StringIterator if there is no error.
 func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {

--- a/tsdb/tsm1/engine_measurement_schema.go
+++ b/tsdb/tsm1/engine_measurement_schema.go
@@ -159,6 +159,14 @@ func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxd
 	return e.tagKeysPredicate(ctx, orgID, bucketID, []byte(measurement), start, end, predicate)
 }
 
+// MeasurementFields returns an iterator which enumerates the field schema for the given
+// bucket and measurement, filtered using the optional the predicate and limited to the
+//// time range (start, end].
+//
+// MeasurementFields will always return a MeasurementFieldsIterator if there is no error.
+//
+// If the context is canceled before MeasurementFields has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
 func (e *Engine) MeasurementFields(ctx context.Context, orgID, bucketID influxdb.ID, measurement string, start, end int64, predicate influxql.Expr) (cursors.MeasurementFieldsIterator, error) {
 	if predicate == nil {
 		return e.fieldsNoPredicate(ctx, orgID, bucketID, []byte(measurement), start, end)

--- a/tsdb/tsm1/engine_measurement_schema.go
+++ b/tsdb/tsm1/engine_measurement_schema.go
@@ -16,7 +16,7 @@ import (
 )
 
 // MeasurementNames returns an iterator which enumerates the measurements for the given
-// bucket and limited to the time range (start, end].
+// bucket and limited to the time range [start, end].
 //
 // MeasurementNames will always return a StringIterator if there is no error.
 //
@@ -124,7 +124,7 @@ func (e *Engine) MeasurementNames(ctx context.Context, orgID, bucketID influxdb.
 
 // MeasurementTagValues returns an iterator which enumerates the tag values for the given
 // bucket, measurement and tag key, filtered using the optional the predicate and limited to the
-// time range (start, end].
+// time range [start, end].
 //
 // MeasurementTagValues will always return a StringIterator if there is no error.
 //
@@ -143,7 +143,7 @@ func (e *Engine) MeasurementTagValues(ctx context.Context, orgID, bucketID influ
 
 // MeasurementTagKeys returns an iterator which enumerates the tag keys for the given
 // bucket and measurement, filtered using the optional the predicate and limited to the
-//// time range (start, end].
+//// time range [start, end].
 //
 // MeasurementTagKeys will always return a StringIterator if there is no error.
 //
@@ -161,7 +161,7 @@ func (e *Engine) MeasurementTagKeys(ctx context.Context, orgID, bucketID influxd
 
 // MeasurementFields returns an iterator which enumerates the field schema for the given
 // bucket and measurement, filtered using the optional the predicate and limited to the
-//// time range (start, end].
+//// time range [start, end].
 //
 // MeasurementFields will always return a MeasurementFieldsIterator if there is no error.
 //

--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -24,7 +24,7 @@ const cancelCheckInterval = 64
 
 // TagValues returns an iterator which enumerates the values for the specific
 // tagKey in the given bucket matching the predicate within the
-// time range (start, end].
+// time range [start, end].
 //
 // TagValues will always return a StringIterator if there is no error.
 //
@@ -321,7 +321,7 @@ func (e *Engine) findCandidateKeys(ctx context.Context, orgBucket []byte, predic
 }
 
 // TagKeys returns an iterator which enumerates the tag keys for the given
-// bucket matching the predicate within the time range (start, end].
+// bucket matching the predicate within the time range [start, end].
 //
 // TagKeys will always return a StringIterator if there is no error.
 //


### PR DESCRIPTION
Completes the work for measurement based schema APIs by making the `MeasurementFields` API public on the `storage.Engine` type.

Additionally, this PR corrects the time intervals for the documentation of the schema APIs.