### PR TITLE
chore(pkger): refactor return values for Apply/DryRun to enable extension

### DIFF
--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -708,8 +708,8 @@ func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args pkgFi
 type fakePkgSVC struct {
 	initStackFn func(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error)
 	createFn    func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
-	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error)
-	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error)
+	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.PkgImpactSummary, error)
+	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
 }
 
 var _ pkger.SVC = (*fakePkgSVC)(nil)
@@ -736,14 +736,14 @@ func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSe
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.dryRunFn != nil {
 		return f.dryRunFn(ctx, orgID, userID, pkg)
 	}
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.applyFn != nil {
 		return f.applyFn(ctx, orgID, userID, pkg, opts...)
 	}

--- a/pkger/http_server.go
+++ b/pkger/http_server.go
@@ -478,11 +478,11 @@ func (s *HTTPServer) applyPkg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reqBody.DryRun {
-		sum, diff, err := s.svc.DryRun(r.Context(), *orgID, userID, parsedPkg, applyOpts...)
+		impact, err := s.svc.DryRun(r.Context(), *orgID, userID, parsedPkg, applyOpts...)
 		if IsParseErr(err) {
 			s.api.Respond(w, r, http.StatusUnprocessableEntity, RespApplyPkg{
-				Diff:    diff,
-				Summary: sum,
+				Diff:    impact.Diff,
+				Summary: impact.Summary,
 				Errors:  convertParseErr(err),
 			})
 			return
@@ -493,23 +493,23 @@ func (s *HTTPServer) applyPkg(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.api.Respond(w, r, http.StatusOK, RespApplyPkg{
-			Diff:    diff,
-			Summary: sum,
+			Diff:    impact.Diff,
+			Summary: impact.Summary,
 		})
 		return
 	}
 
 	applyOpts = append(applyOpts, ApplyWithSecrets(reqBody.Secrets))
 
-	sum, diff, err := s.svc.Apply(r.Context(), *orgID, userID, parsedPkg, applyOpts...)
+	impact, err := s.svc.Apply(r.Context(), *orgID, userID, parsedPkg, applyOpts...)
 	if err != nil && !IsParseErr(err) {
 		s.api.Err(w, r, err)
 		return
 	}
 
 	s.api.Respond(w, r, http.StatusCreated, RespApplyPkg{
-		Diff:    diff,
-		Summary: sum,
+		Diff:    impact.Diff,
+		Summary: impact.Summary,
 		Errors:  convertParseErr(err),
 	})
 }

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -153,9 +153,9 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 							if err := pkg.Validate(); err != nil {
-								return pkger.Summary{}, pkger.Diff{}, err
+								return pkger.PkgImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -166,7 +166,10 @@ func TestPkgerHTTPServer(t *testing.T) {
 									},
 								})
 							}
-							return sum, diff, nil
+							return pkger.PkgImpactSummary{
+								Summary: sum,
+								Diff:    diff,
+							}, nil
 						},
 					}
 
@@ -209,9 +212,9 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 							if err := pkg.Validate(); err != nil {
-								return pkger.Summary{}, pkger.Diff{}, err
+								return pkger.PkgImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -222,7 +225,10 @@ func TestPkgerHTTPServer(t *testing.T) {
 									},
 								})
 							}
-							return sum, diff, nil
+							return pkger.PkgImpactSummary{
+								Diff:    diff,
+								Summary: sum,
+							}, nil
 						},
 					}
 
@@ -313,9 +319,9 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 							if err := pkg.Validate(); err != nil {
-								return pkger.Summary{}, pkger.Diff{}, err
+								return pkger.PkgImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -326,7 +332,11 @@ func TestPkgerHTTPServer(t *testing.T) {
 									},
 								})
 							}
-							return sum, diff, nil
+
+							return pkger.PkgImpactSummary{
+								Diff:    diff,
+								Summary: sum,
+							}, nil
 						},
 					}
 
@@ -385,8 +395,10 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
-							return pkg.Summary(), pkger.Diff{}, nil
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+							return pkger.PkgImpactSummary{
+								Summary: pkg.Summary(),
+							}, nil
 						},
 					}
 
