### PR TITLE
docs(clientLibs): improve client docs

### DIFF
--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -69,9 +69,12 @@ const ClientCSharpOverlay: FunctionComponent<Props> = props => {
         defaults={{
           server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -79,50 +82,22 @@ const ClientCSharpOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="C# Code"
-        defaults={{
-          org: 'orgID',
-          bucket: 'bucketID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataDataPointCodeSnippet}
         label="C# Code"
-        defaults={{
-          org: 'orgID',
-          bucket: 'bucketID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 3: Use POCO and corresponding Class to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPocoCodeSnippet}
         label="C# Code"
-        defaults={{
-          org: 'orgID',
-          bucket: 'bucketID',
-        }}
-        values={{
-          org,
-        }}
       />
       <TemplatedCodeSnippet template={pocoClassCodeSnippet} label="C# Code" />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
         label="C# Code"
-        defaults={{
-          org: 'orgID',
-          bucket: 'bucketID',
-        }}
-        values={{
-          org,
-        }}
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -46,11 +46,14 @@ const ClientGoOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="Go Code"
         defaults={{
+          server: 'basepath',
           token: 'token',
-          server: 'serverUrl',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -58,37 +61,16 @@ const ClientGoOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="Go Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPointCodeSnippet}
         label="Go Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
-        label="Java Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
+        label="Go Code"
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -48,35 +48,25 @@ const ClientJSOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="JavaScript Code"
         defaults={{
-          server: 'server',
+          server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="JavaScript Code"
-        defaults={{
-          org: 'orgID',
-          bucket: 'bucketID',
-        }}
-        values={{
-          org,
-        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
         label="JavaScript Code"
-        defaults={{
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -58,11 +58,14 @@ const ClientJavaOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="Java Code"
         defaults={{
-          server: 'serverUrl',
+          server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -70,50 +73,22 @@ const ClientJavaOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="Java Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPointCodeSnippet}
         label="Java Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 3: Use POJO and corresponding class to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPojoCodeSnippet}
         label="Java Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <TemplatedCodeSnippet template={pojoClassCodeSnippet} label="Java Code" />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
         label="Java Code"
-        defaults={{
-          bucket: 'my_bucket',
-          org: 'myorgid',
-        }}
-        values={{
-          org,
-        }}
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
@@ -53,11 +53,14 @@ const ClientPHPOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="PHP Code"
         defaults={{
-          server: 'serverUrl',
+          server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -65,49 +68,21 @@ const ClientPHPOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="PHP Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPointCodeSnippet}
         label="PHP Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 3: Use an Array structure to write data</p>
       <TemplatedCodeSnippet
         template={writingDataArrayCodeSnippet}
         label="PHP Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
-        label="Ruby Code"
-        defaults={{
-          bucket: 'my_bucket',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
+        label="PHP Code"
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -53,11 +53,14 @@ const ClientPythonOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="Python Code"
         defaults={{
-          server: 'serverUrl',
+          server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -65,49 +68,21 @@ const ClientPythonOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="Python Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPointCodeSnippet}
         label="Python Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 3: Use a Batch Sequence to write data</p>
       <TemplatedCodeSnippet
         template={writingDataBatchCodeSnippet}
         label="Python Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
         label="Python Code"
-        defaults={{
-          bucket: 'my_bucket',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
@@ -51,11 +51,14 @@ const ClientRubyOverlay: FunctionComponent<Props> = props => {
         template={initializeClientCodeSnippet}
         label="Ruby Code"
         defaults={{
-          server: 'serverUrl',
+          server: 'basepath',
           token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
         }}
         values={{
           server,
+          org,
         }}
       />
       <h5>Write Data</h5>
@@ -63,61 +66,26 @@ const ClientRubyOverlay: FunctionComponent<Props> = props => {
       <TemplatedCodeSnippet
         template={writingDataLineProtocolCodeSnippet}
         label="Ruby Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
         template={writingDataPointCodeSnippet}
         label="Ruby Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 3: Use a Hash to write data</p>
       <TemplatedCodeSnippet
         template={writingDataHashCodeSnippet}
         label="Ruby Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <p>Option 4: Use a Batch Sequence to write data</p>
       <TemplatedCodeSnippet
         template={writingDataBatchCodeSnippet}
         label="Ruby Code"
-        defaults={{
-          bucket: 'bucketID',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
         template={executeQueryCodeSnippet}
         label="Ruby Code"
-        defaults={{
-          bucket: 'my_bucket',
-          org: 'orgID',
-        }}
-        values={{
-          org,
-        }}
       />
     </ClientLibraryOverlay>
   )

--- a/ui/src/clientLibraries/constants/index.ts
+++ b/ui/src/clientLibraries/constants/index.ts
@@ -22,40 +22,50 @@ export const clientCSharpLibrary = {
   installingPackageManagerCodeSnippet: `Install-Package InfluxDB.Client`,
   installingPackageDotNetCLICodeSnippet: `dotnet add package InfluxDB.Client`,
   packageReferenceCodeSnippet: `<PackageReference Include="InfluxDB.Client" />`,
-  initializeClientCodeSnippet: `using InfluxDB.Client;
+  initializeClientCodeSnippet: `using System;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core;
+using InfluxDB.Client.Writes;
+
 namespace Examples
 {
   public class Examples
   {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
       // You can generate a Token from the "Tokens Tab" in the UI
-      var client = InfluxDBClientFactory.Create("<%= server %>", "<%= token %>".ToCharArray());
+      const string token = "<%= token %>";
+      const string bucket = "<%= bucket %>";
+      const string org = "<%= org %>";
+            
+      var client = InfluxDBClientFactory.Create("<%= server %>", token.ToCharArray());
     }
   }
 }`,
-  executeQueryCodeSnippet: `const string query = "from(bucket: \\"<%= bucket %>\\") |> range(start: -1h)";
-var tables = await client.GetQueryApi().QueryAsync(query, "<%= org %>");`,
-  writingDataLineProtocolCodeSnippet: `const string data = "mem,host=host1 used_percent=23.43234543 1556896326";
+  executeQueryCodeSnippet: `var query = $"from(bucket: \\"{bucket}\\") |> range(start: -1h)";
+var tables = await client.GetQueryApi().QueryAsync(query, org)`,
+  writingDataLineProtocolCodeSnippet: `const string data = "mem,host=host1 used_percent=23.43234543";
 using (var writeApi = client.GetWriteApi())
 {
-  writeApi.WriteRecord("<%= bucket %>", "<%= org %>", WritePrecision.Ns, data);
+  writeApi.WriteRecord(bucket, org, WritePrecision.Ns, data);
 }`,
   writingDataPointCodeSnippet: `var point = PointData
   .Measurement("mem")
   .Tag("host", "host1")
   .Field("used_percent", 23.43234543)
-  .Timestamp(1556896326L, WritePrecision.Ns);
+  .Timestamp(DateTime.UtcNow, WritePrecision.Ns);
 
 using (var writeApi = client.GetWriteApi())
 {
-  writeApi.WritePoint("<%= bucket %>", "<%= org %>", point);
+  writeApi.WritePoint(bucket, org, point);
 }`,
   writingDataPocoCodeSnippet: `var mem = new Mem { Host = "host1", UsedPercent = 23.43234543, Time = DateTime.UtcNow };
 
 using (var writeApi = client.GetWriteApi())
 {
-  writeApi.WriteMeasurement("<%= bucket %>", "<%= org %>", WritePrecision.Ns, mem);
+  writeApi.WriteMeasurement(bucket, org, WritePrecision.Ns, mem);
 }`,
   pocoClassCodeSnippet: `// Public class
 [Measurement("mem")]
@@ -75,44 +85,50 @@ export const clientGoLibrary = {
   initializeClientCodeSnippet: `package main
 
 import (
+  "context"
+  "fmt"
   "github.com/influxdata/influxdb-client-go"
+  "time"
 )
 
 func main() {
-    // You can generate a Token from the "Tokens Tab" in the UI
-    client := influxdb2.NewClient("<%= server %>", "<%= token %>")
-    // always close client at the end
-    defer client.Close()
- }`,
-  writingDataPointCodeSnippet: `// get non-blocking write client
-writeApi := client.WriteApi("<%= org %>", "<%= bucket %>")
-// create point using full params constructor
+  // You can generate a Token from the "Tokens Tab" in the UI
+  const token = "<%= token %>"
+  const bucket = "<%= bucket %>"
+  const org = "<%= org %>"
+
+  client := influxdb2.NewClient("<%= server %>", token)
+  // always close client at the end
+  defer client.Close()
+}`,
+  writingDataPointCodeSnippet: `// create point using full params constructor
 p := influxdb2.NewPoint("stat",
-    map[string]string{"unit": "temperature"},
-    map[string]interface{}{"avg": 24.5, "max": 45},
-    time.Now())
+  map[string]string{"unit": "temperature"},
+  map[string]interface{}{"avg": 24.5, "max": 45},
+  time.Now())
 // write point asynchronously
 writeApi.WritePoint(p)
 // create point using fluent style
 p = influxdb2.NewPointWithMeasurement("stat").
-    AddTag("unit", "temperature").
-    AddField("avg", 23.2).
-    AddField("max", 45).
-    SetTime(time.Now())
+  AddTag("unit", "temperature").
+  AddField("avg", 23.2).
+  AddField("max", 45).
+  SetTime(time.Now())
 // write point asynchronously
 writeApi.WritePoint(p)
 // Flush writes
-write.Flush()`,
+writeApi.Flush()`,
   writingDataLineProtocolCodeSnippet: `// get non-blocking write client
-writeApi := client.WriteApi("<%= org %>", "<%= bucket %>")
-// write  line protocol
+writeApi := client.WriteApi(org, bucket)
+
+// write line protocol
 writeApi.WriteRecord(fmt.Sprintf("stat,unit=temperature avg=%f,max=%f", 23.5, 45.0))
 writeApi.WriteRecord(fmt.Sprintf("stat,unit=temperature avg=%f,max=%f", 22.5, 45.0))
 // Flush writes
-write.Flush()`,
-  executeQueryCodeSnippet: `query := \`from(bucket:"<%= bucket %>")|> range(start: -1h) |> filter(fn: (r) => r._measurement == "stat")\`
+writeApi.Flush()`,
+  executeQueryCodeSnippet: `query := fmt.Sprintf("from(bucket:\\"%v\\")|> range(start: -1h) |> filter(fn: (r) => r._measurement == \\"stat\\")", bucket)
 // Get query client
-queryApi := client.QueryApi("<%= org %>")
+queryApi := client.QueryApi(org)
 // get QueryTableResult
 result, err := queryApi.Query(context.Background(), query)
 if err == nil {
@@ -142,36 +158,50 @@ export const clientJavaLibrary = {
   buildWithMavenCodeSnippet: `<dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.7.0</version>
 </dependency>`,
   buildWithGradleCodeSnippet: `dependencies {
-  compile "com.influxdb:influxdb-client-java:1.5.0"
+  compile "com.influxdb:influxdb-client-java:1.7.0"
 }`,
   initializeClientCodeSnippet: `package example;
 
+import java.time.Instant;
+import java.util.List;
+
+import com.influxdb.annotations.Column;
+import com.influxdb.annotations.Measurement;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.WriteApi;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import com.influxdb.query.FluxTable;
 
 public class InfluxDB2Example {
   public static void main(final String[] args) {
+  
     // You can generate a Token from the "Tokens Tab" in the UI
-    InfluxDBClient client = InfluxDBClientFactory.create("<%= server %>", "<%= token %>".toCharArray());
+    String token = "<%= token %>";
+    String bucket = "<%= bucket %>";
+    String org = "<%= org %>";
+
+    InfluxDBClient client = InfluxDBClientFactory.create("<%= server %>", token.toCharArray());
   }
 }`,
-  executeQueryCodeSnippet: `String query = "from(bucket: \\"<%= bucket %>\\") |> range(start: -1h)";
-List<FluxTable> tables = client.getQueryApi().query(query, "<%= org %>");`,
-  writingDataLineProtocolCodeSnippet: `String data = "mem,host=host1 used_percent=23.43234543 1556896326";
+  executeQueryCodeSnippet: `String query = String.format("from(bucket: \\"%s\\") |> range(start: -1h)", bucket);
+List<FluxTable> tables = client.getQueryApi().query(query, org);`,
+  writingDataLineProtocolCodeSnippet: `String data = "mem,host=host1 used_percent=23.43234543";
 try (WriteApi writeApi = client.getWriteApi()) {
-  writeApi.writeRecord("<%= bucket %>", "<%= org %>", WritePrecision.NS, data);
+  writeApi.writeRecord(bucket, org, WritePrecision.NS, data);
 }`,
   writingDataPointCodeSnippet: `Point point = Point
   .measurement("mem")
   .addTag("host", "host1")
   .addField("used_percent", 23.43234543)
-  .time(1556896326L, WritePrecision.NS);
+  .time(Instant.now(), WritePrecision.NS);
 
 try (WriteApi writeApi = client.getWriteApi()) {
-  writeApi.writePoint("<%= bucket %>", "<%= org %>", point);
+  writeApi.writePoint(bucket, org, point);
 }`,
   writingDataPojoCodeSnippet: `Mem mem = new Mem();
 mem.host = "host1";
@@ -179,10 +209,10 @@ mem.used_percent = 23.43234543;
 mem.time = Instant.now();
 
 try (WriteApi writeApi = client.getWriteApi()) {
-  writeApi.writeMeasurement("<%= bucket %>", "<%= org %>", WritePrecision.NS, mem);
+  writeApi.writeMeasurement(bucket, org, WritePrecision.NS, mem);
 }`,
   pojoClassCodeSnippet: `@Measurement(name = "mem")
-public class Mem {
+public static class Mem {
   @Column(tag = true)
   String host;
   @Column
@@ -199,11 +229,16 @@ export const clientJSLibrary = {
   image: JSLogo,
   initializeNPMCodeSnippet: `npm i @influxdata/influxdb-client`,
   initializeClientCodeSnippet: `const {InfluxDB} = require('@influxdata/influxdb-client')
-// You can generate a Token from the "Tokens Tab" in the UI
-const client = new InfluxDB({url: '<%= server %>', token: '<%= token %>'})`,
-  executeQueryCodeSnippet: `const queryApi = client.getQueryApi('<%= org %>')
 
-const query = 'from(bucket: "my_bucket") |> range(start: -1h)'
+// You can generate a Token from the "Tokens Tab" in the UI
+const token = '<%= token %>'
+const org = '<%= org %>'
+const bucket = '<%= bucket %>'
+
+const client = new InfluxDB({url: '<%= server %>', token: token})`,
+  executeQueryCodeSnippet: `const queryApi = client.getQueryApi(org)
+
+const query = \`from(bucket: \"\${bucket}\") |> range(start: -1h)\`
 queryApi.queryRows(query, {
   next(row, tableMeta) {
     const o = tableMeta.toObject(row)
@@ -219,12 +254,13 @@ queryApi.queryRows(query, {
     console.log('\\nFinished SUCCESS')
   },
 })`,
-  writingDataLineProtocolCodeSnippet: `const writeApi = client.getWriteApi('<%= org %>', '<%= bucket %>')
+  writingDataLineProtocolCodeSnippet: `const writeApi = client.getWriteApi(org, bucket)
   
-const data = 'mem,host=host1 used_percent=23.43234543 1556896326' // Line protocol string
+const data = 'mem,host=host1 used_percent=23.43234543' // Line protocol string
 writeApi.writeRecord(data)
 
-writeApi.close()
+writeApi
+    .close()
     .then(() => {
         console.log('FINISHED')
     })
@@ -240,26 +276,32 @@ export const clientPythonLibrary = {
   url: 'https://github.com/influxdata/influxdb-client-python',
   image: PythonLogo,
   initializePackageCodeSnippet: `pip install influxdb-client`,
-  initializeClientCodeSnippet: `import influxdb_client
-from influxdb_client import InfluxDBClient
+  initializeClientCodeSnippet: `from datetime import datetime
 
-## You can generate a Token from the "Tokens Tab" in the UI
-client = InfluxDBClient(url="<%= server %>", token="<%= token %>")`,
-  executeQueryCodeSnippet: `query = 'from(bucket: "<%= bucket %>") |> range(start: -1h)'
-tables = client.query_api().query(query, org="<%= org %>")`,
-  writingDataLineProtocolCodeSnippet: `write_api = client.write_api()
+from influxdb_client import InfluxDBClient, Point, WritePrecision
+from influxdb_client.client.write_api import SYNCHRONOUS
 
-data = "mem,host=host1 used_percent=23.43234543 1556896326"
-write_api.write("<%= bucket %>", "<%= org %>", data)`,
+# You can generate a Token from the "Tokens Tab" in the UI
+token = "<%= token %>"
+org = "<%= org %>"
+bucket = "<%= bucket %>"
+
+client = InfluxDBClient(url="<%= server %>", token=token)`,
+  executeQueryCodeSnippet: `query = f'from(bucket: \\"{bucket}\\") |> range(start: -1h)'
+tables = client.query_api().query(query, org=org)`,
+  writingDataLineProtocolCodeSnippet: `write_api = client.write_api(write_options=SYNCHRONOUS)
+
+data = "mem,host=host1 used_percent=23.43234543"
+write_api.write(bucket, org, data)`,
   writingDataPointCodeSnippet: `point = Point("mem")\\
   .tag("host", "host1")\\
   .field("used_percent", 23.43234543)\\
-  .time(1556896326, WritePrecision.NS)
+  .time(datetime.utcnow(), WritePrecision.NS)
 
-write_api.write("<%= bucket %>", "<%= org %>", point)`,
-  writingDataBatchCodeSnippet: `sequence = ["mem,host=host1 used_percent=23.43234543 1556896326",
-            "mem,host=host1 available_percent=15.856523 1556896326"]
-write_api.write("<%= bucket %>", "<%= org %>", sequence)`,
+write_api.write(bucket, org, point)`,
+  writingDataBatchCodeSnippet: `sequence = ["mem,host=host1 used_percent=23.43234543",
+            "mem,host=host1 available_percent=15.856523"]
+write_api.write(bucket, org, sequence)`,
 }
 
 export const clientRubyLibrary = {
@@ -268,39 +310,46 @@ export const clientRubyLibrary = {
   url: 'https://github.com/influxdata/influxdb-client-ruby',
   image: RubyLogo,
   initializeGemCodeSnippet: `gem install influxdb-client`,
-  initializeClientCodeSnippet: `## You can generate a Token from the "Tokens Tab" in the UI
-client = InfluxDB2::Client.new('<%= server %>', '<%= token %>')`,
-  executeQueryCodeSnippet: `query = 'from(bucket: "<%= bucket %>") |> range(start: -1h)'
-tables = client.create_query_api.query(query: query, org: '<%= org %>')`,
+  initializeClientCodeSnippet: `require 'influxdb2/client'
+
+# You can generate a Token from the "Tokens Tab" in the UI
+token = '<%= token %>'
+org = '<%= org %>'
+bucket = '<%= bucket %>'
+
+client = InfluxDB2::Client.new('<%= server %>', token,
+  precision: InfluxDB2::WritePrecision::NANOSECOND)`,
+  executeQueryCodeSnippet: `query = "from(bucket: \\"#{bucket}\\") |> range(start: -1h)"
+tables = client.create_query_api.query(query: query, org: org)`,
   writingDataLineProtocolCodeSnippet: `write_api = client.create_write_api
 
-data = 'mem,host=host1 used_percent=23.43234543 1556896326'
-write_api.write(data: data, bucket: '<%= bucket %>', org: '<%= org %>')`,
+data = 'mem,host=host1 used_percent=23.43234543'
+write_api.write(data: data, bucket: bucket, org: org)`,
   writingDataPointCodeSnippet: `point = InfluxDB2::Point.new(name: 'mem')
   .add_tag('host', 'host1')
   .add_field('used_percent', 23.43234543)
-  .time(1_556_896_326, WritePrecision.NS)
+  .time(Time.now.utc, InfluxDB2::WritePrecision::NANOSECOND)
 
-write_api.write(data: point, bucket: '<%= bucket %>', org: '<%= org %>')`,
-  writingDataHashCodeSnippet: `hash = { name: 'h2o',
-  tags: { host: 'aws', region: 'us' },
-  fields: { level: 5, saturation: '99%' },
-  time: 123 }
+write_api.write(data: point, bucket: bucket, org: org)`,
+  writingDataHashCodeSnippet: `hash = {name: 'h2o',
+  tags: {host: 'aws', region: 'us'},
+  fields: {level: 5, saturation: '99%'},
+  time: Time.now.utc}
 
-write_api.write(data: hash, bucket: '<%= bucket %>', org: '<%= org %>')`,
+write_api.write(data: hash, bucket: bucket, org: org)`,
   writingDataBatchCodeSnippet: `point = InfluxDB2::Point.new(name: 'mem')
   .add_tag('host', 'host1')
   .add_field('used_percent', 23.43234543)
-  .time(1_556_896_326, WritePrecision.NS)
- 
-hash = { name: 'h2o',
-  tags: { host: 'aws', region: 'us' },
-  fields: { level: 5, saturation: '99%' },
-  time: 123 }
-  
-data = 'mem,host=host1 used_percent=23.43234543 1556896326'   
-            
-write_api.write(data: [point, hash, data], bucket: '<%= bucket %>', org: '<%= org %>')`,
+  .time(Time.now.utc, InfluxDB2::WritePrecision::NANOSECOND)
+
+hash = {name: 'h2o',
+  tags: {host: 'aws', region: 'us'},
+  fields: {level: 5, saturation: '99%'},
+  time: Time.now.utc}
+
+data = 'mem,host=host1 used_percent=23.23234543'
+
+write_api.write(data: [point, hash, data], bucket: bucket, org: org)`,
 }
 
 export const clientPHPLibrary = {
@@ -309,30 +358,38 @@ export const clientPHPLibrary = {
   url: 'https://github.com/influxdata/influxdb-client-php',
   image: PHPLogo,
   initializeComposerCodeSnippet: `composer require influxdata/influxdb-client-php`,
-  initializeClientCodeSnippet: `## You can generate a Token from the "Tokens Tab" in the UI
-$client = new InfluxDB2\\Client([
-  "url" => "<%= server %>",
-  "token" => "<%= token %>",
-]);`,
-  executeQueryCodeSnippet: `$query = 'from(bucket: "<%= bucket %>") |> range(start: -1h)';
-$tables = $client->createQueryApi()->query($query, '<%= org %>');`,
-  writingDataLineProtocolCodeSnippet: `$writeApi = $client->createWriteApi();
-  
-$data = "mem,host=host1 used_percent=23.43234543 1556896326";
+  initializeClientCodeSnippet: `use InfluxDB2\\Client;
+use InfluxDB2\\Model\\WritePrecision;
+use InfluxDB2\\Point;
 
-$writeApi->write($data, \\InfluxDB2\\Model\\WritePrecision::S, '<%= bucket %>', '<%= org %>');`,
-  writingDataPointCodeSnippet: `$point = \\InfluxDB2\\Point::measurement('mem')
+# You can generate a Token from the "Tokens Tab" in the UI
+$token = '<%= token %>';
+$org = '<%= org %>';
+$bucket = '<%= bucket %>';
+
+$client = new Client([
+    "url" => "<%= server %>",
+    "token" => $token,
+]);`,
+  executeQueryCodeSnippet: `$query = "from(bucket: \\"{$bucket}\\") |> range(start: -1h)";
+$tables = $client->createQueryApi()->query($query, $org);`,
+  writingDataLineProtocolCodeSnippet: `$writeApi = $client->createWriteApi();
+
+$data = "mem,host=host1 used_percent=23.43234543";
+
+$writeApi->write($data, WritePrecision::S, $bucket, $org);`,
+  writingDataPointCodeSnippet: `$point = Point::measurement('mem')
   ->addTag('host', 'host1')
   ->addField('used_percent', 23.43234543)
-  ->time(1556896326);
+  ->time(microtime(true));
 
-$writeApi->write($point, \\InfluxDB2\\Model\\WritePrecision::S, '<%= bucket %>', '<%= org %>');`,
+$writeApi->write($point, WritePrecision::S, $bucket, $org);`,
   writingDataArrayCodeSnippet: `$dataArray = ['name' => 'cpu',
   'tags' => ['host' => 'server_nl', 'region' => 'us'],
   'fields' => ['internal' => 5, 'external' => 6],
   'time' => microtime(true)];
 
-$writeApi->write($dataArray, \\InfluxDB2\\Model\\WritePrecision::S, '<%= bucket %>', '<%= org %>');`,
+$writeApi->write($dataArray, WritePrecision::S, $bucket, $org);`,
 }
 
 export const clientLibraries: ClientLibrary[] = [


### PR DESCRIPTION
* `Initialize the Client` always contains full range of required imports
* `Initialize the Client` contains `org`, `bucket` and `token` constant for reuse on all places
* Timestamps are always current time => user view written data in default settings of DataExplorer

### C#
![c#](https://user-images.githubusercontent.com/455137/81167231-2f055880-8f95-11ea-9823-4fa44edcf671.png)

### GO
![Screenshot 2020-05-06 at 12 29 27](https://user-images.githubusercontent.com/455137/81167297-493f3680-8f95-11ea-9dbe-d9a2b2e253cc.png)

### Java
![Screenshot 2020-05-06 at 12 30 10](https://user-images.githubusercontent.com/455137/81167351-5c520680-8f95-11ea-90aa-237dafbd9f53.png)

### JavaScript/Node.js
![Screenshot 2020-05-06 at 12 30 54](https://user-images.githubusercontent.com/455137/81167412-74c22100-8f95-11ea-82e0-56a61e3f6188.png)

### PHP
![Screenshot 2020-05-06 at 12 31 27](https://user-images.githubusercontent.com/455137/81167458-886d8780-8f95-11ea-9508-b39f90cf1322.png)

### Python
![Screenshot 2020-05-06 at 12 31 55](https://user-images.githubusercontent.com/455137/81167496-97543a00-8f95-11ea-82a2-b0233e1e6891.png)

### Ruby
![Screenshot 2020-05-06 at 12 32 46](https://user-images.githubusercontent.com/455137/81167571-b783f900-8f95-11ea-9bc6-3a2da83bf19f.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
