### PR TITLE
feat(query): implement the ReadWindowAggregateSource

### DIFF
--- a/mock/store_reader.go
+++ b/mock/store_reader.go
@@ -1,0 +1,62 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
+)
+
+type StoreReader struct {
+	ReadFilterFn    func(ctx context.Context, spec influxdb.ReadFilterSpec, alloc *memory.Allocator) (influxdb.TableIterator, error)
+	ReadGroupFn     func(ctx context.Context, spec influxdb.ReadGroupSpec, alloc *memory.Allocator) (influxdb.TableIterator, error)
+	ReadTagKeysFn   func(ctx context.Context, spec influxdb.ReadTagKeysSpec, alloc *memory.Allocator) (influxdb.TableIterator, error)
+	ReadTagValuesFn func(ctx context.Context, spec influxdb.ReadTagValuesSpec, alloc *memory.Allocator) (influxdb.TableIterator, error)
+	CloseFn         func()
+}
+
+func (s *StoreReader) ReadFilter(ctx context.Context, spec influxdb.ReadFilterSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	return s.ReadFilterFn(ctx, spec, alloc)
+}
+
+func (s *StoreReader) ReadGroup(ctx context.Context, spec influxdb.ReadGroupSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	return s.ReadGroupFn(ctx, spec, alloc)
+}
+
+func (s *StoreReader) ReadTagKeys(ctx context.Context, spec influxdb.ReadTagKeysSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	return s.ReadTagKeysFn(ctx, spec, alloc)
+}
+
+func (s *StoreReader) ReadTagValues(ctx context.Context, spec influxdb.ReadTagValuesSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	return s.ReadTagValuesFn(ctx, spec, alloc)
+}
+
+func (s *StoreReader) Close() {
+	// Only invoke the close function if it is set.
+	// We want this to be a no-op and work without
+	// explicitly setting up a close function.
+	if s.CloseFn != nil {
+		s.CloseFn()
+	}
+}
+
+type WindowAggregateStoreReader struct {
+	*StoreReader
+	HasWindowAggregateCapabilityFn func(ctx context.Context) bool
+	ReadWindowAggregateFn          func(ctx context.Context, spec influxdb.ReadWindowAggregateSpec, alloc *memory.Allocator) (influxdb.TableIterator, error)
+}
+
+func (s *WindowAggregateStoreReader) HasWindowAggregateCapability(ctx context.Context) bool {
+	// Use the function if it exists.
+	if s.HasWindowAggregateCapabilityFn != nil {
+		return s.HasWindowAggregateCapabilityFn(ctx)
+	}
+
+	// Provide a default implementation if one wasn't set.
+	// This will return true if the other function was set.
+	return s.ReadWindowAggregateFn != nil
+}
+
+func (s *WindowAggregateStoreReader) ReadWindowAggregate(ctx context.Context, spec influxdb.ReadWindowAggregateSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	return s.ReadWindowAggregateFn(ctx, spec, alloc)
+}

