### PR TITLE
fix(httpd): Fixes key collisions when serializing /debug/vars

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1455,6 +1455,8 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "\"memstats\": %s", val)
 	}
 
+	uniqueKeys := make(map[string]int)
+
 	for _, s := range stats {
 		val, err := json.Marshal(s)
 		if err != nil {
@@ -1486,6 +1488,12 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		key := buf.String()
+		v := uniqueKeys[key]
+		uniqueKeys[key] = v + 1
+		if v > 0 {
+			fmt.Fprintf(buf, ":%d", v)
+			key = buf.String()
+		}
 
 		if !first {
 			fmt.Fprintln(w, ",")


### PR DESCRIPTION
This PR fixes an issue with `serveExpvar` so that it does not generate invalid JSON. Specifically, the improvement was made to prevent key collisions when serializing `[]*monitor.Statistic` values. 

The algorithm works as such:

1. record each statistic key in a map with a count of occurrences
2. if the count > 0, amend key with the suffix `:<count>`

In practice, key collisions for `hh_processor` were observed with Enterprise:

```json
  "hh:/var/lib/influxdb/hh": {"name":"hh",
  "hh_processor": {"name":"hh_processor","tags":{"db"
  "hh_processor": {"name":"hh_processor","tags":{"db"
  "hh_processor": {"name":"hh_processor","tags":{"db"
  "hh_processor": {"name":"hh_processor","tags":{"db"
  "hh_database": {"name":"hh_database","tags":{"db"
```

This change will serialize these values as:

```json
  "hh:/var/lib/influxdb/hh": {"name":"hh",
  "hh_processor": {"name":"hh_processor","tags":{"db"
  "hh_processor:1": {"name":"hh_processor","tags":{"db"
  "hh_processor:2": {"name":"hh_processor","tags":{"db"
  "hh_processor:3": {"name":"hh_processor","tags":{"db"
  "hh_database": {"name":"hh_database","tags":{"db"
```