### PR TITLE
feat(ui): hide the "Upgrade Now" button for Cloud users when appropriate

### DIFF
--- a/ui/src/cloud/actions/orgsettings.ts
+++ b/ui/src/cloud/actions/orgsettings.ts
@@ -1,0 +1,48 @@
+// API
+import {getOrgSettings as getOrgSettingsAJAX} from 'src/cloud/apis/orgsettings'
+
+// Constants
+import {FREE_ORG_HIDE_UPGRADE_SETTING} from 'src/cloud/constants'
+
+// Types
+import {GetState, OrgSetting} from 'src/types'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+export enum ActionTypes {
+  SetOrgSettings = 'SET_ORG_SETTINGS',
+}
+
+export type Actions = SetOrgSettings
+
+export interface SetOrgSettings {
+  type: ActionTypes.SetOrgSettings
+  payload: {orgSettings: OrgSetting[]}
+}
+
+export const setOrgSettings = (settings: OrgSetting[]): SetOrgSettings => {
+  return {
+    type: ActionTypes.SetOrgSettings,
+    payload: {orgSettings: settings},
+  }
+}
+
+export const setFreeOrgSettings = (): SetOrgSettings => {
+  return {
+    type: ActionTypes.SetOrgSettings,
+    payload: {orgSettings: [FREE_ORG_HIDE_UPGRADE_SETTING]},
+  }
+}
+
+export const getOrgSettings = () => async (dispatch, getState: GetState) => {
+  try {
+    const org = getOrg(getState())
+
+    const result = await getOrgSettingsAJAX(org.id)
+    dispatch(setOrgSettings(result.settings))
+  } catch (error) {
+    dispatch(setFreeOrgSettings())
+    console.error(error)
+  }
+}

--- a/ui/src/cloud/actions/orgsettings.ts
+++ b/ui/src/cloud/actions/orgsettings.ts
@@ -21,7 +21,7 @@ export interface SetOrgSettings {
   payload: {orgSettings: OrgSetting[]}
 }
 
