### PR TITLE
feat: adding notebook context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,10 @@ jobs:
           keys:
             - influxdb-gomod-{{ checksum "go.sum" }} # Just match the go.sum checksum cache.
       - run: make protoc
-      - run: make build
+      - run:
+          name: Make Build
+          no_output_timeout: 30m
+          command: make build
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,10 +393,7 @@ jobs:
           keys:
             - influxdb-gomod-{{ checksum "go.sum" }} # Just match the go.sum checksum cache.
       - run: make protoc
-      - run:
-          name: Make Build
-          no_output_timeout: 30m
-          command: make build
+      - run: make build
       - persist_to_workspace:
           root: .
           paths:

--- a/ui/src/notebooks/components/Notebook.tsx
+++ b/ui/src/notebooks/components/Notebook.tsx
@@ -1,13 +1,16 @@
 import React, {FC} from 'react'
 
 import {Page} from '@influxdata/clockface'
+import {NotebookProvider} from 'src/notebooks/context/notebook'
 
 const NotebookPage: FC = () => {
   return (
-    <Page titleTag="Notebook">
-      <Page.Header fullWidth={false} />
-      <Page.Contents fullWidth={false} scrollable={true} />
-    </Page>
+    <NotebookProvider>
+      <Page titleTag="Notebook">
+        <Page.Header fullWidth={false} />
+        <Page.Contents fullWidth={false} scrollable={true} />
+      </Page>
+    </NotebookProvider>
   )
 }
 

