### PR TITLE
feat(ui): add single-color schemes for visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [17714](https://github.com/influxdata/influxdb/pull/17714): Cloud environments no longer render markdown images, for security reasons.
 1. [17321](https://github.com/influxdata/influxdb/pull/17321): Improve UI for sorting resources
+1. [17740](https://github.com/influxdata/influxdb/pull/17740): Add single-color color schemes for visualizations
 
 ## v2.0.0-beta.8 [2020-04-10]
 

--- a/ui/src/shared/constants/graphColorPalettes.ts
+++ b/ui/src/shared/constants/graphColorPalettes.ts
@@ -171,6 +171,126 @@ export const LINE_COLORS_G = [
   },
 ]
 
+export const LINE_COLORS_SOLID_RED = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#DC4E58',
+    id: uuid.v4(),
+    name: 'Solid Red',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#DC4E58',
+    id: uuid.v4(),
+    name: 'Solid Red',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#DC4E58',
+    id: uuid.v4(),
+    name: 'Solid Red',
+    value: 0,
+  },
+]
+
+export const LINE_COLORS_SOLID_BLUE = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#00A3FF',
+    id: uuid.v4(),
+    name: 'Solid Blue',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#00A3FF',
+    id: uuid.v4(),
+    name: 'Solid Blue',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#00A3FF',
+    id: uuid.v4(),
+    name: 'Solid Blue',
+    value: 0,
+  },
+]
+
+export const LINE_COLORS_SOLID_GREEN = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#34BB55',
+    id: uuid.v4(),
+    name: 'Solid Green',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#34BB55',
+    id: uuid.v4(),
+    name: 'Solid Green',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#34BB55',
+    id: uuid.v4(),
+    name: 'Solid Green',
+    value: 0,
+  },
+]
+
+export const LINE_COLORS_SOLID_YELLOW = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#FFD255',
+    id: uuid.v4(),
+    name: 'Solid Yellow',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#FFD255',
+    id: uuid.v4(),
+    name: 'Solid Yellow',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#FFD255',
+    id: uuid.v4(),
+    name: 'Solid Yellow',
+    value: 0,
+  },
+]
+
+export const LINE_COLORS_SOLID_PURPLE = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#BE2EE4',
+    id: uuid.v4(),
+    name: 'Solid Purple',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#BE2EE4',
+    id: uuid.v4(),
+    name: 'Solid Purple',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#BE2EE4',
+    id: uuid.v4(),
+    name: 'Solid Purple',
+    value: 0,
+  },
+]
+
 export const DEFAULT_LINE_COLORS = LINE_COLORS_A
 
 export const LINE_COLOR_SCALES = [
@@ -181,6 +301,11 @@ export const LINE_COLOR_SCALES = [
   LINE_COLORS_E,
   LINE_COLORS_F,
   LINE_COLORS_G,
+  LINE_COLORS_SOLID_RED,
+  LINE_COLORS_SOLID_BLUE,
+  LINE_COLORS_SOLID_YELLOW,
+  LINE_COLORS_SOLID_GREEN,
+  LINE_COLORS_SOLID_PURPLE,
 ].map(colorScale => {
   const name = colorScale[0].name
   const colors = colorScale


### PR DESCRIPTION
Closes #17546

- Add `Solid Red`, `Solid Blue`, `Solid Yellow`, `Solid Green`, and `Solid Purple` as color schemes

![Screen Shot 2020-04-14 at 2 10 01 PM](https://user-images.githubusercontent.com/2433762/79274971-346df800-7e5a-11ea-98ba-39356c5ef0fa.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
