### PR TITLE
feat(y_axis_domain): updated y-axis domain settings to allow min OR max values to be set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [18011](https://github.com/influxdata/influxdb/pull/18011): Integrate UTC dropdown when making custom time range query
+1. [18040](https://github.com/influxdata/influxdb/pull/18040): Allow for min OR max y-axis visualization settings rather than min AND max
 
 ### Bug Fixes
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -681,6 +681,34 @@ describe('DataExplorer', () => {
         cy.getByTestID('raw-data--toggle').click()
       })
 
+      it('can set min or max y-axis values', () => {
+        // build the query to return data from beforeEach
+        cy.getByTestID(`selector-list m`).click()
+        cy.getByTestID('selector-list v').click()
+        cy.getByTestID(`selector-list tv1`).click()
+
+        cy.getByTestID('time-machine-submit-button').click()
+        cy.getByTestID('cog-cell--button').click()
+        cy.getByTestID('select-group--option')
+          .contains('Custom')
+          .click()
+        cy.getByTestID('min--auto-domain')
+          .type('-100')
+          .blur()
+
+        cy.getByTestID('form--element-error').should('not.exist')
+        // find no errors
+        cy.getByTestID('max--auto-domain')
+          .type('450')
+          .blur()
+        // find no errors
+        cy.getByTestID('form--element-error').should('not.exist')
+        cy.getByTestID('min--auto-domain')
+          .clear()
+          .blur()
+        cy.getByTestID('form--element-error').should('not.exist')
+      })
+
       it('can view table data & sort values numerically', () => {
         // build the query to return data from beforeEach
         cy.getByTestID(`selector-list m`).click()

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -692,18 +692,18 @@ describe('DataExplorer', () => {
         cy.getByTestID('select-group--option')
           .contains('Custom')
           .click()
-        cy.getByTestID('min--auto-domain')
+        cy.getByTestID('auto-domain--min')
           .type('-100')
           .blur()
 
         cy.getByTestID('form--element-error').should('not.exist')
         // find no errors
-        cy.getByTestID('max--auto-domain')
+        cy.getByTestID('auto-domain--max')
           .type('450')
           .blur()
         // find no errors
         cy.getByTestID('form--element-error').should('not.exist')
-        cy.getByTestID('min--auto-domain')
+        cy.getByTestID('auto-domain--min')
           .clear()
           .blur()
         cy.getByTestID('form--element-error').should('not.exist')

--- a/ui/src/shared/components/AutoDomainInput.tsx
+++ b/ui/src/shared/components/AutoDomainInput.tsx
@@ -14,35 +14,25 @@ interface MinMaxInputsProps {
   initialMin: string
   initialMax: string
   onSetMinMax: (minMax: [number, number]) => void
-  onSetErrorMessage: (errorMessage: string) => void
 }
 
 const MinMaxInputs: SFC<MinMaxInputsProps> = ({
   initialMin,
   initialMax,
   onSetMinMax,
-  onSetErrorMessage,
 }) => {
   const [minInput, setMinInput] = useOneWayState(initialMin)
   const [maxInput, setMaxInput] = useOneWayState(initialMax)
 
   const emitIfValid = () => {
-    const newMin = parseFloat(minInput)
-    const newMax = parseFloat(maxInput)
-
+    let newMin = parseFloat(minInput)
+    let newMax = parseFloat(maxInput)
     if (isNaN(newMin)) {
-      onSetErrorMessage('Must supply a valid minimum value')
-      return
+      newMin = null
     }
 
     if (isNaN(newMax)) {
-      onSetErrorMessage('Must supply a valid maximum value')
-      return
-    }
-
-    if (newMin >= newMax) {
-      onSetErrorMessage('Minium value must be less than maximum')
-      return
+      newMax = null
     }
 
     if (initialMin === minInput && initialMax === maxInput) {
@@ -50,7 +40,6 @@ const MinMaxInputs: SFC<MinMaxInputsProps> = ({
       return
     }
 
-    onSetErrorMessage('')
     onSetMinMax([newMin, newMax])
   }
 
@@ -98,28 +87,26 @@ const AutoDomainInput: SFC<AutoDomainInputProps> = ({
   label = 'Set Domain',
 }) => {
   const [showInputs, setShowInputs] = useState(!!domain)
-  const [errorMessage, setErrorMessage] = useState('')
 
   const handleChooseAuto = () => {
     setShowInputs(false)
-    setErrorMessage('')
     onSetDomain(null)
   }
 
   const handleChooseCustom = () => {
     setShowInputs(true)
-    setErrorMessage('')
   }
 
-  const initialMin = domain ? String(domain[0]) : ''
-  const initialMax = domain ? String(domain[1]) : ''
+  const formatDomainValue = (value: null | number): string => {
+    return value === null ? '' : String(value)
+  }
+  const initialMin =
+    domain && Array.isArray(domain) ? formatDomainValue(domain[0]) : ''
+  const initialMax =
+    domain && Array.isArray(domain) ? formatDomainValue(domain[1]) : ''
 
   return (
-    <Form.Element
-      label={label}
-      errorMessage={errorMessage}
-      className="auto-domain-input"
-    >
+    <Form.Element label={label} className="auto-domain-input">
       <Grid>
         <Grid.Row>
           <Grid.Column widthXS={Columns.Twelve}>
@@ -153,7 +140,6 @@ const AutoDomainInput: SFC<AutoDomainInputProps> = ({
               initialMin={initialMin}
               initialMax={initialMax}
               onSetMinMax={onSetDomain}
-              onSetErrorMessage={setErrorMessage}
             />
           </Grid.Row>
         )}

--- a/ui/src/shared/components/AutoDomainInput.tsx
+++ b/ui/src/shared/components/AutoDomainInput.tsx
@@ -58,6 +58,7 @@ const MinMaxInputs: SFC<MinMaxInputsProps> = ({
             onChange={e => setMinInput(e.target.value)}
             onBlur={emitIfValid}
             onKeyPress={handleKeyPress}
+            testID="min--auto-domain"
           />
         </Form.Element>
       </Grid.Column>
@@ -68,6 +69,7 @@ const MinMaxInputs: SFC<MinMaxInputsProps> = ({
             onChange={e => setMaxInput(e.target.value)}
             onBlur={emitIfValid}
             onKeyPress={handleKeyPress}
+            testID="max--auto-domain"
           />
         </Form.Element>
       </Grid.Column>

--- a/ui/src/shared/components/AutoDomainInput.tsx
+++ b/ui/src/shared/components/AutoDomainInput.tsx
@@ -58,7 +58,7 @@ const MinMaxInputs: SFC<MinMaxInputsProps> = ({
             onChange={e => setMinInput(e.target.value)}
             onBlur={emitIfValid}
             onKeyPress={handleKeyPress}
-            testID="min--auto-domain"
+            testID="auto-domain--min"
           />
         </Form.Element>
       </Grid.Column>
@@ -69,12 +69,16 @@ const MinMaxInputs: SFC<MinMaxInputsProps> = ({
             onChange={e => setMaxInput(e.target.value)}
             onBlur={emitIfValid}
             onKeyPress={handleKeyPress}
-            testID="max--auto-domain"
+            testID="auto-domain--max"
           />
         </Form.Element>
       </Grid.Column>
     </>
   )
+}
+
+const formatDomainValue = (value: number | null): string => {
+  return value === null ? '' : String(value)
 }
 
 interface AutoDomainInputProps {
@@ -99,13 +103,8 @@ const AutoDomainInput: SFC<AutoDomainInputProps> = ({
     setShowInputs(true)
   }
 
-  const formatDomainValue = (value: null | number): string => {
-    return value === null ? '' : String(value)
-  }
-  const initialMin =
-    domain && Array.isArray(domain) ? formatDomainValue(domain[0]) : ''
-  const initialMax =
-    domain && Array.isArray(domain) ? formatDomainValue(domain[1]) : ''
+  const initialMin = Array.isArray(domain) ? formatDomainValue(domain[0]) : ''
+  const initialMax = Array.isArray(domain) ? formatDomainValue(domain[1]) : ''
 
   return (
     <Form.Element label={label} className="auto-domain-input">

--- a/ui/src/shared/components/HeatmapPlot.tsx
+++ b/ui/src/shared/components/HeatmapPlot.tsx
@@ -7,7 +7,10 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
-import {useVisDomainSettings} from 'src/shared/utils/useVisDomainSettings'
+import {
+  useVisDomainSettings,
+  useVisYDomainSettings,
+} from 'src/shared/utils/useVisDomainSettings'
 import {getFormatter} from 'src/shared/utils/vis'
 
 // Constants
@@ -65,7 +68,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
     timeRange
   )
 
-  const [yDomain, onSetYDomain, onResetYDomain] = useVisDomainSettings(
+  const [yDomain, onSetYDomain, onResetYDomain] = useVisYDomainSettings(
     storedYDomain,
     table.getColumn(yColumn, 'number')
   )

--- a/ui/src/shared/components/HeatmapPlot.tsx
+++ b/ui/src/shared/components/HeatmapPlot.tsx
@@ -8,7 +8,7 @@ import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
 import {
-  useVisDomainSettings,
+  useVisXDomainSettings,
   useVisYDomainSettings,
 } from 'src/shared/utils/useVisDomainSettings'
 import {getFormatter} from 'src/shared/utils/vis'
@@ -62,7 +62,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const [xDomain, onSetXDomain, onResetXDomain] = useVisDomainSettings(
+  const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
     table.getColumn(xColumn, 'number'),
     timeRange

--- a/ui/src/shared/components/HistogramPlot.tsx
+++ b/ui/src/shared/components/HistogramPlot.tsx
@@ -7,7 +7,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
-import {useVisDomainSettings} from 'src/shared/utils/useVisDomainSettings'
+import {useVisXDomainSettings} from 'src/shared/utils/useVisDomainSettings'
 import {getFormatter} from 'src/shared/utils/vis'
 
 // Constants
@@ -50,7 +50,7 @@ const HistogramPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const [xDomain, onSetXDomain, onResetXDomain] = useVisDomainSettings(
+  const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
     table.getColumn(xColumn, 'number')
   )

--- a/ui/src/shared/components/ScatterPlot.tsx
+++ b/ui/src/shared/components/ScatterPlot.tsx
@@ -7,7 +7,10 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
-import {useVisDomainSettings} from 'src/shared/utils/useVisDomainSettings'
+import {
+  useVisDomainSettings,
+  useVisYDomainSettings,
+} from 'src/shared/utils/useVisDomainSettings'
 import {
   getFormatter,
   defaultXColumn,
@@ -77,7 +80,7 @@ const ScatterPlot: FunctionComponent<Props> = ({
     timeRange
   )
 
-  const [yDomain, onSetYDomain, onResetYDomain] = useVisDomainSettings(
+  const [yDomain, onSetYDomain, onResetYDomain] = useVisYDomainSettings(
     storedYDomain,
     table.getColumn(yColumn, 'number')
   )

--- a/ui/src/shared/components/ScatterPlot.tsx
+++ b/ui/src/shared/components/ScatterPlot.tsx
@@ -8,7 +8,7 @@ import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
 import {
-  useVisDomainSettings,
+  useVisXDomainSettings,
   useVisYDomainSettings,
 } from 'src/shared/utils/useVisDomainSettings'
 import {
@@ -74,7 +74,7 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const columnKeys = table.columnKeys
 
-  const [xDomain, onSetXDomain, onResetXDomain] = useVisDomainSettings(
+  const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
     table.getColumn(xColumn, 'number'),
     timeRange

--- a/ui/src/shared/components/XYPlot.tsx
+++ b/ui/src/shared/components/XYPlot.tsx
@@ -13,12 +13,16 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
-import {useVisDomainSettings} from 'src/shared/utils/useVisDomainSettings'
+import {
+  useVisDomainSettings,
+  useVisYDomainSettings,
+} from 'src/shared/utils/useVisDomainSettings'
 import {
   getFormatter,
   geomToInterpolation,
   filterNoisyColumns,
   parseBounds,
+  parseYBounds,
   defaultXColumn,
   defaultYColumn,
 } from 'src/shared/utils/vis'
@@ -83,8 +87,7 @@ const XYPlot: FunctionComponent<Props> = ({
   theme,
 }) => {
   const storedXDomain = useMemo(() => parseBounds(xBounds), [xBounds])
-  const storedYDomain = useMemo(() => parseBounds(yBounds), [yBounds])
-
+  const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])
   const xColumn = storedXColumn || defaultXColumn(table)
   const yColumn = storedYColumn || defaultYColumn(table)
 
@@ -130,7 +133,7 @@ const XYPlot: FunctionComponent<Props> = ({
     return table.getColumn(yColumn, 'number')
   }, [table, yColumn, position])
 
-  const [yDomain, onSetYDomain, onResetYDomain] = useVisDomainSettings(
+  const [yDomain, onSetYDomain, onResetYDomain] = useVisYDomainSettings(
     storedYDomain,
     memoizedYColumnData
   )

--- a/ui/src/shared/components/XYPlot.tsx
+++ b/ui/src/shared/components/XYPlot.tsx
@@ -14,14 +14,14 @@ import GraphLoadingDots from 'src/shared/components/GraphLoadingDots'
 
 // Utils
 import {
-  useVisDomainSettings,
+  useVisXDomainSettings,
   useVisYDomainSettings,
 } from 'src/shared/utils/useVisDomainSettings'
 import {
   getFormatter,
   geomToInterpolation,
   filterNoisyColumns,
-  parseBounds,
+  parseXBounds,
   parseYBounds,
   defaultXColumn,
   defaultYColumn,
@@ -86,7 +86,7 @@ const XYPlot: FunctionComponent<Props> = ({
   },
   theme,
 }) => {
-  const storedXDomain = useMemo(() => parseBounds(xBounds), [xBounds])
+  const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])
   const xColumn = storedXColumn || defaultXColumn(table)
   const yColumn = storedYColumn || defaultYColumn(table)
@@ -112,7 +112,7 @@ const XYPlot: FunctionComponent<Props> = ({
 
   const groupKey = [...fluxGroupKeyUnion, 'result']
 
-  const [xDomain, onSetXDomain, onResetXDomain] = useVisDomainSettings(
+  const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
     table.getColumn(xColumn, 'number'),
     timeRange

--- a/ui/src/shared/utils/useVisDomainSettings.test.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.test.ts
@@ -1,5 +1,9 @@
 // Funcs
-import {getValidRange} from 'src/shared/utils/useVisDomainSettings'
+import {
+  getValidRange,
+  getRemainingRange,
+  useVisYDomainSettings,
+} from 'src/shared/utils/useVisDomainSettings'
 
 // Types
 import {numericColumnData as data} from 'mocks/dummyData'
@@ -47,7 +51,46 @@ describe('getValidRange', () => {
     const newRange = getValidRange(data, timeRange)
     expect(newRange[1]).toEqual(data[data.length - 1])
   })
-  it('should return the the start and end times based on the data array if no start / endTime are passed', () => {
+  it('should return the start and end times based on the data array if no start / endTime are passed', () => {
     expect(getValidRange(data, null)).toEqual([data[0], data[data.length - 1]])
+  })
+})
+
+describe('getRemainingRange', () => {
+  // const startTime: string = 'Nov 07 2019 02:46:51 GMT-0800'
+  const startTime: string = '2019-11-07T02:46:51Z'
+  const unixStart: number = 1573094811000
+  const endTime: string = '2019-11-28T14:46:51Z'
+  const unixEnd: number = 1574952411000
+  it('should return null when no parameters are input', () => {
+    expect(useVisYDomainSettings(undefined, undefined, undefined)).toEqual(null)
+  })
+  it('should return null when no data is passed', () => {
+    const timeRange: CustomTimeRange = {
+      type: 'custom',
+      lower: startTime,
+      upper: endTime,
+    }
+    expect(getRemainingRange([], timeRange, [null, null])).toEqual(null)
+  })
+  it("should return the min y-axis if it's set", () => {
+    const timeRange: CustomTimeRange = {
+      type: 'custom',
+      lower: startTime,
+      upper: endTime,
+    }
+    const setMin = unixStart - 10
+    const [start] = getRemainingRange(data, timeRange, [setMin, null])
+    expect(start).toEqual(setMin)
+  })
+  it("should return the max y-axis if it's set", () => {
+    const timeRange: CustomTimeRange = {
+      type: 'custom',
+      lower: startTime,
+      upper: endTime,
+    }
+    const setMax = unixEnd + 10
+    const range = getRemainingRange(data, timeRange, [null, setMax])
+    expect(range[1]).toEqual(setMax)
   })
 })

--- a/ui/src/shared/utils/useVisDomainSettings.test.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.test.ts
@@ -2,7 +2,6 @@
 import {
   getValidRange,
   getRemainingRange,
-  useVisYDomainSettings,
 } from 'src/shared/utils/useVisDomainSettings'
 
 // Types
@@ -63,7 +62,7 @@ describe('getRemainingRange', () => {
   const endTime: string = '2019-11-28T14:46:51Z'
   const unixEnd: number = 1574952411000
   it('should return null when no parameters are input', () => {
-    expect(useVisYDomainSettings(undefined, undefined, undefined)).toEqual(null)
+    expect(getRemainingRange(undefined, undefined, undefined)).toEqual(null)
   })
   it('should return null when no data is passed', () => {
     const timeRange: CustomTimeRange = {

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -54,3 +54,42 @@ export const useVisDomainSettings = (
 
   return [domain, setDomain, resetDomain]
 }
+
+export const getRemainingRange = (
+  data: NumericColumnData = [],
+  timeRange: TimeRange | null,
+  storedDomain: number[]
+) => {
+  const range = extent((data as number[]) || [])
+  if (range && range.length >= 2) {
+    const startTime = getStartTime(timeRange)
+    const endTime = getEndTime(timeRange)
+    const start = storedDomain[0]
+      ? storedDomain[0]
+      : Math.min(startTime, range[0])
+    const end = storedDomain[1] ? storedDomain[1] : Math.max(endTime, range[1])
+    return [start, end]
+  }
+  return range
+}
+
+export const useVisYDomainSettings = (
+  storedDomain: number[],
+  data: NumericColumnData,
+  timeRange: TimeRange | null = null
+) => {
+  const initialDomain = useMemo(() => {
+    if (storedDomain === null || storedDomain.every(val => val === null)) {
+      return getValidRange(data, timeRange)
+    }
+    if (storedDomain.includes(null)) {
+      return getRemainingRange(data, timeRange, storedDomain)
+    }
+    return storedDomain
+  }, [storedDomain, data])
+
+  const [domain, setDomain] = useOneWayState(initialDomain)
+  const resetDomain = () => setDomain(initialDomain)
+
+  return [domain, setDomain, resetDomain]
+}

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -36,7 +36,7 @@ export const getValidRange = (
   return range
 }
 
-export const useVisDomainSettings = (
+export const useVisXDomainSettings = (
   storedDomain: number[],
   data: NumericColumnData,
   timeRange: TimeRange | null = null

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -61,7 +61,7 @@ export const getRemainingRange = (
   storedDomain: number[]
 ) => {
   const range = extent((data as number[]) || [])
-  if (range && range.length >= 2) {
+  if (Array.isArray(range) && range.length >= 2) {
     const startTime = getStartTime(timeRange)
     const endTime = getEndTime(timeRange)
     const start = storedDomain[0]

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -60,7 +60,7 @@ export const getRemainingRange = (
   timeRange: TimeRange | null,
   storedDomain: number[]
 ) => {
-  const range = extent((data as number[]) || [])
+  const range = extent(data as number[]) || []
   if (Array.isArray(range) && range.length >= 2) {
     const startTime = getStartTime(timeRange)
     const endTime = getEndTime(timeRange)

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -22,7 +22,7 @@ export const getValidRange = (
   data: NumericColumnData = [],
   timeRange: TimeRange | null
 ) => {
-  const range = extent((data as number[]) || [])
+  const range = extent(data as number[])
   if (isNull(timeRange)) {
     return range
   }
@@ -60,7 +60,7 @@ export const getRemainingRange = (
   timeRange: TimeRange | null,
   storedDomain: number[]
 ) => {
-  const range = extent(data as number[]) || []
+  const range = extent(data as number[])
   if (Array.isArray(range) && range.length >= 2) {
     const startTime = getStartTime(timeRange)
     const endTime = getEndTime(timeRange)

--- a/ui/src/shared/utils/vis.test.ts
+++ b/ui/src/shared/utils/vis.test.ts
@@ -1,0 +1,18 @@
+// Funcs
+import {parseYBounds} from 'src/shared/utils/vis'
+
+describe('parseYBounds', () => {
+  it('should return null when bounds is null', () => {
+    expect(parseYBounds(null)).toEqual(null)
+    expect(parseYBounds([null, null])).toEqual(null)
+  })
+  it('should return [0, 100] when the bounds are ["0", "100"]', () => {
+    expect(parseYBounds(['0', '100'])).toEqual([0, 100])
+  })
+  it('should return [null, 100] when the bounds are [null, "100"]', () => {
+    expect(parseYBounds([null, '100'])).toEqual([null, 100])
+  })
+  it('should return [-10, null] when the bounds are ["-10", null]', () => {
+    expect(parseYBounds(['-10', null])).toEqual([-10, null])
+  })
+})

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -129,6 +129,18 @@ export const parseBounds = (
   return [+bounds[0], +bounds[1]]
 }
 
+export const parseYBounds = (
+  bounds: Axis['bounds']
+): [number | null, number | null] | null => {
+  if (!bounds || (!bounds[0] && !bounds[1])) {
+    return null
+  }
+
+  const min = isNaN(parseInt(bounds[0])) ? null : parseInt(bounds[0])
+  const max = isNaN(parseInt(bounds[1])) ? null : parseInt(bounds[1])
+  return [min, max]
+}
+
 export const extent = (xs: number[]): [number, number] | null => {
   if (!xs || !xs.length) {
     return null

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -113,7 +113,7 @@ export const filterNoisyColumns = (columns: string[], table: Table): string[] =>
     return false
   })
 
-export const parseBounds = (
+export const parseXBounds = (
   bounds: Axis['bounds']
 ): [number, number] | null => {
   if (

--- a/ui/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/LineOptions.tsx
@@ -32,7 +32,7 @@ import {
 } from 'src/timeMachine/actions'
 
 // Utils
-import {parseBounds} from 'src/shared/utils/vis'
+import {parseYBounds} from 'src/shared/utils/vis'
 import {
   getXColumnSelection,
   getYColumnSelection,
@@ -202,14 +202,19 @@ class LineOptions extends PureComponent<Props> {
   }
 
   private get yDomain(): [number, number] {
-    return parseBounds(this.props.axes.y.bounds)
+    return parseYBounds(this.props.axes.y.bounds)
+  }
+
+  private setBoundValues = (value: number | null): string | null => {
+    return value === null ? null : String(value)
   }
 
   private handleSetYDomain = (yDomain: [number, number]): void => {
-    let bounds: [string, string] | [null, null]
+    let bounds: [string | null, string | null]
 
     if (yDomain) {
-      bounds = [String(yDomain[0]), String(yDomain[1])]
+      const [min, max] = yDomain
+      bounds = [this.setBoundValues(min), this.setBoundValues(max)]
     } else {
       bounds = [null, null]
     }


### PR DESCRIPTION
Closes #17793

### Purpose

The purpose of this PR is to allow users to set a Y-domain min/max value without requiring users to set both. In other words, a user should be able to set the Y-domain with either a MIN or a MAX, and should not be required to set both.

### Considerations

This feature required a removal of current restrictions on setting domain values, such as:

- no empty values
- min <= max

The ramifications of these changes were addressed by dynamically setting empty values based on the data range that is returned. If a user set their minimum value to 0, and left the maximum value blank, the upper bounds of their range would be set dynamically based on the data range. Similarly, if a user set their maximum value to 100 and left he minimum value blank, the lower bounds of their range would be set dynamically based on the data range.

In effect, this treats the non-blank input values as the source of truth for data range visualization. Therefore, if a user sets the minimum y value to be greater than the upper bounds of the data range values, and leaves the maximum value blank, then no data will show up (since it is beyond the range). Similarly, if a user sets the maximum y value to be less than the lower bounds of the data range values and leaves the minimum value blank, then no data will show up (for the same reason as before).

The images below list off the different use cases:
Auto Set:
<img width="1103" alt="Screen Shot 2020-05-11 at 13 45 01" src="https://user-images.githubusercontent.com/19984220/81611579-23989f80-9390-11ea-9f04-5520e5ea124a.png">

Set minimum blank:
<img width="1141" alt="Screen Shot 2020-05-11 at 13 45 18" src="https://user-images.githubusercontent.com/19984220/81611492-006df000-9390-11ea-813f-5ad6cc3bd7a5.png">

Set fields blank:
<img width="1146" alt="Screen Shot 2020-05-11 at 13 45 25" src="https://user-images.githubusercontent.com/19984220/81611471-f64bf180-938f-11ea-933b-c1be3c3783be.png">

Set the min greater than the max data range:
<img width="1114" alt="Screen Shot 2020-05-11 at 13 45 33" src="https://user-images.githubusercontent.com/19984220/81611426-df0d0400-938f-11ea-92fe-c30d4eac9968.png">

Set the min > max:
<img width="1118" alt="Screen Shot 2020-05-11 at 13 45 39" src="https://user-images.githubusercontent.com/19984220/81611383-cd2b6100-938f-11ea-8ca8-9dfdaff37b5b.png">

Set the min, doesn't set the max:
<img width="1113" alt="Screen Shot 2020-05-11 at 13 45 48" src="https://user-images.githubusercontent.com/19984220/81611348-bf75db80-938f-11ea-97e1-f133339f5d87.png">

Set Max less than the min data range:
<img width="1113" alt="Screen Shot 2020-05-11 at 13 45 54" src="https://user-images.githubusercontent.com/19984220/81611315-b1c05600-938f-11ea-8e88-8b5c64b0c1a6.png">

Set Both:
<img width="1112" alt="Screen Shot 2020-05-11 at 13 46 00" src="https://user-images.githubusercontent.com/19984220/81611294-a5d49400-938f-11ea-86e9-50a7dd650fc5.png">

<img width="1141" alt="Screen Shot 2020-05-11 at 13 45 10" src="https://user-images.githubusercontent.com/19984220/81611531-1380c000-9390-11ea-9f4c-bd5fdb443117.png">

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] Rebased/mergeable
