### PR TITLE
feat(http): Allow specific API handlers to be proxied for the Algo-W rollout

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -875,6 +875,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		BackupService:        backupService,
 		KVBackupService:      m.kvService,
 		AuthorizationService: authSvc,
+		AlgoWProxy:           &http.NoopProxyHandler{},
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   storage.NewBucketService(bucketSvc, m.engine),
 		SessionService:                  sessionSvc,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -51,6 +51,8 @@ type APIBackend struct {
 	WriteEventRecorder metric.EventRecorder
 	QueryEventRecorder metric.EventRecorder
 
+	AlgoWProxy FeatureProxyHandler
+
 	PointsWriter                    storage.PointsWriter
 	DeleteService                   influxdb.DeleteService
 	BackupService                   influxdb.BackupService

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -24,6 +24,7 @@ type CheckBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
+	AlgoWProxy                 FeatureProxyHandler
 	TaskService                influxdb.TaskService
 	CheckService               influxdb.CheckService
 	UserResourceMappingService influxdb.UserResourceMappingService
@@ -35,9 +36,9 @@ type CheckBackend struct {
 // NewCheckBackend returns a new instance of CheckBackend.
 func NewCheckBackend(log *zap.Logger, b *APIBackend) *CheckBackend {
 	return &CheckBackend{
-		HTTPErrorHandler: b.HTTPErrorHandler,
-		log:              log,
-
+		HTTPErrorHandler:           b.HTTPErrorHandler,
+		log:                        log,
+		AlgoWProxy:                 b.AlgoWProxy,
 		TaskService:                b.TaskService,
 		CheckService:               b.CheckService,
 		UserResourceMappingService: b.UserResourceMappingService,
@@ -87,13 +88,20 @@ func NewCheckHandler(log *zap.Logger, b *CheckBackend) *CheckHandler {
 		TaskService:                b.TaskService,
 		OrganizationService:        b.OrganizationService,
 	}
-	h.HandlerFunc("POST", prefixChecks, h.handlePostCheck)
+
+	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
+		return &proxyHandler{
+			proxy:   b.AlgoWProxy,
+			handler: h,
+		}
+	}
+	h.Handler("POST", prefixChecks, wrapWithProxy(h.handlePostCheck))
 	h.HandlerFunc("GET", prefixChecks, h.handleGetChecks)
 	h.HandlerFunc("GET", checksIDPath, h.handleGetCheck)
 	h.HandlerFunc("GET", checksIDQueryPath, h.handleGetCheckQuery)
 	h.HandlerFunc("DELETE", checksIDPath, h.handleDeleteCheck)
-	h.HandlerFunc("PUT", checksIDPath, h.handlePutCheck)
-	h.HandlerFunc("PATCH", checksIDPath, h.handlePatchCheck)
+	h.Handler("PUT", checksIDPath, wrapWithProxy(h.handlePutCheck))
+	h.Handler("PATCH", checksIDPath, wrapWithProxy(h.handlePatchCheck))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -89,19 +89,13 @@ func NewCheckHandler(log *zap.Logger, b *CheckBackend) *CheckHandler {
 		OrganizationService:        b.OrganizationService,
 	}
 
-	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
-		return &proxyHandler{
-			proxy:   b.AlgoWProxy,
-			handler: h,
-		}
-	}
-	h.Handler("POST", prefixChecks, wrapWithProxy(h.handlePostCheck))
+	h.Handler("POST", prefixChecks, withFeatureProxy(b.AlgoWProxy, h.handlePostCheck))
 	h.HandlerFunc("GET", prefixChecks, h.handleGetChecks)
 	h.HandlerFunc("GET", checksIDPath, h.handleGetCheck)
 	h.HandlerFunc("GET", checksIDQueryPath, h.handleGetCheckQuery)
 	h.HandlerFunc("DELETE", checksIDPath, h.handleDeleteCheck)
-	h.Handler("PUT", checksIDPath, wrapWithProxy(h.handlePutCheck))
-	h.Handler("PATCH", checksIDPath, wrapWithProxy(h.handlePatchCheck))
+	h.Handler("PUT", checksIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePutCheck))
+	h.Handler("PATCH", checksIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePatchCheck))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -32,9 +32,8 @@ type NotificationEndpointBackend struct {
 // NewNotificationEndpointBackend returns a new instance of NotificationEndpointBackend.
 func NewNotificationEndpointBackend(log *zap.Logger, b *APIBackend) *NotificationEndpointBackend {
 	return &NotificationEndpointBackend{
-		HTTPErrorHandler: b.HTTPErrorHandler,
-		log:              log,
-
+		HTTPErrorHandler:            b.HTTPErrorHandler,
+		log:                         log,
 		NotificationEndpointService: b.NotificationEndpointService,
 		UserResourceMappingService:  b.UserResourceMappingService,
 		LabelService:                b.LabelService,

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -99,19 +99,13 @@ func NewNotificationRuleHandler(log *zap.Logger, b *NotificationRuleBackend) *No
 		TaskService:                 b.TaskService,
 	}
 
-	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
-		return &proxyHandler{
-			proxy:   b.AlgoWProxy,
-			handler: h,
-		}
-	}
-	h.Handler("POST", prefixNotificationRules, wrapWithProxy(h.handlePostNotificationRule))
+	h.Handler("POST", prefixNotificationRules, withFeatureProxy(b.AlgoWProxy, h.handlePostNotificationRule))
 	h.HandlerFunc("GET", prefixNotificationRules, h.handleGetNotificationRules)
 	h.HandlerFunc("GET", notificationRulesIDPath, h.handleGetNotificationRule)
 	h.HandlerFunc("GET", notificationRulesIDQueryPath, h.handleGetNotificationRuleQuery)
 	h.HandlerFunc("DELETE", notificationRulesIDPath, h.handleDeleteNotificationRule)
-	h.Handler("PUT", notificationRulesIDPath, wrapWithProxy(h.handlePutNotificationRule))
-	h.Handler("PATCH", notificationRulesIDPath, wrapWithProxy(h.handlePatchNotificationRule))
+	h.Handler("PUT", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePutNotificationRule))
+	h.Handler("PATCH", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePatchNotificationRule))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -29,6 +29,7 @@ type NotificationRuleBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
+	AlgoWProxy                  FeatureProxyHandler
 	NotificationRuleStore       influxdb.NotificationRuleStore
 	NotificationEndpointService influxdb.NotificationEndpointService
 	UserResourceMappingService  influxdb.UserResourceMappingService
