### PR TITLE
chore: restore flux version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -131,7 +131,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "2.2.0",
-    "@influxdata/flux": "^0.4.0",
+    "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.6",
     "@influxdata/giraffe": "0.18.0",
     "@influxdata/influx": "0.5.5",


### PR DESCRIPTION
Keep the version of flux in package.json in sync with yarn.lock

Resolves the conflicts for  
https://github.com/influxdata/influxdb/pull/18046/files  
https://github.com/influxdata/influxdb/pull/18092/files  