### PR TITLE
fix(queryBuilder): display loading text

### DIFF
--- a/ui/src/shared/components/SearchableDropdown.tsx
+++ b/ui/src/shared/components/SearchableDropdown.tsx
@@ -75,7 +75,9 @@ export default class SearchableDropdown extends Component<Props> {
             size={buttonSize}
             status={buttonStatus}
           >
-            {selectedOption}
+            {buttonStatus === ComponentStatus.Loading
+              ? 'Loading...'
+              : selectedOption}
           </Dropdown.Button>
         )}
         menu={onCollapse => (

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -82,7 +82,10 @@ const setBuilderTagKeys = (index: number, keys: string[]) => ({
   payload: {index, keys},
 })
 
-const setBuilderTagKeysStatus = (index: number, status: RemoteDataState) => ({
+export const setBuilderTagKeysStatus = (
+  index: number,
+  status: RemoteDataState
+) => ({
   type: 'SET_BUILDER_TAG_KEYS_STATUS' as 'SET_BUILDER_TAG_KEYS_STATUS',
   payload: {index, status},
 })
@@ -204,6 +207,7 @@ export const loadTagSelector = (index: number) => async (
   if (!tags[index] || !buckets[0]) {
     return
   }
+
   dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Loading))
 
   const state = getState()

--- a/ui/src/timeMachine/components/TagSelector.tsx
+++ b/ui/src/timeMachine/components/TagSelector.tsx
@@ -198,7 +198,10 @@ class TagSelector extends PureComponent<Props> {
       )
     }
 
-    if (valuesStatus === RemoteDataState.Loading) {
+    if (
+      valuesStatus === RemoteDataState.Loading ||
+      valuesStatus === RemoteDataState.NotStarted
+    ) {
       return (
         <BuilderCard.Empty>
           <WaitingText text="Loading tag values" />

--- a/ui/src/timeMachine/reducers/index.test.ts
+++ b/ui/src/timeMachine/reducers/index.test.ts
@@ -5,14 +5,16 @@ import {
   initialState,
   initialStateHelper,
   timeMachinesReducer,
+  timeMachineReducer,
 } from 'src/timeMachine/reducers'
+import {setBuilderTagKeysStatus} from 'src/timeMachine/actions/queryBuilder'
 
 import {RemoteDataState, TableViewProperties} from 'src/types'
 
 describe('the Time Machine reducer', () => {
   describe('setting the default aggregateFunctionType', () => {
     const store = createStore(timeMachinesReducer, initialState())
-    const expectedAggregatefunctionType = initialStateHelper().queryBuilder
+    const expectedAggregateFunctionType = initialStateHelper().queryBuilder
       .tags[0].aggregateFunctionType
 
     it('is set when setting a builder bucket selection', () => {
@@ -26,7 +28,7 @@ describe('the Time Machine reducer', () => {
           .aggregateFunctionType
 
       expect(defaultAggregateFunctionType).toEqual(
-        expectedAggregatefunctionType
+        expectedAggregateFunctionType
       )
     })
 
@@ -38,8 +40,25 @@ describe('the Time Machine reducer', () => {
           .aggregateFunctionType
 
       expect(defaultAggregateFunctionType).toEqual(
-        expectedAggregatefunctionType
+        expectedAggregateFunctionType
       )
+    })
+  })
+
+  describe('setBuilderTagKeyStatus', () => {
+    it('sets tagValues "status" to "NotStarted" when tagKeys are "Loading"', () => {
+      const {Loading, NotStarted} = RemoteDataState
+      const dataExplorer = initialState().timeMachines.de
+      dataExplorer.queryBuilder.tags[0].keysStatus = RemoteDataState.Done
+      dataExplorer.queryBuilder.tags[0].valuesStatus = RemoteDataState.Done
+
+      const state = timeMachineReducer(
+        dataExplorer,
+        setBuilderTagKeysStatus(0, Loading)
+      )
+
+      expect(state.queryBuilder.tags[0].keysStatus).toBe(Loading)
+      expect(state.queryBuilder.tags[0].valuesStatus).toBe(NotStarted)
     })
   })
 

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -764,6 +764,7 @@ export const timeMachineReducer = (
         tags[index].keysStatus = status
 
         if (status === RemoteDataState.Loading) {
+          tags[index].valuesStatus = RemoteDataState.NotStarted
           for (let i = index + 1; i < tags.length; i++) {
             tags[i].keysStatus = RemoteDataState.NotStarted
           }


### PR DESCRIPTION
Closes #17816

### The Problem
After selecting a list of buckets we would go fetch some tagKeys.  Then, we would go fetch some tagValues for said tagKeys.  If no tagValues returned we would set tagValues to `[]` and tagValues `RemoteDataState` to `Done`. 

 With me so far? Great.  

So, the problem occurs after picking a new bucket or tagKey that have tagValues _after_ picking a bucket or tagKey that don't have values .  The state of `Done` and `[]` still existed for tagValues when fetching the new `tagKeys` which caught [this guard clause](https://github.com/influxdata/influxdb/blob/master/ui/src/timeMachine/components/TagSelector.tsx#L209) rendering a confusing message to the user.  

### The Solution
Refresh the tagValues `RemoteDataState` to `NotStarted` when fetching new tagKeys =).

### Notes
This includes a test.  We should write more of these.

### See The Fix in Action! 

You can see it broken in #17963 (@russorat here you go!)

![Kapture 2020-05-05 at 11 49 02](https://user-images.githubusercontent.com/7582765/81103840-796bd400-8ec6-11ea-9a70-3d6e3d18147b.gif)
