### PR TITLE
feat: move cursor to end of text

### DIFF
--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -27,6 +27,7 @@ interface Props {
   onChangeScript: OnChangeScript
   onSubmitScript?: () => void
   setEditorInstance?: (editor: EditorType) => void
+  skipFocus?: boolean
 }
 
 const FluxEditorMonaco: FC<Props> = ({
@@ -34,6 +35,7 @@ const FluxEditorMonaco: FC<Props> = ({
   onChangeScript,
   onSubmitScript,
   setEditorInstance,
+  skipFocus,
 }) => {
   const lspServer = useRef<LSPServer>(null)
   const [editorInst, seteditorInst] = useState<EditorType | null>(null)
@@ -65,12 +67,19 @@ const FluxEditorMonaco: FC<Props> = ({
       }
     })
 
-    editor.focus()
-
     try {
       lspServer.current = await loadServer()
       const diagnostics = await lspServer.current.didOpen(uri, script)
       updateDiagnostics(diagnostics)
+
+      if (!skipFocus) {
+        const lines = (script || '').split('\n')
+        editor.setPosition({
+          lineNumber: lines.length,
+          column: lines[lines.length - 1].length + 1,
+        })
+        editor.focus()
+      }
     } catch (e) {
       // TODO: notify user that lsp failed
     }

--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -12,6 +12,7 @@ import FLUXLANGID from 'src/external/monaco.flux.syntax'
 import THEME_NAME from 'src/external/monaco.flux.theme'
 import loadServer, {LSPServer} from 'src/external/monaco.flux.server'
 import {comments, submit} from 'src/external/monaco.flux.hotkeys'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {OnChangeScript} from 'src/types/flux'
@@ -72,12 +73,16 @@ const FluxEditorMonaco: FC<Props> = ({
       const diagnostics = await lspServer.current.didOpen(uri, script)
       updateDiagnostics(diagnostics)
 
-      if (!skipFocus) {
-        const lines = (script || '').split('\n')
-        editor.setPosition({
-          lineNumber: lines.length,
-          column: lines[lines.length - 1].length + 1,
-        })
+      if (isFlagEnabled('cursorAtEOF')) {
+        if (!skipFocus) {
+          const lines = (script || '').split('\n')
+          editor.setPosition({
+            lineNumber: lines.length,
+            column: lines[lines.length - 1].length + 1,
+          })
+          editor.focus()
+        }
+      } else {
         editor.focus()
       }
     } catch (e) {

--- a/ui/src/shared/selectors/flags.ts
+++ b/ui/src/shared/selectors/flags.ts
@@ -10,6 +10,7 @@ export const OSS_FLAGS = {
   matchingNotificationRules: false,
   demodata: false,
   fluxParser: false,
+  cursorAtEOF: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -22,6 +23,7 @@ export const CLOUD_FLAGS = {
   matchingNotificationRules: false,
   demodata: false,
   fluxParser: false,
+  cursorAtEOF: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -24,6 +24,7 @@ import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 interface StateProps {
   activeQueryText: string
   activeTab: string
+  skipFocus?: boolean
 }
 
 interface DispatchProps {
@@ -38,6 +39,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
   onSubmitQueries,
   onSetActiveQueryText,
   activeTab,
+  skipFocus,
 }) => {
   const [editorInstance, setEditorInstance] = useState<EditorType>(null)
 
@@ -144,6 +146,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
           onChangeScript={onSetActiveQueryText}
           onSubmitScript={onSubmitQueries}
           setEditorInstance={setEditorInstance}
+          skipFocus={skipFocus}
         />
       </div>
       <div className="flux-editor--right-panel">


### PR DESCRIPTION
if you turn on the flag `cursorAtEOF`, the cursor will default to the end of a prepopulated flux query when you open monaco. i found the "focus at top of all editors at initialization" behavior annoying when viewing multiple editors with prepolpulated flux comments for the notebooks project (#17966).

prop drilling through the TimeMachineFluxEditor is an artifact of the need for ongoing state decoupling in this area of the code and needed to verify this work.

since the concept of `cursor position` is nested deep in monaco, the tests for this looked a lot like "let a = [], b = a, expect(b).toEqual(a)", which is why we dont see any here.