### PR TITLE
fix(kit/feature): Ensure host is overridden as a workaround for stdlib bug.

### DIFF
--- a/kit/feature/http_proxy_test.go
+++ b/kit/feature/http_proxy_test.go
@@ -88,7 +88,7 @@ func TestHTTPProxy_RequestHeader(t *testing.T) {
 	proxy := NewHTTPProxy(sURL, logger, en)
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
 	srcHandler(proxy)(w, r)
 }
 
@@ -104,7 +104,7 @@ func testHTTPProxy(logger *zap.Logger, enabler ProxyEnabler) (*http.Response, er
 	proxy := NewHTTPProxy(sURL, logger, enabler)
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
 	srcHandler(proxy)(w, r)
 
 	return w.Result(), nil


### PR DESCRIPTION
This overrides the `net/http.Request.Host` field in the `net/http/httputil.ReverseProxy.Director` function to work around a known bug in the stdlib.

Prohibits an infinite loop in our proxying.

📎 https://github.com/golang/go/issues/28168