### PR TITLE
feat: add a workflow to enforce non-empty PR or Issue descriptions

### DIFF
--- a/.github/workflows/pr-valid-description-body.yml
+++ b/.github/workflows/pr-valid-description-body.yml
@@ -1,0 +1,19 @@
+name: PR and Issue Body Validation
+on: [issues, pull_request]
+jobs:
+  example:
+    name: PR and Issues have non-empty body
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run actions/checkout
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Run fabiankoestring/body-regex-validator-action
+      uses: fabiankoestring/body-regex-validator-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULL_REQUEST_PATTERN: '^(.+)$'
+        PULL_REQUEST_COMMENT: 'Your PR or Issue description body cannot be empty.'
+        ISSUE_PATTERN: '^(.+)$'
+        ISSUE_COMMENT: 'Your PR or Issue description body cannot be empty.'


### PR DESCRIPTION
This adds a Github action which ensure that both pull requests and issue bodies have descriptions with at least 1 character in them.

The action is a little militant as it just closes the PR. But you can update the description and re-open it. I could go make a pull request or fork it to just fail the check status via some configuration option.