### PR TITLE
fix: tenant findBucket action needs to properly route actions

### DIFF
--- a/tenant/service_bucket.go
+++ b/tenant/service_bucket.go
@@ -48,6 +48,14 @@ func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, name 
 
 // FindBucket returns the first bucket that matches filter.
 func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+	if filter.ID != nil {
+		return s.FindBucketByID(ctx, *filter.ID)
+	}
+
+	if filter.Name != nil && filter.OrganizationID != nil {
+		return s.FindBucketByName(ctx, *filter.OrganizationID, *filter.Name)
+	}
+
 	buckets, _, err := s.FindBuckets(ctx, filter, influxdb.FindOptions{
 		Limit: 1,
 	})

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -1136,6 +1136,7 @@ func FindBucket(
 	type args struct {
 		name           string
 		organizationID influxdb.ID
+		id             influxdb.ID
 	}
 
 	type wants struct {
@@ -1184,6 +1185,40 @@ func FindBucket(
 			},
 		},
 		{
+			name: "find bucket by id",
+			fields: BucketFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Buckets: []*influxdb.Bucket{
+					{
+						ID:    MustIDBase16(bucketOneID),
+						OrgID: MustIDBase16(orgOneID),
+						Name:  "abc",
+					},
+					{
+						ID:    MustIDBase16(bucketTwoID),
+						OrgID: MustIDBase16(orgOneID),
+						Name:  "xyz",
+					},
+				},
+			},
+			args: args{
+				id:             MustIDBase16(bucketOneID),
+				organizationID: MustIDBase16(orgOneID),
+			},
+			wants: wants{
+				bucket: &influxdb.Bucket{
+					ID:    MustIDBase16(bucketOneID),
+					OrgID: MustIDBase16(orgOneID),
+					Name:  "abc",
+				},
+			},
+		},
+		{
 			name: "missing bucket returns error",
 			fields: BucketFields{
 				Organizations: []*influxdb.Organization{
@@ -1216,6 +1251,9 @@ func FindBucket(
 			filter := influxdb.BucketFilter{}
 			if tt.args.name != "" {
 				filter.Name = &tt.args.name
+			}
+			if tt.args.id.Valid() {
+				filter.ID = &tt.args.id
 			}
 			if tt.args.organizationID.Valid() {
 				filter.OrganizationID = &tt.args.organizationID


### PR DESCRIPTION
Tenant bucket look up needs route a action to storage to use indexes.
I added an error condtion into the storage code to ensure this was working
but the tests did not exercise this piece of code. Both have been remedied.
