### PR TITLE
feat(task): Allow switching of compiler from outside Executor

### DIFF
--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -47,7 +47,8 @@ func MultiLimit(limits ...LimitFunc) LimitFunc {
 type LimitFunc func(*influxdb.Task, *influxdb.Run) error
 
 type executorConfig struct {
-	maxWorkers int
+	maxWorkers    int
+	buildCompiler CompilerBuilderFunc
 }
 
 type executorOption func(*executorConfig)
@@ -59,10 +60,23 @@ func WithMaxWorkers(n int) executorOption {
 	}
 }
 
+// CompilerBuilderFunc is a function that yields a new flux.Compiler. The
+// context.Context provided can be assumed to be an authorized context.
+type CompilerBuilderFunc func(ctx context.Context, query string, now time.Time) (flux.Compiler, error)
+
+// WithCompilerBuilder is an Executor option that configures a
+// CompilerBuilderFunc to be used when compiling queries.
+func WithCompilerBuilder(builder CompilerBuilderFunc) executorOption {
+	return func(o *executorConfig) {
+		o.buildCompiler = builder
+	}
+}
+
 // NewExecutor creates a new task executor
 func NewExecutor(log *zap.Logger, qs query.QueryService, as influxdb.AuthorizationService, ts influxdb.TaskService, tcs backend.TaskControlService, opts ...executorOption) (*Executor, *ExecutorMetrics) {
 	cfg := &executorConfig{
-		maxWorkers: defaultMaxWorkers,
+		maxWorkers:    defaultMaxWorkers,
+		buildCompiler: NewASTCompiler,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -79,6 +93,7 @@ func NewExecutor(log *zap.Logger, qs query.QueryService, as influxdb.Authorizati
 		promiseQueue:    make(chan *promise, maxPromises),
 		workerLimit:     make(chan struct{}, cfg.maxWorkers),
 		limitFunc:       func(*influxdb.Task, *influxdb.Run) error { return nil }, // noop
+		buildCompiler:   cfg.buildCompiler,
 	}
 
 	e.metrics = NewExecutorMetrics(e)
@@ -113,6 +128,8 @@ type Executor struct {
 	// keep a pool of execution workers.
 	workerPool  sync.Pool
 	workerLimit chan struct{}
+
+	buildCompiler CompilerBuilderFunc
 }
 
 // SetLimitFunc sets the limit func for this task executor
@@ -263,7 +280,11 @@ type workerMaker struct {
 }
 
 func (wm *workerMaker) new() interface{} {
-	return &worker{wm.e, exhaustResultIterators}
+	return &worker{
+		e:                      wm.e,
+		exhaustResultIterators: exhaustResultIterators,
+		buildCompiler:          wm.e.buildCompiler,
+	}
 }
 
 type worker struct {
@@ -272,6 +293,8 @@ type worker struct {
 	// exhaustResultIterators is used to exhaust the result
 	// of a flux query
 	exhaustResultIterators func(res flux.Result) error
+
+	buildCompiler CompilerBuilderFunc
 }
 
 func (w *worker) work() {
@@ -391,24 +414,19 @@ func (w *worker) executeQuery(p *promise) {
 	// start
 	w.start(p)
 
-	pkg, err := flux.Parse(p.task.Flux)
+	ctx = icontext.SetAuthorizer(ctx, p.task.Authorization)
+	compiler, err := w.buildCompiler(ctx, p.task.Flux, p.run.ScheduledFor)
 	if err != nil {
 		w.finish(p, influxdb.RunFail, influxdb.ErrFluxParseError(err))
 		return
 	}
 
-	sf := p.run.ScheduledFor
-
 	req := &query.Request{
 		Authorization:  p.auth,
 		OrganizationID: p.task.OrganizationID,
-		Compiler: lang.ASTCompiler{
-			AST: pkg,
-			Now: sf,
-		},
+		Compiler:       compiler,
 	}
 	req.WithReturnNoContent(true)
-	ctx = icontext.SetAuthorizer(ctx, p.task.Authorization)
 	it, err := w.e.qs.Query(ctx, req)
 	if err != nil {
 		// Assume the error should not be part of the runResult.
@@ -515,4 +533,24 @@ func exhaustResultIterators(res flux.Result) error {
 			return nil
 		})
 	})
+}
+
+// NewASTCompiler parses a Flux query string into an AST representatation.
+func NewASTCompiler(_ context.Context, query string, now time.Time) (flux.Compiler, error) {
+	pkg, err := flux.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	return lang.ASTCompiler{
+		AST: pkg,
+		Now: now,
+	}, nil
+}
+
+// NewFluxCompiler wraps a Flux query string in a raw-query representation.
+func NewFluxCompiler(_ context.Context, query string, now time.Time) (flux.Compiler, error) {
+	return lang.FluxCompiler{
+		Query: query,
+		Now:   now,
+	}, nil
 }

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -444,9 +444,13 @@ func testIteratorFailure(t *testing.T) {
 
 	// replace iterator exhaust function with one which errors
 	tes.ex.workerPool = sync.Pool{New: func() interface{} {
-		return &worker{tes.ex, func(flux.Result) error {
-			return errors.New("something went wrong exhausting iterator")
-		}}
+		return &worker{
+			e: tes.ex,
+			exhaustResultIterators: func(flux.Result) error {
+				return errors.New("something went wrong exhausting iterator")
+			},
+			buildCompiler: NewASTCompiler,
+		}
 	}}
 
 	script := fmt.Sprintf(fmtTestScript, t.Name())


### PR DESCRIPTION
This allows us to inject a constructor function into the Task executor that creates a `flux.Compiler` used in the query request via `WithCompilerBuilder` option. Authorization of a `context.Context` is done ahead of this decision and provided to this builder function so we can perform feature flagging of this behavior on a per-task basis.

By default, the `Executor` uses the existing AST parsing logic.