### PR TITLE
feat(notebooks): add empty state

### DIFF
--- a/ui/assets/images/notebooks-empty.svg
+++ b/ui/assets/images/notebooks-empty.svg
@@ -1,0 +1,1378 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 540 300" style="enable-background:new 0 0 540 300;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.7;}
+	.st1{fill:url(#SVGID_1_);}
+	.st2{fill:url(#SVGID_2_);}
+	.st3{fill:url(#SVGID_3_);}
+	.st4{opacity:0.61;fill:url(#SVGID_4_);}
+	.st5{opacity:0.61;fill:url(#SVGID_5_);}
+	.st6{fill:url(#SVGID_6_);}
+	.st7{fill:url(#SVGID_7_);}
+	.st8{fill:url(#SVGID_8_);}
+	.st9{opacity:0.77;fill:url(#SVGID_9_);}
+	.st10{fill:url(#SVGID_10_);}
+	.st11{fill:url(#SVGID_11_);}
+	.st12{opacity:0.77;fill:url(#SVGID_12_);}
+	.st13{fill:url(#SVGID_13_);}
+	.st14{fill:url(#SVGID_14_);}
+	.st15{opacity:0.77;fill:url(#SVGID_15_);}
+	.st16{fill:url(#SVGID_16_);}
+	.st17{opacity:0.54;fill:url(#SVGID_17_);}
+	.st18{opacity:0.54;fill:url(#SVGID_18_);}
+	.st19{opacity:0.54;fill:url(#SVGID_19_);}
+	.st20{opacity:7.000000e-02;}
+	.st21{fill:url(#SVGID_20_);}
+	.st22{opacity:0.1;}
+	.st23{fill:url(#SVGID_21_);}
+	.st24{opacity:0.54;fill:url(#SVGID_22_);}
+	.st25{opacity:0.95;fill:url(#SVGID_23_);}
+	.st26{opacity:0.54;fill:url(#SVGID_24_);}
+	.st27{opacity:0.18;}
+	.st28{fill:url(#SVGID_25_);}
+	.st29{opacity:0.2;}
+	.st30{fill:url(#SVGID_26_);}
+	.st31{opacity:0.54;fill:url(#SVGID_27_);}
+	.st32{fill:url(#SVGID_28_);}
+	.st33{opacity:0.54;fill:url(#SVGID_29_);}
+	.st34{opacity:0.28;}
+	.st35{fill:url(#SVGID_30_);}
+	.st36{fill:url(#SVGID_31_);}
+	.st37{fill:url(#SVGID_32_);}
+	.st38{opacity:0.69;fill:url(#SVGID_33_);}
+	.st39{fill:url(#SVGID_34_);}
+	.st40{fill:url(#SVGID_35_);}
+	.st41{opacity:0.5;}
+	.st42{fill:#C8E822;}
+	.st43{fill:url(#SVGID_36_);}
+	.st44{fill:#439AD1;}
+	.st45{fill:url(#SVGID_37_);}
+	.st46{opacity:0.55;}
+	.st47{fill:url(#SVGID_38_);}
+	.st48{fill:url(#SVGID_39_);}
+	.st49{opacity:0.6;}
+	.st50{fill:url(#SVGID_40_);}
+	.st51{fill:url(#SVGID_41_);}
+	.st52{fill:url(#SVGID_42_);}
+	.st53{fill:url(#SVGID_43_);}
+	.st54{opacity:0.22;fill:url(#SVGID_44_);}
+	.st55{opacity:0.22;fill:url(#SVGID_45_);}
+	.st56{fill:#E1C5E9;}
+	.st57{opacity:0.74;fill:url(#SVGID_46_);}
+	.st58{opacity:0.95;fill:url(#SVGID_47_);}
+	.st59{fill:url(#SVGID_48_);}
+	.st60{fill:#292933;}
+	.st61{fill:url(#SVGID_49_);}
+	.st62{fill:#249DE8;}
+	.st63{fill:url(#SVGID_50_);}
+	.st64{fill:url(#SVGID_51_);}
+	.st65{fill:url(#SVGID_52_);}
+	.st66{fill:url(#SVGID_53_);}
+	.st67{opacity:0.49;fill:url(#SVGID_54_);}
+	.st68{fill:url(#SVGID_55_);}
+	.st69{opacity:0.14;fill:#25262B;}
+	.st70{fill:url(#SVGID_56_);}
+	.st71{fill:url(#SVGID_57_);}
+	.st72{opacity:0.77;fill:url(#SVGID_58_);}
+	.st73{fill:url(#SVGID_59_);}
+	.st74{opacity:0.77;fill:url(#SVGID_60_);}
+	.st75{fill:url(#SVGID_61_);}
+	.st76{fill:url(#SVGID_62_);}
+	.st77{opacity:0.77;fill:url(#SVGID_63_);}
+	.st78{fill:url(#SVGID_64_);}
+	.st79{fill:url(#SVGID_65_);}
+	.st80{opacity:0.9;}
+	.st81{fill:url(#SVGID_66_);}
+	.st82{fill:url(#SVGID_67_);}
+	.st83{fill:url(#SVGID_68_);}
+	.st84{fill:url(#SVGID_69_);}
+	.st85{fill:url(#SVGID_70_);}
+	.st86{fill:url(#SVGID_71_);}
+	.st87{fill:url(#SVGID_72_);}
+	.st88{fill:url(#SVGID_73_);}
+	.st89{fill:url(#SVGID_74_);}
+	.st90{fill:url(#SVGID_75_);}
+	.st91{fill:url(#SVGID_76_);}
+	.st92{fill:url(#SVGID_77_);}
+	.st93{fill:url(#SVGID_78_);}
+	.st94{opacity:0.63;}
+	.st95{opacity:0.77;fill:url(#SVGID_79_);}
+	.st96{fill:url(#SVGID_80_);}
+	.st97{opacity:0.77;fill:url(#SVGID_81_);}
+	.st98{fill:url(#SVGID_82_);}
+	.st99{opacity:0.77;fill:url(#SVGID_83_);}
+	.st100{fill:url(#SVGID_84_);}
+	.st101{opacity:0.77;fill:url(#SVGID_85_);}
+	.st102{fill:url(#SVGID_86_);}
+	.st103{opacity:0.77;fill:url(#SVGID_87_);}
+	.st104{fill:url(#SVGID_88_);}
+	.st105{opacity:0.77;fill:url(#SVGID_89_);}
+	.st106{fill:url(#SVGID_90_);}
+	.st107{opacity:0.65;fill:url(#SVGID_91_);}
+	.st108{opacity:0.36;}
+	.st109{opacity:0.77;fill:url(#SVGID_92_);}
+	.st110{fill:url(#SVGID_93_);}
+	.st111{opacity:0.77;fill:url(#SVGID_94_);}
+	.st112{fill:url(#SVGID_95_);}
+	.st113{opacity:0.38;}
+	.st114{fill:url(#SVGID_96_);}
+	.st115{opacity:0.78;fill:url(#SVGID_97_);}
+	.st116{fill:url(#SVGID_98_);}
+	.st117{fill:url(#SVGID_99_);}
+	.st118{fill:url(#SVGID_100_);}
+	.st119{fill:url(#SVGID_101_);}
+	.st120{fill:url(#SVGID_102_);}
+	.st121{fill:url(#SVGID_103_);}
+	.st122{fill:url(#SVGID_104_);}
+	.st123{fill:url(#SVGID_105_);}
+	.st124{fill:url(#SVGID_106_);}
+	.st125{fill:url(#SVGID_107_);}
+	.st126{fill:url(#SVGID_108_);}
+	.st127{fill:url(#SVGID_109_);}
+	.st128{fill:url(#SVGID_110_);}
+	.st129{fill:url(#SVGID_111_);}
+	.st130{fill:url(#SVGID_112_);}
+	.st131{fill:url(#SVGID_113_);}
+	.st132{fill:url(#SVGID_114_);}
+	.st133{fill:url(#SVGID_115_);}
+	.st134{fill:url(#SVGID_116_);}
+	.st135{fill:url(#SVGID_117_);}
+	.st136{fill:url(#SVGID_118_);}
+	.st137{fill:url(#SVGID_119_);}
+	.st138{fill:url(#SVGID_120_);}
+	.st139{fill:url(#SVGID_121_);}
+	.st140{fill:url(#SVGID_122_);}
+	.st141{fill:url(#SVGID_123_);}
+	.st142{fill:url(#SVGID_124_);}
+	.st143{fill:url(#SVGID_125_);}
+	.st144{fill:url(#SVGID_126_);}
+	.st145{opacity:0.77;fill:url(#SVGID_127_);}
+	.st146{fill:url(#SVGID_128_);}
+	.st147{fill:url(#SVGID_129_);}
+</style>
+<g class="st0">
+	<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="366.8545" y1="176.8778" x2="438.4858" y2="115.7844">
+		<stop  offset="0" style="stop-color:#AF2FD5"/>
+		<stop  offset="0.1429" style="stop-color:#A239D7"/>
+		<stop  offset="0.4052" style="stop-color:#8153DB"/>
+		<stop  offset="0.7546" style="stop-color:#4C7DE1"/>
+		<stop  offset="1" style="stop-color:#229DE6"/>
+	</linearGradient>
+	<path class="st1" d="M419.9,238.1c-0.2,0-0.4,0-0.6,0c-0.3,0-0.4-0.2-0.4-0.5c0-0.3,0.3-0.4,0.5-0.4c1.9,0.2,3.9-0.5,5.4-1.9
+		c1.4-1.3,2.2-3.2,2.3-5.1l0.2-121.5c0-4.6-2.5-8.9-6.4-11.2l-47.6-27.6c-2.9-1.7-6.4-1.1-8.7,1.3c-0.2,0.2-0.5,0.2-0.6,0
+		c-0.2-0.2-0.2-0.5,0-0.6c2.6-2.7,6.6-3.4,9.8-1.5l47.6,27.6c4.3,2.5,6.9,7.1,6.9,12l-0.2,121.5c0,2.2-0.9,4.3-2.5,5.8
+		C423.8,237.4,421.9,238.1,419.9,238.1z"/>
+</g>
+<g class="st0">
+	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="54.3137" y1="174.0079" x2="233.2668" y2="21.3812">
+		<stop  offset="0" style="stop-color:#AF2FD5"/>
+		<stop  offset="0.1429" style="stop-color:#A239D7"/>
+		<stop  offset="0.4052" style="stop-color:#8153DB"/>
+		<stop  offset="0.7546" style="stop-color:#4C7DE1"/>
+		<stop  offset="1" style="stop-color:#229DE6"/>
+	</linearGradient>
+	<path class="st2" d="M79.9,201.3c-1.2,0-2.3-0.4-3.2-1.2c-1.1-0.9-1.8-2.3-1.8-3.8l-0.2-85.5c0-3.1,1.6-5.9,4.3-7.4l146.8-84.7
+		c1.5-0.9,3.4-0.9,4.9,0c1.5,0.9,2.5,2.5,2.5,4.3c0,0.3-0.2,0.5-0.5,0.5c0,0,0,0,0,0c-0.3,0-0.5-0.2-0.5-0.5c0-1.5-0.8-2.8-2-3.5
+		c-1.3-0.7-2.8-0.7-4,0L79.4,104.2c-2.4,1.4-3.8,3.9-3.8,6.6l0.2,85.5c0,1.2,0.5,2.3,1.4,3.1c0.9,0.8,2.1,1.1,3.3,0.9
+		c0.2,0,0.5,0.1,0.5,0.4c0,0.2-0.1,0.5-0.4,0.5C80.4,201.2,80.1,201.3,79.9,201.3z"/>
+</g>
+<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="95.9263" y1="218.811" x2="220.901" y2="218.811">
+	<stop  offset="0" style="stop-color:#31313D"/>
+	<stop  offset="1" style="stop-color:#31313D;stop-opacity:0"/>
+</linearGradient>
+<path class="st3" d="M96.4,260.9l-0.4-36.5c0-3,1.5-5.7,4.1-7.2l76.3-44.5c3-1.8,6.8,0.4,6.9,3.9l0.4,36.5c0,3-1.5,5.7-4.1,7.2
+	l-76.3,44.5C100.2,266.6,96.4,264.4,96.4,260.9z"/>
+<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="442.4282" y1="148.3675" x2="264.3782" y2="173.1356">
+	<stop  offset="0" style="stop-color:#229FE8"/>
+	<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+	<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+</linearGradient>
+<path class="st4" d="M422.9,111.3l-0.2,121.5c0,3.6-2.4,6.4-5.5,7.2c1.6-1.3,2.7-3.3,2.7-5.7l0.2-121.5c0-4.8-2.5-9.2-6.7-11.6
+	l-47.6-27.6c-1.9-1.1-3.9-1.2-5.7-0.7c2.3-1.9,5.6-2.4,8.5-0.7l47.6,27.6C420.4,102.1,422.9,106.5,422.9,111.3z"/>
+<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="79.8319" y1="112.3619" x2="327.8908" y2="112.3619">
+	<stop  offset="0" style="stop-color:#229FE8"/>
+	<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+	<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+</linearGradient>
+<path class="st5" d="M235.4,22.5c-0.4,0.1-0.9,0.3-1.3,0.5L87.3,107.7c-2.5,1.5-4.1,4.1-4,7l0.2,85.5c0,1.1,0.4,2,0.9,2.7
+	c-2.3-0.1-4.3-1.9-4.4-4.5l-0.2-85c0-2.9,1.5-5.6,4-7l146.8-84.2C232.2,21.5,234,21.6,235.4,22.5z"/>
+<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="3131.1108" y1="157.1381" x2="3235.9126" y2="157.1381" gradientTransform="matrix(-1 0 0 1 3551.2424 0)">
+	<stop  offset="0" style="stop-color:#229FE8"/>
+	<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+	<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+</linearGradient>
+<path class="st6" d="M419.9,234.2l0.2-121.5c0-4.8-2.5-9.2-6.7-11.6l-47.6-27.6c-5-2.9-11.2,0.7-11.2,6.5l-0.2,121.5
+	c0,4.8,2.5,9.2,6.7,11.6l47.6,27.6C413.7,243.6,419.9,240,419.9,234.2z"/>
+<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="80.2489" y1="154.1837" x2="424.8683" y2="-16.6616">
+	<stop  offset="0" style="stop-color:#229FE8"/>
+	<stop  offset="0.4666" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+	<stop  offset="1" style="stop-color:#8058DD;stop-opacity:0"/>
+</linearGradient>
+<path class="st7" d="M83.5,200.2l-0.2-85.5c0-2.9,1.5-5.6,4-7l146.8-84.7c3-1.7,6.7,0.4,6.7,3.9l0.2,85.5c0,2.9-1.5,5.6-4,7
+	L90.2,204.1C87.2,205.8,83.5,203.7,83.5,200.2z"/>
+<g>
+	<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="60.7075" y1="62.9519" x2="60.3876" y2="202.4083">
+		<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+		<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st8" d="M60.5,198.8L60.5,198.8c-0.5,0-0.9-0.4-0.9-0.9l0.2-133.1c0-0.5,0.4-0.9,0.9-0.9h0c0.5,0,0.9,0.4,0.9,0.9
+		L61.3,198C61.3,198.4,60.9,198.8,60.5,198.8z"/>
+	<g>
+		
+			<radialGradient id="SVGID_9_" cx="-2375.6257" cy="-107.8066" r="19.5347" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.2115 157.7808)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+			<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+			<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+			<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+			<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st9" d="M70.2,55.9c-5.3-5.4-13.8-5.4-19,0c-5.2,5.4-5.2,14.2,0,19.6c5.3,5.4,13.8,5.4,19,0
+			C75.4,70.1,75.4,61.3,70.2,55.9L70.2,55.9z"/>
+		
+			<radialGradient id="SVGID_10_" cx="-2375.6257" cy="-107.8066" r="8.1758" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.7163 129.2222)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st10" d="M64.1,62.2c-1.9-1.9-4.9-1.9-6.8,0c-1.9,1.9-1.9,5.1,0,7c1.9,1.9,4.9,1.9,6.8,0C66,67.3,65.9,64.2,64.1,62.2
+			L64.1,62.2z"/>
+	</g>
+</g>
+<g>
+	<linearGradient id="SVGID_11_" gradientUnits="userSpaceOnUse" x1="44.1038" y1="136.3816" x2="43.9098" y2="220.9742">
+		<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+		<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st11" d="M44,218.8L44,218.8c-0.5,0-0.9-0.4-0.9-0.9l0.1-80.1c0-0.5,0.4-0.9,0.9-0.9h0c0.5,0,0.9,0.4,0.9,0.9
+		l-0.1,80.1C44.8,218.4,44.4,218.8,44,218.8z"/>
+	<g>
+		
+			<radialGradient id="SVGID_12_" cx="-2404.9241" cy="-35.0967" r="11.7474" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.4337 187.0251)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+			<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+			<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+			<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+			<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st12" d="M49.8,132.5c-3.2-3.3-8.3-3.3-11.4,0c-3.2,3.2-3.1,8.5,0,11.8c3.2,3.3,8.3,3.3,11.4,0
+			C53,141,53,135.8,49.8,132.5L49.8,132.5z"/>
+		
+			<radialGradient id="SVGID_13_" cx="-2404.9241" cy="-35.0967" r="4.9166" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.674 160.3246)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st13" d="M46.1,136.3c-1.1-1.2-3-1.2-4.1,0c-1.1,1.2-1.1,3,0,4.2c1.1,1.2,3,1.2,4.1,0
+			C47.3,139.3,47.3,137.5,46.1,136.3L46.1,136.3z"/>
+	</g>
+</g>
+<g>
+	<linearGradient id="SVGID_14_" gradientUnits="userSpaceOnUse" x1="273.8052" y1="107.8288" x2="273.5355" y2="225.4431">
+		<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+		<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st14" d="M273.6,222.4L273.6,222.4c-0.5,0-0.9-0.6-0.9-1.2l0.1-111.3c0-0.7,0.4-1.2,0.9-1.2h0c0.5,0,0.9,0.6,0.9,1.2
+		l-0.1,111.3C274.5,221.9,274.1,222.4,273.6,222.4z"/>
+	<g>
+		
+			<radialGradient id="SVGID_15_" cx="-1996.9578" cy="-63.7253" r="11.7474" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.3647 171.2819)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+			<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+			<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+			<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+			<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st15" d="M279.5,104.2c-3.2-3.3-8.3-3.3-11.4,0c-3.2,3.2-3.1,8.5,0,11.8c3.2,3.3,8.3,3.3,11.4,0
+			C282.6,112.7,282.6,107.5,279.5,104.2L279.5,104.2z"/>
+		
+			<radialGradient id="SVGID_16_" cx="-1996.9578" cy="-63.7253" r="4.9166" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6907 148.0784)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st16" d="M275.8,108c-1.1-1.2-3-1.2-4.1,0c-1.1,1.2-1.1,3,0,4.2c1.1,1.2,3,1.2,4.1,0C276.9,111,276.9,109.1,275.8,108
+			L275.8,108z"/>
+	</g>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_17_" gradientUnits="userSpaceOnUse" x1="5919.9736" y1="181.95" x2="5918.7993" y2="218.6441" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#434453"/>
+		<stop  offset="0.5484" style="stop-color:#434453;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st17" d="M267.8,188.6l-12.5-7.4c-0.8-0.5-1.7-0.5-2.5,0l-12.9,7.5c-0.6,0.4-0.6,1.3,0,1.6l12.7,7.3
+		c0.8,0.4,1.7,0.4,2.5,0l12.8-7.3C268.4,189.9,268.4,189,267.8,188.6z"/>
+	<linearGradient id="SVGID_18_" gradientUnits="userSpaceOnUse" x1="247.0878" y1="193.5859" x2="244.3909" y2="234.0401">
+		<stop  offset="0" style="stop-color:#31313D"/>
+		<stop  offset="0.3791" style="stop-color:#31313D;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st18" points="239.3,189.5 239.3,218.7 253.8,213.3 253.8,197.8 	"/>
+	
+		<linearGradient id="SVGID_19_" gradientUnits="userSpaceOnUse" x1="5913.167" y1="192.8459" x2="5911.0659" y2="224.3639" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#292933"/>
+		<stop  offset="0.3339" style="stop-color:#292933;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st19" points="268.1,189.6 268.1,207.6 253.7,213.3 253.7,197.8 	"/>
+	<g class="st20">
+		
+			<linearGradient id="SVGID_20_" gradientUnits="userSpaceOnUse" x1="5915.6523" y1="182.4411" x2="5923.7124" y2="196.4019" gradientTransform="matrix(-1 0 0 1 6173.4907 0)">
+			<stop  offset="0" style="stop-color:#F4F8FB;stop-opacity:0"/>
+			<stop  offset="1" style="stop-color:#F4F8FB"/>
+		</linearGradient>
+		<path class="st21" d="M253.7,198.2c-0.5,0-1-0.1-1.4-0.4l-12.7-7.3c-0.4-0.2-0.6-0.6-0.6-1.1c0-0.4,0.2-0.8,0.6-1.1l12.9-7.5
+			c0.9-0.5,1.9-0.5,2.8,0l12.5,7.4h0c0.4,0.2,0.6,0.6,0.6,1.1c0,0.4-0.2,0.8-0.6,1l-12.8,7.3C254.7,198.1,254.2,198.2,253.7,198.2z
+			 M254,181.2c-0.4,0-0.8,0.1-1.1,0.3l-12.9,7.5c-0.2,0.1-0.3,0.3-0.3,0.6c0,0.2,0.1,0.5,0.3,0.6l12.7,7.3c0.7,0.4,1.5,0.4,2.2,0
+			l12.8-7.3c0.2-0.1,0.3-0.3,0.3-0.6c0-0.2-0.1-0.5-0.3-0.6h0l-12.5-7.4C254.7,181.3,254.4,181.2,254,181.2z"/>
+	</g>
+	<g class="st22">
+		<linearGradient id="SVGID_21_" gradientUnits="userSpaceOnUse" x1="250.4818" y1="199.9533" x2="257.0875" y2="211.3947">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="1" style="stop-color:#F4F8FB;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st23" points="254.1,213.1 253.6,213.3 253.6,198.2 254.1,198.2 		"/>
+	</g>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_22_" gradientUnits="userSpaceOnUse" x1="5944.0112" y1="162.573" x2="5942.8369" y2="199.2671" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#434453"/>
+		<stop  offset="0.5484" style="stop-color:#434453;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st24" d="M243.7,169.2l-12.5-7.4c-0.8-0.5-1.7-0.5-2.5,0l-12.9,7.5c-0.6,0.4-0.6,1.3,0,1.6l12.7,7.3
+		c0.8,0.4,1.7,0.4,2.5,0l12.8-7.3C244.3,170.5,244.3,169.6,243.7,169.2z"/>
+	<linearGradient id="SVGID_23_" gradientUnits="userSpaceOnUse" x1="223.6169" y1="175.9615" x2="219.618" y2="235.9459">
+		<stop  offset="0" style="stop-color:#383846"/>
+		<stop  offset="0.5484" style="stop-color:#31313D;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st25" points="215.3,170.1 215.3,205.5 229.8,214.4 229.7,178.4 	"/>
+	
+		<linearGradient id="SVGID_24_" gradientUnits="userSpaceOnUse" x1="5937.707" y1="175.936" x2="5933.7578" y2="235.1711" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#292933"/>
+		<stop  offset="0.5484" style="stop-color:#292933;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st26" points="244.1,170.2 244.1,205.2 229.7,213.9 229.7,178.4 	"/>
+	<g class="st27">
+		
+			<linearGradient id="SVGID_25_" gradientUnits="userSpaceOnUse" x1="5939.6899" y1="163.0642" x2="5947.75" y2="177.0246" gradientTransform="matrix(-1 0 0 1 6173.4907 0)">
+			<stop  offset="0" style="stop-color:#F4F8FB;stop-opacity:0"/>
+			<stop  offset="1" style="stop-color:#F4F8FB"/>
+		</linearGradient>
+		<path class="st28" d="M229.7,178.8c-0.5,0-1-0.1-1.4-0.4l-12.7-7.3c-0.4-0.2-0.6-0.6-0.6-1.1c0-0.4,0.2-0.8,0.6-1.1l12.9-7.5
+			c0.9-0.5,1.9-0.5,2.8,0l12.5,7.4h0l0,0h0c0.4,0.2,0.6,0.6,0.6,1.1s-0.2,0.8-0.6,1.1l-12.8,7.3
+			C230.6,178.7,230.2,178.8,229.7,178.8z M229.9,161.8c-0.4,0-0.8,0.1-1.1,0.3l-12.9,7.5c-0.2,0.1-0.3,0.3-0.3,0.6
+			c0,0.2,0.1,0.5,0.3,0.6l12.7,7.3c0.7,0.4,1.5,0.4,2.2,0l12.8-7.3c0.2-0.1,0.3-0.3,0.3-0.6c0-0.2-0.1-0.5-0.3-0.6h0l-12.5-7.4
+			C230.7,161.9,230.3,161.8,229.9,161.8z"/>
+	</g>
+	<g class="st29">
+		<linearGradient id="SVGID_26_" gradientUnits="userSpaceOnUse" x1="224.5981" y1="181.4155" x2="234.5129" y2="198.5885">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="1" style="stop-color:#F4F8FB;stop-opacity:0"/>
+		</linearGradient>
+		<rect x="229.3" y="178.7" class="st30" width="0.6" height="22.6"/>
+	</g>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_27_" gradientUnits="userSpaceOnUse" x1="5966.4775" y1="144.8319" x2="5965.3032" y2="181.5261" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#434453"/>
+		<stop  offset="0.5484" style="stop-color:#434453;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st31" d="M221.2,151.5l-12.5-7.4c-0.8-0.5-1.7-0.5-2.5,0l-12.9,7.5c-0.6,0.4-0.6,1.3,0,1.6l12.7,7.3
+		c0.8,0.4,1.7,0.4,2.5,0l12.8-7.3C221.9,152.8,221.9,151.9,221.2,151.5z"/>
+	<linearGradient id="SVGID_28_" gradientUnits="userSpaceOnUse" x1="201.3159" y1="159.033" x2="196.7084" y2="228.1458">
+		<stop  offset="0" style="stop-color:#383846"/>
+		<stop  offset="0.5484" style="stop-color:#31313D;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st32" points="192.8,152.4 192.8,194.4 207.3,203.2 207.3,160.7 	"/>
+	
+		<linearGradient id="SVGID_29_" gradientUnits="userSpaceOnUse" x1="5960.353" y1="159.0779" x2="5955.7432" y2="228.2318" gradientTransform="matrix(-1 0 0 1 6173.5161 0)">
+		<stop  offset="0" style="stop-color:#292933"/>
+		<stop  offset="0.5484" style="stop-color:#292933;stop-opacity:0"/>
+	</linearGradient>
+	<polygon class="st33" points="221.6,152.4 221.6,194.7 207.2,203.3 207.2,160.7 	"/>
+	<g class="st34">
+		
+			<linearGradient id="SVGID_30_" gradientUnits="userSpaceOnUse" x1="5962.1567" y1="145.3233" x2="5970.2163" y2="159.2834" gradientTransform="matrix(-1 0 0 1 6173.4907 0)">
+			<stop  offset="0" style="stop-color:#F4F8FB;stop-opacity:0"/>
+			<stop  offset="1" style="stop-color:#F4F8FB"/>
+		</linearGradient>
+		<path class="st35" d="M207.2,161.1c-0.5,0-1-0.1-1.4-0.4l-12.7-7.3c-0.4-0.2-0.6-0.6-0.6-1.1c0-0.4,0.2-0.8,0.6-1.1l12.9-7.5
+			c0.9-0.5,1.9-0.5,2.8,0l12.5,7.4c0.4,0.2,0.6,0.6,0.6,1.1c0,0.4-0.2,0.8-0.6,1l-12.8,7.3C208.2,161,207.7,161.1,207.2,161.1z
+			 M207.5,144.1c-0.4,0-0.8,0.1-1.1,0.3l-12.9,7.5c-0.2,0.1-0.3,0.3-0.3,0.6c0,0.2,0.1,0.5,0.3,0.6l12.7,7.3c0.7,0.4,1.5,0.4,2.2,0
+			l12.8-7.3c0.2-0.1,0.3-0.3,0.3-0.6c0-0.2-0.1-0.5-0.3-0.6l-12.5-7.4C208.2,144.2,207.8,144.1,207.5,144.1z"/>
+	</g>
+	<g class="st34">
+		<linearGradient id="SVGID_31_" gradientUnits="userSpaceOnUse" x1="201.3793" y1="164.3152" x2="213.0721" y2="184.5677">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="1" style="stop-color:#F4F8FB;stop-opacity:0"/>
+		</linearGradient>
+		<rect x="207" y="161.1" class="st36" width="0.6" height="26.7"/>
+	</g>
+</g>
+<linearGradient id="SVGID_32_" gradientUnits="userSpaceOnUse" x1="92.1158" y1="160.3673" x2="361.2685" y2="26.9347">
+	<stop  offset="0" style="stop-color:#8058DD;stop-opacity:0.2"/>
+	<stop  offset="0.2584" style="stop-color:#4C80E3;stop-opacity:0.36"/>
+	<stop  offset="0.4845" style="stop-color:#229FE8;stop-opacity:0.5"/>
+</linearGradient>
+<path class="st37" d="M239.4,104.2c-14.1-1.7,0-17.5-17.7-16.4c-13.6,0.8-24.9,37.3-39.5,44c-17.4,8-33.4-20-52.5-14.6
+	c-6.4,1.8-38.2,13.7-38.2,13.7v59.5c0,0,107.2-62.3,148-85C239.4,104.7,239.4,105.1,239.4,104.2z"/>
+<linearGradient id="SVGID_33_" gradientUnits="userSpaceOnUse" x1="72.0696" y1="166.3612" x2="265.2817" y2="67.6015">
+	<stop  offset="0" style="stop-color:#CDED22"/>
+	<stop  offset="0.3321" style="stop-color:#C39B73;stop-opacity:0.8137"/>
+	<stop  offset="0.5899" style="stop-color:#BC61AB;stop-opacity:0.6692"/>
+	<stop  offset="0.7132" style="stop-color:#B94BC1;stop-opacity:0.6"/>
+	<stop  offset="0.7932" style="stop-color:#B73CD0;stop-opacity:0.3139"/>
+	<stop  offset="0.881" style="stop-color:#B62FDC;stop-opacity:0"/>
+</linearGradient>
+<path class="st38" d="M239.7,105c-10.2,4.9-22,8.5-30.4-4.4c-8.4-12.9-15.4-25.7-28-24.1c-12.5,1.6-18.6,31.2-23.8,40.5
+	c-5.1,9.3-19,8-30.5,31.5c-6.7,13.5-17.4,21.4-25.3,25.6c-6.2,3.3-10.2,9.7-10.3,16.8v0l100-57.2c15.8-9.1,31.5-18.5,48.5-28.5
+	C239.9,102.7,240,104.9,239.7,105z"/>
+<g>
+	<linearGradient id="SVGID_34_" gradientUnits="userSpaceOnUse" x1="91.1331" y1="133.6508" x2="240.1754" y2="133.6508">
+		<stop  offset="0" style="stop-color:#E4C8EC;stop-opacity:0.2"/>
+		<stop  offset="0.3855" style="stop-color:#E4C8EC"/>
+		<stop  offset="0.4557" style="stop-color:#DDC0EB;stop-opacity:0.8466"/>
+		<stop  offset="0.5646" style="stop-color:#C9AAE8;stop-opacity:0.609"/>
+		<stop  offset="0.6984" style="stop-color:#AA87E3;stop-opacity:0.3169"/>
+		<stop  offset="0.8436" style="stop-color:#8058DD;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st39" d="M91.6,191.3C91.6,191.3,91.6,191.3,91.6,191.3c-0.2,0-0.4-0.2-0.4-0.4c0.1-7.1,4.1-13.7,10.5-17.1
+		c7.8-4.2,18.5-12,25.1-25.4c7.2-14.7,15.2-19.7,21.7-23.7c3.9-2.4,7-4.4,8.9-7.8c1.4-2.6,2.9-6.6,4.6-11.4
+		c4.5-12.5,10.2-28.2,19.5-29.4c11.8-1.5,18.9,9.5,26.4,21.2c0.7,1,1.3,2,2,3.1c7.5,11.6,17.7,6.6,27.5,1.8c0.8-0.4,1.5-0.8,2.3-1.1
+		c0.2-0.1,0.5,0,0.6,0.2c0.1,0.2,0,0.5-0.2,0.6c-0.8,0.4-1.5,0.7-2.3,1.1c-9.7,4.7-20.7,10.1-28.6-2.1c-0.7-1-1.3-2.1-2-3.1
+		c-7.3-11.5-14.3-22.3-25.5-20.8c-8.8,1.1-14.6,17.1-18.8,28.8c-1.7,4.8-3.2,8.9-4.7,11.5c-2,3.6-5.3,5.7-9.2,8.1
+		c-6.3,4-14.2,8.9-21.3,23.4c-6.7,13.6-17.6,21.6-25.5,25.8c-6.1,3.3-9.9,9.5-10,16.4C92,191.1,91.8,191.3,91.6,191.3z"/>
+</g>
+<g>
+	<g>
+		
+			<linearGradient id="SVGID_35_" gradientUnits="userSpaceOnUse" x1="2826.6494" y1="79.3043" x2="2826.6494" y2="126.7188" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="5.586592e-03" style="stop-color:#C8E822"/>
+			<stop  offset="0.2737" style="stop-color:#C8E822"/>
+			<stop  offset="0.8575" style="stop-color:#C8E822;stop-opacity:0.4"/>
+		</linearGradient>
+		<polygon class="st40" points="188.6,126.7 188.4,79.3 189.3,79.3 189.6,126.7 		"/>
+	</g>
+	<g class="st41">
+		
+			<rect x="188.6" y="130.8" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.4928 0.7072)" class="st42" width="1" height="3"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_36_" gradientUnits="userSpaceOnUse" x1="2838.2336" y1="76.9639" x2="2838.2336" y2="132.3563" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st43" points="177.1,132.4 176.8,77 177.7,77 178,132.4 		"/>
+	</g>
+	<g class="st41">
+		<rect x="177.1" y="137.4" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.5173 0.664)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		<linearGradient id="SVGID_37_" gradientUnits="userSpaceOnUse" x1="165.7996" y1="83.652" x2="165.7996" y2="139.0444">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st45" points="165.5,139 165.2,83.7 166.1,83.7 166.4,139 		"/>
+	</g>
+	<g class="st46">
+		<rect x="165.5" y="144" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.5424 0.6208)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		<linearGradient id="SVGID_38_" gradientUnits="userSpaceOnUse" x1="154.2026" y1="90.3479" x2="154.2026" y2="145.7404">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st47" points="153.9,145.7 153.6,90.4 154.5,90.3 154.8,145.7 		"/>
+	</g>
+	<g class="st46">
+		
+			<rect x="153.9" y="150.7" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.5675 0.5775)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		<linearGradient id="SVGID_39_" gradientUnits="userSpaceOnUse" x1="142.6177" y1="97.0361" x2="142.6177" y2="152.4285">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st48" points="142.3,152.4 142,97 142.9,97 143.2,152.4 		"/>
+	</g>
+	<g class="st49">
+		
+			<rect x="142.3" y="157.4" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.5925 0.5343)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_40_" gradientUnits="userSpaceOnUse" x1="2884.5974" y1="103.732" x2="2884.5974" y2="159.1244" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st50" points="130.7,159.1 130.4,103.7 131.3,103.7 131.6,159.1 		"/>
+	</g>
+	<g class="st49">
+		<rect x="130.7" y="164.1" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.6176 0.491)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_41_" gradientUnits="userSpaceOnUse" x1="2896.1824" y1="110.4202" x2="2896.1824" y2="165.8126" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st51" points="119.1,165.8 118.8,110.4 119.8,110.4 120.1,165.8 		"/>
+	</g>
+	<g class="st49">
+		
+			<rect x="119.1" y="170.8" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.6427 0.4478)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_42_" gradientUnits="userSpaceOnUse" x1="2907.7793" y1="117.1161" x2="2907.7793" y2="172.5085" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st52" points="107.5,172.5 107.2,117.1 108.2,117.1 108.5,172.5 		"/>
+	</g>
+	<g class="st49">
+		
+			<rect x="107.5" y="177.5" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.6678 0.4046)" class="st44" width="1" height="3"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_43_" gradientUnits="userSpaceOnUse" x1="2919.3633" y1="123.8042" x2="2919.3633" y2="179.1966" gradientTransform="matrix(-1 0 0 1 3015.6182 0)">
+			<stop  offset="0" style="stop-color:#229FE8;stop-opacity:0"/>
+			<stop  offset="0.4637" style="stop-color:#229FE8"/>
+			<stop  offset="0.986" style="stop-color:#229FE8;stop-opacity:0"/>
+		</linearGradient>
+		<polygon class="st53" points="95.9,179.2 95.6,123.8 96.6,123.8 96.9,179.2 		"/>
+	</g>
+	<g class="st41">
+		<rect x="95.9" y="184.2" transform="matrix(1 -3.734533e-03 3.734533e-03 1 -0.6928 0.3613)" class="st44" width="1" height="3"/>
+	</g>
+</g>
+<linearGradient id="SVGID_44_" gradientUnits="userSpaceOnUse" x1="209.661" y1="156.9779" x2="178.4689" y2="141.6263">
+	<stop  offset="0" style="stop-color:#1C1C23"/>
+	<stop  offset="0.7663" style="stop-color:#292933;stop-opacity:0"/>
+</linearGradient>
+<path class="st54" d="M206.9,154.3l-12.3-0.5l-0.6-0.4l-0.6-0.3c-0.6-0.3-0.6-1.2,0-1.5l3.8-2.2l8.2,1.3L206.9,154.3z"/>
+<linearGradient id="SVGID_45_" gradientUnits="userSpaceOnUse" x1="232.7162" y1="174.7282" x2="200.7966" y2="159.0185">
+	<stop  offset="0" style="stop-color:#1C1C23"/>
+	<stop  offset="0.7663" style="stop-color:#292933;stop-opacity:0"/>
+</linearGradient>
+<path class="st55" d="M230.1,171.5l-13.5-0.4l-0.6-0.3c-0.6-0.3-0.6-1.2,0-1.5l4.2-2.4l7.6,1.2L230.1,171.5z"/>
+<g>
+	<g>
+		<path class="st56" d="M412.8,116.8c-0.1,0-0.2,0-0.2-0.1L393.9,106c-0.2-0.1-0.3-0.4-0.2-0.7c0.1-0.2,0.4-0.3,0.7-0.2l18.7,10.7
+			c0.2,0.1,0.3,0.4,0.2,0.7C413.1,116.7,413,116.8,412.8,116.8z"/>
+	</g>
+	<g>
+		<path class="st56" d="M412.8,120.2c-0.1,0-0.2,0-0.2-0.1l-11.5-6.7c-0.2-0.1-0.2-0.2-0.2-0.4c0-0.1,0-0.2,0.1-0.2
+			c0.1-0.2,0.4-0.3,0.7-0.2l11.5,6.7c0.2,0.1,0.2,0.2,0.2,0.4c0,0.1,0,0.2-0.1,0.2C413.1,120.1,413,120.2,412.8,120.2z"/>
+	</g>
+</g>
+<g>
+	
+		<radialGradient id="SVGID_46_" cx="2817.1875" cy="79.2963" r="10.976" gradientTransform="matrix(-0.4933 0.8699 0.5131 0.2909 1537.9368 -2394.3645)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#C7B955;stop-opacity:0"/>
+		<stop  offset="0.2838" style="stop-color:#C7C24B;stop-opacity:0.2838"/>
+		<stop  offset="0.7567" style="stop-color:#C8D932;stop-opacity:0.7567"/>
+		<stop  offset="1" style="stop-color:#C8E822"/>
+	</radialGradient>
+	<path class="st57" d="M188.9,70c-4.5,2.6-8.1,8.9-8.1,14c0,5.1,3.7,7.2,8.1,4.6c4.5-2.6,8.1-8.9,8.1-14
+		C197.1,69.5,193.4,67.4,188.9,70L188.9,70z"/>
+	
+		<radialGradient id="SVGID_47_" cx="2817.1904" cy="79.2974" r="3.5668" gradientTransform="matrix(-0.5108 0.8597 0.5852 0.3477 1581.506 -2370.2507)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#320D4F;stop-opacity:0"/>
+		<stop  offset="0.3655" style="stop-color:#71693C;stop-opacity:0.2867"/>
+		<stop  offset="0.6674" style="stop-color:#A0AD2E;stop-opacity:0.5235"/>
+		<stop  offset="0.884" style="stop-color:#BDD825;stop-opacity:0.6934"/>
+		<stop  offset="0.9944" style="stop-color:#C8E822;stop-opacity:0.78"/>
+	</radialGradient>
+	<path class="st58" d="M188.9,75.7c-1.7,1-3.1,3.4-3.1,5.3c0,2,1.4,2.8,3.1,1.8c1.7-1,3.1-3.4,3.1-5.3
+		C192,75.5,190.7,74.8,188.9,75.7L188.9,75.7z"/>
+	<path class="st42" d="M189,77.8c0.7-0.4,1.3-0.1,1.3,0.7c0,0.8-0.6,1.8-1.3,2.2c-0.7,0.4-1.3,0.1-1.3-0.7
+		C187.7,79.2,188.2,78.2,189,77.8L189,77.8z"/>
+</g>
+<linearGradient id="SVGID_48_" gradientUnits="userSpaceOnUse" x1="50.978" y1="75.7705" x2="196.5972" y2="75.7705">
+	<stop  offset="0" style="stop-color:#31313D"/>
+	<stop  offset="0.8519" style="stop-color:#31313D;stop-opacity:0"/>
+</linearGradient>
+<path class="st59" d="M142.2,45.9c0-3.4-3.8-5.6-6.7-3.8L55,88.4c-2.5,1.5-4.1,4.2-4.1,7.1l0.1,10.1c0,3.4,3.8,5.6,6.7,3.8
+	l80.4-46.3c2.5-1.5,4.1-4.2,4.1-7.1L142.2,45.9z M61.1,100.2c-1.6,0.9-2.9,0.2-2.9-1.7c0-1.9,1.3-4.1,2.9-5.1
+	c1.6-0.9,2.9-0.2,2.9,1.7C64,97,62.7,99.3,61.1,100.2z M71.1,94.4c-1.6,0.9-2.9,0.2-2.9-1.7c0-1.9,1.3-4.1,2.9-5.1
+	c1.6-0.9,2.9-0.2,2.9,1.7C74,91.2,72.7,93.5,71.1,94.4z M81,88.6c-1.6,0.9-2.9,0.2-2.9-1.7c0-1.9,1.3-4.1,2.9-5.1
+	c1.6-0.9,2.9-0.2,2.9,1.7C84,85.4,82.7,87.7,81,88.6z"/>
+<g>
+	<path class="st60" d="M207.9,151.3v2.2c0,0.6-0.5,1-1.1,0.8c-2.3-0.7-7.7-2.3-9-3.8c0,0,0.3-1.8,1-1.9c0.7-0.1,6.7,1.1,6.7,1.1
+		L207.9,151.3z"/>
+	<path class="st60" d="M231.2,168.6v2.3c0,0.6-0.5,1-1.1,0.8c-2.4-0.7-8.7-2.7-10-4.2c0,0,0.3-1.8,1-1.9s7.4,0.5,7.4,0.5
+		L231.2,168.6z"/>
+	<linearGradient id="SVGID_49_" gradientUnits="userSpaceOnUse" x1="214.7683" y1="97.2489" x2="225.0741" y2="152.9">
+		<stop  offset="0" style="stop-color:#B62FDC"/>
+		<stop  offset="2.535278e-02" style="stop-color:#A939DD"/>
+		<stop  offset="0.1071" style="stop-color:#8653E0"/>
+		<stop  offset="0.1968" style="stop-color:#676AE2"/>
+		<stop  offset="0.2946" style="stop-color:#4F7DE4"/>
+		<stop  offset="0.4038" style="stop-color:#3C8BE6"/>
+		<stop  offset="0.5308" style="stop-color:#2E95E7"/>
+		<stop  offset="0.6919" style="stop-color:#269BE8"/>
+		<stop  offset="1" style="stop-color:#249DE8"/>
+	</linearGradient>
+	<path class="st61" d="M225.5,118.4l1.5,16.3c0,0,4.4,33.8,4.3,34.6c0,0-3.3,0-4.7-2.7l-8.5-30.2l-6.4-19.6L225.5,118.4z"/>
+	<path class="st62" d="M208.1,151.3l-1.1-19.8l13.9-5.6c2.9-1.1,4.7-3.9,4.8-7l0,0l-13.2-2.9l-11.8,8.2c-1.3,0.9-1.9,2.4-1.6,4
+		l4.2,20.6C203.7,150.1,207,151.8,208.1,151.3z"/>
+	<linearGradient id="SVGID_50_" gradientUnits="userSpaceOnUse" x1="225.6486" y1="88.9167" x2="216.2208" y2="85.561">
+		<stop  offset="0" style="stop-color:#6C64BC"/>
+		<stop  offset="0.273" style="stop-color:#7A71C7"/>
+		<stop  offset="0.7902" style="stop-color:#A093E5"/>
+		<stop  offset="1" style="stop-color:#B1A2F2"/>
+	</linearGradient>
+	<path class="st63" d="M219.4,86.1c0,0,0.2,4.2,1.2,4.5c1,0.3-5.3,0.7-5.3,0.7l-1-3c0,0-4.3,1.5-3.6-7.1
+		C211.3,72.4,219.4,86.1,219.4,86.1z"/>
+	<linearGradient id="SVGID_51_" gradientUnits="userSpaceOnUse" x1="202.0123" y1="89.2512" x2="193.7452" y2="86.3087">
+		<stop  offset="0" style="stop-color:#6C64BC"/>
+		<stop  offset="0.273" style="stop-color:#7A71C7"/>
+		<stop  offset="0.7902" style="stop-color:#A093E5"/>
+		<stop  offset="1" style="stop-color:#B1A2F2"/>
+	</linearGradient>
+	<path class="st64" d="M195,93.3l2.7-2.9c0,0-4.5-5.3-6.3-9.5l-1.5-2.5c0,0,0.5,3.2,0.6,3.9c0,0-2.1,3.1-0.9,4.3
+		C191.4,88.4,195,93.3,195,93.3z"/>
+	<linearGradient id="SVGID_52_" gradientUnits="userSpaceOnUse" x1="208.5059" y1="123.6269" x2="208.8391" y2="81.9759">
+		<stop  offset="0.1936" style="stop-color:#25262B"/>
+		<stop  offset="0.8746" style="stop-color:#6D6F80"/>
+	</linearGradient>
+	<path class="st65" d="M219.7,90.2c-3-0.7-2.4-0.5-5.1,0.9c-1,0.5-2,0.9-3.1,1.2c-4.5,1.4-8.4,3.2-13.6-2.5l-6.3,4
+		c5,7.9,13.8,8.5,18,7.6c0,0.8,0.1,1.6,0.1,2.1c0,0.7,0.1,1.3,0.3,1.9c0.5,1.5,1.5,5.2,0.6,10.3c2.4,4.9,10.2,3.3,14.9,3.7
+		C226.7,100.7,224.1,91.3,219.7,90.2z"/>
+	<linearGradient id="SVGID_53_" gradientUnits="userSpaceOnUse" x1="214.7522" y1="90.7175" x2="217.2393" y2="65.2247">
+		<stop  offset="0" style="stop-color:#CDED22"/>
+		<stop  offset="0.1296" style="stop-color:#CBDC33"/>
+		<stop  offset="0.3876" style="stop-color:#C5AE5F"/>
+		<stop  offset="0.7461" style="stop-color:#BD66A6"/>
+		<stop  offset="1" style="stop-color:#B62FDC"/>
+	</linearGradient>
+	<path class="st66" d="M220.3,85.9c0,0-5.3,1.6-6.4-3.2c0,0-5.4-0.2-4-4.4c1.4-4,7.8-1.6,10.6,1.5C223.4,82.9,220.3,85.9,220.3,85.9
+		z"/>
+	<linearGradient id="SVGID_54_" gradientUnits="userSpaceOnUse" x1="211.7118" y1="98.1408" x2="212.2194" y2="126.2241">
+		<stop  offset="0" style="stop-color:#25262B"/>
+		<stop  offset="0.8802" style="stop-color:#25262B;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st67" d="M212,110.8c-0.5,0.7,0.6,6.3,0.6,7.1c-0.8-0.5-1.5-1.2-2-2.2c0.8-5.1-0.1-8.8-0.6-10.3
+		c-0.2-0.6-0.3-1.3-0.3-1.9c0-0.5-0.1-1.2-0.1-2c1.5-0.3,3.6-0.6,4.4-1.4C213.9,100.1,214.3,107.7,212,110.8z"/>
+	
+		<linearGradient id="SVGID_55_" gradientUnits="userSpaceOnUse" x1="755.707" y1="-68.1992" x2="753.1496" y2="-106.7726" gradientTransform="matrix(0.988 -0.1542 0.1542 0.988 -511.0789 285.8414)">
+		<stop  offset="0" style="stop-color:#CDED22"/>
+		<stop  offset="0.1183" style="stop-color:#CBDF30"/>
+		<stop  offset="0.3437" style="stop-color:#C7B955"/>
+		<stop  offset="0.6527" style="stop-color:#BF7C91"/>
+		<stop  offset="1" style="stop-color:#B62FDC"/>
+	</linearGradient>
+	<path class="st68" d="M220.3,96.1c0.5,0.6,5.7,1.8,6.6-0.3c0.8-2,0.1-2.7-1.1-3.3c-1.1-0.6-0.9-2.4-0.7-3.6
+		c0.3-1.6,0.3-3.8-0.6-5.6c-1.2-2.4-2.4-2.8-4.7-2.6c-2.4,0.2-1.3,2.3,0.1,3.4c1.2,0.9,0.5,3-0.3,5.6
+		C218.5,93,219.5,95.1,220.3,96.1z"/>
+	<polygon class="st69" points="215.9,130.1 215.3,128.1 220.9,126 	"/>
+	<linearGradient id="SVGID_56_" gradientUnits="userSpaceOnUse" x1="219.4884" y1="84.2222" x2="219.5287" y2="79.1897">
+		<stop  offset="0.1936" style="stop-color:#7D73CA"/>
+		<stop  offset="0.8746" style="stop-color:#6D6F80"/>
+	</linearGradient>
+	<path class="st70" d="M219.5,83.7c-0.1-0.7,0.3-2.8,1-3s-0.7-0.5-0.7-0.5s-1.1-0.6-1.5,1.4C217.9,83.9,219.5,83.7,219.5,83.7z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<linearGradient id="SVGID_57_" gradientUnits="userSpaceOnUse" x1="437.4765" y1="132.9582" x2="437.2081" y2="249.9813">
+				<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+				<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st71" d="M437.3,247C437.3,247,437.3,247,437.3,247c-0.7,0-1.2-0.6-1.2-1.2l0.2-110.7c0-0.7,0.6-1.2,1.2-1.2
+				c0,0,0,0,0,0c0.7,0,1.2,0.6,1.2,1.2l-0.2,110.7C438.5,246.4,438,247,437.3,247z"/>
+		</g>
+		<g>
+			
+				<radialGradient id="SVGID_58_" cx="-1706.0586" cy="-38.2688" r="16.247" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.4565 178.3082)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#F4F8FB"/>
+				<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+				<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+				<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+				<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+				<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+			</radialGradient>
+			<path class="st72" d="M445.3,127.6c-4.4-4.5-11.5-4.5-15.8,0c-4.4,4.5-4.3,11.8,0,16.3c4.4,4.5,11.5,4.5,15.8,0
+				C449.7,139.4,449.7,132.1,445.3,127.6L445.3,127.6z"/>
+			
+				<radialGradient id="SVGID_59_" cx="-1706.0586" cy="-38.2688" r="6.7999" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6758 158.9677)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#FFFFFF"/>
+				<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+			</radialGradient>
+			<path class="st73" d="M440.3,132.9c-1.6-1.6-4.1-1.6-5.7,0c-1.6,1.6-1.6,4.2,0,5.8c1.6,1.6,4.1,1.6,5.7,0
+				C441.8,137.1,441.8,134.5,440.3,132.9L440.3,132.9z"/>
+		</g>
+	</g>
+	<g>
+		
+			<radialGradient id="SVGID_60_" cx="-1664.3167" cy="13.3143" r="6.4467" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.6169 198.3883)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#22ABF4"/>
+			<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st74" d="M464,184.1c-1.7-1.8-4.5-1.8-6.3,0c-1.7,1.8-1.7,4.7,0,6.5c1.7,1.8,4.5,1.8,6.3,0
+			C465.7,188.8,465.7,185.9,464,184.1L464,184.1z"/>
+		
+			<radialGradient id="SVGID_61_" cx="-1664.3167" cy="13.3143" r="2.6981" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6458 181.0329)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st75" d="M462,186.2c-0.6-0.6-1.6-0.6-2.2,0c-0.6,0.6-0.6,1.7,0,2.3c0.6,0.6,1.6,0.6,2.2,0
+			C462.6,187.9,462.6,186.9,462,186.2L462,186.2z"/>
+	</g>
+	<g>
+		<g class="st46">
+			<g>
+				<linearGradient id="SVGID_62_" gradientUnits="userSpaceOnUse" x1="427.4673" y1="240.1409" x2="427.3885" y2="274.4833">
+					<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+					<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+				</linearGradient>
+				<path class="st76" d="M427.4,273.6L427.4,273.6c-0.2,0-0.3-0.1-0.3-0.3l0-32.6c0-0.2,0.1-0.3,0.3-0.3l0,0c0.2,0,0.3,0.1,0.3,0.3
+					l0,32.6C427.7,273.5,427.6,273.6,427.4,273.6z"/>
+			</g>
+		</g>
+		<g class="st46">
+			
+				<radialGradient id="SVGID_63_" cx="-1723.7371" cy="66.8305" r="6.4467" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.7787 220.3166)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#22ABF4"/>
+				<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+			</radialGradient>
+			<path class="st77" d="M430.5,237.6c-1.7-1.8-4.5-1.8-6.3,0c-1.7,1.8-1.7,4.7,0,6.5c1.7,1.8,4.5,1.8,6.3,0
+				C432.2,242.3,432.2,239.4,430.5,237.6L430.5,237.6z"/>
+			
+				<radialGradient id="SVGID_64_" cx="-1723.7371" cy="66.8305" r="2.6981" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6146 203.9251)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#FFFFFF"/>
+				<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+			</radialGradient>
+			<path class="st78" d="M428.5,239.7c-0.6-0.6-1.6-0.6-2.2,0c-0.6,0.6-0.6,1.7,0,2.3c0.6,0.6,1.6,0.6,2.2,0
+				C429.1,241.4,429.1,240.3,428.5,239.7L428.5,239.7z"/>
+		</g>
+	</g>
+	<g class="st46">
+		<g>
+			<linearGradient id="SVGID_65_" gradientUnits="userSpaceOnUse" x1="460.994" y1="186.2994" x2="460.7382" y2="297.8539">
+				<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+				<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st79" d="M460.8,295L460.8,295c-0.2,0-0.3-0.1-0.3-0.3l0.1-107.3c0-0.2,0.1-0.3,0.3-0.3l0,0c0.2,0,0.3,0.1,0.3,0.3
+				l-0.1,107.3C461.1,294.9,461,295,460.8,295z"/>
+		</g>
+	</g>
+</g>
+<g class="st80">
+	<g>
+		<g>
+			<linearGradient id="SVGID_66_" gradientUnits="userSpaceOnUse" x1="370.1449" y1="161.5186" x2="404.9935" y2="161.5186">
+				<stop  offset="0" style="stop-color:#22ABF4;stop-opacity:0.8"/>
+				<stop  offset="1" style="stop-color:#BD2FE3;stop-opacity:0.8"/>
+			</linearGradient>
+			<path class="st81" d="M395.1,183.8c0,0-0.1,0-0.1,0c-2.4,0-5-0.8-7.7-2.4l0,0c-6.6-3.8-12.5-11.5-15.4-19.9
+				c-2.6-7.5-2.3-14.4,0.7-18.5c1.8-2.4,4.3-3.7,7.4-3.7c0,0,0.1,0,0.1,0c2.4,0,5,0.8,7.7,2.4c6.6,3.8,12.5,11.5,15.4,19.9
+				c2.6,7.5,2.3,14.4-0.7,18.5C400.8,182.5,398.2,183.8,395.1,183.8z M387.7,180.7c2.5,1.5,5,2.2,7.3,2.3c2.9,0.1,5.2-1.1,6.8-3.3
+				c2.8-3.9,3-10.5,0.6-17.7c-2.8-8.3-8.6-15.7-15-19.5c-2.5-1.5-5-2.2-7.3-2.3c-2.9,0-5.2,1.1-6.8,3.3c-2.8,3.9-3,10.5-0.6,17.7
+				C375.6,169.5,381.3,176.9,387.7,180.7L387.7,180.7z"/>
+		</g>
+	</g>
+	<g>
+		<g>
+			<linearGradient id="SVGID_67_" gradientUnits="userSpaceOnUse" x1="377.9653" y1="161.5182" x2="397.1725" y2="161.5182">
+				<stop  offset="0" style="stop-color:#22ABF4;stop-opacity:0.8"/>
+				<stop  offset="1" style="stop-color:#BD2FE3;stop-opacity:0.8"/>
+			</linearGradient>
+			<path class="st82" d="M391.7,173.7C391.6,173.7,391.6,173.7,391.7,173.7c-1.4,0-2.9-0.5-4.3-1.3l0,0c-3.6-2.1-6.8-6.2-8.4-10.9
+				c-1.4-4.1-1.2-7.9,0.4-10.2c1-1.4,2.4-2.1,4.2-2.1c0,0,0,0,0.1,0c1.4,0,2.8,0.5,4.3,1.3c3.6,2.1,6.8,6.2,8.4,10.9
+				c1.4,4.1,1.3,7.9-0.4,10.2C394.8,173,393.4,173.7,391.7,173.7z M387.8,171.7c1.3,0.8,2.6,1.2,3.8,1.2c1.5,0,2.7-0.6,3.5-1.7
+				c1.5-2,1.6-5.6,0.3-9.4c-1.5-4.4-4.6-8.4-8-10.4c-1.3-0.8-2.6-1.2-3.8-1.2c-1.5,0-2.7,0.6-3.5,1.7c-1.5,2-1.6,5.6-0.3,9.4
+				C381.2,165.6,384.4,169.7,387.8,171.7L387.8,171.7z"/>
+		</g>
+	</g>
+	<linearGradient id="SVGID_68_" gradientUnits="userSpaceOnUse" x1="394.7784" y1="182.7218" x2="405.2435" y2="153.6674">
+		<stop  offset="0" style="stop-color:#CDED22"/>
+		<stop  offset="0.1463" style="stop-color:#CAD837;stop-opacity:0.9269"/>
+		<stop  offset="0.4498" style="stop-color:#C4A06D;stop-opacity:0.7751"/>
+		<stop  offset="0.8811" style="stop-color:#B948C3;stop-opacity:0.5594"/>
+		<stop  offset="1" style="stop-color:#B62FDC;stop-opacity:0.5"/>
+	</linearGradient>
+	<path class="st83" d="M406.8,156.8l-19.8,4.6l20.8,25.8l0.2,0.2c3.8-5.5,4.4-14.9,0.7-25.6C408.2,160.1,407.5,158.4,406.8,156.8
+		L406.8,156.8z"/>
+	<linearGradient id="SVGID_69_" gradientUnits="userSpaceOnUse" x1="362.9762" y1="161.5186" x2="412.1618" y2="161.5186">
+		<stop  offset="0" style="stop-color:#22ABF4;stop-opacity:0.8"/>
+		<stop  offset="1" style="stop-color:#BD2FE3;stop-opacity:0.8"/>
+	</linearGradient>
+	<path class="st84" d="M409.7,161.6c-4.1-12-12.5-22.8-21.8-28.3c-3.8-2.2-7.4-3.3-10.9-3.3c-0.1,0-0.1,0-0.2,0
+		c-4.3,0-7.9,1.8-10.4,5.2c-4.2,5.8-4.6,15.6-1,26.2c4.1,12,12.5,22.8,21.8,28.3c3.8,2.2,7.4,3.3,10.9,3.3c0.1,0,0.1,0,0.2,0
+		c4.3,0,7.9-1.8,10.4-5.2C412.9,182,413.3,172.2,409.7,161.6z M366.3,161.1c-3.5-10.3-3.2-19.8,0.8-25.4c2.3-3.2,5.7-4.9,9.8-4.8
+		c3.3,0,6.7,1.1,10.4,3.2l-0.2,0l-0.1,25.8c0,0,0,0,0,0c-0.6,0-0.9,0.7-0.6,1.6l-19.3,1.7C366.8,162.5,366.5,161.8,366.3,161.1z
+		 M398.2,192.1c-3.3,0-6.8-1.1-10.4-3.2c-8.4-4.9-16-14.2-20.3-24.9l19.4-1.7c0.2,0.3,0.5,0.6,0.8,0.7c0.2,0.1,0.3,0.1,0.5,0.2
+		l19.7,24.5C405.4,190.6,402.1,192.2,398.2,192.1z M408.3,186.9l-19.5-24.2c0.1-0.3,0.1-0.7-0.1-1.2c-0.2-0.5-0.5-0.9-0.8-1.3
+		l0.1-25.8c9,5.4,16.9,15.8,20.9,27.4C412.3,172,412.1,181.3,408.3,186.9z"/>
+</g>
+<linearGradient id="SVGID_70_" gradientUnits="userSpaceOnUse" x1="412.4918" y1="185.5503" x2="397.0105" y2="194.7158">
+	<stop  offset="0.1885" style="stop-color:#47BCEA"/>
+	<stop  offset="0.3714" style="stop-color:#39B2DC"/>
+	<stop  offset="0.7179" style="stop-color:#1598B6"/>
+	<stop  offset="0.8985" style="stop-color:#0089A0"/>
+</linearGradient>
+<path class="st85" d="M405.9,188c0,0,2.9-0.7,4.8-1.6c0,0-0.2,4.2-2.4,4.6c0,0-5.5,1.2-6.1,1c-0.5-0.2,0-3.1,0-3.1l3-2.1l1.8-0.6
+	v0.6L405.9,188z"/>
+<g>
+	<linearGradient id="SVGID_71_" gradientUnits="userSpaceOnUse" x1="371.4113" y1="137.8927" x2="356.778" y2="150.9267">
+		<stop  offset="0.1885" style="stop-color:#47BCEA"/>
+		<stop  offset="0.3714" style="stop-color:#39B2DC"/>
+		<stop  offset="0.7179" style="stop-color:#1598B6"/>
+		<stop  offset="0.8985" style="stop-color:#0089A0"/>
+	</linearGradient>
+	<path class="st86" d="M364.4,148.2c0,0,4.3-3.8,4.8-5.7l-0.7-0.6c-0.6,1-1.3,1.4-2,1.5c0,0,0.9-4.1,2.4-5.3l-1.1,0
+		c-0.2,0-0.3,0-0.5,0.2l-4,3l-2.2,6.2L364.4,148.2z"/>
+	
+		<linearGradient id="SVGID_72_" gradientUnits="userSpaceOnUse" x1="42.9067" y1="394.2895" x2="61.141" y2="375.4621" gradientTransform="matrix(0.9958 9.170573e-02 -9.170573e-02 0.9958 336.2654 -144.1163)">
+		<stop  offset="0" style="stop-color:#25252E"/>
+		<stop  offset="1" style="stop-color:#6D6F80"/>
+	</linearGradient>
+	<path class="st87" d="M346.1,243.9c0,0-1.4,4.3,2,3.9c3.5-0.4,11.5-2.4,11.8-4.7c0.3-2.3-8-0.4-8-0.4L346.1,243.9z"/>
+	<linearGradient id="SVGID_73_" gradientUnits="userSpaceOnUse" x1="367.443" y1="256.1441" x2="384.7859" y2="243.0591">
+		<stop  offset="0" style="stop-color:#25252E"/>
+		<stop  offset="1" style="stop-color:#6D6F80"/>
+	</linearGradient>
+	<path class="st88" d="M371.9,247.8c0,0-1,4.4,2.4,3.7c3.4-0.7,11.1-2.3,11.1-4.6c0.1-2.3-7.8-0.8-7.8-0.8L371.9,247.8z"/>
+	<linearGradient id="SVGID_74_" gradientUnits="userSpaceOnUse" x1="322.6919" y1="251.651" x2="397.2355" y2="188.0738">
+		<stop  offset="0" style="stop-color:#229CE5"/>
+		<stop  offset="0.2411" style="stop-color:#4B7CE0"/>
+		<stop  offset="0.5925" style="stop-color:#8053DA"/>
+		<stop  offset="0.8562" style="stop-color:#A139D6"/>
+		<stop  offset="1" style="stop-color:#AE2FD4"/>
+	</linearGradient>
+	<path class="st89" d="M345.5,245.9c0,0,7.8-0.6,9-3.2l15.3-31.3l1.2-8.3l-7.6-4.8L345.5,245.9z"/>
+	<linearGradient id="SVGID_75_" gradientUnits="userSpaceOnUse" x1="379.2219" y1="164.3123" x2="363.1492" y2="173.8279">
+		<stop  offset="0.1885" style="stop-color:#47BCEA"/>
+		<stop  offset="0.3714" style="stop-color:#39B2DC"/>
+		<stop  offset="0.7179" style="stop-color:#1598B6"/>
+		<stop  offset="0.8985" style="stop-color:#0089A0"/>
+	</linearGradient>
+	<path class="st90" d="M374,173.9c0.2-1.3,0.5-3.5,0.3-5.1c0,0,4.8-3-0.1-8.4l-6,3.4c1,3.6,1.9,7.1,1.5,9.2c1.4,1.1,2.7,2.7,4,1.8
+		C373.9,174.6,374.1,174.2,374,173.9z"/>
+	
+		<linearGradient id="SVGID_76_" gradientUnits="userSpaceOnUse" x1="3027.6975" y1="247.2022" x2="3101.1821" y2="184.5283" gradientTransform="matrix(-1 0 0 1 3432.5039 0)">
+		<stop  offset="0" style="stop-color:#229CE5"/>
+		<stop  offset="0.2411" style="stop-color:#4B7CE0"/>
+		<stop  offset="0.5925" style="stop-color:#8053DA"/>
+		<stop  offset="0.8562" style="stop-color:#A139D6"/>
+		<stop  offset="1" style="stop-color:#AE2FD4"/>
+	</linearGradient>
+	<path class="st91" d="M380.2,197.2c-5.1,1.9-12.6,2.6-16.9,0.7c1.4,4.5,2.9,9,3.7,13.6l0.1-0.6L371,224l0.2,23.5
+		c2.9,2.5,7.4-1.6,7.4-1.6l0.7-23.5C379.3,222.4,380.2,197.2,380.2,197.2z"/>
+	<path class="st69" d="M380.1,204c0,0-10.1,1.6-17-4.6l0.2-0.6l16.8,2.8L380.1,204z"/>
+	<path class="st60" d="M369.5,170.3c-1.7-2.9-2.4-1.2-4.3-4.8c-1.6-3.2,0.5-5.9,2.6-6.5c0,0,1.9-2.2,4.3-2.3c2.3-0.1,4.6,2.3,2.6,5
+		c-1,1.3,0.7,1.8-0.7,2.4c-1.9,0.8-0.1,4.6-3.2,5.5L369.5,170.3z"/>
+	<linearGradient id="SVGID_77_" gradientUnits="userSpaceOnUse" x1="375.0458" y1="230.7812" x2="389.1704" y2="86.0036">
+		<stop  offset="9.924473e-02" style="stop-color:#CDED22"/>
+		<stop  offset="0.1613" style="stop-color:#CBDD32"/>
+		<stop  offset="0.4626" style="stop-color:#C2937A"/>
+		<stop  offset="0.7126" style="stop-color:#BC5DAF"/>
+		<stop  offset="0.8986" style="stop-color:#B83CD0"/>
+		<stop  offset="1" style="stop-color:#B62FDC"/>
+	</linearGradient>
+	<path class="st92" d="M402.6,187.7c-7.3,1.7-20.7-10.9-24.3-12.6c-4-1.9-2.1-1.4-7.6-2c-1.5-0.2-1.1-1.5-2.1-2.2
+		c-7-5.1-5-18.5-3.7-22.7c0,0-4.5-1.1-4.7-1c-4.1,8.3-2,24.7,1.3,30.5c0.3,3.7,1.3,20.6,1.3,20.6c2.2,5.2,17.4,4.7,17.4,4.7
+		l0.2-16.7c2.2,2.5,13.7,8.6,22.4,5.9L402.6,187.7z"/>
+</g>
+<g class="st34">
+	<linearGradient id="SVGID_78_" gradientUnits="userSpaceOnUse" x1="82.9756" y1="113.5826" x2="241.3174" y2="113.5826">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="1" style="stop-color:#F4F8FB;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st93" d="M88,205c-0.8,0-1.6-0.2-2.4-0.6c-1.5-0.9-2.4-2.4-2.4-4.1L83,114.8c0-3,1.6-5.8,4.2-7.3l146.8-84.7
+		c1.5-0.9,3.3-0.9,4.8,0c1.5,0.9,2.4,2.4,2.4,4.1l0.2,85.5c0,3-1.6,5.8-4.2,7.3L90.4,204.3C89.6,204.8,88.8,205,88,205z M83.8,200.2
+		c0,1.5,0.8,2.9,2.1,3.6c1.3,0.8,2.9,0.8,4.2,0l146.8-84.7c2.4-1.4,3.9-4,3.9-6.8l-0.2-85.5c0-1.5-0.8-2.9-2.1-3.6s-2.9-0.8-4.2,0
+		L87.4,108c-2.4,1.4-3.9,4-3.9,6.8L83.8,200.2z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_79_" cx="-2337.9026" cy="-126.5402" r="7.5968" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.1558 149.9242)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st95" d="M85.6,43.2c-2-2.1-5.4-2.1-7.4,0c-2,2.1-2,5.5,0,7.6c2,2.1,5.4,2.1,7.4,0C87.7,48.7,87.7,45.3,85.6,43.2
+		L85.6,43.2z"/>
+	
+		<radialGradient id="SVGID_80_" cx="-2337.9026" cy="-126.5402" r="3.1795" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.7272 121.2087)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st96" d="M83.2,45.6c-0.7-0.8-1.9-0.8-2.6,0c-0.7,0.8-0.7,2,0,2.7c0.7,0.8,1.9,0.8,2.6,0C84,47.6,84,46.4,83.2,45.6
+		L83.2,45.6z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_81_" cx="-2032.8422" cy="-18.2312" r="7.5968" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.5029 189.7671)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st97" d="M257.2,151.7c-2-2.1-5.4-2.1-7.4,0c-2,2.1-2,5.5,0,7.6c2,2.1,5.4,2.1,7.4,0
+		C259.2,157.3,259.2,153.9,257.2,151.7L257.2,151.7z"/>
+	
+		<radialGradient id="SVGID_82_" cx="-2032.8422" cy="-18.2312" r="3.1795" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6642 167.539)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st98" d="M254.8,154.2c-0.7-0.8-1.9-0.8-2.6,0c-0.7,0.8-0.7,2,0,2.7c0.7,0.8,1.9,0.8,2.6,0
+		C255.5,156.2,255.5,154.9,254.8,154.2L254.8,154.2z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_83_" cx="-1639.1333" cy="-59.0715" r="7.5968" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.3956 169.3168)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st99" d="M478.8,111.2c-2-2.1-5.4-2.1-7.4,0c-2,2.1-2,5.5,0,7.6c2,2.1,5.4,2.1,7.4,0
+		C480.9,116.7,480.9,113.3,478.8,111.2L478.8,111.2z"/>
+	
+		<radialGradient id="SVGID_84_" cx="-1639.1333" cy="-59.0715" r="3.1795" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6879 150.0691)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st100" d="M476.5,113.7c-0.7-0.8-1.9-0.8-2.6,0c-0.7,0.8-0.7,2,0,2.7c0.7,0.8,1.9,0.8,2.6,0
+		C477.2,115.6,477.2,114.4,476.5,113.7L476.5,113.7z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_85_" cx="-2195.0171" cy="24.5221" r="7.5968" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.6267 208.5088)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st101" d="M165.8,194.4c-2-2.1-5.4-2.1-7.4,0c-2,2.1-2,5.5,0,7.6c2,2.1,5.4,2.1,7.4,0
+		C167.9,199.9,167.9,196.5,165.8,194.4L165.8,194.4z"/>
+	
+		<radialGradient id="SVGID_86_" cx="-2195.0171" cy="24.5221" r="3.1795" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6393 185.8272)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st102" d="M163.5,196.8c-0.7-0.8-1.9-0.8-2.6,0c-0.7,0.8-0.7,2,0,2.7c0.7,0.8,1.9,0.8,2.6,0
+		C164.2,198.8,164.2,197.6,163.5,196.8L163.5,196.8z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_87_" cx="-1913.3939" cy="-64.4456" r="4.0245" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.3663 170.1039)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st103" d="M322.7,107.4c-1.1-1.1-2.8-1.1-3.9,0c-1.1,1.1-1.1,2.9,0,4c1.1,1.1,2.8,1.1,3.9,0
+		C323.8,110.3,323.8,108.5,322.7,107.4L322.7,107.4z"/>
+	
+		<radialGradient id="SVGID_88_" cx="-1913.3939" cy="-64.4456" r="1.6844" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.691 147.7703)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st104" d="M321.5,108.7c-0.4-0.4-1-0.4-1.4,0c-0.4,0.4-0.4,1,0,1.4c0.4,0.4,1,0.4,1.4,0
+		C321.9,109.8,321.9,109.1,321.5,108.7L321.5,108.7z"/>
+</g>
+<g class="st94">
+	
+		<radialGradient id="SVGID_89_" cx="-1855.1433" cy="-81.5835" r="7.273" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.3164 162.6633)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#F4F8FB"/>
+		<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+		<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+		<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+		<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+		<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st105" d="M357.1,88.7c-2-2-5.1-2-7.1,0c-2,2-1.9,5.3,0,7.3c2,2,5.1,2,7.1,0C359.1,94,359.1,90.7,357.1,88.7
+		L357.1,88.7z"/>
+	
+		<radialGradient id="SVGID_90_" cx="-1855.1433" cy="-81.5835" r="3.0439" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.701 140.4394)" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#FFFFFF"/>
+		<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+	</radialGradient>
+	<path class="st106" d="M354.9,91c-0.7-0.7-1.8-0.7-2.5,0c-0.7,0.7-0.7,1.9,0,2.6c0.7,0.7,1.8,0.7,2.5,0
+		C355.6,92.9,355.6,91.8,354.9,91L354.9,91z"/>
+</g>
+<g>
+	<linearGradient id="SVGID_91_" gradientUnits="userSpaceOnUse" x1="466.8484" y1="258.1992" x2="487.8473" y2="42.961">
+		<stop  offset="0" style="stop-color:#31313D"/>
+		<stop  offset="1" style="stop-color:#31313D;stop-opacity:0.5"/>
+	</linearGradient>
+	<path class="st107" d="M446.3,210.6l-0.4-36.5c0-3,1.5-5.8,4.1-7.3l46.4-26.9c3-1.8,6.8,0.4,6.9,3.9l0.4,36.5c0,3-1.5,5.8-4.1,7.3
+		l-46.4,26.9C450.1,216.2,446.3,214.1,446.3,210.6z"/>
+	<g class="st108">
+		<g>
+			<path class="st56" d="M485.3,153.9c-0.2,0-0.3-0.1-0.4-0.2c-0.1-0.2-0.1-0.5,0.2-0.7l14.4-8.3c0.2-0.1,0.5-0.1,0.7,0.2
+				c0.1,0.2,0.1,0.5-0.2,0.7l-14.4,8.3C485.5,153.9,485.4,153.9,485.3,153.9z"/>
+		</g>
+		<g>
+			<path class="st56" d="M485.3,159.3c-0.2,0-0.3-0.1-0.4-0.2c-0.1-0.2-0.1-0.5,0.2-0.7l9.5-5.5c0.2-0.1,0.5-0.1,0.7,0.2
+				c0.1,0.2,0.1,0.5-0.2,0.7l-9.5,5.5C485.5,159.3,485.4,159.3,485.3,159.3z"/>
+		</g>
+	</g>
+	<g class="st94">
+		
+			<radialGradient id="SVGID_92_" cx="-1614.1055" cy="30.5361" r="4.2814" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.6722 204.7054)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+			<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+			<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+			<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+			<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st109" d="M491.2,202.5c-1.2-1.2-3-1.2-4.2,0c-1.1,1.2-1.1,3.1,0,4.3c1.2,1.2,3,1.2,4.2,0
+			C492.3,205.6,492.3,203.7,491.2,202.5L491.2,202.5z"/>
+		
+			<radialGradient id="SVGID_93_" cx="-1614.1055" cy="30.5361" r="1.7919" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6357 188.3997)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st110" d="M489.9,203.9c-0.4-0.4-1.1-0.4-1.5,0c-0.4,0.4-0.4,1.1,0,1.5c0.4,0.4,1.1,0.4,1.5,0
+			C490.3,205,490.3,204.3,489.9,203.9L489.9,203.9z"/>
+	</g>
+	<g class="st94">
+		
+			<radialGradient id="SVGID_94_" cx="-1600.0133" cy="13.9536" r="7.7372" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.6219 197.9568)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#F4F8FB"/>
+			<stop  offset="6.886601e-02" style="stop-color:#EDE8F8;stop-opacity:0.9311"/>
+			<stop  offset="0.4034" style="stop-color:#CC9EE9;stop-opacity:0.5966"/>
+			<stop  offset="0.6809" style="stop-color:#B468DF;stop-opacity:0.3191"/>
+			<stop  offset="0.8874" style="stop-color:#A647D8;stop-opacity:0.1126"/>
+			<stop  offset="1" style="stop-color:#A03AD6;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st111" d="M500.8,184.2c-2.1-2.1-5.5-2.1-7.5,0c-2.1,2.1-2.1,5.6,0,7.8c2.1,2.1,5.5,2.1,7.5,0
+			C502.9,189.8,502.9,186.3,500.8,184.2L500.8,184.2z"/>
+		
+			<radialGradient id="SVGID_95_" cx="-1600.0133" cy="13.9536" r="3.2382" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.6454 181.3064)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st112" d="M498.4,186.7c-0.7-0.8-2-0.8-2.7,0c-0.7,0.8-0.7,2,0,2.8c0.7,0.8,2,0.8,2.7,0
+			C499.2,188.7,499.2,187.4,498.4,186.7L498.4,186.7z"/>
+	</g>
+	<g class="st113">
+		<path class="st56" d="M465.4,190.7c-0.2,0-0.3,0-0.5,0c-5-0.6-12.2-10.7-12.5-11.1c-0.2-0.2-0.1-0.5,0.1-0.7
+			c0.2-0.2,0.5-0.1,0.7,0.1c0.1,0.1,7.3,10.1,11.9,10.7c0.7,0.1,1.3-0.1,1.8-0.5c1.8-1.5,3.1-4.5,4.2-7.1c1.5-3.5,2.9-6.8,5.5-6
+			c1.7,0.5,3.2,1.7,4.5,2.8c2,1.7,3,2.3,3.9,1.3c0.8-0.9,1.2-2.4,1.5-3.8c0.5-2.1,1.1-4.6,3.7-4.3c1.4,0.2,2.5,2.2,3.7,4.7
+			c1.1,2.2,2.5,4.9,3.6,4.5c0.2-0.1,0.5,0,0.6,0.3c0.1,0.2,0,0.5-0.3,0.6c-1.9,0.7-3.4-2.2-4.8-4.9c-0.9-1.8-2.1-4.1-3-4.2
+			c-1.7-0.2-2.1,1.2-2.6,3.6c-0.4,1.5-0.7,3.1-1.7,4.2c-1.6,1.8-3.4,0.3-5.2-1.2c-1.2-1-2.6-2.2-4.1-2.6c-1.8-0.5-3,2.3-4.3,5.5
+			c-1.1,2.7-2.4,5.8-4.5,7.4C466.8,190.4,466.2,190.7,465.4,190.7z"/>
+	</g>
+</g>
+<g class="st34">
+	<linearGradient id="SVGID_96_" gradientUnits="userSpaceOnUse" x1="354.1361" y1="157.1382" x2="420.4065" y2="157.1382">
+		<stop  offset="0" style="stop-color:#F4F8FB;stop-opacity:0"/>
+		<stop  offset="1" style="stop-color:#F4F8FB"/>
+	</linearGradient>
+	<path class="st114" d="M412.4,242c-1.3,0-2.7-0.4-3.9-1.1l-47.6-27.6c-4.2-2.4-6.8-7-6.8-11.8L354.4,80c0-2.8,1.5-5.3,3.9-6.7
+		c2.4-1.4,5.3-1.4,7.8,0l47.6,27.6c4.2,2.4,6.8,7,6.8,11.8l-0.2,121.5c0,2.8-1.5,5.3-3.9,6.7C415.1,241.6,413.8,242,412.4,242z
+		 M362.1,72.8c-1.2,0-2.5,0.3-3.6,1c-2.3,1.3-3.6,3.6-3.6,6.2l-0.2,121.5c0,4.7,2.5,9,6.5,11.4l47.6,27.6c2.3,1.3,4.9,1.3,7.2,0
+		c2.3-1.3,3.6-3.6,3.6-6.2l0.2-121.5c0-4.7-2.5-9-6.5-11.4l-47.6-27.6C364.6,73.2,363.4,72.8,362.1,72.8z"/>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_97_" gradientUnits="userSpaceOnUse" x1="3004.3921" y1="92.5141" x2="3105.9634" y2="92.5141" gradientTransform="matrix(-1 0 0 1 3374.009 0)">
+		<stop  offset="0" style="stop-color:#383846"/>
+		<stop  offset="1" style="stop-color:#383846;stop-opacity:0"/>
+	</linearGradient>
+	<path class="st115" d="M369.3,125.1l0.3-26.1c0-2.1-1.1-4.1-2.9-5.2l-63.2-36.8c-2.2-1.3-4.9,0.3-4.9,2.8L298.3,86
+		c0,2.1,1.1,4.1,2.9,5.2l63.2,36.8C366.5,129.2,369.3,127.6,369.3,125.1z"/>
+	<g>
+		<g>
+			<linearGradient id="SVGID_98_" gradientUnits="userSpaceOnUse" x1="336.7348" y1="89.7239" x2="265.2863" y2="54.8305">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st116" d="M274.2,64.5c-0.3,0-0.5-0.2-0.5-0.5v-9.7c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5V64
+				C274.7,64.3,274.5,64.5,274.2,64.5z"/>
+			<linearGradient id="SVGID_99_" gradientUnits="userSpaceOnUse" x1="335.3112" y1="92.6388" x2="263.8627" y2="57.7454">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st117" d="M276.1,66.5c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5V66
+				C276.6,66.3,276.4,66.5,276.1,66.5z"/>
+			<linearGradient id="SVGID_100_" gradientUnits="userSpaceOnUse" x1="335.239" y1="92.7866" x2="263.7906" y2="57.8932">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st118" d="M278.1,67.6c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C278.5,67.4,278.3,67.6,278.1,67.6z"/>
+			<linearGradient id="SVGID_101_" gradientUnits="userSpaceOnUse" x1="335.1667" y1="92.9348" x2="263.7182" y2="58.0413">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st119" d="M280,68.8c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C280.5,68.5,280.3,68.8,280,68.8z"/>
+			<linearGradient id="SVGID_102_" gradientUnits="userSpaceOnUse" x1="335.0945" y1="93.0826" x2="263.6461" y2="58.1891">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st120" d="M281.9,69.9c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C282.4,69.7,282.2,69.9,281.9,69.9z"/>
+			<linearGradient id="SVGID_103_" gradientUnits="userSpaceOnUse" x1="335.0223" y1="93.2303" x2="263.5739" y2="58.3369">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st121" d="M283.9,71c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C284.3,70.8,284.1,71,283.9,71z"/>
+			<linearGradient id="SVGID_104_" gradientUnits="userSpaceOnUse" x1="334.95" y1="93.3785" x2="263.5015" y2="58.485">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st122" d="M285.8,72.1c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C286.3,71.9,286,72.1,285.8,72.1z"/>
+			<linearGradient id="SVGID_105_" gradientUnits="userSpaceOnUse" x1="334.8778" y1="93.5263" x2="263.4294" y2="58.6328">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st123" d="M287.7,73.3c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C288.2,73,288,73.3,287.7,73.3z"/>
+			<linearGradient id="SVGID_106_" gradientUnits="userSpaceOnUse" x1="334.8056" y1="93.674" x2="263.3572" y2="58.7806">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st124" d="M289.6,74.4c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C290.1,74.2,289.9,74.4,289.6,74.4z"/>
+			<linearGradient id="SVGID_107_" gradientUnits="userSpaceOnUse" x1="336.0722" y1="91.0805" x2="264.6238" y2="56.1871">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st125" d="M291.6,74.6c-0.3,0-0.5-0.2-0.5-0.5v-9.7c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v9.7
+				C292,74.4,291.8,74.6,291.6,74.6z"/>
+			<linearGradient id="SVGID_108_" gradientUnits="userSpaceOnUse" x1="334.6485" y1="93.9958" x2="263.2" y2="59.1023">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st126" d="M293.5,76.7c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C294,76.5,293.8,76.7,293.5,76.7z"/>
+			<linearGradient id="SVGID_109_" gradientUnits="userSpaceOnUse" x1="334.5763" y1="94.1436" x2="263.1279" y2="59.2501">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st127" d="M295.4,77.8c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C295.9,77.6,295.7,77.8,295.4,77.8z"/>
+			<linearGradient id="SVGID_110_" gradientUnits="userSpaceOnUse" x1="334.5042" y1="94.2914" x2="263.0557" y2="59.3979">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st128" d="M297.4,78.9c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C297.8,78.7,297.6,78.9,297.4,78.9z"/>
+			<linearGradient id="SVGID_111_" gradientUnits="userSpaceOnUse" x1="334.4318" y1="94.4395" x2="262.9834" y2="59.5461">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st129" d="M299.3,80c-0.3,0-0.5-0.2-0.5-0.5V75c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C299.8,79.8,299.5,80,299.3,80z"/>
+			<linearGradient id="SVGID_112_" gradientUnits="userSpaceOnUse" x1="334.3596" y1="94.5873" x2="262.9112" y2="59.6938">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st130" d="M301.2,81.2c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C301.7,81,301.5,81.2,301.2,81.2z"/>
+			<linearGradient id="SVGID_113_" gradientUnits="userSpaceOnUse" x1="334.2874" y1="94.7351" x2="262.839" y2="59.8416">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st131" d="M303.1,82.3c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C303.6,82.1,303.4,82.3,303.1,82.3z"/>
+			<linearGradient id="SVGID_114_" gradientUnits="userSpaceOnUse" x1="334.2153" y1="94.8829" x2="262.7668" y2="59.9894">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st132" d="M305.1,83.4c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C305.5,83.2,305.3,83.4,305.1,83.4z"/>
+			<linearGradient id="SVGID_115_" gradientUnits="userSpaceOnUse" x1="334.1429" y1="95.031" x2="262.6945" y2="60.1376">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st133" d="M307,84.5c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C307.5,84.3,307.3,84.5,307,84.5z"/>
+			<linearGradient id="SVGID_116_" gradientUnits="userSpaceOnUse" x1="335.4095" y1="92.4375" x2="263.9611" y2="57.544">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st134" d="M308.9,84.8c-0.3,0-0.5-0.2-0.5-0.5v-9.7c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v9.7
+				C309.4,84.6,309.2,84.8,308.9,84.8z"/>
+			<linearGradient id="SVGID_117_" gradientUnits="userSpaceOnUse" x1="333.9857" y1="95.3531" x2="262.5372" y2="60.4596">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st135" d="M310.9,86.8c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C311.3,86.6,311.1,86.8,310.9,86.8z"/>
+			<linearGradient id="SVGID_118_" gradientUnits="userSpaceOnUse" x1="333.9133" y1="95.5012" x2="262.4648" y2="60.6077">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st136" d="M312.8,87.9c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C313.3,87.7,313,87.9,312.8,87.9z"/>
+			<linearGradient id="SVGID_119_" gradientUnits="userSpaceOnUse" x1="333.8411" y1="95.649" x2="262.3927" y2="60.7555">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st137" d="M314.7,89.1c-0.3,0-0.5-0.2-0.5-0.5V84c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C315.2,88.9,315,89.1,314.7,89.1z"/>
+			<linearGradient id="SVGID_120_" gradientUnits="userSpaceOnUse" x1="333.769" y1="95.7968" x2="262.3205" y2="60.9033">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st138" d="M316.6,90.2c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C317.1,90,316.9,90.2,316.6,90.2z"/>
+			<linearGradient id="SVGID_121_" gradientUnits="userSpaceOnUse" x1="333.6968" y1="95.9446" x2="262.2483" y2="61.0511">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st139" d="M318.6,91.3c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C319,91.1,318.8,91.3,318.6,91.3z"/>
+			<linearGradient id="SVGID_122_" gradientUnits="userSpaceOnUse" x1="333.6244" y1="96.0927" x2="262.176" y2="61.1993">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st140" d="M320.5,92.4c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5V92
+				C321,92.2,320.8,92.4,320.5,92.4z"/>
+			<linearGradient id="SVGID_123_" gradientUnits="userSpaceOnUse" x1="333.5522" y1="96.2405" x2="262.1038" y2="61.347">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st141" d="M322.4,93.6c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C322.9,93.4,322.7,93.6,322.4,93.6z"/>
+			<linearGradient id="SVGID_124_" gradientUnits="userSpaceOnUse" x1="333.4801" y1="96.3883" x2="262.0316" y2="61.4948">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st142" d="M324.4,94.7c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C324.8,94.5,324.6,94.7,324.4,94.7z"/>
+			<linearGradient id="SVGID_125_" gradientUnits="userSpaceOnUse" x1="334.7339" y1="93.8209" x2="263.2855" y2="58.9274">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st143" d="M326.3,95c-0.3,0-0.5-0.2-0.5-0.5v-9.7c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v9.7
+				C326.8,94.8,326.5,95,326.3,95z"/>
+			<linearGradient id="SVGID_126_" gradientUnits="userSpaceOnUse" x1="333.323" y1="96.71" x2="261.8745" y2="61.8166">
+				<stop  offset="0" style="stop-color:#229FE8"/>
+				<stop  offset="0.3975" style="stop-color:#4C80E3;stop-opacity:0.5334"/>
+				<stop  offset="0.8519" style="stop-color:#8058DD;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st144" d="M328.2,97c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C328.7,96.8,328.5,97,328.2,97z"/>
+		</g>
+		<g class="st49">
+			<path class="st56" d="M330.1,98.1c-0.3,0-0.5-0.2-0.5-0.5V93c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C330.6,97.9,330.4,98.1,330.1,98.1z"/>
+			<path class="st56" d="M332.1,99.2c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C332.5,99,332.3,99.2,332.1,99.2z"/>
+			<path class="st56" d="M334,100.4c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C334.5,100.1,334.3,100.4,334,100.4z"/>
+			<path class="st56" d="M335.9,101.5c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C336.4,101.3,336.2,101.5,335.9,101.5z"/>
+			<path class="st56" d="M337.9,102.6c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C338.3,102.4,338.1,102.6,337.9,102.6z"/>
+			<path class="st56" d="M339.8,103.7c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C340.3,103.5,340,103.7,339.8,103.7z"/>
+			<path class="st56" d="M341.7,104.9c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C342.2,104.6,342,104.9,341.7,104.9z"/>
+			<path class="st56" d="M343.6,105.1c-0.3,0-0.5-0.2-0.5-0.5V95c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v9.7
+				C344.1,104.9,343.9,105.1,343.6,105.1z"/>
+			<path class="st56" d="M345.6,107.1c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C346,106.9,345.8,107.1,345.6,107.1z"/>
+			<path class="st56" d="M347.5,108.3c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C348,108.1,347.8,108.3,347.5,108.3z"/>
+			<path class="st56" d="M349.4,109.4c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C349.9,109.2,349.7,109.4,349.4,109.4z"/>
+			<path class="st56" d="M351.4,110.5c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C351.8,110.3,351.6,110.5,351.4,110.5z"/>
+			<path class="st56" d="M353.3,111.6c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C353.8,111.4,353.5,111.6,353.3,111.6z"/>
+			<path class="st56" d="M355.2,112.8c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C355.7,112.6,355.5,112.8,355.2,112.8z"/>
+			<path class="st56" d="M357.2,113.9c-0.3,0-0.5-0.2-0.5-0.5v-4.6c0-0.3,0.2-0.5,0.5-0.5c0.3,0,0.5,0.2,0.5,0.5v4.6
+				C357.6,113.7,357.4,113.9,357.2,113.9z"/>
+			<path class="st56" d="M359.1,115c-0.3,0-0.5-0.2-0.5-0.5V110c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v4.6
+				C359.5,114.8,359.3,115,359.1,115z"/>
+			<path class="st56" d="M361,115.3c-0.3,0-0.5-0.2-0.5-0.5v-9.7c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v9.7
+				C361.5,115.1,361.3,115.3,361,115.3z"/>
+		</g>
+	</g>
+</g>
+<path class="st69" d="M380.5,186.3l-4-2.6c0,0,2,6.3,3.9,8.5L380.5,186.3z"/>
+<polygon class="st69" points="368.2,214.8 365.8,206.5 366,219.2 "/>
+<g>
+	<g>
+		
+			<radialGradient id="SVGID_127_" cx="-1979.1627" cy="-133.5395" r="6.4467" gradientTransform="matrix(0.5628 1.143265e-02 -4.434420e-03 0.6021 1397.151 143.3125)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#22ABF4"/>
+			<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st145" d="M287,37.1c-1.7-1.8-4.5-1.8-6.3,0c-1.7,1.8-1.7,4.7,0,6.5c1.7,1.8,4.5,1.8,6.3,0
+			C288.7,41.7,288.7,38.8,287,37.1L287,37.1z"/>
+		
+			<radialGradient id="SVGID_128_" cx="-1979.1627" cy="-133.5395" r="2.6981" gradientTransform="matrix(0.5629 7.659137e-04 -7.786844e-04 0.5722 1397.7312 118.2146)" gradientUnits="userSpaceOnUse">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
+		</radialGradient>
+		<path class="st146" d="M285,39.1c-0.6-0.6-1.6-0.6-2.2,0c-0.6,0.6-0.6,1.7,0,2.3c0.6,0.6,1.6,0.6,2.2,0
+			C285.6,40.8,285.6,39.8,285,39.1L285,39.1z"/>
+	</g>
+	<g class="st46">
+		<g>
+			<linearGradient id="SVGID_129_" gradientUnits="userSpaceOnUse" x1="283.9816" y1="39.2045" x2="283.7258" y2="150.759">
+				<stop  offset="0" style="stop-color:#BD2FE3;stop-opacity:0.7"/>
+				<stop  offset="1" style="stop-color:#22ABF4;stop-opacity:0"/>
+			</linearGradient>
+			<path class="st147" d="M283.8,147.9L283.8,147.9c-0.2,0-0.3-0.1-0.3-0.3l0.1-107.3c0-0.2,0.1-0.3,0.3-0.3l0,0
+				c0.2,0,0.3,0.1,0.3,0.3l-0.1,107.3C284.1,147.8,284,147.9,283.8,147.9z"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/ui/src/notebooks/components/EmptyPipeList.scss
+++ b/ui/src/notebooks/components/EmptyPipeList.scss
@@ -26,7 +26,7 @@
 .notebook-empty--graphic {
   width: 540px;
   height: 300px;
-  background-image: url('../../../assets/images/notebooks-empty.svg');
+  background-image: url('~src/../assets/images/notebooks-empty.svg');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/ui/src/notebooks/components/EmptyPipeList.scss
+++ b/ui/src/notebooks/components/EmptyPipeList.scss
@@ -26,7 +26,7 @@
 .notebook-empty--graphic {
   width: 540px;
   height: 300px;
-  background-image: url('~src/../assets/images/notebooks-empty.svg');
+  background-image: url('~assets/images/notebooks-empty.svg');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/ui/src/notebooks/components/EmptyPipeList.scss
+++ b/ui/src/notebooks/components/EmptyPipeList.scss
@@ -1,0 +1,33 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.notebook-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 1.25em;
+  color: $g10-wolf;
+  user-select: none;
+
+  p {
+    margin: 0.25em 0;
+  }
+
+  strong {
+    color: $g18-cloud;
+  }
+
+  > *:last-child {
+    margin-bottom: 8em;
+  }
+}
+
+.notebook-empty--graphic {
+  width: 540px;
+  height: 300px;
+  background-image: url('../../../assets/images/notebooks-empty.svg');
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+}

--- a/ui/src/notebooks/components/EmptyPipeList.tsx
+++ b/ui/src/notebooks/components/EmptyPipeList.tsx
@@ -1,0 +1,23 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Styles
+import 'src/notebooks/components/EmptyPipeList.scss'
+
+const EmptyPipeList: FC = () => {
+  return (
+    <div className="notebook-empty">
+      <div className="notebook-empty--graphic" />
+      <h3>Welcome to Notebooks</h3>
+      <p>
+        This is a more flexible way to explore, visualize, and (eventually)
+        alert on your data
+      </p>
+      <p>
+        Get started by <strong>Adding a Cell</strong> from the top left menu
+      </p>
+    </div>
+  )
+}
+
+export default EmptyPipeList

--- a/ui/src/notebooks/components/Notebook.tsx
+++ b/ui/src/notebooks/components/Notebook.tsx
@@ -15,9 +15,7 @@ const NotebookPage: FC = () => {
     <NotebookProvider>
       <Page titleTag="Notebook">
         <Header />
-        <Page.Contents fullWidth={true} scrollable={true}>
-          <PipeList />
-        </Page.Contents>
+        <PipeList />
       </Page>
     </NotebookProvider>
   )

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -1,23 +1,40 @@
+// Libraries
 import React, {FC, useContext, useCallback} from 'react'
+
+// Contexts
 import {NotebookContext} from 'src/notebooks/context/notebook'
+
+// Components
 import NotebookPipe from 'src/notebooks/components/NotebookPipe'
+import EmptyPipeList from 'src/notebooks/components/EmptyPipeList'
+import {Page} from '@influxdata/clockface'
 
 const PipeList: FC = () => {
   const {id, pipes, updatePipe} = useContext(NotebookContext)
   const update = useCallback(updatePipe, [id])
 
-  const _pipes = pipes.map((_, index) => {
-    return (
-      <NotebookPipe
-        key={`pipe-${id}-${index}`}
-        index={index}
-        data={pipes[index]}
-        onUpdate={update}
-      />
-    )
-  })
+  const scrollable = !!pipes.length
 
-  return <>{_pipes}</>
+  let _pipes: JSX.Element | JSX.Element[] = <EmptyPipeList />
+
+  if (pipes.length) {
+    _pipes = pipes.map((_, index) => {
+      return (
+        <NotebookPipe
+          key={`pipe-${id}-${index}`}
+          index={index}
+          data={pipes[index]}
+          onUpdate={update}
+        />
+      )
+    })
+  }
+
+  return (
+    <Page.Contents fullWidth={true} scrollable={scrollable}>
+      {_pipes}
+    </Page.Contents>
+  )
 }
 
 export default PipeList

--- a/ui/src/notebooks/components/header/index.tsx
+++ b/ui/src/notebooks/components/header/index.tsx
@@ -13,6 +13,7 @@ const Header: FC = () => (
     </Page.Header>
     <Page.ControlBar fullWidth={FULL_WIDTH}>
       <Page.ControlBarLeft>
+        <h3 className="notebook--add-cell-label">Add Cell:</h3>
         <AddButtons />
       </Page.ControlBarLeft>
       <Page.ControlBarRight>

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -14,6 +14,13 @@ $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
   align-items: stretch;
 }
 
+.notebook--add-cell-label {
+  user-select: none;
+  margin: 0 $cf-marg-c 0 0;
+  font-size: 14px;
+  font-weight: $cf-font-weight--medium;
+}
+
 .notebook-panel {
   display: flex;
   flex-direction: column;

--- a/ui/webpack.common.ts
+++ b/ui/webpack.common.ts
@@ -26,6 +26,7 @@ module.exports = {
   resolve: {
     alias: {
       src: path.resolve(__dirname, 'src'),
+      assets: path.resolve(__dirname, 'assets'),
       react: path.resolve('./node_modules/react'),
     },
     extensions: ['.tsx', '.ts', '.js', '.wasm'],


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/7393

- Display `EmptyPipeList.tsx` when no pipes exist
- Disable scrolling on `PageContents` when no pipes exist so empty state can be vertically centered
- Display text label next to add cell buttons (to tie in to copy in empty state)
- Create webpack alias `assets` for loading images

![Screen Shot 2020-05-27 at 2 17 49 PM](https://user-images.githubusercontent.com/2433762/83073824-ef76dd00-a025-11ea-867d-2ecdf7163f99.png)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
