### PR TITLE
fix(variable_hydration): limiting variable hydration to changing variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1. [18066](https://github.com/influxdata/influxdb/pull/18066): Fixed bug that wasn't persisting timeFormat for Graph + Single Stat selections
 1. [17959](https://github.com/influxdata/influxdb/pull/17959): Authorizer now exposes full permission set
+1. [18071](https://github.com/influxdata/influxdb/pull/18071): Fixed issue that was causing variable selections to hydrate all variable values
 
 ### UI Improvements
 

--- a/ui/src/shared/components/graph_tips/GraphTips.tsx
+++ b/ui/src/shared/components/graph_tips/GraphTips.tsx
@@ -11,7 +11,7 @@ const GraphTips: FC = () => (
       color={ComponentColor.Primary}
       testID="graphtips-question-mark"
       tooltipContents={
-        <span>
+        <>
           <h1>Graph Tips:</h1>
           <p>
             <code>Click + Drag</code> Zoom in (X or Y)
@@ -26,7 +26,7 @@ const GraphTips: FC = () => (
             <br />
             <code>Shift + Click</code> Show/Hide single Series
           </p>
-        </span>
+        </>
       }
     />
   </>

--- a/ui/src/shared/components/graph_tips/GraphTips.tsx
+++ b/ui/src/shared/components/graph_tips/GraphTips.tsx
@@ -22,7 +22,7 @@ const GraphTips: FC = () => (
           </p>
           <h1>Static Legend Tips:</h1>
           <p>
-            <code>Click</code>Focus on single Series
+            <code>Click</code> Focus on single Series
             <br />
             <code>Shift + Click</code> Show/Hide single Series
           </p>

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -147,12 +147,13 @@ export const hydrateVariables = (skipCache?: boolean) => async (
   await hydration.promise
 }
 
-export const hydrateChangedVariable = (variable: Variable) => async (
+export const hydrateChangedVariable = (variableID: string) => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
   const state = getState()
   const org = getOrg(state)
+  const variable = getVariableFromState(state, variableID)
   const hydration = hydrateVars([variable], getAllVariablesFromState(state), {
     orgID: org.id,
     url: state.links.query.self,
@@ -432,6 +433,7 @@ export const selectValue = (variableID: string, selected: string) => async (
 
   await dispatch(selectValueInState(contextID, variableID, selected))
   // only hydrate the changedVariable
-  dispatch(hydrateChangedVariable(variable))
+  dispatch(hydrateChangedVariable(variableID))
+  // dispatch(hydrateVariables(true))
   dispatch(updateQueryVars({[variable.name]: selected}))
 }

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -434,6 +434,5 @@ export const selectValue = (variableID: string, selected: string) => async (
   await dispatch(selectValueInState(contextID, variableID, selected))
   // only hydrate the changedVariable
   dispatch(hydrateChangedVariable(variableID))
-  // dispatch(hydrateVariables(true))
   dispatch(updateQueryVars({[variable.name]: selected}))
 }

--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -97,9 +97,16 @@ class VariableDropdown extends PureComponent<Props> {
   }
 
   private handleSelect = (selectedValue: string) => {
-    const {variableID, onSelectValue, onSelect} = this.props
+    const {
+      variableID,
+      onSelectValue,
+      onSelect,
+      selectedValue: prevSelectedValue,
+    } = this.props
 
-    onSelectValue(variableID, selectedValue)
+    if (prevSelectedValue !== selectedValue) {
+      onSelectValue(variableID, selectedValue)
+    }
 
     if (onSelect) {
       onSelect()

--- a/ui/src/variables/mocks/index.ts
+++ b/ui/src/variables/mocks/index.ts
@@ -1,6 +1,7 @@
 // Types
 import {Variable, RemoteDataState} from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
+import {VariableNode} from 'src/variables/utils/hydrateVars'
 
 export const defaultVariableAssignments: VariableAssignment[] = [
   {
@@ -78,3 +79,578 @@ export const createMapVariable = (
   },
   status: RemoteDataState.Done,
 })
+
+export const defaultSubGraph: VariableNode[] = [
+  {
+    variable: {
+      id: '05b740973c68e000',
+      orgID: '05b740945a91b000',
+      name: 'static',
+      description: '',
+      selected: ['defbuck'],
+      arguments: {
+        type: 'constant',
+        values: ['beans', 'defbuck'],
+      },
+      createdAt: '2020-05-19T06:00:00.113169-07:00',
+      updatedAt: '2020-05-19T06:00:00.113169-07:00',
+      labels: [],
+      links: {
+        self: '/api/v2/variables/05b740973c68e000',
+        labels: '/api/v2/variables/05b740973c68e000/labels',
+        org: '/api/v2/orgs/05b740945a91b000',
+      },
+      status: RemoteDataState.Done,
+    },
+    values: null,
+    parents: [
+      {
+        variable: {
+          id: '05b740974228e000',
+          orgID: '05b740945a91b000',
+          name: 'dependent',
+          description: '',
+          selected: [],
+          arguments: {
+            type: 'query',
+            values: {
+              query:
+                'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+              language: 'flux',
+              results: [],
+            },
+          },
+          createdAt: '2020-05-19T06:00:00.136597-07:00',
+          updatedAt: '2020-05-19T06:00:00.136597-07:00',
+          labels: [],
+          links: {
+            self: '/api/v2/variables/05b740974228e000',
+            labels: '/api/v2/variables/05b740974228e000/labels',
+            org: '/api/v2/orgs/05b740945a91b000',
+          },
+          status: RemoteDataState.Loading,
+        },
+        cancel: () => {},
+        values: null,
+        parents: [],
+        children: [
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStart',
+              name: 'timeRangeStart',
+              arguments: {
+                type: 'system',
+                values: [
+                  [
+                    {
+                      magnitude: 1,
+                      unit: 'h',
+                    },
+                  ],
+                ],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStop',
+              name: 'timeRangeStop',
+              arguments: {
+                type: 'system',
+                values: ['now()'],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+        ],
+        status: RemoteDataState.NotStarted,
+      },
+    ],
+    children: [],
+    status: RemoteDataState.Done,
+    cancel: () => {},
+  },
+]
+
+export const defaultGraph: VariableNode[] = [
+  {
+    variable: {
+      id: '05b740973c68e000',
+      orgID: '05b740945a91b000',
+      name: 'static',
+      description: '',
+      selected: ['defbuck'],
+      arguments: {
+        type: 'constant',
+        values: ['beans', 'defbuck'],
+      },
+      createdAt: '2020-05-19T06:00:00.113169-07:00',
+      updatedAt: '2020-05-19T06:00:00.113169-07:00',
+      labels: [],
+      links: {
+        self: '/api/v2/variables/05b740973c68e000',
+        labels: '/api/v2/variables/05b740973c68e000/labels',
+        org: '/api/v2/orgs/05b740945a91b000',
+      },
+      status: RemoteDataState.Done,
+    },
+    values: null,
+    parents: [
+      {
+        cancel: () => {},
+        variable: {
+          id: '05b740974228e000',
+          orgID: '05b740945a91b000',
+          name: 'dependent',
+          description: '',
+          selected: [],
+          arguments: {
+            type: 'query',
+            values: {
+              query:
+                'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+              language: 'flux',
+              results: [],
+            },
+          },
+          createdAt: '2020-05-19T06:00:00.136597-07:00',
+          updatedAt: '2020-05-19T06:00:00.136597-07:00',
+          labels: [],
+          links: {
+            self: '/api/v2/variables/05b740974228e000',
+            labels: '/api/v2/variables/05b740974228e000/labels',
+            org: '/api/v2/orgs/05b740945a91b000',
+          },
+          status: RemoteDataState.Loading,
+        },
+        values: null,
+        parents: [],
+        children: [
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStart',
+              name: 'timeRangeStart',
+              arguments: {
+                type: 'system',
+                values: [
+                  [
+                    {
+                      magnitude: 1,
+                      unit: 'h',
+                    },
+                  ],
+                ],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStop',
+              name: 'timeRangeStop',
+              arguments: {
+                type: 'system',
+                values: ['now()'],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+        ],
+        status: RemoteDataState.NotStarted,
+      },
+    ],
+    children: [],
+    status: RemoteDataState.Done,
+    cancel: () => {},
+  },
+  {
+    variable: {
+      id: '05b740974228e000',
+      orgID: '05b740945a91b000',
+      name: 'dependent',
+      description: '',
+      selected: [],
+      arguments: {
+        type: 'query',
+        values: {
+          query:
+            'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+          language: 'flux',
+          results: [],
+        },
+      },
+      createdAt: '2020-05-19T06:00:00.136597-07:00',
+      updatedAt: '2020-05-19T06:00:00.136597-07:00',
+      labels: [],
+      links: {
+        self: '/api/v2/variables/05b740974228e000',
+        labels: '/api/v2/variables/05b740974228e000/labels',
+        org: '/api/v2/orgs/05b740945a91b000',
+      },
+      status: RemoteDataState.Loading,
+    },
+    values: null,
+    parents: [],
+    children: [
+      {
+        variable: {
+          id: '05b740973c68e000',
+          orgID: '05b740945a91b000',
+          name: 'static',
+          description: '',
+          selected: ['defbuck'],
+          arguments: {
+            type: 'constant',
+            values: ['beans', 'defbuck'],
+          },
+          createdAt: '2020-05-19T06:00:00.113169-07:00',
+          updatedAt: '2020-05-19T06:00:00.113169-07:00',
+          labels: [],
+          links: {
+            self: '/api/v2/variables/05b740973c68e000',
+            labels: '/api/v2/variables/05b740973c68e000/labels',
+            org: '/api/v2/orgs/05b740945a91b000',
+          },
+          status: RemoteDataState.Done,
+        },
+        values: null,
+        parents: [null],
+        children: [],
+        status: RemoteDataState.Done,
+        cancel: () => {},
+      },
+      {
+        variable: {
+          orgID: '',
+          id: 'timeRangeStart',
+          name: 'timeRangeStart',
+          arguments: {
+            type: 'system',
+            values: [
+              [
+                {
+                  magnitude: 1,
+                  unit: 'h',
+                },
+              ],
+            ],
+          },
+          status: RemoteDataState.Done,
+          labels: [],
+          selected: [],
+        },
+        values: null,
+        parents: [null],
+        children: [],
+        status: RemoteDataState.Done,
+        cancel: () => {},
+      },
+      {
+        variable: {
+          orgID: '',
+          id: 'timeRangeStop',
+          name: 'timeRangeStop',
+          arguments: {
+            type: 'system',
+            values: ['now()'],
+          },
+          status: RemoteDataState.Done,
+          labels: [],
+          selected: [],
+        },
+        values: null,
+        parents: [null],
+        children: [],
+        status: RemoteDataState.Done,
+        cancel: () => {},
+      },
+    ],
+    status: RemoteDataState.NotStarted,
+    cancel: () => {},
+  },
+  {
+    variable: {
+      orgID: '',
+      id: 'timeRangeStart',
+      name: 'timeRangeStart',
+      arguments: {
+        type: 'system',
+        values: [
+          [
+            {
+              magnitude: 1,
+              unit: 'h',
+            },
+          ],
+        ],
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+      selected: [],
+    },
+    values: null,
+    parents: [
+      {
+        variable: {
+          id: '05b740974228e000',
+          orgID: '05b740945a91b000',
+          name: 'dependent',
+          description: '',
+          selected: [],
+          arguments: {
+            type: 'query',
+            values: {
+              query:
+                'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+              language: 'flux',
+              results: [],
+            },
+          },
+          createdAt: '2020-05-19T06:00:00.136597-07:00',
+          updatedAt: '2020-05-19T06:00:00.136597-07:00',
+          labels: [],
+          links: {
+            self: '/api/v2/variables/05b740974228e000',
+            labels: '/api/v2/variables/05b740974228e000/labels',
+            org: '/api/v2/orgs/05b740945a91b000',
+          },
+          status: RemoteDataState.Loading,
+        },
+        values: null,
+        parents: [],
+        children: [
+          {
+            variable: {
+              id: '05b740973c68e000',
+              orgID: '05b740945a91b000',
+              name: 'static',
+              description: '',
+              selected: ['defbuck'],
+              arguments: {
+                type: 'constant',
+                values: ['beans', 'defbuck'],
+              },
+              createdAt: '2020-05-19T06:00:00.113169-07:00',
+              updatedAt: '2020-05-19T06:00:00.113169-07:00',
+              labels: [],
+              links: {
+                self: '/api/v2/variables/05b740973c68e000',
+                labels: '/api/v2/variables/05b740973c68e000/labels',
+                org: '/api/v2/orgs/05b740945a91b000',
+              },
+              status: RemoteDataState.Done,
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStop',
+              name: 'timeRangeStop',
+              arguments: {
+                type: 'system',
+                values: ['now()'],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+        ],
+        status: RemoteDataState.NotStarted,
+        cancel: () => {},
+      },
+    ],
+    children: [],
+    status: RemoteDataState.Done,
+    cancel: () => {},
+  },
+  {
+    variable: {
+      orgID: '',
+      id: 'timeRangeStop',
+      name: 'timeRangeStop',
+      arguments: {
+        type: 'system',
+        values: ['now()'],
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+      selected: [],
+    },
+    values: null,
+    parents: [
+      {
+        variable: {
+          id: '05b740974228e000',
+          orgID: '05b740945a91b000',
+          name: 'dependent',
+          description: '',
+          selected: [],
+          arguments: {
+            type: 'query',
+            values: {
+              query:
+                'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+              language: 'flux',
+              results: [],
+            },
+          },
+          createdAt: '2020-05-19T06:00:00.136597-07:00',
+          updatedAt: '2020-05-19T06:00:00.136597-07:00',
+          labels: [],
+          links: {
+            self: '/api/v2/variables/05b740974228e000',
+            labels: '/api/v2/variables/05b740974228e000/labels',
+            org: '/api/v2/orgs/05b740945a91b000',
+          },
+          status: RemoteDataState.Loading,
+        },
+        values: null,
+        parents: [],
+        children: [
+          {
+            variable: {
+              id: '05b740973c68e000',
+              orgID: '05b740945a91b000',
+              name: 'static',
+              description: '',
+              selected: ['defbuck'],
+              arguments: {
+                type: 'constant',
+                values: ['beans', 'defbuck'],
+              },
+              createdAt: '2020-05-19T06:00:00.113169-07:00',
+              updatedAt: '2020-05-19T06:00:00.113169-07:00',
+              labels: [],
+              links: {
+                self: '/api/v2/variables/05b740973c68e000',
+                labels: '/api/v2/variables/05b740973c68e000/labels',
+                org: '/api/v2/orgs/05b740945a91b000',
+              },
+              status: RemoteDataState.Done,
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+          {
+            variable: {
+              orgID: '',
+              id: 'timeRangeStart',
+              name: 'timeRangeStart',
+              arguments: {
+                type: 'system',
+                values: [
+                  [
+                    {
+                      magnitude: 1,
+                      unit: 'h',
+                    },
+                  ],
+                ],
+              },
+              status: RemoteDataState.Done,
+              labels: [],
+              selected: [],
+            },
+            values: null,
+            parents: [null],
+            children: [],
+            status: RemoteDataState.Done,
+            cancel: () => {},
+          },
+          null,
+        ],
+        status: RemoteDataState.NotStarted,
+        cancel: () => {},
+      },
+    ],
+    children: [],
+    status: RemoteDataState.Done,
+    cancel: () => {},
+  },
+  {
+    variable: {
+      orgID: '',
+      id: 'windowPeriod',
+      name: 'windowPeriod',
+      arguments: {
+        type: 'system',
+        values: [10000],
+      },
+      status: RemoteDataState.Done,
+      labels: [],
+      selected: [],
+    },
+    values: null,
+    parents: [],
+    children: [],
+    status: RemoteDataState.Done,
+    cancel: () => {},
+  },
+]
+
+export const defaultVariable: Variable[] = [
+  {
+    id: '05b73f4bffe8e000',
+    orgID: '05b73f49a1d1b000',
+    name: 'static',
+    description: '',
+    selected: ['defbuck'],
+    arguments: {type: 'constant', values: ['beans', 'defbuck']},
+    createdAt: '2020-05-19T05:54:20.927477-07:00',
+    updatedAt: '2020-05-19T05:54:20.927477-07:00',
+    labels: [],
+    links: {
+      self: '/api/v2/variables/05b73f4bffe8e000',
+      labels: '/api/v2/variables/05b73f4bffe8e000/labels',
+      org: '/api/v2/orgs/05b73f49a1d1b000',
+    },
+    status: RemoteDataState.Done,
+  },
+]

--- a/ui/src/variables/mocks/index.ts
+++ b/ui/src/variables/mocks/index.ts
@@ -635,6 +635,97 @@ export const defaultGraph: VariableNode[] = [
   },
 ]
 
+export const defaultVariables: Variable[] = [
+  {
+    id: '05b740973c68e000',
+    orgID: '05b740945a91b000',
+    name: 'static',
+    description: '',
+    selected: ['defbuck'],
+    arguments: {
+      type: 'constant',
+      values: ['beans', 'defbuck'],
+    },
+    createdAt: '2020-05-19T06:00:00.113169-07:00',
+    updatedAt: '2020-05-19T06:00:00.113169-07:00',
+    labels: [],
+    links: {
+      self: '/api/v2/variables/05b740973c68e000',
+      labels: '/api/v2/variables/05b740973c68e000/labels',
+      org: '/api/v2/orgs/05b740945a91b000',
+    },
+    status: RemoteDataState.Done,
+  },
+  {
+    id: '05b740974228e000',
+    orgID: '05b740945a91b000',
+    name: 'dependent',
+    description: '',
+    selected: [],
+    arguments: {
+      type: 'query',
+      values: {
+        query:
+          'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+        language: 'flux',
+        results: [],
+      },
+    },
+    createdAt: '2020-05-19T06:00:00.136597-07:00',
+    updatedAt: '2020-05-19T06:00:00.136597-07:00',
+    labels: [],
+    links: {
+      self: '/api/v2/variables/05b740974228e000',
+      labels: '/api/v2/variables/05b740974228e000/labels',
+      org: '/api/v2/orgs/05b740945a91b000',
+    },
+    status: RemoteDataState.Loading,
+  },
+  {
+    orgID: '',
+    id: 'timeRangeStart',
+    name: 'timeRangeStart',
+    arguments: {
+      type: 'system',
+      values: [
+        [
+          {
+            magnitude: 1,
+            unit: 'h',
+          },
+        ],
+      ],
+    },
+    status: RemoteDataState.Done,
+    labels: [],
+    selected: [],
+  },
+  {
+    orgID: '',
+    id: 'timeRangeStop',
+    name: 'timeRangeStop',
+    arguments: {
+      type: 'system',
+      values: ['now()'],
+    },
+    status: RemoteDataState.Done,
+    labels: [],
+    selected: [],
+  },
+  {
+    orgID: '',
+    id: 'windowPeriod',
+    name: 'windowPeriod',
+    arguments: {
+      type: 'system',
+      values: [10000],
+    },
+    status: RemoteDataState.Done,
+    labels: [],
+    selected: [],
+  },
+]
+
 export const defaultVariable: Variable[] = [
   {
     id: '05b73f4bffe8e000',

--- a/ui/src/variables/mocks/index.ts
+++ b/ui/src/variables/mocks/index.ts
@@ -635,71 +635,74 @@ export const defaultGraph: VariableNode[] = [
   },
 ]
 
-export const defaultVariables: Variable[] = [
-  {
-    id: '05b740973c68e000',
-    orgID: '05b740945a91b000',
-    name: 'static',
-    description: '',
-    selected: ['defbuck'],
-    arguments: {
-      type: 'constant',
-      values: ['beans', 'defbuck'],
-    },
-    createdAt: '2020-05-19T06:00:00.113169-07:00',
-    updatedAt: '2020-05-19T06:00:00.113169-07:00',
-    labels: [],
-    links: {
-      self: '/api/v2/variables/05b740973c68e000',
-      labels: '/api/v2/variables/05b740973c68e000/labels',
-      org: '/api/v2/orgs/05b740945a91b000',
-    },
-    status: RemoteDataState.Done,
+export const defaultVariable: Variable = {
+  id: '05b73f4bffe8e000',
+  orgID: '05b73f49a1d1b000',
+  name: 'static',
+  description: '',
+  selected: ['defbuck'],
+  arguments: {type: 'constant', values: ['beans', 'defbuck']},
+  createdAt: '2020-05-19T05:54:20.927477-07:00',
+  updatedAt: '2020-05-19T05:54:20.927477-07:00',
+  labels: [],
+  links: {
+    self: '/api/v2/variables/05b73f4bffe8e000',
+    labels: '/api/v2/variables/05b73f4bffe8e000/labels',
+    org: '/api/v2/orgs/05b73f49a1d1b000',
   },
-  {
-    id: '05b740974228e000',
-    orgID: '05b740945a91b000',
-    name: 'dependent',
-    description: '',
-    selected: [],
-    arguments: {
-      type: 'query',
-      values: {
-        query:
-          'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
-        language: 'flux',
-        results: [],
-      },
+  status: RemoteDataState.Done,
+}
+
+export const associatedVariable: Variable = {
+  id: '05b740974228e000',
+  orgID: '05b740945a91b000',
+  name: 'dependent',
+  description: '',
+  selected: [],
+  arguments: {
+    type: 'query',
+    values: {
+      query:
+        'from(bucket: v.static)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r["_measurement"] == "test")\n  |> keep(columns: ["container_name"])\n  |> rename(columns: {"container_name": "_value"})\n  |> last()\n  |> group()',
+      language: 'flux',
+      results: [],
     },
-    createdAt: '2020-05-19T06:00:00.136597-07:00',
-    updatedAt: '2020-05-19T06:00:00.136597-07:00',
-    labels: [],
-    links: {
-      self: '/api/v2/variables/05b740974228e000',
-      labels: '/api/v2/variables/05b740974228e000/labels',
-      org: '/api/v2/orgs/05b740945a91b000',
-    },
-    status: RemoteDataState.Loading,
   },
-  {
-    orgID: '',
-    id: 'timeRangeStart',
-    name: 'timeRangeStart',
-    arguments: {
-      type: 'system',
-      values: [
-        [
-          {
-            magnitude: 1,
-            unit: 'h',
-          },
-        ],
+  createdAt: '2020-05-19T06:00:00.136597-07:00',
+  updatedAt: '2020-05-19T06:00:00.136597-07:00',
+  labels: [],
+  links: {
+    self: '/api/v2/variables/05b740974228e000',
+    labels: '/api/v2/variables/05b740974228e000/labels',
+    org: '/api/v2/orgs/05b740945a91b000',
+  },
+  status: RemoteDataState.Loading,
+}
+
+export const timeRangeStartVariable: Variable = {
+  orgID: '',
+  id: 'timeRangeStart',
+  name: 'timeRangeStart',
+  arguments: {
+    type: 'system',
+    values: [
+      [
+        {
+          magnitude: 1,
+          unit: 'h',
+        },
       ],
-    },
-    status: RemoteDataState.Done,
-    labels: [],
-    selected: [],
+    ],
   },
+  status: RemoteDataState.Done,
+  labels: [],
+  selected: [],
+}
+
+export const defaultVariables: Variable[] = [
+  defaultVariable,
+  associatedVariable,
+  timeRangeStartVariable,
   {
     orgID: '',
     id: 'timeRangeStop',
@@ -723,25 +726,5 @@ export const defaultVariables: Variable[] = [
     status: RemoteDataState.Done,
     labels: [],
     selected: [],
-  },
-]
-
-export const defaultVariable: Variable[] = [
-  {
-    id: '05b73f4bffe8e000',
-    orgID: '05b73f49a1d1b000',
-    name: 'static',
-    description: '',
-    selected: ['defbuck'],
-    arguments: {type: 'constant', values: ['beans', 'defbuck']},
-    createdAt: '2020-05-19T05:54:20.927477-07:00',
-    updatedAt: '2020-05-19T05:54:20.927477-07:00',
-    labels: [],
-    links: {
-      self: '/api/v2/variables/05b73f4bffe8e000',
-      labels: '/api/v2/variables/05b73f4bffe8e000/labels',
-      org: '/api/v2/orgs/05b73f49a1d1b000',
-    },
-    status: RemoteDataState.Done,
   },
 ]

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -119,9 +119,6 @@ describe('hydrate vars', () => {
     //       f [fontcolor = "green"]
     //       g [fontcolor = "green"]
     //     }
-    //
-    // NOTE: these return falsy and not an empty array, because they are skipped
-    // within hydrateVars as not belonging to the graph
     expect(
       actual.filter(v => v.id === 'a')[0].arguments.values.results
     ).toEqual([])

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -1,9 +1,19 @@
 // Utils
 import {ValueFetcher} from 'src/variables/utils/ValueFetcher'
-import {hydrateVars} from 'src/variables/utils/hydrateVars'
+import {
+  hydrateVars,
+  createVariableGraph,
+  findSubgraph,
+} from 'src/variables/utils/hydrateVars'
 
 // Mocks
-import {createVariable} from 'src/variables/mocks'
+import {
+  createVariable,
+  associatedVariable,
+  defaultVariable,
+  defaultVariables,
+  timeRangeStartVariable,
+} from 'src/variables/mocks'
 
 // Types
 import {Variable, CancellationError, RemoteDataState} from 'src/types'
@@ -114,16 +124,16 @@ describe('hydrate vars', () => {
     // within hydrateVars as not belonging to the graph
     expect(
       actual.filter(v => v.id === 'a')[0].arguments.values.results
-    ).toBeFalsy()
+    ).toEqual([])
     expect(
       actual.filter(v => v.id === 'b')[0].arguments.values.results
-    ).toBeFalsy()
+    ).toEqual([])
     expect(
       actual.filter(v => v.id === 'c')[0].arguments.values.results
-    ).toBeFalsy()
+    ).toEqual([])
     expect(
       actual.filter(v => v.id === 'd')[0].arguments.values.results
-    ).toBeFalsy()
+    ).toEqual([])
 
     expect(
       actual.filter(v => v.id === 'e')[0].arguments.values.results
@@ -241,11 +251,9 @@ describe('hydrate vars', () => {
       actual.filter(v => v.id === 'a')[0].arguments.values.results
     ).toEqual(['aVal'])
     expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
-
     expect(actual.filter(v => v.id === 'b')[0].arguments.values).toEqual({
       k: 'v',
     })
-    expect(actual.filter(v => v.id === 'b')[0].selected).toEqual(['k'])
   })
 
   // This ensures that the update of a dependant variable updates the
@@ -317,5 +325,40 @@ describe('hydrate vars', () => {
     })
 
     cancel()
+  })
+})
+
+describe('findSubgraph', () => {
+  test('should return the update variable with all associated parents', async () => {
+    const variableGraph = await createVariableGraph(defaultVariables)
+    const actual = await findSubgraph(variableGraph, [defaultVariable])
+    // returns the single subgraph result
+    expect(actual.length).toEqual(1)
+    const [subgraph] = actual
+    // expect the subgraph to return the passed in variable
+    expect(subgraph.variable).toEqual(defaultVariable)
+    // expect the parent to be returned with the returning variable
+    expect(subgraph.parents[0].variable).toEqual(associatedVariable)
+  })
+  test('should return the variable with no parents when no association exists', async () => {
+    const a = createVariable('a', 'f(x: v.b)')
+    const variableGraph = await createVariableGraph([...defaultVariables, a])
+    const actual = await findSubgraph(variableGraph, [a])
+    expect(actual.length).toEqual(1)
+    const [subgraph] = actual
+    // expect the subgraph to return the passed in variable
+    expect(subgraph.variable).toEqual(a)
+    // expect the parent to be returned with the returning variable
+    expect(subgraph.parents).toEqual([])
+  })
+  test('should return the update default (timeRange) variable with associated parents', async () => {
+    const variableGraph = await createVariableGraph(defaultVariables)
+    const actual = await findSubgraph(variableGraph, [timeRangeStartVariable])
+    expect(actual.length).toEqual(1)
+    const [subgraph] = actual
+    // expect the subgraph to return the passed in variable
+    expect(subgraph.variable).toEqual(timeRangeStartVariable)
+    // expect the parent to be returned with the returning variable
+    expect(subgraph.parents[0].variable).toEqual(associatedVariable)
   })
 })

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -1,12 +1,18 @@
 // Utils
 import {ValueFetcher} from 'src/variables/utils/ValueFetcher'
-import {hydrateVars} from 'src/variables/utils/hydrateVars'
+import {hydrateVars, findSubgraph} from 'src/variables/utils/hydrateVars'
 
 // Mocks
-import {createVariable} from 'src/variables/mocks'
+import {
+  createVariable,
+  defaultVariable,
+  defaultSubGraph,
+  defaultGraph,
+} from 'src/variables/mocks'
 
 // Types
 import {Variable, CancellationError, RemoteDataState} from 'src/types'
+import {VariableNode} from 'src/variables/utils/hydrateVars'
 
 class FakeFetcher implements ValueFetcher {
   responses = {}
@@ -317,5 +323,33 @@ describe('hydrate vars', () => {
     })
 
     cancel()
+  })
+})
+
+describe('findSubgraph', () => {
+  test('find subgraphs', async () => {
+    const actual = await findSubgraph(defaultGraph, defaultVariable)
+
+    // We expect the end state of the graph to be:
+    //
+    //     digraph {
+    //       a -> b
+    //       b -> c
+    //       c -> d
+    //       d -> e
+    //       d -> b
+    //       f -> g
+    //       a [fontcolor = "red"]
+    //       b [fontcolor = "red"]
+    //       c [fontcolor = "red"]
+    //       d [fontcolor = "red"]
+    //       e [fontcolor = "green"]
+    //       f [fontcolor = "green"]
+    //       g [fontcolor = "green"]
+    //     }
+    //
+    // NOTE: these return falsy and not an empty array, because they are skipped
+    // within hydrateVars as not belonging to the graph
+    expect(actual).toEqual(defaultSubGraph)
   })
 })

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -1,18 +1,12 @@
 // Utils
 import {ValueFetcher} from 'src/variables/utils/ValueFetcher'
-import {hydrateVars, findSubgraph} from 'src/variables/utils/hydrateVars'
+import {hydrateVars} from 'src/variables/utils/hydrateVars'
 
 // Mocks
-import {
-  createVariable,
-  defaultVariable,
-  defaultSubGraph,
-  defaultGraph,
-} from 'src/variables/mocks'
+import {createVariable} from 'src/variables/mocks'
 
 // Types
 import {Variable, CancellationError, RemoteDataState} from 'src/types'
-import {VariableNode} from 'src/variables/utils/hydrateVars'
 
 class FakeFetcher implements ValueFetcher {
   responses = {}
@@ -323,33 +317,5 @@ describe('hydrate vars', () => {
     })
 
     cancel()
-  })
-})
-
-describe('findSubgraph', () => {
-  test('find subgraphs', async () => {
-    const actual = await findSubgraph(defaultGraph, defaultVariable)
-
-    // We expect the end state of the graph to be:
-    //
-    //     digraph {
-    //       a -> b
-    //       b -> c
-    //       c -> d
-    //       d -> e
-    //       d -> b
-    //       f -> g
-    //       a [fontcolor = "red"]
-    //       b [fontcolor = "red"]
-    //       c [fontcolor = "red"]
-    //       d [fontcolor = "red"]
-    //       e [fontcolor = "green"]
-    //       f [fontcolor = "green"]
-    //       g [fontcolor = "green"]
-    //     }
-    //
-    // NOTE: these return falsy and not an empty array, because they are skipped
-    // within hydrateVars as not belonging to the graph
-    expect(actual).toEqual(defaultSubGraph)
   })
 })

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -129,6 +129,8 @@ const findSubgraph = (
 
   // use an ID array to reduce the chance of reference errors
   const varIDs = variables.map(v => v.id)
+  // create an array of IDs to reference later
+  const graphIDs = []
   for (const node of graph) {
     const shouldKeep =
       varIDs.includes(node.variable.id) ||
@@ -138,12 +140,17 @@ const findSubgraph = (
 
     if (shouldKeep) {
       subgraph.add(node)
+      graphIDs.push(node.variable.id)
     }
   }
 
   for (const node of subgraph) {
-    node.parents = node.parents.filter(node => subgraph.has(node))
-    node.children = node.children.filter(node => subgraph.has(node))
+    // node.parents = node.parents.filter(n => {
+    //   const {id} = n.variable
+    //   return !graphIDs.includes(id)
+    // })
+    // node.parents = node.parents.filter(n => !subgraph.has(n))
+    node.children = node.children.filter(n => subgraph.has(n))
   }
 
   return [...subgraph]
@@ -488,6 +495,7 @@ export const hydrateVars = (
   // register listeners for the loading state changes
   Promise.resolve()
     .then(() => {
+      console.log('graph in promise resolve: ', graph)
       return Promise.all(findLeaves(graph).map(resolve))
     })
     .then(() => {

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -121,7 +121,7 @@ const collectAncestors = (
   - The node for one of the passed variables depends on this node
 
 */
-const findSubgraph = (
+export const findSubgraph = (
   graph: VariableNode[],
   variables: Variable[]
 ): VariableNode[] => {

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -121,7 +121,7 @@ const collectAncestors = (
   - The node for one of the passed variables depends on this node
 
 */
-export const findSubgraph = (
+const findSubgraph = (
   graph: VariableNode[],
   variables: Variable[]
 ): VariableNode[] => {

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -121,7 +121,7 @@ const collectAncestors = (
   - The node for one of the passed variables depends on this node
 
 */
-const findSubgraph = (
+export const findSubgraph = (
   graph: VariableNode[],
   variables: Variable[]
 ): VariableNode[] => {
@@ -231,13 +231,13 @@ const hydrateVarsHelper = async (
     node.status = RemoteDataState.Loading
     on.fire('status', node.variable, node.status)
     collectAncestors(node)
-    .filter(parent => parent.variable.arguments.type === 'query')
-    .forEach(parent => {
-      if (parent.status !== RemoteDataState.Loading) {
-        parent.status = RemoteDataState.Loading
-        on.fire('status', parent.variable, parent.status)
-      }
-    })
+      .filter(parent => parent.variable.arguments.type === 'query')
+      .forEach(parent => {
+        if (parent.status !== RemoteDataState.Loading) {
+          parent.status = RemoteDataState.Loading
+          on.fire('status', parent.variable, parent.status)
+        }
+      })
   }
 
   const descendants = collectDescendants(node)
@@ -397,9 +397,10 @@ export const hydrateVars = (
   allVariables: Variable[],
   options: HydrateVarsOptions
 ): EventedCancelBox<Variable[]> => {
-  const graph = findSubgraph(createVariableGraph(allVariables), variables).filter(
-    n => n.variable.arguments.type !== 'system'
-  )
+  const graph = findSubgraph(
+    createVariableGraph(allVariables),
+    variables
+  ).filter(n => n.variable.arguments.type !== 'system')
   invalidateCycles(graph)
 
   let isCancelled = false

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1520,6 +1520,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/webpack-env@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.2.tgz#927997342bb9f4a5185a86e6579a0a18afc33b0a"
+  integrity sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ==
+
 "@types/webpack@^4.4.31", "@types/webpack@^4.4.35":
   version "4.4.35"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.35.tgz#b7088eb2d471d5645e5503d272783cafa753583b"


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/7030

### Problem

This PR aims to address the issue of overly hydrating variables when a variable selection is made. 

### Solution

The solution to this is twofold:

- Compare current selection to previous selection to ensure that selecting the same variable value will not trigger an action to hydrate the variables
- Only pass in the variable that has been selected to hydrate that specific variable

Here's how these changes impact the network requests:

![dehydrate-variables](https://user-images.githubusercontent.com/19984220/81751238-e7cf0a00-9463-11ea-988d-e45e0fdef85f.gif)

### UI Tweak

This PR also includes a minor UI tweak that may have been the result of the clockface pendulum update.

Previous:
<img width="713" alt="Screen Shot 2020-05-12 at 14 26 10" src="https://user-images.githubusercontent.com/19984220/81750792-0680d100-9463-11ea-951e-9afd4542b4a6.png">

Now:
<img width="645" alt="Screen Shot 2020-05-12 at 15 05 58" src="https://user-images.githubusercontent.com/19984220/81750834-1b5d6480-9463-11ea-8fc2-e013be7f843b.png">

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
