### PR TITLE
feat(storage): convert ResultSet to table stream for aggregate window

### DIFF
--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -401,6 +401,59 @@ const (
 	valueColIdx = 3
 )
 
+func determineTableColsForWindowAggregate(tags models.Tags, typ flux.ColType, aggregate bool) ([]flux.ColMeta, [][]byte) {
+	var size int
+	var cols []flux.ColMeta
+	var defs [][]byte
+
+	if aggregate {
+		// aggregates remove the _time column
+		size = 3
+		cols = make([]flux.ColMeta, size+len(tags))
+		defs = make([][]byte, size+len(tags))
+		cols[0] = flux.ColMeta{
+			Label: execute.DefaultStartColLabel,
+			Type:  flux.TTime,
+		}
+		cols[1] = flux.ColMeta{
+			Label: execute.DefaultStopColLabel,
+			Type:  flux.TTime,
+		}
+		cols[2] = flux.ColMeta{
+			Label: execute.DefaultValueColLabel,
+			Type:  typ,
+		}
+	} else {
+		size = 4
+		cols = make([]flux.ColMeta, size+len(tags))
+		defs = make([][]byte, size+len(tags))
+		cols[0] = flux.ColMeta{
+			Label: execute.DefaultStartColLabel,
+			Type:  flux.TTime,
+		}
+		cols[1] = flux.ColMeta{
+			Label: execute.DefaultStopColLabel,
+			Type:  flux.TTime,
+		}
+		cols[2] = flux.ColMeta{
+			Label: execute.DefaultTimeColLabel,
+			Type:  flux.TTime,
+		}
+		cols[3] = flux.ColMeta{
+			Label: execute.DefaultValueColLabel,
+			Type:  typ,
+		}
+	}
+	for j, tag := range tags {
+		cols[size+j] = flux.ColMeta{
+			Label: string(tag.Key),
+			Type:  flux.TString,
+		}
+		defs[size+j] = []byte("")
+	}
+	return cols, defs
+}
+
 func determineTableColsForSeries(tags models.Tags, typ flux.ColType) ([]flux.ColMeta, [][]byte) {
 	cols := make([]flux.ColMeta, 4+len(tags))
 	defs := make([][]byte, 4+len(tags))
@@ -540,10 +593,13 @@ func (wai *windowAggregateIterator) Do(f func(flux.Table) error) error {
 
 	req.WindowEvery = wai.spec.WindowEvery
 	req.Aggregate = make([]*datatypes.Aggregate, len(wai.spec.Aggregates))
+
+	aggregate := false
 	for i, aggKind := range wai.spec.Aggregates {
 		if agg, err := determineAggregateMethod(string(aggKind)); err != nil {
 			return err
 		} else if agg != datatypes.AggregateTypeNone {
+			aggregate = true
 			req.Aggregate[i] = &datatypes.Aggregate{Type: agg}
 		}
 	}
@@ -560,11 +616,81 @@ func (wai *windowAggregateIterator) Do(f func(flux.Table) error) error {
 	if rs == nil {
 		return nil
 	}
-	return wai.handleRead(f, rs)
+	return wai.handleRead(f, rs, aggregate)
 }
 
-func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs storage.ResultSet) error {
-	return nil
+func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs storage.ResultSet, aggregate bool) error {
+	// these resources must be closed if not nil on return
+	var (
+		cur   cursors.Cursor
+		table storageTable
+	)
+
+	defer func() {
+		if table != nil {
+			table.Close()
+		}
+		if cur != nil {
+			cur.Close()
+		}
+		rs.Close()
+		wai.cache.Release()
+	}()
+
+READ:
+	for rs.Next() {
+		cur = rs.Cursor()
+		if cur == nil {
+			// no data for series key + field combination
+			continue
+		}
+
+		bnds := wai.spec.Bounds
+		key := defaultGroupKeyForSeries(rs.Tags(), bnds)
+		done := make(chan struct{})
+		switch typedCur := cur.(type) {
+		case cursors.IntegerArrayCursor:
+			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TInt, aggregate)
+			table = newIntegerTable(done, typedCur, bnds, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+		case cursors.FloatArrayCursor:
+			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TFloat, aggregate)
+			table = newFloatTable(done, typedCur, bnds, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+		case cursors.UnsignedArrayCursor:
+			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TUInt, aggregate)
+			table = newUnsignedTable(done, typedCur, bnds, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+		case cursors.BooleanArrayCursor:
+			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TBool, aggregate)
+			table = newBooleanTable(done, typedCur, bnds, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+		case cursors.StringArrayCursor:
+			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TString, aggregate)
+			table = newStringTable(done, typedCur, bnds, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+		default:
+			panic(fmt.Sprintf("unreachable: %T", typedCur))
+		}
+
+		cur = nil
+
+		if !table.Empty() {
+			if err := f(table); err != nil {
+				table.Close()
+				table = nil
+				return err
+			}
+			select {
+			case <-done:
+			case <-wai.ctx.Done():
+				table.Cancel()
+				break READ
+			}
+		}
+
+		stats := table.Statistics()
+		wai.stats.ScannedValues += stats.ScannedValues
+		wai.stats.ScannedBytes += stats.ScannedBytes
+		table.Close()
+		table = nil
+	}
+	return rs.Err()
 }
 
 type tagKeysIterator struct {


### PR DESCRIPTION
`handleRead` consumes an aggregate window `ResultSet` and translates it to a flux table stream.

Note this relies on a `WindowAggregateStore` producing a `ResultSet` type upon reading. @rockstar let me know if this is not a valid assumption.
