### PR TITLE
fix(http): silence echo command

### DIFF
--- a/http/Makefile
+++ b/http/Makefile
@@ -14,7 +14,7 @@ clean: $(SUBDIRS)
 
 swagger_gen.go: swagger.go redoc.go swagger.yml
 	go generate -x
-	echo '//lint:file-ignore ST1005 Ignore error strings should not be capitalized' >> swagger_gen.go
+	@echo '//lint:file-ignore ST1005 Ignore error strings should not be capitalized' >> swagger_gen.go
 
 GO_RUN := env GO111MODULE=on go run
 


### PR DESCRIPTION
Closes #

removes the line:
`echo '//lint:file-ignore ST1005 Ignore error strings should not be capitalized' >> swagger_gen.go`

everytime you run `make`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
