### PR TITLE
fix(ui): wait for org to be available then fetch org settings just once

### DIFF
--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -1,34 +1,56 @@
 // Libraries
-import {PureComponent} from 'react'
+import {FunctionComponent, useEffect, useState} from 'react'
 import {connect} from 'react-redux'
+import {get} from 'lodash'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
+// Types
+import {AppState, Organization} from 'src/types'
+
 // Actions
 import {getOrgSettings as getOrgSettingsAction} from 'src/cloud/actions/orgsettings'
 
+interface PassedInProps {
+  children: React.ReactElement<any>
+}
+interface StateProps {
+  org: Organization
+}
 interface DispatchProps {
   getOrgSettings: typeof getOrgSettingsAction
 }
 
-class OrgSettings extends PureComponent<DispatchProps> {
-  public componentDidMount() {
-    if (CLOUD) {
-      this.props.getOrgSettings()
-    }
-  }
+type Props = StateProps & DispatchProps & PassedInProps
 
-  public render() {
-    return this.props.children
-  }
+const OrgSettings: FunctionComponent<Props> = ({
+  org,
+  getOrgSettings,
+  children,
+}) => {
+  const [hasFetchedOrgSettings, setHasFetchedOrgSettings] = useState<boolean>(
+    false
+  )
+  useEffect(() => {
+    if (CLOUD && org && !hasFetchedOrgSettings) {
+      setHasFetchedOrgSettings(true)
+      getOrgSettings()
+    }
+  }, [org])
+
+  return children
 }
+
+const mstp = (state: AppState): StateProps => ({
+  org: get(state, 'resources.orgs.org', null),
+})
 
 const mdtp: DispatchProps = {
   getOrgSettings: getOrgSettingsAction,
 }
 
-export default connect<{}, DispatchProps, {}>(
-  null,
+export default connect<StateProps, DispatchProps, PassedInProps>(
+  mstp,
   mdtp
 )(OrgSettings)


### PR DESCRIPTION
Closes #18102 

For Cloud only.

Wait for an org to be loaded before attempting to fetch org settings.
