### PR TITLE
feat: adding basic structure for notebooks

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -79,6 +79,7 @@
     "@types/text-encoding": "^0.0.32",
     "@types/uuid": "^3.4.3",
     "@types/webpack": "^4.4.35",
+    "@types/webpack-env": "^1.15.2",
     "@typescript-eslint/eslint-plugin": "^2.6.0",
     "@typescript-eslint/parser": "^2.6.0",
     "acorn": "^6.0.6",

--- a/ui/src/notebooks/components/AddButtons.tsx
+++ b/ui/src/notebooks/components/AddButtons.tsx
@@ -1,0 +1,28 @@
+import React, {FC, useContext} from 'react'
+import {Button, ComponentColor} from '@influxdata/clockface'
+import {NotebookContext} from 'src/notebooks/context/notebook'
+import {PIPE_DEFINITIONS} from 'src/notebooks'
+
+const AddButtons: FC = () => {
+  const {addPipe} = useContext(NotebookContext)
+
+  const pipes = Object.entries(PIPE_DEFINITIONS).map(([type, def]) => {
+    return (
+      <Button
+        key={def.type}
+        text={def.button}
+        onClick={() => {
+          addPipe({
+            ...def.empty,
+            type,
+          })
+        }}
+        color={ComponentColor.Secondary}
+      />
+    )
+  })
+
+  return <div className="notebook--actions">{pipes}</div>
+}
+
+export default AddButtons

--- a/ui/src/notebooks/components/Header.tsx
+++ b/ui/src/notebooks/components/Header.tsx
@@ -2,7 +2,7 @@ import React, {FC} from 'react'
 
 import {Page} from '@influxdata/clockface'
 
-const Header: FC<{}> = () => {
+const Header: FC = () => {
   return (
     <>
       <Page.Title title="Notebooks" />

--- a/ui/src/notebooks/components/Header.tsx
+++ b/ui/src/notebooks/components/Header.tsx
@@ -1,0 +1,13 @@
+import React, {FC} from 'react'
+
+import {Page} from '@influxdata/clockface'
+
+const Header: FC<{}> = () => {
+  return (
+    <>
+      <Page.Title title="Notebooks" />
+    </>
+  )
+}
+
+export default Header

--- a/ui/src/notebooks/components/Notebook.tsx
+++ b/ui/src/notebooks/components/Notebook.tsx
@@ -2,13 +2,26 @@ import React, {FC} from 'react'
 
 import {Page} from '@influxdata/clockface'
 import {NotebookProvider} from 'src/notebooks/context/notebook'
+import Header from 'src/notebooks/components/Header'
+import PipeList from 'src/notebooks/components/PipeList'
+import AddButtons from 'src/notebooks/components/AddButtons'
+
+// NOTE: uncommon, but using this to scope the project
+// within the page and not bleed it's dependancies outside
+// of the feature flag
+import 'src/notebooks/style.scss'
 
 const NotebookPage: FC = () => {
   return (
     <NotebookProvider>
       <Page titleTag="Notebook">
-        <Page.Header fullWidth={false} />
-        <Page.Contents fullWidth={false} scrollable={true} />
+        <Page.Header fullWidth={false}>
+          <Header />
+        </Page.Header>
+        <Page.Contents fullWidth={false} scrollable={true}>
+          <PipeList />
+          <AddButtons />
+        </Page.Contents>
       </Page>
     </NotebookProvider>
   )

--- a/ui/src/notebooks/components/Panel.tsx
+++ b/ui/src/notebooks/components/Panel.tsx
@@ -1,6 +1,5 @@
 // Libraries
-import React, {FC, ReactChildren, useState} from 'react'
-import classnames from 'classnames'
+import React, {FC, ReactChildren} from 'react'
 
 // Components
 import {
@@ -8,9 +7,10 @@ import {
   ComponentSize,
   AlignItems,
   JustifyContent,
-  SquareButton,
-  IconFont,
 } from '@influxdata/clockface'
+
+import usePanelState from 'src/notebooks/hooks/usePanelState'
+import RemoveButton from 'src/notebooks/components/RemoveButton'
 
 interface Props {
   children: ReactChildren | JSX.Element | JSX.Element[]
@@ -20,17 +20,6 @@ interface Props {
   onRemove?: () => void
 }
 
-type PanelState = 'hidden' | 'small' | 'large'
-interface ProgressMap {
-  [key: PanelState]: PanelState
-}
-
-const PANEL_PROGRESS: ProgressMap = {
-  hidden: 'small',
-  small: 'large',
-  large: 'hidden',
-}
-
 const Panel: FC<Props> = ({
   children,
   title,
@@ -38,28 +27,10 @@ const Panel: FC<Props> = ({
   controlsRight,
   onRemove,
 }) => {
-  const [panelState, setPanelState] = useState<PanelState>('small')
-
-  const panelClassName = classnames('notebook-panel', {
-    [`notebook-panel__${panelState}`]: panelState,
-  })
-  const childrenShouldBeVisible =
-    panelState === 'small' || panelState === 'large'
-
-  const handleToggle = (): void => {
-    setPanelState(PANEL_PROGRESS[panelState])
-  }
-
-  let removePanelButton
-
-  if (onRemove) {
-    removePanelButton = (
-      <SquareButton icon={IconFont.Remove} onClick={onRemove} />
-    )
-  }
+  const [className, showChildren, toggle] = usePanelState()
 
   return (
-    <div className={panelClassName}>
+    <div className={className}>
       <div className="notebook-panel--header">
         <FlexBox
           className="notebook-panel--header-left"
@@ -67,9 +38,9 @@ const Panel: FC<Props> = ({
           margin={ComponentSize.Small}
           justifyContent={JustifyContent.FlexStart}
         >
-          <div className="notebook-panel--toggle" onClick={handleToggle} />
+          <div className="notebook-panel--toggle" onClick={toggle} />
           <div className="notebook-panel--title">{title}</div>
-          {childrenShouldBeVisible && controlsLeft}
+          {showChildren && controlsLeft}
         </FlexBox>
         <FlexBox
           className="notebook-panel--header-right"
@@ -77,13 +48,11 @@ const Panel: FC<Props> = ({
           margin={ComponentSize.Small}
           justifyContent={JustifyContent.FlexEnd}
         >
-          {childrenShouldBeVisible && controlsRight}
-          {removePanelButton}
+          {showChildren && controlsRight}
+          <RemoveButton onRemove={onRemove} />
         </FlexBox>
       </div>
-      <div className="notebook-panel--body">
-        {childrenShouldBeVisible && children}
-      </div>
+      <div className="notebook-panel--body">{showChildren && children}</div>
     </div>
   )
 }

--- a/ui/src/notebooks/components/Panel.tsx
+++ b/ui/src/notebooks/components/Panel.tsx
@@ -1,0 +1,93 @@
+// Libraries
+import React, {FC, ReactChildren, useState} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {
+  FlexBox,
+  ComponentSize,
+  AlignItems,
+  JustifyContent,
+  SquareButton,
+  IconFont,
+} from '@influxdata/clockface'
+
+interface Props {
+  children: ReactChildren | JSX.Element | JSX.Element[]
+  title: string
+  controlsLeft?: JSX.Element | JSX.Element[]
+  controlsRight?: JSX.Element | JSX.Element[]
+  onRemove?: () => void
+}
+
+type PanelState = 'hidden' | 'small' | 'large'
+interface ProgressMap {
+  [key: PanelState]: PanelState
+}
+
+const PANEL_PROGRESS: ProgressMap = {
+  hidden: 'small',
+  small: 'large',
+  large: 'hidden',
+}
+
+const Panel: FC<Props> = ({
+  children,
+  title,
+  controlsLeft,
+  controlsRight,
+  onRemove,
+}) => {
+  const [panelState, setPanelState] = useState<PanelState>('small')
+
+  const panelClassName = classnames('notebook-panel', {
+    [`notebook-panel__${panelState}`]: panelState,
+  })
+  const childrenShouldBeVisible =
+    panelState === 'small' || panelState === 'large'
+
+  const handleToggle = (): void => {
+    setPanelState(PANEL_PROGRESS[panelState])
+  }
+
+  let removePanelButton
+
+  if (onRemove) {
+    removePanelButton = (
+      <SquareButton icon={IconFont.Remove} onClick={onRemove} />
+    )
+  }
+
+  return (
+    <div className={panelClassName}>
+      <div className="notebook-panel--header">
+        <FlexBox
+          className="notebook-panel--header-left"
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Small}
+          justifyContent={JustifyContent.FlexStart}
+        >
+          <div className="notebook-panel--toggle" onClick={handleToggle} />
+          <div className="notebook-panel--title">{title}</div>
+          {childrenShouldBeVisible && controlsLeft}
+        </FlexBox>
+        <FlexBox
+          className="notebook-panel--header-right"
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Small}
+          justifyContent={JustifyContent.FlexEnd}
+        >
+          {childrenShouldBeVisible && controlsRight}
+          {removePanelButton}
+        </FlexBox>
+      </div>
+      <div className="notebook-panel--body">
+        {childrenShouldBeVisible && children}
+      </div>
+    </div>
+  )
+}
+
+export {Panel}
+
+export default Panel

--- a/ui/src/notebooks/components/Pipe.tsx
+++ b/ui/src/notebooks/components/Pipe.tsx
@@ -1,0 +1,21 @@
+import React, {FC, createElement, useContext} from 'react'
+import {NotebookContext} from 'src/notebooks/context/notebook'
+
+import {PIPE_DEFINITIONS} from 'src/notebooks'
+
+interface PipeProps {
+  idx: number
+}
+
+const Pipe: FC<PipeProps> = ({idx}) => {
+  const {pipes} = useContext(NotebookContext)
+
+  if (!PIPE_DEFINITIONS.hasOwnProperty(pipes[idx].type)) {
+    throw new Error(`Pipe type [${type}] not registered`)
+    return null
+  }
+
+  return createElement(PIPE_DEFINITIONS[pipes[idx].type].component, {idx})
+}
+
+export default Pipe

--- a/ui/src/notebooks/components/Pipe.tsx
+++ b/ui/src/notebooks/components/Pipe.tsx
@@ -3,15 +3,15 @@ import {NotebookContext} from 'src/notebooks/context/notebook'
 
 import {PIPE_DEFINITIONS, PipeProp} from 'src/notebooks'
 
-const Pipe: FC<PipeProp> = ({idx}) => {
+const Pipe: FC<PipeProp> = ({index}) => {
   const {pipes} = useContext(NotebookContext)
 
-  if (!PIPE_DEFINITIONS.hasOwnProperty(pipes[idx].type)) {
-    throw new Error(`Pipe type [${pipes[idx].type}] not registered`)
+  if (!PIPE_DEFINITIONS.hasOwnProperty(pipes[index].type)) {
+    throw new Error(`Pipe type [${pipes[index].type}] not registered`)
     return null
   }
 
-  return createElement(PIPE_DEFINITIONS[pipes[idx].type].component, {idx})
+  return createElement(PIPE_DEFINITIONS[pipes[index].type].component, {index})
 }
 
 export default Pipe

--- a/ui/src/notebooks/components/Pipe.tsx
+++ b/ui/src/notebooks/components/Pipe.tsx
@@ -1,17 +1,13 @@
-import React, {FC, createElement, useContext} from 'react'
+import {FC, createElement, useContext} from 'react'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 
-import {PIPE_DEFINITIONS} from 'src/notebooks'
+import {PIPE_DEFINITIONS, PipeProp} from 'src/notebooks'
 
-interface PipeProps {
-  idx: number
-}
-
-const Pipe: FC<PipeProps> = ({idx}) => {
+const Pipe: FC<PipeProp> = ({idx}) => {
   const {pipes} = useContext(NotebookContext)
 
   if (!PIPE_DEFINITIONS.hasOwnProperty(pipes[idx].type)) {
-    throw new Error(`Pipe type [${type}] not registered`)
+    throw new Error(`Pipe type [${pipes[idx].type}] not registered`)
     return null
   }
 

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -1,0 +1,14 @@
+import React, {FC, useContext} from 'react'
+import Pipe from 'src/notebooks/components/Pipe'
+import {NotebookContext} from 'src/notebooks/context/notebook'
+
+const PipeList: FC = () => {
+  const {id, pipes} = useContext(NotebookContext)
+  const _pipes = pipes.map((_, idx) => (
+    <Pipe idx={idx} key={`pipe-${id}-${idx}`} />
+  ))
+
+  return <>{_pipes}</>
+}
+
+export default PipeList

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -4,8 +4,8 @@ import {NotebookContext} from 'src/notebooks/context/notebook'
 
 const PipeList: FC = () => {
   const {id, pipes} = useContext(NotebookContext)
-  const _pipes = pipes.map((_, idx) => (
-    <Pipe idx={idx} key={`pipe-${id}-${idx}`} />
+  const _pipes = pipes.map((_, index) => (
+    <Pipe index={index} key={`pipe-${id}-${index}`} />
   ))
 
   return <>{_pipes}</>

--- a/ui/src/notebooks/components/RemoveButton.tsx
+++ b/ui/src/notebooks/components/RemoveButton.tsx
@@ -1,0 +1,19 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {SquareButton, IconFont} from '@influxdata/clockface'
+
+interface Props {
+  onRemove?: () => void
+}
+
+const RemoveButton: FC<Props> = ({onRemove}) => {
+  if (!onRemove) {
+    return null
+  }
+
+  return <SquareButton icon={IconFont.Remove} onClick={onRemove} />
+}
+
+export default RemoveButton

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -12,7 +12,7 @@ export interface NotebookContextType {
   removePipe: (idx: number) => void
 }
 
-export const DEFAULT_CONTEXT = {
+export const DEFAULT_CONTEXT: NotebookContextType = {
   id: 'new',
   pipes: [],
   addPipe: () => {},

--- a/ui/src/notebooks/hooks/usePanelState.tsx
+++ b/ui/src/notebooks/hooks/usePanelState.tsx
@@ -1,0 +1,31 @@
+import {useState} from 'react'
+import classnames from 'classnames'
+
+type PanelState = 'hidden' | 'small' | 'large'
+interface ProgressMap {
+  [key: PanelState]: PanelState
+}
+
+const PANEL_PROGRESS: ProgressMap = {
+  hidden: 'small',
+  small: 'large',
+  large: 'hidden',
+}
+
+function usePanelState() {
+  const [panelState, setPanelState] = useState<PanelState>('small')
+
+  const className = classnames('notebook-panel', {
+    [`notebook-panel__${panelState}`]: panelState,
+  })
+
+  const showChildren = panelState === 'small' || panelState === 'large'
+
+  const toggle = (): void => {
+    setPanelState(PANEL_PROGRESS[panelState])
+  }
+
+  return [className, showChildren, toggle]
+}
+
+export default usePanelState

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,7 +1,7 @@
 import {FunctionComponent, ComponentClass} from 'react'
 
 export interface PipeProp {
-  idx: number
+  index: number
 }
 
 // NOTE: keep this interface as small as possible and

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,0 +1,35 @@
+// NOTE: keep this interface as small as possible and
+// don't take extending it lightly. this should only
+// define what ALL pipe types require to be included
+// on the page.
+export interface TypeRegistration {
+  type: string // a unique string that identifies a pipe
+  component: JSX.Element // the view component for rendering the interface
+  button: string // a human readable string for appending the type
+  empty: any // the default state for an add
+}
+
+export interface TypeLookup {
+  [key: string]: TypeRegistration
+}
+
+export const PIPE_DEFINITIONS: TypeLookup = {}
+
+export function register(definition: TypeRegistration) {
+  if (PIPE_DEFINITIONS.hasOwnProperty(definition.type)) {
+    throw new Exception(
+      `Pipe of type [${definition.type}] has already been registered`
+    )
+  }
+
+  PIPE_DEFINITIONS[definition.type] = {
+    ...definition,
+  }
+}
+
+// NOTE: this loads in all the modules under the current directory
+// to make it easier to add new types
+const context = require.context('./pipes', true, /index\.(ts|tsx)$/)
+context.keys().forEach(key => {
+  context(key)
+})

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,10 +1,16 @@
+import {FunctionComponent, ComponentClass} from 'react'
+
+export interface PipeProp {
+  idx: number
+}
+
 // NOTE: keep this interface as small as possible and
 // don't take extending it lightly. this should only
 // define what ALL pipe types require to be included
 // on the page.
 export interface TypeRegistration {
   type: string // a unique string that identifies a pipe
-  component: JSX.Element // the view component for rendering the interface
+  component: FunctionComponent<PipeProp> | ComponentClass<PipeProp> // the view component for rendering the interface
   button: string // a human readable string for appending the type
   empty: any // the default state for an add
 }
@@ -17,7 +23,7 @@ export const PIPE_DEFINITIONS: TypeLookup = {}
 
 export function register(definition: TypeRegistration) {
   if (PIPE_DEFINITIONS.hasOwnProperty(definition.type)) {
-    throw new Exception(
+    throw new Error(
       `Pipe of type [${definition.type}] has already been registered`
     )
   }

--- a/ui/src/notebooks/pipes/Example/index.ts
+++ b/ui/src/notebooks/pipes/Example/index.ts
@@ -1,0 +1,12 @@
+import {register} from 'src/notebooks'
+import ExampleView from './view'
+import './style.scss'
+
+register({
+  type: 'example',
+  component: ExampleView,
+  button: 'Example Adding',
+  empty: {
+    text: 'Example Text',
+  },
+})

--- a/ui/src/notebooks/pipes/Example/style.scss
+++ b/ui/src/notebooks/pipes/Example/style.scss
@@ -1,0 +1,5 @@
+.notebook-example {
+    h1 {
+        color: #f00;
+    }
+}

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -1,21 +1,18 @@
 import React, {FC, useContext} from 'react'
+import {PipeProp} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 
 import Panel from 'src/notebooks/components/Panel'
 
-interface PipeProps {
-  idx: number
-}
-
 const TITLE = 'Example Pipe'
 
-const ExampleView: FC<PipeProps> = ({idx}) => {
+const ExampleView: FC<PipeProp> = ({index}) => {
   const {pipes, removePipe} = useContext(NotebookContext)
-  const pipe = pipes[idx]
+  const pipe = pipes[index]
 
-  if (idx) {
+  if (index) {
     return (
-      <Panel onRemove={() => removePipe(idx)} title={TITLE}>
+      <Panel onRemove={() => removePipe(index)} title={TITLE}>
         <h1>{pipe.text}</h1>
       </Panel>
     )

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -1,0 +1,22 @@
+import React, {FC, createElement, useContext} from 'react'
+import {NotebookContext} from 'src/notebooks/context/notebook'
+
+import Panel from 'src/notebooks/components/Panel'
+
+interface PipeProps {
+  idx: number
+}
+
+const ExampleView: FC<PipeProps> = ({idx}) => {
+  const {pipes, removePipe} = useContext(NotebookContext)
+  const pipe = pipes[idx]
+  const remove = idx ? () => removePipe(idx) : false
+
+  return (
+    <Panel onRemove={remove} title="Example Pipe">
+      <h1>{pipe.text}</h1>
+    </Panel>
+  )
+}
+
+export default ExampleView

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -1,4 +1,4 @@
-import React, {FC, createElement, useContext} from 'react'
+import React, {FC, useContext} from 'react'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 
 import Panel from 'src/notebooks/components/Panel'
@@ -7,13 +7,22 @@ interface PipeProps {
   idx: number
 }
 
+const TITLE = 'Example Pipe'
+
 const ExampleView: FC<PipeProps> = ({idx}) => {
   const {pipes, removePipe} = useContext(NotebookContext)
   const pipe = pipes[idx]
-  const remove = idx ? () => removePipe(idx) : false
+
+  if (idx) {
+    return (
+      <Panel onRemove={() => removePipe(idx)} title={TITLE}>
+        <h1>{pipe.text}</h1>
+      </Panel>
+    )
+  }
 
   return (
-    <Panel onRemove={remove} title="Example Pipe">
+    <Panel title={TITLE}>
       <h1>{pipe.text}</h1>
     </Panel>
   )

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -1,0 +1,149 @@
+@import "@influxdata/clockface/dist/variables.scss";
+
+$notebook-header-height: 46px;
+$notebook-size-toggle: 16px;
+
+.notebook-panel {
+  background-color: $g2-kevlar;
+  border-radius: $cf-radius;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin-bottom: $cf-marg-b;
+  transition: height 0.25s ease;
+}
+
+.notebook-panel--header {
+  background-color: $g3-castle;
+  border-radius: $cf-radius;
+  padding: 0 $cf-marg-b;
+  height: $notebook-header-height;
+  flex: 0 0 $notebook-header-height;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.notebook-panel--header-left,
+.notebook-panel--header-right {
+  flex: 1 0 $notebook-header-height;
+}
+
+.notebook-panel--title {
+  user-select: none;
+  font-size: 14px;
+  font-weight: $cf-font-weight--medium;
+  margin-left: $cf-marg-b;
+  margin-right: $cf-marg-c !important;
+}
+
+.notebook-panel--toggle {
+  width: $cf-form-sm-height;
+  height: $cf-form-sm-height;
+  position: relative;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: $notebook-size-toggle;
+    transition: height 0.25s cubic-bezier(0.25, 1, 0.5, 1), border-color 0.25s ease;
+    border: $cf-border solid $g8-storm;
+    border-radius: $cf-radius / 2;
+  }
+
+  &:hover {
+    cursor: pointer;
+    &:after {
+      border-color: $g13-mist;
+    }
+  }
+}
+
+.notebook-panel--body {
+  padding: $cf-marg-b;
+  flex: 1 0 0;
+  position: relative;
+}
+
+// Special styling for query builder inside notebook panel
+.notebook-panel--body .query-builder {
+  top: $cf-marg-b;
+  right: $cf-marg-b;
+  bottom: $cf-marg-b;
+  left: $cf-marg-b;
+  padding-top: 0;
+}
+
+/*
+  Notebook Panel Modes
+  ------------------------------------------------------------------------------
+*/
+
+.notebook-panel__hidden {
+  height: $notebook-header-height;
+
+  .notebook-panel--body {
+    display: none;
+  }
+
+  .notebook-panel--toggle:after {
+    height: $cf-border;
+  }
+}
+
+.notebook-panel__small {
+  height: 320px;
+
+  .notebook-panel--toggle:after {
+    height: $notebook-size-toggle / 2;
+  }
+}
+
+.notebook-panel__large {
+  height: 60vh;
+  min-height: 640px;
+
+  .notebook-panel--toggle:after {
+    height: $notebook-size-toggle;
+  }
+}
+
+
+.notebook-panel--visualization {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+  flex-direction: row;
+}
+
+.notebook-panel--view {
+  flex: 1 0 0;
+  position: relative;
+}
+
+.notebook-header--buttons {
+    display: inline-flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+
+    > * {
+        margin-left: 4px;
+    }
+}
+.notebook--actions {
+    margin-top: $cf-marg-c;
+    display: inline-flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+
+    > * {
+        margin-left: 4px;
+    }
+}
+


### PR DESCRIPTION
This installment adds the structure around notebooks to contain the individual interaction pieces. An example pipe is given to illustrate how a pipe registers into the system and how it connects to the structure. A point of contention currently is if the panel ownership exists on the Pipe component, or on the Pipe's component (_really_ need some more names in this thing). This PR illustrates the latter as it keeps the structure of TypeRegistration smaller and disconnected from the view logic (if it should allow for the first row to be deleted, dynamic titles, etc). From here the PRs should start to diverge between adding individual display types and iterating on the structural components.

part of the initiative to spin #17966 out into real changes

![Kapture 2020-05-14 at 16 16 36](https://user-images.githubusercontent.com/1434802/81995153-6069ce00-95fe-11ea-93f0-0eb1e77c51cd.gif)