@@ -43,6 +44,7 @@ func NewNotificationRuleBackend(log *zap.Logger, b *APIBackend) *NotificationRul
 	return &NotificationRuleBackend{
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              log,
+		AlgoWProxy:       b.AlgoWProxy,
 
 		NotificationRuleStore:       b.NotificationRuleStore,
 		NotificationEndpointService: b.NotificationEndpointService,
@@ -96,13 +98,20 @@ func NewNotificationRuleHandler(log *zap.Logger, b *NotificationRuleBackend) *No
 		OrganizationService:         b.OrganizationService,
 		TaskService:                 b.TaskService,
 	}
-	h.HandlerFunc("POST", prefixNotificationRules, h.handlePostNotificationRule)
+
+	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
+		return &proxyHandler{
+			proxy:   b.AlgoWProxy,
+			handler: h,
+		}
+	}
+	h.Handler("POST", prefixNotificationRules, wrapWithProxy(h.handlePostNotificationRule))
 	h.HandlerFunc("GET", prefixNotificationRules, h.handleGetNotificationRules)
 	h.HandlerFunc("GET", notificationRulesIDPath, h.handleGetNotificationRule)
 	h.HandlerFunc("GET", notificationRulesIDQueryPath, h.handleGetNotificationRuleQuery)
 	h.HandlerFunc("DELETE", notificationRulesIDPath, h.handleDeleteNotificationRule)
