### PR TITLE
fix(API docs): Changing method of set user password to POST

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5425,8 +5425,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   '/users/{userID}/password':
-    put:
-      operationId: PutUsersIDPassword
+    post:
+      operationId: PostUsersIDPassword
       tags:
         - Users
       summary: Update a password


### PR DESCRIPTION
Closes #17919 

Despite the swagger, where update password path defines PUT operation, current server and influx tool implementation requires POST. 
Even  PUT is more suitable, POST is also usable from the RESTfull perspective.

