### PR TITLE
feat(pkger): add stateful management for tasks

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -1088,7 +1088,7 @@ func (b *cmdPkgBuilder) printPkgSummary(sum pkger.Summary) error {
 	}
 
 	if tasks := sum.Tasks; len(tasks) > 0 {
-		headers := []string{"ID", "Name", "Description", "Cycle"}
+		headers := []string{"Package Name", "ID", "Resource Name", "Description", "Cycle"}
 		tablePrintFn("TASKS", headers, len(tasks), func(i int) []string {
 			t := tasks[i]
 			timing := fmt.Sprintf("every: %s offset: %s", t.Every, t.Offset)
@@ -1096,6 +1096,7 @@ func (b *cmdPkgBuilder) printPkgSummary(sum pkger.Summary) error {
 				timing = t.Cron
 			}
 			return []string{
+				t.PkgName,
 				t.ID.String(),
 				t.Name,
 				t.Description,

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -253,7 +253,7 @@ func (ex *resourceExporter) resourceCloneToKind(ctx context.Context, r ResourceT
 		if err != nil {
 			return err
 		}
-		mapResource(t.OrganizationID, t.ID, KindTask, taskToObject(*t, r.Name))
+		mapResource(t.OrganizationID, t.ID, KindTask, TaskToObject(r.Name, *t))
 	case r.Kind.is(KindTelegraf):
 		t, err := ex.teleSVC.FindTelegrafConfigByID(ctx, r.ID)
 		if err != nil {
@@ -913,7 +913,8 @@ func NotificationRuleToObject(name, endpointPkgName string, iRule influxdb.Notif
 // regex used to rip out the hard coded task option stuffs
 var taskFluxRegex = regexp.MustCompile(`option task = {(.|\n)*?}`)
 
-func taskToObject(t influxdb.Task, name string) Object {
+// TaskToObject coverts an influxdb.Task into a pkger.Object.
+func TaskToObject(name string, t influxdb.Task) Object {
 	if name == "" {
 		name = t.Name
 	}


### PR DESCRIPTION
notes on this commit. This commit was grueling ;-(. The task API is not a friendly
API to consume. There are a lot of non obvious things going on and almost every
one of them tripped me up. Things of note:

* the http.TaskService does not satisfy the influxdb.TaskService,
  making it impossible to use as a dependency if expecting a influxdb.TasksService
* the APIs for create and update do not share common types. For example:
  creating a task takes every field as a string, but in the update it is
  taken as a options.Duration type. A step further and you'll notice that
  create does not need an option to be provided, but the update does. Its
  jarring trying to understand the indirection here. I struggled mightily
  trying to make sense of it all with the indirection and differing types.
  Made for a very difficult task (no pun intended) when it should have been
  trivial. Opportunity here to fix these up and make this API more uniform
  and remove unnecessary complexity, like the options type and making types
  consistent.
* Nested IDs that get marshaled, are no bueno when you want to marshal a task
  that does not have an ID in it, for either user/org/or self IDs. Its a challenge
  just to do that.
* Lots of logs in the kv.Task portion where we hit errors and log and others where
  we return. It isn't clear what is happening. The kv implementation is also very
  procedural, and I found myself bouncing around like a ping pong ball trying to
  make heads or tails of it.
* There is auth buried deep inside the kv.Task implementation that kept throwing me
  off b/c it kept throwing errors, instead of warns. I assume, not sure if I'm
  correct on this, but that the stuff being logged is determined inconsequential
  to the task working. I had lots of errors from the auth buried in there, and hadn't
  a clue what to make of it....

leaving these notes here as a look back at why working with tasks is so
difficult. This API can improve dramatically. I spent 5x the time trying
to figure out how to use the task API, in procedural calls, than I did
writing the business logic to consume it.... that's a scary realization ;-(

references: #17434

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass