### PR TITLE
fix(tsdb): Disable series id set cache size by default.

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -68,7 +68,8 @@ const (
 	DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
 
 	// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache in the TSI index.
-	DefaultSeriesIDSetCacheSize = 100
+	// It is disabled by default.
+	DefaultSeriesIDSetCacheSize = 0
 
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.


### PR DESCRIPTION
Backport of #18158