### PR TITLE
fix: faster dashboards

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -246,20 +246,25 @@ export const getDashboards = () => async (
         }
       })
       .forEach(entity => {
-        const viewsData = viewsFromCells(entity.cells, entity.id)
+        setImmediate(() => {
+          const viewsData = viewsFromCells(entity.cells, entity.id)
 
-        const normViews = normalize<View, ViewEntities, string[]>(
-          viewsData,
-          arrayOfViews
-        )
+          const normViews = normalize<View, ViewEntities, string[]>(
+            viewsData,
+            arrayOfViews
+          )
 
-        const normCells = normalize<Dashboard, DashboardEntities, string[]>(
-          entity.cells,
-          arrayOfCells
-        )
+          dispatch(setViews(RemoteDataState.Done, normViews))
+        })
 
-        dispatch(setViews(RemoteDataState.Done, normViews))
-        dispatch(setCells(entity.id, RemoteDataState.Done, normCells))
+        setImmediate(() => {
+          const normCells = normalize<Dashboard, DashboardEntities, string[]>(
+            entity.cells,
+            arrayOfCells
+          )
+
+          dispatch(setCells(entity.id, RemoteDataState.Done, normCells))
+        })
       })
   } catch (error) {
     dispatch(creators.setDashboards(RemoteDataState.Error))

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -246,7 +246,7 @@ export const getDashboards = () => async (
         }
       })
       .forEach(entity => {
-        setImmediate(() => {
+        setTimeout(() => {
           const viewsData = viewsFromCells(entity.cells, entity.id)
 
           const normViews = normalize<View, ViewEntities, string[]>(
@@ -255,16 +255,16 @@ export const getDashboards = () => async (
           )
 
           dispatch(setViews(RemoteDataState.Done, normViews))
-        })
+        }, 0)
 
-        setImmediate(() => {
+        setTimeout(() => {
           const normCells = normalize<Dashboard, DashboardEntities, string[]>(
             entity.cells,
             arrayOfCells
           )
 
           dispatch(setCells(entity.id, RemoteDataState.Done, normCells))
-        })
+        }, 0)
       })
   } catch (error) {
     dispatch(creators.setDashboards(RemoteDataState.Error))

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -64,31 +64,29 @@ class DashboardCard extends PureComponent<Props> {
         testID="dashboard-card"
         contextMenu={this.contextMenu}
       >
-          <div style={{position: 'relative', height: '100%'}}>
-          <ResourceCard.EditableName
-            onUpdate={this.handleUpdateDashboard}
-            onClick={this.handleClickDashboard}
-            name={name}
-            noNameString={DEFAULT_DASHBOARD_NAME}
-            testID="dashboard-card--name"
-            buttonTestID="dashboard-card--name-button"
-            inputTestID="dashboard-card--input"
-          />
-          <ResourceCard.EditableDescription
-            onUpdate={this.handleUpdateDescription}
-            description={description}
-            placeholder={`Describe ${name}`}
-          />
-          <ResourceCard.Meta>
-            {relativeTimestampFormatter(updatedAt, 'Last modified ')}
-          </ResourceCard.Meta>
-          <InlineLabels
-            selectedLabelIDs={labels}
-            onFilterChange={onFilterChange}
-            onAddLabel={this.handleAddLabel}
-            onRemoveLabel={this.handleRemoveLabel}
-          />
-        </div>
+        <ResourceCard.EditableName
+          onUpdate={this.handleUpdateDashboard}
+          onClick={this.handleClickDashboard}
+          name={name}
+          noNameString={DEFAULT_DASHBOARD_NAME}
+          testID="dashboard-card--name"
+          buttonTestID="dashboard-card--name-button"
+          inputTestID="dashboard-card--input"
+        />
+        <ResourceCard.EditableDescription
+          onUpdate={this.handleUpdateDescription}
+          description={description}
+          placeholder={`Describe ${name}`}
+        />
+        <ResourceCard.Meta>
+          {relativeTimestampFormatter(updatedAt, 'Last modified ')}
+        </ResourceCard.Meta>
+        <InlineLabels
+          selectedLabelIDs={labels}
+          onFilterChange={onFilterChange}
+          onAddLabel={this.handleAddLabel}
+          onRemoveLabel={this.handleRemoveLabel}
+        />
       </ResourceCard>
     )
   }

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -64,29 +64,31 @@ class DashboardCard extends PureComponent<Props> {
         testID="dashboard-card"
         contextMenu={this.contextMenu}
       >
-        <ResourceCard.EditableName
-          onUpdate={this.handleUpdateDashboard}
-          onClick={this.handleClickDashboard}
-          name={name}
-          noNameString={DEFAULT_DASHBOARD_NAME}
-          testID="dashboard-card--name"
-          buttonTestID="dashboard-card--name-button"
-          inputTestID="dashboard-card--input"
-        />
-        <ResourceCard.EditableDescription
-          onUpdate={this.handleUpdateDescription}
-          description={description}
-          placeholder={`Describe ${name}`}
-        />
-        <ResourceCard.Meta>
-          {relativeTimestampFormatter(updatedAt, 'Last modified ')}
-        </ResourceCard.Meta>
-        <InlineLabels
-          selectedLabelIDs={labels}
-          onFilterChange={onFilterChange}
-          onAddLabel={this.handleAddLabel}
-          onRemoveLabel={this.handleRemoveLabel}
-        />
+          <div style={{position: 'relative', height: '100%'}}>
+          <ResourceCard.EditableName
+            onUpdate={this.handleUpdateDashboard}
+            onClick={this.handleClickDashboard}
+            name={name}
+            noNameString={DEFAULT_DASHBOARD_NAME}
+            testID="dashboard-card--name"
+            buttonTestID="dashboard-card--name-button"
+            inputTestID="dashboard-card--input"
+          />
+          <ResourceCard.EditableDescription
+            onUpdate={this.handleUpdateDescription}
+            description={description}
+            placeholder={`Describe ${name}`}
+          />
+          <ResourceCard.Meta>
+            {relativeTimestampFormatter(updatedAt, 'Last modified ')}
+          </ResourceCard.Meta>
+          <InlineLabels
+            selectedLabelIDs={labels}
+            onFilterChange={onFilterChange}
+            onAddLabel={this.handleAddLabel}
+            onRemoveLabel={this.handleRemoveLabel}
+          />
+        </div>
       </ResourceCard>
     )
   }

