### PR TITLE
fix: goreleaser should be ignored from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ cypress/videos
 .rustup/
 .yarnrc
 go/
+goreleaser-install


### PR DESCRIPTION
As we now install Goreleaser through official channels, we need to ignore
the file so that its presence isn't picked up as dirty state during a release.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
