### PR TITLE
fix(useVisYDomainSettings): added check for undefined values

### DIFF
--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -80,8 +80,7 @@ export const useVisYDomainSettings = (
 ) => {
   const initialDomain = useMemo(() => {
     if (
-      storedDomain === undefined ||
-      storedDomain === null ||
+      !Array.isArray(storedDomain) ||
       storedDomain.every(val => val === null)
     ) {
       return getValidRange(data, timeRange)

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -79,7 +79,11 @@ export const useVisYDomainSettings = (
   timeRange: TimeRange | null = null
 ) => {
   const initialDomain = useMemo(() => {
-    if (storedDomain === null || storedDomain.every(val => val === null)) {
+    if (
+      storedDomain === undefined ||
+      storedDomain === null ||
+      storedDomain.every(val => val === null)
+    ) {
       return getValidRange(data, timeRange)
     }
     if (storedDomain.includes(null)) {


### PR DESCRIPTION
### Problem

In some situations, storedDomain was being passed as undefined and was triggering a honeybadger error when trying to use the `every` method on undefined

### Solution

Added a check for `undefined` in the `useVisYDomainSettings`