### PR TITLE
fix(query): Disable compiler's Fused Multiply Add to fix test failure in TestHoltWinters_AusTourists

### DIFF
--- a/query/functions.go
+++ b/query/functions.go
@@ -1432,11 +1432,13 @@ func (r *FloatHoltWintersReducer) Emit() []FloatPoint {
 }
 
 // Using the recursive relations compute the next values
+// Use float64() expression explicitly to disable the compiler's Fused Multiply Add (FMA) instruction selection
+// which can result in different rounding errors in floating point computations.
 func (r *FloatHoltWintersReducer) next(alpha, beta, gamma, phi, phiH, yT, lTp, bTp, sTm, sTmh float64) (yTh, lT, bT, sT float64) {
-	lT = alpha*(yT/sTm) + (1-alpha)*(lTp+phi*bTp)
-	bT = beta*(lT-lTp) + (1-beta)*phi*bTp
-	sT = gamma*(yT/(lTp+phi*bTp)) + (1-gamma)*sTm
-	yTh = (lT + phiH*bT) * sTmh
+	lT = float64(alpha*(yT/sTm)) + float64((1-alpha)*(lTp+phi*bTp))
+	bT = float64(beta*(lT-lTp)) + float64((1-beta)*phi*bTp)
+	sT = float64(gamma*(yT/(lTp+phi*bTp))) + float64((1-gamma)*sTm)
+	yTh = float64((lT + phiH*bT) * sTmh)
 	return
 }
 


### PR DESCRIPTION
2 tests are failing (`TestHoltWinters_AusTourists` and `TestSelect/HoltWinters_GroupBy_Agg`) on s390x architecture.  This is due to the compiler's Fused Multiply Add (FMA) instruction selection which can result in different rounding errors in floating point computations.  Proposing to use float64() expression explicitly to disable the compiler's FMA instruction selection.  This will not affect architectures that does not have FMA (e.g. amd64).

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
