### PR TITLE
feat(pkger): add the ability to remove a stack and all its associated resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+1. [17934](https://github.com/influxdata/influxdb/pull/17934): Add ability to delete a stack and all the resources associated with it
+
 ### Bug Fixes
 
 1. [17906](https://github.com/influxdata/influxdb/pull/17906): Ensure UpdateUser cleans up the index when updating names

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -708,6 +708,8 @@ type fakePkgSVC struct {
 	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error)
 }
 
+var _ pkger.SVC = (*fakePkgSVC)(nil)
+
 func (f *fakePkgSVC) InitStack(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error) {
 	if f.initStackFn != nil {
 		return f.initStackFn(ctx, userID, stack)
@@ -716,6 +718,10 @@ func (f *fakePkgSVC) InitStack(ctx context.Context, userID influxdb.ID, stack pk
 }
 
 func (f *fakePkgSVC) ListStacks(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error) {
+	panic("not implemented")
+}
+
+func (f *fakePkgSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	panic("not implemented")
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4510,6 +4510,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /packages/stacks/{stack_id}:
+    delete:
+      operationId: DeleteStack
+      tags:
+        - InfluxPackages
+      summary: Delete a stack and remove all its associated resources
+      parameters:
+        - in: path
+          name: stack_id
+          required: true
+          schema:
+            type: string
+          description: The stack id to be removed
+        - in: query
+          name: orgID
+          required: true
+          schema:
+            type: string
+          description: The organization id of the user
+      responses:
+        '204':
+          description: Stack and all its associated resources are deleted
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /tasks:
     get:
       operationId: GetTasks

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -55,6 +55,13 @@ func (s *HTTPRemoteService) InitStack(ctx context.Context, userID influxdb.ID, s
 	return newStack, nil
 }
 
+func (s *HTTPRemoteService) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
+	return s.Client.
+		Delete(RoutePrefix, "stacks", identifiers.StackID.String()).
+		QueryParams([2]string{"orgID", identifiers.OrgID.String()}).
+		Do(ctx)
+}
+
 func (s *HTTPRemoteService) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	queryParams := [][2]string{{"orgID", orgID.String()}}
 	for _, name := range f.Names {

--- a/pkger/http_server.go
+++ b/pkger/http_server.go
@@ -48,11 +48,14 @@ func NewHTTPServer(log *zap.Logger, svc SVC) *HTTPServer {
 	{
 		r.With(middleware.AllowContentType("text/yml", "application/x-yaml", "application/json")).
 			Post("/", svr.createPkg)
+
 		r.With(middleware.SetHeader("Content-Type", "application/json; charset=utf-8")).
 			Post("/apply", svr.applyPkg)
+
 		r.Route("/stacks", func(r chi.Router) {
 			r.Post("/", svr.createStack)
 			r.Get("/", svr.listStacks)
+			r.Delete("/{stack_id}", svr.deleteStack)
 		})
 	}
 
@@ -201,6 +204,63 @@ func (s *HTTPServer) createStack(w http.ResponseWriter, r *http.Request) {
 		URLs:        stack.URLs,
 		CRUDLog:     stack.CRUDLog,
 	})
+}
+
+func (s *HTTPServer) deleteStack(w http.ResponseWriter, r *http.Request) {
+	orgID, err := getRequiredOrgIDFromQuery(r.URL.Query())
+	if err != nil {
+		s.api.Err(w, err)
+		return
+	}
+
+	stackID, err := influxdb.IDFromString(chi.URLParam(r, "stack_id"))
+	if err != nil {
+		s.api.Err(w, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "the stack id provided in the path was invalid",
+			Err:  err,
+		})
+		return
+	}
+
+	auth, err := pctx.GetAuthorizer(r.Context())
+	if err != nil {
+		s.api.Err(w, err)
+		return
+	}
+	userID := auth.GetUserID()
+
+	err = s.svc.DeleteStack(r.Context(), struct{ OrgID, UserID, StackID influxdb.ID }{
+		OrgID:   orgID,
+		UserID:  userID,
+		StackID: *stackID,
+	})
+	if err != nil {
+		s.api.Err(w, err)
+		return
+	}
+
+	s.api.Respond(w, http.StatusNoContent, nil)
+}
+
+func getRequiredOrgIDFromQuery(q url.Values) (influxdb.ID, error) {
+	orgIDRaw := q.Get("orgID")
+	if orgIDRaw == "" {
+		return 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "the orgID query param is required",
+		}
+	}
+
+	orgID, err := influxdb.IDFromString(orgIDRaw)
+	if err != nil {
+		return 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "the orgID query param was invalid",
+			Err:  err,
+		}
+	}
+	return *orgID, nil
 }
 
 // ReqCreateOrgIDOpt provides options to export resources by organization id.

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -837,6 +837,10 @@ func (f *fakeSVC) InitStack(ctx context.Context, userID influxdb.ID, stack pkger
 	return f.initStack(ctx, userID, stack)
 }
 
+func (f *fakeSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
+	panic("not implemented yet")
+}
+
 func (f *fakeSVC) ListStacks(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error) {
 	if f.listStacksFn == nil {
 		panic("not implemented")

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -36,6 +36,14 @@ func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Sta
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *authMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
+	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, ResourceTypeStack)
+	if err != nil {
+		return err
+	}
+	return s.next.DeleteStack(ctx, identifiers)
+}
+
 func (s *authMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	err := s.authAgent.OrgPermissions(ctx, orgID, influxdb.ReadAction)
 	if err != nil {

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -43,6 +43,24 @@ func (s *loggingMW) InitStack(ctx context.Context, userID influxdb.ID, newStack 
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *loggingMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (err error) {
+	defer func(start time.Time) {
+		if err == nil {
+			return
+		}
+
+		s.logger.Error(
+			"failed to delete stack",
+			zap.Error(err),
+			zap.Stringer("orgID", identifiers.OrgID),
+			zap.Stringer("userID", identifiers.OrgID),
+			zap.Stringer("stackID", identifiers.StackID),
+			zap.Duration("took", time.Since(start)),
+		)
+	}(time.Now())
+	return s.next.DeleteStack(ctx, identifiers)
+}
+
 func (s *loggingMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) (stacks []Stack, err error) {
 	defer func(start time.Time) {
 		if err == nil {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -33,6 +33,11 @@ func (s *mwMetrics) InitStack(ctx context.Context, userID influxdb.ID, newStack 
 	return stack, rec(err)
 }
 
+func (s *mwMetrics) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
+	rec := s.rec.Record("delete_stack")
+	return rec(s.next.DeleteStack(ctx, identifiers))
+}
+
 func (s *mwMetrics) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	rec := s.rec.Record("list_stacks")
 	stacks, err := s.next.ListStacks(ctx, orgID, f)

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -27,6 +27,12 @@ func (s *traceMW) InitStack(ctx context.Context, userID influxdb.ID, newStack St
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *traceMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
+	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "DeleteStack")
+	defer span.Finish()
+	return s.next.DeleteStack(ctx, identifiers)
+}
+
 func (s *traceMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "ListStacks")
 	defer span.Finish()


### PR DESCRIPTION
closes: #17554

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)