### PR TITLE
fix: make single stats work in catalina

### DIFF
--- a/ui/src/shared/components/cells/Cell.scss
+++ b/ui/src/shared/components/cells/Cell.scss
@@ -20,6 +20,8 @@ $cell--header-button-active-color: $c-pool;
 .cell--view {
   flex: 1 0 0;
   position: relative;
+  overflow: hidden;
+  height: 100%;
 
   > .single-stat {
     border-radius: $radius;


### PR DESCRIPTION
Closes influxdata/idpe#6755

that was a weird journey, but the overflow:hidden is so that the later flex boxes are forced to remeasure themselves during dragging, and the height: 100% is to force a redraw on instantiation (or else it just shows up as a black box)