### PR TITLE
feat(clientLibs): add Kotlin and Scala client library

### DIFF
--- a/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
@@ -1,0 +1,86 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
+import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
+
+// Constants
+import {clientKotlinLibrary} from 'src/clientLibraries/constants'
+
+// Types
+import {AppState} from 'src/types'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientKotlinOverlay: FunctionComponent<Props> = props => {
+  const {
+    name,
+    url,
+    buildWithMavenCodeSnippet,
+    buildWithGradleCodeSnippet,
+    initializeClientCodeSnippet,
+    executeQueryCodeSnippet,
+  } = clientKotlinLibrary
+  const {org} = props
+  const server = window.location.origin
+
+  return (
+    <ClientLibraryOverlay title={`${name} Client Library`}>
+      <p>
+        For more detailed and up to date information check out the{' '}
+        <a href={url} target="_blank">
+          GitHub Repository
+        </a>
+      </p>
+      <h5>Add Dependency</h5>
+      <p>Build with Maven</p>
+      <TemplatedCodeSnippet template={buildWithMavenCodeSnippet} label="Code" />
+      <p>Build with Gradle</p>
+      <TemplatedCodeSnippet
+        template={buildWithGradleCodeSnippet}
+        label="Code"
+      />
+      <h5>Initialize the Client</h5>
+      <TemplatedCodeSnippet
+        template={initializeClientCodeSnippet}
+        label="Kotlin Code"
+        defaults={{
+          server: 'basepath',
+          token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
+        }}
+        values={{
+          server,
+          org,
+        }}
+      />
+      <h5>Execute a Flux query</h5>
+      <TemplatedCodeSnippet
+        template={executeQueryCodeSnippet}
+        label="Kotlin Code"
+      />
+    </ClientLibraryOverlay>
+  )
+}
+
+const mstp = (state: AppState): StateProps => {
+  return {
+    org: getOrg(state).id,
+  }
+}
+
+export {ClientKotlinOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null
+)(ClientKotlinOverlay)

--- a/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
@@ -1,0 +1,89 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
+import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
+
+// Constants
+import {clientScalaLibrary} from 'src/clientLibraries/constants'
+
+// Types
+import {AppState} from 'src/types'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientScalaOverlay: FunctionComponent<Props> = props => {
+  const {
+    name,
+    url,
+    buildWithSBTCodeSnippet,
+    buildWithMavenCodeSnippet,
+    buildWithGradleCodeSnippet,
+    initializeClientCodeSnippet,
+    executeQueryCodeSnippet,
+  } = clientScalaLibrary
+  const {org} = props
+  const server = window.location.origin
+
+  return (
+    <ClientLibraryOverlay title={`${name} Client Library`}>
+      <p>
+        For more detailed and up to date information check out the{' '}
+        <a href={url} target="_blank">
+          GitHub Repository
+        </a>
+      </p>
+      <h5>Add Dependency</h5>
+      <p>Build with sbt</p>
+      <TemplatedCodeSnippet template={buildWithSBTCodeSnippet} label="Code" />
+      <p>Build with Maven</p>
+      <TemplatedCodeSnippet template={buildWithMavenCodeSnippet} label="Code" />
+      <p>Build with Gradle</p>
+      <TemplatedCodeSnippet
+        template={buildWithGradleCodeSnippet}
+        label="Code"
+      />
+      <h5>Initialize the Client</h5>
+      <TemplatedCodeSnippet
+        template={initializeClientCodeSnippet}
+        label="Scala Code"
+        defaults={{
+          server: 'basepath',
+          token: 'token',
+          org: 'orgID',
+          bucket: 'bucketID',
+        }}
+        values={{
+          server,
+          org,
+        }}
+      />
+      <h5>Execute a Flux query</h5>
+      <TemplatedCodeSnippet
+        template={executeQueryCodeSnippet}
+        label="Scala Code"
+      />
+    </ClientLibraryOverlay>
+  )
+}
+
+const mstp = (state: AppState): StateProps => {
+  return {
+    org: getOrg(state).id,
+  }
+}
+
+export {ClientScalaOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null
+)(ClientScalaOverlay)

--- a/ui/src/clientLibraries/constants/index.ts
+++ b/ui/src/clientLibraries/constants/index.ts
@@ -1,13 +1,6 @@
 import {SFC} from 'react'
