### PR TITLE
fix(kv): Ensure UpdateUser cleans up the index when updating names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+1. [17906](https://github.com/influxdata/influxdb/pull/17906): Ensure UpdateUser cleans up the index when updating names
+
 ### UI Improvements
 
 1. [17860](https://github.com/influxdata/influxdb/pull/17860): Allow bucket creation from the Data Explorer and Cell Editor

--- a/kv/user.go
+++ b/kv/user.go
@@ -354,7 +354,7 @@ func (s *Service) updateUser(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 	}
 
 	if upd.Name != nil {
-		if err := s.removeUserFromIndex(ctx, tx, id, *upd.Name); err != nil {
+		if err := s.removeUserFromIndex(ctx, tx, id, u.Name); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
`UpdateUser` isn't cleaning up the `userindexv1/<USER_NAME>` index when the name of a user is changed. This change ensures that this key is removed properly.

This work will be superseded by the new tenant service.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass