### PR TITLE
feat(notification/telegram): add telegram notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Features
 
-1. [19075](https://github.com/influxdata/influxdb/pull/19075): Aadd resource links to a stack's resources from public HTTP API list/read calls
+1. [19075](https://github.com/influxdata/influxdb/pull/19075): Add resource links to a stack's resources from public HTTP API list/read calls
+1. [18218](https://github.com/influxdata/influxdb/pull/18218): Add Telegram notification.
 
 ### Bug Fixes
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -11616,9 +11616,6 @@ components:
         messageTemplate:
           description: The message template as a flux interpolated string.
           type: string
-        channel:
-          description: Id of the telegram channel.
-          type: string
         parseMode:
           description: Parse mode of the message text per https://core.telegram.org/bots/api#formatting-options . Defaults to "MarkdownV2" .
           type: string
@@ -11778,9 +11775,13 @@ components:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointBase"
         - type: object
+          required: [token, channel]
           properties:
             token:
               description: Specifies the Telegram bot token. See https://core.telegram.org/bots#creating-a-new-bot .
+              type: string
+            channel:
+              description: ID of the telegram channel, a chat_id in https://core.telegram.org/bots/api#sendmessage .
               type: string
     NotificationEndpointType:
       type: string

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -11391,6 +11391,7 @@ components:
         - $ref: "#/components/schemas/SMTPNotificationRule"
         - $ref: "#/components/schemas/PagerDutyNotificationRule"
         - $ref: "#/components/schemas/HTTPNotificationRule"
+        - $ref: "#/components/schemas/TelegramNotificationRule"
       discriminator:
         propertyName: type
         mapping:
@@ -11398,6 +11399,7 @@ components:
           smtp: "#/components/schemas/SMTPNotificationRule"
           pagerduty: "#/components/schemas/PagerDutyNotificationRule"
           http: "#/components/schemas/HTTPNotificationRule"
+          telegram: "#/components/schemas/TelegramNotificationRule"
     NotificationRule:
       allOf:
         - $ref: "#/components/schemas/NotificationRuleDiscriminator"
@@ -11599,6 +11601,34 @@ components:
           enum: [pagerduty]
         messageTemplate:
           type: string
+    TelegramNotificationRule:
+      allOf:
+        - $ref: "#/components/schemas/NotificationRuleBase"
+        - $ref: "#/components/schemas/TelegramNotificationRuleBase"
+    TelegramNotificationRuleBase:
+      type: object
+      required: [type, messageTemplate, channel]
+      properties:
+        type:
+          description: The discriminator between other types of notification rules is "telegram".
+          type: string
+          enum: [telegram]
+        messageTemplate:
+          description: The message template as a flux interpolated string.
+          type: string
+        channel:
+          description: Id of the telegram channel.
+          type: string
+        parseMode:
+          description: Parse mode of the message text per https://core.telegram.org/bots/api#formatting-options . Defaults to "MarkdownV2" .
+          type: string
+          enum:
+            - MarkdownV2
+            - HTML
+            - Markdown
+        disableWebPagePreview:
+          description: Disables preview of web links in the sent messages when "true". Defaults to "false" .
+          type: boolean
     NotificationEndpointUpdate:
       type: object
 
@@ -11617,12 +11647,14 @@ components:
         - $ref: "#/components/schemas/SlackNotificationEndpoint"
         - $ref: "#/components/schemas/PagerDutyNotificationEndpoint"
         - $ref: "#/components/schemas/HTTPNotificationEndpoint"
+        - $ref: "#/components/schemas/TelegramNotificationEndpoint"
       discriminator:
         propertyName: type
         mapping:
           slack: "#/components/schemas/SlackNotificationEndpoint"
           pagerduty: "#/components/schemas/PagerDutyNotificationEndpoint"
           http: "#/components/schemas/HTTPNotificationEndpoint"
+          telegram: "#/components/schemas/TelegramNotificationEndpoint"
     NotificationEndpoint:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointDiscrimator"
@@ -11741,9 +11773,18 @@ components:
               description: Customized headers.
               additionalProperties:
                 type: string
+    TelegramNotificationEndpoint:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/NotificationEndpointBase"
+        - type: object
+          properties:
+            token:
+              description: Specifies the Telegram bot token. See https://core.telegram.org/bots#creating-a-new-bot .
+              type: string
     NotificationEndpointType:
       type: string
-      enum: ["slack", "pagerduty", "http"]
+      enum: ["slack", "pagerduty", "http", "telegram"]
     DBRP:
       required:
         - orgID

--- a/notification/endpoint/endpoint.go
+++ b/notification/endpoint/endpoint.go
@@ -12,12 +12,14 @@ const (
 	SlackType     = "slack"
 	PagerDutyType = "pagerduty"
 	HTTPType      = "http"
+	TelegramType  = "telegram"
 )
 
 var typeToEndpoint = map[string]func() influxdb.NotificationEndpoint{
 	SlackType:     func() influxdb.NotificationEndpoint { return &Slack{} },
 	PagerDutyType: func() influxdb.NotificationEndpoint { return &PagerDuty{} },
 	HTTPType:      func() influxdb.NotificationEndpoint { return &HTTP{} },
+	TelegramType:  func() influxdb.NotificationEndpoint { return &Telegram{} },
 }
 
 // UnmarshalJSON will convert the bytes to notification endpoint.

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -62,7 +62,8 @@ func TestValidEndpoint(t *testing.T) {
 					OrgID:  influxTesting.MustIDBase16Ptr(id3),
 					Status: influxdb.Active,
 				},
-				Token: influxdb.SecretField{Key: id1 + "-token"},
+				Token:   influxdb.SecretField{Key: id1 + "-token"},
+				Channel: "-1001406363649",
 			},
 			err: &influxdb.Error{
 				Code: influxdb.EInvalid,
@@ -146,10 +147,22 @@ func TestValidEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "valid telegram token",
+			name: "empty telegram channel",
 			src: &endpoint.Telegram{
 				Base:  goodBase,
 				Token: influxdb.SecretField{Key: id1 + "-token"},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "empty telegram channel",
+			},
+		},
+		{
+			name: "valid telegram token",
+			src: &endpoint.Telegram{
+				Base:    goodBase,
+				Token:   influxdb.SecretField{Key: id1 + "-token"},
+				Channel: "-1001406363649",
 			},
 			err: nil,
 		},

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -55,7 +55,23 @@ func TestValidEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "empty name",
+			name: "empty name PagerDuty",
+			src: &endpoint.PagerDuty{
+				Base: endpoint.Base{
+					ID:     influxTesting.MustIDBase16Ptr(id1),
+					OrgID:  influxTesting.MustIDBase16Ptr(id3),
+					Status: influxdb.Active,
+				},
+				ClientURL:  "https://events.pagerduty.com/v2/enqueue",
+				RoutingKey: influxdb.SecretField{Key: id1 + "-routing-key"},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "Notification Endpoint Name can't be empty",
+			},
+		},
+		{
+			name: "empty name Telegram",
 			src: &endpoint.Telegram{
 				Base: endpoint.Base{
 					ID:     influxTesting.MustIDBase16Ptr(id1),

--- a/notification/endpoint/telegram.go
+++ b/notification/endpoint/telegram.go
@@ -1,0 +1,67 @@
+package endpoint
+
+import (
+	"encoding/json"
+
+	"github.com/influxdata/influxdb/v2"
+)
+
+var _ influxdb.NotificationEndpoint = &Telegram{}
+
+const telegramTokenSuffix = "-token"
+
+// Telegram is the notification endpoint config of telegram.
+type Telegram struct {
+	Base
+	// Token is the telegram bot token, see https://core.telegram.org/bots#creating-a-new-bot
+	Token influxdb.SecretField `json:"token"`
+}
+
+// BackfillSecretKeys fill back the secret field key during the unmarshalling
+// if value of that secret field is not nil.
+func (s *Telegram) BackfillSecretKeys() {
+	if s.Token.Key == "" && s.Token.Value != nil {
+		s.Token.Key = s.idStr() + telegramTokenSuffix
+	}
+}
+
+// SecretFields return available secret fields.
+func (s Telegram) SecretFields() []influxdb.SecretField {
+	arr := []influxdb.SecretField{}
+	if s.Token.Key != "" {
+		arr = append(arr, s.Token)
+	}
+	return arr
+}
+
+// Valid returns error if some configuration is invalid
+func (s Telegram) Valid() error {
+	if err := s.Base.valid(); err != nil {
+		return err
+	}
+	if s.Token.Key == "" {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "empty telegram bot token",
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implement json.Marshaler interface.
+func (s Telegram) MarshalJSON() ([]byte, error) {
+	type telegramAlias Telegram
+	return json.Marshal(
+		struct {
+			telegramAlias
+			Type string `json:"type"`
+		}{
+			telegramAlias: telegramAlias(s),
+			Type:          s.Type(),
+		})
+}
+
+// Type returns the type.
+func (s Telegram) Type() string {
+	return TelegramType
+}

--- a/notification/endpoint/telegram.go
+++ b/notification/endpoint/telegram.go
@@ -15,6 +15,8 @@ type Telegram struct {
 	Base
 	// Token is the telegram bot token, see https://core.telegram.org/bots#creating-a-new-bot
 	Token influxdb.SecretField `json:"token"`
+	// Channel is an ID of the telegram channel, see https://core.telegram.org/bots/api#sendmessage
+	Channel string `json:"channel"`
 }
 
 // BackfillSecretKeys fill back the secret field key during the unmarshalling
@@ -43,6 +45,12 @@ func (s Telegram) Valid() error {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "empty telegram bot token",
+		}
+	}
+	if s.Channel == "" {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "empty telegram channel",
 		}
 	}
 	return nil

--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -16,6 +16,7 @@ var typeToRule = map[string](func() influxdb.NotificationRule){
 	"slack":     func() influxdb.NotificationRule { return &Slack{} },
 	"pagerduty": func() influxdb.NotificationRule { return &PagerDuty{} },
 	"http":      func() influxdb.NotificationRule { return &HTTP{} },
+	"telegram":  func() influxdb.NotificationRule { return &Telegram{} },
 }
 
 // UnmarshalJSON will convert

--- a/notification/rule/rule_test.go
+++ b/notification/rule/rule_test.go
@@ -321,6 +321,42 @@ func TestJSON(t *testing.T) {
 				MessageTemplate: "msg1",
 			},
 		},
+		{
+			name: "simple telegram",
+			src: &rule.Telegram{
+				Base: rule.Base{
+					ID:          influxTesting.MustIDBase16(id1),
+					OwnerID:     influxTesting.MustIDBase16(id2),
+					Name:        "name1",
+					OrgID:       influxTesting.MustIDBase16(id3),
+					RunbookLink: "runbooklink1",
+					SleepUntil:  &time3,
+					Every:       mustDuration("1h"),
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "k1",
+								Value: "v1",
+							},
+							Operator: influxdb.NotEqual,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "k2",
+								Value: "v2",
+							},
+							Operator: influxdb.RegexEqual,
+						},
+					},
+					CRUDLog: influxdb.CRUDLog{
+						CreatedAt: timeGen1.Now(),
+						UpdatedAt: timeGen2.Now(),
+					},
+				},
+				Channel:         "channel1",
+				MessageTemplate: "blah",
+			},
+		},
 	}
 	for _, c := range cases {
 		b, err := json.Marshal(c.src)

--- a/notification/rule/rule_test.go
+++ b/notification/rule/rule_test.go
@@ -353,7 +353,6 @@ func TestJSON(t *testing.T) {
 						UpdatedAt: timeGen2.Now(),
 					},
 				},
