### PR TITLE
fix: allow dev mode with prefixes

### DIFF
--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -4,6 +4,9 @@ const merge = require('webpack-merge')
 const common = require('./webpack.common.ts')
 const PORT = parseInt(process.env.PORT, 10) || 8080
 const PUBLIC = process.env.PUBLIC || undefined
+const {
+  BASE_PATH,
+} = require('./src/utils/env')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const webpack = require('webpack')
 
@@ -19,7 +22,9 @@ module.exports = merge(common, {
   },
   devServer: {
     hot: true,
-    historyApiFallback: true,
+    historyApiFallback: {
+        index: `${BASE_PATH}/index.html`
+    },
     compress: true,
     proxy: {
       '/api/v2': 'http://localhost:9999',
@@ -30,6 +35,8 @@ module.exports = merge(common, {
     host: '0.0.0.0',
     port: PORT,
     public: PUBLIC,
+    publicPath: PUBLIC,
+    sockPath: `${BASE_PATH}hmr`
   },
   plugins: [
     new webpack.DllReferencePlugin({


### PR DESCRIPTION
this PR allows dev mode to work properly when running the frontend behind an nginx proxy with a prefix. Previously, only production builds could be run this way. Testing was done in monitor-ci when moving the application between `https://192.168.3.136:8448/influx/` and `https://192.168.3.136:8448/` by changing the environment variable `CHRONOGRAF_BASE_PATH`. Hot reloading, static resources, and api proxies all seem to work fine now.