### PR TITLE
fix(dbrpv2): reflect match count correctly

### DIFF
--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -287,7 +287,7 @@ func (s *Service) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilte
 		}
 	}
 
-	return ms, len(ms), s.store.View(ctx, func(tx kv.Tx) error {
+	err := s.store.View(ctx, func(tx kv.Tx) error {
 		// Optimized path, use index.
 		if orgID := filter.OrgID; orgID != nil {
 			// The index performs a prefix search.
@@ -338,6 +338,8 @@ func (s *Service) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilte
 		}
 		return nil
 	})
+
+	return ms, len(ms), err
 }
 
 // Create creates a new mapping.

--- a/testing/dbrp_mapping_v2.go
+++ b/testing/dbrp_mapping_v2.go
@@ -370,9 +370,12 @@ func CreateDBRPMappingV2(
 				}
 			}
 
-			dbrpMappings, _, err := s.FindMany(ctx, influxdb.DBRPMappingFilterV2{})
+			dbrpMappings, n, err := s.FindMany(ctx, influxdb.DBRPMappingFilterV2{})
 			if err != nil {
 				t.Fatalf("failed to retrieve dbrps: %v", err)
+			}
+			if n != len(tt.wants.dbrpMappings) {
+				t.Errorf("want dbrpMappings count of %d, got %d", len(tt.wants.dbrpMappings), n)
 			}
 			if diff := cmp.Diff(tt.wants.dbrpMappings, dbrpMappings, DBRPMappingCmpOptionsV2...); diff != "" {
 				t.Errorf("dbrpMappings are different -want/+got\ndiff %s", diff)


### PR DESCRIPTION
This PR fixes a bug in the V2 DBRP Mapping Service where the number of matching mappings was returned incorrectly because the length of the match list was calculated before it was populated.

[An illustration of the bug on the Go playground:](https://play.golang.org/p/isuKrz2BtXu)

```
func main() {

	n, a := func() (int, []string) {
		var b []string
		return len(b), func() []string {
			for i := 0; i < 3; i++ {
				b = append(b, fmt.Sprintf("%d", i))
			}
			return b
		}()
	}()

	fmt.Printf("n: %d, a: %v\n", n, a)
}
```

```
n: 0, a: [0 1 2]
```

Tests are also updated and have been confirmed to fail without the fix in place.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