-				Channel:         "channel1",
 				MessageTemplate: "blah",
 			},
 		},

--- a/notification/rule/telegram.go
+++ b/notification/rule/telegram.go
@@ -13,10 +13,10 @@ import (
 // Telegram is the notification rule config of telegram.
 type Telegram struct {
 	Base
+	MessageTemplate       string `json:"messageTemplate"`
 	Channel               string `json:"channel"`
 	ParseMode             string `json:"parseMode"`
 	DisableWebPagePreview bool   `json:"disableWebPagePreview"`
-	MessageTemplate       string `json:"messageTemplate"`
 }
 
 // GenerateFlux generates a flux script for the telegram notification rule.

--- a/notification/rule/telegram.go
+++ b/notification/rule/telegram.go
@@ -36,7 +36,7 @@ func (s *Telegram) GenerateFlux(e influxdb.NotificationEndpoint) (string, error)
 func (s *Telegram) GenerateFluxAST(e *endpoint.Telegram) (*ast.Package, error) {
 	f := flux.File(
 		s.Name,
-		flux.Imports("influxdata/influxdb/monitor", "telegram", "influxdata/influxdb/secrets", "experimental"),
+		flux.Imports("influxdata/influxdb/monitor", "contrib/sranka/telegram", "influxdata/influxdb/secrets", "experimental"),
 		s.generateFluxASTBody(e),
 	)
 	return &ast.Package{Package: "main", Files: []*ast.File{f}}, nil

--- a/notification/rule/telegram.go
+++ b/notification/rule/telegram.go
@@ -1,0 +1,147 @@
+package rule
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/notification/endpoint"
+	"github.com/influxdata/influxdb/v2/notification/flux"
+)
+
+// Telegram is the notification rule config of telegram.
+type Telegram struct {
+	Base
+	Channel               string `json:"channel"`
+	ParseMode             string `json:"parseMode"`
+	DisableWebPagePreview bool   `json:"disableWebPagePreview"`
+	MessageTemplate       string `json:"messageTemplate"`
+}
+
+// GenerateFlux generates a flux script for the telegram notification rule.
+func (s *Telegram) GenerateFlux(e influxdb.NotificationEndpoint) (string, error) {
+	telegramEndpoint, ok := e.(*endpoint.Telegram)
+	if !ok {
+		return "", fmt.Errorf("endpoint provided is a %s, not a Telegram endpoint", e.Type())
+	}
+	p, err := s.GenerateFluxAST(telegramEndpoint)
+	if err != nil {
+		return "", err
+	}
+	return ast.Format(p), nil
+}
+
+// GenerateFluxAST generates a flux AST for the telegram notification rule.
+func (s *Telegram) GenerateFluxAST(e *endpoint.Telegram) (*ast.Package, error) {
+	f := flux.File(
+		s.Name,
+		flux.Imports("influxdata/influxdb/monitor", "telegram", "influxdata/influxdb/secrets", "experimental"),
+		s.generateFluxASTBody(e),
+	)
+	return &ast.Package{Package: "main", Files: []*ast.File{f}}, nil
+}
+
+func (s *Telegram) generateFluxASTBody(e *endpoint.Telegram) []ast.Statement {
+	var statements []ast.Statement
+	statements = append(statements, s.generateTaskOption())
+	if e.Token.Key != "" {
+		statements = append(statements, s.generateFluxASTSecrets(e))
+	}
+	statements = append(statements, s.generateFluxASTEndpoint(e))
+	statements = append(statements, s.generateFluxASTNotificationDefinition(e))
+	statements = append(statements, s.generateFluxASTStatuses())
+	statements = append(statements, s.generateLevelChecks()...)
+	statements = append(statements, s.generateFluxASTNotifyPipe())
+
+	return statements
+}
+
+func (s *Telegram) generateFluxASTSecrets(e *endpoint.Telegram) ast.Statement {
+	call := flux.Call(flux.Member("secrets", "get"), flux.Object(flux.Property("key", flux.String(e.Token.Key))))
+
+	return flux.DefineVariable("telegram_secret", call)
+}
+
+func (s *Telegram) generateFluxASTEndpoint(e *endpoint.Telegram) ast.Statement {
+	props := []*ast.Property{}
+	if e.Token.Key != "" {
+		props = append(props, flux.Property("token", flux.Identifier("telegram_secret")))
+	}
+	if s.ParseMode != "" {
+		props = append(props, flux.Property("parseMode", flux.String(s.ParseMode)))
+	}
+	props = append(props, flux.Property("disableWebPagePreview", flux.Bool(s.DisableWebPagePreview)))
+	call := flux.Call(flux.Member("telegram", "endpoint"), flux.Object(props...))
+
+	return flux.DefineVariable("telegram_endpoint", call)
+}
+
+func (s *Telegram) generateFluxASTNotifyPipe() ast.Statement {
+	endpointProps := []*ast.Property{}
+	endpointProps = append(endpointProps, flux.Property("channel", flux.String(s.Channel)))
+	endpointProps = append(endpointProps, flux.Property("text", flux.String(s.MessageTemplate)))
+	endpointProps = append(endpointProps, flux.Property("silent", s.generateSilent()))
+	endpointFn := flux.Function(flux.FunctionParams("r"), flux.Object(endpointProps...))
+
+	props := []*ast.Property{}
+	props = append(props, flux.Property("data", flux.Identifier("notification")))
+	props = append(props, flux.Property("endpoint",
+		flux.Call(flux.Identifier("telegram_endpoint"), flux.Object(flux.Property("mapFn", endpointFn)))))
+
+	call := flux.Call(flux.Member("monitor", "notify"), flux.Object(props...))
+
+	return flux.ExpressionStatement(flux.Pipe(flux.Identifier("all_statuses"), call))
+}
+
+func (s *Telegram) generateSilent() ast.Expression {
+	level := flux.Member("r", "_level")
+	return flux.If(
+		flux.Equal(level, flux.String("crit")),
+		flux.Bool(true),
+		flux.If(
+			flux.Equal(level, flux.String("warn")),
+			flux.Bool(true),
+			flux.Bool(false),
+		),
+	)
+}
+
+type telegramAlias Telegram
+
+// MarshalJSON implement json.Marshaler interface.
+func (s Telegram) MarshalJSON() ([]byte, error) {
+	return json.Marshal(
+		struct {
+			telegramAlias
+			Type string `json:"type"`
+		}{
+			telegramAlias: telegramAlias(s),
+			Type:          s.Type(),
+		})
+}
+
+// Valid returns where the config is valid.
+func (s Telegram) Valid() error {
+	if err := s.Base.valid(); err != nil {
+		return err
+	}
+	if s.MessageTemplate == "" {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "Telegram MessageTemplate is invalid",
+		}
+	}
+	if s.Channel == "" {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "Telegram Channel is invalid",
+		}
+	}
+	return nil
+}
+
+// Type returns the type of the rule config.
+func (s Telegram) Type() string {
+	return "telegram"
+}

