### PR TITLE
fix(swagger): unique operation id

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4560,7 +4560,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/invites/{inviteID}/resend":
     post:
-      operationId: DeleteOrgsIDInviteID
+      operationId: ResendOrgsIDInviteID
       tags:
         - Invites
         - Organizations


### PR DESCRIPTION
Repaired operationId of /orgs/{orgID}/invites/{inviteID}/resend , swagger operation names must be unique. influxdb client API generators fail when they are not.


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
