### PR TITLE
feat(SigninPage): Updated the Signin checkSession to correspond to API changes

### DIFF
--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -2,7 +2,6 @@
 import React, {ReactElement, PureComponent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
-import auth0js from 'auth0-js'
 
 import {client} from 'src/utils/api'
 
@@ -19,9 +18,6 @@ import {CLOUD, CLOUD_SIGNIN_PATHNAME} from 'src/shared/constants'
 
 // Types
 import {RemoteDataState} from 'src/types'
-
-// Utils
-import {getAuth0Config} from 'src/authorizations/apis'
 
 interface State {
   loading: RemoteDataState

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -86,27 +86,6 @@ export class Signin extends PureComponent<Props, State> {
       clearInterval(this.intervalID)
 
       if (CLOUD) {
-        const config = await getAuth0Config()
-        if (config.socialSignUpOn) {
-          // The responseType is arbitrary as it needs to be a non-empty, non "code" value:
-          // https://auth0.github.io/auth0.js/web-auth_index.js.html#line564
-          const auth0 = new auth0js.WebAuth({
-            domain: config.domain,
-            clientID: config.clientID,
-            state: config.state,
-            redirectUri: config.redirectURL,
-            responseType: 'token',
-          })
-
-          auth0.checkSession({}, error => {
-            if (error) {
-              this.setState({loading: RemoteDataState.Error})
-              console.error(error)
-              return
-            }
-          })
-        }
-
         // TODO: add returnTo to CLOUD signin
         window.location.pathname = CLOUD_SIGNIN_PATHNAME
         throw error

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -85,31 +85,30 @@ export class Signin extends PureComponent<Props, State> {
 
       clearInterval(this.intervalID)
 
-      const config = await getAuth0Config()
-      if (CLOUD && config.socialSignUpOn) {
-        // The responseType is arbitrary as it needs to be a non-empty, non "code" value:
-        // https://auth0.github.io/auth0.js/web-auth_index.js.html#line564
-        const auth0 = new auth0js.WebAuth({
-          domain: config.domain,
-          clientID: config.clientID,
-          state: config.state,
-          redirectUri: config.redirectURL,
-          responseType: 'token',
-        })
+      if (CLOUD) {
+        const config = await getAuth0Config()
+        if (config.socialSignUpOn) {
+          // The responseType is arbitrary as it needs to be a non-empty, non "code" value:
+          // https://auth0.github.io/auth0.js/web-auth_index.js.html#line564
+          const auth0 = new auth0js.WebAuth({
+            domain: config.domain,
+            clientID: config.clientID,
+            state: config.state,
+            redirectUri: config.redirectURL,
+            responseType: 'token',
+          })
 
-        auth0.checkSession({}, (error) => {
+          auth0.checkSession({}, error => {
             if (error) {
               this.setState({loading: RemoteDataState.Error})
               console.error(error)
               return
             }
-        })
-      }
+          })
+        }
 
-      // TODO: add returnTo to CLOUD signin
-      if (CLOUD) {
+        // TODO: add returnTo to CLOUD signin
         window.location.pathname = CLOUD_SIGNIN_PATHNAME
-
         throw error
       }
 

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -87,37 +87,23 @@ export class Signin extends PureComponent<Props, State> {
 
       const config = await getAuth0Config()
       if (CLOUD && config.socialSignUpOn) {
-        // The redirectUri must be the same as the url for the origin of the request
-        // otherwise there's a mismatch and Auth0 cannot validate the response
-        const redirectUri = window.location.href
         // The responseType is arbitrary as it needs to be a non-empty, non "code" value:
         // https://auth0.github.io/auth0.js/web-auth_index.js.html#line564
-        const responseType = 'token'
-
         const auth0 = new auth0js.WebAuth({
           domain: config.domain,
           clientID: config.clientID,
-          redirectUri,
-          responseType,
+          state: config.state,
+          redirectUri: config.redirectURL,
+          responseType: 'token',
         })
-        // This is the result of JS & Auth0 weirdness
-        return new Promise((resolve, reject) => {
-          // The TLDR is that checkSession is not awaiting the callback to complete
-          // So checkSession can return a successful response and continue with the operation
-          // without the callback being completely finished
-          return auth0.checkSession({}, (error, webResponse) => {
+
+        auth0.checkSession({}, (error) => {
             if (error) {
-              reject(error)
+              this.setState({loading: RemoteDataState.Error})
+              console.error(error)
+              return
             }
-            resolve(webResponse)
-          })
         })
-          .then(() => {
-            window.location.pathname = CLOUD_SIGNIN_PATHNAME
-          })
-          .catch(() => {
-            this.props.router.replace('/login')
-          })
       }
 
       // TODO: add returnTo to CLOUD signin

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -89,6 +89,7 @@ class LoginPageContents extends PureComponent<DispatchProps> {
         clientID: config.clientID,
         redirectUri: config.redirectURL,
         responseType: 'code',
+        state: config.state,
       })
     } catch (error) {
       console.error(error)
@@ -421,6 +422,7 @@ class LoginPageContents extends PureComponent<DispatchProps> {
   }
 
   private displayErrorMessage = (errors, auth0Err) => {
+    const {activeTab} = this.state
     // eslint-disable-next-line
     if (/error in email/.test(auth0Err.code)) {
       this.setState({
@@ -431,8 +433,13 @@ class LoginPageContents extends PureComponent<DispatchProps> {
       auth0Err.code === 'access_denied' ||
       auth0Err.code === 'user_exists'
     ) {
-      const emailError = `An account with that email address already exists. Try logging in instead.`
-      this.setState({...errors, emailError})
+      if (activeTab === ActiveTab.Login) {
+        const emailError = `The email and password combination you submitted are don't match. Please try again`
+        this.setState({...errors, emailError})
+      } else {
+        const emailError = `An account with that email address already exists.  Try logging in instead.`
+        this.setState({...errors, emailError})
+      }
     } else {
       const emailError = `We have been notified of an issue while accessing your account. If this issue persists, please contact support@influxdata.com`
       this.setState({...errors, emailError})

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -434,7 +434,7 @@ class LoginPageContents extends PureComponent<DispatchProps> {
       auth0Err.code === 'user_exists'
     ) {
       if (activeTab === ActiveTab.Login) {
-        const emailError = `The email and password combination you submitted are don't match. Please try again`
+        const emailError = `The email and password combination you submitted don't match. Please try again`
         this.setState({...errors, emailError})
       } else {
         const emailError = `An account with that email address already exists.  Try logging in instead.`

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -11,4 +11,5 @@ export type Auth0Config = {
   domain: string
   redirectURL: string
   socialSignUpOn: boolean
+  state: string
 }


### PR DESCRIPTION
### Problem

Previously we were using the current window location href as a means to redirect the user after performing a checkSession on their Auth0 session. However, if the user was making the request from an un-whitelisted origin, the request would fail, thereby preventing the single sign-on flow.

### Solution

Reverted the Signin page redirect logic so that the redirects are happening from the API rather than the UI. This simplifies our authentication flow by reducing the complexity of session validation while maintaining our single sign-on flow

Co-authored-by: Iris Scholten <ischolten.is@gmail.com>
