### PR TITLE
fix: change logging level to debug to reduce noise

### DIFF
--- a/authorization/middleware_logging.go
+++ b/authorization/middleware_logging.go
@@ -28,7 +28,7 @@ func (l *AuthLogger) CreateAuthorization(ctx context.Context, a *influxdb.Author
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to create authorization", zap.Error(err), dur)
+			l.logger.Debug("failed to create authorization", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("authorization create", dur)
@@ -41,7 +41,7 @@ func (l *AuthLogger) FindAuthorizationByID(ctx context.Context, id influxdb.ID) 
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to find authorization with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("auth find by ID", dur)
@@ -53,7 +53,7 @@ func (l *AuthLogger) FindAuthorizationByToken(ctx context.Context, t string) (a 
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find authorization with token", zap.Error(err), dur)
+			l.logger.Debug("failed to find authorization with token", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("auth find", dur)
@@ -66,7 +66,7 @@ func (l *AuthLogger) FindAuthorizations(ctx context.Context, filter influxdb.Aut
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find authorizations matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find authorizations matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("authorizations find", dur)
@@ -78,7 +78,7 @@ func (l *AuthLogger) UpdateAuthorization(ctx context.Context, id influxdb.ID, up
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to update authorization", zap.Error(err), dur)
+			l.logger.Debug("failed to update authorization", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("authorizationauthorization update", dur)
@@ -91,7 +91,7 @@ func (l *AuthLogger) DeleteAuthorization(ctx context.Context, id influxdb.ID) (e
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete authorization with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("authorization delete", dur)

--- a/session/middleware_logging.go
+++ b/session/middleware_logging.go
@@ -29,7 +29,7 @@ func (l *SessionLogger) FindSession(ctx context.Context, key string) (session *i
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to session find", zap.Error(err), dur)
+			l.logger.Debug("failed to session find", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("session find", dur)
@@ -43,7 +43,7 @@ func (l *SessionLogger) ExpireSession(ctx context.Context, key string) (err erro
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to session expire", zap.Error(err), dur)
+			l.logger.Debug("failed to session expire", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("session expire", dur)
@@ -57,7 +57,7 @@ func (l *SessionLogger) CreateSession(ctx context.Context, user string) (s *infl
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to session create", zap.Error(err), dur)
+			l.logger.Debug("failed to session create", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("session create", dur)
@@ -71,7 +71,7 @@ func (l *SessionLogger) RenewSession(ctx context.Context, session *influxdb.Sess
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to session renew", zap.Error(err), dur)
+			l.logger.Debug("failed to session renew", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("session renew", dur)

--- a/tenant/middleware_bucket_logging.go
+++ b/tenant/middleware_bucket_logging.go
@@ -28,7 +28,7 @@ func (l *BucketLogger) CreateBucket(ctx context.Context, u *influxdb.Bucket) (er
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to create bucket", zap.Error(err), dur)
+			l.logger.Debug("failed to create bucket", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket create", dur)
@@ -41,7 +41,7 @@ func (l *BucketLogger) FindBucketByID(ctx context.Context, id influxdb.ID) (u *i
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to find bucket with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket find by ID", dur)
@@ -54,7 +54,7 @@ func (l *BucketLogger) FindBucketByName(ctx context.Context, orgID influxdb.ID, 
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to find bucket with name %v in org %v", name, orgID)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket find by name", dur)
@@ -66,7 +66,7 @@ func (l *BucketLogger) FindBucket(ctx context.Context, filter influxdb.BucketFil
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find bucket matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find bucket matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket find", dur)
@@ -78,7 +78,7 @@ func (l *BucketLogger) FindBuckets(ctx context.Context, filter influxdb.BucketFi
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find bucket matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find bucket matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("buckets find", dur)
@@ -90,7 +90,7 @@ func (l *BucketLogger) UpdateBucket(ctx context.Context, id influxdb.ID, upd inf
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to update bucket", zap.Error(err), dur)
+			l.logger.Debug("failed to update bucket", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket update", dur)
@@ -103,7 +103,7 @@ func (l *BucketLogger) DeleteBucket(ctx context.Context, id influxdb.ID) (err er
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete bucket with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("bucket delete", dur)

--- a/tenant/middleware_onboarding_logging.go
+++ b/tenant/middleware_onboarding_logging.go
@@ -28,7 +28,7 @@ func (l *OnboardingLogger) IsOnboarding(ctx context.Context) (available bool, er
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to check onboarding", zap.Error(err), dur)
+			l.logger.Debug("failed to check onboarding", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("is onboarding", dur)
@@ -41,7 +41,7 @@ func (l *OnboardingLogger) OnboardInitialUser(ctx context.Context, req *influxdb
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to onboard user %s", req.User)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("onboard initial user", dur)
@@ -54,7 +54,7 @@ func (l *OnboardingLogger) OnboardUser(ctx context.Context, req *influxdb.Onboar
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to onboard user %s", req.User)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("onboard user", dur)

--- a/tenant/middleware_org_logging.go
+++ b/tenant/middleware_org_logging.go
@@ -28,7 +28,7 @@ func (l *OrgLogger) CreateOrganization(ctx context.Context, u *influxdb.Organiza
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to create org", zap.Error(err), dur)
+			l.logger.Debug("failed to create org", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("org create", dur)
@@ -41,7 +41,7 @@ func (l *OrgLogger) FindOrganizationByID(ctx context.Context, id influxdb.ID) (u
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to find org with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("org find by ID", dur)
@@ -53,7 +53,7 @@ func (l *OrgLogger) FindOrganization(ctx context.Context, filter influxdb.Organi
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find org matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find org matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("org find", dur)
@@ -66,7 +66,7 @@ func (l *OrgLogger) FindOrganizations(ctx context.Context, filter influxdb.Organ
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find org matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find org matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("orgs find", dur)
@@ -78,7 +78,7 @@ func (l *OrgLogger) UpdateOrganization(ctx context.Context, id influxdb.ID, upd 
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to update org", zap.Error(err), dur)
+			l.logger.Debug("failed to update org", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("org update", dur)
@@ -91,7 +91,7 @@ func (l *OrgLogger) DeleteOrganization(ctx context.Context, id influxdb.ID) (err
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete org with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("org delete", dur)

--- a/tenant/middleware_user_logging.go
+++ b/tenant/middleware_user_logging.go
@@ -29,7 +29,7 @@ func (l *UserLogger) CreateUser(ctx context.Context, u *influxdb.User) (err erro
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to create user", zap.Error(err), dur)
+			l.logger.Debug("failed to create user", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("user create", dur)
@@ -42,7 +42,7 @@ func (l *UserLogger) FindUserByID(ctx context.Context, id influxdb.ID) (u *influ
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to find user with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("user find by ID", dur)
@@ -54,7 +54,7 @@ func (l *UserLogger) FindUser(ctx context.Context, filter influxdb.UserFilter) (
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find user matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find user matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("user find", dur)
@@ -66,7 +66,7 @@ func (l *UserLogger) FindUsers(ctx context.Context, filter influxdb.UserFilter, 
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to find users matching the given filter", zap.Error(err), dur)
+			l.logger.Debug("failed to find users matching the given filter", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("users find", dur)
@@ -78,7 +78,7 @@ func (l *UserLogger) UpdateUser(ctx context.Context, id influxdb.ID, upd influxd
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Error("failed to update user", zap.Error(err), dur)
+			l.logger.Debug("failed to update user", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("user update", dur)
@@ -91,7 +91,7 @@ func (l *UserLogger) DeleteUser(ctx context.Context, id influxdb.ID) (err error)
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete user with ID %v", id)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("user create", dur)
@@ -117,7 +117,7 @@ func (l *PasswordLogger) SetPassword(ctx context.Context, userID influxdb.ID, pa
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to set password for user with ID %v", userID)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("set password", dur)
@@ -130,7 +130,7 @@ func (l *PasswordLogger) ComparePassword(ctx context.Context, userID influxdb.ID
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to compare password for user with ID %v", userID)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("compare password", dur)
@@ -143,7 +143,7 @@ func (l *PasswordLogger) CompareAndSetPassword(ctx context.Context, userID influ
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to compare and set password for user with ID %v", userID)
-			l.logger.Error(msg, zap.Error(err), dur)
+			l.logger.Debug(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("compare and set password", dur)


### PR DESCRIPTION
Closes #18053

Change logging level in tenant service from "error" to "debug" to reduce noise.

- [x] Rebased/mergeable
- [x] Tests pass

