### PR TITLE
fix(swagger): update opID for post resend endpoint

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4531,7 +4531,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/invites/{inviteID}/resend":
     post:
-      operationId: DeleteOrgsIDInviteID
+      operationId: PostOrgsIDInviteID
       tags:
         - Invites
         - Organizations


### PR DESCRIPTION
Closes #

fixes a swagger error:
```
Semantic error at paths./orgs/{orgID}/invites/{inviteID}/resend.post.operationId
Operations must have unique operationIds.
Jump to line 4535
```

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
