### PR TITLE
feat: integrate the new session system behind a feature flag

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -33,3 +33,10 @@
   default: false
   contact: Alirie Gray
   lifetime: temporary
+
+- name: Session Service
+  description: A temporary switching system for the new session system
+  key: sessionService
+  default: false
+  contact: Lyon Hill
+  expose: true

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -177,11 +177,6 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 		b.OrganizationService)
 	h.Mount(prefixTargets, NewScraperHandler(b.Logger, scraperBackend))
 
-	sessionBackend := newSessionBackend(b.Logger.With(zap.String("handler", "session")), b)
-	sessionHandler := NewSessionHandler(b.Logger, sessionBackend)
-	h.Mount(prefixSignIn, sessionHandler)
-	h.Mount(prefixSignOut, sessionHandler)
-
 	sourceBackend := NewSourceBackend(b.Logger.With(zap.String("handler", "source")), b)
 	sourceBackend.SourceService = authorizer.NewSourceService(b.SourceService)
 	sourceBackend.BucketService = authorizer.NewBucketService(b.BucketService, noAuthUserResourceMappingService)

--- a/http/session_handler.go
+++ b/http/session_handler.go
@@ -25,8 +25,8 @@ type SessionBackend struct {
 	UserService      platform.UserService
 }
 
-// newSessionBackend creates a new SessionBackend with associated logger.
-func newSessionBackend(log *zap.Logger, b *APIBackend) *SessionBackend {
+// NewSessionBackend creates a new SessionBackend with associated logger.
+func NewSessionBackend(log *zap.Logger, b *APIBackend) *SessionBackend {
 	return &SessionBackend{
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              log,

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -44,14 +44,30 @@ func NewAuthPackage() BoolFlag {
 	return newAuth
 }
 
+var sessionService = MakeBoolFlag(
+	"Session Service",
+	"sessionService",
+	"Lyon Hill",
+	false,
+	Temporary,
+	true,
+)
+
+// SessionService - A temporary switching system for the new session system
+func SessionService() BoolFlag {
+	return sessionService
+}
+
 var all = []Flag{
 	backendExample,
 	frontendExample,
 	newAuth,
+	sessionService,
 }
 
 var byKey = map[string]Flag{
 	"backendExample":  backendExample,
 	"frontendExample": frontendExample,
 	"newAuth":         newAuth,
+	"sessionService":  sessionService,
 }

--- a/session/controller.go
+++ b/session/controller.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"context"
+	"time"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/feature"
+)
+
+var _ influxdb.SessionService = (*ServiceController)(nil)
+
+// ServiceController is a temporary switching mechanism to allow
+// a safe rollout of the new session service
+type ServiceController struct {
+	flagger           feature.Flagger
+	oldSessionService influxdb.SessionService
+	newSessionService influxdb.SessionService
+}
+
+func NewServiceController(flagger feature.Flagger, oldSessionService influxdb.SessionService, newSessionService influxdb.SessionService) *ServiceController {
+	return &ServiceController{
+		flagger:           flagger,
+		oldSessionService: oldSessionService,
+		newSessionService: newSessionService,
+	}
+}
+
+func (s *ServiceController) useNew(ctx context.Context) bool {
+	return feature.SessionService().Enabled(ctx, s.flagger)
+}
+
+func (s *ServiceController) FindSession(ctx context.Context, key string) (*influxdb.Session, error) {
+	if s.useNew(ctx) {
+		return s.newSessionService.FindSession(ctx, key)
+	}
+	return s.oldSessionService.FindSession(ctx, key)
+}
+
+func (s *ServiceController) ExpireSession(ctx context.Context, key string) error {
+	if s.useNew(ctx) {
+		return s.newSessionService.ExpireSession(ctx, key)
+	}
+	return s.oldSessionService.ExpireSession(ctx, key)
+}
+
+func (s *ServiceController) CreateSession(ctx context.Context, user string) (*influxdb.Session, error) {
+	if s.useNew(ctx) {
+		return s.newSessionService.CreateSession(ctx, user)
+	}
+	return s.oldSessionService.CreateSession(ctx, user)
+}
+
+func (s *ServiceController) RenewSession(ctx context.Context, session *influxdb.Session, newExpiration time.Time) error {
+	if s.useNew(ctx) {
+		return s.newSessionService.RenewSession(ctx, session, newExpiration)
+	}
+	return s.oldSessionService.RenewSession(ctx, session, newExpiration)
+}


### PR DESCRIPTION
This is the integration step for the new session service. It is currently backed by an in memory store. this should be sufficient for our OSS use. I added a control system around using the new session system as a service as well as using it as a front end piece.