-import CSharpLogo from '../graphics/CSharpLogo'
-import GoLogo from '../graphics/GoLogo'
-import JavaLogo from '../graphics/JavaLogo'
-import JSLogo from '../graphics/JSLogo'
-import KotlinLogo from '../graphics/KotlinLogo'
-import PHPLogo from '../graphics/PHPLogo'
-import PythonLogo from '../graphics/PythonLogo'
-import RubyLogo from '../graphics/RubyLogo'
-import ScalaLogo from '../graphics/ScalaLogo'
+import {
+  CSharpLogo,GoLogo,JavaLogo,JSLogo,KotlinLogo,PHPLogo,PythonLogo,RubyLogo,ScalaLogo} from '../graphics'
 
 export interface ClientLibrary {
   id: string

--- a/ui/src/clientLibraries/constants/index.ts
+++ b/ui/src/clientLibraries/constants/index.ts
@@ -1,6 +1,15 @@
 import {SFC} from 'react'
 import {
-  CSharpLogo,GoLogo,JavaLogo,JSLogo,KotlinLogo,PHPLogo,PythonLogo,RubyLogo,ScalaLogo} from '../graphics'
+  CSharpLogo,
+  GoLogo,
+  JavaLogo,
+  JSLogo,
+  KotlinLogo,
+  PHPLogo,
+  PythonLogo,
+  RubyLogo,
+  ScalaLogo,
+} from '../graphics'
 
 export interface ClientLibrary {
   id: string

--- a/ui/src/clientLibraries/graphics/KotlinLogo.tsx
+++ b/ui/src/clientLibraries/graphics/KotlinLogo.tsx
@@ -3,56 +3,56 @@ import React, {SFC} from 'react'
 
 const KotlinLogo: SFC = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
-      <linearGradient
-        id="kotlin-a"
-        gradientUnits="userSpaceOnUse"
-        x1="15.959"
-        y1="-13.014"
-        x2="44.307"
-        y2="15.333"
-        gradientTransform="matrix(1 0 0 -1 0 61)"
-      >
-        <stop offset=".097" stopColor="#0095d5" />
-        <stop offset=".301" stopColor="#238ad9" />
-        <stop offset=".621" stopColor="#557bde" />
-        <stop offset=".864" stopColor="#7472e2" />
-        <stop offset="1" stopColor="#806ee3" />
-      </linearGradient>
-      <path fill="url(#kotlin-a)" d="M0 60l30.1-30.1L60 60z" />
-      <linearGradient
-        id="kotlin-b"
-        gradientUnits="userSpaceOnUse"
-        x1="4.209"
-        y1="48.941"
-        x2="20.673"
-        y2="65.405"
-        gradientTransform="matrix(1 0 0 -1 0 61)"
-      >
-        <stop offset=".118" stopColor="#0095d5" />
-        <stop offset=".418" stopColor="#3c83dc" />
-        <stop offset=".696" stopColor="#6d74e1" />
-        <stop offset=".833" stopColor="#806ee3" />
-      </linearGradient>
-      <path fill="url(#kotlin-b)" d="M0 0h30.1L0 32.5z" />
-      <linearGradient
-        id="c"
-        gradientUnits="userSpaceOnUse"
-        x1="-10.102"
-        y1="5.836"
-        x2="45.731"
-        y2="61.669"
-        gradientTransform="matrix(1 0 0 -1 0 61)"
-      >
-        <stop offset=".107" stopColor="#c757bc" />
-        <stop offset=".214" stopColor="#d0609a" />
-        <stop offset=".425" stopColor="#e1725c" />
-        <stop offset=".605" stopColor="#ee7e2f" />
-        <stop offset=".743" stopColor="#f58613" />
-        <stop offset=".823" stopColor="#f88909" />
-      </linearGradient>
-      <path fill="url(#c)" d="M30.1 0L0 31.7V60l30.1-30.1L60 0z" />
-    </svg>
+    <svg x={0} y={0} viewBox="0 0 60 60" xmlSpace="preserve" width="80" height="100">
+    <linearGradient
+      id="kotlin-a"
+      gradientUnits="userSpaceOnUse"
+      x1={15.959}
+      y1={-13.014}
+      x2={44.307}
+      y2={15.333}
+      gradientTransform="matrix(1 0 0 -1 0 61)"
+    >
+      <stop offset={0.097} stopColor="#0095d5" />
+      <stop offset={0.301} stopColor="#238ad9" />
+      <stop offset={0.621} stopColor="#557bde" />
+      <stop offset={0.864} stopColor="#7472e2" />
+      <stop offset={1} stopColor="#806ee3" />
+    </linearGradient>
+    <path fill="url(#kotlin-a)" d="M0 60L30.1 29.9 60 60z" />
+    <linearGradient
+      id="kotlin-b"
+      gradientUnits="userSpaceOnUse"
+      x1={4.209}
+      y1={48.941}
+      x2={20.673}
+      y2={65.405}
+      gradientTransform="matrix(1 0 0 -1 0 61)"
+    >
+      <stop offset={0.118} stopColor="#0095d5" />
+      <stop offset={0.418} stopColor="#3c83dc" />
+      <stop offset={0.696} stopColor="#6d74e1" />
+      <stop offset={0.833} stopColor="#806ee3" />
+    </linearGradient>
+    <path fill="url(#kotlin-b)" d="M0 0L30.1 0 0 32.5z" />
+    <linearGradient
+      id="kotlin-c"
+      gradientUnits="userSpaceOnUse"
+      x1={-10.102}
+      y1={5.836}
+      x2={45.731}
+      y2={61.669}
+      gradientTransform="matrix(1 0 0 -1 0 61)"
+    >
+      <stop offset={0.107} stopColor="#c757bc" />
+      <stop offset={0.214} stopColor="#d0609a" />
+      <stop offset={0.425} stopColor="#e1725c" />
+      <stop offset={0.605} stopColor="#ee7e2f" />
+      <stop offset={0.743} stopColor="#f58613" />
+      <stop offset={0.823} stopColor="#f88909" />
+    </linearGradient>
+    <path fill="url(#kotlin-c)" d="M30.1 0L0 31.7 0 60 30.1 29.9 60 0z" />
+  </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/KotlinLogo.tsx
+++ b/ui/src/clientLibraries/graphics/KotlinLogo.tsx
@@ -13,11 +13,11 @@ const KotlinLogo: SFC = () => {
         y2="15.333"
         gradientTransform="matrix(1 0 0 -1 0 61)"
       >
-        <stop offset=".097" stop-color="#0095d5" />
-        <stop offset=".301" stop-color="#238ad9" />
-        <stop offset=".621" stop-color="#557bde" />
-        <stop offset=".864" stop-color="#7472e2" />
-        <stop offset="1" stop-color="#806ee3" />
+        <stop offset=".097" stopColor="#0095d5" />
+        <stop offset=".301" stopColor="#238ad9" />
+        <stop offset=".621" stopColor="#557bde" />
+        <stop offset=".864" stopColor="#7472e2" />
+        <stop offset="1" stopColor="#806ee3" />
       </linearGradient>
       <path fill="url(#kotlin-a)" d="M0 60l30.1-30.1L60 60z" />
       <linearGradient
@@ -29,10 +29,10 @@ const KotlinLogo: SFC = () => {
         y2="65.405"
         gradientTransform="matrix(1 0 0 -1 0 61)"
       >
-        <stop offset=".118" stop-color="#0095d5" />
-        <stop offset=".418" stop-color="#3c83dc" />
-        <stop offset=".696" stop-color="#6d74e1" />
-        <stop offset=".833" stop-color="#806ee3" />
+        <stop offset=".118" stopColor="#0095d5" />
+        <stop offset=".418" stopColor="#3c83dc" />
+        <stop offset=".696" stopColor="#6d74e1" />
+        <stop offset=".833" stopColor="#806ee3" />
       </linearGradient>
       <path fill="url(#kotlin-b)" d="M0 0h30.1L0 32.5z" />
       <linearGradient
@@ -44,12 +44,12 @@ const KotlinLogo: SFC = () => {
         y2="61.669"
         gradientTransform="matrix(1 0 0 -1 0 61)"
       >
-        <stop offset=".107" stop-color="#c757bc" />
-        <stop offset=".214" stop-color="#d0609a" />
-        <stop offset=".425" stop-color="#e1725c" />
-        <stop offset=".605" stop-color="#ee7e2f" />
-        <stop offset=".743" stop-color="#f58613" />
-        <stop offset=".823" stop-color="#f88909" />
+        <stop offset=".107" stopColor="#c757bc" />
+        <stop offset=".214" stopColor="#d0609a" />
+        <stop offset=".425" stopColor="#e1725c" />
+        <stop offset=".605" stopColor="#ee7e2f" />
+        <stop offset=".743" stopColor="#f58613" />
+        <stop offset=".823" stopColor="#f88909" />
       </linearGradient>
       <path fill="url(#c)" d="M30.1 0L0 31.7V60l30.1-30.1L60 0z" />
     </svg>

--- a/ui/src/clientLibraries/graphics/KotlinLogo.tsx
+++ b/ui/src/clientLibraries/graphics/KotlinLogo.tsx
@@ -3,56 +3,63 @@ import React, {SFC} from 'react'
 
 const KotlinLogo: SFC = () => {
   return (
-    <svg x={0} y={0} viewBox="0 0 60 60" xmlSpace="preserve" width="80" height="100">
-    <linearGradient
-      id="kotlin-a"
-      gradientUnits="userSpaceOnUse"
-      x1={15.959}
-      y1={-13.014}
-      x2={44.307}
-      y2={15.333}
-      gradientTransform="matrix(1 0 0 -1 0 61)"
+    <svg
+      x={0}
+      y={0}
+      viewBox="0 0 60 60"
+      xmlSpace="preserve"
+      width="80"
+      height="100"
     >
-      <stop offset={0.097} stopColor="#0095d5" />
-      <stop offset={0.301} stopColor="#238ad9" />
-      <stop offset={0.621} stopColor="#557bde" />
-      <stop offset={0.864} stopColor="#7472e2" />
-      <stop offset={1} stopColor="#806ee3" />
-    </linearGradient>
-    <path fill="url(#kotlin-a)" d="M0 60L30.1 29.9 60 60z" />
-    <linearGradient
-      id="kotlin-b"
-      gradientUnits="userSpaceOnUse"
-      x1={4.209}
-      y1={48.941}
-      x2={20.673}
-      y2={65.405}
-      gradientTransform="matrix(1 0 0 -1 0 61)"
-    >
-      <stop offset={0.118} stopColor="#0095d5" />
-      <stop offset={0.418} stopColor="#3c83dc" />
-      <stop offset={0.696} stopColor="#6d74e1" />
-      <stop offset={0.833} stopColor="#806ee3" />
-    </linearGradient>
-    <path fill="url(#kotlin-b)" d="M0 0L30.1 0 0 32.5z" />
-    <linearGradient
-      id="kotlin-c"
-      gradientUnits="userSpaceOnUse"
-      x1={-10.102}
-      y1={5.836}
-      x2={45.731}
-      y2={61.669}
-      gradientTransform="matrix(1 0 0 -1 0 61)"
-    >
-      <stop offset={0.107} stopColor="#c757bc" />
-      <stop offset={0.214} stopColor="#d0609a" />
-      <stop offset={0.425} stopColor="#e1725c" />
-      <stop offset={0.605} stopColor="#ee7e2f" />
-      <stop offset={0.743} stopColor="#f58613" />
-      <stop offset={0.823} stopColor="#f88909" />
-    </linearGradient>
-    <path fill="url(#kotlin-c)" d="M30.1 0L0 31.7 0 60 30.1 29.9 60 0z" />
-  </svg>
+      <linearGradient
+        id="kotlin-a"
+        gradientUnits="userSpaceOnUse"
+        x1={15.959}
+        y1={-13.014}
+        x2={44.307}
+        y2={15.333}
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset={0.097} stopColor="#0095d5" />
+        <stop offset={0.301} stopColor="#238ad9" />
+        <stop offset={0.621} stopColor="#557bde" />
+        <stop offset={0.864} stopColor="#7472e2" />
+        <stop offset={1} stopColor="#806ee3" />
+      </linearGradient>
+      <path fill="url(#kotlin-a)" d="M0 60L30.1 29.9 60 60z" />
+      <linearGradient
+        id="kotlin-b"
+        gradientUnits="userSpaceOnUse"
+        x1={4.209}
+        y1={48.941}
+        x2={20.673}
+        y2={65.405}
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset={0.118} stopColor="#0095d5" />
+        <stop offset={0.418} stopColor="#3c83dc" />
+        <stop offset={0.696} stopColor="#6d74e1" />
+        <stop offset={0.833} stopColor="#806ee3" />
+      </linearGradient>
+      <path fill="url(#kotlin-b)" d="M0 0L30.1 0 0 32.5z" />
+      <linearGradient
+        id="kotlin-c"
+        gradientUnits="userSpaceOnUse"
+        x1={-10.102}
+        y1={5.836}
+        x2={45.731}
+        y2={61.669}
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset={0.107} stopColor="#c757bc" />
+        <stop offset={0.214} stopColor="#d0609a" />
+        <stop offset={0.425} stopColor="#e1725c" />
+        <stop offset={0.605} stopColor="#ee7e2f" />
+        <stop offset={0.743} stopColor="#f58613" />
+        <stop offset={0.823} stopColor="#f88909" />
+      </linearGradient>
+      <path fill="url(#kotlin-c)" d="M30.1 0L0 31.7 0 60 30.1 29.9 60 0z" />
+    </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/KotlinLogo.tsx
+++ b/ui/src/clientLibraries/graphics/KotlinLogo.tsx
@@ -1,0 +1,16 @@
+// Libraries
+import React, {SFC} from 'react'
+
+const KotlinLogo: SFC = () => {
+  return (
+    <svg
+      width="50%"
+      height="50%"
+      id="kotlin_logo"
+      viewBox="0 0 100 100"
+      xmlSpace="preserve"
+    />
+  )
+}
+
+export default KotlinLogo

--- a/ui/src/clientLibraries/graphics/KotlinLogo.tsx
+++ b/ui/src/clientLibraries/graphics/KotlinLogo.tsx
@@ -3,13 +3,56 @@ import React, {SFC} from 'react'
 
 const KotlinLogo: SFC = () => {
   return (
-    <svg
-      width="50%"
-      height="50%"
-      id="kotlin_logo"
-      viewBox="0 0 100 100"
-      xmlSpace="preserve"
-    />
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
+      <linearGradient
+        id="kotlin-a"
+        gradientUnits="userSpaceOnUse"
+        x1="15.959"
+        y1="-13.014"
+        x2="44.307"
+        y2="15.333"
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset=".097" stop-color="#0095d5" />
+        <stop offset=".301" stop-color="#238ad9" />
+        <stop offset=".621" stop-color="#557bde" />
+        <stop offset=".864" stop-color="#7472e2" />
+        <stop offset="1" stop-color="#806ee3" />
+      </linearGradient>
+      <path fill="url(#kotlin-a)" d="M0 60l30.1-30.1L60 60z" />
+      <linearGradient
+        id="kotlin-b"
+        gradientUnits="userSpaceOnUse"
+        x1="4.209"
+        y1="48.941"
+        x2="20.673"
+        y2="65.405"
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset=".118" stop-color="#0095d5" />
+        <stop offset=".418" stop-color="#3c83dc" />
+        <stop offset=".696" stop-color="#6d74e1" />
+        <stop offset=".833" stop-color="#806ee3" />
+      </linearGradient>
+      <path fill="url(#kotlin-b)" d="M0 0h30.1L0 32.5z" />
+      <linearGradient
+        id="c"
+        gradientUnits="userSpaceOnUse"
+        x1="-10.102"
+        y1="5.836"
+        x2="45.731"
+        y2="61.669"
+        gradientTransform="matrix(1 0 0 -1 0 61)"
+      >
+        <stop offset=".107" stop-color="#c757bc" />
+        <stop offset=".214" stop-color="#d0609a" />
+        <stop offset=".425" stop-color="#e1725c" />
+        <stop offset=".605" stop-color="#ee7e2f" />
+        <stop offset=".743" stop-color="#f58613" />
+        <stop offset=".823" stop-color="#f88909" />
+      </linearGradient>
+      <path fill="url(#c)" d="M30.1 0L0 31.7V60l30.1-30.1L60 0z" />
+    </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/ScalaLogo.tsx
+++ b/ui/src/clientLibraries/graphics/ScalaLogo.tsx
@@ -3,27 +3,86 @@ import React, {SFC} from 'react'
 
 const ScalaLogo: SFC = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 550">
-      <defs>
-        <linearGradient id="scala-b" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#a00000" />
-          <stop offset="100%" stopColor="red" />
-        </linearGradient>
-        <linearGradient id="scala-a" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#646464" />
-          <stop offset="100%" />
-        </linearGradient>
-      </defs>
-      <g fill="url(#scala-a)">
-        <path d="M30 200s300 30 300 80V160s0-50-300-80V-40z" />
-        <path d="M30 360s300 30 300 80V320s0-50-300-80V120z" />
-      </g>
-      <g fill="url(#scala-b)">
-        <path d="M30 80S330 50 330 0v120s0 50-300 80v120z" />
-        <path d="M30 240s300-30 300-80v120s0 50-300 80v120z" />
-        <path d="M30 400s300-30 300-80v120s0 50-300 80v120z" />
-      </g>
-    </svg>
+    <svg viewBox="0 0 64 64" height={100} width={100}>
+    <linearGradient id="scala-a">
+      <stop offset={0} stopColor="#656565" />
+      <stop offset={1} stopColor="#010101" />
+    </linearGradient>
+    <linearGradient
+      id="scala-c"
+      gradientUnits="userSpaceOnUse"
+      x1={13.528}
+      x2={88.264}
+      xlinkHref="#scala-a"
+      y1={-36.176}
+      y2={-36.176}
+    />
+    <linearGradient
+      id="scala-d"
+      gradientUnits="userSpaceOnUse"
+      x1={13.528}
+      x2={88.264}
+      xlinkHref="#scala-a"
+      y1={3.91}
+      y2={3.91}
+    />
+    <linearGradient id="scala-b">
+      <stop offset={0} stopColor="#9f1c20" />
+      <stop offset={1} stopColor="#ed2224" />
+    </linearGradient>
+    <linearGradient
+      id="scala-e"
+      gradientUnits="userSpaceOnUse"
+      x1={13.528}
+      x2={88.264}
+      xlinkHref="#scala-b"
+      y1={-55.974}
+      y2={-55.974}
+    />
+    <linearGradient
+      id="scala-f"
+      gradientUnits="userSpaceOnUse"
+      x1={13.528}
+      x2={88.264}
+      xlinkHref="#scala-b"
+      y1={-15.87}
+      y2={-15.87}
+    />
+    <linearGradient
+      id="scala-g"
+      gradientUnits="userSpaceOnUse"
+      x1={13.528}
+      x2={88.264}
+      xlinkHref="#scala-b"
+      y1={24.22}
+      y2={24.22}
+    />
+    <path
+      d="M13.4-31s75 7.5 75 20v-30s0-12.5-75-20z"
+      fill="url(#scala-d)"
+      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+    />
+    <path
+      d="M13.4 9s75 7.5 75 20V-1s0-12.5-75-20z"
+      fill="url(#scala-d)"
+      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+    />
+    <path
+      d="M88.4-81v30s0 12.5-75 20v-30s75-7.5 75-20"
+      fill="url(#scala-e)"
+      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+    />
+    <path
+      d="M13.4-21s75-7.5 75-20v30s0 12.5-75 20z"
+      fill="url(#scala-f)"
+      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+    />
+    <path
+      d="M13.4 49V19s75-7.5 75-20v30s0 12.5-75 20"
+      fill="url(#scala-g)"
+      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+    />
+  </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/ScalaLogo.tsx
+++ b/ui/src/clientLibraries/graphics/ScalaLogo.tsx
@@ -3,13 +3,27 @@ import React, {SFC} from 'react'
 
 const ScalaLogo: SFC = () => {
   return (
-    <svg
-      width="50%"
-      height="50%"
-      id="scala_logo"
-      viewBox="0 0 100 100"
-      xmlSpace="preserve"
-    />
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 550">
+      <defs>
+        <linearGradient id="scala-b" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="#a00000" />
+          <stop offset="100%" stopColor="red" />
+        </linearGradient>
+        <linearGradient id="scala-a" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="#646464" />
+          <stop offset="100%" />
+        </linearGradient>
+      </defs>
+      <g fill="url(#scala-a)">
+        <path d="M30 200s300 30 300 80V160s0-50-300-80V-40z" />
+        <path d="M30 360s300 30 300 80V320s0-50-300-80V120z" />
+      </g>
+      <g fill="url(#scala-b)">
+        <path d="M30 80S330 50 330 0v120s0 50-300 80v120z" />
+        <path d="M30 240s300-30 300-80v120s0 50-300 80v120z" />
+        <path d="M30 400s300-30 300-80v120s0 50-300 80v120z" />
+      </g>
+    </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/ScalaLogo.tsx
+++ b/ui/src/clientLibraries/graphics/ScalaLogo.tsx
@@ -4,85 +4,85 @@ import React, {SFC} from 'react'
 const ScalaLogo: SFC = () => {
   return (
     <svg viewBox="0 0 64 64" height={100} width={100}>
-    <linearGradient id="scala-a">
-      <stop offset={0} stopColor="#656565" />
-      <stop offset={1} stopColor="#010101" />
-    </linearGradient>
-    <linearGradient
-      id="scala-c"
-      gradientUnits="userSpaceOnUse"
-      x1={13.528}
-      x2={88.264}
-      xlinkHref="#scala-a"
-      y1={-36.176}
-      y2={-36.176}
-    />
-    <linearGradient
-      id="scala-d"
-      gradientUnits="userSpaceOnUse"
-      x1={13.528}
-      x2={88.264}
-      xlinkHref="#scala-a"
-      y1={3.91}
-      y2={3.91}
-    />
-    <linearGradient id="scala-b">
-      <stop offset={0} stopColor="#9f1c20" />
-      <stop offset={1} stopColor="#ed2224" />
-    </linearGradient>
-    <linearGradient
-      id="scala-e"
-      gradientUnits="userSpaceOnUse"
-      x1={13.528}
-      x2={88.264}
-      xlinkHref="#scala-b"
-      y1={-55.974}
-      y2={-55.974}
-    />
-    <linearGradient
-      id="scala-f"
-      gradientUnits="userSpaceOnUse"
-      x1={13.528}
-      x2={88.264}
-      xlinkHref="#scala-b"
-      y1={-15.87}
-      y2={-15.87}
-    />
-    <linearGradient
-      id="scala-g"
-      gradientUnits="userSpaceOnUse"
-      x1={13.528}
-      x2={88.264}
-      xlinkHref="#scala-b"
-      y1={24.22}
-      y2={24.22}
-    />
-    <path
-      d="M13.4-31s75 7.5 75 20v-30s0-12.5-75-20z"
-      fill="url(#scala-d)"
-      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
-    />
-    <path
-      d="M13.4 9s75 7.5 75 20V-1s0-12.5-75-20z"
-      fill="url(#scala-d)"
-      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
-    />
-    <path
-      d="M88.4-81v30s0 12.5-75 20v-30s75-7.5 75-20"
-      fill="url(#scala-e)"
-      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
-    />
-    <path
-      d="M13.4-21s75-7.5 75-20v30s0 12.5-75 20z"
-      fill="url(#scala-f)"
-      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
-    />
-    <path
-      d="M13.4 49V19s75-7.5 75-20v30s0 12.5-75 20"
-      fill="url(#scala-g)"
-      transform="matrix(.4923 0 0 .4923 6.942 39.877)"
-    />
-  </svg>
+      <linearGradient id="scala-a">
+        <stop offset={0} stopColor="#656565" />
+        <stop offset={1} stopColor="#010101" />
+      </linearGradient>
+      <linearGradient
+        id="scala-c"
+        gradientUnits="userSpaceOnUse"
+        x1={13.528}
+        x2={88.264}
+        xlinkHref="#scala-a"
+        y1={-36.176}
+        y2={-36.176}
+      />
+      <linearGradient
+        id="scala-d"
+        gradientUnits="userSpaceOnUse"
+        x1={13.528}
+        x2={88.264}
+        xlinkHref="#scala-a"
+        y1={3.91}
+        y2={3.91}
+      />
+      <linearGradient id="scala-b">
+        <stop offset={0} stopColor="#9f1c20" />
+        <stop offset={1} stopColor="#ed2224" />
+      </linearGradient>
+      <linearGradient
+        id="scala-e"
+        gradientUnits="userSpaceOnUse"
+        x1={13.528}
+        x2={88.264}
+        xlinkHref="#scala-b"
+        y1={-55.974}
+        y2={-55.974}
+      />
+      <linearGradient
+        id="scala-f"
+        gradientUnits="userSpaceOnUse"
+        x1={13.528}
+        x2={88.264}
+        xlinkHref="#scala-b"
+        y1={-15.87}
+        y2={-15.87}
+      />
+      <linearGradient
+        id="scala-g"
+        gradientUnits="userSpaceOnUse"
+        x1={13.528}
+        x2={88.264}
+        xlinkHref="#scala-b"
+        y1={24.22}
+        y2={24.22}
+      />
+      <path
+        d="M13.4-31s75 7.5 75 20v-30s0-12.5-75-20z"
+        fill="url(#scala-d)"
+        transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+      />
+      <path
+        d="M13.4 9s75 7.5 75 20V-1s0-12.5-75-20z"
+        fill="url(#scala-d)"
+        transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+      />
+      <path
+        d="M88.4-81v30s0 12.5-75 20v-30s75-7.5 75-20"
+        fill="url(#scala-e)"
+        transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+      />
+      <path
+        d="M13.4-21s75-7.5 75-20v30s0 12.5-75 20z"
+        fill="url(#scala-f)"
+        transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+      />
+      <path
+        d="M13.4 49V19s75-7.5 75-20v30s0 12.5-75 20"
+        fill="url(#scala-g)"
+        transform="matrix(.4923 0 0 .4923 6.942 39.877)"
+      />
+    </svg>
   )
 }
 

--- a/ui/src/clientLibraries/graphics/ScalaLogo.tsx
+++ b/ui/src/clientLibraries/graphics/ScalaLogo.tsx
@@ -1,0 +1,16 @@
+// Libraries
+import React, {SFC} from 'react'
+
+const ScalaLogo: SFC = () => {
+  return (
+    <svg
+      width="50%"
+      height="50%"
+      id="scala_logo"
+      viewBox="0 0 100 100"
+      xmlSpace="preserve"
+    />
+  )
+}
+
+export default ScalaLogo

--- a/ui/src/clientLibraries/graphics/index.ts
+++ b/ui/src/clientLibraries/graphics/index.ts
@@ -4,9 +4,11 @@ import GoLogo from 'src/clientLibraries/graphics/GoLogo'
 import {GoogleLogo} from 'src/clientLibraries/graphics/GoogleLogo'
 import JavaLogo from 'src/clientLibraries/graphics/JavaLogo'
 import JSLogo from 'src/clientLibraries/graphics/JSLogo'
+import KotlinLogo from 'src/clientLibraries/graphics/KotlinLogo'
 import PHPLogo from 'src/clientLibraries/graphics/PHPLogo'
 import PythonLogo from 'src/clientLibraries/graphics/PythonLogo'
 import RubyLogo from 'src/clientLibraries/graphics/RubyLogo'
+import ScalaLogo from 'src/clientLibraries/graphics/ScalaLogo'
 
 export {
   CSharpLogo,
@@ -15,7 +17,9 @@ export {
   GoogleLogo,
   JavaLogo,
   JSLogo,
+  KotlinLogo,
   PHPLogo,
   PythonLogo,
   RubyLogo,
+  ScalaLogo,
 }

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -54,9 +54,11 @@ import ClientCSharpOverlay from 'src/clientLibraries/components/ClientCSharpOver
 import ClientGoOverlay from 'src/clientLibraries/components/ClientGoOverlay'
 import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
 import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
+import ClientKotlinOverlay from 'src/clientLibraries/components/ClientKotlinOverlay'
 import ClientPHPOverlay from 'src/clientLibraries/components/ClientPHPOverlay'
 import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
 import ClientRubyOverlay from 'src/clientLibraries/components/ClientRubyOverlay'
+import ClientScalaOverlay from 'src/clientLibraries/components/ClientScalaOverlay'
 import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
 import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
@@ -372,6 +374,10 @@ class Root extends PureComponent {
                                   component={ClientJSOverlay}
                                 />
                                 <Route
+                                  path="kotlin"
+                                  component={ClientKotlinOverlay}
+                                />
+                                <Route
                                   path="php"
                                   component={ClientPHPOverlay}
                                 />
@@ -382,6 +388,10 @@ class Root extends PureComponent {
                                 <Route
                                   path="ruby"
                                   component={ClientRubyOverlay}
+                                />
+                                <Route
+                                  path="scala"
+                                  component={ClientScalaOverlay}
                                 />
                               </Route>
                             </Route>


### PR DESCRIPTION
1. add Kotlin client library
1. add Scala client library

`KotlinLogo.tsx` and `ScalaLogo.tsx` are just placeholders.

![Screenshot 2020-05-22 at 09 09 55](https://user-images.githubusercontent.com/455137/82642311-fceb2c00-9c0d-11ea-9c7a-0a4da85dbbbc.png)

![Screenshot 2020-05-22 at 09 10 25](https://user-images.githubusercontent.com/455137/82642329-01afe000-9c0e-11ea-95ae-5268395c1506.png)
![Screenshot 2020-05-22 at 09 10 11](https://user-images.githubusercontent.com/455137/82642334-02487680-9c0e-11ea-85c4-60418061a9c3.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
