### PR TITLE
feat(query): Improve query performance

### DIFF
--- a/query/iterator.gen.go
+++ b/query/iterator.gen.go
@@ -127,11 +127,23 @@ type floatMergeIterator struct {
 
 // newFloatMergeIterator returns a new instance of floatMergeIterator.
 func newFloatMergeIterator(inputs []FloatIterator, opt IteratorOptions) *floatMergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &floatMergeIterator{
 		inputs: inputs,
 		heap: &floatMergeHeap{
-			items: make([]*floatMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*floatMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -257,8 +269,9 @@ func (itr *floatMergeIterator) Next() (*FloatPoint, error) {
 // floatMergeHeap represents a heap of floatMergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type floatMergeHeap struct {
-	opt   IteratorOptions
-	items []*floatMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*floatMergeHeapItem
 }
 
 func (h *floatMergeHeap) Len() int      { return len(h.items) }
@@ -276,14 +289,14 @@ func (h *floatMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -321,11 +334,23 @@ type floatSortedMergeIterator struct {
 
 // newFloatSortedMergeIterator returns an instance of floatSortedMergeIterator.
 func newFloatSortedMergeIterator(inputs []FloatIterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &floatSortedMergeIterator{
 		inputs: inputs,
 		heap: &floatSortedMergeHeap{
-			items: make([]*floatSortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*floatSortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -409,8 +434,9 @@ func (itr *floatSortedMergeIterator) pop() (*FloatPoint, error) {
 //     - By their Aux field values.
 //
 type floatSortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*floatSortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*floatSortedMergeHeapItem
 }
 
 func (h *floatSortedMergeHeap) Len() int      { return len(h.items) }
@@ -421,8 +447,8 @@ func (h *floatSortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time {
@@ -448,8 +474,8 @@ func (h *floatSortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time {
@@ -2791,11 +2817,23 @@ type integerMergeIterator struct {
 
 // newIntegerMergeIterator returns a new instance of integerMergeIterator.
 func newIntegerMergeIterator(inputs []IntegerIterator, opt IteratorOptions) *integerMergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &integerMergeIterator{
 		inputs: inputs,
 		heap: &integerMergeHeap{
-			items: make([]*integerMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*integerMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -2921,8 +2959,9 @@ func (itr *integerMergeIterator) Next() (*IntegerPoint, error) {
 // integerMergeHeap represents a heap of integerMergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type integerMergeHeap struct {
-	opt   IteratorOptions
-	items []*integerMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*integerMergeHeapItem
 }
 
 func (h *integerMergeHeap) Len() int      { return len(h.items) }
@@ -2940,14 +2979,14 @@ func (h *integerMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -2985,11 +3024,23 @@ type integerSortedMergeIterator struct {
 
 // newIntegerSortedMergeIterator returns an instance of integerSortedMergeIterator.
 func newIntegerSortedMergeIterator(inputs []IntegerIterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &integerSortedMergeIterator{
 		inputs: inputs,
 		heap: &integerSortedMergeHeap{
-			items: make([]*integerSortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*integerSortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -3073,8 +3124,9 @@ func (itr *integerSortedMergeIterator) pop() (*IntegerPoint, error) {
 //     - By their Aux field values.
 //
 type integerSortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*integerSortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*integerSortedMergeHeapItem
 }
 
 func (h *integerSortedMergeHeap) Len() int      { return len(h.items) }
@@ -3085,8 +3137,8 @@ func (h *integerSortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time {
@@ -3112,8 +3164,8 @@ func (h *integerSortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time {
@@ -5455,11 +5507,23 @@ type unsignedMergeIterator struct {
 
 // newUnsignedMergeIterator returns a new instance of unsignedMergeIterator.
 func newUnsignedMergeIterator(inputs []UnsignedIterator, opt IteratorOptions) *unsignedMergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &unsignedMergeIterator{
 		inputs: inputs,
 		heap: &unsignedMergeHeap{
-			items: make([]*unsignedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*unsignedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -5585,8 +5649,9 @@ func (itr *unsignedMergeIterator) Next() (*UnsignedPoint, error) {
 // unsignedMergeHeap represents a heap of unsignedMergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type unsignedMergeHeap struct {
-	opt   IteratorOptions
-	items []*unsignedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*unsignedMergeHeapItem
 }
 
 func (h *unsignedMergeHeap) Len() int      { return len(h.items) }
@@ -5604,14 +5669,14 @@ func (h *unsignedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -5649,11 +5714,23 @@ type unsignedSortedMergeIterator struct {
 
 // newUnsignedSortedMergeIterator returns an instance of unsignedSortedMergeIterator.
 func newUnsignedSortedMergeIterator(inputs []UnsignedIterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &unsignedSortedMergeIterator{
 		inputs: inputs,
 		heap: &unsignedSortedMergeHeap{
-			items: make([]*unsignedSortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*unsignedSortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -5737,8 +5814,9 @@ func (itr *unsignedSortedMergeIterator) pop() (*UnsignedPoint, error) {
 //     - By their Aux field values.
 //
 type unsignedSortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*unsignedSortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*unsignedSortedMergeHeapItem
 }
 
 func (h *unsignedSortedMergeHeap) Len() int      { return len(h.items) }
@@ -5749,8 +5827,8 @@ func (h *unsignedSortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time {
@@ -5776,8 +5854,8 @@ func (h *unsignedSortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time {
@@ -8119,11 +8197,23 @@ type stringMergeIterator struct {
 
 // newStringMergeIterator returns a new instance of stringMergeIterator.
 func newStringMergeIterator(inputs []StringIterator, opt IteratorOptions) *stringMergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &stringMergeIterator{
 		inputs: inputs,
 		heap: &stringMergeHeap{
-			items: make([]*stringMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*stringMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -8249,8 +8339,9 @@ func (itr *stringMergeIterator) Next() (*StringPoint, error) {
 // stringMergeHeap represents a heap of stringMergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type stringMergeHeap struct {
-	opt   IteratorOptions
-	items []*stringMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*stringMergeHeapItem
 }
 
 func (h *stringMergeHeap) Len() int      { return len(h.items) }
@@ -8268,14 +8359,14 @@ func (h *stringMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -8313,11 +8404,23 @@ type stringSortedMergeIterator struct {
 
 // newStringSortedMergeIterator returns an instance of stringSortedMergeIterator.
 func newStringSortedMergeIterator(inputs []StringIterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &stringSortedMergeIterator{
 		inputs: inputs,
 		heap: &stringSortedMergeHeap{
-			items: make([]*stringSortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*stringSortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -8401,8 +8504,9 @@ func (itr *stringSortedMergeIterator) pop() (*StringPoint, error) {
 //     - By their Aux field values.
 //
 type stringSortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*stringSortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*stringSortedMergeHeapItem
 }
 
 func (h *stringSortedMergeHeap) Len() int      { return len(h.items) }
@@ -8413,8 +8517,8 @@ func (h *stringSortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time {
@@ -8440,8 +8544,8 @@ func (h *stringSortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time {
@@ -10769,11 +10873,23 @@ type booleanMergeIterator struct {
 
 // newBooleanMergeIterator returns a new instance of booleanMergeIterator.
 func newBooleanMergeIterator(inputs []BooleanIterator, opt IteratorOptions) *booleanMergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &booleanMergeIterator{
 		inputs: inputs,
 		heap: &booleanMergeHeap{
-			items: make([]*booleanMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*booleanMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -10899,8 +11015,9 @@ func (itr *booleanMergeIterator) Next() (*BooleanPoint, error) {
 // booleanMergeHeap represents a heap of booleanMergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type booleanMergeHeap struct {
-	opt   IteratorOptions
-	items []*booleanMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*booleanMergeHeapItem
 }
 
 func (h *booleanMergeHeap) Len() int      { return len(h.items) }
@@ -10918,14 +11035,14 @@ func (h *booleanMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -10963,11 +11080,23 @@ type booleanSortedMergeIterator struct {
 
 // newBooleanSortedMergeIterator returns an instance of booleanSortedMergeIterator.
 func newBooleanSortedMergeIterator(inputs []BooleanIterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &booleanSortedMergeIterator{
 		inputs: inputs,
 		heap: &booleanSortedMergeHeap{
-			items: make([]*booleanSortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*booleanSortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -11051,8 +11180,9 @@ func (itr *booleanSortedMergeIterator) pop() (*BooleanPoint, error) {
 //     - By their Aux field values.
 //
 type booleanSortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*booleanSortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*booleanSortedMergeHeapItem
 }
 
 func (h *booleanSortedMergeHeap) Len() int      { return len(h.items) }
@@ -11063,8 +11193,8 @@ func (h *booleanSortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time {
@@ -11090,8 +11220,8 @@ func (h *booleanSortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time {

--- a/query/iterator.gen.go.tmpl
+++ b/query/iterator.gen.go.tmpl
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"sync"
 	"time"
-	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/influxql"
@@ -125,11 +124,23 @@ type {{$k.name}}MergeIterator struct {
 
 // new{{$k.Name}}MergeIterator returns a new instance of {{$k.name}}MergeIterator.
 func new{{$k.Name}}MergeIterator(inputs []{{$k.Name}}Iterator, opt IteratorOptions) *{{$k.name}}MergeIterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &{{$k.name}}MergeIterator{
 		inputs: inputs,
 		heap: &{{$k.name}}MergeHeap{
-			items: make([]*{{$k.name}}MergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*{{$k.name}}MergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -255,8 +266,9 @@ func (itr *{{$k.name}}MergeIterator) Next() (*{{$k.Name}}Point, error) {
 // {{$k.name}}MergeHeap represents a heap of {{$k.name}}MergeHeapItems.
 // Items are sorted by their next window and then by name/tags.
 type {{$k.name}}MergeHeap struct {
-	opt   IteratorOptions
-	items []*{{$k.name}}MergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*{{$k.name}}MergeHeapItem
 }
 
 func (h *{{$k.name}}MergeHeap) Len() int      { return len(h.items) }
@@ -274,14 +286,14 @@ func (h *{{$k.name}}MergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 	} else {
 		if x.Name != y.Name {
 			return x.Name > y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); xTags.ID() != yTags.ID() {
-			return xTags.ID() > yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == 1
 		}
 	}
 
@@ -320,11 +332,23 @@ type {{$k.name}}SortedMergeIterator struct {
 
 // new{{$k.Name}}SortedMergeIterator returns an instance of {{$k.name}}SortedMergeIterator.
 func new{{$k.Name}}SortedMergeIterator(inputs []{{$k.Name}}Iterator, opt IteratorOptions) Iterator {
+	var sorted []string
+	if len(opt.Dimensions) > 0 {
+		if sort.StringsAreSorted(opt.Dimensions) {
+			sorted = opt.Dimensions
+		} else {
+			sorted = make([]string, len(opt.Dimensions))
+			copy(sorted, opt.Dimensions)
+			sort.Strings(sorted)
+		}
+	}
+
 	itr := &{{$k.name}}SortedMergeIterator{
 		inputs: inputs,
 		heap:   &{{$k.name}}SortedMergeHeap{
-			items: make([]*{{$k.name}}SortedMergeHeapItem, 0, len(inputs)),
-			opt:   opt,
+			items:            make([]*{{$k.name}}SortedMergeHeapItem, 0, len(inputs)),
+			opt:              opt,
+			sortedDimensions: sorted,
 		},
 	}
 
@@ -408,8 +432,9 @@ func (itr *{{$k.name}}SortedMergeIterator) pop() (*{{$k.Name}}Point, error) {
 //     - By their Aux field values.
 //
 type {{$k.name}}SortedMergeHeap struct {
-	opt   IteratorOptions
-	items []*{{$k.name}}SortedMergeHeapItem
+	opt              IteratorOptions
+	sortedDimensions []string
+	items            []*{{$k.name}}SortedMergeHeapItem
 }
 
 func (h *{{$k.name}}SortedMergeHeap) Len() int      { return len(h.items) }
@@ -420,8 +445,8 @@ func (h *{{$k.name}}SortedMergeHeap) Less(i, j int) bool {
 	if h.opt.Ascending {
 		if x.Name != y.Name {
 			return x.Name < y.Name
-		} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-			return xTags.ID() < yTags.ID()
+		} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+			return cmp == -1
 		}
 
 		if x.Time != y.Time{
@@ -447,8 +472,8 @@ func (h *{{$k.name}}SortedMergeHeap) Less(i, j int) bool {
 
 	if x.Name != y.Name {
 		return x.Name > y.Name
-	} else if xTags, yTags := x.Tags.Subset(h.opt.Dimensions), y.Tags.Subset(h.opt.Dimensions); !xTags.Equals(&yTags) {
-		return xTags.ID() > yTags.ID()
+	} else if cmp := x.Tags.CompareKeys(h.sortedDimensions, &y.Tags); cmp != 0 {
+		return cmp == 1
 	}
 
 	if x.Time != y.Time{

--- a/query/point.go
+++ b/query/point.go
@@ -156,6 +156,26 @@ func (t *Tags) Subset(keys []string) Tags {
 	return NewTags(m)
 }
 
+// CompareKeys returns an integer comparing the keys and values of the two Tags
+// lexicographically.
+func (t *Tags) CompareKeys(keys []string, other *Tags) int {
+	if len(keys) == 0 {
+		return 0
+	}
+
+	for _, k := range keys {
+		a, b := t.m[k], other.m[k]
+		if a == b {
+			continue
+		}
+		if a < b {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
 // Equals returns true if t equals other.
 func (t *Tags) Equals(other *Tags) bool {
 	if t == nil && other == nil {


### PR DESCRIPTION
As a follow on to #17596, performance of both sort and unsorted merge operations can be improved significantly by removing allocations when comparing tags.

This PR makes the following improvements:

* Adds a method, `CompareKeys`, to the `Tags` struct in `points.go`. `CompareKeys` performs a lexicographical comparison of the two `Tags` using the specified `keys` without performing any allocations. The comparison of the values is in the order determined by `keys`. This is important in maintaining compatibility with the replaced `Tags#ID` sort behavior.

* Updates the `Less` methods of `<type>MergeHeap` and `<type>SortedMergeHeap`, replacing multiple calls to the costly `Tags#Subset` API with the `CompareKeys` API.

* In order to keep the same sort behavior, `<type>MergeIterator` and `<type>SortedMergeIterator` were updated to store a cached, sorted list of the `IteratorOptions#Dimensions` slice, which is passed to `CompareKeys`. This ensures the Tags sort in lexicographical order based on the lexicographical sort order of the Dimensions slice. Doing this retains the same sort behavior as the `Tags#ID` API, previously used for comparisons.

`benchstat` results:

```
name                    old time/op    new time/op    delta
SortedMergeIterator-16    32.4ms ± 2%     5.2ms ± 3%  -83.81%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
SortedMergeIterator-16    36.5MB ± 0%     5.8MB ± 0%  -84.20%  (p=0.000 n=10+9)

name                    old allocs/op  new allocs/op  delta
SortedMergeIterator-16      420k ± 0%       60k ± 0%  -85.71%  (p=0.000 n=9+10)
```
