### PR TITLE
fix(reads): Fix ResultSetToLineProtocol to generate correct output

### DIFF
--- a/mock/reads_resultset_test.go
+++ b/mock/reads_resultset_test.go
@@ -24,10 +24,9 @@ func mustNewSpecFromToml(tb testing.TB, toml string) *gen.Spec {
 }
 
 func TestNewResultSetFromSeriesGenerator(t *testing.T) {
-	checkResult := func(t *testing.T, sg gen.SeriesGenerator, expData string, expStats cursors.CursorStats) {
+	checkResult := func(t *testing.T, rs reads.ResultSet, expData string, expStats cursors.CursorStats) {
 		t.Helper()
 
-		rs := mock.NewResultSetFromSeriesGenerator(sg)
 		var sb strings.Builder
 		err := reads.ResultSetToLineProtocol(&sb, rs)
 		if err != nil {
@@ -80,7 +79,34 @@ m0,tag0=value2,tag1=value1 v0=1 1333333000000
 m0,tag0=value2,tag1=value1 v0=1 1666666000000
 `
 		expStats := cursors.CursorStats{ScannedValues: 18, ScannedBytes: 18 * 8}
-		checkResult(t, sg, expData, expStats)
+		checkResult(t, mock.NewResultSetFromSeriesGenerator(sg), expData, expStats)
+	})
+
+	t.Run("max", func(t *testing.T) {
+		spec := mustNewSpecFromToml(t, `
+[[measurements]]
+name = "m0"
+sample = 1.0
+tags = [
+	{ name = "tag0", source = { type = "sequence", start = 0, count = 3 } },
+	{ name = "tag1", source = { type = "sequence", start = 0, count = 2 } },
+]
+fields = [
+	{ name = "v0", count = 3, source = 1.0 },
+]`)
+
+		sg := gen.NewSeriesGeneratorFromSpec(spec, gen.TimeRange{
+			Start: time.Unix(1000, 0),
+			End:   time.Unix(2000, 0),
+		})
+		const expData = `m0,tag0=value0,tag1=value0 v0=1 1000000000000
+m0,tag0=value0,tag1=value0 v0=1 1333333000000
+m0,tag0=value0,tag1=value0 v0=1 1666666000000
+m0,tag0=value0,tag1=value1 v0=1 1000000000000
+m0,tag0=value0,tag1=value1 v0=1 1333333000000
+`
+		expStats := cursors.CursorStats{ScannedValues: 5, ScannedBytes: 5 * 8}
+		checkResult(t, mock.NewResultSetFromSeriesGenerator(sg, mock.WithGeneratorMaxValues(5)), expData, expStats)
 	})
 
 }

--- a/storage/reads/resultset_lineprotocol.go
+++ b/storage/reads/resultset_lineprotocol.go
@@ -111,7 +111,7 @@ func cursorToLineProtocol(wr io.Writer, line []byte, cur cursors.Cursor) error {
 			if a.Len() > 0 {
 				for i := range a.Timestamps {
 					buf := strconv.AppendQuote(line, a.Values[i])
-					buf = append(buf, 'i', ' ')
+					buf = append(buf, ' ')
 					buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 					wr.Write(buf)
 					wr.Write(newLine)


### PR DESCRIPTION
This PR includes two changes.

1. The `ResultSetToLineProtocol` test class was generating incorrect line protocol for string output, by appending `i` to the value. This PR fixes that issue.

2. Improves the `mock.NewResultSetFromSeriesGenerator` type by adding functional options. The one option added is `WithGeneratorMaxValues`, to limit the total number of values produced by the `ResultSet`.

These types are used for mocks and testing.
