### PR TITLE
chore: upgrade ts to 3.8.3

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -122,7 +122,7 @@
     "ts-loader": "^5.3.3",
     "ts-node": "^8.3.0",
     "tslib": "^1.9.0",
-    "typescript": "3.6.4",
+    "typescript": "3.8.3",
     "webpack": "^4.41.4",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.7.2",

--- a/ui/src/dashboards/actions/ranges.ts
+++ b/ui/src/dashboards/actions/ranges.ts
@@ -1,11 +1,11 @@
 // Libraries
 import qs from 'qs'
 import {replace, RouterAction} from 'react-router-redux'
-import {Dispatch, Action} from 'redux'
+import {Dispatch} from 'redux'
 import {get, pickBy} from 'lodash'
 
 // Actions
-import {notify} from 'src/shared/actions/notifications'
+import {notify, Action as NotifyAction} from 'src/shared/actions/notifications'
 
 // Utils
 import {stripPrefix} from 'src/utils/basepath'
@@ -104,7 +104,7 @@ export const updateQueryVars = varsObj => {
 }
 
 export const updateTimeRangeFromQueryParams = (dashboardID: string) => (
-  dispatch: Dispatch<Action>,
+  dispatch: Dispatch<Action | NotifyAction>,
   getState
 ): void => {
   const {ranges} = getState()

--- a/ui/src/notifications/rules/components/RuleOverlay.reducer.tsx
+++ b/ui/src/notifications/rules/components/RuleOverlay.reducer.tsx
@@ -21,11 +21,11 @@ export const reducer = (state: RuleState, action: Action) => {
       let newState: RuleState = state
 
       if (schedule === 'every') {
-        newState = omit(state, 'cron')
+        newState = omit(state, 'cron') as NotificationRuleDraft
       }
 
       if (schedule === 'cron') {
-        newState = omit(state, 'every')
+        newState = omit(state, 'every') as NotificationRuleDraft
       }
 
       return {...newState, [schedule]: ''}

--- a/ui/src/shared/components/EventMarker.tsx
+++ b/ui/src/shared/components/EventMarker.tsx
@@ -43,7 +43,7 @@ const EventMarker: FC<Props> = ({xScale, xDomain, events, xFormatter}) => {
   let triggerRect: DOMRect = null
 
   if (trigger.current) {
-    triggerRect = trigger.current.getBoundingClientRect() as DOMRect
+    triggerRect = trigger.current.getBoundingClientRect()
   }
 
   const {time} = events[0]

--- a/ui/src/types/alerting.ts
+++ b/ui/src/types/alerting.ts
@@ -9,12 +9,12 @@ import {
   SMTPNotificationRuleBase,
   PagerDutyNotificationRuleBase,
   HTTPNotificationRuleBase,
-  Check as GenCheck,
-  ThresholdCheck as GenThresholdCheck,
-  DeadmanCheck as GenDeadmanCheck,
+  Check as GCheck,
+  ThresholdCheck as GThresholdCheck,
+  DeadmanCheck as GDeadmanCheck,
   CustomCheck as GenCustomCheck,
-  NotificationRule as GenRule,
-  NotificationEndpoint as GenEndpoint,
+  NotificationRule as GRule,
+  NotificationEndpoint as GEndpoint,
   TaskStatusType,
   Threshold,
   CheckBase as GenCheckBase,
@@ -37,7 +37,7 @@ type EndpointOverrides = {
   labels: string[]
 }
 // GenEndpoint is the shape of a NotificationEndpoint from the server -- before any UI specific fields are or modified
-export type GenEndpoint = GenEndpoint
+export type GenEndpoint = GEndpoint
 export type NotificationEndpoint =
   | (Omit<SlackNotificationEndpoint, 'status' | 'labels'> & EndpointOverrides)
   | (Omit<PagerDutyNotificationEndpoint, 'status' | 'labels'> &
@@ -50,7 +50,7 @@ export type NotificationEndpointBase = Omit<GenEndpointBase, 'labels'> &
 type RuleOverrides = {status: RemoteDataState; activeStatus: TaskStatusType}
 
 // GenRule is the shape of a NotificationRule from the server -- before any UI specific fields are added or modified
-export type GenRule = GenRule
+export type GenRule = GRule
 export type NotificationRule = GenRule & RuleOverrides
 
 export type StatusRuleDraft = WithClientID<StatusRule>
@@ -127,9 +127,9 @@ type CheckOverrides = {
 export type CheckBase = Omit<GenCheckBase, 'status'> & CheckOverrides
 
 // GenCheck is the shape of a Check from the server -- before UI specific properties are added
-export type GenCheck = GenCheck
-export type GenThresholdCheck = GenThresholdCheck
-export type GenDeadmanCheck = GenDeadmanCheck
+export type GenCheck = GCheck
+export type GenThresholdCheck = GThresholdCheck
+export type GenDeadmanCheck = GDeadmanCheck
 
 export type ThresholdCheck = Omit<GenThresholdCheck, 'status' | 'labels'> &
   CheckOverrides

--- a/ui/src/types/labels.ts
+++ b/ui/src/types/labels.ts
@@ -1,9 +1,9 @@
-import {Label as GenLabel} from 'src/client'
+import {Label as GLabel} from 'src/client'
 import {RemoteDataState} from 'src/types'
 
 // GenLabel is the shape of a Label returned from the server -- before it has
 // been modified with UI specific fields
-export type GenLabel = GenLabel
+export type GenLabel = GLabel
 export interface Label extends GenLabel {
   status: RemoteDataState
   properties: LabelProperties

--- a/ui/src/types/variables.ts
+++ b/ui/src/types/variables.ts
@@ -1,4 +1,4 @@
-import {Variable as GenVariable, Label} from 'src/client'
+import {Variable as GVariable, Label} from 'src/client'
 import {
   QueryVariableProperties as GenQueryVariableProperties,
   ConstantVariableProperties as GenConstantVariableProperties,
@@ -7,7 +7,7 @@ import {
 
 import {
   VariableArgumentType,
-  VariableMapObject,
+  VariableMapObject as GenVariableMapObject,
   QueryArguments,
   MapArguments,
   CSVArguments,
@@ -16,7 +16,7 @@ import {
 } from 'src/types'
 
 // GenVariable is the shape of a variable from the server
-export type GenVariable = GenVariable
+export type GenVariable = GVariable
 export interface SystemVariableProperties {
   type?: 'system'
   values?: any
@@ -66,7 +66,7 @@ export interface VariableMapObject {
   [mapKey: string]: mapValue
 }
 export interface VariableValues {
-  values?: VariableMapObject | string[]
+  values?: GenVariableMapObject | string[]
   valueType?: FluxColumnType
   selected?: string[]
   error?: string

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11674,10 +11674,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
### What && Why

TypeScript 3.8 introduces a bunch of [cool features](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)

Specifically, I'm super excited about [Optional Chaning](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) which would allow us to replace / stop using `lodash/get` and the foo && foo.bar && foo.baz patterns!

All we had to do to upgrade was fix a couple of conflicting import / exports

