### PR TITLE
fix(api/health): report version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [18040](https://github.com/influxdata/influxdb/pull/18040): Allow for min OR max y-axis visualization settings rather than min AND max
 1. [17764](https://github.com/influxdata/influxdb/pull/17764): Add CSV to line protocol conversion library
 1. [18059](https://github.com/influxdata/influxdb/pull/18059): Make the dropdown width adjustable
+1. [18173](https://github.com/influxdata/influxdb/pull/18173): Add version to /health response
 
 ### Bug Fixes
 

--- a/http/health.go
+++ b/http/health.go
@@ -3,11 +3,13 @@ package http
 import (
 	"fmt"
 	"net/http"
+
+	platform "github.com/influxdata/influxdb/v2"
 )
 
 // HealthHandler returns the status of the process.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-	msg := `{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[]}`
+	msg := fmt.Sprintf(`{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[], "version": %q}`, platform.GetBuildInfo().Version)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, msg)

--- a/http/health.go
+++ b/http/health.go
@@ -9,7 +9,7 @@ import (
 
 // HealthHandler returns the status of the process.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-	msg := fmt.Sprintf(`{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[], "version": %q}`, platform.GetBuildInfo().Version)
+	msg := fmt.Sprintf(`{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[], "version": %q, "commit": %q}`, platform.GetBuildInfo().Version, platform.GetBuildInfo().Commit)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, msg)

--- a/http/health_test.go
+++ b/http/health_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,7 @@ func TestHealthHandler(t *testing.T) {
 	type wants struct {
 		statusCode  int
 		contentType string
-		body        string
+		status      string
 	}
 	tests := []struct {
 		name  string
@@ -26,7 +27,7 @@ func TestHealthHandler(t *testing.T) {
 			wants: wants{
 				statusCode:  http.StatusOK,
 				contentType: "application/json; charset=utf-8",
-				body:        `{"name":"influxdb", "message":"ready for queries and writes", "status":"pass", "checks":[]}`,
+				status:      "pass",
 			},
 		},
 	}
@@ -34,21 +35,34 @@ func TestHealthHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			HealthHandler(tt.w, tt.r)
 			res := tt.w.Result()
-			content := res.Header.Get("Content-Type")
+			contentType := res.Header.Get("Content-Type")
 			body, _ := ioutil.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. HealthHandler() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
 			}
-			if tt.wants.contentType != "" && content != tt.wants.contentType {
-				t.Errorf("%q. HealthHandler() = %v, want %v", tt.name, content, tt.wants.contentType)
+			if tt.wants.contentType != "" && contentType != tt.wants.contentType {
+				t.Errorf("%q. HealthHandler() = %v, want %v", tt.name, contentType, tt.wants.contentType)
 			}
-			if tt.wants.body != "" {
-				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, HealthHandler(). error unmarshaling json %v", tt.name, err)
-				} else if !eq {
-					t.Errorf("%q. HealthHandler() = ***%s***", tt.name, diff)
-				}
+			var content map[string]interface{}
+			if err := json.Unmarshal(body, &content); err != nil {
+				t.Errorf("%q, HealthHandler(). error unmarshaling json %v", tt.name, err)
+				return
+			}
+			if _, found := content["name"]; !found {
+				t.Errorf("%q. HealthHandler() no name reported", tt.name)
+			}
+			if content["status"] != tt.wants.status {
+				t.Errorf("%q. HealthHandler() status= %v, want %v", tt.name, content["status"], tt.wants.status)
+			}
+			if _, found := content["message"]; !found {
+				t.Errorf("%q. HealthHandler() no message reported", tt.name)
+			}
+			if _, found := content["checks"]; !found {
+				t.Errorf("%q. HealthHandler() no checks reported", tt.name)
+			}
+			if _, found := content["version"]; !found {
+				t.Errorf("%q. HealthHandler() no version reported", tt.name)
 			}
 		})
 	}

--- a/http/health_test.go
+++ b/http/health_test.go
@@ -64,6 +64,9 @@ func TestHealthHandler(t *testing.T) {
 			if _, found := content["version"]; !found {
 				t.Errorf("%q. HealthHandler() no version reported", tt.name)
 			}
+			if _, found := content["commit"]; !found {
+				t.Errorf("%q. HealthHandler() no commit reported", tt.name)
+			}
 		})
 	}
 }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10893,6 +10893,8 @@ components:
           enum:
             - pass
             - fail
+        version:
+          type: string
     Labels:
       type: array
       items:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10895,6 +10895,8 @@ components:
             - fail
         version:
           type: string
+        commit:
+          type: string
     Labels:
       type: array
       items:


### PR DESCRIPTION
Closes #13907 

InfluxDB 1.8 "/health" endpoint already returns version, 
```js
{
"checks": [],
"message": "ready for queries and writes",
"name": "influxdb",
"status": "pass",
"version": "1.8.0"
}
```
This PR also adds version to 2.0 "/health" endpoint

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