@@ -407,7 +419,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 
 	t.Run("apply a pkg", func(t *testing.T) {
 		svc := &fakeSVC{
-			applyFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+			applyFn: func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 				var opt pkger.ApplyOpt
 				for _, o := range opts {
 					o(&opt)
@@ -425,7 +437,11 @@ func TestPkgerHTTPServer(t *testing.T) {
 				for key := range opt.MissingSecrets {
 					sum.MissingSecrets = append(sum.MissingSecrets, key)
 				}
-				return sum, diff, nil
+
+				return pkger.PkgImpactSummary{
+					Diff:    diff,
+					Summary: sum,
+				}, nil
 			},
 		}
 
@@ -824,8 +840,8 @@ func decodeBody(t *testing.T, r io.Reader, v interface{}) {
 type fakeSVC struct {
 	initStack    func(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error)
 	listStacksFn func(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error)
-	dryRunFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error)
-	applyFn      func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error)
+	dryRunFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
+	applyFn      func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
 }
 
 var _ pkger.SVC = (*fakeSVC)(nil)
@@ -852,7 +868,7 @@ func (f *fakeSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn
 	panic("not implemented")
 }
 
-func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.dryRunFn == nil {
 		panic("not implemented")
 	}
@@ -860,7 +876,7 @@ func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pk
 	return f.dryRunFn(ctx, orgID, userID, pkg, opts...)
 }
 
-func (f *fakeSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.Summary, pkger.Diff, error) {
+func (f *fakeSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.applyFn == nil {
 		panic("not implemented")
 	}

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -64,8 +64,8 @@ type SVC interface {
 	ListStacks(ctx context.Context, orgID influxdb.ID, filter ListFilter) ([]Stack, error)
 
 	CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error)
-	DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error)
-	Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error)
+	DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error)
+	Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error)
 }
 
 // SVCMiddleware is a service middleware func.
@@ -690,28 +690,38 @@ func (s *Service) filterOrgResourceKinds(resourceKindFilters []Kind) []struct {
 	return resourceTypeGens
 }
 
+// PkgImpactSummary represents the impact the application of a pkg will have on the system.
+type PkgImpactSummary struct {
+	Diff    Diff
+	Summary Summary
+}
+
 // DryRun provides a dry run of the pkg application. The pkg will be marked verified
 // for later calls to Apply. This func will be run on an Apply if it has not been run
 // already.
-func (s *Service) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+func (s *Service) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	opt := applyOptFromOptFns(opts...)
 
 	if opt.StackID != 0 {
 		remotePkgs, err := s.getStackRemotePackages(ctx, opt.StackID)
 		if err != nil {
-			return Summary{}, Diff{}, err
+			return PkgImpactSummary{}, err
 		}
 		pkg, err = Combine(append(remotePkgs, pkg), ValidWithoutResources())
 		if err != nil {
-			return Summary{}, Diff{}, err
+			return PkgImpactSummary{}, err
 		}
 	}
 
 	state, err := s.dryRun(ctx, orgID, pkg, opt)
 	if err != nil {
-		return Summary{}, Diff{}, err
+		return PkgImpactSummary{}, err
 	}
