### PR TITLE
fix(tsdb): address staticcheck warning st1006

### DIFF
--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -169,12 +169,12 @@ func (e EmptyValue) Size() int { return 0 }
 // String returns the empty string.
 func (e EmptyValue) String() string { return "" }
 
-func (_ EmptyValue) internalOnly()    {}
-func (_ StringValue) internalOnly()   {}
-func (_ IntegerValue) internalOnly()  {}
-func (_ UnsignedValue) internalOnly() {}
-func (_ BooleanValue) internalOnly()  {}
-func (_ FloatValue) internalOnly()    {}
+func (EmptyValue) internalOnly()    {}
+func (StringValue) internalOnly()   {}
+func (IntegerValue) internalOnly()  {}
+func (UnsignedValue) internalOnly() {}
+func (BooleanValue) internalOnly()  {}
+func (FloatValue) internalOnly()    {}
 
 // Encode converts the values to a byte slice.  If there are no values,
 // this function panics.


### PR DESCRIPTION
This change removes an unnesessary underscore from method declarations that don't accept a receiver value.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
