### PR TITLE
fix(ui): add error messaging for cells in dashdboard view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. [17694](https://github.com/influxdata/influxdb/pull/17694): Fixed typos in the Flux functions list
 1. [17701](https://github.com/influxdata/influxdb/pull/17701): Allow mouse cursor inside Script Editor for Safari
 1. [17609](https://github.com/influxdata/influxdb/pull/17609): Fixed an issue where Variables could not use other Variables
+1. [17754](https://github.com/influxdata/influxdb/pull/17754): Adds error messaging for Cells in Dashboard View
 
 ### UI Improvements
 

--- a/ui/src/shared/components/EmptyGraphError.scss
+++ b/ui/src/shared/components/EmptyGraphError.scss
@@ -7,7 +7,7 @@
   color: $c-dreamsicle;
   border: $cf-border solid $g2-kevlar;
 
-   pre {
+  pre {
     font-size: 14px;
     padding: $cf-marg-b;
     user-select: text !important;
@@ -15,7 +15,7 @@
   }
 }
 
- .empty-graph-error--icon {
+.empty-graph-error--icon {
   display: inline-block;
   margin-right: $cf-marg-b;
 }
@@ -23,4 +23,8 @@
 .empty-graph-error--copy {
   margin-top: $cf-marg-a;
   margin-right: $cf-marg-a;
+}
+
+.empty-graph-error--scroll {
+  margin-top: $cf-marg-c;
 }

--- a/ui/src/shared/components/EmptyGraphError.scss
+++ b/ui/src/shared/components/EmptyGraphError.scss
@@ -3,7 +3,6 @@
   height: 100%;
   border-radius: $cf-radius;
   background-color: $g0-obsidian;
-  position: relative;
   color: $c-dreamsicle;
   border: $cf-border solid $g2-kevlar;
 

--- a/ui/src/shared/components/EmptyGraphError.tsx
+++ b/ui/src/shared/components/EmptyGraphError.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   ComponentSize,
   ComponentColor,
+  Icon,
   IconFont,
   DapperScrollbars,
 } from '@influxdata/clockface'
@@ -40,19 +41,10 @@ const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
             className="empty-graph-error--copy"
           />
         </CopyToClipboard>
-        <DapperScrollbars
-          className="empty-graph-error--scroll"
-          autoHide={false}
-          thumbStartColor="#FF8564"
-          thumbStopColor="#DC4E58"
-        >
+        <DapperScrollbars className="empty-graph-error--scroll" autoHide={true}>
           <pre>
-            <span
-              className={`icon ${
-                IconFont.AlertTriangle
-              } empty-graph-error--icon`}
-            />
-            <code className="cell--error-message">{message}</code>
+            <Icon glyph={IconFont.AlertTriangle} />
+            <code className="cell--error-message"> {message}</code>
           </pre>
         </DapperScrollbars>
       </div>

--- a/ui/src/shared/components/RefreshingView.tsx
+++ b/ui/src/shared/components/RefreshingView.tsx
@@ -95,7 +95,7 @@ class RefreshingView extends PureComponent<Props, State> {
         }) => {
           return (
             <EmptyQueryView
-              errorFormat={ErrorFormat.Tooltip}
+              errorFormat={ErrorFormat.Scroll}
               errorMessage={errorMessage}
               hasResults={checkResultsLength(giraffeResult)}
               loading={loading}

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -179,6 +179,7 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
     try {
       const startTime = Date.now()
+      let errorMessage: string = ''
 
       // Cancel any existing queries
       this.pendingResults.forEach(({cancel}) => cancel())
@@ -212,10 +213,12 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
       for (const result of results) {
         if (result.type === 'UNKNOWN_ERROR') {
+          errorMessage = result.message
           throw new Error(result.message)
         }
 
         if (result.type === 'RATE_LIMIT_ERROR') {
+          errorMessage = result.message
           notify(rateLimitReached(result.retryAfter))
 
           throw new Error(result.message)
@@ -234,6 +237,7 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
       this.setState({
         giraffeResult,
+        errorMessage,
         files,
         duration,
         loading: RemoteDataState.Done,

--- a/ui/src/shared/components/cells/Cell.scss
+++ b/ui/src/shared/components/cells/Cell.scss
@@ -56,7 +56,7 @@ $cell--header-button-active-color: $c-pool;
   white-space: normal;
 }
 
-.dashboard .cell--view-empty .empty-graph-error {
+.dashboard .cell--view-empty {
   top: $ix-marg-c + $cell--header-size;
 }
 
@@ -148,7 +148,7 @@ $cell--header-button-active-color: $c-pool;
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%,-50%);
+    transform: translate(-50%, -50%);
   }
 
   .cell:hover &:not(.cell--context__active) {

--- a/ui/src/shared/utils/checkQueryResult.ts
+++ b/ui/src/shared/utils/checkQueryResult.ts
@@ -13,7 +13,7 @@
 
   See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#errors.
 */
-export const checkQueryResult = (file: string): void => {
+export const checkQueryResult = (file: string = ''): void => {
   // Don't check the whole file, since it could be huge and the error table
   // will be within the first few lines (if it exists)
   const fileHead = file.slice(0, findNthIndex(file, '\n', 6))


### PR DESCRIPTION
Closes #17594 

Add error messaging for cells in the Dashboard View.

Example: when one cell has error
<img width="1680" alt="Screen Shot 2020-04-15 at 11 25 11 AM" src="https://user-images.githubusercontent.com/10736577/79376553-32b23c00-7f0f-11ea-9e3c-974ef5a32596.png">

Example: when all cells have error
<img width="1680" alt="Screen Shot 2020-04-15 at 11 25 39 AM" src="https://user-images.githubusercontent.com/10736577/79376567-38a81d00-7f0f-11ea-990b-96ca83e6728b.png">


