### PR TITLE
fix: filling views and cells when we grab dashboards

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -234,6 +234,10 @@ export const getDashboards = () => async (
 
     dispatch(setDashboards(RemoteDataState.Done, dashboards))
 
+    if (!dashboards.result.length) {
+      return
+    }
+
     Object.values(dashboards.entities.dashboards)
       .map(d => {
         return {

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -239,14 +239,14 @@ export const getDashboards = () => async (
     }
 
     Object.values(dashboards.entities.dashboards)
-      .map(d => {
+      .map(dashboard => {
         return {
-          id: d.id,
-          cells: d.cells.map(c => dashboards.entities.cells[c]),
+          id: dashboard.id,
+          cells: dashboard.cells.map(cell => dashboards.entities.cells[cell]),
         }
       })
-      .forEach(e => {
-        const viewsData = viewsFromCells(e.cells, e.id)
+      .forEach(entity => {
+        const viewsData = viewsFromCells(entity.cells, entity.id)
 
         const normViews = normalize<View, ViewEntities, string[]>(
           viewsData,
@@ -254,12 +254,12 @@ export const getDashboards = () => async (
         )
 
         const normCells = normalize<Dashboard, DashboardEntities, string[]>(
-          e.cells,
+          entity.cells,
           arrayOfCells
         )
 
         dispatch(setViews(RemoteDataState.Done, normViews))
-        dispatch(setCells(e.id, RemoteDataState.Done, normCells))
+        dispatch(setCells(entity.id, RemoteDataState.Done, normCells))
       })
   } catch (error) {
     dispatch(creators.setDashboards(RemoteDataState.Error))

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -15,6 +15,7 @@ import {
   arrayOfDashboards,
   labelSchema,
   arrayOfViews,
+  arrayOfCells,
 } from 'src/schemas'
 import {viewsFromCells} from 'src/schemas/dashboards'
 
@@ -27,10 +28,11 @@ import {
   deleteTimeRange,
   updateTimeRangeFromQueryParams,
 } from 'src/dashboards/actions/ranges'
-import {setViews} from 'src/views/actions/creators'
 import {getVariables, hydrateVariables} from 'src/variables/actions/thunks'
 import {setExportTemplate} from 'src/templates/actions/creators'
 import {checkDashboardLimits} from 'src/cloud/actions/limits'
+import {setCells, Action as CellAction} from 'src/cells/actions/creators'
+import {setViews, Action as ViewAction} from 'src/views/actions/creators'
 import {updateViewAndVariables} from 'src/views/actions/thunks'
 import {setLabelOnResource} from 'src/labels/actions/creators'
 import * as creators from 'src/dashboards/actions/creators'
@@ -201,8 +203,10 @@ export const cloneDashboard = (
   }
 }
 
+type FullAction = Action | CellAction | ViewAction
+
 export const getDashboards = () => async (
-  dispatch: Dispatch<Action>,
+  dispatch: Dispatch<FullAction>,
   getState: GetState
 ): Promise<void> => {
   try {
@@ -229,6 +233,30 @@ export const getDashboards = () => async (
     )
 
     dispatch(setDashboards(RemoteDataState.Done, dashboards))
+
+    Object.values(dashboards.entities.dashboards)
+      .map(d => {
+        return {
+          id: d.id,
+          cells: d.cells.map(c => dashboards.entities.cells[c]),
+        }
+      })
+      .forEach(e => {
+        const viewsData = viewsFromCells(e.cells, e.id)
+
+        const normViews = normalize<View, ViewEntities, string[]>(
+          viewsData,
+          arrayOfViews
+        )
+
+        const normCells = normalize<Dashboard, DashboardEntities, string[]>(
+          e.cells,
+          arrayOfCells
+        )
+
+        dispatch(setViews(RemoteDataState.Done, normViews))
+        dispatch(setCells(e.id, RemoteDataState.Done, normCells))
+      })
   } catch (error) {
     dispatch(creators.setDashboards(RemoteDataState.Error))
     console.error(error)

--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -52,7 +52,7 @@ export const getNewDashboardCell = (
 
   const cells = dashboard.cells
     .map(cellID => state.resources.cells.byID[cellID])
-    .filter(c => !!c)
+    .filter(cell => !!cell)
 
   if (!cells.length) {
     return defaultCell

--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -50,9 +50,9 @@ export const getNewDashboardCell = (
     status: RemoteDataState.Done,
   }
 
-  const cells = dashboard.cells.map(
-    cellID => state.resources.cells.byID[cellID]
-  )
+  const cells = dashboard.cells
+    .map(cellID => state.resources.cells.byID[cellID])
+    .filter(c => !!c)
 
   if (!cells.length) {
     return defaultCell


### PR DESCRIPTION
Closes #17787

when fetching a list of dashboards, we weren't filling the cells / views that also come back from the result of this api call.