### PR TITLE
chore(shared/constants): increase flux response limit to 27MB

### DIFF
--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -65,7 +65,7 @@ export const CLOUD_LOGOUT_PATH = '/logout'
 export const CLOUD_USERS_PATH = '/users'
 
 export const FLUX_RESPONSE_BYTES_LIMIT = CLOUD
-  ? 10 * 1024 * 1024 // 10 MiB
+  ? 27 * 1024 * 1024 // 27 MiB  (desa: this was determined by looking at queries responses in the cloud app)
   : 100 * 1024 * 1024 // 100 MiB
 
 export const VIS_SIG_DIGITS = 4


### PR DESCRIPTION
This was detemined by looking at the 99th percentile of query responses.

- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