-	return newSummaryFromStatePkg(state, pkg), state.diff(), nil
+
+	return PkgImpactSummary{
+		Diff:    state.diff(),
+		Summary: newSummaryFromStatePkg(state, pkg),
+	}, nil
 }
 
 func (s *Service) dryRun(ctx context.Context, orgID influxdb.ID, pkg *Pkg, opt ApplyOpt) (*stateCoordinator, error) {
@@ -1177,32 +1187,32 @@ func applyOptFromOptFns(opts ...ApplyOptFn) ApplyOpt {
 // Apply will apply all the resources identified in the provided pkg. The entire pkg will be applied
 // in its entirety. If a failure happens midway then the entire pkg will be rolled back to the state
 // from before the pkg were applied.
-func (s *Service) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (sum Summary, diff Diff, e error) {
+func (s *Service) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (impact PkgImpactSummary, e error) {
 	opt := applyOptFromOptFns(opts...)
 
 	if opt.StackID != 0 {
 		remotePkgs, err := s.getStackRemotePackages(ctx, opt.StackID)
 		if err != nil {
-			return Summary{}, Diff{}, err
+			return PkgImpactSummary{}, err
 		}
 
 		pkg, err = Combine(append(remotePkgs, pkg), ValidWithoutResources())
 		if err != nil {
-			return Summary{}, Diff{}, err
+			return PkgImpactSummary{}, err
 		}
 	}
 
 	if err := pkg.Validate(ValidWithoutResources()); err != nil {
-		return Summary{}, Diff{}, failedValidationErr(err)
+		return PkgImpactSummary{}, failedValidationErr(err)
 	}
 
 	if err := pkg.applyEnvRefs(opt.EnvRefs); err != nil {
-		return Summary{}, Diff{}, failedValidationErr(err)
+		return PkgImpactSummary{}, failedValidationErr(err)
 	}
 
 	state, err := s.dryRun(ctx, orgID, pkg, opt)
 	if err != nil {
-		return Summary{}, Diff{}, err
+		return PkgImpactSummary{}, err
 	}
 
 	defer func(stackID influxdb.ID) {
@@ -1224,12 +1234,15 @@ func (s *Service) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg
 
 	err = s.applyState(ctx, coordinator, orgID, userID, state, opt.MissingSecrets)
 	if err != nil {
-		return Summary{}, Diff{}, err
+		return PkgImpactSummary{}, err
 	}
 
 	pkg.applySecrets(opt.MissingSecrets)
 
-	return newSummaryFromStatePkg(state, pkg), state.diff(), err
+	return PkgImpactSummary{
+		Diff:    state.diff(),
+		Summary: newSummaryFromStatePkg(state, pkg),
+	}, nil
 }
 
 func (s *Service) applyState(ctx context.Context, coordinator *rollbackCoordinator, orgID, userID influxdb.ID, state *stateCoordinator, missingSecrets map[string]string) (e error) {

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -56,10 +56,10 @@ func (s *authMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
 }
 
-func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	return s.next.Apply(ctx, orgID, userID, pkg, opts...)
 }

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -96,7 +96,7 @@ func (s *loggingMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (p
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (sum Summary, diff Diff, err error) {
+func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -114,7 +114,7 @@ func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *
 			o(&opt)
 		}
 
-		fields := s.summaryLogFields(sum)
+		fields := s.summaryLogFields(impact.Summary)
 		if opt.StackID != 0 {
 			fields = append(fields, zap.Stringer("stackID", opt.StackID))
 		}
@@ -124,7 +124,7 @@ func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *
 	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
 }
 
-func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (sum Summary, diff Diff, err error) {
+func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -137,7 +137,7 @@ func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *P
 			return
 		}
 
-		fields := s.summaryLogFields(sum)
+		fields := s.summaryLogFields(impact.Summary)
 
 		opt := applyOptFromOptFns(opts...)
 		if opt.StackID != 0 {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -50,14 +50,14 @@ func (s *mwMetrics) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*
 	return pkg, rec(err)
 }
 
-func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	rec := s.rec.Record("dry_run")
-	sum, diff, err := s.next.DryRun(ctx, orgID, userID, pkg, opts...)
-	return sum, diff, rec(err)
+	impact, err := s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+	return impact, rec(err)
 }
 
-func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (Summary, Diff, error) {
+func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	rec := s.rec.Record("apply")
-	sum, diff, err := s.next.Apply(ctx, orgID, userID, pkg, opts...)
-	return sum, diff, rec(err)
+	impact, err := s.next.Apply(ctx, orgID, userID, pkg, opts...)
+	return impact, rec(err)
 }

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -78,10 +78,10 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 					require.NoError(t, err)
 
-					require.Len(t, diff.Buckets, 2)
+					require.Len(t, impact.Diff.Buckets, 2)
 
 					expected := DiffBucket{
 						DiffIdentifier: DiffIdentifier{
@@ -101,7 +101,7 @@ func TestService(t *testing.T) {
 							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 						},
 					}
-					assert.Contains(t, diff.Buckets, expected)
+					assert.Contains(t, impact.Diff.Buckets, expected)
 				})
 			})
 
@@ -113,10 +113,10 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 					require.NoError(t, err)
 
-					require.Len(t, diff.Buckets, 2)
+					require.Len(t, impact.Diff.Buckets, 2)
 
 					expected := DiffBucket{
 						DiffIdentifier: DiffIdentifier{
@@ -129,7 +129,7 @@ func TestService(t *testing.T) {
 							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 						},
 					}
-					assert.Contains(t, diff.Buckets, expected)
+					assert.Contains(t, impact.Diff.Buckets, expected)
 				})
 			})
 		})
