### PR TITLE
feat(github): removing the Github social sign-up option until further notice

### DIFF
--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -21,7 +21,7 @@ import auth0js, {WebAuth} from 'auth0-js'
 // Components
 import {LoginForm} from 'src/onboarding/components/LoginForm'
 import {SocialButton} from 'src/shared/components/SocialButton'
-import {/* Github, */ GoogleLogo} from 'src/clientLibraries/graphics'
+import {GoogleLogo} from 'src/clientLibraries/graphics'
 
 // Types
 import {Auth0Connection, FormFieldValidation} from 'src/types'
@@ -127,14 +127,6 @@ class LoginPageContents extends PureComponent<DispatchProps> {
                   >
                     <GoogleLogo className="signup-icon" />
                   </SocialButton>
-                  {/* <SocialButton
-                    buttonText="Github"
-                    handleClick={() => {
-                      this.handleSocialClick(Auth0Connection.Github)
-                    }}
-                  >
-                    <GithubLogo className="signup-icon" />
-                  </SocialButton> */}
                 </FlexBox>
               </Grid.Row>
             </Grid>

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -21,7 +21,7 @@ import auth0js, {WebAuth} from 'auth0-js'
 // Components
 import {LoginForm} from 'src/onboarding/components/LoginForm'
 import {SocialButton} from 'src/shared/components/SocialButton'
-import {GoogleLogo, GithubLogo} from 'src/clientLibraries/graphics'
+import {/* Github, */ GoogleLogo} from 'src/clientLibraries/graphics'
 
 // Types
 import {Auth0Connection, FormFieldValidation} from 'src/types'
@@ -127,14 +127,14 @@ class LoginPageContents extends PureComponent<DispatchProps> {
                   >
                     <GoogleLogo className="signup-icon" />
                   </SocialButton>
-                  <SocialButton
+                  {/* <SocialButton
                     buttonText="Github"
                     handleClick={() => {
                       this.handleSocialClick(Auth0Connection.Github)
                     }}
                   >
                     <GithubLogo className="signup-icon" />
-                  </SocialButton>
+                  </SocialButton> */}
                 </FlexBox>
               </Grid.Row>
             </Grid>


### PR DESCRIPTION
### Problem 

This feature is set to release very soon. In the event of any failures with the feature, we want to reduce the scope of the problem in order to get a more focused understanding of what is going wrong, and where we should focus our efforts. In order to narrow the scope of this feature, we are commenting out the Github option for social sign-ups.

### Solution

By deleting the Github-related UI, we are limiting social sign-up to only allow for Google users. Once this feature has proven successful, we will reintroduce the code to allow Github integration

![Screen Shot 2020-04-29 at 14 13 43](https://user-images.githubusercontent.com/19984220/80647638-aaaa5700-8a23-11ea-9c9f-dcbe256aed39.png)


Co-authored-by: Iris Scholten <ischolten.is@gmail.com>

