### PR TITLE
fix(http): enforce orgID parameter on list checks endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1. [18066](https://github.com/influxdata/influxdb/pull/18066): Fixed bug that wasn't persisting timeFormat for Graph + Single Stat selections
 1. [17959](https://github.com/influxdata/influxdb/pull/17959): Authorizer now exposes full permission set
+1. [18083](https://github.com/influxdata/influxdb/pull/18083): Checks now enforces orgID on list action as per swagger specification
 
 ### UI Improvements
 

--- a/authorization/middleware_auth.go
+++ b/authorization/middleware_auth.go
@@ -23,7 +23,7 @@ func NewAuthedAuthorizationService(s influxdb.AuthorizationService, ts TenantSer
 }
 
 func (s *AuthedAuthorizationService) CreateAuthorization(ctx context.Context, a *influxdb.Authorization) error {
-	if _, _, err := authorizer.AuthorizeCreate(ctx, influxdb.AuthorizationsResourceType, a.OrgID); err != nil {
+	if _, _, err := authorizer.AuthorizeCreate(ctx, influxdb.AuthorizationsResourceType, &a.OrgID); err != nil {
 		return err
 	}
 	if _, _, err := authorizer.AuthorizeWriteResource(ctx, influxdb.UsersResourceType, a.UserID); err != nil {

--- a/authorizer/agent.go
+++ b/authorizer/agent.go
@@ -30,7 +30,7 @@ func (a *AuthAgent) OrgPermissions(ctx context.Context, orgID influxdb.ID, actio
 }
 
 func (a *AuthAgent) IsWritable(ctx context.Context, orgID influxdb.ID, resType influxdb.ResourceType) error {
-	_, _, resTypeErr := AuthorizeOrgWriteResource(ctx, resType, orgID)
+	_, _, resTypeErr := AuthorizeOrgWriteResource(ctx, resType, &orgID)
 	_, _, orgErr := AuthorizeWriteOrg(ctx, orgID)
 
 	if resTypeErr != nil && orgErr != nil {

--- a/authorizer/auth.go
+++ b/authorizer/auth.go
@@ -65,7 +65,7 @@ func (s *AuthorizationService) FindAuthorizations(ctx context.Context, filter in
 
 // CreateAuthorization checks to see if the authorizer on context has write access to the global authorizations resource.
 func (s *AuthorizationService) CreateAuthorization(ctx context.Context, a *influxdb.Authorization) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.AuthorizationsResourceType, a.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.AuthorizationsResourceType, &a.OrgID); err != nil {
 		return err
 	}
 	if _, _, err := AuthorizeWriteResource(ctx, influxdb.UsersResourceType, a.UserID); err != nil {

--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -137,21 +137,25 @@ func AuthorizeWriteResource(ctx context.Context, rt influxdb.ResourceType, rid i
 }
 
 // AuthorizeOrgReadResource authorizes the given org to read the resources of the given type.
+// When orgID is nil this method ensures the authorizer has the permission to read the given
+// resource type for all organizations.
 // NOTE: this is pretty much the same as AuthorizeRead, in the case that the resource ID is ignored.
 // Use it in the case that you do not know which resource in particular you want to give access to.
-func AuthorizeOrgReadResource(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
-	return authorize(ctx, influxdb.ReadAction, rt, nil, &oid)
+func AuthorizeOrgReadResource(ctx context.Context, rt influxdb.ResourceType, oid *influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.ReadAction, rt, nil, oid)
 }
 
 // AuthorizeOrgWriteResource authorizes the given org to write the resources of the given type.
+// When orgID is nil this method ensures the authorizer has the permission to write the given
+// resource type for all organizations.
 // NOTE: this is pretty much the same as AuthorizeWrite, in the case that the resource ID is ignored.
 // Use it in the case that you do not know which resource in particular you want to give access to.
-func AuthorizeOrgWriteResource(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
-	return authorize(ctx, influxdb.WriteAction, rt, nil, &oid)
+func AuthorizeOrgWriteResource(ctx context.Context, rt influxdb.ResourceType, oid *influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+	return authorize(ctx, influxdb.WriteAction, rt, nil, oid)
 }
 
-// AuthorizeCreate authorizes a user to create a resource of the given type for the given org.
-func AuthorizeCreate(ctx context.Context, rt influxdb.ResourceType, oid influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
+// AuthorizeCreate authorizes a user to create a resource of the given type for the given org or all orgs (orgID == nil).
+func AuthorizeCreate(ctx context.Context, rt influxdb.ResourceType, oid *influxdb.ID) (influxdb.Authorizer, influxdb.Permission, error) {
 	return AuthorizeOrgWriteResource(ctx, rt, oid)
 }
 

--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -2,6 +2,7 @@ package authorizer
 
 import (
 	"context"
+
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/tracing"
 )
@@ -87,7 +88,7 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) er
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	if _, _, err := AuthorizeCreate(ctx, influxdb.BucketsResourceType, b.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.BucketsResourceType, &b.OrgID); err != nil {
 		return err
 	}
 	return s.s.CreateBucket(ctx, b)

--- a/authorizer/dashboard.go
+++ b/authorizer/dashboard.go
@@ -46,7 +46,7 @@ func (s *DashboardService) FindDashboards(ctx context.Context, filter influxdb.D
 
 // CreateDashboard checks to see if the authorizer on context has write access to the global dashboards resource.
 func (s *DashboardService) CreateDashboard(ctx context.Context, b *influxdb.Dashboard) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.DashboardsResourceType, b.OrganizationID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.DashboardsResourceType, &b.OrganizationID); err != nil {
 		return err
 	}
 	return s.s.CreateDashboard(ctx, b)

--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -76,7 +76,7 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 
 // CreateLabel checks to see if the authorizer on context has write access to the new label's org.
 func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.LabelsResourceType, l.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.LabelsResourceType, &l.OrgID); err != nil {
 		return err
 	}
 	return s.s.CreateLabel(ctx, l)

--- a/authorizer/notification_endpoint.go
+++ b/authorizer/notification_endpoint.go
@@ -62,7 +62,8 @@ func (s *NotificationEndpointService) FindNotificationEndpoints(ctx context.Cont
 
 // CreateNotificationEndpoint checks to see if the authorizer on context has write access to the global notification endpoint resource.
 func (s *NotificationEndpointService) CreateNotificationEndpoint(ctx context.Context, edp influxdb.NotificationEndpoint, userID influxdb.ID) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationEndpointResourceType, edp.GetOrgID()); err != nil {
+	orgID := edp.GetOrgID()
+	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationEndpointResourceType, &orgID); err != nil {
 		return err
 	}
 	return s.s.CreateNotificationEndpoint(ctx, edp, userID)

--- a/authorizer/notification_rule.go
+++ b/authorizer/notification_rule.go
@@ -50,7 +50,8 @@ func (s *NotificationRuleStore) FindNotificationRules(ctx context.Context, filte
 
 // CreateNotificationRule checks to see if the authorizer on context has write access to the global notification rule resource.
 func (s *NotificationRuleStore) CreateNotificationRule(ctx context.Context, nr influxdb.NotificationRuleCreate, userID influxdb.ID) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationRuleResourceType, nr.GetOrgID()); err != nil {
+	orgID := nr.GetOrgID()
+	if _, _, err := AuthorizeCreate(ctx, influxdb.NotificationRuleResourceType, &orgID); err != nil {
 		return err
 	}
 	return s.s.CreateNotificationRule(ctx, nr, userID)

--- a/authorizer/scraper.go
+++ b/authorizer/scraper.go
@@ -53,7 +53,7 @@ func (s *ScraperTargetStoreService) ListTargets(ctx context.Context, filter infl
 
 // AddTarget checks to see if the authorizer on context has write access to the global scraper target resource.
 func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, st *influxdb.ScraperTarget, userID influxdb.ID) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.ScraperResourceType, st.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.ScraperResourceType, &st.OrgID); err != nil {
 		return err
 	}
 	if _, _, err := AuthorizeWrite(ctx, influxdb.BucketsResourceType, st.BucketID, st.OrgID); err != nil {

--- a/authorizer/secret.go
+++ b/authorizer/secret.go
@@ -23,7 +23,7 @@ func NewSecretService(s influxdb.SecretService) *SecretService {
 
 // LoadSecret checks to see if the authorizer on context has read access to the secret key provided.
 func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key string) (string, error) {
-	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return "", err
 	}
 	secret, err := s.s.LoadSecret(ctx, orgID, key)
@@ -35,7 +35,7 @@ func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key s
 
 // GetSecretKeys checks to see if the authorizer on context has read access to all the secrets belonging to orgID.
 func (s *SecretService) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
-	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return []string{}, err
 	}
 	secrets, err := s.s.GetSecretKeys(ctx, orgID)
@@ -47,7 +47,7 @@ func (s *SecretService) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([
 
 // PutSecret checks to see if the authorizer on context has write access to the secret key provided.
 func (s *SecretService) PutSecret(ctx context.Context, orgID influxdb.ID, key string, val string) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return err
 	}
 	err := s.s.PutSecret(ctx, orgID, key, val)
@@ -61,10 +61,10 @@ func (s *SecretService) PutSecret(ctx context.Context, orgID influxdb.ID, key st
 func (s *SecretService) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
 	// PutSecrets operates on intersection between m and keys beloging to orgID.
 	// We need to have read access to those secrets since it deletes the secrets (within the intersection) that have not be overridden.
-	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgReadResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return err
 	}
-	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return err
 	}
 	err := s.s.PutSecrets(ctx, orgID, m)
@@ -76,7 +76,7 @@ func (s *SecretService) PutSecrets(ctx context.Context, orgID influxdb.ID, m map
 
 // PatchSecrets checks to see if the authorizer on context has write access to the secret keys provided.
 func (s *SecretService) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
-	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return err
 	}
 	err := s.s.PatchSecrets(ctx, orgID, m)
@@ -88,7 +88,7 @@ func (s *SecretService) PatchSecrets(ctx context.Context, orgID influxdb.ID, m m
 
 // DeleteSecret checks to see if the authorizer on context has write access to the secret keys provided.
 func (s *SecretService) DeleteSecret(ctx context.Context, orgID influxdb.ID, keys ...string) error {
-	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, orgID); err != nil {
+	if _, _, err := AuthorizeOrgWriteResource(ctx, influxdb.SecretsResourceType, &orgID); err != nil {
 		return err
 	}
 	err := s.s.DeleteSecret(ctx, orgID, keys...)

--- a/authorizer/source.go
+++ b/authorizer/source.go
@@ -57,7 +57,7 @@ func (s *SourceService) FindSources(ctx context.Context, opts influxdb.FindOptio
 
 // CreateSource checks to see if the authorizer on context has write access to the global source resource.
 func (s *SourceService) CreateSource(ctx context.Context, src *influxdb.Source) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.SourcesResourceType, src.OrganizationID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.SourcesResourceType, &src.OrganizationID); err != nil {
 		return err
 	}
 	return s.s.CreateSource(ctx, src)

--- a/authorizer/task.go
+++ b/authorizer/task.go
@@ -95,7 +95,7 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t influxdb.TaskC
 		return nil, influxdb.ErrInvalidOwnerID
 	}
 
-	a, p, err := AuthorizeCreate(ctx, influxdb.TasksResourceType, t.OrganizationID)
+	a, p, err := AuthorizeCreate(ctx, influxdb.TasksResourceType, &t.OrganizationID)
 	loggerFields := []zap.Field{zap.String("method", "CreateTask")}
 	if err := ts.processPermissionError(a, p, err, loggerFields...); err != nil {
 		return nil, err

--- a/authorizer/telegraf.go
+++ b/authorizer/telegraf.go
@@ -48,7 +48,7 @@ func (s *TelegrafConfigService) FindTelegrafConfigs(ctx context.Context, filter 
 
 // CreateTelegrafConfig checks to see if the authorizer on context has write access to the global telegraf config resource.
 func (s *TelegrafConfigService) CreateTelegrafConfig(ctx context.Context, tc *influxdb.TelegrafConfig, userID influxdb.ID) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.TelegrafsResourceType, tc.OrgID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.TelegrafsResourceType, &tc.OrgID); err != nil {
 		return err
 	}
 	return s.s.CreateTelegrafConfig(ctx, tc, userID)

--- a/authorizer/variable.go
+++ b/authorizer/variable.go
@@ -46,7 +46,7 @@ func (s *VariableService) FindVariables(ctx context.Context, filter influxdb.Var
 
 // CreateVariable checks to see if the authorizer on context has write access to the global variable resource.
 func (s *VariableService) CreateVariable(ctx context.Context, v *influxdb.Variable) error {
-	if _, _, err := AuthorizeCreate(ctx, influxdb.VariablesResourceType, v.OrganizationID); err != nil {
+	if _, _, err := AuthorizeCreate(ctx, influxdb.VariablesResourceType, &v.OrganizationID); err != nil {
 		return err
 	}
 	return s.s.CreateVariable(ctx, v)

--- a/authz.go
+++ b/authz.go
@@ -91,7 +91,12 @@ func (r Resource) String() string {
 		return filepath.Join(string(r.Type), r.ID.String())
 	}
 
-	return string(r.Type)
+	switch r.Type {
+	case OrgsResourceType, UsersResourceType:
+		return string(r.Type)
+	default:
+		return filepath.Join(string(OrgsResourceType), "*", string(r.Type))
+	}
 }
 
 const (

--- a/authz_test.go
+++ b/authz_test.go
@@ -404,7 +404,7 @@ func TestPermission_String(t *testing.T) {
 					Type: platform.BucketsResourceType,
 				},
 			},
-			want: `write:buckets`,
+			want: `write:orgs/*/buckets`,
 		},
 		{
 			name: "valid permission with no org id",

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -371,19 +371,16 @@ func decodeCheckFilter(ctx context.Context, r *http.Request) (*influxdb.CheckFil
 	}
 
 	q := r.URL.Query()
-	if orgIDStr := q.Get("orgID"); orgIDStr != "" {
-		orgID, err := influxdb.IDFromString(orgIDStr)
-		if err != nil {
-			return f, opts, &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "orgID is invalid",
-				Err:  err,
-			}
+	orgIDStr := q.Get("orgID")
+	if orgIDStr == "" {
+		return nil, nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "orgID is required",
 		}
-		f.OrgID = orgID
-	} else if orgNameStr := q.Get("org"); orgNameStr != "" {
-		f.Org = &orgNameStr
 	}
+
+	f.OrgID, err = influxdb.IDFromString(orgIDStr)
+
 	return f, opts, err
 }
 

--- a/tenant/middleware_bucket_auth.go
+++ b/tenant/middleware_bucket_auth.go
@@ -91,7 +91,7 @@ func (s *AuthedBucketService) CreateBucket(ctx context.Context, b *influxdb.Buck
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	if _, _, err := authorizer.AuthorizeCreate(ctx, influxdb.BucketsResourceType, b.OrgID); err != nil {
+	if _, _, err := authorizer.AuthorizeCreate(ctx, influxdb.BucketsResourceType, &b.OrgID); err != nil {
 		return err
 	}
 	return s.s.CreateBucket(ctx, b)


### PR DESCRIPTION
Updating `/api/v2/checks` to enforce `orgID` parameter as per spec:
https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L5505-L5510

I've had a look around and can't find anywhere that doesn't already consume this API in this way.

Not enforcing this has its own problems. I am cleaning up the check service at the moment and this will make a big difference.

UPDATE:

This PR also includes one subtle change to `authorizer.AuthorizerOrg(Read|Write)Resource`.

Prior to this change the method took a `influxdb.ID` for an orgID. Now it takes a pointer to one.

This allows the caller to provider a nil orgID. The meaning of which is documented, but to elaborate, this mean the authorizer requires the caller to have the specific permission to read or write the specified resource type for **all** organizations.
Prior to this change, this method could only enforce for specified orgs.
This makes this authorize method suitable to called before delegating to list actions. Allowing us to stop authorizing the result set, rather instead we can now authorize the parameters.
If the caller omits an orgID from the filter, they are intrinsically asking for all organizations. This just makes sure they can do that, if they attempt it.

No more will we infer based on permissions what they can see after the action has already taken place. (this is what breaks pagination for all resources). If we move more list actions to use this, then we can fix our pagination issues.

This PR just switch the `FindChecks` call to authorize in this way.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
