### PR TITLE
feat(custom-tz): added the ability to set UTC as the timezone when making custom time range queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ workflows:
   hourly-e2e:
     triggers:
       - schedule:
-          cron: '0 * * * *'
+          cron: "0 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,10 +159,6 @@ jobs:
   jstest:
     docker:
       - image: circleci/golang:1.13-node-browsers
-        environment:
-          TZ: "America/Los_Angeles"
-    environment:
-      TZ: "America/Los_Angeles"
     working_directory: /go/src/github.com/influxdata/influxdb
     parallelism: 8
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,10 @@ jobs:
   jstest:
     docker:
       - image: circleci/golang:1.13-node-browsers
+        environment:
+          TZ: "America/Los_Angeles"
+    environment:
+      TZ: "America/Los_Angeles"
     working_directory: /go/src/github.com/influxdata/influxdb
     parallelism: 8
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.0.0-beta.11 [unreleased]
+
+### Features
+
+1. [18011](https://github.com/influxdata/influxdb/pull/18011): Integrate UTC dropdown when making custom time range query
+
+### Bug Fixes
+
+### UI Improvements
+
 ## v2.0.0-beta.10 [2020-05-07]
 
 ### Features

--- a/ui/src/checks/components/CheckHistory.tsx
+++ b/ui/src/checks/components/CheckHistory.tsx
@@ -21,6 +21,7 @@ import {STATUS_FIELDS} from 'src/alerting/constants/history'
 // Utils
 import {loadStatuses, getInitialState} from 'src/alerting/utils/history'
 import {getCheckIDs} from 'src/checks/selectors'
+import {getTimeZone} from 'src/dashboards/selectors'
 
 // Types
 import {ResourceIDs} from 'src/checks/reducers'
@@ -101,7 +102,7 @@ const CheckHistory: FC<Props> = ({
 }
 
 const mstp = (state: AppState, props: OwnProps) => {
-  const timeZone = state.app.persisted.timeZone
+  const timeZone = getTimeZone(state)
   const checkIDs = getCheckIDs(state)
   const check = getByID<Check>(state, ResourceType.Checks, props.params.checkID)
 

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -3,6 +3,7 @@ import {
   getTimeRange,
   getTimeRangeWithTimezone,
 } from 'src/dashboards/selectors/index'
+import moment from 'moment'
 
 // Types
 import {RangeState} from 'src/dashboards/reducers/ranges'
@@ -34,9 +35,15 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8000',
     '04c6f3976f4b8002',
   ]
+  const lower = '2020-05-05T10:00:00-07:00'
+  const upper = '2020-05-05T11:00:00-07:00'
   const customTimeRange = {
-    lower: '2020-05-05T10:00:00-07:00',
-    upper: '2020-05-05T11:00:00-07:00',
+    lower: moment(lower)
+      .utcOffset(lower)
+      .format(),
+    upper: moment(upper)
+      .utcOffset(upper)
+      .format(),
     type: 'custom',
   } as CustomTimeRange
   const ranges: RangeState = {

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -2,6 +2,7 @@
 import {
   getTimeRange,
   getTimeRangeWithTimezone,
+  setTimeToUTC,
 } from 'src/dashboards/selectors/index'
 import moment from 'moment'
 
@@ -38,12 +39,8 @@ describe('Dashboards.Selector', () => {
   const lower = '2020-05-05T10:00:00-07:00'
   const upper = '2020-05-05T11:00:00-07:00'
   const customTimeRange = {
-    lower: moment(lower)
-      .utcOffset(lower)
-      .format(),
-    upper: moment(upper)
-      .utcOffset(upper)
-      .format(),
+    lower: moment(lower).toISOString(),
+    upper: moment(upper).toISOString(),
     type: 'custom',
   } as CustomTimeRange
   const ranges: RangeState = {
@@ -113,8 +110,8 @@ describe('Dashboards.Selector', () => {
     }
 
     const expected = {
-      lower: '2020-05-05T10:00:00Z',
-      upper: '2020-05-05T11:00:00Z',
+      lower: setTimeToUTC(lower),
+      upper: setTimeToUTC(upper),
       type: 'custom',
     }
 

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -36,8 +36,8 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8000',
     '04c6f3976f4b8002',
   ]
-  const lower = moment('2020-05-05T10:00:00-07:00').toISOString()
-  const upper = moment('2020-05-05T11:00:00-07:00').toISOString()
+  const lower = `2020-05-05T10:00:00${moment().format('Z')}`
+  const upper = `2020-05-05T11:00:00${moment().format('Z')}`
   const customTimeRange = {
     lower,
     upper,
@@ -110,8 +110,8 @@ describe('Dashboards.Selector', () => {
     }
 
     const expected = {
-      lower: setTimeToUTC(lower),
-      upper: setTimeToUTC(upper),
+      lower: `2020-05-05T10:00:00Z`,
+      upper: `2020-05-05T11:00:00Z`,
       type: 'custom',
     }
 

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -1,10 +1,14 @@
 // Funcs
-import {getTimeRange} from 'src/dashboards/selectors/index'
+import {
+  getTimeRange,
+  getTimeRangeWithTimezone,
+} from 'src/dashboards/selectors/index'
 
 // Types
 import {RangeState} from 'src/dashboards/reducers/ranges'
 import {CurrentDashboardState} from 'src/shared/reducers/currentDashboard'
-import {TimeRange} from 'src/types'
+import {TimeRange, CustomTimeRange} from 'src/types'
+import {AppState as AppPresentationState} from 'src/shared/reducers/app'
 
 // Constants
 import {
@@ -18,14 +22,30 @@ const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
   currentDashboard: CurrentDashboardState
 }) => TimeRange
 
+const untypedGetTimeRangeWithTimeZone = getTimeRangeWithTimezone as (a: {
+  ranges: RangeState
+  currentDashboard: CurrentDashboardState
+  app: AppPresentationState
+}) => TimeRange
+
 describe('Dashboards.Selector', () => {
-  const dashboardIDs = ['04c6f3976f4b8001', '04c6f3976f4b8000']
+  const dashboardIDs = [
+    '04c6f3976f4b8001',
+    '04c6f3976f4b8000',
+    '04c6f3976f4b8002',
+  ]
+  const customTimeRange = {
+    lower: '2020-05-05T10:00:00-07:00',
+    upper: '2020-05-05T11:00:00-07:00',
+    type: 'custom',
+  } as CustomTimeRange
   const ranges: RangeState = {
     [dashboardIDs[0]]: pastFifteenMinTimeRange,
     [dashboardIDs[1]]: pastHourTimeRange,
+    [dashboardIDs[2]]: customTimeRange,
   }
 
-  it('should return the the correct range when a matching dashboard ID is found', () => {
+  it('should return the correct range when a matching dashboard ID is found', () => {
     const currentDashboard = {id: dashboardIDs[0]}
 
     expect(
@@ -33,7 +53,7 @@ describe('Dashboards.Selector', () => {
     ).toEqual(pastFifteenMinTimeRange)
   })
 
-  it('should return the the default range when no matching dashboard ID is found', () => {
+  it('should return the default range when no matching dashboard ID is found', () => {
     const currentDashboard = {id: 'Oogum Boogum'}
 
     expect(
@@ -41,11 +61,45 @@ describe('Dashboards.Selector', () => {
     ).toEqual(DEFAULT_TIME_RANGE)
   })
 
-  it('should return the the default range when no ranges are passed in', () => {
+  it('should return the default range when no ranges are passed in', () => {
     const currentDashboard = {id: dashboardIDs[0]}
 
     expect(
       untypedGetTimeRangeByDashboardID({ranges: {}, currentDashboard})
     ).toEqual(DEFAULT_TIME_RANGE)
+  })
+
+  it('should return the an unmodified version of the timeRange when the timeZone is local', () => {
+    const currentDashboard = {id: dashboardIDs[2]}
+
+    const app = {
+      persisted: {
+        timeZone: 'Local',
+      },
+    } as AppPresentationState
+
+    expect(
+      untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
+    ).toEqual(customTimeRange)
+  })
+
+  it('should return the timeRange for the same hour with a UTC timezone when the timeZone is UTC', () => {
+    const currentDashboard = {id: dashboardIDs[2]}
+
+    const app = {
+      persisted: {
+        timeZone: 'UTC',
+      },
+    } as AppPresentationState
+
+    const expected = {
+      lower: '2020-05-05T10:00:00Z',
+      upper: '2020-05-05T11:00:00Z',
+      type: 'custom',
+    }
+
+    expect(
+      untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
+    ).toEqual(expected)
   })
 })

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -36,11 +36,11 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8000',
     '04c6f3976f4b8002',
   ]
-  const lower = '2020-05-05T10:00:00-07:00'
-  const upper = '2020-05-05T11:00:00-07:00'
+  const lower = moment('2020-05-05T10:00:00-07:00').toISOString()
+  const upper = moment('2020-05-05T11:00:00-07:00').toISOString()
   const customTimeRange = {
-    lower: moment(lower).toISOString(),
-    upper: moment(upper).toISOString(),
+    lower,
+    upper,
     type: 'custom',
   } as CustomTimeRange
   const ranges: RangeState = {

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -8,7 +8,7 @@ import {
 import {RangeState} from 'src/dashboards/reducers/ranges'
 import {CurrentDashboardState} from 'src/shared/reducers/currentDashboard'
 import {TimeRange, CustomTimeRange} from 'src/types'
-import {AppState as AppPresentationState} from 'src/shared/reducers/app'
+import {AppState} from 'src/shared/reducers/app'
 
 // Constants
 import {
@@ -25,7 +25,7 @@ const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
 const untypedGetTimeRangeWithTimeZone = getTimeRangeWithTimezone as (a: {
   ranges: RangeState
   currentDashboard: CurrentDashboardState
-  app: AppPresentationState
+  app: AppState
 }) => TimeRange
 
 describe('Dashboards.Selector', () => {
@@ -76,7 +76,7 @@ describe('Dashboards.Selector', () => {
       persisted: {
         timeZone: 'Local',
       },
-    } as AppPresentationState
+    } as AppState
 
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
@@ -90,7 +90,7 @@ describe('Dashboards.Selector', () => {
       persisted: {
         timeZone: 'UTC',
       },
-    } as AppPresentationState
+    } as AppState
 
     const expected = {
       lower: '2020-05-05T10:00:00Z',
@@ -98,6 +98,7 @@ describe('Dashboards.Selector', () => {
       type: 'custom',
     }
 
+    expect(app.persisted.timeZone).toEqual('UTC')
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
     ).toEqual(expected)

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -35,8 +35,8 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8000',
     '04c6f3976f4b8002',
   ]
-  const lower = `2020-05-05T10:00:00${moment().format('Z')}`
-  const upper = `2020-05-05T11:00:00${moment().format('Z')}`
+  const lower = moment('2020-05-05T10:00:00-07:00').format()
+  const upper = moment('2020-05-05T11:00:00-07:00').format()
   const customTimeRange = {
     lower,
     upper,

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -16,7 +16,6 @@ import {
   pastFifteenMinTimeRange,
   pastHourTimeRange,
 } from 'src/shared/constants/timeRanges'
-import appReducer from 'src/shared/reducers/app'
 
 const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
   ranges: RangeState

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -98,7 +98,6 @@ describe('Dashboards.Selector', () => {
       type: 'custom',
     }
 
-    expect(app.persisted.timeZone).toEqual('UTC')
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
     ).toEqual(expected)

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -7,8 +7,8 @@ import {
 // Types
 import {RangeState} from 'src/dashboards/reducers/ranges'
 import {CurrentDashboardState} from 'src/shared/reducers/currentDashboard'
-import {TimeRange, CustomTimeRange} from 'src/types'
-import {AppState} from 'src/shared/reducers/app'
+import {TimeRange, TimeZone, CustomTimeRange} from 'src/types'
+import {AppState as AppPresentationState} from 'src/shared/reducers/app'
 
 // Constants
 import {
@@ -16,6 +16,7 @@ import {
   pastFifteenMinTimeRange,
   pastHourTimeRange,
 } from 'src/shared/constants/timeRanges'
+import appReducer from 'src/shared/reducers/app'
 
 const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
   ranges: RangeState
@@ -25,7 +26,7 @@ const untypedGetTimeRangeByDashboardID = getTimeRange as (a: {
 const untypedGetTimeRangeWithTimeZone = getTimeRangeWithTimezone as (a: {
   ranges: RangeState
   currentDashboard: CurrentDashboardState
-  app: AppState
+  app: AppPresentationState
 }) => TimeRange
 
 describe('Dashboards.Selector', () => {
@@ -71,12 +72,18 @@ describe('Dashboards.Selector', () => {
 
   it('should return the an unmodified version of the timeRange when the timeZone is local', () => {
     const currentDashboard = {id: dashboardIDs[2]}
-
-    const app = {
-      persisted: {
-        timeZone: 'Local',
+    const app: AppPresentationState = {
+      ephemeral: {
+        inPresentationMode: false,
       },
-    } as AppState
+      persisted: {
+        autoRefresh: 0,
+        showTemplateControlBar: false,
+        navBarState: 'expanded',
+        timeZone: 'Local' as TimeZone,
+        theme: 'dark',
+      },
+    }
 
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
@@ -86,11 +93,18 @@ describe('Dashboards.Selector', () => {
   it('should return the timeRange for the same hour with a UTC timezone when the timeZone is UTC', () => {
     const currentDashboard = {id: dashboardIDs[2]}
 
-    const app = {
-      persisted: {
-        timeZone: 'UTC',
+    const app: AppPresentationState = {
+      ephemeral: {
+        inPresentationMode: false,
       },
-    } as AppState
+      persisted: {
+        autoRefresh: 0,
+        showTemplateControlBar: false,
+        navBarState: 'expanded',
+        timeZone: 'UTC' as TimeZone,
+        theme: 'dark',
+      },
+    }
 
     const expected = {
       lower: '2020-05-05T10:00:00Z',

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -2,7 +2,6 @@
 import {
   getTimeRange,
   getTimeRangeWithTimezone,
-  setTimeToUTC,
 } from 'src/dashboards/selectors/index'
 import moment from 'moment'
 

--- a/ui/src/dashboards/selectors/index.test.ts
+++ b/ui/src/dashboards/selectors/index.test.ts
@@ -35,8 +35,8 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8000',
     '04c6f3976f4b8002',
   ]
-  const lower = moment('2020-05-05T10:00:00-07:00').format()
-  const upper = moment('2020-05-05T11:00:00-07:00').format()
+  const lower = `2020-05-05T10:00:00${moment().format('Z')}`
+  const upper = `2020-05-05T11:00:00${moment().format('Z')}`
   const customTimeRange = {
     lower,
     upper,

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -20,6 +20,8 @@ export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
   const timeZone = getTimeZone(state)
 
   const newTimeRange = {...timeRange}
+  console.log('timeZone: ', timeZone)
+  console.log('timeRange: ', timeRange)
   if (timeRange.type === 'custom' && timeZone === 'UTC') {
     // conforms dates to account to UTC with proper offset if needed
     newTimeRange.lower = setTimeToUTC(newTimeRange.lower)

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -49,7 +49,7 @@ export const setTimeToUTC = (date: string): string => {
       .add(offset, 'minutes')
       .format()
   }
-  return new Date(date).toISOString()
+  return moment.utc(date).format()
 }
 
 export const getTimeZone = (state: AppState): TimeZone => {

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -1,5 +1,5 @@
 import {get} from 'lodash'
-
+import moment from 'moment'
 import {AppState, View, Check, ViewType, TimeRange, TimeZone} from 'src/types'
 import {currentContext} from 'src/shared/selectors/currentContext'
 
@@ -13,6 +13,43 @@ export const getTimeRange = (state: AppState): TimeRange => {
   }
 
   return state.ranges[contextID] || DEFAULT_TIME_RANGE
+}
+
+export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
+  const timeRange = getTimeRange(state)
+  const timeZone = getTimeZone(state)
+  // create a copy of the timeRange so as not to mutate the original timeRange
+  const newTimeRange = Object.assign({}, timeRange)
+  if (timeRange.type === 'custom' && timeZone === 'UTC') {
+    // check to see if the timeRange has an offset
+    newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
+    newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
+  }
+  return newTimeRange
+}
+
+export const setTimeToUTC = (date: string): string => {
+  const offset = new Date(date).getTimezoneOffset()
+  // check if date has offset
+  if (offset === 0) {
+    return date
+  }
+  let offsetDate = date
+  if (offset > 0) {
+    // subtract tz minute difference
+    offsetDate = moment
+      .utc(date)
+      .subtract(offset, 'minutes')
+      .format()
+  }
+  if (offset < 0) {
+    // add tz minute difference
+    offsetDate = moment
+      .utc(date)
+      .add(offset, 'minutes')
+      .format()
+  }
+  return offsetDate
 }
 
 export const getTimeZone = (state: AppState): TimeZone => {

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -1,6 +1,6 @@
 import {get} from 'lodash'
 
-import {AppState, View, Check, ViewType, TimeRange} from 'src/types'
+import {AppState, View, Check, ViewType, TimeRange, TimeZone} from 'src/types'
 import {currentContext} from 'src/shared/selectors/currentContext'
 
 // Constants
@@ -13,6 +13,10 @@ export const getTimeRange = (state: AppState): TimeRange => {
   }
 
   return state.ranges[contextID] || DEFAULT_TIME_RANGE
+}
+
+export const getTimeZone = (state: AppState): TimeZone => {
+  return state.app.persisted.timeZone || 'Local'
 }
 
 export const getCheckForView = (

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -28,24 +28,22 @@ export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
   return newTimeRange
 }
 
+// The purpose of this function is to set a user's custom time range selection
+// from the local time to the same time in UTC if UTC is selected from the
+// timezone dropdown. This is feature was original requested here:
+// https://github.com/influxdata/influxdb/issues/17877
+// Example: user selected 10-11:00am and sets the dropdown to UTC
+// Query should run against 10-11:00am UTC rather than querying
+// 10-11:00am local time (offset depending on timezone)
 export const setTimeToUTC = (date: string): string => {
-  // The purpose of this function is to set a user's custom time range selection
-  // from the local time to the same time in UTC if UTC is selected from the
-  // timezone dropdown. This is feature was original requested here:
-  // https://github.com/influxdata/influxdb/issues/17877
-  // Example: user selected 10-11:00am and sets the dropdown to UTC
-  // Query should run against 10-11:00am UTC rather than querying
-  // 10-11:00am local time (offset depending on timezone)
   const offset = new Date(date).getTimezoneOffset()
   if (offset > 0) {
-    // subtract tz minute difference
     return moment
       .utc(date)
       .subtract(offset, 'minutes')
       .format()
   }
   if (offset < 0) {
-    // add tz minute difference
     return moment
       .utc(date)
       .add(offset, 'minutes')

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -49,7 +49,7 @@ export const setTimeToUTC = (date: string): string => {
       .add(offset, 'minutes')
       .format()
   }
-  return date
+  return new Date(date).toISOString()
 }
 
 export const getTimeZone = (state: AppState): TimeZone => {

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -20,8 +20,6 @@ export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
   const timeZone = getTimeZone(state)
 
   const newTimeRange = {...timeRange}
-  console.log('timeZone: ', timeZone)
-  console.log('timeRange: ', timeRange)
   if (timeRange.type === 'custom' && timeZone === 'UTC') {
     // conforms dates to account to UTC with proper offset if needed
     newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
@@ -39,6 +37,7 @@ export const setTimeToUTC = (date: string): string => {
   // Query should run against 10-11:00am UTC rather than querying
   // 10-11:00am local time (offset depending on timezone)
   const offset = new Date(date).getTimezoneOffset()
+  console.log('offset: ', offset)
   if (offset > 0) {
     // subtract tz minute difference
     return moment

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -18,10 +18,10 @@ export const getTimeRange = (state: AppState): TimeRange => {
 export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
   const timeRange = getTimeRange(state)
   const timeZone = getTimeZone(state)
-  // create a copy of the timeRange so as not to mutate the original timeRange
-  const newTimeRange = Object.assign({}, timeRange)
+
+  const newTimeRange = {...timeRange}
   if (timeRange.type === 'custom' && timeZone === 'UTC') {
-    // check to see if the timeRange has an offset
+    // conforms dates to account to UTC with proper offset if needed
     newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
     newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
   }
@@ -29,27 +29,29 @@ export const getTimeRangeWithTimezone = (state: AppState): TimeRange => {
 }
 
 export const setTimeToUTC = (date: string): string => {
+  // The purpose of this function is to set a user's custom time range selection
+  // from the local time to the same time in UTC if UTC is selected from the
+  // timezone dropdown. This is feature was original requested here:
+  // https://github.com/influxdata/influxdb/issues/17877
+  // Example: user selected 10-11:00am and sets the dropdown to UTC
+  // Query should run against 10-11:00am UTC rather than querying
+  // 10-11:00am local time (offset depending on timezone)
   const offset = new Date(date).getTimezoneOffset()
-  // check if date has offset
-  if (offset === 0) {
-    return date
-  }
-  let offsetDate = date
   if (offset > 0) {
     // subtract tz minute difference
-    offsetDate = moment
+    return moment
       .utc(date)
       .subtract(offset, 'minutes')
       .format()
   }
   if (offset < 0) {
     // add tz minute difference
-    offsetDate = moment
+    return moment
       .utc(date)
       .add(offset, 'minutes')
       .format()
   }
-  return offsetDate
+  return date
 }
 
 export const getTimeZone = (state: AppState): TimeZone => {

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -37,7 +37,6 @@ export const setTimeToUTC = (date: string): string => {
   // Query should run against 10-11:00am UTC rather than querying
   // 10-11:00am local time (offset depending on timezone)
   const offset = new Date(date).getTimezoneOffset()
-  console.log('offset: ', offset)
   if (offset > 0) {
     // subtract tz minute difference
     return moment

--- a/ui/src/mockState.tsx
+++ b/ui/src/mockState.tsx
@@ -21,7 +21,7 @@ export const localState: LocalStorage = {
       autoRefresh: 0,
       showTemplateControlBar: false,
       navBarState: 'expanded',
-      timeZone: 'Local' as TimeZone,
+      timeZone: 'UTC' as TimeZone,
       theme: 'dark',
     },
   },

--- a/ui/src/mockState.tsx
+++ b/ui/src/mockState.tsx
@@ -21,7 +21,7 @@ export const localState: LocalStorage = {
       autoRefresh: 0,
       showTemplateControlBar: false,
       navBarState: 'expanded',
-      timeZone: 'UTC' as TimeZone,
+      timeZone: 'Local' as TimeZone,
       theme: 'dark',
     },
   },

--- a/ui/src/shared/components/TimeZoneDropdown.tsx
+++ b/ui/src/shared/components/TimeZoneDropdown.tsx
@@ -3,8 +3,9 @@ import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 import {SelectDropdown, IconFont} from '@influxdata/clockface'
 
-// Actions
+// Actions & Selectors
 import {setTimeZone} from 'src/shared/actions/app'
+import {getTimeZone} from 'src/dashboards/selectors'
 
 // Constants
 import {TIME_ZONES} from 'src/shared/constants/timeZones'
@@ -38,7 +39,7 @@ const TimeZoneDropdown: FunctionComponent<Props> = ({
 }
 
 const mstp = (state: AppState): StateProps => {
-  return {timeZone: state.app.persisted.timeZone || 'Local'}
+  return {timeZone: getTimeZone(state)}
 }
 
 const mdtp = {onSetTimeZone: setTimeZone}

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -240,7 +240,7 @@ export const loadTagSelector = (index: number) => async (
       bucket,
       tagsSelections,
       searchTerm,
-      timeRange,
+      timeRange: newTimeRange,
     })
 
     const {key} = tags[index]
@@ -279,8 +279,6 @@ const loadTagSelectorValues = (index: number) => async (
 ) => {
   const state = getState()
   const {buckets, tags} = getActiveQuery(state).builderConfig
-  console.log('buckets: ', buckets)
-  console.log('tags: ', tags)
   const tagsSelections = tags.slice(0, index)
   const queryURL = state.links.query.self
 
@@ -309,9 +307,6 @@ const loadTagSelectorValues = (index: number) => async (
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
       .valuesSearchTerm
 
-    console.log('key: ', key)
-    console.log('tagsSelections: ', tagsSelections)
-
     const values = await queryBuilderFetcher.findValues(index, {
       url: queryURL,
       orgID,
@@ -319,10 +314,8 @@ const loadTagSelectorValues = (index: number) => async (
       tagsSelections,
       key,
       searchTerm,
-      newTimeRange,
+      timeRange: newTimeRange,
     })
-
-    console.log('values in the action: ', values)
 
     const {values: selectedValues} = tags[index]
 
@@ -389,7 +382,6 @@ export const selectBuilderFunction = (name: string) => (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
-  console.log('does this trigger?')
   const state = getState()
   const {
     timeMachines: {activeTimeMachineID},

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -6,8 +6,7 @@ import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
 
 // Utils
 import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
-import {getTimeRange, getTimeZone} from 'src/dashboards/selectors'
-import {setTimeToUTC} from 'src/variables/selectors'
+import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -223,14 +222,8 @@ export const loadTagSelector = (index: number) => async (
   const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
 
   try {
-    const timeRange = getTimeRange(state)
-    const timeZone = getTimeZone(state)
-    const newTimeRange = Object.assign({}, timeRange)
-    if (timeRange.type === 'custom' && timeZone === 'UTC') {
-      // check to see if the timeRange has an offset
-      newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
-      newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
-    }
+    const timeRange = getTimeRangeWithTimezone(state)
+
     const searchTerm = getActiveTimeMachine(state).queryBuilder.tags[index]
       .keysSearchTerm
 
@@ -240,7 +233,7 @@ export const loadTagSelector = (index: number) => async (
       bucket,
       tagsSelections,
       searchTerm,
-      timeRange: newTimeRange,
+      timeRange,
     })
 
     const {key} = tags[index]
@@ -295,14 +288,7 @@ const loadTagSelectorValues = (index: number) => async (
   dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
 
   try {
-    const timeRange = getTimeRange(state)
-    const timeZone = getTimeZone(state)
-    const newTimeRange = Object.assign({}, timeRange)
-    if (timeRange.type === 'custom' && timeZone === 'UTC') {
-      // check to see if the timeRange has an offset
-      newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
-      newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
-    }
+    const timeRange = getTimeRangeWithTimezone(state)
     const key = getActiveQuery(getState()).builderConfig.tags[index].key
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
       .valuesSearchTerm
@@ -314,7 +300,7 @@ const loadTagSelectorValues = (index: number) => async (
       tagsSelections,
       key,
       searchTerm,
-      timeRange: newTimeRange,
+      timeRange,
     })
 
     const {values: selectedValues} = tags[index]

--- a/ui/src/timeMachine/components/Vis.tsx
+++ b/ui/src/timeMachine/components/Vis.tsx
@@ -21,7 +21,7 @@ import {
   getFillColumnsSelection,
   getSymbolColumnsSelection,
 } from 'src/timeMachine/selectors'
-import {getTimeRange} from 'src/dashboards/selectors'
+import {getTimeRange, getTimeZone} from 'src/dashboards/selectors'
 
 // Types
 import {
@@ -164,7 +164,7 @@ const mstp = (state: AppState): StateProps => {
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
 
-  const timeZone = state.app.persisted.timeZone
+  const timeZone = getTimeZone(state)
 
   return {
     loading,

--- a/ui/src/variables/selectors/index.test.tsx
+++ b/ui/src/variables/selectors/index.test.tsx
@@ -7,6 +7,11 @@ import {
 import {AppState} from 'src/types'
 
 const MOCKSTATE = ({
+  app: {
+    persisted: {
+      timeZone: 'Local',
+    },
+  },
   currentDashboard: {
     id: '',
   },

--- a/ui/src/variables/selectors/index.test.tsx
+++ b/ui/src/variables/selectors/index.test.tsx
@@ -9,7 +9,7 @@ import {AppState} from 'src/types'
 const MOCKSTATE = ({
   app: {
     persisted: {
-      timeZone: 'Local',
+      timeZone: 'UTC',
     },
   },
   currentDashboard: {

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -115,7 +115,7 @@ export const getAllVariables = (
   return vars
 }
 
-const setTimeToUTC = (date: string): string => {
+export const setTimeToUTC = (date: string): string => {
   const offset = new Date(date).getTimezoneOffset()
   // check if date has offset
   if (offset === 0) {

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -4,7 +4,7 @@ import {get} from 'lodash'
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
-import {getTimeRange} from 'src/dashboards/selectors'
+import {getTimeRange, getTimeZone} from 'src/dashboards/selectors'
 import {getWindowPeriodVariable} from 'src/variables/utils/getWindowVars'
 import {
   TIME_RANGE_START,
@@ -22,6 +22,7 @@ import {
 } from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
 import {AppState, VariableArgumentType, Variable} from 'src/types'
+import moment from 'moment'
 
 export const extractVariableEditorName = (state: AppState): string => {
   return state.variableEditor.name
@@ -108,12 +109,34 @@ export const getAllVariables = (
     .concat([TIME_RANGE_START, TIME_RANGE_STOP, WINDOW_PERIOD])
     .reduce((prev, curr) => {
       prev.push(getVariable(state, curr))
-
       return prev
     }, [])
     .filter(v => !!v)
-
   return vars
+}
+
+const setTimeToUTC = (date: string): string => {
+  const offset = new Date(date).getTimezoneOffset()
+  // check if date has offset
+  if (offset === 0) {
+    return date
+  }
+  let offsetDate = date
+  if (offset > 0) {
+    // subtract tz minute difference
+    offsetDate = moment
+      .utc(date)
+      .subtract(offset, 'minutes')
+      .format()
+  }
+  if (offset < 0) {
+    // add tz minute difference
+    offsetDate = moment
+      .utc(date)
+      .add(offset, 'minutes')
+      .format()
+  }
+  return offsetDate
 }
 
 export const getVariable = (state: AppState, variableID: string): Variable => {
@@ -127,8 +150,16 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
 
   if (variableID === TIME_RANGE_START || variableID === TIME_RANGE_STOP) {
     const timeRange = getTimeRange(state)
+    const timeZone = getTimeZone(state)
+    // create a copy of the timeRange so as not to mutate the original timeRange
+    const newTimeRange = Object.assign({}, timeRange)
+    if (timeRange.type === 'custom' && timeZone === 'UTC') {
+      // check to see if the timeRange has an offset
+      newTimeRange.lower = setTimeToUTC(newTimeRange.lower)
+      newTimeRange.upper = setTimeToUTC(newTimeRange.upper)
+    }
 
-    vari = getRangeVariable(variableID, timeRange)
+    vari = getRangeVariable(variableID, newTimeRange)
   }
 
   if (variableID === WINDOW_PERIOD) {


### PR DESCRIPTION
Closes #17877

### Purpose
The primary purpose of this PR is to ensure that whenever a user sets UTC as their timeZone and is querying a custom timeRange, their query will query data that was set at that set time in UTC (not the adjusted locale -> UTC time).

### Problem
The UI for the timeZone (local or UTC) was often confusing and seemed to indicate functionality beyond displaying graphs in UTC.

### Solution
Created a selector to update the timeRange whenever a query is executed with a custom timeRange and the timeZone set to UTC.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
