### PR TITLE
fix(client/v2): use non-nil context.Context value

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -516,7 +516,7 @@ type Result struct {
 
 // Query sends a command to the server and returns the Response.
 func (c *client) Query(q Query) (*Response, error) {
-	return c.QueryCtx(nil, q)
+	return c.QueryCtx(context.Background(), q)
 }
 
 // QueryCtx sends a command to the server and returns the Response.
@@ -591,7 +591,7 @@ func (c *client) QueryCtx(ctx context.Context, q Query) (*Response, error) {
 
 // QueryAsChunk sends a command to the server and returns the Response.
 func (c *client) QueryAsChunk(q Query) (*ChunkedResponse, error) {
-	req, err := c.createDefaultRequest(nil, q)
+	req, err := c.createDefaultRequest(context.Background(), q)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prior to this commit, we passed a nil context to the .QueryCtx() and .createDefaultRequest() methods.

Using any of the context.Context method-set against a nil value will cause a panic.

This patch passes context.Background() instead of nil.

Closes #18137


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
