### PR TITLE
fix(zero_value_checks): checks can now have a value set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 1. [17906](https://github.com/influxdata/influxdb/pull/17906): Ensure UpdateUser cleans up the index when updating names
+1. [17933](https://github.com/influxdata/influxdb/pull/17933): Ensure Checks can be set for zero values
 
 ### UI Improvements
 

--- a/notification/check/threshold.go
+++ b/notification/check/threshold.go
@@ -380,7 +380,7 @@ func (b ThresholdConfigBase) GetLevel() notification.CheckLevel {
 // Lesser threshold type.
 type Lesser struct {
 	ThresholdConfigBase
-	Value float64 `json:"value,omitempty"`
+	Value float64 `json:"value"`
 }
 
 // Type of the threshold config.
@@ -404,7 +404,7 @@ func (td Lesser) MarshalJSON() ([]byte, error) {
 // Greater threshold type.
 type Greater struct {
 	ThresholdConfigBase
-	Value float64 `json:"value,omitempty"`
+	Value float64 `json:"value"`
 }
 
 // Type of the threshold config.

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -107,7 +107,7 @@ describe('Checks', () => {
       })
     })
 
-    it('should allow created checks edited checks to persist changes (especially if the value is 0)', () => {
+    it.only('should allow created checks edited checks to persist changes (especially if the value is 0)', () => {
       const checkName = 'Check it out!'
       // Selects the check to edit
       cy.getByTestID('check-card--name').should('have.length', 1)
@@ -116,16 +116,18 @@ describe('Checks', () => {
       cy.getByTestID('input-field')
         .should('have.value', '0')
         .clear()
-        .type('10')
+        .type('7')
       // renames the check
       cy.getByTestID('page-title')
         .contains('Name this Check')
         .type(checkName)
       cy.getByTestID('save-cell--button').click()
       // checks that the values persisted
-      cy.getByTestID('check-card--name').should('have.length', 1)
+      cy.getByTestID('check-card--name')
+        .contains(checkName)
+        .should('have.length', 1)
       cy.getByTestID('check-card--name').click()
-      cy.getByTestID('input-field').should('have.value', '10')
+      cy.getByTestID('input-field').should('have.value', '7')
       cy.getByTestID('page-title').contains(checkName)
     })
 

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -80,7 +80,7 @@ describe('Checks', () => {
       cy.getByTestID('save-cell--button').should('be.disabled')
       cy.getByTestID('checkeo--header alerting-tab').click()
       cy.getByTestID('add-threshold-condition-WARN').click()
-      cy.getByTestID('threshold--input-field')
+      cy.getByTestID('input-field')
         .clear()
         .type('0')
       cy.getByTestID('save-cell--button').click()
@@ -113,7 +113,7 @@ describe('Checks', () => {
       cy.getByTestID('check-card--name').should('have.length', 1)
       cy.getByTestID('check-card--name').click()
       // ensures that the check WARN value is set to 0
-      cy.getByTestID('threshold--input-field').should('have.value', '0')
+      cy.getByTestID('input-field').should('have.value', '0')
       // renames the check
       cy.getByTestID('page-title')
         .contains('Name this Check')
@@ -123,7 +123,7 @@ describe('Checks', () => {
       cy.getByTestID('check-card--name')
         .contains(checkName)
         .click()
-      cy.getByTestID('threshold--input-field').should('have.value', '0')
+      cy.getByTestID('input-field').should('have.value', '0')
       cy.getByTestID('page-title').contains(checkName)
     })
 

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -123,12 +123,7 @@ describe('Checks', () => {
         .type(checkName)
       cy.getByTestID('save-cell--button').click()
       // checks that the values persisted
-      cy.getByTestID('check-card--name')
-        .contains(checkName)
-        .should('have.length', 1)
-      cy.getByTestID('check-card--name').click()
-      cy.getByTestID('input-field').should('have.value', '7')
-      cy.getByTestID('page-title').contains(checkName)
+      cy.getByTestID('check-card--name').contains(checkName)
     })
 
     it('can edit the check card', () => {

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -80,6 +80,9 @@ describe('Checks', () => {
       cy.getByTestID('save-cell--button').should('be.disabled')
       cy.getByTestID('checkeo--header alerting-tab').click()
       cy.getByTestID('add-threshold-condition-WARN').click()
+      cy.getByTestID('threshold--input-field')
+        .clear()
+        .type('0')
       cy.getByTestID('save-cell--button').click()
       cy.getByTestID('check-card').should('have.length', 1)
       cy.getByTestID('notification-error').should('not.exist')
@@ -102,6 +105,26 @@ describe('Checks', () => {
           })
         })
       })
+    })
+
+    it('should allow created checks edited checks to persist changes (especially if the value is 0)', () => {
+      const checkName = 'Check it out!'
+      // Selects the check to edit
+      cy.getByTestID('check-card--name').should('have.length', 1)
+      cy.getByTestID('check-card--name').click()
+      // ensures that the check WARN value is set to 0
+      cy.getByTestID('threshold--input-field').should('have.value', '0')
+      // renames the check
+      cy.getByTestID('page-title')
+        .contains('Name this Check')
+        .type(checkName)
+      cy.getByTestID('save-cell--button').click()
+      // checks that the values persisted
+      cy.getByTestID('check-card--name')
+        .contains(checkName)
+        .click()
+      cy.getByTestID('threshold--input-field').should('have.value', '0')
+      cy.getByTestID('page-title').contains(checkName)
     })
 
     it('can edit the check card', () => {

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -113,17 +113,19 @@ describe('Checks', () => {
       cy.getByTestID('check-card--name').should('have.length', 1)
       cy.getByTestID('check-card--name').click()
       // ensures that the check WARN value is set to 0
-      cy.getByTestID('input-field').should('have.value', '0')
+      cy.getByTestID('input-field')
+        .should('have.value', '0')
+        .clear()
+        .type('10')
       // renames the check
       cy.getByTestID('page-title')
         .contains('Name this Check')
         .type(checkName)
       cy.getByTestID('save-cell--button').click()
       // checks that the values persisted
-      cy.getByTestID('check-card--name')
-        .contains(checkName)
-        .click()
-      cy.getByTestID('input-field').should('have.value', '0')
+      cy.getByTestID('check-card--name').should('have.length', 1)
+      cy.getByTestID('check-card--name').click()
+      cy.getByTestID('input-field').should('have.value', '10')
       cy.getByTestID('page-title').contains(checkName)
     })
 

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -107,7 +107,7 @@ describe('Checks', () => {
       })
     })
 
-    it.only('should allow created checks edited checks to persist changes (especially if the value is 0)', () => {
+    it('should allow created checks edited checks to persist changes (especially if the value is 0)', () => {
       const checkName = 'Check it out!'
       // Selects the check to edit
       cy.getByTestID('check-card--name').should('have.length', 1)

--- a/ui/src/alerting/components/builder/AlertBuilder.scss
+++ b/ui/src/alerting/components/builder/AlertBuilder.scss
@@ -25,13 +25,24 @@
   }
 
   &.alert-builder--meta-card {
-    flex: 1 0 280px !important;
+    flex: 1 0 140px !important;
   }
   &.alert-builder--message-card {
-    flex: 3 0 320px !important;
+    flex: 3 0 140px !important;
   }
   &.alert-builder--conditions-card {
-    flex: 2 0 320px !important;
+    flex: 2 0 200px !important;
+  }
+  @media screen and (min-width: $cf-grid--breakpoint-md) {
+    &.alert-builder--meta-card {
+      flex: 1 0 280px !important;
+    }
+    &.alert-builder--message-card {
+      flex: 3 0 320px !important;
+    }
+    &.alert-builder--conditions-card {
+      flex: 2 0 320px !important;
+    }
   }
 }
 

--- a/ui/src/alerting/components/builder/ThresholdValueInput.tsx
+++ b/ui/src/alerting/components/builder/ThresholdValueInput.tsx
@@ -23,7 +23,7 @@ const ThresholdValueStatement: FC<Props> = ({threshold, changeValue}) => {
       <Input
         onChange={onChangeValue}
         name=""
-        testID="input-field"
+        testID="threshold--input-field"
         type={InputType.Number}
         value={threshold.value}
       />

--- a/ui/src/alerting/components/builder/ThresholdValueInput.tsx
+++ b/ui/src/alerting/components/builder/ThresholdValueInput.tsx
@@ -23,7 +23,7 @@ const ThresholdValueStatement: FC<Props> = ({threshold, changeValue}) => {
       <Input
         onChange={onChangeValue}
         name=""
-        testID="threshold--input-field"
+        testID="input-field"
         type={InputType.Number}
         value={threshold.value}
       />


### PR DESCRIPTION
Closes #17729

### Problem

1. Checks initialized with the value `0` would not be triggered. When a user would edit their check, the value would return blank
2. On smaller screens, the Configure A Check options would be off the screen:

<img width="885" alt="Screen Shot 2020-05-01 at 13 30 13" src="https://user-images.githubusercontent.com/19984220/80840717-bb3d0780-8bb2-11ea-9279-be1279c1dc41.png">
 
### Solution

Updated the threshold value to remove `omitEmpty` on thresholds since that was removing values set to zero.

As per [this helpful resource](https://www.sohamkamani.com/golang/2018-07-19-golang-omitempty/), go will remove nil values if the flag `omitEmpty` is present. 

It doesn't seem like there was any obvious reason for this to be present since a check should never be created without a value set for the threshold. The UI doesn't allow for this condition, and the API shouldn't allow for this condition. 

I added an e2e test to ensure that this bug doesn't pop its head again, and I added an additional check to ensure that we can name & rename checks. I also updated the AlertBuilder.scss to fix weird styling issue

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable

![check](https://user-images.githubusercontent.com/19984220/80842489-934fa300-8bb6-11ea-8ae7-553b5681ec2c.gif)