-export const setOrgSettings = (settings: OrgSetting[]): SetOrgSettings => {
+export const setOrgSettings = (settings: OrgSetting[] = []): SetOrgSettings => {
   return {
     type: ActionTypes.SetOrgSettings,
     payload: {orgSettings: settings},

--- a/ui/src/cloud/apis/orgsettings.ts
+++ b/ui/src/cloud/apis/orgsettings.ts
@@ -1,13 +1,12 @@
-import AJAX from 'src/utils/ajax'
 import {OrgSettings} from 'src/types'
+import {getAPIBasepath} from 'src/utils/basepath'
 
 export const getOrgSettings = async (orgID: string): Promise<OrgSettings> => {
   try {
-    const {data} = await AJAX({
-      method: 'GET',
-      url: `/api/v2private/orgs/${orgID}/settings`,
-    })
-
+    const response = await fetch(
+      `${getAPIBasepath()}/api/v2private/orgs/${orgID}/settings`
+    )
+    const data = await response.json()
     return data
   } catch (error) {
     console.error(error)

--- a/ui/src/cloud/apis/orgsettings.ts
+++ b/ui/src/cloud/apis/orgsettings.ts
@@ -1,15 +1,7 @@
-import {OrgSettings} from 'src/types'
 import {getAPIBasepath} from 'src/utils/basepath'
+import {OrgSettingsResponse} from 'src/types'
 
-export const getOrgSettings = async (orgID: string): Promise<OrgSettings> => {
-  try {
-    const response = await fetch(
-      `${getAPIBasepath()}/api/v2private/orgs/${orgID}/settings`
-    )
-    const data = await response.json()
-    return data
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
-}
+export const fetchOrgSettings = async (
+  orgID: string
+): Promise<OrgSettingsResponse> =>
+  await fetch(`${getAPIBasepath()}/api/v2private/orgs/${orgID}/settings`)

--- a/ui/src/cloud/apis/orgsettings.ts
+++ b/ui/src/cloud/apis/orgsettings.ts
@@ -1,0 +1,16 @@
+import AJAX from 'src/utils/ajax'
+import {OrgSettings} from 'src/types'
+
+export const getOrgSettings = async (orgID: string): Promise<OrgSettings> => {
+  try {
+    const {data} = await AJAX({
+      method: 'GET',
+      url: `/api/v2private/orgs/${orgID}/settings`,
+    })
+
+    return data
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -1,0 +1,34 @@
+// Libraries
+import {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Actions
+import {getOrgSettings as getOrgSettingsAction} from 'src/cloud/actions/orgsettings'
+
+interface DispatchProps {
+  getOrgSettings: typeof getOrgSettingsAction
+}
+
+class OrgSettings extends PureComponent<DispatchProps> {
+  public componentDidMount() {
+    if (CLOUD) {
+      this.props.getOrgSettings()
+    }
+  }
+
+  public render() {
+    return this.props.children
+  }
+}
+
+const mdtp: DispatchProps = {
+  getOrgSettings: getOrgSettingsAction,
+}
+
+export default connect<{}, DispatchProps, {}>(
+  null,
+  mdtp
+)(OrgSettings)

--- a/ui/src/cloud/constants/index.ts
+++ b/ui/src/cloud/constants/index.ts
@@ -25,3 +25,13 @@ export const DemoDataTemplates = {
     DemoDataDashboards[WebsiteMonitoringBucket]
   ),
 }
+
+export const HIDE_UPGRADE_CTA_KEY = 'hide_upgrade_cta'
+export const FREE_ORG_HIDE_UPGRADE_SETTING = {
+  key: HIDE_UPGRADE_CTA_KEY,
+  value: 'false',
+}
+export const PAID_ORG_HIDE_UPGRADE_SETTING = {
+  key: HIDE_UPGRADE_CTA_KEY,
+  value: 'true',
+}

--- a/ui/src/cloud/reducers/orgsettings.ts
+++ b/ui/src/cloud/reducers/orgsettings.ts
@@ -1,0 +1,26 @@
+import {produce} from 'immer'
+
+import {Actions, ActionTypes} from 'src/cloud/actions/orgsettings'
+import {OrgSetting} from 'src/types'
+
+import {PAID_ORG_HIDE_UPGRADE_SETTING} from 'src/cloud/constants'
+
+export interface OrgSettingsState {
+  settings: OrgSetting[]
+}
+
+export const defaultState: OrgSettingsState = {
+  settings: [PAID_ORG_HIDE_UPGRADE_SETTING],
+}
+
+export const orgSettingsReducer = (
+  state = defaultState,
+  action: Actions
+): OrgSettingsState =>
+  produce(state, draftState => {
+    if (action.type === ActionTypes.SetOrgSettings) {
+      const {orgSettings} = action.payload
+      draftState.settings = orgSettings
+    }
+    return
+  })

--- a/ui/src/cloud/reducers/orgsettings.ts
+++ b/ui/src/cloud/reducers/orgsettings.ts
@@ -1,6 +1,6 @@
 import {produce} from 'immer'
 
-import {Actions, ActionTypes} from 'src/cloud/actions/orgsettings'
+import {Action, SET_ORG_SETTINGS} from 'src/cloud/actions/orgsettings'
 import {OrgSetting} from 'src/types'
 
 import {PAID_ORG_HIDE_UPGRADE_SETTING} from 'src/cloud/constants'
@@ -14,13 +14,12 @@ export const defaultState: OrgSettingsState = {
 }
 
 export const orgSettingsReducer = (
-  state = defaultState,
-  action: Actions
+  state: OrgSettingsState = defaultState,
+  action: Action
 ): OrgSettingsState =>
   produce(state, draftState => {
-    if (action.type === ActionTypes.SetOrgSettings) {
-      const {orgSettings} = action.payload
-      draftState.settings = orgSettings
+    if (action.type === SET_ORG_SETTINGS) {
+      draftState.settings = action.payload.orgSettings
     }
     return
   })

--- a/ui/src/pageLayout/containers/TreeNav.tsx
+++ b/ui/src/pageLayout/containers/TreeNav.tsx
@@ -11,16 +11,21 @@ import NavHeader from 'src/pageLayout/components/NavHeader'
 import CloudUpgradeNavBanner from 'src/shared/components/CloudUpgradeNavBanner'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
+import OrgSettings from 'src/cloud/components/OrgSettings'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
+import {
+  HIDE_UPGRADE_CTA_KEY,
+  PAID_ORG_HIDE_UPGRADE_SETTING,
+} from 'src/cloud/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
 
 // Types
-import {AppState, NavBarState} from 'src/types'
+import {AppState, NavBarState, OrgSetting} from 'src/types'
 
 // Actions
 import {setNavBarState} from 'src/shared/actions/app'
@@ -31,6 +36,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface StateProps {
   isHidden: boolean
   navBarState: NavBarState
+  showUpgradeButton: boolean
 }
 
 interface DispatchProps {
@@ -47,6 +53,7 @@ class TreeSidebar extends PureComponent<Props> {
       params: {orgID},
       navBarState,
       handleSetNavBarState,
+      showUpgradeButton,
     } = this.props
 
     if (isHidden) {
@@ -67,132 +74,134 @@ class TreeSidebar extends PureComponent<Props> {
     const navItems = generateNavItems(orgID)
 
     return (
-      <TreeNav
-        expanded={isExpanded}
-        headerElement={<NavHeader link={orgPrefix} />}
-        userElement={<UserWidget />}
-        onToggleClick={handleToggleNavExpansion}
-        bannerElement={<CloudUpgradeNavBanner />}
-      >
-        {navItems.map(item => {
-          const linkElement = (className: string): JSX.Element => {
-            if (item.link.type === 'href') {
-              return <a href={item.link.location} className={className} />
-            }
+      <OrgSettings>
+        <TreeNav
+          expanded={isExpanded}
+          headerElement={<NavHeader link={orgPrefix} />}
+          userElement={<UserWidget />}
+          onToggleClick={handleToggleNavExpansion}
+          bannerElement={showUpgradeButton ? <CloudUpgradeNavBanner /> : null}
+        >
+          {navItems.map(item => {
+            const linkElement = (className: string): JSX.Element => {
+              if (item.link.type === 'href') {
+                return <a href={item.link.location} className={className} />
+              }
 
-            return <Link to={item.link.location} className={className} />
-          }
-          let navItemElement = (
-            <TreeNav.Item
-              key={item.id}
-              id={item.id}
-              testID={item.testID}
-              icon={<Icon glyph={item.icon} />}
-              label={item.label}
-              shortLabel={item.shortLabel}
-              active={getNavItemActivation(
-                item.activeKeywords,
-                location.pathname
-              )}
-              linkElement={linkElement}
-            >
-              {Boolean(item.menu) && (
-                <TreeNav.SubMenu>
-                  {item.menu.map(menuItem => {
-                    const linkElement = (className: string): JSX.Element => {
-                      if (menuItem.link.type === 'href') {
+              return <Link to={item.link.location} className={className} />
+            }
+            let navItemElement = (
+              <TreeNav.Item
+                key={item.id}
+                id={item.id}
+                testID={item.testID}
+                icon={<Icon glyph={item.icon} />}
+                label={item.label}
+                shortLabel={item.shortLabel}
+                active={getNavItemActivation(
+                  item.activeKeywords,
+                  location.pathname
+                )}
+                linkElement={linkElement}
+              >
+                {Boolean(item.menu) && (
+                  <TreeNav.SubMenu>
+                    {item.menu.map(menuItem => {
+                      const linkElement = (className: string): JSX.Element => {
+                        if (menuItem.link.type === 'href') {
+                          return (
+                            <a
+                              href={menuItem.link.location}
+                              className={className}
+                            />
+                          )
+                        }
+
                         return (
-                          <a
-                            href={menuItem.link.location}
+                          <Link
+                            to={menuItem.link.location}
                             className={className}
                           />
                         )
                       }
 
-                      return (
-                        <Link
-                          to={menuItem.link.location}
-                          className={className}
+                      let navSubItemElement = (
+                        <TreeNav.SubItem
+                          key={menuItem.id}
+                          id={menuItem.id}
+                          testID={menuItem.testID}
+                          active={getNavItemActivation(
+                            [menuItem.id],
+                            location.pathname
+                          )}
+                          label={menuItem.label}
+                          linkElement={linkElement}
                         />
                       )
-                    }
 
-                    let navSubItemElement = (
-                      <TreeNav.SubItem
-                        key={menuItem.id}
-                        id={menuItem.id}
-                        testID={menuItem.testID}
-                        active={getNavItemActivation(
-                          [menuItem.id],
-                          location.pathname
-                        )}
-                        label={menuItem.label}
-                        linkElement={linkElement}
-                      />
-                    )
+                      if (menuItem.cloudExclude) {
+                        navSubItemElement = (
+                          <CloudExclude key={menuItem.id}>
+                            {navSubItemElement}
+                          </CloudExclude>
+                        )
+                      }
 
-                    if (menuItem.cloudExclude) {
-                      navSubItemElement = (
-                        <CloudExclude key={menuItem.id}>
-                          {navSubItemElement}
-                        </CloudExclude>
-                      )
-                    }
+                      if (menuItem.cloudOnly) {
+                        navSubItemElement = (
+                          <CloudOnly key={menuItem.id}>
+                            {navSubItemElement}
+                          </CloudOnly>
+                        )
+                      }
 
-                    if (menuItem.cloudOnly) {
-                      navSubItemElement = (
-                        <CloudOnly key={menuItem.id}>
-                          {navSubItemElement}
-                        </CloudOnly>
-                      )
-                    }
+                      if (menuItem.featureFlag) {
+                        navSubItemElement = (
+                          <FeatureFlag
+                            key={menuItem.id}
+                            name={menuItem.featureFlag}
+                            equals={menuItem.featureFlagValue}
+                          >
+                            {navSubItemElement}
+                          </FeatureFlag>
+                        )
+                      }
 
-                    if (menuItem.featureFlag) {
-                      navSubItemElement = (
-                        <FeatureFlag
-                          key={menuItem.id}
-                          name={menuItem.featureFlag}
-                          equals={menuItem.featureFlagValue}
-                        >
-                          {navSubItemElement}
-                        </FeatureFlag>
-                      )
-                    }
-
-                    return navSubItemElement
-                  })}
-                </TreeNav.SubMenu>
-              )}
-            </TreeNav.Item>
-          )
-
-          if (item.cloudExclude) {
-            navItemElement = (
-              <CloudExclude key={item.id}>{navItemElement}</CloudExclude>
+                      return navSubItemElement
+                    })}
+                  </TreeNav.SubMenu>
+                )}
+              </TreeNav.Item>
             )
-          }
 
-          if (item.cloudOnly) {
-            navItemElement = (
-              <CloudOnly key={item.id}>{navItemElement}</CloudOnly>
-            )
-          }
+            if (item.cloudExclude) {
+              navItemElement = (
+                <CloudExclude key={item.id}>{navItemElement}</CloudExclude>
+              )
+            }
 
-          if (item.featureFlag) {
-            navItemElement = (
-              <FeatureFlag
-                key={item.id}
-                name={item.featureFlag}
-                equals={item.featureFlagValue}
-              >
-                {navItemElement}
-              </FeatureFlag>
-            )
-          }
+            if (item.cloudOnly) {
+              navItemElement = (
+                <CloudOnly key={item.id}>{navItemElement}</CloudOnly>
+              )
+            }
 
-          return navItemElement
-        })}
-      </TreeNav>
+            if (item.featureFlag) {
+              navItemElement = (
+                <FeatureFlag
+                  key={item.id}
+                  name={item.featureFlag}
+                  equals={item.featureFlagValue}
+                >
+                  {navItemElement}
+                </FeatureFlag>
+              )
+            }
+
+            return navItemElement
+          })}
+        </TreeNav>
+      </OrgSettings>
     )
   }
 }
@@ -204,8 +213,18 @@ const mdtp: DispatchProps = {
 const mstp = (state: AppState): StateProps => {
   const isHidden = get(state, 'app.ephemeral.inPresentationMode', false)
   const navBarState = get(state, 'app.persisted.navBarState', 'collapsed')
-
-  return {isHidden, navBarState}
+  const {settings} = get(state, 'cloud.orgSettings')
+  let showUpgradeButton = false
+  const hideUpgradeCTA = settings.find(
+    (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
+  )
+  if (
+    !hideUpgradeCTA ||
+    hideUpgradeCTA.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
+  ) {
+    showUpgradeButton = true
+  }
+  return {isHidden, navBarState, showUpgradeButton}
 }
 
 export default connect<StateProps, DispatchProps>(

--- a/ui/src/pageLayout/containers/TreeNav.tsx
+++ b/ui/src/pageLayout/containers/TreeNav.tsx
@@ -16,16 +16,12 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
-import {
-  HIDE_UPGRADE_CTA_KEY,
-  PAID_ORG_HIDE_UPGRADE_SETTING,
-} from 'src/cloud/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
 
 // Types
-import {AppState, NavBarState, OrgSetting} from 'src/types'
+import {AppState, NavBarState} from 'src/types'
 
 // Actions
 import {setNavBarState} from 'src/shared/actions/app'
@@ -36,7 +32,6 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface StateProps {
   isHidden: boolean
   navBarState: NavBarState
-  showUpgradeButton: boolean
 }
 
 interface DispatchProps {
@@ -53,7 +48,6 @@ class TreeSidebar extends PureComponent<Props> {
       params: {orgID},
       navBarState,
       handleSetNavBarState,
-      showUpgradeButton,
     } = this.props
 
     if (isHidden) {
@@ -80,7 +74,7 @@ class TreeSidebar extends PureComponent<Props> {
           headerElement={<NavHeader link={orgPrefix} />}
           userElement={<UserWidget />}
           onToggleClick={handleToggleNavExpansion}
-          bannerElement={showUpgradeButton ? <CloudUpgradeNavBanner /> : null}
+          bannerElement={<CloudUpgradeNavBanner />}
         >
           {navItems.map(item => {
             const linkElement = (className: string): JSX.Element => {
@@ -213,18 +207,8 @@ const mdtp: DispatchProps = {
 const mstp = (state: AppState): StateProps => {
   const isHidden = get(state, 'app.ephemeral.inPresentationMode', false)
   const navBarState = get(state, 'app.persisted.navBarState', 'collapsed')
-  const {settings} = get(state, 'cloud.orgSettings')
-  let showUpgradeButton = false
-  const hideUpgradeCTA = settings.find(
-    (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
-  )
-  if (
-    !hideUpgradeCTA ||
-    hideUpgradeCTA.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
-  ) {
-    showUpgradeButton = true
-  }
-  return {isHidden, navBarState, showUpgradeButton}
+
+  return {isHidden, navBarState}
 }
 
 export default connect<StateProps, DispatchProps>(

--- a/ui/src/shared/components/CloudUpgradeButton.tsx
+++ b/ui/src/shared/components/CloudUpgradeButton.tsx
@@ -17,13 +17,13 @@ import {
 import {AppState, OrgSetting} from 'src/types'
 
 interface StateProps {
-  show: boolean
+  inView: boolean
 }
 
-const CloudUpgradeButton: FC<StateProps> = ({show}) => {
+const CloudUpgradeButton: FC<StateProps> = ({inView}) => {
   return (
     <CloudOnly>
-      {show ? (
+      {inView ? (
         <Link
           className="cf-button cf-button-sm cf-button-success upgrade-payg--button"
           to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
@@ -41,16 +41,16 @@ const mstp = ({
     orgSettings: {settings},
   },
 }: AppState) => {
-  const hideUpgradeCTA = settings.find(
+  const hideUpgradeButtonSetting = settings.find(
     (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
   )
   if (
-    !hideUpgradeCTA ||
-    hideUpgradeCTA.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
+    !hideUpgradeButtonSetting ||
+    hideUpgradeButtonSetting.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
   ) {
-    return {show: true}
+    return {inView: true}
   }
-  return {show: false}
+  return {inView: false}
 }
 
 export default connect<StateProps>(mstp)(CloudUpgradeButton)

--- a/ui/src/shared/components/CloudUpgradeButton.tsx
+++ b/ui/src/shared/components/CloudUpgradeButton.tsx
@@ -1,25 +1,56 @@
 // Libraries
 import React, {FC} from 'react'
 import {Link} from 'react-router'
+import {connect} from 'react-redux'
 
 // Components
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
 import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
+import {
+  HIDE_UPGRADE_CTA_KEY,
+  PAID_ORG_HIDE_UPGRADE_SETTING,
+} from 'src/cloud/constants'
 
-const CloudUpgradeButton: FC = () => {
+// Types
+import {AppState, OrgSetting} from 'src/types'
+
+interface StateProps {
+  show: boolean
+}
+
+const CloudUpgradeButton: FC<StateProps> = ({show}) => {
   return (
     <CloudOnly>
-      <Link
-        className="cf-button cf-button-sm cf-button-success upgrade-payg--button"
-        to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-        target="_self"
-      >
-        Upgrade Now
-      </Link>
+      {show ? (
+        <Link
+          className="cf-button cf-button-sm cf-button-success upgrade-payg--button"
+          to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+          target="_self"
+        >
+          Upgrade Now
+        </Link>
+      ) : null}
     </CloudOnly>
   )
 }
 
-export default CloudUpgradeButton
+const mstp = ({
+  cloud: {
+    orgSettings: {settings},
+  },
+}: AppState) => {
+  const hideUpgradeCTA = settings.find(
+    (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
+  )
+  if (
+    !hideUpgradeCTA ||
+    hideUpgradeCTA.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
+  ) {
+    return {show: true}
+  }
+  return {show: false}
+}
+
+export default connect<StateProps>(mstp)(CloudUpgradeButton)

--- a/ui/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/ui/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {Link} from 'react-router'
+import {connect} from 'react-redux'
 
 // Components
 import {
@@ -17,44 +18,74 @@ import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
 import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
+import {
+  HIDE_UPGRADE_CTA_KEY,
+  PAID_ORG_HIDE_UPGRADE_SETTING,
+} from 'src/cloud/constants'
 
-const CloudUpgradeNavBanner: FC = () => {
+// Types
+import {AppState, OrgSetting} from 'src/types'
+
+interface StateProps {
+  inView: boolean
+}
+
+const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
   return (
     <>
-      <CloudOnly>
-        <Panel
-          gradient={Gradients.HotelBreakfast}
-          className="cloud-upgrade-banner"
-        >
-          <Panel.Header
-            size={ComponentSize.ExtraSmall}
-            justifyContent={JustifyContent.Center}
+      {inView ? (
+        <CloudOnly>
+          <Panel
+            gradient={Gradients.HotelBreakfast}
+            className="cloud-upgrade-banner"
           >
-            <Heading element={HeadingElement.H5}>
-              Need more wiggle room?
-            </Heading>
-          </Panel.Header>
-          <Panel.Footer size={ComponentSize.ExtraSmall}>
-            <Link
-              className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button"
-              to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-              target="_self"
+            <Panel.Header
+              size={ComponentSize.ExtraSmall}
+              justifyContent={JustifyContent.Center}
             >
-              Upgrade Now
-            </Link>
-          </Panel.Footer>
-        </Panel>
-        <Link
-          className="cloud-upgrade-banner__collapsed"
-          to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-          target="_self"
-        >
-          <Icon glyph={IconFont.Star} />
-          <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
-        </Link>
-      </CloudOnly>
+              <Heading element={HeadingElement.H5}>
+                Need more wiggle room?
+              </Heading>
+            </Panel.Header>
+            <Panel.Footer size={ComponentSize.ExtraSmall}>
+              <Link
+                className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button"
+                to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+                target="_self"
+              >
+                Upgrade Now
+              </Link>
+            </Panel.Footer>
+          </Panel>
+          <Link
+            className="cloud-upgrade-banner__collapsed"
+            to={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+            target="_self"
+          >
+            <Icon glyph={IconFont.Star} />
+            <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
+          </Link>
+        </CloudOnly>
+      ) : null}
     </>
   )
 }
 
-export default CloudUpgradeNavBanner
+const mstp = ({
+  cloud: {
+    orgSettings: {settings},
+  },
+}: AppState) => {
+  const hideUpgradeButtonSetting = settings.find(
+    (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
+  )
+  if (
+    !hideUpgradeButtonSetting ||
+    hideUpgradeButtonSetting.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
+  ) {
+    return {inView: true}
+  }
+  return {inView: false}
+}
+
+export default connect<StateProps>(mstp)(CloudUpgradeNavBanner)

--- a/ui/src/store/configureStore.ts
+++ b/ui/src/store/configureStore.ts
@@ -37,6 +37,10 @@ import {membersReducer} from 'src/members/reducers'
 import {autoRefreshReducer} from 'src/shared/reducers/autoRefresh'
 import {limitsReducer, LimitsState} from 'src/cloud/reducers/limits'
 import {demoDataReducer, DemoDataState} from 'src/cloud/reducers/demodata'
+import {
+  orgSettingsReducer,
+  OrgSettingsState,
+} from 'src/cloud/reducers/orgsettings'
 import checksReducer from 'src/checks/reducers'
 import rulesReducer from 'src/notifications/rules/reducers'
 import endpointsReducer from 'src/notifications/endpoints/reducers'
@@ -58,9 +62,14 @@ export const rootReducer = combineReducers<ReducerState>({
   ...sharedReducers,
   autoRefresh: autoRefreshReducer,
   alertBuilder: alertBuilderReducer,
-  cloud: combineReducers<{limits: LimitsState; demoData: DemoDataState}>({
+  cloud: combineReducers<{
+    limits: LimitsState
+    demoData: DemoDataState
+    orgSettings: OrgSettingsState
+  }>({
     limits: limitsReducer,
     demoData: demoDataReducer,
+    orgSettings: orgSettingsReducer,
   }),
   currentPage: currentPageReducer,
   currentDashboard: currentDashboardReducer,

--- a/ui/src/types/cloud.ts
+++ b/ui/src/types/cloud.ts
@@ -39,3 +39,12 @@ export interface LimitsStatus {
     status: string
   }
 }
+export interface OrgSetting {
+  key: string
+  value: string
+}
+
+export interface OrgSettings {
+  orgID: string
+  settings: OrgSetting[]
+}

--- a/ui/src/types/cloud.ts
+++ b/ui/src/types/cloud.ts
@@ -48,3 +48,9 @@ export interface OrgSettings {
   orgID: string
   settings: OrgSetting[]
 }
+
+export interface OrgSettingsResponse {
+  status: number
+  statusText: string
+  json: () => Promise<OrgSettings>
+}

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -25,6 +25,7 @@ import {LimitsState} from 'src/cloud/reducers/limits'
 import {AlertBuilderState} from 'src/alerting/reducers/alertBuilder'
 import {CurrentPage} from 'src/shared/reducers/currentPage'
 import {DemoDataState} from 'src/cloud/reducers/demodata'
+import {OrgSettingsState} from 'src/cloud/reducers/orgsettings'
 
 import {ResourceState} from 'src/types'
 
@@ -32,7 +33,11 @@ export interface AppState {
   alertBuilder: AlertBuilderState
   app: AppPresentationState
   autoRefresh: AutoRefreshState
-  cloud: {limits: LimitsState; demoData: DemoDataState}
+  cloud: {
+    limits: LimitsState
+    demoData: DemoDataState
+    orgSettings: OrgSettingsState
+  }
   currentPage: CurrentPage
   currentDashboard: CurrentDashboardState
   dataLoading: DataLoadingState


### PR DESCRIPTION
Closes idpe 5891

For Cloud Users only.

To provide the best experience for paid users, by default, we hide the "Upgrade Now" button. The button immediately reveals itself if:
- getting org settings from IDPE results in a failure
- getting org settings from IDPE is successful but a particular setting is not found

The particular setting that we are looking for is updated by Quartz and that functionality will be active soon. For paid users, a successful check on this setting means that the button continues to be hidden.

**Screenshots**

getting org settings fails: **Upgrade Now** button reveals itself
![upgrade_button_on_failure](https://user-images.githubusercontent.com/10736577/81131170-1c404480-8eff-11ea-8af5-da5d6fe60a78.gif)

getting org settings successful but particular setting not found: **Upgrade Now** button reveals itself
![upgrade_button_on_success](https://user-images.githubusercontent.com/10736577/81132309-ca012280-8f02-11ea-9c9e-2b1fd1555c7d.gif)

getting org settings successful and particular setting found: No upgrade button (no need to upgrade)
![no_upgrade_button](https://user-images.githubusercontent.com/10736577/81132553-ae4a4c00-8f03-11ea-9e13-fbb9a0da4126.gif)




