### PR TITLE
fix(http): call PATCH endpoint in checks service PatchCheck

### DIFF
--- a/http/check_service.go
+++ b/http/check_service.go
@@ -814,7 +814,7 @@ func (s *CheckService) PatchCheck(ctx context.Context, id influxdb.ID, u influxd
 
 	var r Check
 	err := s.Client.
-		PutJSON(u, checkIDPath(id)).
+		PatchJSON(u, checkIDPath(id)).
 		DecodeJSON(&r).
 		Do(ctx)
 	if err != nil {


### PR DESCRIPTION
I was writing tests using this client and came across this bug.
The PatchCheck now uses the `PATCH` http method.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