--- a/notification/rule/telegram.go
+++ b/notification/rule/telegram.go
@@ -14,7 +14,6 @@ import (
 type Telegram struct {
 	Base
 	MessageTemplate       string `json:"messageTemplate"`
-	Channel               string `json:"channel"`
 	ParseMode             string `json:"parseMode"`
 	DisableWebPagePreview bool   `json:"disableWebPagePreview"`
 }
@@ -52,7 +51,7 @@ func (s *Telegram) generateFluxASTBody(e *endpoint.Telegram) []ast.Statement {
 	statements = append(statements, s.generateFluxASTNotificationDefinition(e))
 	statements = append(statements, s.generateFluxASTStatuses())
 	statements = append(statements, s.generateLevelChecks()...)
-	statements = append(statements, s.generateFluxASTNotifyPipe())
+	statements = append(statements, s.generateFluxASTNotifyPipe(e))
 
 	return statements
 }
@@ -77,9 +76,9 @@ func (s *Telegram) generateFluxASTEndpoint(e *endpoint.Telegram) ast.Statement {
 	return flux.DefineVariable("telegram_endpoint", call)
 }
 
-func (s *Telegram) generateFluxASTNotifyPipe() ast.Statement {
+func (s *Telegram) generateFluxASTNotifyPipe(e *endpoint.Telegram) ast.Statement {
 	endpointProps := []*ast.Property{}
-	endpointProps = append(endpointProps, flux.Property("channel", flux.String(s.Channel)))
+	endpointProps = append(endpointProps, flux.Property("channel", flux.String(e.Channel)))
 	endpointProps = append(endpointProps, flux.Property("text", flux.String(s.MessageTemplate)))
 	endpointProps = append(endpointProps, flux.Property("silent", s.generateSilent()))
 	endpointFn := flux.Function(flux.FunctionParams("r"), flux.Object(endpointProps...))
@@ -130,12 +129,6 @@ func (s Telegram) Valid() error {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "Telegram MessageTemplate is invalid",
-		}
-	}
-	if s.Channel == "" {
-		return &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "Telegram Channel is invalid",
 		}
 	}
 	return nil

--- a/notification/rule/telegram_test.go
+++ b/notification/rule/telegram_test.go
@@ -105,7 +105,7 @@ func TestTelegram_GenerateFlux(t *testing.T) {
 			script: `package main
 // foo
 import "influxdata/influxdb/monitor"
-import "telegram"
+import "contrib/sranka/telegram"
 import "influxdata/influxdb/secrets"
 import "experimental"
 
@@ -177,7 +177,7 @@ all_statuses
 			script: `package main
 // foo
 import "influxdata/influxdb/monitor"
-import "telegram"
+import "contrib/sranka/telegram"
 import "influxdata/influxdb/secrets"
 import "experimental"
 

--- a/notification/rule/telegram_test.go
+++ b/notification/rule/telegram_test.go
@@ -1,0 +1,336 @@
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/notification"
+	"github.com/influxdata/influxdb/v2/notification/endpoint"
+	"github.com/influxdata/influxdb/v2/notification/rule"
+	influxTesting "github.com/influxdata/influxdb/v2/testing"
+)
+
+var _ influxdb.NotificationRule = &rule.Telegram{}
+
+func TestTelegram_GenerateFlux(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     *rule.Telegram
+		endpoint influxdb.NotificationEndpoint
+		script   string
+	}{
+		{
+			name: "incompatible with endpoint",
+			endpoint: &endpoint.Slack{
+				Base: endpoint.Base{
+					ID:   idPtr(3),
+					Name: "foo",
+				},
+				URL: "http://whatever",
+			},
+			rule: &rule.Telegram{
+				MessageTemplate: "blah",
+				Channel:         "-12345",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: "", //no script generater, because of incompatible endpoint
+		},
+		{
+			name: "notify on crit",
+			endpoint: &endpoint.Telegram{
+				Base: endpoint.Base{
+					ID:   idPtr(3),
+					Name: "foo",
+				},
+				Token: influxdb.SecretField{Key: "3-key"},
+			},
+			rule: &rule.Telegram{
+				MessageTemplate: "blah",
+				Channel:         "-12345",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "telegram"
+import "influxdata/influxdb/secrets"
+import "experimental"
+
+option task = {name: "foo", every: 1h}
+
+telegram_secret = secrets["get"](key: "3-key")
+telegram_endpoint = telegram["endpoint"](token: telegram_secret, disableWebPagePreview: false)
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000003",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor["from"](start: -2h, fn: (r) =>
+	(r["foo"] == "bar" and r["baz"] == "bang"))
+crit = statuses
+	|> filter(fn: (r) =>
+		(r["_level"] == "crit"))
+all_statuses = crit
+	|> filter(fn: (r) =>
+		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+
+all_statuses
+	|> monitor["notify"](data: notification, endpoint: telegram_endpoint(mapFn: (r) =>
+		({channel: "-12345", text: "blah", silent: if r["_level"] == "crit" then true else if r["_level"] == "warn" then true else false})))`,
+		},
+		{
+			name: "with DisableWebPagePreview and ParseMode",
+			endpoint: &endpoint.Telegram{
+				Base: endpoint.Base{
+					ID:   idPtr(3),
+					Name: "foo",
+				},
+				Token: influxdb.SecretField{Key: "3-key"},
+			},
+			rule: &rule.Telegram{
+				MessageTemplate:       "blah",
+				Channel:               "-12345",
+				DisableWebPagePreview: true,
+				ParseMode:             "HTML",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Any,
+						},
+					},
+					TagRules: []notification.TagRule{
+						{
+							Tag: influxdb.Tag{
+								Key:   "foo",
+								Value: "bar",
+							},
+							Operator: influxdb.Equal,
+						},
+						{
+							Tag: influxdb.Tag{
+								Key:   "baz",
+								Value: "bang",
+							},
+							Operator: influxdb.Equal,
+						},
+					},
+				},
+			},
+			script: `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "telegram"
+import "influxdata/influxdb/secrets"
+import "experimental"
+
+option task = {name: "foo", every: 1h}
+
+telegram_secret = secrets["get"](key: "3-key")
+telegram_endpoint = telegram["endpoint"](token: telegram_secret, parseMode: "HTML", disableWebPagePreview: true)
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000003",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor["from"](start: -2h, fn: (r) =>
+	(r["foo"] == "bar" and r["baz"] == "bang"))
+any = statuses
+	|> filter(fn: (r) =>
+		(true))
+all_statuses = any
+	|> filter(fn: (r) =>
+		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+
+all_statuses
+	|> monitor["notify"](data: notification, endpoint: telegram_endpoint(mapFn: (r) =>
+		({channel: "-12345", text: "blah", silent: if r["_level"] == "crit" then true else if r["_level"] == "warn" then true else false})))`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, err := tt.rule.GenerateFlux(tt.endpoint)
+			if err != nil {
+				if script != "" {
+					t.Errorf("Failed to generate flux: %v", err)
+				}
+				return
+			}
+
+			if got, want := script, tt.script; got != want {
+				t.Errorf("\n\nStrings do not match:\n\n%s", diff.LineDiff(got, want))
+			}
+		})
+	}
+}
+
+func TestTelegram_Valid(t *testing.T) {
+	cases := []struct {
+		name string
+		rule *rule.Telegram
+		err  error
+	}{
+		{
+			name: "valid template",
+			rule: &rule.Telegram{
+				MessageTemplate: "blah",
+				Channel:         "-12345",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					OwnerID:    4,
+					OrgID:      5,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "missing MessageTemplate",
+			rule: &rule.Telegram{
+				MessageTemplate: "",
+				Channel:         "-12345",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					OwnerID:    4,
+					OrgID:      5,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{},
+				},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "Telegram MessageTemplate is invalid",
+			},
+		},
+		{
+			name: "missing EndpointID",
+			rule: &rule.Telegram{
+				MessageTemplate: "",
+				Channel:         "-12345",
+				Base: rule.Base{
+					ID: 1,
+					// EndpointID: 3,
+					OwnerID: 4,
+					OrgID:   5,
+					Name:    "foo",
+					Every:   mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{},
+				},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "Notification Rule EndpointID is invalid",
+			},
+		},
+		{
+			name: "missing Channel",
+			rule: &rule.Telegram{
+				MessageTemplate: "blah",
+				Base: rule.Base{
+					ID:         1,
+					EndpointID: 3,
+					OwnerID:    4,
+					OrgID:      5,
+					Name:       "foo",
+					Every:      mustDuration("1h"),
+					StatusRules: []notification.StatusRule{
+						{
+							CurrentLevel: notification.Critical,
+						},
+					},
+					TagRules: []notification.TagRule{},
+				},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "Telegram Channel is invalid",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.rule.Valid()
+			influxTesting.ErrorsEqual(t, got, c.err)
+		})
+	}
+
+}

--- a/notification/rule/telegram_test.go
+++ b/notification/rule/telegram_test.go
@@ -31,7 +31,6 @@ func TestTelegram_GenerateFlux(t *testing.T) {
 			},
 			rule: &rule.Telegram{
 				MessageTemplate: "blah",
-				Channel:         "-12345",
 				Base: rule.Base{
 					ID:         1,
 					EndpointID: 3,
@@ -69,11 +68,11 @@ func TestTelegram_GenerateFlux(t *testing.T) {
 					ID:   idPtr(3),
 					Name: "foo",
 				},
-				Token: influxdb.SecretField{Key: "3-key"},
+				Token:   influxdb.SecretField{Key: "3-key"},
+				Channel: "-12345",
 			},
 			rule: &rule.Telegram{
 				MessageTemplate: "blah",
-				Channel:         "-12345",
 				Base: rule.Base{
 					ID:         1,
 					EndpointID: 3,
@@ -139,11 +138,11 @@ all_statuses
 					ID:   idPtr(3),
 					Name: "foo",
 				},
-				Token: influxdb.SecretField{Key: "3-key"},
+				Token:   influxdb.SecretField{Key: "3-key"},
+				Channel: "-12345",
 			},
 			rule: &rule.Telegram{
 				MessageTemplate:       "blah",
-				Channel:               "-12345",
 				DisableWebPagePreview: true,
 				ParseMode:             "HTML",
 				Base: rule.Base{
@@ -233,7 +232,6 @@ func TestTelegram_Valid(t *testing.T) {
 			name: "valid template",
 			rule: &rule.Telegram{
 				MessageTemplate: "blah",
-				Channel:         "-12345",
 				Base: rule.Base{
 					ID:         1,
 					EndpointID: 3,
@@ -255,7 +253,6 @@ func TestTelegram_Valid(t *testing.T) {
 			name: "missing MessageTemplate",
 			rule: &rule.Telegram{
 				MessageTemplate: "",
-				Channel:         "-12345",
 				Base: rule.Base{
 					ID:         1,
 					EndpointID: 3,
@@ -280,7 +277,6 @@ func TestTelegram_Valid(t *testing.T) {
 			name: "missing EndpointID",
 			rule: &rule.Telegram{
 				MessageTemplate: "",
-				Channel:         "-12345",
 				Base: rule.Base{
 					ID: 1,
 					// EndpointID: 3,
@@ -299,30 +295,6 @@ func TestTelegram_Valid(t *testing.T) {
 			err: &influxdb.Error{
 				Code: influxdb.EInvalid,
 				Msg:  "Notification Rule EndpointID is invalid",
-			},
-		},
-		{
-			name: "missing Channel",
-			rule: &rule.Telegram{
-				MessageTemplate: "blah",
-				Base: rule.Base{
-					ID:         1,
-					EndpointID: 3,
-					OwnerID:    4,
-					OrgID:      5,
-					Name:       "foo",
-					Every:      mustDuration("1h"),
-					StatusRules: []notification.StatusRule{
-						{
-							CurrentLevel: notification.Critical,
-						},
-					},
-					TagRules: []notification.TagRule{},
-				},
-			},
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "Telegram Channel is invalid",
 			},
 		},
 	}

--- a/ui/src/notifications/endpoints/components/EndpointCards.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointCards.tsx
@@ -57,7 +57,7 @@ const EmptyEndpointList: FC<{searchTerm: string}> = ({searchTerm}) => {
       <EmptyState.Text>
         Want to send notifications to Slack,
         <br />
-        PagerDuty or an HTTP server?
+        PagerDuty, Telegram or an HTTP server?
         <br />
         <br />
         Try creating a <b>Notification Endpoint</b>

--- a/ui/src/notifications/endpoints/components/EndpointOptions.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointOptions.tsx
@@ -5,6 +5,7 @@ import React, {FC, ChangeEvent} from 'react'
 import EndpointOptionsSlack from './EndpointOptionsSlack'
 import EndpointOptionsPagerDuty from './EndpointOptionsPagerDuty'
 import EndpointOptionsHTTP from './EndpointOptionsHTTP'
+import EndpointOptionsTelegram from './EndpointOptionsTelegram'
 
 // Types
 import {
@@ -12,6 +13,7 @@ import {
   SlackNotificationEndpoint,
   PagerDutyNotificationEndpoint,
   HTTPNotificationEndpoint,
+  TelegramNotificationEndpoint,
 } from 'src/types'
 
 interface Props {
@@ -39,6 +41,10 @@ const EndpointOptions: FC<Props> = ({
           onChange={onChange}
         />
       )
+    }
+    case 'telegram': {
+      const {token} = endpoint as TelegramNotificationEndpoint
+      return <EndpointOptionsTelegram token={token} onChange={onChange} />
     }
     case 'http': {
       const {

--- a/ui/src/notifications/endpoints/components/EndpointOptions.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointOptions.tsx
@@ -43,8 +43,14 @@ const EndpointOptions: FC<Props> = ({
       )
     }
     case 'telegram': {
-      const {token} = endpoint as TelegramNotificationEndpoint
-      return <EndpointOptionsTelegram token={token} onChange={onChange} />
+      const {token, channel} = endpoint as TelegramNotificationEndpoint
+      return (
+        <EndpointOptionsTelegram
+          token={token}
+          channel={channel}
+          onChange={onChange}
+        />
+      )
     }
     case 'http': {
       const {

--- a/ui/src/notifications/endpoints/components/EndpointOptionsTelegram.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointOptionsTelegram.tsx
@@ -1,0 +1,46 @@
+// Libraries
+import React, {FC, ChangeEvent} from 'react'
+
+// Components
+import {
+  Input,
+  InputType,
+  FormElement,
+  Panel,
+  Grid,
+  Columns,
+} from '@influxdata/clockface'
+
+interface Props {
+  token: string
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+}
+
+const EndpointOptionsTelegram: FC<Props> = ({token, onChange}) => {
+  return (
+    <Panel>
+      <Panel.Header>
+        <h4>Telegram Options</h4>
+      </Panel.Header>
+      <Panel.Body>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve}>
+              <FormElement label="Bot Token">
+                <Input
+                  name="token"
+                  value={token}
+                  testID="token"
+                  onChange={onChange}
+                  type={InputType.Password}
+                />
+              </FormElement>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default EndpointOptionsTelegram

--- a/ui/src/notifications/endpoints/components/EndpointOptionsTelegram.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointOptionsTelegram.tsx
@@ -13,10 +13,11 @@ import {
 
 interface Props {
   token: string
+  channel: string
   onChange: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
-const EndpointOptionsTelegram: FC<Props> = ({token, onChange}) => {
+const EndpointOptionsTelegram: FC<Props> = ({token, channel, onChange}) => {
   return (
     <Panel>
       <Panel.Header>
@@ -33,6 +34,15 @@ const EndpointOptionsTelegram: FC<Props> = ({token, onChange}) => {
                   testID="token"
                   onChange={onChange}
                   type={InputType.Password}
+                />
+              </FormElement>
+              <FormElement label="Chat ID">
+                <Input
+                  name="channel"
+                  value={channel}
+                  testID="channel"
+                  onChange={onChange}
+                  type={InputType.Text}
                 />
               </FormElement>
             </Grid.Column>

--- a/ui/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
+++ b/ui/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
@@ -64,6 +64,7 @@ export const reducer = (
               ...baseProps,
               type: 'telegram',
               token: '',
+              channel: '',
             }
         }
       }

--- a/ui/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
+++ b/ui/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
@@ -59,6 +59,12 @@ export const reducer = (
               url: DEFAULT_ENDPOINT_URLS.slack,
               token: '',
             }
+          case 'telegram':
+            return {
+              ...baseProps,
+              type: 'telegram',
+              token: '',
+            }
         }
       }
       return state

--- a/ui/src/notifications/endpoints/components/EndpointTypeDropdown.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointTypeDropdown.tsx
@@ -32,6 +32,7 @@ const types: EndpointType[] = [
   {name: 'HTTP', type: 'http', id: 'http'},
   {name: 'Slack', type: 'slack', id: 'slack'},
   {name: 'Pagerduty', type: 'pagerduty', id: 'pagerduty'},
+  {name: 'Telegram', type: 'telegram', id: 'telegram'},
 ]
 
 const EndpointTypeDropdown: FC<Props> = ({

--- a/ui/src/notifications/endpoints/components/EndpointsColumn.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointsColumn.tsx
@@ -30,7 +30,7 @@ const EndpointsColumn: FC<Props> = ({history, match, endpoints}) => {
       <br />
       to a third party service that can receive notifications
       <br />
-      like Slack, PagerDuty, or an HTTP server
+      like Slack, PagerDuty, Telegram, or an HTTP server
       <br />
       <br />
       <a

--- a/ui/src/notifications/rules/components/RuleMessageContents.tsx
+++ b/ui/src/notifications/rules/components/RuleMessageContents.tsx
@@ -5,6 +5,7 @@ import React, {FC} from 'react'
 import SlackMessage from './SlackMessage'
 import SMTPMessage from './SMTPMessage'
 import PagerDutyMessage from './PagerDutyMessage'
+import TelegramMessage from './TelegramMessage'
 
 // Utils
 import {useRuleDispatch} from './RuleOverlayProvider'
@@ -57,6 +58,16 @@ const RuleMessageContents: FC<Props> = ({rule}) => {
       return (
         <PagerDutyMessage
           messageTemplate={messageTemplate}
+          onChange={onChange}
+        />
+      )
+    }
+    case 'telegram': {
+      const {messageTemplate, channel} = rule
+      return (
+        <TelegramMessage
+          messageTemplate={messageTemplate}
+          channel={channel}
           onChange={onChange}
         />
       )

--- a/ui/src/notifications/rules/components/RuleMessageContents.tsx
+++ b/ui/src/notifications/rules/components/RuleMessageContents.tsx
@@ -63,11 +63,10 @@ const RuleMessageContents: FC<Props> = ({rule}) => {
       )
     }
     case 'telegram': {
-      const {messageTemplate, channel} = rule
+      const {messageTemplate} = rule
       return (
         <TelegramMessage
           messageTemplate={messageTemplate}
-          channel={channel}
           onChange={onChange}
         />
       )

--- a/ui/src/notifications/rules/components/TelegramMessage.tsx
+++ b/ui/src/notifications/rules/components/TelegramMessage.tsx
@@ -1,0 +1,46 @@
+// Libraries
+import React, {FC, ChangeEvent} from 'react'
+
+// Components
+import {Form, TextArea, Input} from '@influxdata/clockface'
+import {TelegramNotificationRuleBase} from 'src/types/alerting'
+
+interface EventHandlers {
+  onChange: (e: ChangeEvent) => void
+}
+type Props = Omit<TelegramNotificationRuleBase, 'type'> & EventHandlers
+
+const TelegramMessage: FC<Props> = ({messageTemplate, channel, onChange}) => {
+  return (
+    <>
+      <Form.Element label="Channel ID">
+        <Input value={channel} name="channel" onChange={onChange} />
+      </Form.Element>
+      <Form.Element label="Message Template">
+        <TextArea
+          name="messageTemplate"
+          testID="slack-message-template--textarea"
+          value={messageTemplate}
+          onChange={onChange}
+          rows={3}
+        />
+      </Form.Element>
+      {/*
+      // keep it simple, these following elements are possible, but too advanced
+      <Form.Element label="Parse Mode">
+        <Input value={parseMode} name="parseMode" onChange={onChange} />
+      </Form.Element>
+      <Form.Element label="">
+        <Input
+          value={String(!disableWebPagePreview)}
+          name="disableWebPagePreview"
+          onChange={onChange}
+          type={InputType.Checkbox}
+        />
+      </Form.Element> 
+      */}
+    </>
+  )
+}
+
+export default TelegramMessage

--- a/ui/src/notifications/rules/components/TelegramMessage.tsx
+++ b/ui/src/notifications/rules/components/TelegramMessage.tsx
@@ -2,7 +2,7 @@
 import React, {FC, ChangeEvent} from 'react'
 
 // Components
-import {Form, TextArea, Input} from '@influxdata/clockface'
+import {Form, TextArea} from '@influxdata/clockface'
 import {TelegramNotificationRuleBase} from 'src/types/alerting'
 
 interface EventHandlers {
@@ -10,23 +10,19 @@ interface EventHandlers {
 }
 type Props = Omit<TelegramNotificationRuleBase, 'type'> & EventHandlers
 
-const TelegramMessage: FC<Props> = ({messageTemplate, channel, onChange}) => {
+const TelegramMessage: FC<Props> = ({messageTemplate, onChange}) => {
   return (
-    <>
-      <Form.Element label="Channel ID">
-        <Input value={channel} name="channel" onChange={onChange} />
-      </Form.Element>
-      <Form.Element label="Message Template">
-        <TextArea
-          name="messageTemplate"
-          testID="slack-message-template--textarea"
-          value={messageTemplate}
-          onChange={onChange}
-          rows={3}
-        />
-      </Form.Element>
-      {/*
-      // keep it simple, these following elements are possible, but too advanced
+    <Form.Element label="Message Template">
+      <TextArea
+        name="messageTemplate"
+        testID="slack-message-template--textarea"
+        value={messageTemplate}
+        onChange={onChange}
+        rows={3}
+      />
+    </Form.Element>
+    /*
+      // keep it simple, the following elements are possible, but too advanced
       <Form.Element label="Parse Mode">
         <Input value={parseMode} name="parseMode" onChange={onChange} />
       </Form.Element>
@@ -38,8 +34,7 @@ const TelegramMessage: FC<Props> = ({messageTemplate, channel, onChange}) => {
           type={InputType.Checkbox}
         />
       </Form.Element> 
-      */}
-    </>
+    */
   )
 }
 

--- a/ui/src/notifications/rules/utils/index.ts
+++ b/ui/src/notifications/rules/utils/index.ts
@@ -8,6 +8,7 @@ import {
   SlackNotificationRuleBase,
   SMTPNotificationRuleBase,
   PagerDutyNotificationRuleBase,
+  TelegramNotificationRuleBase,
   NotificationEndpoint,
   NotificationRuleDraft,
   HTTPNotificationRuleBase,
@@ -22,6 +23,7 @@ type RuleVariantFields =
   | SMTPNotificationRuleBase
   | PagerDutyNotificationRuleBase
   | HTTPNotificationRuleBase
+  | TelegramNotificationRuleBase
 
 const defaultMessage =
   'Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }'
@@ -43,6 +45,16 @@ export const getRuleVariantDefaults = (
 
     case 'http': {
       return {type: 'http', url: ''}
+    }
+
+    case 'telegram': {
+      return {
+        messageTemplate: defaultMessage,
+        channel: '',
+        parseMode: 'MarkdownV2',
+        disableWebPagePreview: false,
+        type: 'telegram',
+      }
     }
 
     default: {

--- a/ui/src/notifications/rules/utils/index.ts
+++ b/ui/src/notifications/rules/utils/index.ts
@@ -48,8 +48,13 @@ export const getRuleVariantDefaults = (
     }
 
     case 'telegram': {
+      // wrap all variable values into `` to prevent telegram's markdown errors
+      const messageTemplate = defaultMessage.replace(
+        /\$\{[^\}]+\}/g,
+        x => `\`${x}\``
+      )
       return {
-        messageTemplate: defaultMessage,
+        messageTemplate: messageTemplate,
         channel: '',
         parseMode: 'MarkdownV2',
         disableWebPagePreview: false,

--- a/ui/src/notifications/rules/utils/index.ts
+++ b/ui/src/notifications/rules/utils/index.ts
@@ -55,7 +55,6 @@ export const getRuleVariantDefaults = (
       )
       return {
         messageTemplate: messageTemplate,
-        channel: '',
         parseMode: 'MarkdownV2',
         disableWebPagePreview: false,
         type: 'telegram',

--- a/ui/src/types/alerting.ts
+++ b/ui/src/types/alerting.ts
@@ -19,6 +19,7 @@ import {
   Threshold,
   CheckBase as GenCheckBase,
   NotificationEndpointBase as GenEndpointBase,
+  TelegramNotificationRuleBase,
 } from 'src/client'
 import {RemoteDataState} from 'src/types'
 
@@ -69,7 +70,7 @@ export type NotificationRuleBaseDraft = Overwrite<
   }
 >
 
-type RuleDraft = SlackRule | SMTPRule | PagerDutyRule | HTTPRule
+type RuleDraft = SlackRule | SMTPRule | PagerDutyRule | HTTPRule | TelegramRule
 
 export type NotificationRuleDraft = RuleDraft
 
@@ -87,6 +88,10 @@ type PagerDutyRule = NotificationRuleBaseDraft &
 
 type HTTPRule = NotificationRuleBaseDraft &
   HTTPNotificationRuleBase &
+  RuleOverrides
+
+type TelegramRule = NotificationRuleBaseDraft &
+  TelegramNotificationRuleBase &
   RuleOverrides
 
 export type LowercaseCheckStatusLevel =

--- a/ui/src/types/alerting.ts
+++ b/ui/src/types/alerting.ts
@@ -20,6 +20,7 @@ import {
   CheckBase as GenCheckBase,
   NotificationEndpointBase as GenEndpointBase,
   TelegramNotificationRuleBase,
+  TelegramNotificationEndpoint,
 } from 'src/client'
 import {RemoteDataState} from 'src/types'
 
@@ -44,6 +45,8 @@ export type NotificationEndpoint =
   | (Omit<PagerDutyNotificationEndpoint, 'status' | 'labels'> &
       EndpointOverrides)
   | (Omit<HTTPNotificationEndpoint, 'status' | 'labels'> & EndpointOverrides)
+  | (Omit<TelegramNotificationEndpoint, 'status' | 'labels'> &
+      EndpointOverrides)
 export type NotificationEndpointBase = Omit<GenEndpointBase, 'labels'> &
   EndpointOverrides
 
@@ -187,4 +190,7 @@ export {
   PostNotificationRule,
   CheckPatch,
   TaskStatusType,
+  TelegramNotificationEndpoint,
+  TelegramNotificationRuleBase,
+  TelegramNotificationRule,
 } from '../client'


### PR DESCRIPTION
Closes #17899 

This PR adds [telegram](https://telegram.org) notification endpoint and notification rules. It depends on influxdata/flux#2857 that introduces a new *telegram* package to send notifications.

What is in this PR
  * implementation and tests of telegram endpoint and rule
  * swagger updated with telegram notification rule and endpoint
  * updated UI to use the new swagger + new UI for telegram endpoint and rule:
      * Create/Edit Telegram Notification Endpoint
![image](https://user-images.githubusercontent.com/16321466/87057478-351eec00-c207-11ea-9ef3-0c2c917c0149.png)
      * Create/Edit Telegram Notification Rule
![image](https://user-images.githubusercontent.com/16321466/87057647-68fa1180-c207-11ea-8c71-8c32d3b5f1b9.png)
  * note that telegram default message template wraps variables  into \`preformatted text\` to prevent telegram markdown errors

What is not in this PR
  * telegram endpoint and rule in =pkger= 
  * new UI tests

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr : influxdata/docs-v2#1246 )
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
