### PR TITLE
chore(http): Remove Algorithm W proxying behavior since that's merged

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -892,7 +892,6 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		BackupService:        backupService,
 		KVBackupService:      m.kvService,
 		AuthorizationService: authSvc,
-		AlgoWProxy:           &http.NoopProxyHandler{},
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   storage.NewBucketService(bucketSvc, m.engine),
 		SessionService:                  sessionSvc,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -52,8 +52,6 @@ type APIBackend struct {
 	WriteEventRecorder metric.EventRecorder
 	QueryEventRecorder metric.EventRecorder
 
-	AlgoWProxy FeatureProxyHandler
-
 	PointsWriter                    storage.PointsWriter
 	DeleteService                   influxdb.DeleteService
 	BackupService                   influxdb.BackupService

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -24,7 +24,6 @@ type CheckBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
-	AlgoWProxy                 FeatureProxyHandler
 	TaskService                influxdb.TaskService
 	CheckService               influxdb.CheckService
 	UserResourceMappingService influxdb.UserResourceMappingService
@@ -39,7 +38,6 @@ func NewCheckBackend(log *zap.Logger, b *APIBackend) *CheckBackend {
 	return &CheckBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,
 		log:                        log,
-		AlgoWProxy:                 b.AlgoWProxy,
 		TaskService:                b.TaskService,
 		CheckService:               b.CheckService,
 		UserResourceMappingService: b.UserResourceMappingService,
@@ -93,13 +91,13 @@ func NewCheckHandler(log *zap.Logger, b *CheckBackend) *CheckHandler {
 		FluxLanguageService:        b.FluxLanguageService,
 	}
 
-	h.Handler("POST", prefixChecks, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostCheck)))
+	h.HandlerFunc("POST", prefixChecks, h.handlePostCheck)
 	h.HandlerFunc("GET", prefixChecks, h.handleGetChecks)
 	h.HandlerFunc("GET", checksIDPath, h.handleGetCheck)
 	h.HandlerFunc("GET", checksIDQueryPath, h.handleGetCheckQuery)
 	h.HandlerFunc("DELETE", checksIDPath, h.handleDeleteCheck)
-	h.Handler("PUT", checksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePutCheck)))
-	h.Handler("PATCH", checksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePatchCheck)))
+	h.HandlerFunc("PUT", checksIDPath, h.handlePutCheck)
+	h.HandlerFunc("PATCH", checksIDPath, h.handlePatchCheck)
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -29,7 +29,6 @@ type NotificationRuleBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
-	AlgoWProxy                  FeatureProxyHandler
 	NotificationRuleStore       influxdb.NotificationRuleStore
 	NotificationEndpointService influxdb.NotificationEndpointService
 	UserResourceMappingService  influxdb.UserResourceMappingService
@@ -44,7 +43,6 @@ func NewNotificationRuleBackend(log *zap.Logger, b *APIBackend) *NotificationRul
 	return &NotificationRuleBackend{
 		HTTPErrorHandler: b.HTTPErrorHandler,
 		log:              log,
-		AlgoWProxy:       b.AlgoWProxy,
 
 		NotificationRuleStore:       b.NotificationRuleStore,
 		NotificationEndpointService: b.NotificationEndpointService,
@@ -99,13 +97,13 @@ func NewNotificationRuleHandler(log *zap.Logger, b *NotificationRuleBackend) *No
 		TaskService:                 b.TaskService,
 	}
 
-	h.Handler("POST", prefixNotificationRules, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostNotificationRule)))
+	h.HandlerFunc("POST", prefixNotificationRules, h.handlePostNotificationRule)
 	h.HandlerFunc("GET", prefixNotificationRules, h.handleGetNotificationRules)
 	h.HandlerFunc("GET", notificationRulesIDPath, h.handleGetNotificationRule)
 	h.HandlerFunc("GET", notificationRulesIDQueryPath, h.handleGetNotificationRuleQuery)
 	h.HandlerFunc("DELETE", notificationRulesIDPath, h.handleDeleteNotificationRule)
-	h.Handler("PUT", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePutNotificationRule)))
-	h.Handler("PATCH", notificationRulesIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePatchNotificationRule)))
+	h.HandlerFunc("PUT", notificationRulesIDPath, h.handlePutNotificationRule)
+	h.HandlerFunc("PATCH", notificationRulesIDPath, h.handlePatchNotificationRule)
 
 	memberBackend := MemberBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,

