### PR TITLE
refactor(ui): use find util rather than rely on having an array

### DIFF
--- a/ui/src/shared/components/CloudUpgradeButton.tsx
+++ b/ui/src/shared/components/CloudUpgradeButton.tsx
@@ -2,7 +2,7 @@
 import React, {FC} from 'react'
 import {Link} from 'react-router'
 import {connect} from 'react-redux'
-import {get, defaultTo} from 'lodash'
+import {get, find} from 'lodash'
 
 // Components
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
@@ -38,8 +38,9 @@ const CloudUpgradeButton: FC<StateProps> = ({inView}) => {
 }
 
 const mstp = (state: AppState) => {
-  const settings = defaultTo(get(state, 'cloud.orgSettings.settings', []), [])
-  const hideUpgradeButtonSetting = settings.find(
+  const settings = get(state, 'cloud.orgSettings.settings', [])
+  const hideUpgradeButtonSetting = find(
+    settings,
     (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
   )
   if (

--- a/ui/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/ui/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -2,7 +2,7 @@
 import React, {FC} from 'react'
 import {Link} from 'react-router'
 import {connect} from 'react-redux'
-import {get, defaultTo} from 'lodash'
+import {get, find} from 'lodash'
 
 // Components
 import {
@@ -73,8 +73,9 @@ const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
 }
 
 const mstp = (state: AppState) => {
-  const settings = defaultTo(get(state, 'cloud.orgSettings.settings', []), [])
-  const hideUpgradeButtonSetting = settings.find(
+  const settings = get(state, 'cloud.orgSettings.settings', [])
+  const hideUpgradeButtonSetting = find(
+    settings,
     (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
   )
   if (


### PR DESCRIPTION
As a followup to https://github.com/influxdata/influxdb/pull/18062 and https://github.com/influxdata/influxdb/pull/18065

A better way to do this is to use an external function for `find` that guarantees a return value rather than throwing an error.

Using the `Array.prototype.find` is hazardous because when `settings` is not falsy, it might not necessarily be an array. We _assume_ the api will give back an array and try to call a built-in function based on that assumption. Very bad. TypeScript can't help us here either.

The best way is to guarantee an error won't be thrown, and a `find` utility function does that.