--- a/ui/src/notebooks/context/notebook.mock.json
+++ b/ui/src/notebooks/context/notebook.mock.json
@@ -1,0 +1,78 @@
+{
+  "id": "testing",
+  "pipes": [
+    {
+      "type": "query",
+      "activeQuery": 0,
+      "queries": [
+        {
+          "text": "from(bucket: \"project\")\n |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n |> filter(fn: (r) => r[\"_measurement\"] == \"docker_container_cpu\")",
+          "editMode": "advanced",
+          "builderConfig": {
+            "buckets": [],
+            "tags": [],
+            "functions": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "activeQuery": 0,
+      "queries": [
+        {
+          "text": "// Tip: Use the __PREVIOUS_RESULT__ variable to link your queries\n\n__PREVIOUS_RESULT__\n |> filter(fn: (r) => r[\"_field\"] == \"usage_percent\")",
+          "editMode": "advanced",
+          "builderConfig": {
+            "buckets": [],
+            "tags": [],
+            "functions": []
+          }
+        }
+      ]
+    },
+    {
+        "type": "visualization"
+    },
+    {
+        "type": "visualization"
+    },
+    {
+      "type": "query",
+      "activeQuery": 0,
+      "queries": [
+        {
+          "text": "// Tip: Use the __PREVIOUS_RESULT__ variable to link your queries\n\n__PREVIOUS_RESULT__\n |> sum()",
+          "editMode": "advanced",
+          "builderConfig": {
+            "buckets": [],
+            "tags": [],
+            "functions": []
+          }
+        }
+      ]
+    },
+    {
+        "type": "visualization"
+    },
+    {
+      "type": "query",
+      "activeQuery": 0,
+      "queries": [
+        {
+          "text": "// Tip: Use the __PREVIOUS_RESULT__ variable to link your queries\n\nfrom(bucket: \"project\")\n |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n |> filter(fn: (r) => r[\"_measurement\"] == \"docker_container_cpu\")",
+          "editMode": "advanced",
+          "builderConfig": {
+            "buckets": [],
+            "tags": [],
+            "functions": []
+          }
+        }
+      ]
+    },
+    {
+        "type": "visualization"
+    }
+  ]
+}
+

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -23,7 +23,7 @@ export const DEFAULT_CONTEXT = {
 // NOTE: this just loads some test data for exploring the
 // interactions between types. Make sure it's never true
 // during the pull review process
-const TEST_MODE = true
+const TEST_MODE = false
 if (TEST_MODE) {
   const TEST_NOTEBOOK = require('src/notebooks/context/notebook.mock.json')
   DEFAULT_CONTEXT.id = TEST_NOTEBOOK.id

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -35,7 +35,7 @@ export const NotebookContext = React.createContext<NotebookContextType>(
 )
 
 export const NotebookProvider: FC = ({children}) => {
-  const [id, setID] = useState(DEFAULT_CONTEXT.id)
+  const [id] = useState(DEFAULT_CONTEXT.id)
   const [pipes, setPipes] = useState(DEFAULT_CONTEXT.pipes)
 
   function addPipe(pipe: Pipe) {

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -1,0 +1,78 @@
+import React, {FC, useState} from 'react'
+
+// TODO make this polymorphic to mimic the self registration
+// of pipe stages
+export type Pipe = any
+
+export interface NotebookContextType {
+  id: string
+  pipes: Pipe[]
+  addPipe: (pipe: Pipe) => void
+  updatePipe: (idx: number, pipe: Pipe) => void
+  removePipe: (idx: number) => void
+}
+
+export const DEFAULT_CONTEXT = {
+  id: 'new',
+  pipes: [],
+  addPipe: () => {},
+  updatePipe: () => {},
+  removePipe: () => {},
+}
+
+// NOTE: this just loads some test data for exploring the
+// interactions between types. Make sure it's never true
+// during the pull review process
+const TEST_MODE = false
+if (TEST_MODE) {
+  const TEST_NOTEBOOK = require('src/notesbooks/context/notebook.mock.json')
+  DEFAULT_CONTEXT.id = TEST_NOTEBOOK.id
+  DEFAULT_CONTEXT.pipes = TEST_NOTEBOOK.pipes
+}
+
+export const NotebookContext = React.createContext<NotebookContextType>(
+  DEFAULT_CONTEXT
+)
+
+export const NotebookProvider: FC = ({children}) => {
+  const [id, setID] = useState(DEFAULT_CONTEXT.id)
+  const [pipes, setPipes] = useState(DEFAULT_CONTEXT.pipes)
+
+  function addPipe(pipe: Pipe) {
+    setPipes(pipes => {
+      pipes.push(pipe)
+      return pipes.slice()
+    })
+  }
+
+  function updatePipe(idx: number, pipe: Pipe) {
+    setPipes(pipes => {
+      pipes[idx] = {
+        ...pipes[idx],
+        ...pipe,
+      }
+      return pipes.slice()
+    })
+  }
+
+  function removePipe(idx: number) {
+    setPipes(pipes => {
+      pipes.splice(idx, 1)
+      return pipes.slice()
+    })
+  }
+
+  return (
+    <NotebookContext.Provider
+      value={{
+        id,
+        pipes,
+        updatePipe,
+        addPipe,
+        removePipe,
+      }}
+    >
+      {children}
+    </NotebookContext.Provider>
+  )
+}

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -23,9 +23,9 @@ export const DEFAULT_CONTEXT = {
 // NOTE: this just loads some test data for exploring the
 // interactions between types. Make sure it's never true
 // during the pull review process
-const TEST_MODE = false
+const TEST_MODE = true
 if (TEST_MODE) {
-  const TEST_NOTEBOOK = require('src/notesbooks/context/notebook.mock.json')
+  const TEST_NOTEBOOK = require('src/notebooks/context/notebook.mock.json')
   DEFAULT_CONTEXT.id = TEST_NOTEBOOK.id
   DEFAULT_CONTEXT.pipes = TEST_NOTEBOOK.pipes
 }


### PR DESCRIPTION
creating a context provider for the notebook interaction (#17966) based on the suggested structure from this talk (thanks @121watts):
https://www.youtube.com/watch?v=CDGBTjMBJzg&t=523s

I've anchored the context provider to the page for now. we'll probably want to figure out a better solution than `useState` in the near future so that components can define their own state requirements more towards the leaf nodes, and have that state shared between them, but this technique should hold up through the prototyping phase.

i've included the test mock data i've been using to ensure that interactions between notebook stages are working properly, figuring that they might be useful until we have more of the crud level interactions fleshed out.