### PR TITLE
feat(custom-timerange-tz): timeZone dropdown is now integrated in setting custom time ranges for queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,10 +159,6 @@ jobs:
   jstest:
     docker:
       - image: circleci/golang:1.13-node-browsers
-        environment:
-          TZ: "America/Los_Angeles"
-    environment:
-      TZ: "America/Los_Angeles"
     working_directory: /go/src/github.com/influxdata/influxdb
     parallelism: 8
     steps:
@@ -498,7 +494,7 @@ workflows:
   hourly-e2e:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: '0 * * * *'
           filters:
             branches:
               only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 1. [17934](https://github.com/influxdata/influxdb/pull/17934): Add ability to delete a stack and all the resources associated with it
-1. [17992](https://github.com/influxdata/influxdb/pull/17992): Add ability to specify UTC when making custom time range queries
 1. [17941](https://github.com/influxdata/influxdb/pull/17941): Enforce DNS name compliance on all pkger resources' metadata.name field
 1. [17989](https://github.com/influxdata/influxdb/pull/17989): Add stateful pkg management with stacks
 

--- a/ui/src/checks/components/CheckHistory.tsx
+++ b/ui/src/checks/components/CheckHistory.tsx
@@ -21,7 +21,6 @@ import {STATUS_FIELDS} from 'src/alerting/constants/history'
 // Utils
 import {loadStatuses, getInitialState} from 'src/alerting/utils/history'
 import {getCheckIDs} from 'src/checks/selectors'
-import {getTimeZone} from 'src/dashboards/selectors'
 
 // Types
 import {ResourceIDs} from 'src/checks/reducers'
@@ -102,7 +101,7 @@ const CheckHistory: FC<Props> = ({
 }
 
 const mstp = (state: AppState, props: OwnProps) => {
-  const timeZone = getTimeZone(state)
+  const timeZone = state.app.persisted.timeZone
   const checkIDs = getCheckIDs(state)
   const check = getByID<Check>(state, ResourceType.Checks, props.params.checkID)
 

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -1,14 +1,10 @@
 // Funcs
-import {
-  getTimeRange,
-  getTimeRangeWithTimezone,
-} from 'src/dashboards/selectors/index'
+import {getTimeRange} from 'src/dashboards/selectors/index'
 
 // Types
 import {RangeState} from 'src/dashboards/reducers/ranges'
 import {CurrentDashboardState} from 'src/shared/reducers/currentDashboard'
-import {TimeRange, TimeZone, CustomTimeRange} from 'src/types'
-import {AppState as AppPresentationState} from 'src/shared/reducers/app'
+import {TimeRange} from 'src/types'
 
 // Constants
 import {
@@ -22,30 +18,14 @@ const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
   currentDashboard: CurrentDashboardState
 }) => TimeRange
 
-const untypedGetTimeRangeWithTimeZone = getTimeRangeWithTimezone as (a: {
-  ranges: RangeState
-  currentDashboard: CurrentDashboardState
-  app: AppPresentationState
-}) => TimeRange
-
 describe('Dashboards.Selector', () => {
-  const dashboardIDs = [
-    '04c6f3976f4b8001',
-    '04c6f3976f4b8000',
-    '04c6f3976f4b8002',
-  ]
-  const customTimeRange = {
-    lower: '2020-05-05T10:00:00-07:00',
-    upper: '2020-05-05T11:00:00-07:00',
-    type: 'custom',
-  } as CustomTimeRange
+  const dashboardIDs = ['04c6f3976f4b8001', '04c6f3976f4b8000']
   const ranges: RangeState = {
     [dashboardIDs[0]]: pastFifteenMinTimeRange,
     [dashboardIDs[1]]: pastHourTimeRange,
-    [dashboardIDs[2]]: customTimeRange,
   }
 
-  it('should return the correct range when a matching dashboard ID is found', () => {
+  it('should return the the correct range when a matching dashboard ID is found', () => {
     const currentDashboard = {id: dashboardIDs[0]}
 
     expect(
@@ -53,7 +33,7 @@ describe('Dashboards.Selector', () => {
     ).toEqual(pastFifteenMinTimeRange)
   })
 
-  it('should return the default range when no matching dashboard ID is found', () => {
+  it('should return the the default range when no matching dashboard ID is found', () => {
     const currentDashboard = {id: 'Oogum Boogum'}
 
     expect(
@@ -61,58 +41,11 @@ describe('Dashboards.Selector', () => {
     ).toEqual(DEFAULT_TIME_RANGE)
   })
 
-  it('should return the default range when no ranges are passed in', () => {
+  it('should return the the default range when no ranges are passed in', () => {
     const currentDashboard = {id: dashboardIDs[0]}
 
     expect(
       untypedGetTimeRangeByDashboardID({ranges: {}, currentDashboard})
     ).toEqual(DEFAULT_TIME_RANGE)
-  })
-
-  it('should return the an unmodified version of the timeRange when the timeZone is local', () => {
-    const currentDashboard = {id: dashboardIDs[2]}
-    const app: AppPresentationState = {
-      ephemeral: {
-        inPresentationMode: false,
-      },
-      persisted: {
-        autoRefresh: 0,
-        showTemplateControlBar: false,
-        navBarState: 'expanded',
-        timeZone: 'Local' as TimeZone,
-        theme: 'dark',
-      },
-    }
-
-    expect(
-      untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
-    ).toEqual(customTimeRange)
-  })
-
-  it('should return the timeRange for the same hour with a UTC timezone when the timeZone is UTC', () => {
-    const currentDashboard = {id: dashboardIDs[2]}
-
-    const app: AppPresentationState = {
-      ephemeral: {
-        inPresentationMode: false,
-      },
-      persisted: {
-        autoRefresh: 0,
-        showTemplateControlBar: false,
-        navBarState: 'expanded',
-        timeZone: 'UTC' as TimeZone,
-        theme: 'dark',
-      },
-    }
-
-    const expected = {
-      lower: '2020-05-05T10:00:00Z',
-      upper: '2020-05-05T11:00:00Z',
-      type: 'custom',
-    }
-
-    expect(
-      untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
-    ).toEqual(expected)
   })
 })

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -1,6 +1,6 @@
 import {get} from 'lodash'
-import moment from 'moment'
-import {AppState, View, Check, ViewType, TimeRange, TimeZone} from 'src/types'
+
+import {AppState, View, Check, ViewType, TimeRange} from 'src/types'
 import {currentContext} from 'src/shared/selectors/currentContext'
 
 // Constants
@@ -13,49 +13,6 @@ export const getTimeRange = (state: AppState): TimeRange => {
   }
 
   return state.ranges[contextID] || DEFAULT_TIME_RANGE
-}
-
-export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
-  const timeRange = getTimeRange(state)
-  const timeZone = getTimeZone(state)
-
-  const newTimeRange = {...timeRange}
-  if (timeRange.type === 'custom' && timeZone === 'UTC') {
-    // conforms dates to account to UTC with proper offset if needed
-    newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
-    newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
-  }
-  return newTimeRange
-}
-
-export const setTimeToUTC = (date: string): string => {
-  // The purpose of this function is to set a user's custom time range selection
-  // from the local time to the same time in UTC if UTC is selected from the
-  // timezone dropdown. This is feature was original requested here:
-  // https://github.com/influxdata/influxdb/issues/17877
-  // Example: user selected 10-11:00am and sets the dropdown to UTC
-  // Query should run against 10-11:00am UTC rather than querying
-  // 10-11:00am local time (offset depending on timezone)
-  const offset = new Date(date).getTimezoneOffset()
-  if (offset > 0) {
-    // subtract tz minute difference
-    return moment
-      .utc(date)
-      .subtract(offset, 'minutes')
-      .format()
-  }
-  if (offset < 0) {
-    // add tz minute difference
-    return moment
-      .utc(date)
-      .add(offset, 'minutes')
-      .format()
-  }
-  return date
-}
-
-export const getTimeZone = (state: AppState): TimeZone => {
-  return state.app.persisted.timeZone || 'Local'
 }
 
 export const getCheckForView = (

--- a/ui/src/shared/components/TimeZoneDropdown.tsx
+++ b/ui/src/shared/components/TimeZoneDropdown.tsx
@@ -3,9 +3,8 @@ import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 import {SelectDropdown, IconFont} from '@influxdata/clockface'
 
-// Actions & Selectors
+// Actions
 import {setTimeZone} from 'src/shared/actions/app'
-import {getTimeZone} from 'src/dashboards/selectors'
 
 // Constants
 import {TIME_ZONES} from 'src/shared/constants/timeZones'
@@ -39,7 +38,7 @@ const TimeZoneDropdown: FunctionComponent<Props> = ({
 }
 
 const mstp = (state: AppState): StateProps => {
-  return {timeZone: getTimeZone(state)}
+  return {timeZone: state.app.persisted.timeZone || 'Local'}
 }
 
 const mdtp = {onSetTimeZone: setTimeZone}

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -6,7 +6,7 @@ import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
 
 // Utils
 import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
-import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
+import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -222,8 +222,7 @@ export const loadTagSelector = (index: number) => async (
   const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
 
   try {
-    const timeRange = getTimeRangeWithTimezone(state)
-
+    const timeRange = getTimeRange(state)
     const searchTerm = getActiveTimeMachine(state).queryBuilder.tags[index]
       .keysSearchTerm
 
@@ -288,7 +287,7 @@ const loadTagSelectorValues = (index: number) => async (
   dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
 
   try {
-    const timeRange = getTimeRangeWithTimezone(state)
+    const timeRange = getTimeRange(state)
     const key = getActiveQuery(getState()).builderConfig.tags[index].key
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
       .valuesSearchTerm

--- a/ui/src/timeMachine/components/Vis.tsx
+++ b/ui/src/timeMachine/components/Vis.tsx
@@ -21,7 +21,7 @@ import {
   getFillColumnsSelection,
   getSymbolColumnsSelection,
 } from 'src/timeMachine/selectors'
-import {getTimeRange, getTimeZone} from 'src/dashboards/selectors'
+import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -164,7 +164,7 @@ const mstp = (state: AppState): StateProps => {
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
 
-  const timeZone = getTimeZone(state)
+  const timeZone = state.app.persisted.timeZone
 
   return {
     loading,

--- a/ui/src/variables/selectors/index.test.tsx
+++ b/ui/src/variables/selectors/index.test.tsx
@@ -7,11 +7,6 @@ import {
 import {AppState} from 'src/types'
 
 const MOCKSTATE = ({
-  app: {
-    persisted: {
-      timeZone: 'UTC',
-    },
-  },
   currentDashboard: {
     id: '',
   },

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -4,7 +4,7 @@ import {get} from 'lodash'
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
-import {getTimeRange, getTimeRangeWithTimezone} from 'src/dashboards/selectors'
+import {getTimeRange} from 'src/dashboards/selectors'
 import {getWindowPeriodVariable} from 'src/variables/utils/getWindowVars'
 import {
   TIME_RANGE_START,
@@ -108,9 +108,11 @@ export const getAllVariables = (
     .concat([TIME_RANGE_START, TIME_RANGE_STOP, WINDOW_PERIOD])
     .reduce((prev, curr) => {
       prev.push(getVariable(state, curr))
+
       return prev
     }, [])
     .filter(v => !!v)
+
   return vars
 }
 
@@ -124,7 +126,8 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   }
 
   if (variableID === TIME_RANGE_START || variableID === TIME_RANGE_STOP) {
-    const timeRange = getTimeRangeWithTimezone(state)
+    const timeRange = getTimeRange(state)
+
     vari = getRangeVariable(variableID, timeRange)
   }
 


### PR DESCRIPTION
Reverts influxdata/influxdb#17992