### PR TITLE
chore(errors): interpret more cases as influxdb error type in http.CheckError

### DIFF
--- a/http/errors.go
+++ b/http/errors.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	platform "github.com/influxdata/influxdb/v2"
-	"github.com/pkg/errors"
+	khttp "github.com/influxdata/influxdb/v2/kit/transport/http"
 )
 
 // AuthzError is returned for authorization errors. When this error type is returned,
@@ -58,11 +58,13 @@ func CheckError(resp *http.Response) (err error) {
 		}
 	}
 
+	perr := &platform.Error{
+		Code: khttp.StatusCodeToErrorCode(resp.StatusCode),
+	}
+
 	if resp.StatusCode == http.StatusUnsupportedMediaType {
-		return &platform.Error{
-			Code: platform.EInvalid,
-			Msg:  fmt.Sprintf("invalid media type: %q", resp.Header.Get("Content-Type")),
-		}
+		perr.Msg = fmt.Sprintf("invalid media type: %q", resp.Header.Get("Content-Type"))
+		return perr
 	}
 
 	contentType := resp.Header.Get("Content-Type")
@@ -74,24 +76,32 @@ func CheckError(resp *http.Response) (err error) {
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, resp.Body); err != nil {
-		return &platform.Error{
-			Code: platform.EInternal,
-			Msg:  err.Error(),
-		}
+		perr.Msg = "failed to read error response"
+		perr.Err = err
+		return perr
 	}
 
 	switch mediatype {
 	case "application/json":
-		pe := new(platform.Error)
-		if err := json.Unmarshal(buf.Bytes(), pe); err != nil {
-			line, _ := buf.ReadString('\n')
-			return errors.Wrap(stderrors.New(strings.TrimSuffix(line, "\n")), err.Error())
+		if err := json.Unmarshal(buf.Bytes(), perr); err != nil {
+			perr.Msg = fmt.Sprintf("attempted to unmarshal error as JSON but failed: %q", err)
+			perr.Err = firstLineAsError(buf)
 		}
-		return pe
 	default:
-		line, _ := buf.ReadString('\n')
-		return stderrors.New(strings.TrimSuffix(line, "\n"))
+		perr.Err = firstLineAsError(buf)
 	}
+
+	if perr.Code == "" {
+		// given it was unset during attempt to unmarshal as JSON
+		perr.Code = khttp.StatusCodeToErrorCode(resp.StatusCode)
+	}
+
+	return perr
+}
+
+func firstLineAsError(buf bytes.Buffer) error {
+	line, _ := buf.ReadString('\n')
+	return stderrors.New(strings.TrimSuffix(line, "\n"))
 }
 
 // UnauthorizedError encodes a error message and status code for unauthorized access.

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/http"
 	kithttp "github.com/influxdata/influxdb/v2/kit/transport/http"
