### PR TITLE
feat: added PushDownWindowAggregate planner rewrite rule

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -26,3 +26,15 @@
   default: 42
   contact: Gavin Cabbage
   expose: true
+
+- name: Push Down Window Aggregate Count
+  description: Enable Count variant of PushDownWindowAggregateRule
+  key: pushDownWindowAggregateCount
+  default: false
+  contact: Query Team
+
+- name: Push Down Window Aggregate Rest
+  description: Enable non-Count variants of PushDownWindowAggregateRule (stage 2)
+  key: pushDownWindowAggregateRest
+  default: false
+  contact: Query Team

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6
-	github.com/influxdata/flux v0.67.1-0.20200429154143-b42d4177e03e
+	github.com/influxdata/flux v0.67.1-0.20200504203345-528f07c316a9
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/pkg-config v0.2.0
@@ -94,7 +94,7 @@ require (
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	go.uber.org/multierr v1.4.0
 	go.uber.org/zap v1.9.1
-	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -244,8 +246,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6 h1:OtjKkeWDjUbyMi82C7XXy7Tvm2LXMwiBBXyFIGNPaGA=
 github.com/influxdata/cron v0.0.0-20191203200038-ded12750aac6/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.67.1-0.20200429154143-b42d4177e03e h1:kcsFqnxlImwDTTqNPRJeePWfaCFteO0/gppYk5L5x+k=
-github.com/influxdata/flux v0.67.1-0.20200429154143-b42d4177e03e/go.mod h1:4PVm7oUSOMJgXbEsEZgHmWZRjIPtB6gF0F9et2i3+3w=
+github.com/influxdata/flux v0.67.1-0.20200504203345-528f07c316a9 h1:G7W9rZ8BIcZs3UfOis94NWEpHvsfxHeOewJt5HBJj+Y=
+github.com/influxdata/flux v0.67.1-0.20200504203345-528f07c316a9/go.mod h1:AdzL5HnjdFlcBiNz0wE69rSTGRX9CQHqtJUF8ptiDeY=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
@@ -381,6 +383,8 @@ github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -427,6 +431,8 @@ github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUr
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/snowflakedb/gosnowflake v1.3.4 h1:Gyoi6g4lMHsilEwW9+KV+bgYkJTgf5pVfvL7Utus920=
+github.com/snowflakedb/gosnowflake v1.3.4/go.mod h1:NsRq2QeiMUuoNUJhp5Q6xGC4uBrsS9g6LwZVEkTWgsE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
@@ -503,6 +509,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 h1:iMGN4xG0cnqj3t+zOM8wUB
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -30,12 +30,44 @@ func FrontendExample() IntFlag {
 	return frontendExample
 }
 
+var pushDownWindowAggregateCount = MakeBoolFlag(
+	"Push Down Window Aggregate Count",
+	"pushDownWindowAggregateCount",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownWindowAggregateCount - Enable Count variant of PushDownWindowAggregateRule
+func PushDownWindowAggregateCount() BoolFlag {
+	return pushDownWindowAggregateCount
+}
+
+var pushDownWindowAggregateRest = MakeBoolFlag(
+	"Push Down Window Aggregate Rest",
+	"pushDownWindowAggregateRest",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownWindowAggregateRest - Enable non-Count variants of PushDownWindowAggregateRule (stage 2)
+func PushDownWindowAggregateRest() BoolFlag {
+	return pushDownWindowAggregateRest
+}
+
 var all = []Flag{
 	backendExample,
 	frontendExample,
+	pushDownWindowAggregateCount,
+	pushDownWindowAggregateRest,
 }
 
 var byKey = map[string]Flag{
-	"backendExample":  backendExample,
-	"frontendExample": frontendExample,
+	"backendExample":               backendExample,
+	"frontendExample":              frontendExample,
+	"pushDownWindowAggregateCount": pushDownWindowAggregateCount,
+	"pushDownWindowAggregateRest":  pushDownWindowAggregateRest,
 }

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1,6 +1,7 @@
 package influxdb_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,13 +10,44 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2/query"
 	"github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/v2/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 )
+
+// A small mock reader so we can indicate if rule-related capabilities are
+// present
+type mockReaderCaps struct {
+	query.StorageReader
+	Have bool
+}
+
+func (caps mockReaderCaps) GetWindowAggregateCapability(ctx context.Context) query.WindowAggregateCapability {
+	return mockWAC{ Have: caps.Have }
+}
+
+func (caps mockReaderCaps) ReadWindowAggregate(ctx context.Context, spec query.ReadWindowAggregateSpec, alloc *memory.Allocator) (query.TableIterator, error) {
+	return nil, nil
+}
+
+// Mock Window Aggregate Capability
+type mockWAC struct {
+	Have bool
+}
+
+func (m mockWAC) HaveMin() bool { return m.Have }
+func (m mockWAC) HaveMax() bool { return m.Have }
+func (m mockWAC) HaveMean() bool { return m.Have }
+func (m mockWAC) HaveCount() bool { return m.Have }
+func (m mockWAC) HaveSum() bool { return m.Have }
 
 func fluxTime(t int64) flux.Time {
 	return flux.Time{
@@ -1105,6 +1137,428 @@ func TestReadTagValuesRule(t *testing.T) {
 			},
 		},
 	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+//
+// Window Aggregate Testing
+//
+func TestPushDownWindowAggregateRule(t *testing.T) {
+	// Turn on all variants.
+	flagger := mock.NewFlagger(map[feature.Flag] interface{}{
+		feature.PushDownWindowAggregateCount(): true,
+		feature.PushDownWindowAggregateRest(): true,
+	})
+
+	withFlagger, _ := feature.Annotate(context.Background(), flagger)
+
+	// Construct dependencies either with or without aggregate window caps.
+	deps := func(have bool) influxdb.StorageDependencies {
+		return influxdb.StorageDependencies{
+			FromDeps: influxdb.FromDependencies{
+				Reader:  mockReaderCaps{ Have: have },
+				Metrics: influxdb.NewMetrics(nil),
+			},
+		}
+	}
+
+	haveCaps := deps(true).Inject(withFlagger)
+	noCaps := deps(false).Inject(withFlagger)
+
+	readRange := influxdb.ReadRangePhysSpec{
+		Bucket: "my-bucket",
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+
+	dur1m := values.ConvertDuration(60 * time.Second)
+	dur2m := values.ConvertDuration(120 * time.Second)
+	dur0 := values.ConvertDuration(0)
+	durNeg, _ := values.ParseDuration("-60s")
+	dur1y, _ := values.ParseDuration("1y")
+
+	window := func(dur values.Duration) universe.WindowProcedureSpec{
+		return universe.WindowProcedureSpec{
+			Window: plan.WindowSpec{
+				Every:  dur,
+				Period: dur,
+				Offset: dur0,
+			},
+			TimeColumn:  "_time",
+			StartColumn: "_start",
+			StopColumn:  "_stop",
+			CreateEmpty: false,
+		}
+	}
+
+	window1m := window(dur1m)
+	window2m := window(dur2m)
+	windowNeg := window(durNeg)
+	window1y := window(dur1y)
+
+	tests := make([]plantest.RuleTestCase, 0)
+
+	// construct a simple plan with a specific window
+	simplePlanWithWindowAgg := func( window universe.WindowProcedureSpec, agg plan.NodeID, spec plan.ProcedureSpec ) *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window),
+				plan.CreateLogicalNode(agg, spec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		}
+	}
+
+	// construct a simple result
+	simpleResult := func( proc plan.ProcedureKind ) *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates: []plan.ProcedureKind{proc},
+					WindowEvery: 60000000000,
+				}),
+			},
+		}
+	}
+
+	minProcedureSpec := func() *universe.MinProcedureSpec {
+		return &universe.MinProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column: "_value"},
+		}
+	}
+	maxProcedureSpec := func() *universe.MaxProcedureSpec {
+		return &universe.MaxProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column: "_value"},
+		}
+	}
+	meanProcedureSpec := func() *universe.MeanProcedureSpec {
+		return &universe.MeanProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value"}},
+		}
+	}
+	countProcedureSpec := func() *universe.CountProcedureSpec {
+		return &universe.CountProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value"}},
+		}
+	}
+	sumProcedureSpec := func() *universe.SumProcedureSpec {
+		return &universe.SumProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value"}},
+		}
+	}
+
+
+	// ReadRange -> window -> min => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "SimplePassMin",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "min", minProcedureSpec() ),
+		After: simpleResult( "min" ),
+	})
+
+	// ReadRange -> window -> max => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "SimplePassMax",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "max", maxProcedureSpec() ),
+		After: simpleResult( "max" ),
+	})
+
+	// ReadRange -> window -> mean => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "SimplePassMean",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "mean", meanProcedureSpec() ),
+		After: simpleResult( "mean" ),
+	})
+
+	// ReadRange -> window -> count => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "SimplePassCount",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "count", countProcedureSpec() ),
+		After: simpleResult( "count" ),
+	})
+
+	// ReadRange -> window -> sum => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "SimplePassSum",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "sum", sumProcedureSpec() ),
+		After: simpleResult( "sum" ),
+	})
+
+
+	// Rewrite with successors
+	// ReadRange -> window -> min -> count {2} => ReadWindowAggregate -> count {2}
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name: "WithSuccessor",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+				plan.CreateLogicalNode("count", countProcedureSpec() ),
+				plan.CreateLogicalNode("count", countProcedureSpec() ),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{2, 4},
+			},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates: []plan.ProcedureKind{"min"},
+					WindowEvery: 60000000000,
+				}),
+				plan.CreateLogicalNode("count", countProcedureSpec() ),
+				plan.CreateLogicalNode("count", countProcedureSpec() ),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{0, 2},
+			},
+		},
+	})
+
+	// Helper that adds a test with a simple plan that does not pass due to a
+	// specified bad window
+	simpleMinUnchanged := func( name string, window universe.WindowProcedureSpec ) {
+		// Note: NoChange is not working correctly for these tests. It is
+		// expecting empty time, start, and stop column fields.
+		tests = append( tests, plantest.RuleTestCase{
+			Name: name,
+			Context: haveCaps,
+			Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+			Before: simplePlanWithWindowAgg( window, "min", countProcedureSpec() ),
+			NoChange: true,
+		})
+	}
+
+	// Condition not met: period not equal to every
+	badWindow1 := window1m
+	badWindow1.Window.Period = dur2m
+	simpleMinUnchanged( "BadPeriod", badWindow1 )
+
+	// Condition not met: offset non-zero
+	badWindow2 := window1m
+	badWindow2.Window.Offset = dur1m
+	simpleMinUnchanged( "BadOffset", badWindow2 )
+
+	// Condition not met: non-standard _time column
+	badWindow3 := window1m
+	badWindow3.TimeColumn = "_timmy"
+	simpleMinUnchanged( "BadTime", badWindow3 )
+
+	// Condition not met: non-standard start column
+	badWindow4 := window1m
+	badWindow4.StartColumn = "_stooort"
+	simpleMinUnchanged( "BadStart", badWindow4 )
+
+	// Condition not met: non-standard stop column
+	badWindow5 := window1m
+	badWindow5.StopColumn = "_stappp"
+	simpleMinUnchanged( "BadStop", badWindow5 )
+
+	// Condition not met: createEmpty is not false
+	badWindow6 := window1m
+	badWindow6.CreateEmpty = true
+	simpleMinUnchanged( "BadCreateEmpty", badWindow6 )
+
+	// Condition not met: duration too long.
+	simpleMinUnchanged( "WindowTooLarge", window1y )
+
+	// Condition not met: neg duration.
+	simpleMinUnchanged( "WindowNeg", windowNeg )
+
+	// Bad min column
+	// ReadRange -> window -> min => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "BadMinCol",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "min", &universe.MinProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column:"_valmoo"},
+		}),
+		NoChange: true,
+	})
+
+	// Bad max column
+	// ReadRange -> window -> max => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "BadMaxCol",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "max",  &universe.MaxProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column:"_valmoo"},
+		}),
+		NoChange: true,
+	})
+
+	// Bad mean columns
+	// ReadRange -> window -> mean => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "BadMeanCol1",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "mean", &universe.MeanProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns:[]string{"_valmoo"}},
+		}),
+		NoChange: true,
+	})
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "BadMeanCol2",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "mean", &universe.MeanProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns:[]string{"_value", "_valmoo"}},
+		}),
+		NoChange: true,
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> window -> min
+	//                    \-> min
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "CollapsedWithSuccessor1",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{1, 3},
+			},
+		},
+		NoChange: true,
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> window -> min
+	//          \-> window
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "CollapsedWithSuccessor2",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+				plan.CreateLogicalNode("window", &window2m),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{0, 3},
+			},
+		},
+		NoChange: true,
+	})
+
+
+	// No pattern match
+	// ReadRange -> filter -> window -> min -> NO-CHANGE
+	pushableFn1 := executetest.FunctionExpression(t, `(r) => true`)
+
+	makeResolvedFilterFn := func(expr *semantic.FunctionExpression) interpreter.ResolvedFunction {
+		return interpreter.ResolvedFunction{
+			Scope: nil,
+			Fn:    expr,
+		}
+	}
+	noPatternMatch1 := func() *plantest.PlanSpec{
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+					Fn: makeResolvedFilterFn(pushableFn1),
+				}),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		}
+	}
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "NoPatternMatch1",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: noPatternMatch1(),
+		NoChange: true,
+	})
+
+	// No pattern match 2
+	// ReadRange -> window -> filter -> min -> NO-CHANGE
+	noPatternMatch2 := func() *plantest.PlanSpec{
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+					Fn: makeResolvedFilterFn(pushableFn1),
+				}),
+				plan.CreateLogicalNode("min", minProcedureSpec() ),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		}
+	}
+	tests = append(tests, plantest.RuleTestCase{
+		Name: "NoPatternMatch2",
+		Context: haveCaps,
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: noPatternMatch2(),
+		NoChange: true,
+	})
+
+	// Fail due to no capabilities present.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: noCaps,
+		Name: "FailNoCaps",
+		Rules: []plan.Rule{ influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg( window1m, "count", countProcedureSpec() ),
+		After: simpleResult( "count" ),
+		NoChange: true,
+	})
 
 	for _, tc := range tests {
 		tc := tc

--- a/query/storage.go
+++ b/query/storage.go
@@ -25,7 +25,13 @@ type StorageReader interface {
 }
 
 // WindowAggregateCapability describes what is supported by WindowAggregateReader.
-type WindowAggregateCapability interface{}
+type WindowAggregateCapability interface {
+	HaveMin() bool
+	HaveMax() bool
+	HaveMean() bool
+	HaveCount() bool
+	HaveSum() bool
+}
 
 // WindowAggregateReader implements the WindowAggregate capability.
 type WindowAggregateReader interface {


### PR DESCRIPTION
Added a (disabled and feature-flagged) planner rule that matches:

ReadRange -> window -> { min, max, mean, count, sum }

The rule requires:
 * the pushDownWindowAggregate{Count,Rest} feature flags enabled
 * having WindowAggregateCapability
   (which StorageReader does not currently have)
 * use of "_value" columns only
 * window.period == window.every
 * window.every.months == 0
 * window.every is positive
 * window.offset == 0
 * standard time columns
 * createEmpty is false