@@ -154,10 +154,10 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithCheckSVC(fakeCheckSVC))
 
-				_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 				require.NoError(t, err)
 
-				checks := diff.Checks
+				checks := impact.Diff.Checks
 				require.Len(t, checks, 2)
 				check0 := checks[0]
 				assert.True(t, check0.IsNew())
@@ -192,10 +192,10 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 					require.NoError(t, err)
 
-					require.Len(t, diff.Labels, 3)
+					require.Len(t, impact.Diff.Labels, 3)
 
 					expected := DiffLabel{
 						DiffIdentifier: DiffIdentifier{
@@ -214,14 +214,14 @@ func TestService(t *testing.T) {
 							Description: "label 1 description",
 						},
 					}
-					assert.Contains(t, diff.Labels, expected)
+					assert.Contains(t, impact.Diff.Labels, expected)
 
 					expected.PkgName = "label-2"
 					expected.New.Name = "label-2"
 					expected.New.Color = "#000000"
 					expected.New.Description = "label 2 description"
 					expected.Old.Name = "label-2"
-					assert.Contains(t, diff.Labels, expected)
+					assert.Contains(t, impact.Diff.Labels, expected)
 				})
 			})
 
@@ -233,10 +233,11 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 					require.NoError(t, err)
 
-					require.Len(t, diff.Labels, 3)
+					labels := impact.Diff.Labels
+					require.Len(t, labels, 3)
 
 					expected := DiffLabel{
 						DiffIdentifier: DiffIdentifier{
@@ -249,13 +250,13 @@ func TestService(t *testing.T) {
 							Description: "label 1 description",
 						},
 					}
-					assert.Contains(t, diff.Labels, expected)
+					assert.Contains(t, labels, expected)
 
 					expected.PkgName = "label-2"
 					expected.New.Name = "label-2"
 					expected.New.Color = "#000000"
 					expected.New.Description = "label 2 description"
-					assert.Contains(t, diff.Labels, expected)
+					assert.Contains(t, labels, expected)
 				})
 			})
 		})
@@ -281,16 +282,16 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithNotificationEndpointSVC(fakeEndpointSVC))
 
-				_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 				require.NoError(t, err)
 
-				require.Len(t, diff.NotificationEndpoints, 5)
+				require.Len(t, impact.Diff.NotificationEndpoints, 5)
 
 				var (
 					newEndpoints      []DiffNotificationEndpoint
 					existingEndpoints []DiffNotificationEndpoint
 				)
-				for _, e := range diff.NotificationEndpoints {
+				for _, e := range impact.Diff.NotificationEndpoints {
 					if e.Old != nil {
 						existingEndpoints = append(existingEndpoints, e)
 						continue
@@ -349,12 +350,12 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithNotificationEndpointSVC(fakeEndpointSVC))
 
-				_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 				require.NoError(t, err)
 
-				require.Len(t, diff.NotificationRules, 1)
+				require.Len(t, impact.Diff.NotificationRules, 1)
 
-				actual := diff.NotificationRules[0].New
+				actual := impact.Diff.NotificationRules[0].New
 				assert.Equal(t, "rule_0", actual.Name)
 				assert.Equal(t, "desc_0", actual.Description)
 				assert.Equal(t, "slack", actual.EndpointType)
@@ -385,10 +386,10 @@ func TestService(t *testing.T) {
 				}
 				svc := newTestService(WithSecretSVC(fakeSecretSVC))
 
-				sum, _, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 				require.NoError(t, err)
 
-				assert.Equal(t, []string{"routing-key"}, sum.MissingSecrets)
+				assert.Equal(t, []string{"routing-key"}, impact.Summary.MissingSecrets)
 			})
 		})
 
@@ -406,10 +407,11 @@ func TestService(t *testing.T) {
 				}
 				svc := newTestService(WithVariableSVC(fakeVarSVC))
 
-				_, diff, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
 				require.NoError(t, err)
 
