### PR TITLE
fix(query): do not free the column reader in the no content encoders

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -55,7 +55,6 @@ func (e *NoContentEncoder) Encode(w io.Writer, results flux.ResultIterator) (int
 	for results.More() {
 		if err := results.Next().Tables().Do(func(tbl flux.Table) error {
 			return tbl.Do(func(cr flux.ColReader) error {
-				cr.Release()
 				return nil
 			})
 		}); err != nil {
@@ -114,7 +113,6 @@ func (e *NoContentWithErrorEncoder) Encode(w io.Writer, results flux.ResultItera
 	for results.More() {
 		if err := results.Next().Tables().Do(func(tbl flux.Table) error {
 			return tbl.Do(func(cr flux.ColReader) error {
-				cr.Release()
 				return nil
 			})
 		}); err != nil {


### PR DESCRIPTION
The column reader passed to `flux.Table.Do` is automatically released.
The function passed to the column reader should never release it
manually. This causes a double release which causes the table to be
erroneously freed when it might be referenced by another transformation.

In particular, this affected the following:

    tables
    |> yield()
    |> to()

This is because this would produce a buffered table with two references
and pass it to both `yield()` and `to()` because `yield()` is a
pseudo-node that doesn't really exist. The real graph looks more like:

    tables |> yield()
    tables |> to()

The `yield()` would double release which would release the `to()`
transformation's copy of the column readers. The `to()` method would
then be invoked with an invalid column reader.