### PR TITLE
fix: show buckets in alerting

### DIFF
--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -55,7 +55,7 @@ const AlertingIndex: FunctionComponent<StateProps> = ({
           scrollable={false}
           className={pageContentsClassName}
         >
-          <GetResources resources={[ResourceType.Labels]}>
+          <GetResources resources={[ResourceType.Labels,ResourceType.Buckets]}>
             <GetAssetLimits>
               <AssetLimitAlert
                 resourceName={limitedResources}

--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -55,7 +55,7 @@ const AlertingIndex: FunctionComponent<StateProps> = ({
           scrollable={false}
           className={pageContentsClassName}
         >
-          <GetResources resources={[ResourceType.Labels,ResourceType.Buckets]}>
+          <GetResources resources={[ResourceType.Labels, ResourceType.Buckets]}>
             <GetAssetLimits>
               <AssetLimitAlert
                 resourceName={limitedResources}


### PR DESCRIPTION
<img width="537" alt="Screen Shot 2020-05-01 at 10 30 49 AM" src="https://user-images.githubusercontent.com/1434802/80826970-fed64800-8b97-11ea-825c-2bfac2ec2a97.png">

just wanna get that working before going into the weekend