### PR TITLE
refactor(query): return detailed capabilities for the read window aggregate interfaces

### DIFF
--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -149,10 +149,15 @@ type ReadWindowAggregateSpec struct {
 	// TODO(issue #17784): add attributes for the window aggregate spec.
 }
 
+// WindowAggregateCapability describes what is supported by WindowAggregateReader.
+type WindowAggregateCapability struct{}
+
 // WindowAggregateReader implements the WindowAggregate capability.
 type WindowAggregateReader interface {
 	// HasWindowAggregateCapability will test if this Reader source supports the ReadWindowAggregate capability.
-	HasWindowAggregateCapability(ctx context.Context) bool
+	// If WindowAggregateCapability is passed to the method, then the struct
+	// is filled with a detailed list of what the RPC call supports.
+	HasWindowAggregateCapability(ctx context.Context, capability ...*WindowAggregateCapability) bool
 
 	// ReadWindowAggregate will read a table using the WindowAggregate method.
 	ReadWindowAggregate(ctx context.Context, spec ReadWindowAggregateSpec, alloc *memory.Allocator) (TableIterator, error)

--- a/storage/reads/store.go
+++ b/storage/reads/store.go
@@ -83,10 +83,15 @@ type Store interface {
 	GetSource(orgID, bucketID uint64) proto.Message
 }
 
+// WindowAggregateCapability describes what is supported by WindowAggregateReader.
+type WindowAggregateCapability struct{}
+
 // WindowAggregateReader implements the WindowAggregate capability.
 type WindowAggregateReader interface {
 	// HasWindowAggregateCapability checks if this Store supports the capability.
-	HasWindowAggregateCapability(ctx context.Context) bool
+	// If WindowAggregateCapability is passed to the method, then the struct
+	// is filled with a detailed list of what the RPC call supports.
+	HasWindowAggregateCapability(ctx context.Context, capability ...*WindowAggregateCapability) bool
 
 	// WindowAggregate will invoke a ReadWindowAggregateRequest against the Store.
 	WindowAggregate(ctx context.Context, req *datatypes.ReadWindowAggregateRequest) (ResultSet, error)


### PR DESCRIPTION
This modifies the read window aggregate interfaces to future-proof it
if and when we add additional capabilities to the method. Previously,
the interface was all or nothing. If we modified the RPC call itself, we
would have to make a new interface to denote the change to the Go code.

This changes the interface so now a `WindowAggregateCapability` exists.
This way, we can modify the struct to include things like:

```go
type WindowAggregateCapability struct {
    WindowPeriodCapability bool
    MeanAggregateCapability bool
}
```

This way we can learn if the RPC call itself supports some specific
option. If the first iteration doesn't support a mean aggregate or the
mean aggregate is only supported by single server implementations, the
window aggregate can tell the caller that it won't be able to compute
the mean aggregate.

Since it fills in a struct with these capabilities, the struct can
safely introduce new values. If a downstream consumer wants to take
advantage of that functionality, then all interfaces in the chain have
to be updated to consume the upstream capabilities.