### PR TITLE
refactor!: replace authorizer.Allowed method with PermissionSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 1. [18066](https://github.com/influxdata/influxdb/pull/18066): Fixed bug that wasn't persisting timeFormat for Graph + Single Stat selections
+1. [17959](https://github.com/influxdata/influxdb/pull/17959): Authorizer now exposes full permission set
 
 ### UI Improvements
 

--- a/auth.go
+++ b/auth.go
@@ -46,14 +46,16 @@ func (a *Authorization) Valid() error {
 	return nil
 }
 
-// Allowed returns true if the authorization is active and request permission
-// exists in the authorization's list of permissions.
-func (a *Authorization) Allowed(p Permission) bool {
+// PermissionSet returns the set of permissions associated with the Authorization.
+func (a *Authorization) PermissionSet() (PermissionSet, error) {
 	if !a.IsActive() {
-		return false
+		return nil, &Error{
+			Code: EUnauthorized,
+			Msg:  "token is inactive",
+		}
 	}
 
-	return PermissionAllowed(p, a.Permissions)
+	return a.Permissions, nil
 }
 
 // IsActive is a stub for idpe.

--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -9,8 +9,13 @@ import (
 )
 
 func isAllowedAll(a influxdb.Authorizer, permissions []influxdb.Permission) error {
+	pset, err := a.PermissionSet()
+	if err != nil {
+		return err
+	}
+
 	for _, p := range permissions {
-		if !a.Allowed(p) {
+		if !pset.Allowed(p) {
 			return &influxdb.Error{
 				Code: influxdb.EUnauthorized,
 				Msg:  fmt.Sprintf("%s is unauthorized", p),
@@ -47,8 +52,12 @@ func IsAllowedAny(ctx context.Context, permissions []influxdb.Permission) error 
 	if err != nil {
 		return err
 	}
+	pset, err := a.PermissionSet()
+	if err != nil {
+		return err
+	}
 	for _, p := range permissions {
-		if a.Allowed(p) {
+		if pset.Allowed(p) {
 			return nil
 		}
 	}

--- a/authz.go
+++ b/authz.go
@@ -17,8 +17,8 @@ var (
 
 // Authorizer will authorize a permission.
 type Authorizer interface {
-	// Allowed returns true is the associated permission is allowed by the authorizer
-	Allowed(p Permission) bool
+	// PermissionSet returns the PermissionSet associated with the authorizer
+	PermissionSet() (PermissionSet, error)
 
 	// ID returns an identifier used for auditing.
 	Identifier() ID
@@ -199,6 +199,12 @@ func (t ResourceType) Valid() (err error) {
 	}
 
 	return err
+}
+
+type PermissionSet []Permission
+
+func (ps PermissionSet) Allowed(p Permission) bool {
+	return PermissionAllowed(p, ps)
 }
 
 // Permission defines an action and a resource.

--- a/http/delete_handler.go
+++ b/http/delete_handler.go
@@ -105,7 +105,7 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.Allowed(*p) {
+	if pset, err := a.PermissionSet(); err != nil || !pset.Allowed(*p) {
 		h.HandleHTTPError(ctx, &influxdb.Error{
 			Code: influxdb.EForbidden,
 			Op:   "http/handleDelete",

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -244,8 +244,8 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.Allowed(*p) {
-		handleError(err, influxdb.EForbidden, "insufficient permissions for write")
+	if pset, err := a.PermissionSet(); err != nil || !pset.Allowed(*p) {
+		handleError(nil, influxdb.EForbidden, "insufficient permissions for write")
 		return
 	}
 

--- a/jsonweb/token.go
+++ b/jsonweb/token.go
@@ -93,20 +93,9 @@ type Token struct {
 	UserID string `json:"uid,omitempty"`
 }
 
-// Allowed returns whether or not a permission is allowed based
-// on the set of permissions within the Token
-func (t *Token) Allowed(p influxdb.Permission) bool {
-	if err := p.Valid(); err != nil {
-		return false
-	}
-
-	for _, perm := range t.Permissions {
-		if perm.Matches(p) {
-			return true
-		}
-	}
-
-	return false
+// PermissionSet returns the set of permissions associated with the token.
+func (t *Token) PermissionSet() (influxdb.PermissionSet, error) {
+	return t.Permissions, nil
 }
 
 // Identifier returns the identifier for this Token

--- a/mock/authorization.go
+++ b/mock/authorization.go
@@ -4,6 +4,9 @@ import (
 	influxdb "github.com/influxdata/influxdb/v2"
 )
 
+// ensure Authorizer implements influxdb.Authorizer
+var _ influxdb.Authorizer = (*Authorizer)(nil)
+
 // Authorizer is an Authorizer for testing that can allow everything or use specific permissions
 type Authorizer struct {
 	Permissions []influxdb.Permission
@@ -22,11 +25,12 @@ func NewMockAuthorizer(allowAll bool, permissions []influxdb.Permission) *Author
 	}
 }
 
-func (a *Authorizer) Allowed(p influxdb.Permission) bool {
+func (a *Authorizer) PermissionSet() (influxdb.PermissionSet, error) {
 	if a.AllowAll {
-		return true
+		return influxdb.OperPermissions(), nil
 	}
-	return influxdb.PermissionAllowed(p, a.Permissions)
+
+	return a.Permissions, nil
 }
 
 func (a *Authorizer) Identifier() influxdb.ID {

--- a/session.go
+++ b/session.go
@@ -54,14 +54,16 @@ func (s *Session) Expired() error {
 	return nil
 }
 
-// Allowed returns true if the authorization is unexpired and request permission
-// exists in the sessions list of permissions.
-func (s *Session) Allowed(p Permission) bool {
+// PermissionSet returns the set of permissions associated with the session.
+func (s *Session) PermissionSet() (PermissionSet, error) {
 	if err := s.Expired(); err != nil {
-		return false
+		return nil, &Error{
+			Code: EUnauthorized,
+			Err:  err,
+		}
 	}
 
-	return PermissionAllowed(p, s.Permissions)
+	return s.Permissions, nil
 }
 
 // Kind returns session and is used for auditing.


### PR DESCRIPTION
This is a proposal to change the shape of the Authorizer interface.
Each of our authorizers use a slice of Permissions to evaluate whether a single supplied permission is allowed. This changes that contract to simply return the set of permissions and allow the consumer to validate them itself. The `Allowed` method still exists, though now it just exists on the new type `PermissionSet` which is the slice of Permissions.

One advantage of this will be the ability to derive from an authorizer which organizations the authorizer has access to read or write without going via a URM service.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
