### PR TITLE
fix(tsdb): Address staticcheck warning sa4006

### DIFF
--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -296,9 +296,7 @@ func TestCompactor_DecodeError(t *testing.T) {
 
 	compactor.Open()
 
-	files, err = compactor.CompactFull([]string{f1, f2, f3})
-	if err == nil ||
-		!strings.Contains(err.Error(), "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp") {
+	if _, err = compactor.CompactFull([]string{f1, f2, f3}); err == nil || !strings.Contains(err.Error(), "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp") {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
 }

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -685,7 +685,7 @@ func (c *SeriesPartitionCompactor) insertKeyIDMap(dst []byte, capacity int64, se
 			binary.BigEndian.PutUint64(elem[8:], id)
 
 			// Swap with values in that position.
-			hash, key, offset, id = elemHash, elemKey, elemOffset, elemID
+			offset, id = elemOffset, elemID
 
 			// Update current distance.
 			dist = d
@@ -722,7 +722,7 @@ func (c *SeriesPartitionCompactor) insertIDOffsetMap(dst []byte, capacity int64,
 			binary.BigEndian.PutUint64(elem[8:], uint64(offset))
 
 			// Swap with values in that position.
-			hash, id, offset = elemHash, elemID, elemOffset
+			id, offset = elemID, elemOffset
 
 			// Update current distance.
 			dist = d


### PR DESCRIPTION
This commit addresses staticcheck warning SA4006 "this value of VAR is never used" by removing unused variables.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
