### PR TITLE
feat(query): add a planner rule to push down bare aggregates

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -28,13 +28,13 @@
   expose: true
 
 - name: Push Down Window Aggregate Count
-  description: Enable Count variant of PushDownWindowAggregateRule
+  description: Enable Count variant of PushDownWindowAggregateRule and PushDownBareAggregateRule
   key: pushDownWindowAggregateCount
   default: false
   contact: Query Team
 
 - name: Push Down Window Aggregate Rest
-  description: Enable non-Count variants of PushDownWindowAggregateRule (stage 2)
+  description: Enable non-Count variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
   key: pushDownWindowAggregateRest
   default: false
   contact: Query Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -39,7 +39,7 @@ var pushDownWindowAggregateCount = MakeBoolFlag(
 	false,
 )
 
-// PushDownWindowAggregateCount - Enable Count variant of PushDownWindowAggregateRule
+// PushDownWindowAggregateCount - Enable Count variant of PushDownWindowAggregateRule and PushDownBareAggregateRule
 func PushDownWindowAggregateCount() BoolFlag {
 	return pushDownWindowAggregateCount
 }
@@ -53,7 +53,7 @@ var pushDownWindowAggregateRest = MakeBoolFlag(
 	false,
 )
 
-// PushDownWindowAggregateRest - Enable non-Count variants of PushDownWindowAggregateRule (stage 2)
+// PushDownWindowAggregateRest - Enable non-Count variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
 func PushDownWindowAggregateRest() BoolFlag {
 	return pushDownWindowAggregateRest
 }


### PR DESCRIPTION
This adds a rule to push down aggregates that are directly over a `ReadRange` source.

I followed the existing example of `PushDownWindowAggregateRule` and did some refactoring to avoid duplicating logic.

I'll follow up with a pipeline test and a Flux end-to-end test.