### PR TITLE
fix: [Swagger] adding default handler for POST on /setup

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -107,6 +107,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OnboardingResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /documents/templates:
     get:
       operationId: GetDocumentsTemplates


### PR DESCRIPTION
Closes #17972 

Added the default handler for POST on /setup, as it is on other POSTs.