### PR TITLE
fix: address static check warning s1039

### DIFF
--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -59,7 +59,7 @@ func (r *Registry) MustRegisterGroup(name string) GID {
 
 func (r *Registry) mustGetGroupRegistry(id GID) *groupRegistry {
 	if int(id) >= len(r.groups) {
-		panic(fmt.Sprintf("invalid group ID"))
+		panic(fmt.Sprintf("invalid group ID %v", id))
 	}
 	return &r.groups[id]
 }

--- a/query/executor.go
+++ b/query/executor.go
@@ -399,7 +399,7 @@ func (e *Executor) recover(query *influxql.Query, results chan *Result) {
 		}
 
 		if willCrash {
-			e.Logger.Error(fmt.Sprintf("\n\n=====\nAll goroutines now follow:"))
+			e.Logger.Error("\n\n=====\nAll goroutines now follow:")
 			buf := debug.Stack()
 			e.Logger.Error(fmt.Sprintf("%s", buf))
 			os.Exit(1)

--- a/services/httpd/response_writer_test.go
+++ b/services/httpd/response_writer_test.go
@@ -230,7 +230,7 @@ func TestResponseWriter_MessagePack_Error(t *testing.T) {
 			if _, err := reader.WriteToJSON(&buf); err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
-			want := fmt.Sprintf(`{"error":"test error"}`)
+			want := `{"error":"test error"}`
 			if have := strings.TrimSpace(buf.String()); have != want {
 				t.Fatalf("unexpected output: %s != %s", have, want)
 			}

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -132,7 +132,7 @@ func (s *RemoteServer) DropDatabase(db string) error {
 
 // Reset attempts to remove all database state by dropping everything
 func (s *RemoteServer) Reset() error {
-	stmt := fmt.Sprintf("SHOW+DATABASES")
+	stmt := "SHOW+DATABASES"
 	results, err := s.HTTPPost(s.URL()+"/query?q="+stmt, nil)
 	if err != nil {
 		return err

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -1081,7 +1081,7 @@ func TestServer_Query_Math(t *testing.T) {
 		&Query{
 			name:    "SELECT sum of aggregates",
 			command: `SELECT max(value) + min(value) from db.rp.integer`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","max_min"],"values":[["1970-01-01T00:00:00Z",84]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","max_min"],"values":[["1970-01-01T00:00:00Z",84]]}]}]}`,
 		},
 		&Query{
 			name:    "SELECT square of enclosed integer value",
@@ -1824,7 +1824,7 @@ func TestServer_Query_SelectRawDerivative(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf("cpu value=210 1278010021000000000\ncpu value=10 1278010022000000000")},
+		&Write{data: "cpu value=210 1278010021000000000\ncpu value=10 1278010022000000000"},
 	}
 
 	test.addQueries([]*Query{
@@ -1914,7 +1914,7 @@ func TestServer_Query_SelectGroupByTimeDerivative(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=15 1278010021000000000
 cpu value=20 1278010022000000000
 cpu value=25 1278010023000000000
@@ -1927,7 +1927,7 @@ cpu0,host=server02 ticks=40,total=100 1278010020000000000
 cpu0,host=server02 ticks=45,total=100 1278010021000000000
 cpu0,host=server02 ticks=84,total=100 1278010022000000000
 cpu0,host=server02 ticks=101,total=100 1278010023000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2066,9 +2066,9 @@ func TestServer_Query_SelectGroupByTimeDerivativeWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=20 1278010021000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2301,11 +2301,11 @@ func TestServer_Query_SelectGroupByTimeDifference(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=15 1278010021000000000
 cpu value=20 1278010022000000000
 cpu value=25 1278010023000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2388,9 +2388,9 @@ func TestServer_Query_SelectGroupByTimeDifferenceWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=20 1278010021000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2523,13 +2523,13 @@ func TestServer_Query_SelectGroupByTimeMovingAverage(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=15 1278010021000000000
 cpu value=20 1278010022000000000
 cpu value=25 1278010023000000000
 cpu value=30 1278010024000000000
 cpu value=35 1278010025000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2612,11 +2612,11 @@ func TestServer_Query_SelectGroupByTimeMovingAverageWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=15 1278010021000000000
 cpu value=30 1278010024000000000
 cpu value=35 1278010025000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2749,11 +2749,11 @@ func TestServer_Query_SelectGroupByTimeCumulativeSum(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=15 1278010021000000000
 cpu value=20 1278010022000000000
 cpu value=25 1278010023000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2836,9 +2836,9 @@ func TestServer_Query_SelectGroupByTimeCumulativeSumWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=10 1278010020000000000
+		&Write{data: `cpu value=10 1278010020000000000
 cpu value=20 1278010021000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -2970,13 +2970,13 @@ func TestServer_Query_CumulativeCount(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`events signup=t 1005832000
+		&Write{data: `events signup=t 1005832000
 events signup=t 1048283000
 events signup=t 1784832000
 events signup=t 2000000000
 events signup=t 3084890000
 events signup=t 3838400000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -3013,13 +3013,13 @@ func TestServer_Query_SelectGroupByTime_MultipleAggregates(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`test,t=a x=1i 1000000000
+		&Write{data: `test,t=a x=1i 1000000000
 test,t=b y=1i 1000000000
 test,t=a x=2i 2000000000
 test,t=b y=2i 2000000000
 test,t=a x=3i 3000000000
 test,t=b y=3i 3000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
@@ -3056,8 +3056,8 @@ func TestServer_Query_MathWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=15 1278010020000000000
-`)},
+		&Write{data: `cpu value=15 1278010020000000000
+`},
 	}
 
 	test.addQueries([]*Query{

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -260,7 +260,7 @@ func benchmarkTagSets(b *testing.B, n int, opt query.IteratorOptions) {
 
 	for i := 0; i < n; i++ {
 		tags := map[string]string{"tag1": "value1", "tag2": "value2"}
-		s := newSeries(uint64(i), m, fmt.Sprintf("m,tag1=value1,tag2=value2"), models.NewTags(tags))
+		s := newSeries(uint64(i), m, "m,tag1=value1,tag2=value2", models.NewTags(tags))
 		ss.Add(uint64(i))
 		m.AddSeries(s)
 	}

--- a/tsdb/series_set_test.go
+++ b/tsdb/series_set_test.go
@@ -212,7 +212,7 @@ func BenchmarkSeriesIDSet_Add(b *testing.B) {
 	lookup := uint64(300032)
 
 	// Add the same value over and over.
-	b.Run(fmt.Sprint("cardinality_1000000_add"), func(b *testing.B) {
+	b.Run("cardinality_1000000_add", func(b *testing.B) {
 		b.Run("same", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				set.Add(lookup)
@@ -245,7 +245,7 @@ func BenchmarkSeriesIDSet_Add(b *testing.B) {
 	})
 
 	// Add the same value over and over with no lock
-	b.Run(fmt.Sprint("cardinality_1000000_check_add"), func(b *testing.B) {
+	b.Run("cardinality_1000000_check_add", func(b *testing.B) {
 		b.Run("same no lock", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if !set.ContainsNoLock(lookup) {
@@ -533,7 +533,7 @@ func BenchmarkSeriesIDSet_Remove(b *testing.B) {
 	lookup := uint64(300032)
 
 	// Remove the same value over and over.
-	b.Run(fmt.Sprint("cardinality_1000000_remove_same"), func(b *testing.B) {
+	b.Run("cardinality_1000000_remove_same", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			set.Remove(lookup)
 		}
@@ -541,7 +541,7 @@ func BenchmarkSeriesIDSet_Remove(b *testing.B) {
 
 	// Check if the value exists before adding it. Subsequent repeats of the code
 	// will result in contains checks.
-	b.Run(fmt.Sprint("cardinality_1000000_check_remove_global_lock"), func(b *testing.B) {
+	b.Run("cardinality_1000000_check_remove_global_lock", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			set.Lock()
 			if set.ContainsNoLock(lookup) {
@@ -552,7 +552,7 @@ func BenchmarkSeriesIDSet_Remove(b *testing.B) {
 	})
 
 	// Check if the value exists before adding it under two locks.
-	b.Run(fmt.Sprint("cardinality_1000000_check_remove_multi_lock"), func(b *testing.B) {
+	b.Run("cardinality_1000000_check_remove_multi_lock", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			if set.Contains(lookup) {
 				set.Remove(lookup)


### PR DESCRIPTION
This commit quiets staticcheck's warnings about "unnecessary use of
fmt.Sprintf" and "unnecessary use of fmt.Sprint".

Prior to this commit we were wrapping simple constant strings without
any formatting verbs with fmt.Sprintf().

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
