### PR TITLE
refactor!(notifications): drop URM and Org services from NotificationRuleService

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -35,12 +35,6 @@ type NotificationRule interface {
 
 // NotificationRuleStore represents a service for managing notification rule.
 type NotificationRuleStore interface {
-	// UserResourceMappingService must be part of all NotificationRuleStore service,
-	// for create, search, delete.
-	UserResourceMappingService
-	// OrganizationService is needed for search filter
-	OrganizationService
-
 	// FindNotificationRuleByID returns a single notification rule by ID.
 	FindNotificationRuleByID(ctx context.Context, id ID) (NotificationRule, error)
 

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -346,14 +346,6 @@ func CreateNotificationRule(
 			if diff := cmp.Diff(nrs, tt.wants.notificationRules, notificationRuleCmpOptions...); diff != "" {
 				t.Errorf("notificationRules are different -got/+want\ndiff %s", diff)
 			}
-
-			urms, _, err := s.FindUserResourceMappings(ctx, urmFilter)
-			if err != nil {
-				t.Fatalf("failed to retrieve user resource mappings: %v", err)
-			}
-			if diff := cmp.Diff(urms, tt.wants.userResourceMapping, userResourceMappingCmpOptions...); diff != "" {
-				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
-			}
 		})
 	}
 }
@@ -2709,17 +2701,6 @@ func DeleteNotificationRule(
 			}
 			if diff := cmp.Diff(nrs, tt.wants.notificationRules, notificationRuleCmpOptions...); diff != "" {
 				t.Errorf("notification rules are different -got/+want\ndiff %s", diff)
-			}
-
-			urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
-				UserID:       tt.args.userID,
-				ResourceType: influxdb.NotificationRuleResourceType,
-			})
-			if err != nil {
-				t.Fatalf("failed to retrieve user resource mappings: %v", err)
-			}
-			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
-				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This a similar refactor to https://github.com/influxdata/influxdb/pull/17969

NotificationRuleService only has the URM and Organization service embedded to support tests. This is just interface misuse.

This PR stops asserting that URMs are created by the notification rule service as I am undertaking work to remove all references for URMs from this service. In the near future this service (along with most other services) won't know that URMs exist. They will not need them to behave properly.

Also, this test should never have asserted that this happened in the first place. All it needs to do is ensure that it can list notification rules created by the owner or anyone within the org. The presence of the URM is an implementation detail.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