-				require.Len(t, diff.Variables, 4)
+				variables := impact.Diff.Variables
+				require.Len(t, variables, 4)
 
 				expected := DiffVariable{
 					DiffIdentifier: DiffIdentifier{
@@ -430,7 +432,7 @@ func TestService(t *testing.T) {
 						},
 					},
 				}
-				assert.Equal(t, expected, diff.Variables[0])
+				assert.Equal(t, expected, variables[0])
 
 				expected = DiffVariable{
 					DiffIdentifier: DiffIdentifier{
@@ -447,7 +449,7 @@ func TestService(t *testing.T) {
 						},
 					},
 				}
-				assert.Equal(t, expected, diff.Variables[1])
+				assert.Equal(t, expected, variables[1])
 			})
 		})
 	})
@@ -473,9 +475,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Buckets, 2)
 
 					expected := SummaryBucket{
@@ -523,9 +526,10 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Buckets, 2)
 
 					expected := SummaryBucket{
@@ -561,7 +565,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeBktSVC.DeleteBucketCalls.Count(), 1)
@@ -582,9 +586,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Checks, 2)
 
 					containsWithID := func(t *testing.T, name string) {
@@ -623,7 +628,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeCheckSVC.DeleteCheckCalls.Count(), 1)
@@ -648,9 +653,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Labels, 3)
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
@@ -698,7 +704,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeLabelSVC.DeleteLabelCalls.Count(), 1)
@@ -754,9 +760,10 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Labels, 3)
 
 					assert.Contains(t, sum.Labels, SummaryLabel{
@@ -808,8 +815,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
+
+					sum := impact.Summary
 
 					require.Len(t, sum.Dashboards, 2)
 					dash1 := sum.Dashboards[0]
@@ -848,7 +857,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.True(t, deletedDashs[1])
@@ -857,7 +866,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("label mapping", func(t *testing.T) {
-			testLabelMappingV2ApplyFn := func(t *testing.T, filename string, numExpected int, settersFn func() []ServiceSetterFn) {
+			testLabelMappingApplyFn := func(t *testing.T, filename string, numExpected int, settersFn func() []ServiceSetterFn) {
 				t.Helper()
 				testfileRunner(t, filename, func(t *testing.T, pkg *Pkg) {
 					t.Helper()
@@ -883,14 +892,14 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
 					assert.Equal(t, numExpected, fakeLabelSVC.CreateLabelMappingCalls.Count())
 				})
 			}
 
-			testLabelMappingV2RollbackFn := func(t *testing.T, filename string, killCount int, settersFn func() []ServiceSetterFn) {
+			testLabelMappingRollbackFn := func(t *testing.T, filename string, killCount int, settersFn func() []ServiceSetterFn) {
 				t.Helper()
 				testfileRunner(t, filename, func(t *testing.T, pkg *Pkg) {
 					t.Helper()
@@ -919,7 +928,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeLabelSVC.DeleteLabelMappingCalls.Count(), killCount)
@@ -941,11 +950,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/bucket_associates_label.yml", 4, bktOpt)
+					testLabelMappingApplyFn(t, "testdata/bucket_associates_label.yml", 4, bktOpt)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/bucket_associates_label.yml", 2, bktOpt)
+					testLabelMappingRollbackFn(t, "testdata/bucket_associates_label.yml", 2, bktOpt)
 				})
 			})
 
@@ -964,11 +973,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/checks.yml", 2, opts)
+					testLabelMappingApplyFn(t, "testdata/checks.yml", 2, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/checks.yml", 1, opts)
+					testLabelMappingRollbackFn(t, "testdata/checks.yml", 1, opts)
 				})
 			})
 
@@ -983,11 +992,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/dashboard_associates_label.yml", 2, opts)
+					testLabelMappingApplyFn(t, "testdata/dashboard_associates_label.yml", 2, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/dashboard_associates_label.yml", 1, opts)
+					testLabelMappingRollbackFn(t, "testdata/dashboard_associates_label.yml", 1, opts)
 				})
 			})
 
@@ -1002,11 +1011,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/notification_endpoint.yml", 5, opts)
+					testLabelMappingApplyFn(t, "testdata/notification_endpoint.yml", 5, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/notification_endpoint.yml", 3, opts)
+					testLabelMappingRollbackFn(t, "testdata/notification_endpoint.yml", 3, opts)
 				})
 			})
 
