### PR TITLE
refactor: [Swagger] Permission.Resource made top level type

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6993,6 +6993,8 @@ components:
             - read
             - write
         resource:
+          $ref: "#/components/schemas/Resource"
+    Resource:
           type: object
           required: [type]
           properties:


### PR DESCRIPTION
[Permission.Resource](https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L6995) is an embedded object of the `Permission` type in the swagger types definition.
When using [oapi-codegen](https://github.com/deepmap/oapi-codegen) for generating types from the swagger, such type is kept embedded and instantiating such anonymous type requires a  boilerplate code. 
Promoting Resource as a top-level type makes [usage of Authorization API much easier](https://github.com/influxdata/influxdb-client-go/blob/master/client_e2e_test.go#L165).
