### PR TITLE
chore: multiUser defaults to true

### DIFF
--- a/ui/src/shared/selectors/flags.ts
+++ b/ui/src/shared/selectors/flags.ts
@@ -14,7 +14,7 @@ export const OSS_FLAGS = {
 
 export const CLOUD_FLAGS = {
   deleteWithPredicate: false,
-  multiUser: false,
+  multiUser: true,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
   downloadCellCSV: false,
   telegrafEditor: false,


### PR DESCRIPTION
### What && Why
In preparation for multi user release.  Setting `multiUser` to `true`.  DO NOT MERGE. 