### PR TITLE
fix(dshell): update Dockerfile for Flux dependency on pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,21 @@ RUN apt install --yes \
         llvm-dev \
         make \
         nodejs \
+        pkg-config \
         protobuf-compiler \
         ragel \
         rustc \
         yarn
 
+ENV GOPATH=/go
+ENV PATH /go/bin:$PATH
+RUN go get github.com/influxdata/pkg-config
+
 FROM dbuild AS dshell
 
 ARG USERID=1000
 RUN adduser --quiet --home /code --uid ${USERID} --disabled-password --gecos "" influx
+RUN chown -R ${USERID} /go
 USER influx
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Flux currently needs a wrapper for pkg-config to be available to build,
which directly affects running or building influxd.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
