### PR TITLE
fix: monaco polish

### DIFF
--- a/ui/src/external/monaco.flux.hotkeys.ts
+++ b/ui/src/external/monaco.flux.hotkeys.ts
@@ -62,7 +62,7 @@ export function comments(editor: EditorType) {
 
 export function submit(editor: EditorType, submitFn: () => any) {
   editor.addCommand(
-    [window.monaco.KeyMod.CtrlCmd | window.monaco.KeyCode.Enter],
+    window.monaco.KeyMod.CtrlCmd | window.monaco.KeyCode.Enter,
     () => {
       submitFn()
     }

--- a/ui/src/external/monaco.flux.hotkeys.ts
+++ b/ui/src/external/monaco.flux.hotkeys.ts
@@ -61,11 +61,10 @@ export function comments(editor: EditorType) {
 }
 
 export function submit(editor: EditorType, submitFn: () => any) {
-  editor.onKeyUp(evt => {
-    const {ctrlKey, code} = evt
-
-    if (ctrlKey && code === 'Enter') {
+  editor.addCommand(
+    [window.monaco.KeyMod.CtrlCmd | window.monaco.KeyCode.Enter],
+    () => {
       submitFn()
     }
-  })
+  )
 }

--- a/ui/src/timeMachine/components/EditorShortcutsTooltip.scss
+++ b/ui/src/timeMachine/components/EditorShortcutsTooltip.scss
@@ -1,15 +1,21 @@
 .editor-shortcuts {
   width: 250px;
+
+  h5 {
+      margin: 8px 0 12px;
+  }
 }
 
 .editor-shortcuts--body {
+    font-size: 14px;
+    line-height: 16px;
   dt {
-    float: left;
     padding-right: $ix-marg-a;
     font-weight: 700;
     color: $g18-cloud;
+    margin-top: 8px;
   }
   dd {
-    white-space: nowrap;
+    display: block
   }
 }

--- a/ui/src/timeMachine/components/EditorShortcutsTooltip.tsx
+++ b/ui/src/timeMachine/components/EditorShortcutsTooltip.tsx
@@ -12,8 +12,10 @@ const EditorShortcutsTooltip: FC = () => {
         <div className="editor-shortcuts">
           <h5>Shortcuts</h5>
           <dl className="editor-shortcuts--body">
-            <dt>Ctl-/:</dt> <dd>Toggle comment for line or lines</dd>
-            <dt>Ctl-Enter:</dt> <dd>Submit Script</dd>
+            <dt>[Ctl or ⌘] + /:</dt>
+            <dd>Toggle comment for line or lines</dd>
+            <dt>[Ctl or ⌘] + [Enter]:</dt>
+            <dd>Submit Script</dd>
           </dl>
         </div>
       }

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -31,7 +31,7 @@ interface DispatchProps {
 
 type Props = StateProps & DispatchProps
 
-class SubmitQueryButton extends PureComponent<Props, State> {
+class SubmitQueryButton extends PureComponent<Props> {
   public render() {
     return (
       <Button

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -31,22 +31,7 @@ interface DispatchProps {
 
 type Props = StateProps & DispatchProps
 
-interface State {
-  didClick: boolean
-}
-
 class SubmitQueryButton extends PureComponent<Props, State> {
-  public state: State = {didClick: false}
-
-  public componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.queryStatus === RemoteDataState.Loading &&
-      this.props.queryStatus === RemoteDataState.Done
-    ) {
-      this.setState({didClick: false})
-    }
-  }
-
   public render() {
     return (
       <Button
@@ -62,14 +47,12 @@ class SubmitQueryButton extends PureComponent<Props, State> {
 
   private get buttonStatus(): ComponentStatus {
     const {queryStatus, submitButtonDisabled} = this.props
-    const {didClick} = this.state
 
     if (submitButtonDisabled) {
       return ComponentStatus.Disabled
     }
 
-    if (queryStatus === RemoteDataState.Loading && didClick) {
-      // Only show loading state for button if it was just clicked
+    if (queryStatus === RemoteDataState.Loading) {
       return ComponentStatus.Loading
     }
 
@@ -78,7 +61,6 @@ class SubmitQueryButton extends PureComponent<Props, State> {
 
   private handleClick = (): void => {
     this.props.onSubmit()
-    this.setState({didClick: true})
   }
 }
 


### PR DESCRIPTION

![Kapture 2020-04-29 at 13 09 07](https://user-images.githubusercontent.com/1434802/80642127-c78e5c80-8a1a-11ea-9fab-20e9213f4fbb.gif)

Closes #17820
Closes #17821

there was some weird code in there about "only show the loading icon if it was clicked by a person", and i threw that out. also added some verbage around "use ctrl OR cmd" to capture the different environments. This turns off ctrl on macs in favor of cmd. @russorat weigh in if we still want to force the ctrl key on macs in addition to cmd.