### PR TITLE
fix(influx): fixup display message for onboarding with interactive and rp flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [17941](https://github.com/influxdata/influxdb/pull/17941): Enforce DNS name compliance on all pkger resources' metadata.name field
 1. [17989](https://github.com/influxdata/influxdb/pull/17989): Add stateful pkg management with stacks
 1. [18007](https://github.com/influxdata/influxdb/pull/18007): Add remove and list pkger stack commands to influx CLI
+1. [18017](https://github.com/influxdata/influxdb/pull/18017): Fixup display message for interactive influx setup cmd
 
 ### Bug Fixes
 

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -316,7 +316,7 @@ func getConfirm(ui *input.UI, or *influxdb.OnboardingRequest) bool {
 	for {
 		rp := "infinite"
 		if or.RetentionPeriod > 0 {
-			rp = fmt.Sprintf("%d hrs", or.RetentionPeriod)
+			rp = fmt.Sprintf("%d hrs", or.RetentionPeriod/uint(time.Hour))
 		}
 		ui.Writer.Write(promptWithColor(fmt.Sprintf(`
 You have entered:


### PR DESCRIPTION
closes: #17862

before:
![image](https://user-images.githubusercontent.com/17263167/81429574-d8258d80-9112-11ea-89c0-092a26f6a482.png)


after:
![image](https://user-images.githubusercontent.com/17263167/81429548-c93edb00-9112-11ea-948a-3b06754a4ae6.png)


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass