### PR TITLE
fix(kit/feature): lookup typed flag if base is passed to override

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -853,13 +853,13 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	flagger := feature.DefaultFlagger()
 	if len(m.featureFlags) > 0 {
-		f, err := overrideflagger.Make(m.featureFlags)
+		f, err := overrideflagger.Make(m.featureFlags, feature.ByKey)
 		if err != nil {
 			m.log.Error("Failed to configure feature flag overrides",
 				zap.Error(err), zap.Any("overrides", m.featureFlags))
 			return err
 		}
-		m.log.Info("Running with feature flag overrides", zap.Any("config", m.featureFlags))
+		m.log.Info("Running with feature flag overrides", zap.Any("overrides", m.featureFlags))
 		flagger = f
 	}
 

--- a/kit/feature/override/override.go
+++ b/kit/feature/override/override.go
@@ -16,6 +16,9 @@ type Flagger struct {
 
 // Make a Flagger that returns defaults with any overrides parsed from the string.
 func Make(m map[string]string, byKey feature.ByKeyFn) (Flagger, error) {
+	if byKey == nil {
+		byKey = feature.ByKey
+	}
 	return Flagger{
 		overrides: m,
 		byKey:     byKey,

--- a/kit/feature/override/override.go
+++ b/kit/feature/override/override.go
@@ -11,12 +11,14 @@ import (
 // Flagger can override default flag values.
 type Flagger struct {
 	overrides map[string]string
+	byKey     feature.ByKeyFn
 }
 
 // Make a Flagger that returns defaults with any overrides parsed from the string.
-func Make(m map[string]string) (Flagger, error) {
+func Make(m map[string]string, byKey feature.ByKeyFn) (Flagger, error) {
 	return Flagger{
 		overrides: m,
+		byKey:     byKey,
 	}, nil
 }
 
@@ -42,7 +44,11 @@ func (f Flagger) Flags(_ context.Context, flags ...feature.Flag) (map[string]int
 	return m, nil
 }
 
-func (Flagger) coerce(s string, flag feature.Flag) (iface interface{}, err error) {
+func (f Flagger) coerce(s string, flag feature.Flag) (iface interface{}, err error) {
+	if base, ok := flag.(feature.Base); ok {
+		flag, _ = f.byKey(base.Key())
+	}
+
 	switch flag.(type) {
 	case feature.BoolFlag:
 		iface, err = strconv.ParseBool(s)

--- a/kit/feature/override/override_test.go
+++ b/kit/feature/override/override_test.go
@@ -70,7 +70,7 @@ func TestFlagger(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			subject, err := Make(test.env)
+			subject, err := Make(test.env, feature.ByKey)
 			if err != nil {
 				if test.expectMakeErr {
 					return

--- a/kit/feature/override/override_test.go
+++ b/kit/feature/override/override_test.go
@@ -16,6 +16,7 @@ func TestFlagger(t *testing.T) {
 		expected       map[string]interface{}
 		expectMakeErr  bool
 		expectFlagsErr bool
+		byKey          feature.ByKeyFn
 	}{
 		{
 			name: "enabled happy path filtering",
@@ -66,11 +67,40 @@ func TestFlagger(t *testing.T) {
 			},
 			expectFlagsErr: true,
 		},
+		{
+			name: "typed base flags",
+			env: map[string]string{
+				"flag1": "411",
+				"flag2": "new2",
+				"flag3": "true",
+			},
+			defaults: []feature.Flag{
+				newBaseFlag("flag0", "original0"),
+				newBaseFlag("flag1", 41),
+				newBaseFlag("flag2", "original2"),
+				newBaseFlag("flag3", false),
+				newBaseFlag("flag4", "original4"),
+			},
+			byKey: newByKey(map[string]feature.Flag{
+				"flag0": newFlag("flag0", "original0"),
+				"flag1": newFlag("flag1", 41),
+				"flag2": newFlag("flag2", "original2"),
+				"flag3": newFlag("flag3", false),
+				"flag4": newFlag("flag4", "original4"),
+			}),
+			expected: map[string]interface{}{
+				"flag0": "original0",
+				"flag1": 411,
+				"flag2": "new2",
+				"flag3": true,
+				"flag4": "original4",
+			},
+		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			subject, err := Make(test.env, feature.ByKey)
+			subject, err := Make(test.env, test.byKey)
 			if err != nil {
 				if test.expectMakeErr {
 					return
@@ -95,7 +125,7 @@ func TestFlagger(t *testing.T) {
 				if xv, found := test.expected[k]; !found {
 					t.Errorf("unexpected key %s", k)
 				} else if v != xv {
-					t.Errorf("incorrect value for key %s: expected %v, got %v", k, xv, v)
+					t.Errorf("incorrect value for key %s: expected %v [%T], got %v [%T]", k, xv, xv, v, v)
 				}
 			}
 
@@ -111,4 +141,15 @@ func TestFlagger(t *testing.T) {
 
 func newFlag(key string, defaultValue interface{}) feature.Flag {
 	return feature.MakeFlag(key, key, "", defaultValue, feature.Temporary, false)
+}
+
+func newBaseFlag(key string, defaultValue interface{}) feature.Base {
+	return feature.MakeBase(key, key, "", defaultValue, feature.Temporary, false)
+}
+
+func newByKey(m map[string]feature.Flag) feature.ByKeyFn {
+	return func(k string) (feature.Flag, bool) {
+		v, found := m[k]
+		return v, found
+	}
 }


### PR DESCRIPTION
This change addresses a bug in the `override.Flagger` implementation.

When the override flagger is passed to a `Flag`, e.g. in a call to `Enabled` like this

```feature.BackendExample().Enabled(ctx, flagger)```

the `Flag`'s underlying `Base` type is [passed to `override.Flagger#Flags`](https://github.com/influxdata/influxdb/blob/95913534a0a6148f39b41138c31ab48dfad1bed2/kit/feature/flag.go#L95). This prevents the override flagger from being able to coerce the value type based on the flag type.

This PR fixes the problem by providing the `ByKey` lookup function to the `override.Flagger`, letting it look up the concrete type of any `Base` it is provided.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
