### PR TITLE
feat: add dshell environment for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,15 @@ cypress/videos
 
 # vendored files
 /vendor
+
+# DShell Ignores
+.ash_history
+.bash_history
+.cache/
+.cargo/
+.dockerignore
+.influxdbv2/
+.profile
+.rustup/
+.yarnrc
+go/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,22 @@
 
 ## Quickstart
 
+## Docker
+
+We've provided `make` targets that provide an "interactive" development experience using Docker.
+
+
+```console
+make dshell
+```
+
+This command builds a development container image and puts you inside a container with all the tooling you require to develop and build InfluxDB.
+You can use the "Local" instructions once inside this container and work on the premise that you have everything installed.
+
+Other container runtimes should work, but we've only tested with Docker and Podman (`alias docker=podman`).
+
+## Local
+
 Assuming you have Go 1.13, Node LTS, and yarn installed, and some means of ingesting data locally (e.g. telegraf):
 
 You'll need two terminal tabs to run influxdb from source: one to run the go application server, the other to run the development server that will listen for front-end changes, rebuild the bundle, serve the new bundle, then reload your webpage for you.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:20.04 AS dbuild
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Needed for Yarn steps to veryify the keys
+RUN apt update
+RUN apt install --yes curl gnupg2
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Now update index with Yarn
+RUN apt update
+RUN apt install --yes \
+        cargo \
+        git \
+        golang \
+        libclang-dev \
+        llvm-dev \
+        make \
+        nodejs \
+        protobuf-compiler \
+        ragel \
+        rustc \
+        yarn
+
+FROM dbuild AS dshell
+
+ARG USERID=1000
+RUN adduser --quiet --home /code --uid ${USERID} --disabled-password --gecos "" influx
+USER influx
+
+ENTRYPOINT [ "/bin/bash" ]
+
+FROM dbuild AS dbuild-all
+
+COPY . /code
+WORKDIR /code
+RUN make
+
+##
+# InfluxDB Image (Monolith)
+##
+FROM debian:stretch-slim AS influx
+
+COPY --from=dbuild-all /code/bin/linux/influxd /usr/bin/influxd
+COPY --from=dbuild-all /code/bin/linux/influx /usr/bin/influx
+
+EXPOSE 9999
+
+ENTRYPOINT [ "/usr/bin/influxd" ]
+
+##
+# InfluxDB UI Image
+##
+FROM nginx:alpine AS ui
+
+EXPOSE 80
+
+COPY --from=dbuild-all /code/ui/build /usr/share/nginx/html

--- a/Makefile
+++ b/Makefile
@@ -210,5 +210,20 @@ protoc:
 flags:
 	$(GO_GENERATE) ./kit/feature
 
+docker-image-influx:
+	@cp .gitignore .dockerignore
+	@docker image build -t influxdb:dev --target influx .
+
+docker-image-ui:
+	@cp .gitignore .dockerignore
+	@docker image build -t influxui:dev --target ui .
+	
+dshell-image:
+	@cp .gitignore .dockerignore
+	@docker image build --build-arg "USERID=$(shell id -u)" -t influxdb:dshell --target dshell .
+
+dshell: dshell-image
+	@docker container run --rm -p 9999:9999 -p 8080:8080 -u $(shell id -u) -it -v $(shell pwd):/code -w /code influxdb:dshell 
+
 # .PHONY targets represent actions that do not create an actual file.
-.PHONY: all $(SUBDIRS) run fmt checkfmt tidy checktidy checkgenerate test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe dist ping protoc e2e run-e2e influxd libflux flags
+.PHONY: all $(SUBDIRS) run fmt checkfmt tidy checktidy checkgenerate test test-go test-js test-go-race bench clean node_modules vet nightly chronogiraffe dist ping protoc e2e run-e2e influxd libflux flags dshell dclean docker-image-flux docker-image-influx


### PR DESCRIPTION
Building and developing InfluxDB 2 locally can be a bit of a pain, as the dependencies are growing and changing with a regular cadence.

These changes allow for the user to develop in an "interactive terminal" that's inside of a container.

While putting this together, I also took it as an opportunity to adopt multi-stage Dockerfile to provide multiple targets. Currently this Dockerfile is capable of building the monolithic InfluxDB 2 image, as well as the UI on its own.


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
