### PR TITLE
feat(http): Client disconnections should return a HTTP 499 error code.

### DIFF
--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -321,18 +321,18 @@ func newBucketsResponse(ctx context.Context, opts influxdb.FindOptions, f influx
 func (h *BucketHandler) handlePostBucket(w http.ResponseWriter, r *http.Request) {
 	var b postBucketRequest
 	if err := h.api.DecodeJSON(r.Body, &b); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	bucket := b.toInfluxDB()
 	if err := h.BucketService.CreateBucket(r.Context(), bucket); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Bucket created", zap.String("bucket", fmt.Sprint(bucket)))
 
-	h.api.Respond(w, http.StatusCreated, NewBucketResponse(bucket, []*influxdb.Label{}))
+	h.api.Respond(w, r, http.StatusCreated, NewBucketResponse(bucket, []*influxdb.Label{}))
 }
 
 type postBucketRequest struct {
@@ -395,25 +395,25 @@ func (h *BucketHandler) handleGetBucket(w http.ResponseWriter, r *http.Request) 
 
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	b, err := h.BucketService.FindBucketByID(ctx, id)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	labels, err := h.LabelService.FindResourceLabels(ctx, influxdb.LabelMappingFilter{ResourceID: b.ID, ResourceType: influxdb.BucketsResourceType})
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	h.log.Debug("Bucket retrieved", zap.String("bucket", fmt.Sprint(b)))
 
-	h.api.Respond(w, http.StatusOK, NewBucketResponse(b, labels))
+	h.api.Respond(w, r, http.StatusOK, NewBucketResponse(b, labels))
 }
 
 func bucketIDPath(id influxdb.ID) string {
@@ -424,25 +424,25 @@ func bucketIDPath(id influxdb.ID) string {
 func (h *BucketHandler) handleGetBucketLog(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	opts, err := influxdb.DecodeFindOptions(r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	log, _, err := h.BucketOperationLogService.GetBucketOperationLog(r.Context(), id, *opts)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	h.log.Debug("Bucket log retrived", zap.String("bucket", fmt.Sprint(log)))
 
-	h.api.Respond(w, http.StatusOK, newBucketLogResponse(id, log))
+	h.api.Respond(w, r, http.StatusOK, newBucketLogResponse(id, log))
 }
 
 func newBucketLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
@@ -462,18 +462,18 @@ func newBucketLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *ope
 func (h *BucketHandler) handleDeleteBucket(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	if err := h.BucketService.DeleteBucket(r.Context(), id); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	h.log.Debug("Bucket deleted", zap.String("bucketID", id.String()))
 
-	h.api.Respond(w, http.StatusNoContent, nil)
+	h.api.Respond(w, r, http.StatusNoContent, nil)
 }
 
 // handleGetBuckets is the HTTP handler for the GET /api/v2/buckets route.
@@ -489,7 +489,7 @@ func (h *BucketHandler) handleGetBuckets(w http.ResponseWriter, r *http.Request)
 
 	bucketID, err := decodeIDFromQuery(q, "id")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	if bucketID > 0 {
@@ -498,7 +498,7 @@ func (h *BucketHandler) handleGetBuckets(w http.ResponseWriter, r *http.Request)
 
 	orgID, err := decodeIDFromQuery(q, "orgID")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	if orgID > 0 {
@@ -507,18 +507,18 @@ func (h *BucketHandler) handleGetBuckets(w http.ResponseWriter, r *http.Request)
 
 	opts, err := influxdb.DecodeFindOptions(r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	bs, _, err := h.BucketService.FindBuckets(r.Context(), filter, *opts)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Buckets retrieved", zap.String("buckets", fmt.Sprint(bs)))
 
-	h.api.Respond(w, http.StatusOK, newBucketsResponse(r.Context(), *opts, filter, bs, h.LabelService))
+	h.api.Respond(w, r, http.StatusOK, newBucketsResponse(r.Context(), *opts, filter, bs, h.LabelService))
 }
 
 type getBucketsRequest struct {
@@ -568,32 +568,32 @@ func decodeGetBucketsRequest(r *http.Request) (*getBucketsRequest, error) {
 func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	var reqBody bucketUpdate
 	if err := h.api.DecodeJSON(r.Body, &reqBody); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	if reqBody.Name != nil {
 		b, err := h.BucketService.FindBucketByID(r.Context(), id)
 		if err != nil {
-			h.api.Err(w, err)
+			h.api.Err(w, r, err)
 			return
 		}
 		b.Name = *reqBody.Name
 		if err := validBucketName(b); err != nil {
-			h.api.Err(w, err)
+			h.api.Err(w, r, err)
 			return
 		}
 	}
 
 	b, err := h.BucketService.UpdateBucket(r.Context(), id, *reqBody.toInfluxDB())
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
@@ -604,12 +604,12 @@ func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request
 		ResourceType: influxdb.BucketsResourceType,
 	})
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Bucket updated", zap.String("bucket", fmt.Sprint(b)))
 
-	h.api.Respond(w, http.StatusOK, NewBucketResponse(b, labels))
+	h.api.Respond(w, r, http.StatusOK, NewBucketResponse(b, labels))
 }
 
 // BucketService connects to Influx via HTTP using tokens to manage buckets

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -79,12 +79,12 @@ func checkOrganizationExists(orgHandler *OrgHandler) kithttp.Middleware {
 			ctx := r.Context()
 			orgID, err := decodeIDFromCtx(ctx, "id")
 			if err != nil {
-				orgHandler.API.Err(w, err)
+				orgHandler.API.Err(w, r, err)
 				return
 			}
 
 			if _, err := orgHandler.OrgSVC.FindOrganizationByID(ctx, orgID); err != nil {
-				orgHandler.API.Err(w, err)
+				orgHandler.API.Err(w, r, err)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -210,35 +210,35 @@ func newOrgResponse(o influxdb.Organization) orgResponse {
 func (h *OrgHandler) handlePostOrg(w http.ResponseWriter, r *http.Request) {
 	var org influxdb.Organization
 	if err := h.API.DecodeJSON(r.Body, &org); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	if err := h.OrgSVC.CreateOrganization(r.Context(), &org); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org created", zap.String("org", fmt.Sprint(org)))
 
-	h.API.Respond(w, http.StatusCreated, newOrgResponse(org))
+	h.API.Respond(w, r, http.StatusCreated, newOrgResponse(org))
 }
 
 // handleGetOrg is the HTTP handler for the GET /api/v2/orgs/:id route.
 func (h *OrgHandler) handleGetOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	org, err := h.OrgSVC.FindOrganizationByID(r.Context(), id)
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org retrieved", zap.String("org", fmt.Sprint(org)))
 
-	h.API.Respond(w, http.StatusOK, newOrgResponse(*org))
+	h.API.Respond(w, r, http.StatusOK, newOrgResponse(*org))
 }
 
 // handleGetOrgs is the HTTP handler for the GET /api/v2/orgs route.
@@ -251,7 +251,7 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 	if orgID := qp.Get("orgID"); orgID != "" {
 		id, err := influxdb.IDFromString(orgID)
 		if err != nil {
-			h.API.Err(w, err)
+			h.API.Err(w, r, err)
 			return
 		}
 		filter.ID = id
@@ -260,7 +260,7 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 	if userID := qp.Get("userID"); userID != "" {
 		id, err := influxdb.IDFromString(userID)
 		if err != nil {
-			h.API.Err(w, err)
+			h.API.Err(w, r, err)
 			return
 		}
 		filter.UserID = id
@@ -268,54 +268,54 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 
 	orgs, _, err := h.OrgSVC.FindOrganizations(r.Context(), filter)
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
 
-	h.API.Respond(w, http.StatusOK, newOrgsResponse(orgs))
+	h.API.Respond(w, r, http.StatusOK, newOrgsResponse(orgs))
 }
 
 // handleDeleteOrganization is the HTTP handler for the DELETE /api/v2/orgs/:id route.
 func (h *OrgHandler) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	ctx := r.Context()
 	if err := h.OrgSVC.DeleteOrganization(ctx, id); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org deleted", zap.String("orgID", fmt.Sprint(id)))
 
-	h.API.Respond(w, http.StatusNoContent, nil)
+	h.API.Respond(w, r, http.StatusNoContent, nil)
 }
 
 // handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.
 func (h *OrgHandler) handlePatchOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	var upd influxdb.OrganizationUpdate
 	if err := h.API.DecodeJSON(r.Body, &upd); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	org, err := h.OrgSVC.UpdateOrganization(r.Context(), id, upd)
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org updated", zap.String("org", fmt.Sprint(org)))
 
-	h.API.Respond(w, http.StatusOK, newOrgResponse(*org))
+	h.API.Respond(w, r, http.StatusOK, newOrgResponse(*org))
 }
 
 type secretsResponse struct {
@@ -340,39 +340,39 @@ func newSecretsResponse(orgID influxdb.ID, ks []string) *secretsResponse {
 func (h *OrgHandler) handleGetSecrets(w http.ResponseWriter, r *http.Request) {
 	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	ks, err := h.SecretService.GetSecretKeys(r.Context(), orgID)
 	if err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
-	h.API.Respond(w, http.StatusOK, newSecretsResponse(orgID, ks))
+	h.API.Respond(w, r, http.StatusOK, newSecretsResponse(orgID, ks))
 }
 
 // handleGetPatchSecrets is the HTTP handler for the PATCH /api/v2/orgs/:id/secrets route.
 func (h *OrgHandler) handlePatchSecrets(w http.ResponseWriter, r *http.Request) {
 	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	var secrets map[string]string
 	if err := h.API.DecodeJSON(r.Body, &secrets); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	if err := h.SecretService.PatchSecrets(r.Context(), orgID, secrets); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
-	h.API.Respond(w, http.StatusNoContent, nil)
+	h.API.Respond(w, r, http.StatusNoContent, nil)
 }
 
 type secretsDeleteBody struct {
@@ -383,47 +383,47 @@ type secretsDeleteBody struct {
 func (h *OrgHandler) handleDeleteSecrets(w http.ResponseWriter, r *http.Request) {
 	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	var reqBody secretsDeleteBody
 
 	if err := h.API.DecodeJSON(r.Body, &reqBody); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	if err := h.SecretService.DeleteSecret(r.Context(), orgID, reqBody.Secrets...); err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
-	h.API.Respond(w, http.StatusNoContent, nil)
+	h.API.Respond(w, r, http.StatusNoContent, nil)
 }
 
 // hanldeGetOrganizationLog retrieves a organization log by the organizations ID.
 func (h *OrgHandler) handleGetOrgLog(w http.ResponseWriter, r *http.Request) {
 	orgID, err := decodeIDFromCtx(r.Context(), "id")
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	opts, err := influxdb.DecodeFindOptions(r)
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 
 	log, _, err := h.OrganizationOperationLogService.GetOrganizationOperationLog(r.Context(), orgID, *opts)
 	if err != nil {
-		h.API.Err(w, err)
+		h.API.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org logs retrieved", zap.String("log", fmt.Sprint(log)))
 
-	h.API.Respond(w, http.StatusOK, newOrganizationLogResponse(orgID, log))
+	h.API.Respond(w, r, http.StatusOK, newOrganizationLogResponse(orgID, log))
 }
 
 func newOrganizationLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {

--- a/kit/transport/http/api.go
+++ b/kit/transport/http/api.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
@@ -26,7 +27,7 @@ type API struct {
 
 	unmarshalErrFn func(encoding string, err error) error
 	okErrFn        func(err error) error
-	errFn          func(err error) (interface{}, int, error)
+	errFn          func(ctx context.Context, err error) (interface{}, int, error)
 }
 
 // APIOptFn is a functional option for setting fields on the API type.
@@ -40,7 +41,7 @@ func WithLog(logger *zap.Logger) APIOptFn {
 }
 
 // WithErrFn sets the err handling func for issues when writing to the response body.
-func WithErrFn(fn func(err error) (interface{}, int, error)) APIOptFn {
+func WithErrFn(fn func(ctx context.Context, err error) (interface{}, int, error)) APIOptFn {
 	return func(api *API) {
 		api.errFn = fn
 	}
@@ -86,7 +87,7 @@ func NewAPI(opts ...APIOptFn) *API {
 				Msg:  fmt.Sprintf("failed to unmarshal %s: %s", encoding, err),
 			}
 		},
-		errFn: func(err error) (interface{}, int, error) {
+		errFn: func(ctx context.Context, err error) (interface{}, int, error) {
 			msg := err.Error()
 			if msg == "" {
 				msg = "an internal error has occurred"
@@ -95,7 +96,7 @@ func NewAPI(opts ...APIOptFn) *API {
 			return ErrBody{
 				Code: code,
 				Msg:  msg,
-			}, ErrorCodeToStatusCode(code), nil
+			}, ErrorCodeToStatusCode(ctx, code), nil
 		},
 	}
 	for _, o := range opts {
@@ -144,7 +145,7 @@ func (a *API) decode(encoding string, dec decoder, v interface{}) error {
 }
 
 // Respond writes to the response writer, handling all errors in writing.
-func (a *API) Respond(w http.ResponseWriter, status int, v interface{}) {
+func (a *API) Respond(w http.ResponseWriter, r *http.Request, status int, v interface{}) {
 	if status == http.StatusNoContent {
 		w.WriteHeader(status)
 		return
@@ -179,7 +180,7 @@ func (a *API) Respond(w http.ResponseWriter, status int, v interface{}) {
 		b, err = json.Marshal(v)
 	}
 	if err != nil {
-		a.Err(w, err)
+		a.Err(w, r, err)
 		return
 	}
 
@@ -194,17 +195,17 @@ func (a *API) Respond(w http.ResponseWriter, status int, v interface{}) {
 }
 
 // Err is used for writing an error to the response.
-func (a *API) Err(w http.ResponseWriter, err error) {
+func (a *API) Err(w http.ResponseWriter, r *http.Request, err error) {
 	if err == nil {
 		return
 	}
 
 	a.logErr("api error encountered", zap.Error(err))
 
-	v, status, err := a.errFn(err)
+	v, status, err := a.errFn(r.Context(), err)
 	if err != nil {
 		a.logErr("failed to write err to response writer", zap.Error(err))
-		a.Respond(w, http.StatusInternalServerError, ErrBody{
+		a.Respond(w, r, http.StatusInternalServerError, ErrBody{
 			Code: "internal error",
 			Msg:  "an unexpected error occured",
 		})
@@ -215,7 +216,7 @@ func (a *API) Err(w http.ResponseWriter, err error) {
 		w.Header().Set(PlatformErrorCodeHeader, eb.Code)
 	}
 
-	a.Respond(w, status, v)
+	a.Respond(w, r, status, v)
 }
 
 func (a *API) logErr(msg string, fields ...zap.Field) {

--- a/kit/transport/http/api_test.go
+++ b/kit/transport/http/api_test.go
@@ -142,7 +142,7 @@ func Test_API(t *testing.T) {
 				responder := kithttp.NewAPI()
 
 				svr := func(w http.ResponseWriter, r *http.Request) {
-					responder.Respond(w, statusCode, map[string]string{
+					responder.Respond(w, r, statusCode, map[string]string{
 						"foo": "bar",
 					})
 				}
@@ -208,7 +208,7 @@ func Test_API(t *testing.T) {
 				responder := kithttp.NewAPI()
 
 				svr := func(w http.ResponseWriter, r *http.Request) {
-					responder.Err(w, tt.expectedErr)
+					responder.Err(w, r, tt.expectedErr)
 				}
 
 				testttp.

--- a/session/http_server.go
+++ b/session/http_server.go
@@ -81,7 +81,7 @@ func (h *SessionHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
 
 	req, decErr := decodeSigninRequest(ctx, r)
 	if decErr != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 
@@ -89,18 +89,18 @@ func (h *SessionHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
 		Name: &req.Username,
 	})
 	if err != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 
 	if err := h.passSvc.ComparePassword(ctx, u.ID, req.Password); err != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 
 	s, e := h.sessionSvc.CreateSession(ctx, req.Username)
 	if e != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 
@@ -134,12 +134,12 @@ func (h *SessionHandler) handleSignout(w http.ResponseWriter, r *http.Request) {
 
 	req, err := decodeSignoutRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 
 	if err := h.sessionSvc.ExpireSession(ctx, req.Key); err != nil {
-		h.api.Err(w, ErrUnauthorized)
+		h.api.Err(w, r, ErrUnauthorized)
 		return
 	}
 

--- a/tenant/http_handler_urm.go
+++ b/tenant/http_handler_urm.go
@@ -48,7 +48,7 @@ func (h *urmHandler) getURMsByType(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	req, err := h.decodeGetRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
@@ -59,7 +59,7 @@ func (h *urmHandler) getURMsByType(w http.ResponseWriter, r *http.Request) {
 	}
 	mappings, _, err := h.svc.FindUserResourceMappings(ctx, filter)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
@@ -70,7 +70,7 @@ func (h *urmHandler) getURMsByType(w http.ResponseWriter, r *http.Request) {
 		}
 		user, err := h.userSvc.FindUserByID(ctx, m.UserID)
 		if err != nil {
-			h.api.Err(w, err)
+			h.api.Err(w, r, err)
 			return
 		}
 
@@ -78,7 +78,7 @@ func (h *urmHandler) getURMsByType(w http.ResponseWriter, r *http.Request) {
 	}
 	h.log.Debug("Members/owners retrieved", zap.String("users", fmt.Sprint(users)))
 
-	h.api.Respond(w, http.StatusOK, newResourceUsersResponse(filter, users))
+	h.api.Respond(w, r, http.StatusOK, newResourceUsersResponse(filter, users))
 
 }
 
@@ -112,13 +112,13 @@ func (h *urmHandler) postURMByType(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	req, err := h.decodePostRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	user, err := h.userSvc.FindUserByID(ctx, req.UserID)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
@@ -129,12 +129,12 @@ func (h *urmHandler) postURMByType(w http.ResponseWriter, r *http.Request) {
 		UserType:     userType,
 	}
 	if err := h.svc.CreateUserResourceMapping(ctx, mapping); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Member/owner created", zap.String("mapping", fmt.Sprint(mapping)))
 
-	h.api.Respond(w, http.StatusCreated, newResourceUserResponse(user, userType))
+	h.api.Respond(w, r, http.StatusCreated, newResourceUserResponse(user, userType))
 }
 
 type postRequest struct {
@@ -178,12 +178,12 @@ func (h *urmHandler) deleteURM(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	req, err := h.decodeDeleteRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	if err := h.svc.DeleteUserResourceMapping(ctx, req.resourceID, req.userID); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Member deleted", zap.String("resourceID", req.resourceID.String()), zap.String("memberID", req.userID.String()))

--- a/tenant/http_server.go
+++ b/tenant/http_server.go
@@ -20,7 +20,7 @@ func ValidResource(api *kit.API, lookupOrgByResourceID func(context.Context, inf
 			statusW := kit.NewStatusResponseWriter(w)
 			id, err := influxdb.IDFromString(chi.URLParam(r, "id"))
 			if err != nil {
-				api.Err(w, ErrCorruptID(err))
+				api.Err(w, r, ErrCorruptID(err))
 				return
 			}
 
@@ -28,7 +28,7 @@ func ValidResource(api *kit.API, lookupOrgByResourceID func(context.Context, inf
 
 			orgID, err := lookupOrgByResourceID(ctx, *id)
 			if err != nil {
-				api.Err(w, err)
+				api.Err(w, r, err)
 				return
 			}
 

--- a/tenant/http_server_onboarding.go
+++ b/tenant/http_server_onboarding.go
@@ -65,12 +65,12 @@ func (h *OnboardHandler) handleIsOnboarding(w http.ResponseWriter, r *http.Reque
 	ctx := r.Context()
 	result, err := h.onboardingSvc.IsOnboarding(ctx)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Onboarding eligibility check finished", zap.String("result", fmt.Sprint(result)))
 
-	h.api.Respond(w, http.StatusOK, isOnboardingResponse{result})
+	h.api.Respond(w, r, http.StatusOK, isOnboardingResponse{result})
 }
 
 // handleInitialOnboardRequest is the HTTP handler for the GET /api/v2/setup route.
@@ -78,17 +78,17 @@ func (h *OnboardHandler) handleInitialOnboardRequest(w http.ResponseWriter, r *h
 	ctx := r.Context()
 	req, err := decodeOnboardRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	results, err := h.onboardingSvc.OnboardInitialUser(ctx, req)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Onboarding setup completed", zap.String("results", fmt.Sprint(results)))
 
-	h.api.Respond(w, http.StatusCreated, NewOnboardingResponse(results))
+	h.api.Respond(w, r, http.StatusCreated, NewOnboardingResponse(results))
 }
 
 // isOnboarding is the HTTP handler for the POST /api/v2/setup route.
@@ -96,17 +96,17 @@ func (h *OnboardHandler) handleOnboardRequest(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 	req, err := decodeOnboardRequest(ctx, r)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	results, err := h.onboardingSvc.OnboardUser(ctx, req)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Onboarding setup completed", zap.String("results", fmt.Sprint(results)))
 
-	h.api.Respond(w, http.StatusCreated, NewOnboardingResponse(results))
+	h.api.Respond(w, r, http.StatusCreated, NewOnboardingResponse(results))
 }
 
 type onboardingResponse struct {

--- a/tenant/http_server_org.go
+++ b/tenant/http_server_org.go
@@ -95,36 +95,36 @@ func newOrgsResponse(orgs []*influxdb.Organization) *orgsResponse {
 func (h *OrgHandler) handlePostOrg(w http.ResponseWriter, r *http.Request) {
 	var org influxdb.Organization
 	if err := h.api.DecodeJSON(r.Body, &org); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	if err := h.orgSvc.CreateOrganization(r.Context(), &org); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	h.log.Debug("Org created", zap.String("org", fmt.Sprint(org)))
 
-	h.api.Respond(w, http.StatusCreated, newOrgResponse(org))
+	h.api.Respond(w, r, http.StatusCreated, newOrgResponse(org))
 }
 
 // handleGetOrg is the HTTP handler for the GET /api/v2/orgs/:id route.
 func (h *OrgHandler) handleGetOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := influxdb.IDFromString(chi.URLParam(r, "id"))
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	org, err := h.orgSvc.FindOrganizationByID(r.Context(), *id)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org retrieved", zap.String("org", fmt.Sprint(org)))
 
-	h.api.Respond(w, http.StatusOK, newOrgResponse(*org))
+	h.api.Respond(w, r, http.StatusOK, newOrgResponse(*org))
 }
 
 // handleGetOrgs is the HTTP handler for the GET /api/v2/orgs route.
@@ -151,54 +151,54 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 
 	orgs, _, err := h.orgSvc.FindOrganizations(r.Context(), filter)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
 
-	h.api.Respond(w, http.StatusOK, newOrgsResponse(orgs))
+	h.api.Respond(w, r, http.StatusOK, newOrgsResponse(orgs))
 }
 
 // handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.
 func (h *OrgHandler) handlePatchOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := influxdb.IDFromString(chi.URLParam(r, "id"))
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	var upd influxdb.OrganizationUpdate
 	if err := h.api.DecodeJSON(r.Body, &upd); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	org, err := h.orgSvc.UpdateOrganization(r.Context(), *id, upd)
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org updated", zap.String("org", fmt.Sprint(org)))
 
-	h.api.Respond(w, http.StatusOK, newOrgResponse(*org))
+	h.api.Respond(w, r, http.StatusOK, newOrgResponse(*org))
 }
 
 // handleDeleteOrganization is the HTTP handler for the DELETE /api/v2/orgs/:id route.
 func (h *OrgHandler) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 	id, err := influxdb.IDFromString(chi.URLParam(r, "id"))
 	if err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 
 	ctx := r.Context()
 	if err := h.orgSvc.DeleteOrganization(ctx, *id); err != nil {
-		h.api.Err(w, err)
+		h.api.Err(w, r, err)
 		return
 	}
 	h.log.Debug("Org deleted", zap.String("orgID", fmt.Sprint(id)))
 
-	h.api.Respond(w, http.StatusNoContent, nil)
+	h.api.Respond(w, r, http.StatusNoContent, nil)
 }
 
 func (h *OrgHandler) lookupOrgByID(ctx context.Context, id influxdb.ID) (influxdb.ID, error) {


### PR DESCRIPTION
This commit checks `http.Request.Context().Err()` to see if the context has been canceled or deadlined before writing an error code. It uses the non-standard Nginx `499` error code for client disconnection and `408` for client timeout.

https://httpstatuses.com/499

Helps influxdata/idpe#7124