### PR TITLE
fix: need to rebuild the query request before the second e2e test run

### DIFF
--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -190,6 +190,16 @@ func testFlux(t testing.TB, l *launcher.TestLauncher, file *ast.File) {
 	// this time we use a call to `run` so that the assertion error is triggered
 	runCalls := stdlib.TestingRunCalls(pkg)
 	pkg.Files[len(pkg.Files)-1] = runCalls
+
+	bs, err = json.Marshal(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = &query.Request{
+		OrganizationID: l.Org.ID,
+		Compiler:       lang.ASTCompiler{AST: bs},
+	}
 	r, err := l.FluxQueryService().Query(ctx, req)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The e2e test driver in influxdb run the tests twice to get past the fact that there
is no way to force order between the write to storage and the read back. When
the json.Marshal call became mandatory it was added to the first run, but not
the second.