### PR TITLE
feat(demodata): Place dd dashboard errors behind feature flag

### DIFF
--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -14,10 +14,9 @@ import {notify} from 'src/shared/actions/notifications'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
-import {getAll} from 'src/resources/selectors'
 
 // Constants
-import {DemoDataTemplates, DemoDataDashboards} from 'src/cloud/constants'
+import {DemoDataTemplates} from 'src/cloud/constants'
 import {
   demoDataAddBucketFailed,
   demoDataDeleteBucketFailed,
@@ -25,14 +24,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Types
-import {
-  Bucket,
-  RemoteDataState,
-  GetState,
-  DemoBucket,
-  ResourceType,
-  Dashboard,
-} from 'src/types'
+import {Bucket, RemoteDataState, GetState, DemoBucket} from 'src/types'
 import {reportError} from 'src/shared/utils/errors'
 import {getErrorMessage} from 'src/utils/api'
 

--- a/ui/src/cloud/actions/demodata.ts
+++ b/ui/src/cloud/actions/demodata.ts
@@ -117,17 +117,7 @@ export const getDemoDataBucketMembership = ({
       throw new Error(`dashboard template was not found`)
     }
 
-    await createDashboardFromTemplate(template, orgID)
-
-    const allDashboards = getAll<Dashboard>(getState(), ResourceType.Dashboards)
-
-    const createdDashboard = allDashboards.find(
-      d => d.name === DemoDataDashboards[bucketName]
-    )
-
-    if (!createdDashboard) {
-      throw new Error(`dashboard was not found`)
-    }
+    const createdDashboard = await createDashboardFromTemplate(template, orgID)
 
     const url = `/orgs/${orgID}/dashboards/${createdDashboard.id}`
 

--- a/ui/src/cloud/utils/demoDataErrors.ts
+++ b/ui/src/cloud/utils/demoDataErrors.ts
@@ -1,31 +1,17 @@
 import {WebsiteMonitoringBucket} from 'src/cloud/constants'
-import {reportError} from 'src/shared/utils/errors'
 import {CLOUD} from 'src/shared/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-export const isDemoDataAvailabilityError = (errorMessage: string): boolean => {
+export const isDemoDataAvailabilityError = (
+  errorCode: string,
+  errorMessage: string
+): boolean => {
   if (!CLOUD || isFlagEnabled('demodata')) {
     return false
   }
-  const findBucketErrorMessage =
-    'failed to initialize execute state: could not find bucket /"'
 
-  if (errorMessage.startsWith(findBucketErrorMessage)) {
-    const missingBucket = errorMessage
-      .replace(findBucketErrorMessage, '')
-      .replace('/"', '')
-
-    if (missingBucket === WebsiteMonitoringBucket) {
-      reportError(
-        {
-          name: 'demodata switched off but user had demodata dashboard',
-          message: errorMessage,
-        },
-        {
-          context: {},
-          name: 'demodata switched off but user had demodata dashboard',
-        }
-      )
+  if (errorCode === 'not found') {
+    if (errorMessage.includes(WebsiteMonitoringBucket)) {
       return true
     }
   }

--- a/ui/src/cloud/utils/demoDataErrors.ts
+++ b/ui/src/cloud/utils/demoDataErrors.ts
@@ -1,0 +1,33 @@
+import {WebsiteMonitoringBucket} from 'src/cloud/constants'
+import {reportError} from 'src/shared/utils/errors'
+import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+export const isDemoDataAvailabilityError = (errorMessage: string): boolean => {
+  if (!CLOUD || isFlagEnabled('demodata')) {
+    return false
+  }
+  const findBucketErrorMessage =
+    'failed to initialize execute state: could not find bucket /"'
+
+  if (errorMessage.startsWith(findBucketErrorMessage)) {
+    const missingBucket = errorMessage
+      .replace(findBucketErrorMessage, '')
+      .replace('/"', '')
+
+    if (missingBucket === WebsiteMonitoringBucket) {
+      reportError(
+        {
+          name: 'demodata switched off but user had demodata dashboard',
+          message: errorMessage,
+        },
+        {
+          context: {},
+          name: 'demodata switched off but user had demodata dashboard',
+        }
+      )
+      return true
+    }
+  }
+  return false
+}

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -139,7 +139,7 @@ const processErrorResponse = async (
     const body = await response.text()
     const json = JSON.parse(body)
     const message = json.message || json.error
-    const code = json.code || ''
+    const code = json.code
 
     return {type: 'UNKNOWN_ERROR', message, code}
   } catch {

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -30,6 +30,7 @@ export interface RunQueryLimitResult {
 export interface RunQueryErrorResult {
   type: 'UNKNOWN_ERROR'
   message: string
+  code?: string
 }
 
 export const runQuery = (
@@ -138,8 +139,9 @@ const processErrorResponse = async (
     const body = await response.text()
     const json = JSON.parse(body)
     const message = json.message || json.error
+    const code = json.code || ''
 
-    return {type: 'UNKNOWN_ERROR', message}
+    return {type: 'UNKNOWN_ERROR', message, code}
   } catch {
     return {type: 'UNKNOWN_ERROR', message: 'Failed to execute Flux query'}
   }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -476,6 +476,12 @@ export const demoDataSucceeded = (
   link,
 })
 
+export const demoDataSwitchedOff = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Demo data buckets are temporarily unavailable. Please try again later.`,
+  duration: TEN_SECONDS,
+})
+
 // Limits
 export const readWriteCardinalityLimitReached = (
   message: string

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -60,7 +60,7 @@ import {
 export const createDashboardFromTemplate = async (
   template: DashboardTemplate,
   orgID: string
-): Promise<void> => {
+): Promise<Dashboard> => {
   try {
     const {content} = template
 
@@ -103,6 +103,8 @@ export const createDashboardFromTemplate = async (
     if (getResp.status !== 200) {
       throw new Error(getResp.data.message)
     }
+
+    return getResp.data as Dashboard
   } catch (error) {
     console.error(error)
     throw new Error(error.message)

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -15,7 +15,11 @@ import {notify} from 'src/shared/actions/notifications'
 import {hydrateVariables} from 'src/variables/actions/thunks'
 
 // Constants
-import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
+import {
+  rateLimitReached,
+  resultTooLarge,
+  demoDataSwitchedOff,
+} from 'src/shared/copy/notifications'
 
 // Utils
 import {getActiveTimeMachine, getActiveQuery} from 'src/timeMachine/selectors'
@@ -23,6 +27,7 @@ import fromFlux from 'src/shared/utils/fromFlux'
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {findNodes} from 'src/shared/utils/ast'
+import {isDemoDataAvailabilityError} from 'src/cloud/utils/demoDataErrors'
 
 // Types
 import {CancelBox} from 'src/types/promises'
@@ -150,6 +155,10 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
 
     for (const result of results) {
       if (result.type === 'UNKNOWN_ERROR') {
+        if (isDemoDataAvailabilityError(result.message)) {
+          dispatch(notify(demoDataSwitchedOff()))
+        }
+
         throw new Error(result.message)
       }
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -155,7 +155,7 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
 
     for (const result of results) {
       if (result.type === 'UNKNOWN_ERROR') {
-        if (isDemoDataAvailabilityError(result.message)) {
+        if (isDemoDataAvailabilityError(result.code, result.message)) {
           dispatch(notify(demoDataSwitchedOff()))
         }
 


### PR DESCRIPTION
In order to feel more comfortable releasing the demodata, we'd like to be able to switch the feature off in case of errore. We also want to give users a seamless experience even if demodata is switched off after they have added dd buckets, or dashboards. 
Before this PR- toggling the demodata feature flag off would 
- remove the dd dropdown, and 
- stop displaying dd buckets a user may have subscribed to.
But dd dashboards would still remain and generate a `failed to initialize execute state: could not find bucket` error from flux. 

after the changes in this PR, toggling the demodata feature flag will also:
- show a notification to the user that the "demodata feature is temporarily unavailable" if they already had dashboards set up to query the demodata bucket, and receive a `failed to initialize execute state: could not find bucket` error