### PR TITLE
chore(http): stop tracing system related api paths

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -108,17 +108,30 @@ func NewHandlerFromRegistry(name string, reg *prom.Registry, opts ...HandlerOptF
 	h.initMetrics()
 
 	r := chi.NewRouter()
-	r.Use(
-		kithttp.Trace(name),
-		kithttp.Metrics(name, h.requests, h.requestDur),
-	)
-	{
-		r.Mount(MetricsPath, opt.metricsHandler)
-		r.Mount(ReadyPath, opt.readyHandler)
-		r.Mount(HealthPath, opt.healthHandler)
-		r.Mount(DebugPath, opt.debugHandler)
-		r.Mount("/", opt.apiHandler)
-	}
+	// only gather metrics for system handlers
+	r.Group(func(r chi.Router) {
+		r.Use(
+			kithttp.Metrics(name, h.requests, h.requestDur),
+		)
+		{
+			r.Mount(MetricsPath, opt.metricsHandler)
+			r.Mount(ReadyPath, opt.readyHandler)
+			r.Mount(HealthPath, opt.healthHandler)
+			r.Mount(DebugPath, opt.debugHandler)
+		}
+	})
+
+	// gather metrics and traces for everything else
+	r.Group(func(r chi.Router) {
+		r.Use(
+			kithttp.Trace(name),
+			kithttp.Metrics(name, h.requests, h.requestDur),
+		)
+		{
+			r.Mount("/", opt.apiHandler)
+		}
+	})
+
 	h.r = r
 
 	reg.MustRegister(h.PrometheusCollectors()...)


### PR DESCRIPTION
This changes the following paths (prefixes) to stop being traced:
- `/health`
- `/ready`
- `/debug`
- `/metrics`

These endpoints are often hit frequently and finish quickly. If they don't finish quickly, metrics suffice to identify them as a problem. Traces offer little insight for these endpoints; especially since they don't tend to cross process boundaries.
Tracing systems often sample aggressively and these kinds of endpoints end up getting picked a lot. Removing them makes room for more traces which relate to user behaviour.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
