### PR TITLE
feat: add window.performance measurements for query execution time

### DIFF
--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -185,6 +185,7 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
       this.pendingResults.forEach(({cancel}) => cancel())
 
       // Issue new queries
+      window.performance.mark('query_start')
       this.pendingResults = queries.map(({text}) => {
         const orgID =
           getOrgIDFromBuckets(text, buckets) || this.props.params.orgID
@@ -197,6 +198,10 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
       // Wait for new queries to complete
       const results = await Promise.all(this.pendingResults.map(r => r.promise))
+      window.performance.measure(
+        'timeseries_query_execution_time',
+        'query_start'
+      )
 
       let statuses = [] as StatusRow[][]
       if (check) {


### PR DESCRIPTION
Adds [`performance.measurements`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) to dashboard query execution.

These values will be stored in the browser's performance entry buffer. This buffer is inspectable in the browser window, but it's read only. It's almost like writing to `window` but it's less janky and leaky.

To get a sense of how a dashboard page loads and feels, I fired this script off locally in the console on the dashboard page:

```js
(() => {
  const output = {
    queryExecutionTime: [],
  }

  performance.getEntriesByType("measure").forEach(measurement => {
    if (measurement.name === 'dashboard_query_execution_time') {
      output.queryExecutionTime.push(Math.round(measurement.duration))
    }
  })

  const [timing] = performance.getEntriesByType('navigation')
  output.domInteractive = Math.round(timing.domInteractive)

  console.log(output)
})()
```
It produced something like this:

![Screen Shot 2020-04-17 at 5 04 41 PM](https://user-images.githubusercontent.com/146112/79623178-971bf980-80cf-11ea-9f88-8cf6a7af0192.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass