### PR TITLE
feat: allow monaco to autogrow

### DIFF
--- a/ui/src/external/monaco.autogrow.ts
+++ b/ui/src/external/monaco.autogrow.ts
@@ -18,7 +18,7 @@ export const registerAutogrow = editor => {
 
     if (prevHeight !== Math.max(MIN_HEIGHT, height)) {
       prevHeight = Math.max(MIN_HEIGHT, height)
-      editorElement.style.height = `${height}px`
+      editorElement.style.height = `${prevHeight}px`
       editor.layout()
     }
   }

--- a/ui/src/external/monaco.flux.autogrow.ts
+++ b/ui/src/external/monaco.flux.autogrow.ts
@@ -10,7 +10,9 @@ export const registerAutogrow = editor => {
       return
     }
 
-    const lineHeight = editor.getOption(window.monaco.editor.EditorOption.lineHeight)
+    const lineHeight = editor.getOption(
+      window.monaco.editor.EditorOption.lineHeight
+    )
     const lineCount = (editor.getModel() || {}).getLineCount() || 1
     const height = editor.getTopForLineNumber(lineCount + 1) + lineHeight
 

--- a/ui/src/external/monaco.flux.autogrow.ts
+++ b/ui/src/external/monaco.flux.autogrow.ts
@@ -10,7 +10,7 @@ export const registerAutogrow = editor => {
       return
     }
 
-    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight)
+    const lineHeight = editor.getOption(window.monaco.editor.EditorOption.lineHeight)
     const lineCount = (editor.getModel() || {}).getLineCount() || 1
     const height = editor.getTopForLineNumber(lineCount + 1) + lineHeight
 

--- a/ui/src/external/monaco.flux.autogrow.ts
+++ b/ui/src/external/monaco.flux.autogrow.ts
@@ -1,0 +1,39 @@
+const MIN_HEIGHT = 100
+
+export const registerAutogrow = editor => {
+  let prevHeight = 0
+
+  const updateEditorHeight = () => {
+    const editorElement = editor.getDomNode()
+
+    if (!editorElement) {
+      return
+    }
+
+    const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight)
+    const lineCount = (editor.getModel() || {}).getLineCount() || 1
+    const height = editor.getTopForLineNumber(lineCount + 1) + lineHeight
+
+    if (prevHeight !== Math.max(MIN_HEIGHT, height)) {
+      prevHeight = Math.max(MIN_HEIGHT, height)
+      editorElement.style.height = `${height}px`
+      editor.layout()
+    }
+  }
+
+  editor.updateOptions({
+    minimap: {
+      enabled: false,
+    },
+    scrollbar: {
+      vertical: 'hidden',
+      handleMouseWheel: false,
+    },
+    scrollBeyondLastLine: false,
+  })
+
+  editor.onDidChangeModelDecorations(() => {
+    updateEditorHeight() // typing
+    requestAnimationFrame(updateEditorHeight) // folding
+  })
+}

--- a/ui/src/notebooks/pipes/Query/style.scss
+++ b/ui/src/notebooks/pipes/Query/style.scss
@@ -1,4 +1,8 @@
-.notebook-query {
-    height: 300px;
-    position: relative;
+.notebook-panel--body .flux-editor--monaco {
+  position: relative;
+
+  .react-monaco-editor-container {
+      min-height: 100px;
+  }
 }
+

--- a/ui/src/notebooks/pipes/Query/view.tsx
+++ b/ui/src/notebooks/pipes/Query/view.tsx
@@ -23,6 +23,7 @@ const Query: FC<PipeProp> = ({data, onUpdate, Context}) => {
           script={query.text}
           onChangeScript={updateText}
           onSubmitScript={() => {}}
+          autogrow
         />
       </Context>
     ),

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -156,15 +156,6 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
   padding-top: 0;
 }
 
-.notebook-panel--body .flux-editor--monaco {
-  position: relative;
-  min-height: 320px;
-
-  .react-monaco-editor-container {
-    position: absolute;
-  }
-}
-
 .notebook-panel--results {
   width: 100%;
   height: 320px;

--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -10,7 +10,7 @@ import FLUXLANGID from 'src/external/monaco.flux.syntax'
 import THEME_NAME from 'src/external/monaco.flux.theme'
 import loadServer, {LSPServer} from 'src/external/monaco.flux.server'
 import {comments, submit} from 'src/external/monaco.flux.hotkeys'
-import {registerAutogrow} from 'src/external/monaco.flux.autogrow'
+import {registerAutogrow} from 'src/external/monaco.autogrow'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types

--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -10,6 +10,7 @@ import FLUXLANGID from 'src/external/monaco.flux.syntax'
 import THEME_NAME from 'src/external/monaco.flux.theme'
 import loadServer, {LSPServer} from 'src/external/monaco.flux.server'
 import {comments, submit} from 'src/external/monaco.flux.hotkeys'
+import {registerAutogrow} from 'src/external/monaco.flux.autogrow'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
@@ -27,6 +28,7 @@ interface Props {
   onSubmitScript?: () => void
   setEditorInstance?: (editor: EditorType) => void
   skipFocus?: boolean
+  autogrow?: boolean
 }
 
 const FluxEditorMonaco: FC<Props> = ({
@@ -35,6 +37,7 @@ const FluxEditorMonaco: FC<Props> = ({
   onSubmitScript,
   setEditorInstance,
   skipFocus,
+  autogrow,
 }) => {
   const lspServer = useRef<LSPServer>(null)
   const [editorInst, seteditorInst] = useState<EditorType | null>(null)
@@ -65,6 +68,10 @@ const FluxEditorMonaco: FC<Props> = ({
         onSubmitScript()
       }
     })
+
+    if (autogrow) {
+      registerAutogrow(editor)
+    }
 
     try {
       lspServer.current = await loadServer()


### PR DESCRIPTION

![Kapture 2020-05-22 at 17 26 18](https://user-images.githubusercontent.com/1434802/82717518-70625d00-9c51-11ea-88c6-13b524097665.gif)


This allows monaco to grow to whatever hight it wants to fill the content, allowing interfaces that grow vertically. Removes minimap and the scrollbar as well, as they dont make sense when you can't scroll