### PR TITLE
fix: Adjusting the width of dropdown

### DIFF
--- a/ui/src/variables/components/VariableDropdown.scss
+++ b/ui/src/variables/components/VariableDropdown.scss
@@ -93,3 +93,7 @@
     cursor: grab !important;
   }
 }
+
+.variable-dropdown--item {
+  font-family: $cf-code-font;
+}

--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -43,12 +43,12 @@ class VariableDropdown extends PureComponent<Props> {
     const dropdownStatus =
       values.length === 0 ? ComponentStatus.Disabled : ComponentStatus.Default
 
-    const widthLength = Math.max(
-      140,
-      values.reduce(function(a, b) {
+    const longestItemWidth =
+      Math.floor(values.reduce(function(a, b) {
         return a.length > b.length ? a : b
-      }, '').length * 8
-    )
+      }, '').length * 8.5)
+
+    const widthLength = Math.max(140, longestItemWidth)
 
     return (
       <div className="variable-dropdown">
@@ -82,7 +82,7 @@ class VariableDropdown extends PureComponent<Props> {
                     onClick={this.handleSelect}
                     selected={val === selectedValue}
                     testID="variable-dropdown--item"
-                    // wrapText={true}
+                    className="variable-dropdown--item"
                   >
                     {val}
                   </Dropdown.Item>

--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -43,10 +43,11 @@ class VariableDropdown extends PureComponent<Props> {
     const dropdownStatus =
       values.length === 0 ? ComponentStatus.Disabled : ComponentStatus.Default
 
-    const longestItemWidth =
-      Math.floor(values.reduce(function(a, b) {
+    const longestItemWidth = Math.floor(
+      values.reduce(function(a, b) {
         return a.length > b.length ? a : b
-      }, '').length * 8.5)
+      }, '').length * 8.5
+    )
 
     const widthLength = Math.max(140, longestItemWidth)
 

--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -43,6 +43,13 @@ class VariableDropdown extends PureComponent<Props> {
     const dropdownStatus =
       values.length === 0 ? ComponentStatus.Disabled : ComponentStatus.Default
 
+    const widthLength = Math.max(
+      140,
+      values.reduce(function(a, b) {
+        return a.length > b.length ? a : b
+      }, '').length * 8
+    )
+
     return (
       <div className="variable-dropdown">
         {/* TODO: Add variable description to title attribute when it is ready */}
@@ -62,6 +69,7 @@ class VariableDropdown extends PureComponent<Props> {
           )}
           menu={onCollapse => (
             <Dropdown.Menu
+              style={{width: `${widthLength}px`}}
               onCollapse={onCollapse}
               theme={DropdownMenuTheme.Amethyst}
             >
@@ -74,6 +82,7 @@ class VariableDropdown extends PureComponent<Props> {
                     onClick={this.handleSelect}
                     selected={val === selectedValue}
                     testID="variable-dropdown--item"
+                    // wrapText={true}
                   >
                     {val}
                   </Dropdown.Item>


### PR DESCRIPTION
This will make it so the width of the dropdown will adjust to the longest variable name

Closes #18021 

Describe your proposed changes here.
Ive done a simple math problem that determines the longest length in the values and makes that the width px
<img width="656" alt="Screen Shot 2020-05-12 at 12 04 44 PM" src="https://user-images.githubusercontent.com/6667389/81729736-b47f8180-9449-11ea-9c88-94812e88082a.png">

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
