### PR TITLE
fix: dont add system buckets when filtering by name

### DIFF
--- a/tenant/service_bucket.go
+++ b/tenant/service_bucket.go
@@ -121,6 +121,11 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 		return buckets, len(buckets), nil
 	}
 
+	// if a name is provided dont fill in system buckets
+	if filter.Name != nil {
+		return buckets, len(buckets), nil
+	}
+
 	// NOTE: this is a remnant of the old system.
 	// There are org that do not have system buckets stored, but still need to be displayed.
 	needsSystemBuckets := true

--- a/tenant/service_bucket_test.go
+++ b/tenant/service_bucket_test.go
@@ -84,3 +84,39 @@ func TestBucketFind(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSystemBucketsInNameFind(t *testing.T) {
+	s, close, err := NewTestInmemStore(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close()
+	storage, err := tenant.NewStore(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := tenant.NewService(storage)
+	o := &influxdb.Organization{
+		Name: "theorg",
+	}
+
+	if err := svc.CreateOrganization(context.Background(), o); err != nil {
+		t.Fatal(err)
+	}
+	b := &influxdb.Bucket{
+		OrgID: o.ID,
+		Name:  "thebucket",
+	}
+	if err := svc.CreateBucket(context.Background(), b); err != nil {
+		t.Fatal(err)
+	}
+	name := "thebucket"
+	buckets, _, _ := svc.FindBuckets(context.Background(), influxdb.BucketFilter{
+		Name: &name,
+		Org:  &o.Name,
+	})
+	if len(buckets) != 1 {
+		t.Fatal("failed to return a single bucket when doing a bucket lookup by name")
+	}
+}


### PR DESCRIPTION
Closes #18221

bring tenant inline with the behavior of the old kv system as it comes to bucket lookups.
This regression was allowed through testing because the testing suite eliminate the system buckets when comparing results. That functionality can be removed soon but because we have multiple implementations of the service that behave a little different we need to leave that in for now. I wrote a test to eliminate this regression in the future.