-	h.HandlerFunc("PUT", notificationRulesIDPath, h.handlePutNotificationRule)
-	h.HandlerFunc("PATCH", notificationRulesIDPath, h.handlePatchNotificationRule)
+	h.Handler("PUT", notificationRulesIDPath, wrapWithProxy(h.handlePutNotificationRule))
+	h.Handler("PATCH", notificationRulesIDPath, wrapWithProxy(h.handlePatchNotificationRule))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_rule_test.go
+++ b/http/notification_rule_test.go
@@ -17,6 +17,7 @@ func NewMockNotificationRuleBackend(t *testing.T) *NotificationRuleBackend {
 	return &NotificationRuleBackend{
 		log: zaptest.NewLogger(t),
 
+		AlgoWProxy:                      &NoopProxyHandler{},
 		UserResourceMappingService: mock.NewUserResourceMappingService(),
 		LabelService:               mock.NewLabelService(),
 		UserService:                mock.NewUserService(),

--- a/http/proxy_handler.go
+++ b/http/proxy_handler.go
@@ -4,6 +4,19 @@ import (
 	"net/http"
 )
 
+var _ http.Handler = &proxyHandler{}
+
+// withFeatureProxy wraps an HTTP handler in a proxyHandler
+func withFeatureProxy(proxy FeatureProxyHandler, h http.HandlerFunc) *proxyHandler {
+	if proxy == nil {
+		proxy = &NoopProxyHandler{}
+	}
+	return &proxyHandler{
+		proxy:   proxy,
+		handler: h,
+	}
+}
+
 // proxyHandler is a wrapper around an http.Handler that conditionally forwards
 // a request to another HTTP backend using a proxy. If the proxy doesn't decide
 // to forward the request, we fall-back to our normal http.Handler behavior.

--- a/http/proxy_handler.go
+++ b/http/proxy_handler.go
@@ -1,0 +1,36 @@
+package http
+
+import (
+	"net/http"
+)
+
+// proxyHandler is a wrapper around an http.Handler that conditionally forwards
+// a request to another HTTP backend using a proxy. If the proxy doesn't decide
+// to forward the request, we fall-back to our normal http.Handler behavior.
+type proxyHandler struct {
+	proxy   FeatureProxyHandler
+	handler http.Handler
+}
+
+// ServeHTTP implements http.Handler interface. It first
+func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.proxy.Do(w, r) {
+		return
+	}
+	h.handler.ServeHTTP(w, r)
+}
+
+// FeatureProxyHandler is an HTTP proxy that conditionally forwards requests to
+// another backend.
+type FeatureProxyHandler interface {
+	Do(w http.ResponseWriter, r *http.Request) bool
+}
+
+// NoopProxyHandler is a no-op FeatureProxyHandler. It should be used if
+// no feature-flag driven proxying is necessary.
+type NoopProxyHandler struct{}
+
+// Do implements FeatureProxyHandler.
+func (h *NoopProxyHandler) Do(http.ResponseWriter, *http.Request) bool {
+	return false
+}

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -99,18 +99,11 @@ func NewTaskHandler(log *zap.Logger, b *TaskBackend) *TaskHandler {
 		BucketService:              b.BucketService,
 	}
 
-	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
-		return &proxyHandler{
-			proxy:   b.AlgoWProxy,
-			handler: h,
-		}
-	}
-
 	h.HandlerFunc("GET", prefixTasks, h.handleGetTasks)
-	h.Handler("POST", prefixTasks, wrapWithProxy(h.handlePostTask))
+	h.Handler("POST", prefixTasks, withFeatureProxy(b.AlgoWProxy, h.handlePostTask))
 
 	h.HandlerFunc("GET", tasksIDPath, h.handleGetTask)
-	h.Handler("PATCH", tasksIDPath, wrapWithProxy(h.handleUpdateTask))
+	h.Handler("PATCH", tasksIDPath, withFeatureProxy(b.AlgoWProxy, h.handleUpdateTask))
 	h.HandlerFunc("DELETE", tasksIDPath, h.handleDeleteTask)
 
 	h.HandlerFunc("GET", tasksIDLogsPath, h.handleGetLogs)

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -26,6 +26,7 @@ type TaskBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
+	AlgoWProxy                 FeatureProxyHandler
 	TaskService                influxdb.TaskService
 	AuthorizationService       influxdb.AuthorizationService
 	OrganizationService        influxdb.OrganizationService