-	"github.com/pkg/errors"
 )
 
 func TestCheckError(t *testing.T) {
@@ -43,7 +42,10 @@ func TestCheckError(t *testing.T) {
 				w.WriteHeader(500)
 				_, _ = io.WriteString(w, "upstream timeout\n")
 			},
-			want: stderrors.New("upstream timeout"),
+			want: &influxdb.Error{
+				Code: influxdb.EInternal,
+				Err:  stderrors.New("upstream timeout"),
+			},
 		},
 		{
 			name: "error with bad json",
@@ -52,7 +54,44 @@ func TestCheckError(t *testing.T) {
 				w.WriteHeader(500)
 				_, _ = io.WriteString(w, "upstream timeout\n")
 			},
-			want: errors.Wrap(stderrors.New("upstream timeout"), "invalid character 'u' looking for beginning of value"),
+			want: &influxdb.Error{
+				Code: influxdb.EInternal,
+				Msg:  `attempted to unmarshal error as JSON but failed: "invalid character 'u' looking for beginning of value"`,
+				Err:  stderrors.New("upstream timeout"),
+			},
+		},
+		{
+			name: "error with no content-type (encoded as json - with code)",
+			write: func(w *httptest.ResponseRecorder) {
+				w.WriteHeader(500)
+				_, _ = io.WriteString(w, `{"error": "service unavailable", "code": "unavailable"}`)
+			},
+			want: &influxdb.Error{
+				Code: influxdb.EUnavailable,
+				Err:  stderrors.New("service unavailable"),
+			},
+		},
+		{
+			name: "error with no content-type (encoded as json - no code)",
+			write: func(w *httptest.ResponseRecorder) {
+				w.WriteHeader(503)
+				_, _ = io.WriteString(w, `{"error": "service unavailable"}`)
+			},
+			want: &influxdb.Error{
+				Code: influxdb.EUnavailable,
+				Err:  stderrors.New("service unavailable"),
+			},
+		},
+		{
+			name: "error with no content-type (not json encoded)",
+			write: func(w *httptest.ResponseRecorder) {
+				w.WriteHeader(503)
+			},
+			want: &influxdb.Error{
+				Code: influxdb.EUnavailable,
+				Msg:  `attempted to unmarshal error as JSON but failed: "unexpected end of JSON input"`,
+				Err:  stderrors.New(""),
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/kit/transport/http/api.go
+++ b/kit/transport/http/api.go
@@ -87,19 +87,15 @@ func NewAPI(opts ...APIOptFn) *API {
 			}
 		},
 		errFn: func(err error) (interface{}, int, error) {
-			code := influxdb.ErrorCode(err)
-			httpStatusCode, ok := statusCodePlatformError[code]
-			if !ok {
-				httpStatusCode = http.StatusBadRequest
-			}
 			msg := err.Error()
 			if msg == "" {
 				msg = "an internal error has occurred"
 			}
+			code := influxdb.ErrorCode(err)
 			return ErrBody{
 				Code: code,
 				Msg:  msg,
-			}, httpStatusCode, nil
+			}, ErrorCodeToStatusCode(code), nil
 		},
 	}
 	for _, o := range opts {
@@ -241,20 +237,4 @@ func (n noopCloser) Close() error {
 type ErrBody struct {
 	Code string `json:"code"`
 	Msg  string `json:"message"`
-}
-
-// statusCodePlatformError is the map convert platform.Error to error
-var statusCodePlatformError = map[string]int{
-	influxdb.EInternal:            http.StatusInternalServerError,
-	influxdb.EInvalid:             http.StatusBadRequest,
-	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
-	influxdb.EEmptyValue:          http.StatusBadRequest,
-	influxdb.EConflict:            http.StatusUnprocessableEntity,
-	influxdb.ENotFound:            http.StatusNotFound,
-	influxdb.EUnavailable:         http.StatusServiceUnavailable,
-	influxdb.EForbidden:           http.StatusForbidden,
-	influxdb.ETooManyRequests:     http.StatusTooManyRequests,
-	influxdb.EUnauthorized:        http.StatusUnauthorized,
-	influxdb.EMethodNotAllowed:    http.StatusMethodNotAllowed,
-	influxdb.ETooLarge:            http.StatusRequestEntityTooLarge,
 }

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -21,13 +21,9 @@ func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.Res
 	}
 
 	code := influxdb.ErrorCode(err)
-	httpCode, ok := statusCodePlatformError[code]
-	if !ok {
-		httpCode = http.StatusBadRequest
-	}
 	w.Header().Set(PlatformErrorCodeHeader, code)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(httpCode)
+	w.WriteHeader(ErrorCodeToStatusCode(code))
 	var e struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
@@ -40,4 +36,50 @@ func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.Res
 	}
 	b, _ := json.Marshal(e)
 	_, _ = w.Write(b)
+}
+
+// StatusCodeToErrorCode maps a http status code integer to an
+// influxdb error code string.
+func StatusCodeToErrorCode(statusCode int) string {
+	errorCode, ok := httpStatusCodeToInfluxDBError[statusCode]
+	if ok {
+		return errorCode
+	}
+
+	return influxdb.EInternal
+}
+
+// ErrorCodeToStatusCode maps an influxdb error code string to a
+// http status code integer.
+func ErrorCodeToStatusCode(code string) int {
+	statusCode, ok := influxDBErrorToStatusCode[code]
+	if ok {
+		return statusCode
+	}
+
+	return http.StatusInternalServerError
+}
+
+// influxDBErrorToStatusCode is a mapping of ErrorCode to http status code.
+var influxDBErrorToStatusCode = map[string]int{
+	influxdb.EInternal:            http.StatusInternalServerError,
+	influxdb.EInvalid:             http.StatusBadRequest,
+	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
+	influxdb.EEmptyValue:          http.StatusBadRequest,
+	influxdb.EConflict:            http.StatusUnprocessableEntity,
+	influxdb.ENotFound:            http.StatusNotFound,
+	influxdb.EUnavailable:         http.StatusServiceUnavailable,
+	influxdb.EForbidden:           http.StatusForbidden,
+	influxdb.ETooManyRequests:     http.StatusTooManyRequests,
+	influxdb.EUnauthorized:        http.StatusUnauthorized,
+	influxdb.EMethodNotAllowed:    http.StatusMethodNotAllowed,
+	influxdb.ETooLarge:            http.StatusRequestEntityTooLarge,
+}
+
+var httpStatusCodeToInfluxDBError = map[int]string{}
+
+func init() {
+	for k, v := range influxDBErrorToStatusCode {
+		httpStatusCodeToInfluxDBError[v] = k
+	}
 }


### PR DESCRIPTION
This is just a little proposal PR to restructure some of the `http.CheckError` behaviour to get a little more context in some cases.

We recently experience what appeared to be a response between tasks and gateway with a non 2XX or 3XX with no content type and an empty body. This is turning up in a task run log as an `Unexpected end of JSON input: ""` error.
While I am unsure if we can get much more context, the status code in the situation is getting dropped on the floor. This change ensures that we at least attempt to convert it into one of our influxdb error codes.
It also leverages both `message` and `error` fields in the event of a failure to unmarshal an error as json. The `error` contains the first line of the response body and the `message` contains an explanation and the error received after the attempt to unmarshal.

I also promoted the error code to status code and back as a function in `errors.go`. I am not sure if this is a bad thing. But seems like something we can standardize and share somewhere.

Lastly, it changes the default status code to `500` from `400`, because if we can't figure out what an error is we shouldn't be reporting it as a user error.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
