### PR TITLE
fix(parseYBounds): parseYBounds was parsing integers, causing floating numbers to be trimmed. Updated parseYBounds to parseFloat instead

### DIFF
--- a/ui/src/shared/utils/vis.test.ts
+++ b/ui/src/shared/utils/vis.test.ts
@@ -15,4 +15,7 @@ describe('parseYBounds', () => {
   it('should return [-10, null] when the bounds are ["-10", null]', () => {
     expect(parseYBounds(['-10', null])).toEqual([-10, null])
   })
+  it('should return [0.1, .6] when the bounds are ["0.1", "0.6"]', () => {
+    expect(parseYBounds(['0.1', '0.6'])).toEqual([0.1, 0.6])
+  })
 })

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -136,8 +136,8 @@ export const parseYBounds = (
     return null
   }
 
-  const min = isNaN(parseInt(bounds[0])) ? null : parseInt(bounds[0])
-  const max = isNaN(parseInt(bounds[1])) ? null : parseInt(bounds[1])
+  const min = isNaN(parseFloat(bounds[0])) ? null : parseFloat(bounds[0])
+  const max = isNaN(parseFloat(bounds[1])) ? null : parseFloat(bounds[1])
   return [min, max]
 }
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1520,6 +1520,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/webpack-env@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.2.tgz#927997342bb9f4a5185a86e6579a0a18afc33b0a"
+  integrity sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ==
+
 "@types/webpack@^4.4.31", "@types/webpack@^4.4.35":
   version "4.4.35"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.35.tgz#b7088eb2d471d5645e5503d272783cafa753583b"


### PR DESCRIPTION
Closes #18101 

### Problem

Specifying a y-axis floating number would round the number

### Solution

Refactor the implementation to use parseFloat rather than parseInt as part of the parseYBounds function 

<img width="1024" alt="Screen Shot 2020-05-19 at 11 07 58" src="https://user-images.githubusercontent.com/19984220/82366597-48f85f80-99c7-11ea-92ed-9af1fe507d9e.png">

