### PR TITLE
refactor: remove urm and org service from check service interface definition

### DIFF
--- a/check.go
+++ b/check.go
@@ -48,12 +48,6 @@ var (
 
 // CheckService represents a service for managing checks.
 type CheckService interface {
-	// UserResourceMappingService must be part of all NotificationRuleStore service,
-	// for create, search, delete.
-	UserResourceMappingService
-	// OrganizationService is needed for search filter
-	OrganizationService
-
 	// FindCheckByID returns a single check by ID.
 	FindCheckByID(ctx context.Context, id ID) (Check, error)
 

--- a/kv/check_test.go
+++ b/kv/check_test.go
@@ -14,20 +14,20 @@ func TestBoltCheckService(t *testing.T) {
 	influxdbtesting.CheckService(initBoltCheckService, t)
 }
 
-func initBoltCheckService(f influxdbtesting.CheckFields, t *testing.T) (influxdb.CheckService, string, func()) {
+func initBoltCheckService(f influxdbtesting.CheckFields, t *testing.T) (influxdb.CheckService, *kv.Service, string, func()) {
 	s, closeBolt, err := NewTestBoltStore(t)
 	if err != nil {
 		t.Fatalf("failed to create new kv store: %v", err)
 	}
 
 	svc, op, closeSvc := initCheckService(s, f, t)
-	return svc, op, func() {
+	return svc, svc, op, func() {
 		closeSvc()
 		closeBolt()
 	}
 }
 
-func initCheckService(s kv.Store, f influxdbtesting.CheckFields, t *testing.T) (influxdb.CheckService, string, func()) {
+func initCheckService(s kv.Store, f influxdbtesting.CheckFields, t *testing.T) (*kv.Service, string, func()) {
 	svc := kv.NewService(zaptest.NewLogger(t), s)
 	svc.IDGenerator = f.IDGenerator
 	svc.TimeGenerator = f.TimeGenerator

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/notification"
 	"github.com/influxdata/influxdb/v2/notification/check"
@@ -158,14 +159,16 @@ type CheckFields struct {
 	Tasks                []influxdb.TaskCreate
 }
 
+type checkServiceFactory func(CheckFields, *testing.T) (influxdb.CheckService, *kv.Service, string, func())
+
 type checkServiceF func(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 )
 
 // CheckService tests all the service functions.
 func CheckService(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	tests := []struct {
@@ -210,7 +213,7 @@ func CheckService(
 
 // CreateCheck testing
 func CreateCheck(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -752,7 +755,7 @@ func CreateCheck(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, done := init(tt.fields, t)
+			s, kv, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			createCheck := influxdb.CheckCreate{Check: tt.args.check, Status: influxdb.Active}
@@ -760,7 +763,7 @@ func CreateCheck(
 			influxErrsEqual(t, tt.wants.err, err)
 
 			defer s.DeleteCheck(ctx, tt.args.check.GetID())
-			urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
+			urms, _, err := kv.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
 				ResourceType: influxdb.ChecksResourceType,
 			})
 			if err != nil {
@@ -786,7 +789,7 @@ func CreateCheck(
 
 // FindCheckByID testing
 func FindCheckByID(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -853,7 +856,7 @@ func FindCheckByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -869,7 +872,7 @@ func FindCheckByID(
 
 // FindChecks testing
 func FindChecks(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -1157,7 +1160,7 @@ func FindChecks(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1192,7 +1195,7 @@ func FindChecks(
 
 // DeleteCheck testing
 func DeleteCheck(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -1314,7 +1317,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteCheck(ctx, MustIDBase16(tt.args.ID))
@@ -1339,7 +1342,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 // FindCheck testing
 func FindCheck(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -1434,7 +1437,7 @@ func FindCheck(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 
 			var filter influxdb.CheckFilter
@@ -1457,7 +1460,7 @@ func FindCheck(
 
 // UpdateCheck testing
 func UpdateCheck(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -1701,7 +1704,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1719,7 +1722,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 // PatchCheck testing
 func PatchCheck(
-	init func(CheckFields, *testing.T) (influxdb.CheckService, string, func()),
+	init checkServiceFactory,
 	t *testing.T,
 ) {
 	type args struct {
@@ -1873,7 +1876,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 


### PR DESCRIPTION
This changes removes the URM and Organization services from being embedded in the CheckService interface. Nothing out there needs a CheckService to be a URM or and Org service. This was just a hack for tests.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
