### PR TITLE
chore: Fix gitignore for accidental binary commits.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,15 +83,12 @@ cmd/influxd/version.go
 **/influx_stress
 !**/influx_stress/
 
-/influxd
 **/influxd
 !**/influxd/
 
-/influx
 **/influx
 !**/influx/
 
-/influxdb
 **/influxdb
 !**/influxdb/
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,27 +75,27 @@ cmd/influxd/version.go
 
 *.test
 
-influx_tsm
+/influx_tsm
 **/influx_tsm
 !**/influx_tsm/
 
-influx_stress
+/influx_stress
 **/influx_stress
 !**/influx_stress/
 
-influxd
+/influxd
 **/influxd
 !**/influxd/
 
-influx
+/influx
 **/influx
 !**/influx/
 
-influxdb
+/influxdb
 **/influxdb
 !**/influxdb/
 
-influx_inspect
+/influx_inspect
 **/influx_inspect
 !**/influx_inspect/
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,26 +75,23 @@ cmd/influxd/version.go
 
 *.test
 
-/influx_tsm
-**/influx_tsm
 !**/influx_tsm/
+**/influx_tsm
 
-/influx_stress
-**/influx_stress
 !**/influx_stress/
+**/influx_stress
 
-**/influxd
 !**/influxd/
+**/influxd
 
-**/influx
 !**/influx/
+**/influx
 
-**/influxdb
 !**/influxdb/
+**/influxdb
 
-/influx_inspect
-**/influx_inspect
 !**/influx_inspect/
+**/influx_inspect
 
 /benchmark-tool
 /main


### PR DESCRIPTION
The current `.gitignore` patterns for accidental commits of binaries like `influxd` and `influx` are too aggressive. It's common for tooling to use `.gitignore` to filter out files from listings.

These rules cause the entire `cmd/*` directory to be excluded before the exclusion (!*) rules are applied. Per gitignore manfile:

    An optional prefix "!" which negates the pattern; any matching file
    excluded by a previous pattern will become included again. It is not
    possible to re-include a file if a parent directory of that file is
    excluded.

The result is that any files/packages inside `cmd/*` directories cannot be found by tooling  that use `.gitignore` for file-filtering.

This adjusts the most permissive of the rules to target project root only. Files found at other locations in the tree will be ignored correctly. I've tested this by touching files in many places with names that should be ignored; all the while still being able to use `fzf` to access files inside `cmd/influxd/` directory 😸 

This has been problematic for me for some time now when searching for files inside  of directories like `cmd/influxd/launcher/` using `fzf` (which follows `.gitignore` rules).