### PR TITLE
fix: remove toggle on note cell

### DIFF
--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -83,7 +83,7 @@ class NoteEditor extends PureComponent<Props, State> {
     const {hasQuery, showNoteWhenEmpty, onToggleShowNoteWhenEmpty} = this.props
 
     if (!hasQuery) {
-      return false
+      return null
     }
 
     return (

--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -27,7 +27,7 @@ import {AppState, NoteEditorMode} from 'src/types'
 interface StateProps {
   note: string
   showNoteWhenEmpty: boolean
-  mode: NoteEditorMode
+  hasQuery: boolean
 }
 
 interface DispatchProps {
@@ -80,9 +80,9 @@ class NoteEditor extends PureComponent<Props, State> {
   }
 
   private get visibilityToggle(): JSX.Element {
-    const {mode, showNoteWhenEmpty, onToggleShowNoteWhenEmpty} = this.props
+    const {hasQuery, showNoteWhenEmpty, onToggleShowNoteWhenEmpty} = this.props
 
-    if (mode === NoteEditorMode.Adding) {
+    if (!hasQuery) {
       return false
     }
 
@@ -114,9 +114,14 @@ class NoteEditor extends PureComponent<Props, State> {
 }
 
 const mstp = (state: AppState) => {
-  const {note, mode, isPreviewing, showNoteWhenEmpty} = state.noteEditor
+  const {note, mode, viewID, isPreviewing, showNoteWhenEmpty} = state.noteEditor
+  let hasQuery =
+    mode === NoteEditorMode.Editing &&
+    viewID &&
+    state.resources.views.byID[viewID] &&
+    state.resources.views.byID[viewID].properties.type !== 'markdown'
 
-  return {note, mode, isPreviewing, showNoteWhenEmpty}
+  return {note, hasQuery, isPreviewing, showNoteWhenEmpty}
 }
 
 const mdtp = {

--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -22,11 +22,12 @@ import {
 } from 'src/dashboards/actions/notes'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, NoteEditorMode} from 'src/types'
 
 interface StateProps {
   note: string
   showNoteWhenEmpty: boolean
+  mode: NoteEditorMode
 }
 
 interface DispatchProps {
@@ -79,7 +80,11 @@ class NoteEditor extends PureComponent<Props, State> {
   }
 
   private get visibilityToggle(): JSX.Element {
-    const {showNoteWhenEmpty, onToggleShowNoteWhenEmpty} = this.props
+    const {mode, showNoteWhenEmpty, onToggleShowNoteWhenEmpty} = this.props
+
+    if (mode === NoteEditorMode.Adding) {
+      return false
+    }
 
     return (
       <FlexBox
@@ -109,9 +114,9 @@ class NoteEditor extends PureComponent<Props, State> {
 }
 
 const mstp = (state: AppState) => {
-  const {note, isPreviewing, showNoteWhenEmpty} = state.noteEditor
+  const {note, mode, isPreviewing, showNoteWhenEmpty} = state.noteEditor
 
-  return {note, isPreviewing, showNoteWhenEmpty}
+  return {note, mode, isPreviewing, showNoteWhenEmpty}
 }
 
 const mdtp = {

--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -115,7 +115,7 @@ class NoteEditor extends PureComponent<Props, State> {
 
 const mstp = (state: AppState) => {
   const {note, mode, viewID, isPreviewing, showNoteWhenEmpty} = state.noteEditor
-  let hasQuery =
+  const hasQuery =
     mode === NoteEditorMode.Editing &&
     viewID &&
     state.resources.views.byID[viewID] &&

--- a/ui/src/dashboards/reducers/notes.ts
+++ b/ui/src/dashboards/reducers/notes.ts
@@ -6,6 +6,7 @@ export interface NoteEditorState {
   note: string
   showNoteWhenEmpty: boolean
   isPreviewing: boolean
+  viewID?: string
 }
 
 const initialState = (): NoteEditorState => ({


### PR DESCRIPTION
Closes #17412
 just checks to see if it's a markdown view (denoting no query) or a new cell (denoting it wont be added to a query)