### PR TITLE
feat(http): Allow query handlers to be proxied for Algo-W testing.

### DIFF
--- a/http/check_service.go
+++ b/http/check_service.go
@@ -89,13 +89,13 @@ func NewCheckHandler(log *zap.Logger, b *CheckBackend) *CheckHandler {
 		OrganizationService:        b.OrganizationService,
 	}
 
-	h.Handler("POST", prefixChecks, withFeatureProxy(b.AlgoWProxy, h.handlePostCheck))
+	h.Handler("POST", prefixChecks, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostCheck)))
 	h.HandlerFunc("GET", prefixChecks, h.handleGetChecks)
 	h.HandlerFunc("GET", checksIDPath, h.handleGetCheck)
 	h.HandlerFunc("GET", checksIDQueryPath, h.handleGetCheckQuery)
 	h.HandlerFunc("DELETE", checksIDPath, h.handleDeleteCheck)
-	h.Handler("PUT", checksIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePutCheck))
-	h.Handler("PATCH", checksIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePatchCheck))
+	h.Handler("PUT", checksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePutCheck)))
+	h.Handler("PATCH", checksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePatchCheck)))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -99,13 +99,13 @@ func NewNotificationRuleHandler(log *zap.Logger, b *NotificationRuleBackend) *No
 		TaskService:                 b.TaskService,
 	}
 
-	h.Handler("POST", prefixNotificationRules, withFeatureProxy(b.AlgoWProxy, h.handlePostNotificationRule))
+	h.Handler("POST", prefixNotificationRules, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostNotificationRule)))
 	h.HandlerFunc("GET", prefixNotificationRules, h.handleGetNotificationRules)
 	h.HandlerFunc("GET", notificationRulesIDPath, h.handleGetNotificationRule)
 	h.HandlerFunc("GET", notificationRulesIDQueryPath, h.handleGetNotificationRuleQuery)
 	h.HandlerFunc("DELETE", notificationRulesIDPath, h.handleDeleteNotificationRule)
-	h.Handler("PUT", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePutNotificationRule))
-	h.Handler("PATCH", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, h.handlePatchNotificationRule))
+	h.Handler("PUT", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePutNotificationRule)))
+	h.Handler("PATCH", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePatchNotificationRule)))
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/proxy_handler.go
+++ b/http/proxy_handler.go
@@ -7,7 +7,7 @@ import (
 var _ http.Handler = &proxyHandler{}
 
 // withFeatureProxy wraps an HTTP handler in a proxyHandler
-func withFeatureProxy(proxy FeatureProxyHandler, h http.HandlerFunc) *proxyHandler {
+func withFeatureProxy(proxy FeatureProxyHandler, h http.Handler) *proxyHandler {
 	if proxy == nil {
 		proxy = &NoopProxyHandler{}
 	}

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -46,6 +46,7 @@ type FluxBackend struct {
 	log                *zap.Logger
 	QueryEventRecorder metric.EventRecorder
 
+	AlgoWProxy          FeatureProxyHandler
 	OrganizationService influxdb.OrganizationService
 	ProxyQueryService   query.ProxyQueryService
 }
@@ -56,7 +57,7 @@ func NewFluxBackend(log *zap.Logger, b *APIBackend) *FluxBackend {
 		HTTPErrorHandler:   b.HTTPErrorHandler,
 		log:                log,
 		QueryEventRecorder: b.QueryEventRecorder,
-
+		AlgoWProxy:         b.AlgoWProxy,
 		ProxyQueryService: routingQueryService{
 			InfluxQLService: b.InfluxQLService,
 			DefaultService:  b.FluxService,
@@ -103,11 +104,11 @@ func NewFluxHandler(log *zap.Logger, b *FluxBackend) *FluxHandler {
 
 	// query reponses can optionally be gzip encoded
 	qh := gziphandler.GzipHandler(http.HandlerFunc(h.handleQuery))
-	h.Handler("POST", prefixQuery, qh)
-	h.HandlerFunc("POST", "/api/v2/query/ast", h.postFluxAST)
-	h.HandlerFunc("POST", "/api/v2/query/analyze", h.postQueryAnalyze)
-	h.HandlerFunc("GET", "/api/v2/query/suggestions", h.getFluxSuggestions)
-	h.HandlerFunc("GET", "/api/v2/query/suggestions/:name", h.getFluxSuggestion)
+	h.Handler("POST", prefixQuery, withFeatureProxy(b.AlgoWProxy, qh))
+	h.Handler("POST", "/api/v2/query/ast", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.postFluxAST)))
+	h.Handler("POST", "/api/v2/query/analyze", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.postQueryAnalyze)))
+	h.Handler("GET", "/api/v2/query/suggestions", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.getFluxSuggestions)))
+	h.Handler("GET", "/api/v2/query/suggestions/:name", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.getFluxSuggestion)))
 	return h
 }
 

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -100,10 +100,10 @@ func NewTaskHandler(log *zap.Logger, b *TaskBackend) *TaskHandler {
 	}
 
 	h.HandlerFunc("GET", prefixTasks, h.handleGetTasks)
-	h.Handler("POST", prefixTasks, withFeatureProxy(b.AlgoWProxy, h.handlePostTask))
+	h.Handler("POST", prefixTasks, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostTask)))
 
 	h.HandlerFunc("GET", tasksIDPath, h.handleGetTask)
-	h.Handler("PATCH", tasksIDPath, withFeatureProxy(b.AlgoWProxy, h.handleUpdateTask))
+	h.Handler("PATCH", tasksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handleUpdateTask)))
 	h.HandlerFunc("DELETE", tasksIDPath, h.handleDeleteTask)
 
 	h.HandlerFunc("GET", tasksIDLogsPath, h.handleGetLogs)


### PR DESCRIPTION
This is an extension of the work done in #17970 to give us a foothold in proxying specific HTTP handlers to another location for safe vetting of Flux (Algo-W) parsing at the gateway layer before merging. It expands the handlers being proxied to include:

- `POST /api/v2/query`
- `POST /api/v2/query/ast`
- `POST /api/v2/query/analyze`
- `GET /api/v2/query/suggestions`
- `GET /api/v2/query/suggestions/:name`