### PR TITLE
fix(tsdb): Fix variables masked by a declaration in test

### DIFF
--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1054,7 +1054,7 @@ func testStoreCardinalityDuplicates(t *testing.T, store *Store) {
 			// For other shards we write a random sub-section of all the points.
 			// which will duplicate the series and shouldn't increase the
 			// cardinality.
-			from, to := rand.Intn(len(points)), rand.Intn(len(points))
+			from, to = rand.Intn(len(points)), rand.Intn(len(points))
 			if from > to {
 				from, to = to, from
 			}


### PR DESCRIPTION
Before this commit, the to and from variables were being re-declared in a block in such a way that the values were not being used.

This patch uses regular assignment so that the values are visable outside of the block where they're set.

Closes #18128

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
