### PR TITLE
fix(tenant): Allow tenant to update user and org with same name

### DIFF
--- a/tenant/storage_org.go
+++ b/tenant/storage_org.go
@@ -212,7 +212,7 @@ func (s *Store) UpdateOrg(ctx context.Context, tx kv.Tx, id influxdb.ID, upd inf
 	}
 
 	u.SetUpdatedAt(time.Now())
-	if upd.Name != nil {
+	if upd.Name != nil && u.Name != *upd.Name {
 		if err := s.uniqueOrgName(ctx, tx, *upd.Name); err != nil {
 			return nil, err
 		}

--- a/tenant/storage_user.go
+++ b/tenant/storage_user.go
@@ -200,7 +200,7 @@ func (s *Store) UpdateUser(ctx context.Context, tx kv.Tx, id influxdb.ID, upd in
 		return nil, err
 	}
 
-	if upd.Name != nil {
+	if upd.Name != nil && *upd.Name != u.Name {
 		if err := s.uniqueUserName(ctx, tx, *upd.Name); err != nil {
 			return nil, err
 		}

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -895,6 +895,34 @@ func UpdateOrganization(
 			},
 		},
 		{
+			name: "update name to same name",
+			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Organizations: []*influxdb.Organization{
+					{
+						ID:   MustIDBase16(orgOneID),
+						Name: "organization1",
+					},
+					{
+						ID:   MustIDBase16(orgTwoID),
+						Name: "organization2",
+					},
+				},
+			},
+			args: args{
+				id:   MustIDBase16(orgOneID),
+				name: strPtr("organization1"),
+			},
+			wants: wants{
+				organization: &influxdb.Organization{
+					ID:   MustIDBase16(orgOneID),
+					Name: "organization1",
+					CRUDLog: influxdb.CRUDLog{
+						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+					},
+				},
+			},
+		}, {
 			name: "update name not unique",
 			fields: OrganizationFields{
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},

--- a/testing/user_service.go
+++ b/testing/user_service.go
@@ -865,6 +865,34 @@ func UpdateUser(
 			},
 		},
 		{
+			name: "update name to same name",
+			fields: UserFields{
+				Users: []*platform.User{
+					{
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: platform.Active,
+					},
+					{
+						ID:     MustIDBase16(userTwoID),
+						Name:   "user2",
+						Status: platform.Active,
+					},
+				},
+			},
+			args: args{
+				id:   MustIDBase16(userOneID),
+				name: "user1",
+			},
+			wants: wants{
+				user: &platform.User{
+					ID:     MustIDBase16(userOneID),
+					Name:   "user1",
+					Status: platform.Active,
+				},
+			},
+		},
+		{
 			name: "update status",
 			fields: UserFields{
 				Users: []*platform.User{


### PR DESCRIPTION
This will allow us to match the existing behavior that allows for update requests to go through with the same name.
