### PR TITLE
fix(timeFormat-single-stat-graph): fixed issue where setting the timeFormat on single-state + graph wasn't persisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+1. [18066](https://github.com/influxdata/influxdb/pull/18066): Fixed bug that wasn't persisting timeFormat for Graph + Single Stat selections
+
 ### UI Improvements
 
 ## v2.0.0-beta.10 [2020-05-07]

--- a/dashboard.go
+++ b/dashboard.go
@@ -688,6 +688,7 @@ type LinePlusSingleStatProperties struct {
 	YColumn           string           `json:"yColumn"`
 	ShadeBelow        bool             `json:"shadeBelow"`
 	Position          string           `json:"position"`
+	TimeFormat        string           `json:"timeFormat"`
 }
 
 // XYViewProperties represents options for line, bar, step, or stacked view in Chronograf

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8720,6 +8720,8 @@ components:
         - decimalPlaces
         - position
       properties:
+        timeFormat:
+          type: string
         type:
           type: string
           enum: [line-plus-single-stat]


### PR DESCRIPTION
Closes #18033

### Problem

timeFormat selections were not persisted for Graph + Single-Stat

### Solution

Updated the struct and yml file to correctly return timeFormat when it is included in the patch / get

![timeFormat-single-line](https://user-images.githubusercontent.com/19984220/81741877-104f0800-9454-11ea-8db1-75b6ff64df03.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)

