### PR TITLE
feat(demodata): get error message from error for notification

### DIFF
--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -34,6 +34,7 @@ import {
   Dashboard,
 } from 'src/types'
 import {reportError} from 'src/shared/utils/errors'
+import {getErrorMessage} from 'src/utils/api'
 
 export type Actions =
   | ReturnType<typeof setDemoDataStatus>
@@ -124,7 +125,7 @@ export const getDemoDataBucketMembership = ({
 
     dispatch(notify(demoDataSucceeded(bucketName, url)))
   } catch (error) {
-    dispatch(notify(demoDataAddBucketFailed(error)))
+    dispatch(notify(demoDataAddBucketFailed(getErrorMessage(error))))
 
     reportError(error, {
       name: 'getDemoDataBucketMembership function',


### PR DESCRIPTION
I was passing the error object rather than the message from the error object as a string to notifications so app would break. :(