--- a/query/stdlib/influxdata/influxdb/operators.go
+++ b/query/stdlib/influxdata/influxdb/operators.go
@@ -129,6 +129,7 @@ type ReadWindowAggregatePhysSpec struct {
 func (s *ReadWindowAggregatePhysSpec) Kind() plan.ProcedureKind {
 	return ReadWindowAggregatePhysKind
 }
+
 func (s *ReadWindowAggregatePhysSpec) Copy() plan.ProcedureSpec {
 	ns := new(ReadWindowAggregatePhysSpec)
 

--- a/query/stdlib/influxdata/influxdb/source.go
+++ b/query/stdlib/influxdata/influxdb/source.go
@@ -20,6 +20,7 @@ import (
 func init() {
 	execute.RegisterSource(ReadRangePhysKind, createReadFilterSource)
 	execute.RegisterSource(ReadGroupPhysKind, createReadGroupSource)
+	execute.RegisterSource(ReadWindowAggregatePhysKind, createReadWindowAggregateSource)
 	execute.RegisterSource(ReadTagKeysPhysKind, createReadTagKeysSource)
 	execute.RegisterSource(ReadTagValuesPhysKind, createReadTagValuesSource)
 }
@@ -275,6 +276,94 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
 			GroupMode:       ToGroupMode(spec.GroupMode),
 			GroupKeys:       spec.GroupKeys,
 			AggregateMethod: spec.AggregateMethod,
+		},
+		a,
+	), nil
+}
+
+type readWindowAggregateSource struct {
+	Source
+	reader   WindowAggregateReader
+	readSpec ReadWindowAggregateSpec
+}
+
+func ReadWindowAggregateSource(id execute.DatasetID, r WindowAggregateReader, readSpec ReadWindowAggregateSpec, a execute.Administration) execute.Source {
+	src := new(readWindowAggregateSource)
+
+	src.id = id
+	src.alloc = a.Allocator()
+
+	src.reader = r
+	src.readSpec = readSpec
+
+	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
+	src.orgID = readSpec.OrganizationID
+	src.op = "readWindowAggregate"
+
+	src.runner = src
+	return src
+}
+
+func (s *readWindowAggregateSource) run(ctx context.Context) error {
+	stop := s.readSpec.Bounds.Stop
+	tables, err := s.reader.ReadWindowAggregate(
+		ctx,
+		s.readSpec,
+		s.alloc,
+	)
+	if err != nil {
+		return err
+	}
+	return s.processTables(ctx, tables, stop)
+}
+
+func createReadWindowAggregateSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	span, ctx := tracing.StartSpanFromContext(a.Context())
+	defer span.Finish()
+
+	spec := s.(*ReadWindowAggregatePhysSpec)
+
+	bounds := a.StreamContext().Bounds()
+	if bounds == nil {
+		return nil, &flux.Error{
+			Code: codes.Internal,
+			Msg:  "nil bounds passed to from",
+		}
+	}
+
+	deps := GetStorageDependencies(a.Context()).FromDeps
+	reader := deps.Reader.(WindowAggregateReader)
+
+	req := query.RequestFromContext(a.Context())
+	if req == nil {
+		return nil, &flux.Error{
+			Code: codes.Internal,
+			Msg:  "missing request on context",
+		}
+	}
+
+	orgID := req.OrganizationID
+	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
+	if err != nil {
+		return nil, err
+	}
+
+	var filter *semantic.FunctionExpression
+	if spec.FilterSet {
+		filter = spec.Filter
+	}
+	return ReadWindowAggregateSource(
+		id,
+		reader,
+		ReadWindowAggregateSpec{
+			ReadFilterSpec: ReadFilterSpec{
+				OrganizationID: orgID,
+				BucketID:       bucketID,
+				Bounds:         *bounds,
+				Predicate:      filter,
+			},
+			WindowEvery: spec.WindowEvery,
+			Aggregates:  spec.Aggregates,
 		},
 		a,
 	), nil

--- a/query/stdlib/influxdata/influxdb/source_internal_test.go
+++ b/query/stdlib/influxdata/influxdb/source_internal_test.go
@@ -1,0 +1,10 @@
+package influxdb
+
+import (
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
+)
+
+func CreateReadWindowAggregateSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	return createReadWindowAggregateSource(s, id, a)
+}

--- a/query/stdlib/influxdata/influxdb/source_test.go
+++ b/query/stdlib/influxdata/influxdb/source_test.go
@@ -5,13 +5,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/stdlib/universe"
 	platform "github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
 	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/influxdata/influxdb/v2/query"
 	"github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
 	"github.com/influxdata/influxdb/v2/uuid"
