### PR TITLE
fix: [Swagger] Make LabelUpdate.properties consistent with Label and LabelCreateRequest

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10971,6 +10971,8 @@ components:
           type: string
         properties:
           type: object
+          additionalProperties:
+            type: string
           description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example: { "color": "ffb3b3", "description": "this is a description" }
     LabelMapping:


### PR DESCRIPTION
Current [LabelUpdate.properties](https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L10972) makes generator producing Go code mapping as `map[string]inferface{}`, whereas [LabelCreateRequest.properties](https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L10961) and [Label.properties](https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L10947) produce correctly `map[string]string`.

This PR makes the `LabelUpdate.properties` consistent with others.