@@ -40,6 +41,7 @@ func NewTaskBackend(log *zap.Logger, b *APIBackend) *TaskBackend {
 	return &TaskBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,
 		log:                        log,
+		AlgoWProxy:                 b.AlgoWProxy,
 		TaskService:                b.TaskService,
 		AuthorizationService:       b.AuthorizationService,
 		OrganizationService:        b.OrganizationService,
@@ -97,11 +99,18 @@ func NewTaskHandler(log *zap.Logger, b *TaskBackend) *TaskHandler {
 		BucketService:              b.BucketService,
 	}
 
+	wrapWithProxy := func(h http.HandlerFunc) http.Handler {
+		return &proxyHandler{
+			proxy:   b.AlgoWProxy,
+			handler: h,
+		}
+	}
+
 	h.HandlerFunc("GET", prefixTasks, h.handleGetTasks)
-	h.HandlerFunc("POST", prefixTasks, h.handlePostTask)
+	h.Handler("POST", prefixTasks, wrapWithProxy(h.handlePostTask))
 
 	h.HandlerFunc("GET", tasksIDPath, h.handleGetTask)
-	h.HandlerFunc("PATCH", tasksIDPath, h.handleUpdateTask)
+	h.Handler("PATCH", tasksIDPath, wrapWithProxy(h.handleUpdateTask))
 	h.HandlerFunc("DELETE", tasksIDPath, h.handleDeleteTask)
 
 	h.HandlerFunc("GET", tasksIDLogsPath, h.handleGetLogs)

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -30,6 +30,7 @@ func NewMockTaskBackend(t *testing.T) *TaskBackend {
 	return &TaskBackend{
 		log: zaptest.NewLogger(t).With(zap.String("handler", "task")),
 
+		AlgoWProxy:                &NoopProxyHandler{},
 		AuthorizationService: mock.NewAuthorizationService(),
 		TaskService:          &mock.TaskService{},
 		OrganizationService: &mock.OrganizationService{

--- a/kit/feature/http_proxy.go
+++ b/kit/feature/http_proxy.go
@@ -1,0 +1,65 @@
+package feature
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"go.uber.org/zap"
+)
+
+// HTTPProxy is an HTTP proxy that's guided by a feature flag. If the feature flag
+// presented to it is enabled, it will perform the proxying behavior. Otherwise
+// it will be a no-op.
+type HTTPProxy struct {
+	proxy   *httputil.ReverseProxy
+	logger  *zap.Logger
+	enabler ProxyEnabler
+}
+
+// NewHTTPProxy returns a new Proxy.
+func NewHTTPProxy(dest *url.URL, logger *zap.Logger, enabler ProxyEnabler) *HTTPProxy {
+	return &HTTPProxy{
+		proxy:   newReverseProxy(dest, enabler.Key()),
+		logger:  logger,
+		enabler: enabler,
+	}
+}
+
+// Do performs the proxying. It returns whether or not the request was proxied.
+func (p *HTTPProxy) Do(w http.ResponseWriter, r *http.Request) bool {
+	if p.enabler.Enabled(r.Context()) {
+		p.proxy.ServeHTTP(w, r)
+		return true
+	}
+	return false
+}
+
+const (
+	// headerProxyFlag is the HTTP header for enriching the request and response
+	// with the feature flag key that precipitated the proxying behavior.
+	headerProxyFlag = "X-Proxy-Flag"
+)
+
+// newReverseProxy creates a new single-host reverse proxy.
+func newReverseProxy(dest *url.URL, enablerKey string) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(dest)
+
+	defaultDirector := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		defaultDirector(r)
+		r.Header.Set(headerProxyFlag, enablerKey)
+	}
+	proxy.ModifyResponse = func(r *http.Response) error {
+		r.Header.Set(headerProxyFlag, enablerKey)
+		return nil
+	}
+	return proxy
+}
+
+// ProxyEnabler is a boolean feature flag.
+type ProxyEnabler interface {
+	Key() string
+	Enabled(ctx context.Context, fs ...Flagger) bool
+}

--- a/kit/feature/http_proxy.go
+++ b/kit/feature/http_proxy.go
@@ -39,7 +39,7 @@ func (p *HTTPProxy) Do(w http.ResponseWriter, r *http.Request) bool {
 const (
 	// headerProxyFlag is the HTTP header for enriching the request and response
 	// with the feature flag key that precipitated the proxying behavior.
-	headerProxyFlag = "X-Proxy-Flag"
+	headerProxyFlag = "X-Platform-Proxy-Flag"
 )
 
 // newReverseProxy creates a new single-host reverse proxy.

--- a/kit/feature/http_proxy_test.go
+++ b/kit/feature/http_proxy_test.go
@@ -27,9 +27,9 @@ func TestHTTPProxy_Proxying(t *testing.T) {
 		t.Error(err)
 	}
 
-	proxyFlag := resp.Header.Get("X-Proxy-Flag")
+	proxyFlag := resp.Header.Get("X-Platform-Proxy-Flag")
 	if proxyFlag != flagKey {
-		t.Error("X-Proxy-Flag header not populated")
+		t.Error("X-Platform-Proxy-Flag header not populated")
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -51,9 +51,9 @@ func TestHTTPProxy_DefaultBehavior(t *testing.T) {
 		t.Error(err)
 	}
 
-	proxyFlag := resp.Header.Get("X-Proxy-Flag")
+	proxyFlag := resp.Header.Get("X-Platform-Proxy-Flag")
 	if proxyFlag != "" {
-		t.Error("X-Proxy-Flag header populated")
+		t.Error("X-Platform-Proxy-Flag header populated")
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -69,7 +69,7 @@ func TestHTTPProxy_DefaultBehavior(t *testing.T) {
 
 func TestHTTPProxy_RequestHeader(t *testing.T) {
 	h := func(w http.ResponseWriter, r *http.Request) {
-		proxyFlag := r.Header.Get("X-Proxy-Flag")
+		proxyFlag := r.Header.Get("X-Platform-Proxy-Flag")
 		if proxyFlag != flagKey {
 			t.Error("expected X-Proxy-Flag to contain feature flag key")
 		}

--- a/kit/feature/http_proxy_test.go
+++ b/kit/feature/http_proxy_test.go
@@ -1,0 +1,137 @@
+package feature
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	destBody = "hello from destination"
+	srcBody  = "hello from source"
+	flagKey  = "fancy-feature"
+)
+
+func TestHTTPProxy_Proxying(t *testing.T) {
+	en := enabler{key: flagKey, state: true}
+	logger := zaptest.NewLogger(t)
+	resp, err := testHTTPProxy(logger, en)
+	if err != nil {
+		t.Error(err)
+	}
+
+	proxyFlag := resp.Header.Get("X-Proxy-Flag")
+	if proxyFlag != flagKey {
+		t.Error("X-Proxy-Flag header not populated")
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err)
+	}
+
+	bodyStr := string(body)
+	if bodyStr != destBody {
+		t.Errorf("expected body of destination handler, but got: %q", bodyStr)
+	}
+}
+
+func TestHTTPProxy_DefaultBehavior(t *testing.T) {
+	en := enabler{key: flagKey, state: false}
+	logger := zaptest.NewLogger(t)
+	resp, err := testHTTPProxy(logger, en)
+	if err != nil {
+		t.Error(err)
+	}
+
+	proxyFlag := resp.Header.Get("X-Proxy-Flag")
+	if proxyFlag != "" {
+		t.Error("X-Proxy-Flag header populated")
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err)
+	}
+
+	bodyStr := string(body)
+	if bodyStr != srcBody {
+		t.Errorf("expected body of source handler, but got: %q", bodyStr)
+	}
+}
+
+func TestHTTPProxy_RequestHeader(t *testing.T) {
+	h := func(w http.ResponseWriter, r *http.Request) {
+		proxyFlag := r.Header.Get("X-Proxy-Flag")
+		if proxyFlag != flagKey {
+			t.Error("expected X-Proxy-Flag to contain feature flag key")
+		}
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(h))
+	defer s.Close()
+
+	sURL, err := url.Parse(s.URL)
+	if err != nil {
+		t.Error(err)
+	}
+
+	logger := zaptest.NewLogger(t)
+	en := enabler{key: flagKey, state: true}
+	proxy := NewHTTPProxy(sURL, logger, en)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	srcHandler(proxy)(w, r)
+}
+
+func testHTTPProxy(logger *zap.Logger, enabler ProxyEnabler) (*http.Response, error) {
+	s := httptest.NewServer(http.HandlerFunc(destHandler))
+	defer s.Close()
+
+	sURL, err := url.Parse(s.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := NewHTTPProxy(sURL, logger, enabler)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	srcHandler(proxy)(w, r)
+
+	return w.Result(), nil
+}
+
+func destHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, destBody)
+}
+
+func srcHandler(proxy *HTTPProxy) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if proxy.Do(w, r) {
+			return
+		}
+		fmt.Fprint(w, srcBody)
+	}
+}
+
+type enabler struct {
+	key   string
+	state bool
+}
+
+func (e enabler) Key() string {
+	return e.key
+}
+
+func (e enabler) Enabled(context.Context, ...Flagger) bool {
+	return e.state
+}


### PR DESCRIPTION
This introduces the ability to specify a feature flag driven proxy for specific HTTP handlers known to perform Flux `options` parsing. This change should be seen as a temporary measure to ensure the safe rollout of the Algo-W changes to the API. 

In `influxd`, a no-op structure (`http.NoopProxyHandler`) is used which does not do proxying. The Algo-W branch in our rollout will use this same no-op structure to force the use of in-process logic. The `feature.HTTPProxy` will be used in other contexts to direct the traffic to another endpoint.

The handlers that are targeted in this change are:

- Checks
  - `POST /api/v2/checks`
  - `PUT /api/v2/checks/:id`
  - `PATCH /api/v2/checks/:id`
- Tasks
  - `POST /api/v2/tasks`
  - `PATCH /api/v2/tasks/:id`
- Notification Rules
  - `POST /api/v2/notificationRules`
  - `PUT /api/v2/notificationRules/:id`
  - `PATCH /api/v2/notificationRules/:id`

Open questions:

- Are there any more API endpoints that need to be included in the proxying behavior?