### PR TITLE
feat(query): add conditional option to LoggingProxyQueryService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8
-	github.com/docker/docker v1.13.1
+	github.com/docker/docker v1.13.1 // indirect
 	github.com/editorconfig-checker/editorconfig-checker v0.0.0-20190819115812-1474bdeaf2a2
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/fatih/color v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8
-	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/docker v1.13.1
 	github.com/editorconfig-checker/editorconfig-checker v0.0.0-20190819115812-1474bdeaf2a2
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/fatih/color v1.7.0

--- a/query/logging.go
+++ b/query/logging.go
@@ -21,15 +21,35 @@ type LoggingProxyQueryService struct {
 	queryLogger       Logger
 	nowFunction       func() time.Time
 	log               *zap.Logger
+	cond              func(ctx context.Context) bool
 }
 
-func NewLoggingProxyQueryService(log *zap.Logger, queryLogger Logger, proxyQueryService ProxyQueryService) *LoggingProxyQueryService {
-	return &LoggingProxyQueryService{
+// LoggingProxyQueryServiceOption provides a way to modify the
+// behavior of LoggingProxyQueryService.
+type LoggingProxyQueryServiceOption func(lpqs *LoggingProxyQueryService)
+
+// ConditionalLogging returns a LoggingProxyQueryServiceOption
+// that only logs if the passed in function returns true.
+// Thus logging can be controlled by a request-scoped attribute, e.g., a feature flag.
+func ConditionalLogging(cond func(context.Context) bool) LoggingProxyQueryServiceOption {
+	return func(lpqs *LoggingProxyQueryService) {
+		lpqs.cond = cond
+	}
+}
+
+func NewLoggingProxyQueryService(log *zap.Logger, queryLogger Logger, proxyQueryService ProxyQueryService, opts ...LoggingProxyQueryServiceOption) *LoggingProxyQueryService {
+	lpqs := &LoggingProxyQueryService{
 		proxyQueryService: proxyQueryService,
 		queryLogger:       queryLogger,
 		nowFunction:       time.Now,
 		log:               log,
 	}
+
+	for _, o := range opts {
+		o(lpqs)
+	}
+
+	return lpqs
 }
 
 func (s *LoggingProxyQueryService) SetNowFunctionForTesting(nowFunction func() time.Time) {
@@ -38,6 +58,12 @@ func (s *LoggingProxyQueryService) SetNowFunctionForTesting(nowFunction func() t
 
 // Query executes and logs the query.
 func (s *LoggingProxyQueryService) Query(ctx context.Context, w io.Writer, req *ProxyRequest) (stats flux.Statistics, err error) {
+	if s.cond != nil && !s.cond(ctx) {
+		// Logging is conditional, and we are not logging this request.
+		// Just invoke the wrapped service directly.
+		return s.proxyQueryService.Query(ctx, w, req)
+	}
+
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 

--- a/query/logging_test.go
+++ b/query/logging_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
@@ -69,13 +70,6 @@ func TestLoggingProxyQueryService(t *testing.T) {
 		},
 	}
 
-	wantTime := time.Now()
-	lpqs := query.NewLoggingProxyQueryService(zap.NewNop(), logger, pqs)
-	lpqs.SetNowFunctionForTesting(func() time.Time {
-		return wantTime
-	})
-
-	var buf bytes.Buffer
 	req := &query.ProxyRequest{
 		Request: query.Request{
 			Authorization:  nil,
@@ -84,25 +78,69 @@ func TestLoggingProxyQueryService(t *testing.T) {
 		},
 		Dialect: nil,
 	}
-	stats, err := lpqs.Query(context.Background(), &buf, req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cmp.Equal(wantStats, stats, opts...) {
-		t.Errorf("unexpected query stats: -want/+got\n%s", cmp.Diff(wantStats, stats, opts...))
-	}
-	traceID := reporter.GetSpans()[0].Context().(jaeger.SpanContext).TraceID().String()
-	wantLogs := []query.Log{{
-		Time:           wantTime,
-		OrganizationID: orgID,
-		TraceID:        traceID,
-		Sampled:        true,
-		Error:          nil,
-		ProxyRequest:   req,
-		ResponseSize:   int64(wantBytes),
-		Statistics:     wantStats,
-	}}
-	if !cmp.Equal(wantLogs, logs, opts...) {
-		t.Errorf("unexpected query logs: -want/+got\n%s", cmp.Diff(wantLogs, logs, opts...))
-	}
+
+	t.Run("log", func(t *testing.T) {
+		defer func() {
+			logs = nil
+		}()
+		wantTime := time.Now()
+		lpqs := query.NewLoggingProxyQueryService(zap.NewNop(), logger, pqs)
+		lpqs.SetNowFunctionForTesting(func() time.Time {
+			return wantTime
+		})
+
+		var buf bytes.Buffer
+		stats, err := lpqs.Query(context.Background(), &buf, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cmp.Equal(wantStats, stats, opts...) {
+			t.Errorf("unexpected query stats: -want/+got\n%s", cmp.Diff(wantStats, stats, opts...))
+		}
+		traceID := reporter.GetSpans()[0].Context().(jaeger.SpanContext).TraceID().String()
+		wantLogs := []query.Log{{
+			Time:           wantTime,
+			OrganizationID: orgID,
+			TraceID:        traceID,
+			Sampled:        true,
+			Error:          nil,
+			ProxyRequest:   req,
+			ResponseSize:   int64(wantBytes),
+			Statistics:     wantStats,
+		}}
+		if !cmp.Equal(wantLogs, logs, opts...) {
+			t.Errorf("unexpected query logs: -want/+got\n%s", cmp.Diff(wantLogs, logs, opts...))
+		}
+	})
+
+	t.Run("conditional logging", func(t *testing.T) {
+		defer func() {
+			logs = nil
+		}()
+
+		loggingKey := "do-logging"
+		condLog := query.ConditionalLogging(func(ctx context.Context) bool {
+			return ctx.Value(loggingKey) != nil
+		})
+
+		lpqs := query.NewLoggingProxyQueryService(zap.NewNop(), logger, pqs, condLog)
+		_, err := lpqs.Query(context.Background(), &ioutils.NopWriter{}, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(logs) != 0 {
+			t.Fatal("expected query service not to log")
+		}
+
+		ctx := context.WithValue(context.Background(), loggingKey, true)
+		_, err = lpqs.Query(ctx, &ioutils.NopWriter{}, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(logs) != 1 {
+			t.Fatal("expected query service to log")
+		}
+	})
 }

--- a/query/logging_test.go
+++ b/query/logging_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/ioutil"
 	"testing"
 	"time"
 
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
@@ -124,7 +124,7 @@ func TestLoggingProxyQueryService(t *testing.T) {
 		})
 
 		lpqs := query.NewLoggingProxyQueryService(zap.NewNop(), logger, pqs, condLog)
-		_, err := lpqs.Query(context.Background(), &ioutils.NopWriter{}, req)
+		_, err := lpqs.Query(context.Background(), ioutil.Discard, req)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -134,7 +134,7 @@ func TestLoggingProxyQueryService(t *testing.T) {
 		}
 
 		ctx := context.WithValue(context.Background(), loggingKey, true)
-		_, err = lpqs.Query(ctx, &ioutils.NopWriter{}, req)
+		_, err = lpqs.Query(ctx, ioutil.Discard, req)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This updates `LoggingProxyQueryService` to only conditionally log queries, based on a condition function passed in when the service is created.