### PR TITLE
feat: add onboard user to the swagger doc

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -112,6 +112,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /setup/user:
+    post:
+      operationId: PostSetupUser
+      tags:
+        - Setup
+      summary: Set up a new user, org and bucket
+      description: Post an onboarding request to set up a new user, org and bucket.
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+      requestBody:
+        description: Source to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OnboardingRequest"
+      responses:
+        "201":
+          description: Created default user, bucket, org
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OnboardingResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /documents/templates:
     get:
       operationId: GetDocumentsTemplates


### PR DESCRIPTION
This feature has been live for a while but I left it out of the swagger doc
because I wanted to test it in the cloud environment before I added it to the doc
