### PR TITLE
chore(build): start running nightly builds 2hour earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 7 * * *"
+          cron: "0 5 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
It was a request from boonito QA to start running nightly builds 2 hours earlier, instead of 7am UTC to start running nightly builds at 5am UTC (10pm PDT) to give them time to debug test failures.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
