### PR TITLE
feat(github-ssup): integrated social sign-up for github

### DIFF
--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -21,7 +21,7 @@ import auth0js, {WebAuth} from 'auth0-js'
 // Components
 import {LoginForm} from 'src/onboarding/components/LoginForm'
 import {SocialButton} from 'src/shared/components/SocialButton'
-import {GoogleLogo} from 'src/clientLibraries/graphics'
+import {GithubLogo, GoogleLogo} from 'src/clientLibraries/graphics'
 
 // Types
 import {Auth0Connection, FormFieldValidation} from 'src/types'
@@ -126,6 +126,14 @@ class LoginPageContents extends PureComponent<DispatchProps> {
                     buttonText="Google"
                   >
                     <GoogleLogo className="signup-icon" />
+                  </SocialButton>
+                  <SocialButton
+                    handleClick={() => {
+                      this.handleSocialClick(Auth0Connection.Github)
+                    }}
+                    buttonText="Github"
+                  >
+                    <GithubLogo className="signup-icon" />
                   </SocialButton>
                 </FlexBox>
               </Grid.Row>


### PR DESCRIPTION
This PR is part of a multi-pronged roll-out of the Social Sign Up Feature for Cloud customers. This particular PR integrates Github as a social identity provider for users to log-in to their Cloud accounts.
