### PR TITLE
refactor(http): replace string(w.Body.Bytes()) with w.Body.String()

### DIFF
--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -1188,7 +1188,7 @@ func TestHandler_Flux_DisabledByDefault(t *testing.T) {
 	}
 
 	exp := "Flux query service disabled. Verify flux-enabled=true in the [http] section of the InfluxDB config.\n"
-	if got := string(w.Body.Bytes()); !cmp.Equal(got, exp) {
+	if got := w.Body.String(); got != exp {
 		t.Fatalf("unexpected body -got/+exp\n%s", cmp.Diff(got, exp))
 	}
 }
@@ -1408,7 +1408,7 @@ func TestHandler_Flux(t *testing.T) {
 			}
 
 			if test.expBody != "" {
-				if got := string(w.Body.Bytes()); !cmp.Equal(got, test.expBody) {
+				if got := w.Body.String(); got != test.expBody {
 					t.Fatalf("unexpected body -got/+exp\n%s", cmp.Diff(got, test.expBody))
 				}
 			}


### PR DESCRIPTION
Instead of type converting the Body.Bytes() to a string, we can simply
call Body.String().

While we're at it, this patch also uses a simple string comparison
instead of cmp.Equal() for two strings.

According to the docs, they're equivalent.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