--- a/http/notification_rule_test.go
+++ b/http/notification_rule_test.go
@@ -17,7 +17,6 @@ func NewMockNotificationRuleBackend(t *testing.T) *NotificationRuleBackend {
 	return &NotificationRuleBackend{
 		log: zaptest.NewLogger(t),
 
-		AlgoWProxy:                 &NoopProxyHandler{},
 		UserResourceMappingService: mock.NewUserResourceMappingService(),
 		LabelService:               mock.NewLabelService(),
 		UserService:                mock.NewUserService(),

--- a/http/proxy_handler.go
+++ b/http/proxy_handler.go
@@ -4,18 +4,10 @@ import (
 	"net/http"
 )
 
-var _ http.Handler = &proxyHandler{}
-
-// withFeatureProxy wraps an HTTP handler in a proxyHandler
-func withFeatureProxy(proxy FeatureProxyHandler, h http.Handler) *proxyHandler {
-	if proxy == nil {
-		proxy = &NoopProxyHandler{}
-	}
-	return &proxyHandler{
-		proxy:   proxy,
-		handler: h,
-	}
-}
+var (
+	_ http.Handler        = &proxyHandler{}
+	_ FeatureProxyHandler = &NoopProxyHandler{}
+)
 
 // proxyHandler is a wrapper around an http.Handler that conditionally forwards
 // a request to another HTTP backend using a proxy. If the proxy doesn't decide

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -44,7 +44,6 @@ type FluxBackend struct {
 	log                *zap.Logger
 	QueryEventRecorder metric.EventRecorder
 
-	AlgoWProxy          FeatureProxyHandler
 	OrganizationService influxdb.OrganizationService
 	ProxyQueryService   query.ProxyQueryService
 	FluxLanguageService influxdb.FluxLanguageService
@@ -56,7 +55,6 @@ func NewFluxBackend(log *zap.Logger, b *APIBackend) *FluxBackend {
 		HTTPErrorHandler:   b.HTTPErrorHandler,
 		log:                log,
 		QueryEventRecorder: b.QueryEventRecorder,
-		AlgoWProxy:         b.AlgoWProxy,
 		ProxyQueryService: routingQueryService{
 			InfluxQLService: b.InfluxQLService,
 			DefaultService:  b.FluxService,
@@ -106,11 +104,11 @@ func NewFluxHandler(log *zap.Logger, b *FluxBackend) *FluxHandler {
 
 	// query reponses can optionally be gzip encoded
 	qh := gziphandler.GzipHandler(http.HandlerFunc(h.handleQuery))
-	h.Handler("POST", prefixQuery, withFeatureProxy(b.AlgoWProxy, qh))
-	h.Handler("POST", "/api/v2/query/ast", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.postFluxAST)))
-	h.Handler("POST", "/api/v2/query/analyze", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.postQueryAnalyze)))
-	h.Handler("GET", "/api/v2/query/suggestions", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.getFluxSuggestions)))
-	h.Handler("GET", "/api/v2/query/suggestions/:name", withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.getFluxSuggestion)))
+	h.Handler("POST", prefixQuery, qh)
+	h.HandlerFunc("POST", "/api/v2/query/ast", h.postFluxAST)
+	h.HandlerFunc("POST", "/api/v2/query/analyze", h.postQueryAnalyze)
+	h.HandlerFunc("GET", "/api/v2/query/suggestions", h.getFluxSuggestions)
+	h.HandlerFunc("GET", "/api/v2/query/suggestions/:name", h.getFluxSuggestion)
 	return h
 }
 

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -26,7 +26,6 @@ type TaskBackend struct {
 	influxdb.HTTPErrorHandler
 	log *zap.Logger
 
-	AlgoWProxy                 FeatureProxyHandler
 	TaskService                influxdb.TaskService
 	AuthorizationService       influxdb.AuthorizationService
 	OrganizationService        influxdb.OrganizationService
@@ -41,7 +40,6 @@ func NewTaskBackend(log *zap.Logger, b *APIBackend) *TaskBackend {
 	return &TaskBackend{
 		HTTPErrorHandler:           b.HTTPErrorHandler,
 		log:                        log,
-		AlgoWProxy:                 b.AlgoWProxy,
 		TaskService:                b.TaskService,
 		AuthorizationService:       b.AuthorizationService,
 		OrganizationService:        b.OrganizationService,
@@ -100,10 +98,10 @@ func NewTaskHandler(log *zap.Logger, b *TaskBackend) *TaskHandler {
 	}
 
 	h.HandlerFunc("GET", prefixTasks, h.handleGetTasks)
-	h.Handler("POST", prefixTasks, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handlePostTask)))
+	h.HandlerFunc("POST", prefixTasks, h.handlePostTask)
 
 	h.HandlerFunc("GET", tasksIDPath, h.handleGetTask)
-	h.Handler("PATCH", tasksIDPath, withFeatureProxy(b.AlgoWProxy, http.HandlerFunc(h.handleUpdateTask)))
+	h.HandlerFunc("PATCH", tasksIDPath, h.handleUpdateTask)
 	h.HandlerFunc("DELETE", tasksIDPath, h.handleDeleteTask)
 
 	h.HandlerFunc("GET", tasksIDLogsPath, h.handleGetLogs)

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -30,7 +30,6 @@ func NewMockTaskBackend(t *testing.T) *TaskBackend {
 	return &TaskBackend{
 		log: zaptest.NewLogger(t).With(zap.String("handler", "task")),
 
-		AlgoWProxy:           &NoopProxyHandler{},
 		AuthorizationService: mock.NewAuthorizationService(),
 		TaskService:          &mock.TaskService{},
 		OrganizationService: &mock.OrganizationService{


### PR DESCRIPTION
This removes the temporary proxying behavior installed a few weeks ago. Algorithm W has been merged into `master` so this is no longer necessary.