@@ -1023,11 +1032,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/notification_rule.yml", 2, opts)
+					testLabelMappingApplyFn(t, "testdata/notification_rule.yml", 2, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/notification_rule.yml", 1, opts)
+					testLabelMappingRollbackFn(t, "testdata/notification_rule.yml", 1, opts)
 				})
 			})
 
@@ -1055,11 +1064,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/tasks.yml", 2, opts)
+					testLabelMappingApplyFn(t, "testdata/tasks.yml", 2, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/tasks.yml", 1, opts)
+					testLabelMappingRollbackFn(t, "testdata/tasks.yml", 1, opts)
 				})
 			})
 
@@ -1074,11 +1083,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/telegraf.yml", 2, opts)
+					testLabelMappingApplyFn(t, "testdata/telegraf.yml", 2, opts)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/telegraf.yml", 1, opts)
+					testLabelMappingRollbackFn(t, "testdata/telegraf.yml", 1, opts)
 				})
 			})
 
@@ -1093,11 +1102,11 @@ func TestService(t *testing.T) {
 				}
 
 				t.Run("applies successfully", func(t *testing.T) {
-					testLabelMappingV2ApplyFn(t, "testdata/variable_associates_label.yml", 1, opt)
+					testLabelMappingApplyFn(t, "testdata/variable_associates_label.yml", 1, opt)
 				})
 
 				t.Run("deletes new label mappings on error", func(t *testing.T) {
-					testLabelMappingV2RollbackFn(t, "testdata/variable_associates_label.yml", 0, opt)
+					testLabelMappingRollbackFn(t, "testdata/variable_associates_label.yml", 0, opt)
 				})
 			})
 		})
@@ -1115,9 +1124,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.NotificationEndpoints, 5)
 
 					containsWithID := func(t *testing.T, name string) {
@@ -1163,7 +1173,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeEndpointSVC.DeleteNotificationEndpointCalls.Count(), 3)
@@ -1192,9 +1202,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.NotificationRules, 1)
 					assert.Equal(t, "rule-uuid", sum.NotificationRules[0].PkgName)
 					assert.Equal(t, "rule_0", sum.NotificationRules[0].Name)
@@ -1234,7 +1245,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeRuleStore.DeleteNotificationRuleCalls.Count())
@@ -1268,9 +1279,10 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithTaskSVC(fakeTaskSVC))
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Tasks, 2)
 					assert.NotZero(t, sum.Tasks[0].ID)
 					assert.Equal(t, "task-1", sum.Tasks[0].PkgName)
@@ -1300,7 +1312,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeTaskSVC.DeleteTaskCalls.Count())
@@ -1321,9 +1333,10 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithTelegrafSVC(fakeTeleSVC))
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.TelegrafConfigs, 2)
 					assert.Equal(t, "display name", sum.TelegrafConfigs[0].TelegrafConfig.Name)
 					assert.Equal(t, "desc", sum.TelegrafConfigs[0].TelegrafConfig.Description)
@@ -1353,7 +1366,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeTeleSVC.DeleteTelegrafConfigCalls.Count())
@@ -1374,9 +1387,10 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Variables, 4)
 
 					expected := sum.Variables[0]
@@ -1408,7 +1422,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeVarSVC.DeleteVariableCalls.Count(), 1)
@@ -1449,9 +1463,10 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithVariableSVC(fakeVarSVC))
 
-					sum, _, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
 					require.NoError(t, err)
 
+					sum := impact.Summary
 					require.Len(t, sum.Variables, 4)
 					expected := sum.Variables[0]
 					assert.Equal(t, SafeID(1), expected.ID)

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -51,14 +51,14 @@ func (s *traceMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (pkg
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (sum Summary, diff Diff, err error) {
+func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "DryRun")
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
 	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
 }
 
-func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (sum Summary, diff Diff, err error) {
+func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "Apply")
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()


### PR DESCRIPTION
references: #17997

This is a refactor to enable extending the new return type with additional arguments that are outside the domain of a summary or diff.  Nothing external to influxdb (HTTP API) is changing.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass