### PR TITLE
fix: removing overflow

### DIFF
--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
@@ -16,7 +16,6 @@ $flux-editor--right-panel: 330px;
   flex: 1 0 0;
   position: relative;
   border-radius: $cf-radius;
-  overflow: hidden;
 }
 
 // Variables / Functions List


### PR DESCRIPTION
this allows the user to use the context menu of the flux editor at the expense of having rounded borders on the editor.