@@ -52,7 +57,8 @@ func (mockReader) Close() {
 }
 
 type mockAdministration struct {
-	Ctx context.Context
+	Ctx          context.Context
+	StreamBounds *execute.Bounds
 }
 
 func (a mockAdministration) Context() context.Context {
@@ -63,8 +69,12 @@ func (mockAdministration) ResolveTime(qt flux.Time) execute.Time {
 	return 0
 }
 
-func (mockAdministration) StreamContext() execute.StreamContext {
-	return nil
+func (a mockAdministration) StreamContext() execute.StreamContext {
+	return a
+}
+
+func (a mockAdministration) Bounds() *execute.Bounds {
+	return a.StreamBounds
 }
 
 func (mockAdministration) Allocator() *memory.Allocator {
@@ -128,4 +138,149 @@ func TestMetrics(t *testing.T) {
 	if want, got := uint64(1), *(m.Histogram.SampleCount); want != got {
 		t.Fatalf("expected sample count of %v, got %v", want, got)
 	}
+}
+
+type TableIterator struct {
+	Tables []*executetest.Table
+}
+
+func (t *TableIterator) Do(f func(flux.Table) error) error {
+	for _, table := range t.Tables {
+		if err := f(table); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *TableIterator) Statistics() cursors.CursorStats {
+	return cursors.CursorStats{}
+}
+
+func TestReadWindowAggregateSource(t *testing.T) {
+	orgID, bucketID := platform.ID(1), platform.ID(2)
+	executetest.RunSourceHelper(t,
+		[]*executetest.Table{
+			{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_field", Type: flux.TString},
+					{Label: "host", Type: flux.TString},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				KeyCols: []string{"_measurement", "_field", "host"},
+				Data: [][]interface{}{
+					{execute.Time(0), "cpu", "usage_user", "server01", 2.0},
+					{execute.Time(10), "cpu", "usage_user", "server01", 1.5},
+					{execute.Time(20), "cpu", "usage_user", "server01", 5.0},
+				},
+			},
+			{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_field", Type: flux.TString},
+					{Label: "host", Type: flux.TString},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				KeyCols: []string{"_measurement", "_field", "host"},
+				Data: [][]interface{}{
+					{execute.Time(0), "cpu", "usage_system", "server01", 8.0},
+					{execute.Time(10), "cpu", "usage_system", "server01", 3.0},
+					{execute.Time(20), "cpu", "usage_system", "server01", 6.0},
+				},
+			},
+		},
+		nil,
+		func(id execute.DatasetID) execute.Source {
+			pspec := &influxdb.ReadWindowAggregatePhysSpec{
+				ReadRangePhysSpec: influxdb.ReadRangePhysSpec{
+					BucketID: bucketID.String(),
+				},
+				WindowEvery: 10,
+				Aggregates: []plan.ProcedureKind{
+					universe.SumKind,
+				},
+			}
+			reader := &mock.WindowAggregateStoreReader{
+				ReadWindowAggregateFn: func(ctx context.Context, spec influxdb.ReadWindowAggregateSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+					if want, got := orgID, spec.OrganizationID; want != got {
+						t.Errorf("unexpected organization id -want/+got:\n\t- %s\n\t+ %s", want, got)
+					}
+					if want, got := bucketID, spec.BucketID; want != got {
+						t.Errorf("unexpected bucket id -want/+got:\n\t- %s\n\t+ %s", want, got)
+					}
+					if want, got := (execute.Bounds{Start: 0, Stop: 30}), spec.Bounds; want != got {
+						t.Errorf("unexpected bounds -want/+got:\n%s", cmp.Diff(want, got))
+					}
+					if want, got := int64(10), spec.WindowEvery; want != got {
+						t.Errorf("unexpected window every value -want/+got:\n\t- %d\n\t+ %d", want, got)
+					}
+					if want, got := []plan.ProcedureKind{universe.SumKind}, spec.Aggregates; !cmp.Equal(want, got) {
+						t.Errorf("unexpected aggregates -want/+got:\n%s", cmp.Diff(want, got))
+					}
+					return &TableIterator{
+						Tables: []*executetest.Table{
+							{
+								ColMeta: []flux.ColMeta{
+									{Label: "_time", Type: flux.TTime},
+									{Label: "_measurement", Type: flux.TString},
+									{Label: "_field", Type: flux.TString},
+									{Label: "host", Type: flux.TString},
+									{Label: "_value", Type: flux.TFloat},
+								},
+								KeyCols: []string{"_measurement", "_field", "host"},
+								Data: [][]interface{}{
+									{execute.Time(0), "cpu", "usage_user", "server01", 2.0},
+									{execute.Time(10), "cpu", "usage_user", "server01", 1.5},
+									{execute.Time(20), "cpu", "usage_user", "server01", 5.0},
+								},
+							},
+							{
+								ColMeta: []flux.ColMeta{
+									{Label: "_time", Type: flux.TTime},
+									{Label: "_measurement", Type: flux.TString},
+									{Label: "_field", Type: flux.TString},
+									{Label: "host", Type: flux.TString},
+									{Label: "_value", Type: flux.TFloat},
+								},
+								KeyCols: []string{"_measurement", "_field", "host"},
+								Data: [][]interface{}{
+									{execute.Time(0), "cpu", "usage_system", "server01", 8.0},
+									{execute.Time(10), "cpu", "usage_system", "server01", 3.0},
+									{execute.Time(20), "cpu", "usage_system", "server01", 6.0},
+								},
+							},
+						},
+					}, nil
+				},
+			}
+
+			metrics := influxdb.NewMetrics(nil)
+			deps := influxdb.StorageDependencies{
+				FromDeps: influxdb.FromDependencies{
+					Reader:  reader,
+					Metrics: metrics,
+				},
+			}
+			ctx := deps.Inject(context.Background())
+			ctx = query.ContextWithRequest(ctx, &query.Request{
+				OrganizationID: orgID,
+			})
+			a := mockAdministration{
+				Ctx: ctx,
+				StreamBounds: &execute.Bounds{
+					Start: execute.Time(0),
+					Stop:  execute.Time(30),
+				},
+			}
+
+			s, err := influxdb.CreateReadWindowAggregateSource(pspec, id, a)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return s
+		},
+	)
 }

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	platform "github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/prom"
@@ -146,7 +147,8 @@ type TableIterator interface {
 
 type ReadWindowAggregateSpec struct {
 	ReadFilterSpec
-	// TODO(issue #17784): add attributes for the window aggregate spec.
+	WindowEvery int64
+	Aggregates  []plan.ProcedureKind
 }
 
 // WindowAggregateReader implements the WindowAggregate capability.


### PR DESCRIPTION
The `ReadWindowAggregateSource` will invoke the `ReadWindowAggregate`
method on the `influxdb.Reader` and return the table. It is implemented
using the same common methods that are used for the other sources.

Fixes #17785.