--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -32,29 +32,15 @@ export default class DashboardCards extends PureComponent<Props> {
   )
 
   state = {
-    hasMeasured: false,
     pages: 1,
     windowSize: 0,
   }
 
   public componentDidMount() {
     this.setState({
-      hasMeasured: false,
       page: 1,
-      windowSize: 0,
+      windowSize: 15,
     })
-  }
-
-  public componentDidUpdate() {
-    this.addMore()
-  }
-
-  private registerFrame = elem => {
-    this._frame = elem
-  }
-
-  private registerWindow = elem => {
-    this._window = elem
   }
 
   private registerSpinner = elem => {
@@ -87,44 +73,7 @@ export default class DashboardCards extends PureComponent<Props> {
         .reduce((prev, curr) => prev || curr, false)
     ) {
       this.setState({
-        pages: this.state.pages + 2,
-      })
-    }
-  }
-
-  private addMore = () => {
-    if (this.state.hasMeasured) {
-      return
-    }
-
-    if (
-      this.state.windowSize * this.state.pages >=
-      this.props.dashboards.length
-    ) {
-      return
-    }
-
-    if (!this._frame) {
-      return
-    }
-
-    const frame = this._frame.getBoundingClientRect()
-    const win = this._window.getBoundingClientRect()
-
-    if (frame.height <= win.height) {
-      this.setState(
-        {
-          windowSize: this.state.windowSize + 1,
-        },
-        () => {
-          this.addMore()
-        }
-      )
-    } else {
-      this.setState({
-        windowSize: this.state.windowSize,
-        pages: 3,
-        hasMeasured: true,
+        pages: this.state.pages + 1,
       })
     }
   }
@@ -144,7 +93,7 @@ export default class DashboardCards extends PureComponent<Props> {
       sortType
     )
 
-    const {windowSize, pages, hasMeasured} = this.state
+    const {windowSize, pages} = this.state
 
     return (
       <div style={{height: '100%', display: 'grid'}} ref={this.registerFrame}>
@@ -164,9 +113,9 @@ export default class DashboardCards extends PureComponent<Props> {
               />
             ))}
         </div>
-        {hasMeasured && windowSize * pages < dashboards.length && (
+        {windowSize * pages < dashboards.length && (
           <div
-            style={{height: '140px', margin: '24px auto'}}
+            style={{height: '140px', margin: '14px auto'}}
             ref={this.registerSpinner}
           >
             <TechnoSpinner />

--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -22,8 +22,6 @@ interface Props {
 }
 
 export default class DashboardCards extends PureComponent<Props> {
-  private _frame
-  private _window
   private _observer
   private _spinner
 
@@ -96,8 +94,8 @@ export default class DashboardCards extends PureComponent<Props> {
     const {windowSize, pages} = this.state
 
     return (
-      <div style={{height: '100%', display: 'grid'}} ref={this.registerFrame}>
-        <div className="dashboards-card-grid" ref={this.registerWindow}>
+      <div style={{height: '100%', display: 'grid'}}>
+        <div className="dashboards-card-grid">
           {sortedDashboards
             .filter(d => d.status === RemoteDataState.Done)
             .slice(0, pages * windowSize)


### PR DESCRIPTION
hopefully addresses #17931 and influxdata/idpe#7172

super hard to detangle, but it seems to have been a combination of rendering pagination being turned off for an EAR and a thunk blocking the ui thread when trying to hydrate extra data.

Moved the follow up thunk actions further down the event loop with `setImmediate` to unblock the ui thread, effectively delaying view / cell hydration until after the dashboard list is populated (should be ok as these aren't accessed until the dashboard is opened), as well as turned pagination back on to reduce rendering of nested resources, but this time with a fixed window size instead of using react to measure the number of dashboards that are visible on the page. The EAR was an issue with a small number of dashboards not registering a full window size in firefox during this measuring cycle, so i just stopped measuring.