### PR TITLE
refactor: unify WindowAggregateCapability

### DIFF
--- a/mock/reader.go
+++ b/mock/reader.go
@@ -42,19 +42,16 @@ func (s *StorageReader) Close() {
 
 type WindowAggregateStoreReader struct {
 	*StorageReader
-	HasWindowAggregateCapabilityFn func(ctx context.Context) bool
+	GetWindowAggregateCapabilityFn func(ctx context.Context) query.WindowAggregateCapability
 	ReadWindowAggregateFn          func(ctx context.Context, spec query.ReadWindowAggregateSpec, alloc *memory.Allocator) (query.TableIterator, error)
 }
 
-func (s *WindowAggregateStoreReader) HasWindowAggregateCapability(ctx context.Context, capability ...*query.WindowAggregateCapability) bool {
+func (s *WindowAggregateStoreReader) GetWindowAggregateCapability(ctx context.Context) query.WindowAggregateCapability {
 	// Use the function if it exists.
-	if s.HasWindowAggregateCapabilityFn != nil {
-		return s.HasWindowAggregateCapabilityFn(ctx)
+	if s.GetWindowAggregateCapabilityFn != nil {
+		return s.GetWindowAggregateCapabilityFn(ctx)
 	}
-
-	// Provide a default implementation if one wasn't set.
-	// This will return true if the other function was set.
-	return s.ReadWindowAggregateFn != nil
+	return nil
 }
 
 func (s *WindowAggregateStoreReader) ReadWindowAggregate(ctx context.Context, spec query.ReadWindowAggregateSpec, alloc *memory.Allocator) (query.TableIterator, error) {

--- a/query/storage.go
+++ b/query/storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/storage/reads"
 	"github.com/influxdata/influxdb/v2/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
 )
@@ -25,14 +26,15 @@ type StorageReader interface {
 }
 
 // WindowAggregateCapability describes what is supported by WindowAggregateReader.
-type WindowAggregateCapability struct{}
+type WindowAggregateCapability interface {
+	reads.WindowAggregateCapability
+}
 
 // WindowAggregateReader implements the WindowAggregate capability.
 type WindowAggregateReader interface {
-	// HasWindowAggregateCapability will test if this Reader source supports the ReadWindowAggregate capability.
-	// If WindowAggregateCapability is passed to the method, then the struct
-	// is filled with a detailed list of what the RPC call supports.
-	HasWindowAggregateCapability(ctx context.Context, capability ...*WindowAggregateCapability) bool
+	// GetWindowAggregateCapability will get a detailed list of what the RPC call supports
+	// for window aggregate.
+	GetWindowAggregateCapability(ctx context.Context) WindowAggregateCapability
 
 	// ReadWindowAggregate will read a table using the WindowAggregate method.
 	ReadWindowAggregate(ctx context.Context, spec ReadWindowAggregateSpec, alloc *memory.Allocator) (TableIterator, error)

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -80,11 +80,11 @@ func (r *storeReader) ReadGroup(ctx context.Context, spec query.ReadGroupSpec, a
 	}, nil
 }
 
-func (r *storeReader) HasWindowAggregateCapability(ctx context.Context, capability ...*query.WindowAggregateCapability) bool {
+func (r *storeReader) GetWindowAggregateCapability(ctx context.Context) query.WindowAggregateCapability {
 	if aggStore, ok := r.s.(storage.WindowAggregateStore); ok {
-		return aggStore.HasWindowAggregateCapability(ctx)
+		return aggStore.GetWindowAggregateCapability(ctx)
 	}
-	return false
+	return nil
 }
 
 func (r *storeReader) ReadWindowAggregate(ctx context.Context, spec query.ReadWindowAggregateSpec, alloc *memory.Allocator) (query.TableIterator, error) {

--- a/storage/reads/store.go
+++ b/storage/reads/store.go
@@ -84,14 +84,13 @@ type Store interface {
 }
 
 // WindowAggregateCapability describes what is supported by WindowAggregateStore.
-type WindowAggregateCapability struct{}
+type WindowAggregateCapability interface{}
 
 // WindowAggregateStore implements the WindowAggregate capability.
 type WindowAggregateStore interface {
-	// HasWindowAggregateCapability checks if this Store supports the capability.
-	// If WindowAggregateCapability is passed to the method, then the struct
-	// is filled with a detailed list of what the RPC call supports.
-	HasWindowAggregateCapability(ctx context.Context, capability ...*WindowAggregateCapability) bool
+	// GetWindowAggregateCapability will get a detailed list of what the RPC call supports
+	// for window aggregate.
+	GetWindowAggregateCapability(ctx context.Context) WindowAggregateCapability
 
 	// WindowAggregate will invoke a ReadWindowAggregateRequest against the Store.
 	WindowAggregate(ctx context.Context, req *datatypes.ReadWindowAggregateRequest) (ResultSet, error)

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -154,8 +154,8 @@ func (s *store) GetSource(orgID, bucketID uint64) proto.Message {
 	}
 }
 
-func (s *store) HasWindowAggregateCapability(ctx context.Context, capability ...*reads.WindowAggregateCapability) bool {
-	return false
+func (s *store) GetWindowAggregateCapability(ctx context.Context) reads.WindowAggregateCapability {
+	return nil
 }
 
 // WindowAggregate will invoke a ReadWindowAggregateRequest against the Store.


### PR DESCRIPTION
This PR is a follow-up for #17885

We currently have two `WindowAggregateCapability` struct definitions. One is in [query/stdlib/influxdata/influxdb/storage.go](https://github.com/influxdata/influxdb/blob/master/query/stdlib/influxdata/influxdb/storage.go#L154) used by the `WindowAggregateReader` implementations, the other one is in [influxdb/storage/reads/store.go](https://github.com/influxdata/influxdb/blob/master/storage/reads/store.go#L87) used by the `WindowAggregateStore` implementations.

The plan is to add more supported feature flags to those `WindowAggregateCapability` structs in the future as we move forward to add more storage API capabilities. For example:

```go
type WindowAggregateCapability struct {
    SupportMutipleAggregates bool
    SupportSpreadFunction bool
    ...
}
```
Then in OSS we can do something like:
```go
func pushDownSpreadAggregate() bool {
	if aggStore, ok := store.(storage.WindowAggregateStore); ok {
		var capability WindowAggregateCapability
		aggStore.HasWindowAggregateCapability(ctx, &capability)
		return capability.SupportSpreadFunction
	}
	return false
}
```

I want to eliminate the struct definition in [query/stdlib/influxdata/influxdb/storage.go](https://github.com/influxdata/influxdb/blob/master/query/stdlib/influxdata/influxdb/storage.go#L154), only use the one in [influxdb/storage/reads/store.go](https://github.com/influxdata/influxdb/blob/master/storage/reads/store.go#L87) for the following reasons:

1. We don't need to keep both `WindowAggregateCapability` definitions in sync.
2. The `Reader`'s implementation is simpler, otherwise, we need to introduce code to convert from a `Store`'s `WindowAggregateCapability` to a `Reader`'s `WindowAggregateCapability`.

@jsternberg 's opinion is to keep the duplicated structs in their respective package because he does not want the `influxdb` package to have a dependency on the `reads` package. Quote his comment:

>My thought process on this is that we shouldn't have this dependency as part of the interface because it assumes the reader is the specific reader from reads.Store and there's no other part of the interface that is dependent on that package. I can make an influxdb.Reader and have it live completely within the flux code. The implementation is in a separate package.

>In general, I think it's an anti-pattern if an interface has a dependency on structs from other packages.