### PR TITLE
feat(query): update planner rules to accept a context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6
-	github.com/influxdata/flux v0.66.1
+	github.com/influxdata/flux v0.66.1-0.20200420164259-509c5a5ec3da
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.66.1 h1:d98L5k9mmP7bU7d2zAx6C3dCe5B8/PEa1wkWzZAE+Ok=
-github.com/influxdata/flux v0.66.1/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
+github.com/influxdata/flux v0.66.1-0.20200420164259-509c5a5ec3da h1:ojgE8YAwTrdNMghkAHFCV0ZoA6YKqtJGNnk3LG6nG0I=
+github.com/influxdata/flux v0.66.1-0.20200420164259-509c5a5ec3da/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=

--- a/query/querytest/compiler.go
+++ b/query/querytest/compiler.go
@@ -1,6 +1,8 @@
 package querytest
 
 import (
+	"context"
+
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
 	"github.com/influxdata/influxdb/v2/query/influxql"
@@ -24,7 +26,7 @@ func (ReplaceFromRule) Pattern() plan.Pattern {
 	return plan.Pat(influxdb.FromKind)
 }
 
-func (r ReplaceFromRule) Rewrite(n plan.Node) (plan.Node, bool, error) {
+func (r ReplaceFromRule) Rewrite(ctx context.Context, n plan.Node) (plan.Node, bool, error) {
 	if err := n.ReplaceSpec(&v1.FromInfluxJSONProcedureSpec{
 		File: r.Filename,
 	}); err != nil {

--- a/query/stdlib/influxdata/influxdb/from_test.go
+++ b/query/stdlib/influxdata/influxdb/from_test.go
@@ -1,6 +1,7 @@
 package influxdb_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -180,7 +181,7 @@ func TestFromValidation(t *testing.T) {
 		influxdb.PushDownFilterRule{},
 		influxdb.PushDownGroupRule{},
 	))
-	_, err := pp.Plan(ps)
+	_, err := pp.Plan(context.Background(), ps)
 	if err == nil {
 		t.Error("Expected query with no call to range to fail physical planning")
 	}

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -1,6 +1,8 @@
 package influxdb
 
 import (
+	"context"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
@@ -31,7 +33,7 @@ func (rule PushDownGroupRule) Pattern() plan.Pattern {
 	return plan.Pat(universe.GroupKind, plan.Pat(ReadRangePhysKind))
 }
 
-func (rule PushDownGroupRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+func (rule PushDownGroupRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
 	src := node.Predecessors()[0].ProcedureSpec().(*ReadRangePhysSpec)
 	grp := node.ProcedureSpec().(*universe.GroupProcedureSpec)
 
@@ -71,7 +73,7 @@ func (rule PushDownRangeRule) Pattern() plan.Pattern {
 }
 
 // Rewrite converts 'from |> range' into 'ReadRange'
-func (rule PushDownRangeRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+func (rule PushDownRangeRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
 	fromNode := node.Predecessors()[0]
 	fromSpec := fromNode.ProcedureSpec().(*FromProcedureSpec)
 
@@ -96,7 +98,7 @@ func (PushDownFilterRule) Pattern() plan.Pattern {
 	return plan.Pat(universe.FilterKind, plan.Pat(ReadRangePhysKind))
 }
 
-func (PushDownFilterRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (PushDownFilterRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	filterSpec := pn.ProcedureSpec().(*universe.FilterProcedureSpec)
 	fromNode := pn.Predecessors()[0]
 	fromSpec := fromNode.ProcedureSpec().(*ReadRangePhysSpec)
@@ -183,7 +185,7 @@ func (rule PushDownReadTagKeysRule) Pattern() plan.Pattern {
 				plan.Pat(ReadRangePhysKind))))
 }
 
-func (rule PushDownReadTagKeysRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (rule PushDownReadTagKeysRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	// Retrieve the nodes and specs for all of the predecessors.
 	distinctSpec := pn.ProcedureSpec().(*universe.DistinctProcedureSpec)
 	keepNode := pn.Predecessors()[0]
@@ -245,7 +247,7 @@ func (rule PushDownReadTagValuesRule) Pattern() plan.Pattern {
 				plan.Pat(ReadRangePhysKind))))
 }
 
-func (rule PushDownReadTagValuesRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (rule PushDownReadTagValuesRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	// Retrieve the nodes and specs for all of the predecessors.
 	distinctNode := pn
 	distinctSpec := distinctNode.ProcedureSpec().(*universe.DistinctProcedureSpec)
@@ -556,7 +558,7 @@ func (SortedPivotRule) Pattern() plan.Pattern {
 	return plan.Pat(universe.PivotKind, plan.Pat(ReadRangePhysKind))
 }
 
-func (SortedPivotRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (SortedPivotRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	pivotSpec := pn.ProcedureSpec().Copy().(*universe.PivotProcedureSpec)
 	pivotSpec.IsSortedByFunc = func(cols []string, desc bool) bool {
 		if desc {


### PR DESCRIPTION
The `Rewrite` method for planner rules was updated to take in the
context used when running the query.

Related to influxdata/flux#2755.