### PR TITLE
fix(tsdb): Disable series id set cache size by default.

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -68,7 +68,8 @@ const (
 	DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
 
 	// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache in the TSI index.
-	DefaultSeriesIDSetCacheSize = 100
+	// It is disabled by default.
+	DefaultSeriesIDSetCacheSize = 0
 
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.


### PR DESCRIPTION
This commit changes `DefaultSeriesIDSetCacheSize` to zero so that the tag value cache is disabled by default. There is a rare known bug where the cache can cause a segfault which crashes the process. The cache is being disabled instead of removed as some users may still need the cache for performance reasons.

Closes: #14455, #12137