### PR TITLE
feat: keep notebook meta out of the pipes

### DIFF
--- a/ui/src/notebooks/components/Pipe.tsx
+++ b/ui/src/notebooks/components/Pipe.tsx
@@ -1,18 +1,16 @@
-import {FC, createElement, useContext} from 'react'
-import {NotebookContext} from 'src/notebooks/context/notebook'
+import {FC, createElement} from 'react'
 
 import {PIPE_DEFINITIONS, PipeProp} from 'src/notebooks'
 
 const Pipe: FC<PipeProp> = props => {
-  const {index} = props
-  const {pipes} = useContext(NotebookContext)
+  const {data} = props
 
-  if (!PIPE_DEFINITIONS.hasOwnProperty(pipes[index].type)) {
-    throw new Error(`Pipe type [${pipes[index].type}] not registered`)
+  if (!PIPE_DEFINITIONS.hasOwnProperty(data.type)) {
+    throw new Error(`Pipe type [${data.type}] not registered`)
     return null
   }
 
-  return createElement(PIPE_DEFINITIONS[pipes[index].type].component, props)
+  return createElement(PIPE_DEFINITIONS[data.type].component, props)
 }
 
 export default Pipe

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -1,22 +1,29 @@
 import React, {FC, useContext} from 'react'
 import Pipe from 'src/notebooks/components/Pipe'
 import {NotebookContext} from 'src/notebooks/context/notebook'
+import NotebookPanel from 'src/notebooks/components/panel/NotebookPanel'
 
 const PipeList: FC = () => {
   const {id, pipes, removePipe, movePipe} = useContext(NotebookContext)
   const _pipes = pipes.map((_, index) => {
-    const remove = () => removePipe(index)
-    const moveUp = () => movePipe(index, index - 1)
-    const moveDown = () => movePipe(index, index + 1)
+    const canBeMovedUp = index > 0
+    const canBeMovedDown = index < pipes.length - 1
+    const canBeRemoved = index !== 0
+
+    const moveUp = canBeMovedUp ? () => movePipe(index, index - 1) : null
+    const moveDown = canBeMovedDown ? () => movePipe(index, index + 1) : null
+    const remove = canBeRemoved ? () => removePipe(index) : null
 
     return (
-      <Pipe
-        index={index}
-        remove={remove}
-        moveUp={moveUp}
-        moveDown={moveDown}
+      <NotebookPanel
         key={`pipe-${id}-${index}`}
-      />
+        index={index}
+        onMoveUp={moveUp}
+        onMoveDown={moveDown}
+        onRemove={remove}
+      >
+        <Pipe index={index} />
+      </NotebookPanel>
     )
   })
 

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -1,26 +1,30 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, createElement} from 'react'
+import {PipeContextProps, PipeData} from 'src/notebooks'
 import Pipe from 'src/notebooks/components/Pipe'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 import NotebookPanel from 'src/notebooks/components/panel/NotebookPanel'
 
 const PipeList: FC = () => {
-  const {id, pipes, meta} = useContext(NotebookContext)
-  const _pipes = pipes.map((_, index) => {
-    const header = <NotebookPanel index={index} />
+  const {id, pipes, updatePipe} = useContext(NotebookContext)
+  const _pipes = pipes.map((pipe, index) => {
+      const panel: FC<PipeContextProps> = (props) => {
+          const _props = {
+              ...props,
+              index
+          }
 
-    if (!meta[index].visible) {
-      return (
-        <div key={`pipe-${id}-${index}`} className="panel-empty">
-          {header}
-        </div>
-      )
+          return createElement(NotebookPanel, _props)
+      }
+    const onUpdate = (data: PipeData) => {
+        updatePipe(index, data)
     }
 
     return (
       <Pipe
-        index={index}
         key={`pipe-${id}-${index}`}
-        contextInteraction={header}
+        data={pipe}
+        onUpdate={onUpdate}
+        Context={panel}
       />
     )
   })

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -4,26 +4,24 @@ import {NotebookContext} from 'src/notebooks/context/notebook'
 import NotebookPanel from 'src/notebooks/components/panel/NotebookPanel'
 
 const PipeList: FC = () => {
-  const {id, pipes, removePipe, movePipe} = useContext(NotebookContext)
+  const {id, pipes, meta} = useContext(NotebookContext)
   const _pipes = pipes.map((_, index) => {
-    const canBeMovedUp = index > 0
-    const canBeMovedDown = index < pipes.length - 1
-    const canBeRemoved = index !== 0
+    const header = <NotebookPanel index={index} />
 
-    const moveUp = canBeMovedUp ? () => movePipe(index, index - 1) : null
-    const moveDown = canBeMovedDown ? () => movePipe(index, index + 1) : null
-    const remove = canBeRemoved ? () => removePipe(index) : null
+    if (!meta[index].visible) {
+      return (
+        <div key={`pipe-${id}-${index}`} className="panel-empty">
+          {header}
+        </div>
+      )
+    }
 
     return (
-      <NotebookPanel
-        key={`pipe-${id}-${index}`}
+      <Pipe
         index={index}
-        onMoveUp={moveUp}
-        onMoveDown={moveDown}
-        onRemove={remove}
-      >
-        <Pipe index={index} />
-      </NotebookPanel>
+        key={`pipe-${id}-${index}`}
+        contextInteraction={header}
+      />
     )
   })
 

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -7,16 +7,16 @@ import NotebookPanel from 'src/notebooks/components/panel/NotebookPanel'
 const PipeList: FC = () => {
   const {id, pipes, updatePipe} = useContext(NotebookContext)
   const _pipes = pipes.map((pipe, index) => {
-      const panel: FC<PipeContextProps> = (props) => {
-          const _props = {
-              ...props,
-              index
-          }
-
-          return createElement(NotebookPanel, _props)
+    const panel: FC<PipeContextProps> = props => {
+      const _props = {
+        ...props,
+        index,
       }
+
+      return createElement(NotebookPanel, _props)
+    }
     const onUpdate = (data: PipeData) => {
-        updatePipe(index, data)
+      updatePipe(index, data)
     }
 
     return (

--- a/ui/src/notebooks/components/panel/NotebookPanel.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanel.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, ReactChildren, useState} from 'react'
+import React, {FC, ReactChildren, useContext} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -9,43 +9,33 @@ import {
   AlignItems,
   JustifyContent,
 } from '@influxdata/clockface'
+import {NotebookContext} from 'src/notebooks/context/notebook'
 import RemovePanelButton from 'src/notebooks/components/panel/RemovePanelButton'
 import PanelVisibilityToggle from 'src/notebooks/components/panel/PanelVisibilityToggle'
 import MovePanelButton from 'src/notebooks/components/panel/MovePanelButton'
 import NotebookPanelTitle from 'src/notebooks/components/panel/NotebookPanelTitle'
 
-interface Props {
-  id: string
+export interface Props {
+  index: number
   children: ReactChildren | JSX.Element | JSX.Element[]
-  title: string
-  onTitleChange?: (title: string) => void
-  previousPanelTitle?: string
-  controlsLeft?: JSX.Element | JSX.Element[]
-  controlsRight?: JSX.Element | JSX.Element[]
-  onRemove?: () => void
   onMoveUp?: () => void
   onMoveDown?: () => void
+  onRemove?: () => void
 }
 
-export type NotebookPanelVisibility = 'hidden' | 'visible'
-
 const NotebookPanel: FC<Props> = ({
+  index,
   children,
-  title,
-  previousPanelTitle,
-  onTitleChange,
-  controlsLeft,
-  controlsRight,
-  onRemove,
   onMoveUp,
   onMoveDown,
+  onRemove,
 }) => {
-  const [panelVisibility, setPanelVisibility] = useState<
-    NotebookPanelVisibility
-  >('visible')
+  const {meta} = useContext(NotebookContext)
+  const isVisible = meta[index].visible
 
   const panelClassName = classnames('notebook-panel', {
-    [`notebook-panel__${panelVisibility}`]: panelVisibility,
+    [`notebook-panel__visible`]: isVisible,
+    [`notebook-panel__hidden`]: !isVisible,
   })
 
   return (
@@ -57,12 +47,7 @@ const NotebookPanel: FC<Props> = ({
           margin={ComponentSize.Small}
           justifyContent={JustifyContent.FlexStart}
         >
-          <NotebookPanelTitle
-            title={title}
-            onTitleChange={onTitleChange}
-            previousPanelTitle={previousPanelTitle}
-          />
-          {controlsLeft}
+          <NotebookPanelTitle index={index} />
         </FlexBox>
         <FlexBox
           className="notebook-panel--header-right"
@@ -70,19 +55,13 @@ const NotebookPanel: FC<Props> = ({
           margin={ComponentSize.Small}
           justifyContent={JustifyContent.FlexEnd}
         >
-          {controlsRight}
           <MovePanelButton direction="up" onClick={onMoveUp} />
           <MovePanelButton direction="down" onClick={onMoveDown} />
-          <PanelVisibilityToggle
-            onToggle={setPanelVisibility}
-            visibility={panelVisibility}
-          />
+          <PanelVisibilityToggle index={index} />
           <RemovePanelButton onRemove={onRemove} />
         </FlexBox>
       </div>
-      <div className="notebook-panel--body">
-        {panelVisibility === 'visible' && children}
-      </div>
+      <div className="notebook-panel--body">{isVisible && children}</div>
     </div>
   )
 }

--- a/ui/src/notebooks/components/panel/NotebookPanel.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanel.tsx
@@ -38,29 +38,29 @@ const NotebookPanel: FC<Props> = ({index, children}) => {
   })
 
   return (
-      <div className={panelClassName}>
-    <div className="notebook-panel--header">
-      <FlexBox
-        className="notebook-panel--header-left"
-        alignItems={AlignItems.Center}
-        margin={ComponentSize.Small}
-        justifyContent={JustifyContent.FlexStart}
-      >
-        <NotebookPanelTitle index={index} />
-      </FlexBox>
-      <FlexBox
-        className="notebook-panel--header-right"
-        alignItems={AlignItems.Center}
-        margin={ComponentSize.Small}
-        justifyContent={JustifyContent.FlexEnd}
-      >
-        <MovePanelButton direction="up" onClick={moveUp} />
-        <MovePanelButton direction="down" onClick={moveDown} />
-        <PanelVisibilityToggle index={index} />
-        <RemovePanelButton onRemove={remove} />
-      </FlexBox>
-    </div>
-    <div className="notebook-panel--body">{isVisible && children}</div>
+    <div className={panelClassName}>
+      <div className="notebook-panel--header">
+        <FlexBox
+          className="notebook-panel--header-left"
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Small}
+          justifyContent={JustifyContent.FlexStart}
+        >
+          <NotebookPanelTitle index={index} />
+        </FlexBox>
+        <FlexBox
+          className="notebook-panel--header-right"
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Small}
+          justifyContent={JustifyContent.FlexEnd}
+        >
+          <MovePanelButton direction="up" onClick={moveUp} />
+          <MovePanelButton direction="down" onClick={moveDown} />
+          <PanelVisibilityToggle index={index} />
+          <RemovePanelButton onRemove={remove} />
+        </FlexBox>
+      </div>
+      <div className="notebook-panel--body">{isVisible && children}</div>
     </div>
   )
 }

--- a/ui/src/notebooks/components/panel/NotebookPanel.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanel.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
+import classnames from 'classnames'
 
 // Components
 import {
@@ -8,18 +9,19 @@ import {
   AlignItems,
   JustifyContent,
 } from '@influxdata/clockface'
+import {PipeContextProps} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 import RemovePanelButton from 'src/notebooks/components/panel/RemovePanelButton'
 import PanelVisibilityToggle from 'src/notebooks/components/panel/PanelVisibilityToggle'
 import MovePanelButton from 'src/notebooks/components/panel/MovePanelButton'
 import NotebookPanelTitle from 'src/notebooks/components/panel/NotebookPanelTitle'
 
-export interface Props {
+export interface Props extends PipeContextProps {
   index: number
 }
 
-const NotebookPanel: FC<Props> = ({index}) => {
-  const {pipes, removePipe, movePipe} = useContext(NotebookContext)
+const NotebookPanel: FC<Props> = ({index, children}) => {
+  const {pipes, removePipe, movePipe, meta} = useContext(NotebookContext)
   const canBeMovedUp = index > 0
   const canBeMovedDown = index < pipes.length - 1
   const canBeRemoved = index !== 0
@@ -28,7 +30,15 @@ const NotebookPanel: FC<Props> = ({index}) => {
   const moveDown = canBeMovedDown ? () => movePipe(index, index + 1) : null
   const remove = canBeRemoved ? () => removePipe(index) : null
 
+  const isVisible = meta[index].visible
+
+  const panelClassName = classnames('notebook-panel', {
+    [`notebook-panel__visible`]: isVisible,
+    [`notebook-panel__hidden`]: !isVisible,
+  })
+
   return (
+      <div className={panelClassName}>
     <div className="notebook-panel--header">
       <FlexBox
         className="notebook-panel--header-left"
@@ -49,6 +59,8 @@ const NotebookPanel: FC<Props> = ({index}) => {
         <PanelVisibilityToggle index={index} />
         <RemovePanelButton onRemove={remove} />
       </FlexBox>
+    </div>
+    <div className="notebook-panel--body">{isVisible && children}</div>
     </div>
   )
 }

--- a/ui/src/notebooks/components/panel/NotebookPanel.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanel.tsx
@@ -1,6 +1,5 @@
 // Libraries
-import React, {FC, ReactChildren, useContext} from 'react'
-import classnames from 'classnames'
+import React, {FC, useContext} from 'react'
 
 // Components
 import {
@@ -17,51 +16,39 @@ import NotebookPanelTitle from 'src/notebooks/components/panel/NotebookPanelTitl
 
 export interface Props {
   index: number
-  children: ReactChildren | JSX.Element | JSX.Element[]
-  onMoveUp?: () => void
-  onMoveDown?: () => void
-  onRemove?: () => void
 }
 
-const NotebookPanel: FC<Props> = ({
-  index,
-  children,
-  onMoveUp,
-  onMoveDown,
-  onRemove,
-}) => {
-  const {meta} = useContext(NotebookContext)
-  const isVisible = meta[index].visible
+const NotebookPanel: FC<Props> = ({index}) => {
+  const {pipes, removePipe, movePipe} = useContext(NotebookContext)
+  const canBeMovedUp = index > 0
+  const canBeMovedDown = index < pipes.length - 1
+  const canBeRemoved = index !== 0
 
-  const panelClassName = classnames('notebook-panel', {
-    [`notebook-panel__visible`]: isVisible,
-    [`notebook-panel__hidden`]: !isVisible,
-  })
+  const moveUp = canBeMovedUp ? () => movePipe(index, index - 1) : null
+  const moveDown = canBeMovedDown ? () => movePipe(index, index + 1) : null
+  const remove = canBeRemoved ? () => removePipe(index) : null
 
   return (
-    <div className={panelClassName}>
-      <div className="notebook-panel--header">
-        <FlexBox
-          className="notebook-panel--header-left"
-          alignItems={AlignItems.Center}
-          margin={ComponentSize.Small}
-          justifyContent={JustifyContent.FlexStart}
-        >
-          <NotebookPanelTitle index={index} />
-        </FlexBox>
-        <FlexBox
-          className="notebook-panel--header-right"
-          alignItems={AlignItems.Center}
-          margin={ComponentSize.Small}
-          justifyContent={JustifyContent.FlexEnd}
-        >
-          <MovePanelButton direction="up" onClick={onMoveUp} />
-          <MovePanelButton direction="down" onClick={onMoveDown} />
-          <PanelVisibilityToggle index={index} />
-          <RemovePanelButton onRemove={onRemove} />
-        </FlexBox>
-      </div>
-      <div className="notebook-panel--body">{isVisible && children}</div>
+    <div className="notebook-panel--header">
+      <FlexBox
+        className="notebook-panel--header-left"
+        alignItems={AlignItems.Center}
+        margin={ComponentSize.Small}
+        justifyContent={JustifyContent.FlexStart}
+      >
+        <NotebookPanelTitle index={index} />
+      </FlexBox>
+      <FlexBox
+        className="notebook-panel--header-right"
+        alignItems={AlignItems.Center}
+        margin={ComponentSize.Small}
+        justifyContent={JustifyContent.FlexEnd}
+      >
+        <MovePanelButton direction="up" onClick={moveUp} />
+        <MovePanelButton direction="down" onClick={moveDown} />
+        <PanelVisibilityToggle index={index} />
+        <RemovePanelButton onRemove={remove} />
+      </FlexBox>
     </div>
   )
 }

--- a/ui/src/notebooks/components/panel/NotebookPanelTitle.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanelTitle.tsx
@@ -1,55 +1,41 @@
 // Libraries
-import React, {FC, ChangeEvent} from 'react'
-
-// Components
-import {Icon, IconFont} from '@influxdata/clockface'
+import React, {FC, ChangeEvent, useContext} from 'react'
+import {NotebookContext, PipeMeta} from 'src/notebooks/context/notebook'
 
 interface Props {
-  title: string
-  onTitleChange?: (title: string) => void
-  previousPanelTitle?: string
+  index: number
 }
 
-const NotebookPanelTitle: FC<Props> = ({
-  title,
-  onTitleChange,
-  previousPanelTitle,
-}) => {
+const NotebookPanelTitle: FC<Props> = ({index}) => {
+  const {meta, updateMeta} = useContext(NotebookContext)
+  const title = meta[index].title
+  const onTitleChange = (value: string) => {
+    updateMeta(index, {
+      title: value,
+    } as PipeMeta)
+  }
+
   let sourceName
   let titleElement = <div className="notebook-panel--title">{title}</div>
 
-  if (previousPanelTitle) {
-    sourceName = (
-      <div className="notebook-panel--data-source">
-        {previousPanelTitle}
-        <Icon
-          glyph={IconFont.CaretRight}
-          className="notebook-panel--data-caret"
-        />
-      </div>
-    )
+  const onChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const trimmedValue = e.target.value.replace(' ', '_')
+    onTitleChange(trimmedValue)
   }
 
-  if (onTitleChange) {
-    const onChange = (e: ChangeEvent<HTMLInputElement>): void => {
-      const trimmedValue = e.target.value.replace(' ', '_')
-      onTitleChange(trimmedValue)
-    }
-
-    titleElement = (
-      <input
-        type="text"
-        value={title}
-        onChange={onChange}
-        placeholder="Enter an ID"
-        className="notebook-panel--editable-title"
-        autoComplete="off"
-        autoCorrect="off"
-        spellCheck={false}
-        maxLength={30}
-      />
-    )
-  }
+  titleElement = (
+    <input
+      type="text"
+      value={title}
+      onChange={onChange}
+      placeholder="Enter an ID"
+      className="notebook-panel--editable-title"
+      autoComplete="off"
+      autoCorrect="off"
+      spellCheck={false}
+      maxLength={30}
+    />
+  )
 
   return (
     <>

--- a/ui/src/notebooks/components/panel/PanelVisibilityToggle.tsx
+++ b/ui/src/notebooks/components/panel/PanelVisibilityToggle.tsx
@@ -1,26 +1,23 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 
 // Components
 import {SquareButton, IconFont} from '@influxdata/clockface'
+import {NotebookContext, PipeMeta} from 'src/notebooks/context/notebook'
 
-// Types
-import {NotebookPanelVisibility} from 'src/notebooks/components/panel/NotebookPanel'
-
-interface Props {
-  visibility: NotebookPanelVisibility
-  onToggle: (visibility: NotebookPanelVisibility) => void
+export interface Props {
+  index: number
 }
 
-const PanelVisibilityToggle: FC<Props> = ({visibility, onToggle}) => {
-  const icon = visibility === 'visible' ? IconFont.EyeOpen : IconFont.EyeClosed
+const PanelVisibilityToggle: FC<Props> = ({index}) => {
+  const {meta, updateMeta} = useContext(NotebookContext)
+
+  const icon = meta[index].visible ? IconFont.EyeOpen : IconFont.EyeClosed
 
   const handleClick = (): void => {
-    if (visibility === 'hidden') {
-      onToggle('visible')
-    } else if (visibility === 'visible') {
-      onToggle('hidden')
-    }
+    updateMeta(index, {
+      visible: !meta[index].visible,
+    } as PipeMeta)
   }
 
   return <SquareButton icon={icon} onClick={handleClick} />

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -62,7 +62,7 @@ export const NotebookProvider: FC = ({children}) => {
     setPipes(add(pipe))
     setMeta(
       add({
-        title: `Notebook ${++GENERATOR_INDEX}`,
+        title: `Notebook_${++GENERATOR_INDEX}`,
         visible: true,
       })
     )

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -1,8 +1,5 @@
 import React, {FC, useState} from 'react'
-
-// TODO make this polymorphic to mimic the self registration
-// of pipe stages
-export type Pipe = any
+import {PipeData} from 'src/notebooks'
 
 export interface PipeMeta {
   title: string
@@ -11,10 +8,10 @@ export interface PipeMeta {
 
 export interface NotebookContextType {
   id: string
-  pipes: Pipe[]
+  pipes: PipeData[]
   meta: PipeMeta[] // data only used for the view layer for Notebooks
-  addPipe: (pipe: Pipe) => void
-  updatePipe: (idx: number, pipe: Pipe) => void
+  addPipe: (pipe: PipeData) => void
+  updatePipe: (idx: number, pipe: PipeData) => void
   updateMeta: (idx: number, pipe: PipeMeta) => void
   movePipe: (currentIdx: number, newIdx: number) => void
   removePipe: (idx: number) => void
@@ -52,7 +49,7 @@ export const NotebookProvider: FC = ({children}) => {
   const [pipes, setPipes] = useState(DEFAULT_CONTEXT.pipes)
   const [meta, setMeta] = useState(DEFAULT_CONTEXT.meta)
 
-  function addPipe(pipe: Pipe) {
+  function addPipe(pipe: PipeData) {
     const add = data => {
       return pipes => {
         pipes.push(data)
@@ -68,7 +65,7 @@ export const NotebookProvider: FC = ({children}) => {
     )
   }
 
-  function updatePipe(idx: number, pipe: Pipe) {
+  function updatePipe(idx: number, pipe: PipeData) {
     setPipes(pipes => {
       pipes[idx] = {
         ...pipes[idx],

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -2,9 +2,6 @@ import {FunctionComponent, ComponentClass} from 'react'
 
 export interface PipeProp {
   index: number
-  remove: () => void
-  moveUp: () => void
-  moveDown: () => void
 }
 
 // NOTE: keep this interface as small as possible and

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,7 +1,7 @@
 import {FunctionComponent, ComponentClass, ReactNode} from 'react'
 
 export interface PipeContextProps {
-    children?: ReactNode
+  children?: ReactNode
 }
 
 export type PipeData = any
@@ -9,7 +9,9 @@ export type PipeData = any
 export interface PipeProp {
   data: PipeData
   onUpdate: (data: PipeData) => void
-  Context: FunctionComponent<PipeContextProps> | ComponentClass<PipeContextProps>
+  Context:
+    | FunctionComponent<PipeContextProps>
+    | ComponentClass<PipeContextProps>
 }
 
 // NOTE: keep this interface as small as possible and

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -2,6 +2,7 @@ import {FunctionComponent, ComponentClass} from 'react'
 
 export interface PipeProp {
   index: number
+  contextInteraction?: FunctionComponent | ComponentClass | JSX.Element
 }
 
 // NOTE: keep this interface as small as possible and

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,8 +1,15 @@
-import {FunctionComponent, ComponentClass} from 'react'
+import {FunctionComponent, ComponentClass, ReactNode} from 'react'
+
+export interface PipeContextProps {
+    children?: ReactNode
+}
+
+export type PipeData = any
 
 export interface PipeProp {
-  index: number
-  contextInteraction?: FunctionComponent | ComponentClass | JSX.Element
+  data: PipeData
+  onUpdate: (data: PipeData) => void
+  Context: FunctionComponent<PipeContextProps> | ComponentClass<PipeContextProps>
 }
 
 // NOTE: keep this interface as small as possible and

--- a/ui/src/notebooks/pipes/Example/style.scss
+++ b/ui/src/notebooks/pipes/Example/style.scss
@@ -1,5 +1,18 @@
-.notebook-example {
+.pipe-example {
+    .notebook-panel--header {
+        transition: opacity 0.2s;
+        opacity: 0;
+    }
+
+    &:hover {
+        .notebook-panel--header {
+            opacity: 1;
+
+        }
+    }
+
     h1 {
-        color: #f00;
+        margin: 0;
+        padding: 1em 0;
     }
 }

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -2,14 +2,15 @@ import React, {FC, useContext} from 'react'
 import {PipeProp} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 
-const ExampleView: FC<PipeProp> = ({index}) => {
+const ExampleView: FC<PipeProp> = ({index, contextInteraction}) => {
   const {pipes} = useContext(NotebookContext)
   const pipe = pipes[index]
 
   return (
-    <>
+    <div className="pipe-example">
+      {contextInteraction}
       <h1>{pipe.text}</h1>
-    </>
+    </div>
   )
 }
 

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -2,28 +2,14 @@ import React, {FC, useContext} from 'react'
 import {PipeProp} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook'
 
-import {NotebookPanel} from 'src/notebooks/components/Notebook'
-
-const TITLE = 'Example Pipe'
-
-const ExampleView: FC<PipeProp> = ({index, remove, moveUp, moveDown}) => {
+const ExampleView: FC<PipeProp> = ({index}) => {
   const {pipes} = useContext(NotebookContext)
   const pipe = pipes[index]
 
-  const canBeMovedUp = index > 0
-  const canBeMovedDown = index < pipes.length - 1
-  const canBeRemoved = index !== 0
-
   return (
-    <NotebookPanel
-      id={`pipe${index}`}
-      onMoveUp={canBeMovedUp && moveUp}
-      onMoveDown={canBeMovedDown && moveDown}
-      onRemove={canBeRemoved && remove}
-      title={TITLE}
-    >
+    <>
       <h1>{pipe.text}</h1>
-    </NotebookPanel>
+    </>
   )
 }
 

--- a/ui/src/notebooks/pipes/Example/view.tsx
+++ b/ui/src/notebooks/pipes/Example/view.tsx
@@ -1,16 +1,11 @@
-import React, {FC, useContext} from 'react'
+import React, {FC} from 'react'
 import {PipeProp} from 'src/notebooks'
-import {NotebookContext} from 'src/notebooks/context/notebook'
 
-const ExampleView: FC<PipeProp> = ({index, contextInteraction}) => {
-  const {pipes} = useContext(NotebookContext)
-  const pipe = pipes[index]
-
+const ExampleView: FC<PipeProp> = ({data, Context}) => {
   return (
-    <div className="pipe-example">
-      {contextInteraction}
-      <h1>{pipe.text}</h1>
-    </div>
+    <Context>
+      <h1>{data.text}</h1>
+    </Context>
   )
 }
 

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -19,13 +19,26 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
   flex-direction: column;
   align-items: stretch;
   border-radius: $cf-radius;
-
+  
   &:after {
     content: '';
     height: $cf-border;
     background-color: $g2-kevlar;
     border-radius: $cf-border / 2;
     margin: $cf-marg-a 0;
+  }
+}
+
+// Highlight panel on hover
+.notebook-panel--header,
+.notebook-panel--body {
+  transition: background-color 0.25s ease;
+}
+
+.notebook-panel:hover {
+  .notebook-panel--header,
+  .notebook-panel--body {
+    background-color: $notebook-panel--bg;
   }
 }
 
@@ -42,6 +55,15 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
 .notebook-panel--header-left,
 .notebook-panel--header-right {
   flex: 1 0 $notebook-header-height;
+}
+
+.notebook-panel--header-right {
+  transition: opacity 0.25s ease;
+  opacity: 0;
+}
+
+.notebook-panel:hover .notebook-panel--header-right {
+  opacity: 1;
 }
 
 .notebook-panel--title,

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -19,26 +19,13 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
   flex-direction: column;
   align-items: stretch;
   border-radius: $cf-radius;
-  
+
   &:after {
     content: '';
     height: $cf-border;
     background-color: $g2-kevlar;
     border-radius: $cf-border / 2;
     margin: $cf-marg-a 0;
-  }
-}
-
-// Highlight panel on hover
-.notebook-panel--header,
-.notebook-panel--body {
-  transition: background-color 0.25s ease;
-}
-
-.notebook-panel:hover {
-  .notebook-panel--header,
-  .notebook-panel--body {
-    background-color: $notebook-panel--bg;
   }
 }
 
@@ -55,15 +42,6 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
 .notebook-panel--header-left,
 .notebook-panel--header-right {
   flex: 1 0 $notebook-header-height;
-}
-
-.notebook-panel--header-right {
-  transition: opacity 0.25s ease;
-  opacity: 0;
-}
-
-.notebook-panel:hover .notebook-panel--header-right {
-  opacity: 1;
 }
 
 .notebook-panel--title,


### PR DESCRIPTION
![Kapture 2020-05-19 at 10 24 06](https://user-images.githubusercontent.com/1434802/82358383-50197080-99bb-11ea-8e9e-5e241c03cba8.gif)

this keeps the notebook metadata (of known type) away from the Pipe data (of unknown type) so that we can build better visualizations around it. code kind of smells when we're keeping two arrays in sync and not keeping order separate from a lookup table, but this is just a demo. Also removed the concept of a NotebookPanel from a Pipe type and a bunch of "future interfaces", not because i have any feelings about then, but because they need to be redone with the context 