### PR TITLE
fix(kv): don't set session expiration time to earlier than existing expiration on renew session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 1. [17618](https://github.com/influxdata/influxdb/pull/17618): Add index for URM by user ID to improve lookup performance
+1. [17751](https://github.com/influxdata/influxdb/pull/17751): Existing session expiration time is respected on session renewal
 
 ### UI Improvements
 

--- a/kv/session.go
+++ b/kv/session.go
@@ -28,13 +28,33 @@ func (s *Service) RenewSession(ctx context.Context, session *influxdb.Session, n
 			Msg: "session is nil",
 		}
 	}
+
+	// session already has longer expiration
+	if newExpiration.Before(session.ExpiresAt) {
+		return nil
+	}
+
 	return s.kv.Update(ctx, func(tx Tx) error {
-		session.ExpiresAt = newExpiration
-		if err := s.putSession(ctx, tx, session); err != nil {
+		sess, err := s.findSession(ctx, tx, session.Key)
+		if err != nil {
+			return err
+		}
+
+		// session already has longer expiration
+		if newExpiration.Before(session.ExpiresAt) {
+			return nil
+		}
+
+		sess.ExpiresAt = newExpiration
+
+		if err := s.putSession(ctx, tx, sess); err != nil {
 			return &influxdb.Error{
 				Err: err,
 			}
 		}
+
+		*session = *sess
+
 		return nil
 	})
 }

--- a/testing/session.go
+++ b/testing/session.go
@@ -18,19 +18,23 @@ const (
 	sessionTwoID = "020f755c3c082001"
 )
 
-var sessionCmpOptions = cmp.Options{
-	cmp.Comparer(func(x, y []byte) bool {
-		return bytes.Equal(x, y)
-	}),
-	cmp.Transformer("Sort", func(in []*platform.Session) []*platform.Session {
-		out := append([]*platform.Session(nil), in...) // Copy input to avoid mutating it
-		sort.Slice(out, func(i, j int) bool {
-			return out[i].ID.String() > out[j].ID.String()
-		})
-		return out
-	}),
-	cmpopts.IgnoreFields(platform.Session{}, "CreatedAt", "ExpiresAt", "Permissions"),
-	cmpopts.EquateEmpty(),
+var sessionCmpOptions = sessionCompareOptions("CreatedAt", "ExpiresAt", "Permissions")
+
+func sessionCompareOptions(ignore ...string) cmp.Options {
+	return cmp.Options{
+		cmp.Comparer(func(x, y []byte) bool {
+			return bytes.Equal(x, y)
+		}),
+		cmp.Transformer("Sort", func(in []*platform.Session) []*platform.Session {
+			out := append([]*platform.Session(nil), in...) // Copy input to avoid mutating it
+			sort.Slice(out, func(i, j int) bool {
+				return out[i].ID.String() > out[j].ID.String()
+			})
+			return out
+		}),
+		cmpopts.IgnoreFields(platform.Session{}, ignore...),
+		cmpopts.EquateEmpty(),
+	}
 }
 
 // SessionFields will include the IDGenerator, TokenGenerator, Sessions, and Users
@@ -337,6 +341,39 @@ func RenewSession(
 			},
 		},
 		{
+			name: "renew session with an earlier time than existing expiration",
+			fields: SessionFields{
+				IDGenerator:    mock.NewIDGenerator(sessionTwoID, t),
+				TokenGenerator: mock.NewTokenGenerator("abc123xyz", nil),
+				Sessions: []*platform.Session{
+					{
+						ID:        MustIDBase16(sessionOneID),
+						UserID:    MustIDBase16(sessionTwoID),
+						Key:       "abc123xyz",
+						ExpiresAt: time.Date(2031, 9, 26, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			args: args{
+				session: &platform.Session{
+					ID:        MustIDBase16(sessionOneID),
+					UserID:    MustIDBase16(sessionTwoID),
+					Key:       "abc123xyz",
+					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 0, 0, time.UTC),
+				},
+				key:      "abc123xyz",
+				expireAt: time.Date(2030, 9, 26, 0, 0, 10, 0, time.UTC),
+			},
+			wants: wants{
+				session: &platform.Session{
+					ID:        MustIDBase16(sessionOneID),
+					UserID:    MustIDBase16(sessionTwoID),
+					Key:       "abc123xyz",
+					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 10, 0, time.UTC),
+				},
+			},
+		},
+		{
 			name: "renew nil session",
 			fields: SessionFields{
 				IDGenerator:    mock.NewIDGenerator(sessionTwoID, t),
@@ -364,7 +401,7 @@ func RenewSession(
 					ID:        MustIDBase16(sessionOneID),
 					UserID:    MustIDBase16(sessionTwoID),
 					Key:       "abc123xyz",
-					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 10, 0, time.UTC),
+					ExpiresAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
 				},
 			},
 		},
@@ -384,7 +421,8 @@ func RenewSession(
 				t.Errorf("err in find session %v", err)
 			}
 
-			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
+			cmpOptions := sessionCompareOptions("CreatedAt", "Permissions")
+			if diff := cmp.Diff(session, tt.wants.session, cmpOptions...); diff != "" {
 				t.Errorf("session is different -got/+want\ndiff %s", diff)
 			}
 		})

--- a/testing/session.go
+++ b/testing/session.go
@@ -362,14 +362,14 @@ func RenewSession(
 					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 0, 0, time.UTC),
 				},
 				key:      "abc123xyz",
-				expireAt: time.Date(2030, 9, 26, 0, 0, 10, 0, time.UTC),
+				expireAt: time.Date(2030, 9, 26, 0, 0, 0, 0, time.UTC),
 			},
 			wants: wants{
 				session: &platform.Session{
 					ID:        MustIDBase16(sessionOneID),
 					UserID:    MustIDBase16(sessionTwoID),
 					Key:       "abc123xyz",
-					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 10, 0, time.UTC),
+					ExpiresAt: time.Date(2031, 9, 26, 0, 0, 0, 0, time.UTC),
 				},
 			},
 		},


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17750

This change ensures the current expiration time on a session is respected and retained until a new expiration time is presented which extends the life of the session.
Until this change, a session could be shortened via `RenewSession`.
This was happening frequently within the `http.AuthenticationMiddleware`. Rendering all sessions around 5 minutes long.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
