### PR TITLE
fix(swagger): added missing Permission type: dbrp

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7393,6 +7393,7 @@ components:
             - notificationRules
             - notificationEndpoints
             - checks
+            - dbrp
         id:
           type: string
           nullable: true

--- a/ui/src/authorizations/utils/permissions.test.ts
+++ b/ui/src/authorizations/utils/permissions.test.ts
@@ -62,6 +62,20 @@ const hvhs: Permission[] = [
     action: 'read',
     resource: {
       orgID: 'bulldogs',
+      type: 'dbrp',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'dbrp',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
       type: 'documents',
     },
   },

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -11,6 +11,7 @@ const allPermissionTypes: PermissionTypes[] = [
   'buckets',
   'checks',
   'dashboards',
+  'dbrp',
   'documents',
   'labels',
   'notificationRules',
@@ -36,6 +37,7 @@ const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
     case 'buckets':
     case 'checks':
     case 'dashboards':
+    case 'dbrp':
     case 'documents':
     case 'labels':
     case 'notificationRules':


### PR DESCRIPTION
Added missing Permission type  `dbrp`. 
 https://github.com/influxdata/influxdb/blob/1cf64fd721f855596fb270dcd7c2495240cfeea4/authz.go#L133

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
