### PR TITLE
feat: added PushDownGroupAggregate planner rewrite rule

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -52,3 +52,9 @@
   default: false
   contact: Lyon Hill
   expose: true
+
+- name: Push Down Group Aggregate Count
+  description: Enable the count variant of PushDownGroupAggregate planner rule
+  key: pushDownGroupAggregateCount
+  default: false
+  contact: Query Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -86,6 +86,20 @@ func SessionService() BoolFlag {
 	return sessionService
 }
 
+var pushDownGroupAggregateCount = MakeBoolFlag(
+	"Push Down Group Aggregate Count",
+	"pushDownGroupAggregateCount",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownGroupAggregateCount - Enable the count variant of PushDownGroupAggregate planner rule
+func PushDownGroupAggregateCount() BoolFlag {
+	return pushDownGroupAggregateCount
+}
+
 var all = []Flag{
 	backendExample,
 	frontendExample,
@@ -93,6 +107,7 @@ var all = []Flag{
 	pushDownWindowAggregateRest,
 	newAuth,
 	sessionService,
+	pushDownGroupAggregateCount,
 }
 
 var byKey = map[string]Flag{
@@ -102,4 +117,5 @@ var byKey = map[string]Flag{
 	"pushDownWindowAggregateRest":  pushDownWindowAggregateRest,
 	"newAuth":                      newAuth,
 	"sessionService":               sessionService,
+	"pushDownGroupAggregateCount":  pushDownGroupAggregateCount,
 }


### PR DESCRIPTION
Added a (disabled) planner rule that matches:
   ReadGroupPhys -> { count, sum }

It uses the same physical spec node for group to implement the aggregate. The
rule requires:
 * the pushDownGroupAggregate{Count,Sum} feature flags enabled
 * no existing aggregate present in the ReadGroup
 * use of the "_value" column only

Closes influxdata/influxdb#17892