### PR TITLE
 feat(pkger): add stateful management for dashboards

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -1049,10 +1049,10 @@ func (b *cmdPkgBuilder) printPkgSummary(sum pkger.Summary) error {
 	}
 
 	if dashes := sum.Dashboards; len(dashes) > 0 {
-		headers := []string{"ID", "Name", "Description"}
+		headers := []string{"Package Name", "ID", "Resource Name", "Description"}
 		tablePrintFn("DASHBOARDS", headers, len(dashes), func(i int) []string {
 			d := dashes[i]
-			return []string{d.ID.String(), d.Name, d.Description}
+			return []string{d.PkgName, d.ID.String(), d.Name, d.Description}
 		})
 	}
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -223,8 +223,9 @@ func (f DashboardFilter) QueryParams() map[string][]string {
 
 // DashboardUpdate is the patch structure for a dashboard.
 type DashboardUpdate struct {
-	Name        *string `json:"name"`
-	Description *string `json:"description"`
+	Name        *string  `json:"name"`
+	Description *string  `json:"description"`
+	Cells       *[]*Cell `json:"cells"`
 }
 
 // Apply applies an update to a dashboard.
@@ -235,6 +236,10 @@ func (u DashboardUpdate) Apply(d *Dashboard) error {
 
 	if u.Description != nil {
 		d.Description = *u.Description
+	}
+
+	if u.Cells != nil {
+		d.Cells = *u.Cells
 	}
 
 	return nil

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2282,7 +2282,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                type: object
+                properties:
+                  name:
+                    description: optional, when provided will replace the name
+                    type: string
+                  description:
+                    description: optional, when provided will replace the description
+                    type: string
+                  cells:
+                    description: optional, when provided will replace all existing cells with the cells provided
+                    $ref: "#/components/schemas/CellWithViewProperties"
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -1044,6 +1044,7 @@ func UpdateDashboard(
 		name        string
 		description string
 		id          platform.ID
+		cells       []*platform.Cell
 	}
 	type wants struct {
 		err       error
@@ -1156,6 +1157,69 @@ func UpdateDashboard(
 			},
 		},
 		{
+			name: "update description name and cells",
+			fields: DashboardFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC)},
+				IDGenerator: mock.IDGenerator{IDFn: func() platform.ID {
+					return 5
+				}},
+				Dashboards: []*platform.Dashboard{
+					{
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
+					},
+					{
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
+					},
+				},
+			},
+			args: args{
+				id:          MustIDBase16(dashOneID),
+				description: "changed",
+				name:        "changed",
+				cells: []*platform.Cell{
+					{
+						CellProperty: platform.CellProperty{X: 0, Y: 2},
+						View: &platform.View{
+							Properties: &platform.SingleStatViewProperties{
+								Type:    platform.ViewPropertyTypeSingleStat,
+								Queries: []platform.DashboardQuery{{Text: "buckets() |> count()"}},
+							},
+						},
+					},
+				},
+			},
+			wants: wants{
+				dashboard: &platform.Dashboard{
+					ID:             MustIDBase16(dashOneID),
+					OrganizationID: 1,
+					Name:           "changed",
+					Description:    "changed",
+					Meta: platform.DashboardMeta{
+						UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
+					},
+					Cells: []*platform.Cell{
+						{
+							ID:           5,
+							CellProperty: platform.CellProperty{X: 0, Y: 2},
+							View: &platform.View{
+								ViewContents: platform.ViewContents{
+									ID: 5,
+								},
+								Properties: &platform.SingleStatViewProperties{
+									Type:    platform.ViewPropertyTypeSingleStat,
+									Queries: []platform.DashboardQuery{{Text: "buckets() |> count()"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "update with id not exist",
 			fields: DashboardFields{
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC)},
@@ -1199,6 +1263,9 @@ func UpdateDashboard(
 			}
 			if tt.args.description != "" {
 				upd.Description = &tt.args.description
+			}
+			if tt.args.cells != nil {
+				upd.Cells = &tt.args.cells
 			}
 
 			dashboard, err := s.UpdateDashboard(ctx, tt.args.id, upd)

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -353,7 +353,10 @@ export const updateDashboard = (
   try {
     const resp = await api.patchDashboard({
       dashboardID: dashboard.id,
-      data: dashboard,
+      data: {
+        name: dashboard.name,
+        description: dashboard.description,
+      },
     })
 
     if (resp.status !== 200) {


### PR DESCRIPTION
references: #17434 

note: the first commit here updates the dashboard update to allow for updating cells (as a collection) as part of the dashboard update.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)