### PR TITLE
refactor: Change ToLower comparisons to EqualFold

### DIFF
--- a/pkg/slices/strings.go
+++ b/pkg/slices/strings.go
@@ -31,9 +31,8 @@ func Exists(set []string, find string) bool {
 
 // ExistsIgnoreCase checks if a string is in a set but ignores its case.
 func ExistsIgnoreCase(set []string, find string) bool {
-	find = strings.ToLower(find)
 	for _, s := range set {
-		if strings.ToLower(s) == find {
+		if strings.EqualFold(s, find) {
 			return true
 		}
 	}

--- a/query/compile.go
+++ b/query/compile.go
@@ -900,7 +900,7 @@ func (c *compiledStatement) compileDimensions(stmt *influxql.SelectStatement) er
 
 		switch expr := expr.(type) {
 		case *influxql.VarRef:
-			if strings.ToLower(expr.Val) == "time" {
+			if strings.EqualFold(expr.Val, "time") {
 				return errors.New("time() is a function and expects at least one argument")
 			}
 		case *influxql.Call:

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -151,9 +151,9 @@ func (s *Service) Open() error {
 	go s.processBatches(s.batcher)
 
 	var err error
-	if strings.ToLower(s.protocol) == "tcp" {
+	if strings.EqualFold(s.protocol, "tcp") {
 		s.addr, err = s.openTCPServer()
-	} else if strings.ToLower(s.protocol) == "udp" {
+	} else if strings.EqualFold(s.protocol, "udp") {
 		s.addr, err = s.openUDPServer()
 	} else {
 		return fmt.Errorf("unrecognized Graphite input protocol %s", s.protocol)

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -429,7 +429,7 @@ func (data *Data) CreateContinuousQuery(database, name, query string) error {
 			// If the query string is the same, we'll silently return,
 			// otherwise we'll assume the user might be trying to
 			// overwrite an existing CQ with a different query.
-			if strings.ToLower(cq.Query) == strings.ToLower(query) {
+			if strings.EqualFold(cq.Query, query) {
 				return nil
 			}
 			return ErrContinuousQueryExists


### PR DESCRIPTION
When comparing strings in a case-insensitive way, strings.EqualFold() is
(almost?) always faster than comparing the results of strings.ToLower().

In addition, strings.EqualFold() never causes an allocation.

This patch replaces case-insensitive string comparisons that use
strings.ToLower() with a strings.EqualFold() call.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
