### PR TITLE
feat(storage/flux): implement create empty for the window table reader

### DIFF
--- a/query/stdlib/influxdata/influxdb/operators.go
+++ b/query/stdlib/influxdata/influxdb/operators.go
@@ -111,6 +111,7 @@ type ReadWindowAggregatePhysSpec struct {
 
 	WindowEvery int64
 	Aggregates  []plan.ProcedureKind
+	CreateEmpty bool
 }
 
 func (s *ReadWindowAggregatePhysSpec) Kind() plan.ProcedureKind {
@@ -123,6 +124,7 @@ func (s *ReadWindowAggregatePhysSpec) Copy() plan.ProcedureSpec {
 	ns.ReadRangePhysSpec = *s.ReadRangePhysSpec.Copy().(*ReadRangePhysSpec)
 	ns.WindowEvery = s.WindowEvery
 	ns.Aggregates = s.Aggregates
+	ns.CreateEmpty = s.CreateEmpty
 
 	return ns
 }

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -766,8 +766,7 @@ func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 		!window.Offset.IsZero() ||
 		windowSpec.TimeColumn != "_time" ||
 		windowSpec.StartColumn != "_start" ||
-		windowSpec.StopColumn != "_stop" ||
-		windowSpec.CreateEmpty {
+		windowSpec.StopColumn != "_stop" {
 		return pn, false, nil
 	}
 
@@ -776,6 +775,7 @@ func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 		ReadRangePhysSpec: *fromSpec.Copy().(*ReadRangePhysSpec),
 		Aggregates:        []plan.ProcedureKind{fnNode.Kind()},
 		WindowEvery:       window.Every.Nanoseconds(),
+		CreateEmpty:       windowSpec.CreateEmpty,
 	}), true, nil
 }
 

--- a/query/stdlib/influxdata/influxdb/source.go
+++ b/query/stdlib/influxdata/influxdb/source.go
@@ -351,6 +351,7 @@ func createReadWindowAggregateSource(s plan.ProcedureSpec, id execute.DatasetID,
 			},
 			WindowEvery: spec.WindowEvery,
 			Aggregates:  spec.Aggregates,
+			CreateEmpty: spec.CreateEmpty,
 		},
 		a,
 	), nil

--- a/query/storage.go
+++ b/query/storage.go
@@ -73,6 +73,7 @@ type ReadWindowAggregateSpec struct {
 	ReadFilterSpec
 	WindowEvery int64
 	Aggregates  []plan.ProcedureKind
+	CreateEmpty bool
 }
 
 // TableIterator is a table iterator that also keeps track of cursor statistics from the storage engine.

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -592,10 +592,13 @@ func (wai *windowAggregateIterator) Do(f func(flux.Table) error) error {
 	if rs == nil {
 		return nil
 	}
-	return wai.handleRead(f, rs, req.WindowEvery)
+	return wai.handleRead(f, rs)
 }
 
-func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs storage.ResultSet, windowEvery int64) error {
+func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs storage.ResultSet) error {
+	windowEvery := wai.spec.WindowEvery
+	createEmpty := wai.spec.CreateEmpty
+
 	// these resources must be closed if not nil on return
 	var (
 		cur   cursors.Cursor
@@ -627,19 +630,19 @@ READ:
 		switch typedCur := cur.(type) {
 		case cursors.IntegerArrayCursor:
 			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TInt)
-			table = newIntegerWindowTable(done, typedCur, bnds, windowEvery, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			table = newIntegerWindowTable(done, typedCur, bnds, windowEvery, createEmpty, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
 		case cursors.FloatArrayCursor:
 			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TFloat)
-			table = newFloatWindowTable(done, typedCur, bnds, windowEvery, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			table = newFloatWindowTable(done, typedCur, bnds, windowEvery, createEmpty, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
 		case cursors.UnsignedArrayCursor:
 			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TUInt)
-			table = newUnsignedWindowTable(done, typedCur, bnds, windowEvery, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			table = newUnsignedWindowTable(done, typedCur, bnds, windowEvery, createEmpty, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
 		case cursors.BooleanArrayCursor:
 			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TBool)
-			table = newBooleanWindowTable(done, typedCur, bnds, windowEvery, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			table = newBooleanWindowTable(done, typedCur, bnds, windowEvery, createEmpty, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
 		case cursors.StringArrayCursor:
 			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TString)
-			table = newStringWindowTable(done, typedCur, bnds, windowEvery, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			table = newStringWindowTable(done, typedCur, bnds, windowEvery, createEmpty, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
 		default:
 			panic(fmt.Sprintf("unreachable: %T", typedCur))
 		}
@@ -647,7 +650,7 @@ READ:
 		cur = nil
 
 		if !table.Empty() {
-			if err := f(table); err != nil {
+			if err := splitWindows(wai.ctx, table, f); err != nil {
 				table.Close()
 				table = nil
 				return err

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -9,6 +9,7 @@ package storageflux
 import (
 	"sync"
 
+	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
@@ -102,7 +103,9 @@ type floatWindowTable struct {
 	floatTable
 	windowEvery int64
 	arr         *cursors.FloatArray
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func newFloatWindowTable(
@@ -110,6 +113,7 @@ func newFloatWindowTable(
 	cur cursors.FloatArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -123,6 +127,11 @@ func newFloatWindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start%every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -130,40 +139,126 @@ func newFloatWindowTable(
 	return t
 }
 
-func (t *floatWindowTable) advance() bool {
+func (t *floatWindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *floatWindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *floatWindowTable) nextAt(ts int64) (v float64, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *floatWindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *floatWindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *floatWindowTable) appendValues(intervals []int64, appendValue func(v float64), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *floatWindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 
@@ -363,7 +458,9 @@ type integerWindowTable struct {
 	integerTable
 	windowEvery int64
 	arr         *cursors.IntegerArray
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func newIntegerWindowTable(
@@ -371,6 +468,7 @@ func newIntegerWindowTable(
 	cur cursors.IntegerArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -384,6 +482,11 @@ func newIntegerWindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start%every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -391,40 +494,126 @@ func newIntegerWindowTable(
 	return t
 }
 
-func (t *integerWindowTable) advance() bool {
+func (t *integerWindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *integerWindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *integerWindowTable) nextAt(ts int64) (v int64, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *integerWindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *integerWindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *integerWindowTable) appendValues(intervals []int64, appendValue func(v int64), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *integerWindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 
@@ -624,7 +813,9 @@ type unsignedWindowTable struct {
 	unsignedTable
 	windowEvery int64
 	arr         *cursors.UnsignedArray
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func newUnsignedWindowTable(
@@ -632,6 +823,7 @@ func newUnsignedWindowTable(
 	cur cursors.UnsignedArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -645,6 +837,11 @@ func newUnsignedWindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start%every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -652,40 +849,126 @@ func newUnsignedWindowTable(
 	return t
 }
 
-func (t *unsignedWindowTable) advance() bool {
+func (t *unsignedWindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *unsignedWindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *unsignedWindowTable) nextAt(ts int64) (v uint64, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *unsignedWindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *unsignedWindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *unsignedWindowTable) appendValues(intervals []int64, appendValue func(v uint64), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *unsignedWindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 
@@ -885,7 +1168,9 @@ type stringWindowTable struct {
 	stringTable
 	windowEvery int64
 	arr         *cursors.StringArray
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func newStringWindowTable(
@@ -893,6 +1178,7 @@ func newStringWindowTable(
 	cur cursors.StringArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -906,6 +1192,11 @@ func newStringWindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start%every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -913,40 +1204,126 @@ func newStringWindowTable(
 	return t
 }
 
-func (t *stringWindowTable) advance() bool {
+func (t *stringWindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *stringWindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *stringWindowTable) nextAt(ts int64) (v string, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *stringWindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *stringWindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *stringWindowTable) appendValues(intervals []int64, appendValue func(v string), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *stringWindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 
@@ -1146,7 +1523,9 @@ type booleanWindowTable struct {
 	booleanTable
 	windowEvery int64
 	arr         *cursors.BooleanArray
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func newBooleanWindowTable(
@@ -1154,6 +1533,7 @@ func newBooleanWindowTable(
 	cur cursors.BooleanArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -1167,6 +1547,11 @@ func newBooleanWindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start%every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -1174,40 +1559,126 @@ func newBooleanWindowTable(
 	return t
 }
 
-func (t *booleanWindowTable) advance() bool {
+func (t *booleanWindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *booleanWindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *booleanWindowTable) nextAt(ts int64) (v bool, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *booleanWindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *booleanWindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *booleanWindowTable) appendValues(intervals []int64, appendValue func(v bool), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *booleanWindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -3,6 +3,7 @@ package storageflux
 import (
 	"sync"
 
+	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
@@ -96,7 +97,9 @@ type {{.name}}WindowTable struct {
 	{{.name}}Table
 	windowEvery int64
 	arr         *cursors.{{.Name}}Array
+	nextTS      int64
 	idxInArr    int
+	createEmpty bool
 }
 
 func new{{.Name}}WindowTable(
@@ -104,6 +107,7 @@ func new{{.Name}}WindowTable(
 	cur cursors.{{.Name}}ArrayCursor,
 	bounds execute.Bounds,
 	every int64,
+	createEmpty bool,
 	key flux.GroupKey,
 	cols []flux.ColMeta,
 	tags models.Tags,
@@ -117,6 +121,11 @@ func new{{.Name}}WindowTable(
 			cur:   cur,
 		},
 		windowEvery: every,
+		createEmpty: createEmpty,
+	}
+	if t.createEmpty {
+		start := int64(bounds.Start)
+		t.nextTS = start + (every - start % every)
 	}
 	t.readTags(tags)
 	t.advance()
@@ -124,40 +133,126 @@ func new{{.Name}}WindowTable(
 	return t
 }
 
-func (t *{{.name}}WindowTable) advance() bool {
+func (t *{{.name}}WindowTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+// createNextWindow will read the timestamps from the array
+// cursor and construct the values for the next window.
+func (t *{{.name}}WindowTable) createNextWindow() (start, stop *array.Int64, ok bool) {
+	var stopT int64
+	if t.createEmpty {
+		stopT = t.nextTS
+		t.nextTS += t.windowEvery
+	} else {
+		if !t.nextBuffer() {
+			return nil, nil, false
+		}
+		stopT = t.arr.Timestamps[t.idxInArr]
+	}
+
+	// Regain the window start time from the window end time.
+	startT := stopT - t.windowEvery
+	if startT < int64(t.bounds.Start) {
+		startT = int64(t.bounds.Start)
+	}
+	if stopT > int64(t.bounds.Stop) {
+		stopT = int64(t.bounds.Stop)
+	}
+
+	// If the start time is after our stop boundary,
+	// we exit here when create empty is true.
+	if t.createEmpty && startT >= int64(t.bounds.Stop) {
+		return nil, nil, false
+	}
+	start = arrow.NewInt([]int64{startT}, t.alloc)
+	stop = arrow.NewInt([]int64{stopT}, t.alloc)
+	return start, stop, true
+}
+
+// nextAt will retrieve the next value that can be used with
+// the given stop timestamp. If no values can be used with the timestamp,
+// it will return the default value and false.
+func (t *{{.name}}WindowTable) nextAt(ts int64) (v {{.Type}}, ok bool) {
+	if !t.nextBuffer() {
+		return
+	} else if !t.isInWindow(ts, t.arr.Timestamps[t.idxInArr]) {
+		return
+	}
+	v, ok = t.arr.Values[t.idxInArr], true
+	t.idxInArr++
+	return v, ok
+}
+
+// isInWindow will check if the given time at stop can be used within
+// the window stop time for ts. The ts may be a truncated stop time
+// because of a restricted boundary while stop will be the true
+// stop time returned by storage.
+func (t *{{.name}}WindowTable) isInWindow(ts int64, stop int64) bool {
+	// This method checks if the stop time is a valid stop time for
+	// that interval. This calculation is different from the calculation
+	// of the window itself. For example, for a 10 second window that
+	// starts at 20 seconds, we would include points between [20, 30).
+	// The stop time for this interval would be 30, but because the stop
+	// time can be truncated, valid stop times range from anywhere between
+	// (20, 30]. The storage engine will always produce 30 as the end time
+	// but we may have truncated the stop time because of the boundary
+	// and this is why we are checking for this range instead of checking
+	// if the two values are equal.
+	start := stop - t.windowEvery
+	return start < ts && ts <= stop
+}
+
+// nextBuffer will ensure the array cursor is filled
+// and will return true if there is at least one value
+// that can be read from it.
+func (t *{{.name}}WindowTable) nextBuffer() bool {
+	// Discard the current array cursor if we have
+	// exceeded it.
+	if t.arr != nil && t.idxInArr >= t.arr.Len() {
+		t.arr = nil
+	}
+
+	// Retrieve the next array cursor if needed.
 	if t.arr == nil {
-		t.arr = t.cur.Next()
-		if t.arr.Len() == 0 {
-			t.arr = nil
+		arr := t.cur.Next()
+		if arr.Len() == 0 {
 			return false
 		}
-		t.idxInArr = 0
+		t.arr, t.idxInArr = arr, 0
 	}
+	return true
+}
+
+// appendValues will scan the timestamps and append values
+// that match those timestamps from the buffer.
+func (t *{{.name}}WindowTable) appendValues(intervals []int64, appendValue func(v {{.Type}}), appendNull func()) {
+	for i := 0; i < len(intervals); i++ {
+		if v, ok := t.nextAt(intervals[i]); ok {
+			appendValue(v)
+			continue
+		}
+		appendNull()
+	}
+}
+
+func (t *{{.name}}WindowTable) advance() bool {
+	// Create the timestamps for the next window.
+	start, stop, ok := t.createNextWindow()
+	if !ok {
+		return false
+	}
+	values := t.mergeValues(stop.Int64Values())
 
 	// Retrieve the buffer for the data to avoid allocating
 	// additional slices. If the buffer is still being used
 	// because the references were retained, then we will
 	// allocate a new buffer.
-	columnReader := t.allocateBuffer(1)
-	// regain the window start time from the window end time
-	rangeStart := int64(t.bounds.Start)
-	rangeEnd := int64(t.bounds.Stop)
-	stop := t.arr.Timestamps[t.idxInArr]
-	start := stop - t.windowEvery
-	if start < rangeStart {
-		start = rangeStart
-	}
-	if stop > rangeEnd {
-		stop = rangeEnd
-	}
-	columnReader.cols[startColIdx] = arrow.NewInt([]int64{start}, t.alloc)
-	columnReader.cols[stopColIdx] = arrow.NewInt([]int64{stop}, t.alloc)
-	columnReader.cols[windowedValueColIdx] = t.toArrowBuffer(t.arr.Values[t.idxInArr : t.idxInArr+1])
-	t.appendTags(columnReader)
-	t.idxInArr++
-	if t.idxInArr == t.arr.Len() {
-		t.arr = nil
-	}
+	cr := t.allocateBuffer(stop.Len())
+	cr.cols[startColIdx] = start
+	cr.cols[stopColIdx] = stop
+	cr.cols[windowedValueColIdx] = values
+	t.appendTags(cr)
 	return true
 }
 

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -224,11 +224,23 @@ func (t *floatTable) toArrowBuffer(vs []float64) *array.Float64 {
 func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float64 {
 	return arrow.NewFloat(vs, t.alloc)
 }
+func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float64 {
+	b := arrow.NewFloatBuilder(t.alloc)
+	b.Resize(len(intervals))
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewFloat64Array()
+}
 func (t *integerTable) toArrowBuffer(vs []int64) *array.Int64 {
 	return arrow.NewInt(vs, t.alloc)
 }
 func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int64 {
 	return arrow.NewInt(vs, t.alloc)
+}
+func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
+	b := arrow.NewIntBuilder(t.alloc)
+	b.Resize(len(intervals))
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewInt64Array()
 }
 func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint64 {
 	return arrow.NewUint(vs, t.alloc)
@@ -236,15 +248,33 @@ func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint64 {
 func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint64 {
 	return arrow.NewUint(vs, t.alloc)
 }
+func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint64 {
+	b := arrow.NewUintBuilder(t.alloc)
+	b.Resize(len(intervals))
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewUint64Array()
+}
 func (t *stringTable) toArrowBuffer(vs []string) *array.Binary {
 	return arrow.NewString(vs, t.alloc)
 }
 func (t *stringGroupTable) toArrowBuffer(vs []string) *array.Binary {
 	return arrow.NewString(vs, t.alloc)
 }
+func (t *stringWindowTable) mergeValues(intervals []int64) *array.Binary {
+	b := arrow.NewStringBuilder(t.alloc)
+	b.Resize(len(intervals))
+	t.appendValues(intervals, b.AppendString, b.AppendNull)
+	return b.NewBinaryArray()
+}
 func (t *booleanTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)
 }
 func (t *booleanGroupTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)
+}
+func (t *booleanWindowTable) mergeValues(intervals []int64) *array.Boolean {
+	b := arrow.NewBoolBuilder(t.alloc)
+	b.Resize(len(intervals))
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewBooleanArray()
 }

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -7,13 +7,19 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/generate"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/models"
@@ -25,104 +31,498 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func BenchmarkReadFilter(b *testing.B) {
+type SetupFunc func(org, bucket influxdb.ID) (gen.SeriesGenerator, gen.TimeRange)
+
+type StorageReader struct {
+	Org    influxdb.ID
+	Bucket influxdb.ID
+	Bounds execute.Bounds
+	Close  func()
+	query.StorageReader
+}
+
+func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
+	logger := zaptest.NewLogger(tb)
+	rootDir, err := ioutil.TempDir("", "storage-flux-test")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	close := func() { _ = os.RemoveAll(rootDir) }
+
 	idgen := mock.NewMockIDGenerator()
-	tagsSpec := &gen.TagsSpec{
-		Tags: []*gen.TagValuesSpec{
-			{
-				TagKey: "t0",
-				Values: func() gen.CountableSequence {
-					return gen.NewCounterByteSequence("a-%d", 0, 5)
+	org, bucket := idgen.ID(), idgen.ID()
+	sg, tr := setupFn(org, bucket)
+
+	generator := generate.Generator{}
+	if _, err := generator.Run(context.Background(), rootDir, sg); err != nil {
+		tb.Fatal(err)
+	}
+
+	enginePath := filepath.Join(rootDir, "engine")
+	engine := storage.NewEngine(enginePath, storage.NewConfig())
+	engine.WithLogger(logger)
+
+	if err := engine.Open(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+	reader := storageflux.NewReader(readservice.NewStore(engine))
+	return &StorageReader{
+		Org:    org,
+		Bucket: bucket,
+		Bounds: execute.Bounds{
+			Start: values.ConvertTime(tr.Start),
+			Stop:  values.ConvertTime(tr.End),
+		},
+		Close:         close,
+		StorageReader: reader,
+	}
+}
+
+func (r *StorageReader) ReadWindowAggregate(ctx context.Context, spec query.ReadWindowAggregateSpec, alloc *memory.Allocator) (query.TableIterator, error) {
+	wr := r.StorageReader.(query.WindowAggregateReader)
+	return wr.ReadWindowAggregate(ctx, spec, alloc)
+}
+
+func TestStorageReader_ReadWindowAggregate(t *testing.T) {
+	reader := NewStorageReader(t, func(org, bucket influxdb.ID) (gen.SeriesGenerator, gen.TimeRange) {
+		tagsSpec := &gen.TagsSpec{
+			Tags: []*gen.TagValuesSpec{
+				{
+					TagKey: "t0",
+					Values: func() gen.CountableSequence {
+						return gen.NewCounterByteSequence("a-%s", 0, 3)
+					},
 				},
 			},
-			{
-				TagKey: "t1",
-				Values: func() gen.CountableSequence {
-					return gen.NewCounterByteSequence("b-%d", 0, 1000)
+		}
+		spec := gen.Spec{
+			OrgID:    org,
+			BucketID: bucket,
+			Measurements: []gen.MeasurementSpec{
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f0",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: 10 * time.Second,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatArrayValuesSequence([]float64{1.0, 2.0, 3.0, 4.0}),
+							)
+						},
+					},
 				},
+			},
+		}
+		tr := gen.TimeRange{
+			Start: mustParseTime("2019-11-25T00:00:00Z"),
+			End:   mustParseTime("2019-11-25T00:02:00Z"),
+		}
+		return gen.NewSeriesGeneratorFromSpec(&spec, tr), tr
+	})
+	defer reader.Close()
+
+	mem := &memory.Allocator{}
+	ti, err := reader.ReadWindowAggregate(context.Background(), query.ReadWindowAggregateSpec{
+		ReadFilterSpec: query.ReadFilterSpec{
+			OrganizationID: reader.Org,
+			BucketID:       reader.Bucket,
+			Bounds:         reader.Bounds,
+		},
+		WindowEvery: int64(30 * time.Second),
+		Aggregates: []plan.ProcedureKind{
+			universe.CountKind,
+		},
+	}, mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	windowEvery := values.ConvertDuration(30 * time.Second)
+	makeWindowTable := func(t0 string, start execute.Time, value interface{}) *executetest.Table {
+		valueType := flux.ColumnType(values.New(value).Type())
+		stop := start.Add(windowEvery)
+		return &executetest.Table{
+			KeyCols: []string{"_start", "_stop", "_field", "_measurement", "t0"},
+			ColMeta: []flux.ColMeta{
+				{Label: "_start", Type: flux.TTime},
+				{Label: "_stop", Type: flux.TTime},
+				{Label: "_value", Type: valueType},
+				{Label: "_field", Type: flux.TString},
+				{Label: "_measurement", Type: flux.TString},
+				{Label: "t0", Type: flux.TString},
+			},
+			Data: [][]interface{}{
+				{start, stop, value, "f0", "m0", t0},
+			},
+		}
+	}
+
+	var want []*executetest.Table
+	for _, t0 := range []string{"a-0", "a-1", "a-2"} {
+		for i := 0; i < 4; i++ {
+			offset := windowEvery.Mul(i)
+			start := reader.Bounds.Start.Add(offset)
+			want = append(want, makeWindowTable(t0, start, int64(3)))
+		}
+	}
+	executetest.NormalizeTables(want)
+	sort.Sort(executetest.SortedTables(want))
+
+	var got []*executetest.Table
+	if err := ti.Do(func(table flux.Table) error {
+		t, err := executetest.ConvertTable(table)
+		if err != nil {
+			return err
+		}
+		got = append(got, t)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	executetest.NormalizeTables(got)
+	sort.Sort(executetest.SortedTables(got))
+
+	// compare these two
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected results -want/+got:\n%s", diff)
+	}
+}
+
+func TestStorageReader_ReadWindowAggregate_CreateEmpty(t *testing.T) {
+	reader := NewStorageReader(t, func(org, bucket influxdb.ID) (gen.SeriesGenerator, gen.TimeRange) {
+		tagsSpec := &gen.TagsSpec{
+			Tags: []*gen.TagValuesSpec{
+				{
+					TagKey: "t0",
+					Values: func() gen.CountableSequence {
+						return gen.NewCounterByteSequence("a-%s", 0, 3)
+					},
+				},
+			},
+		}
+		spec := gen.Spec{
+			OrgID:    org,
+			BucketID: bucket,
+			Measurements: []gen.MeasurementSpec{
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f0",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: 15 * time.Second,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatArrayValuesSequence([]float64{1.0, 2.0, 3.0, 4.0}),
+							)
+						},
+					},
+				},
+			},
+		}
+		tr := gen.TimeRange{
+			Start: mustParseTime("2019-11-25T00:00:00Z"),
+			End:   mustParseTime("2019-11-25T00:02:00Z"),
+		}
+		return gen.NewSeriesGeneratorFromSpec(&spec, tr), tr
+	})
+	defer reader.Close()
+
+	mem := &memory.Allocator{}
+	ti, err := reader.ReadWindowAggregate(context.Background(), query.ReadWindowAggregateSpec{
+		ReadFilterSpec: query.ReadFilterSpec{
+			OrganizationID: reader.Org,
+			BucketID:       reader.Bucket,
+			Bounds:         reader.Bounds,
+		},
+		WindowEvery: int64(10 * time.Second),
+		Aggregates: []plan.ProcedureKind{
+			universe.CountKind,
+		},
+		CreateEmpty: true,
+	}, mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	windowEvery := values.ConvertDuration(10 * time.Second)
+	makeWindowTable := func(t0 string, start execute.Time, value interface{}, isNull bool) *executetest.Table {
+		valueType := flux.ColumnType(values.New(value).Type())
+		stop := start.Add(windowEvery)
+		if isNull {
+			value = nil
+		}
+		return &executetest.Table{
+			KeyCols: []string{"_start", "_stop", "_field", "_measurement", "t0"},
+			ColMeta: []flux.ColMeta{
+				{Label: "_start", Type: flux.TTime},
+				{Label: "_stop", Type: flux.TTime},
+				{Label: "_value", Type: valueType},
+				{Label: "_field", Type: flux.TString},
+				{Label: "_measurement", Type: flux.TString},
+				{Label: "t0", Type: flux.TString},
+			},
+			Data: [][]interface{}{
+				{start, stop, value, "f0", "m0", t0},
+			},
+		}
+	}
+
+	var want []*executetest.Table
+	for _, t0 := range []string{"a-0", "a-1", "a-2"} {
+		for i := 0; i < 12; i++ {
+			offset := windowEvery.Mul(i)
+			start := reader.Bounds.Start.Add(offset)
+			isNull := (i+1)%3 == 0
+			want = append(want, makeWindowTable(t0, start, int64(1), isNull))
+		}
+	}
+	executetest.NormalizeTables(want)
+	sort.Sort(executetest.SortedTables(want))
+
+	var got []*executetest.Table
+	if err := ti.Do(func(table flux.Table) error {
+		t, err := executetest.ConvertTable(table)
+		if err != nil {
+			return err
+		}
+		got = append(got, t)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	executetest.NormalizeTables(got)
+	sort.Sort(executetest.SortedTables(got))
+
+	// compare these two
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected results -want/+got:\n%s", diff)
+	}
+}
+
+func TestStorageReader_ReadWindowAggregate_TruncatedBounds(t *testing.T) {
+	reader := NewStorageReader(t, func(org, bucket influxdb.ID) (gen.SeriesGenerator, gen.TimeRange) {
+		tagsSpec := &gen.TagsSpec{
+			Tags: []*gen.TagValuesSpec{
+				{
+					TagKey: "t0",
+					Values: func() gen.CountableSequence {
+						return gen.NewCounterByteSequence("a-%s", 0, 3)
+					},
+				},
+			},
+		}
+		spec := gen.Spec{
+			OrgID:    org,
+			BucketID: bucket,
+			Measurements: []gen.MeasurementSpec{
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f0",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: 5 * time.Second,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatArrayValuesSequence([]float64{1.0, 2.0, 3.0, 4.0}),
+							)
+						},
+					},
+				},
+			},
+		}
+		tr := gen.TimeRange{
+			Start: mustParseTime("2019-11-25T00:00:00Z"),
+			End:   mustParseTime("2019-11-25T00:01:00Z"),
+		}
+		return gen.NewSeriesGeneratorFromSpec(&spec, tr), tr
+	})
+	defer reader.Close()
+
+	mem := &memory.Allocator{}
+	ti, err := reader.ReadWindowAggregate(context.Background(), query.ReadWindowAggregateSpec{
+		ReadFilterSpec: query.ReadFilterSpec{
+			OrganizationID: reader.Org,
+			BucketID:       reader.Bucket,
+			Bounds: execute.Bounds{
+				Start: values.ConvertTime(mustParseTime("2019-11-25T00:00:05Z")),
+				Stop:  values.ConvertTime(mustParseTime("2019-11-25T00:00:25Z")),
 			},
 		},
-	}
-	spec := gen.Spec{
-		OrgID:    idgen.ID(),
-		BucketID: idgen.ID(),
-		Measurements: []gen.MeasurementSpec{
-			{
-				Name:     "m0",
-				TagsSpec: tagsSpec,
-				FieldValuesSpec: &gen.FieldValuesSpec{
-					Name: "f0",
-					TimeSequenceSpec: gen.TimeSequenceSpec{
-						Count: math.MaxInt32,
-						Delta: time.Minute,
-					},
-					DataType: models.Float,
-					Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
-						r := rand.New(rand.NewSource(10))
-						return gen.NewTimeFloatValuesSequence(
-							spec.Count,
-							gen.NewTimestampSequenceFromSpec(spec),
-							gen.NewFloatRandomValuesSequence(0, 90, r),
-						)
-					},
-				},
-			},
-			{
-				Name:     "m0",
-				TagsSpec: tagsSpec,
-				FieldValuesSpec: &gen.FieldValuesSpec{
-					Name: "f1",
-					TimeSequenceSpec: gen.TimeSequenceSpec{
-						Count: math.MaxInt32,
-						Delta: time.Minute,
-					},
-					DataType: models.Float,
-					Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
-						r := rand.New(rand.NewSource(11))
-						return gen.NewTimeFloatValuesSequence(
-							spec.Count,
-							gen.NewTimestampSequenceFromSpec(spec),
-							gen.NewFloatRandomValuesSequence(0, 180, r),
-						)
-					},
-				},
-			},
-			{
-				Name:     "m0",
-				TagsSpec: tagsSpec,
-				FieldValuesSpec: &gen.FieldValuesSpec{
-					Name: "f1",
-					TimeSequenceSpec: gen.TimeSequenceSpec{
-						Count: math.MaxInt32,
-						Delta: time.Minute,
-					},
-					DataType: models.Float,
-					Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
-						r := rand.New(rand.NewSource(12))
-						return gen.NewTimeFloatValuesSequence(
-							spec.Count,
-							gen.NewTimestampSequenceFromSpec(spec),
-							gen.NewFloatRandomValuesSequence(10, 10000, r),
-						)
-					},
-				},
-			},
+		WindowEvery: int64(10 * time.Second),
+		Aggregates: []plan.ProcedureKind{
+			universe.CountKind,
 		},
+	}, mem)
+	if err != nil {
+		t.Fatal(err)
 	}
-	tr := gen.TimeRange{
-		Start: mustParseTime("2019-11-25T00:00:00Z"),
-		End:   mustParseTime("2019-11-26T00:00:00Z"),
+
+	makeWindowTable := func(t0 string, start, stop time.Duration, value interface{}) *executetest.Table {
+		startT := reader.Bounds.Start.Add(values.ConvertDuration(start))
+		stopT := reader.Bounds.Start.Add(values.ConvertDuration(stop))
+		valueType := flux.ColumnType(values.New(value).Type())
+		return &executetest.Table{
+			KeyCols: []string{"_start", "_stop", "_field", "_measurement", "t0"},
+			ColMeta: []flux.ColMeta{
+				{Label: "_start", Type: flux.TTime},
+				{Label: "_stop", Type: flux.TTime},
+				{Label: "_value", Type: valueType},
+				{Label: "_field", Type: flux.TString},
+				{Label: "_measurement", Type: flux.TString},
+				{Label: "t0", Type: flux.TString},
+			},
+			Data: [][]interface{}{
+				{startT, stopT, value, "f0", "m0", t0},
+			},
+		}
 	}
-	sg := gen.NewSeriesGeneratorFromSpec(&spec, tr)
-	benchmarkRead(b, sg, func(r query.StorageReader) error {
+
+	var want []*executetest.Table
+	for _, t0 := range []string{"a-0", "a-1", "a-2"} {
+		want = append(want,
+			makeWindowTable(t0, 5*time.Second, 10*time.Second, int64(1)),
+			makeWindowTable(t0, 10*time.Second, 20*time.Second, int64(2)),
+			makeWindowTable(t0, 20*time.Second, 25*time.Second, int64(1)),
+		)
+	}
+	executetest.NormalizeTables(want)
+	sort.Sort(executetest.SortedTables(want))
+
+	var got []*executetest.Table
+	if err := ti.Do(func(table flux.Table) error {
+		t, err := executetest.ConvertTable(table)
+		if err != nil {
+			return err
+		}
+		got = append(got, t)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	executetest.NormalizeTables(got)
+	sort.Sort(executetest.SortedTables(got))
+
+	// compare these two
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected results -want/+got:\n%s", diff)
+	}
+}
+
+func BenchmarkReadFilter(b *testing.B) {
+	setupFn := func(org, bucket influxdb.ID) (gen.SeriesGenerator, gen.TimeRange) {
+		tagsSpec := &gen.TagsSpec{
+			Tags: []*gen.TagValuesSpec{
+				{
+					TagKey: "t0",
+					Values: func() gen.CountableSequence {
+						return gen.NewCounterByteSequence("a-%s", 0, 5)
+					},
+				},
+				{
+					TagKey: "t1",
+					Values: func() gen.CountableSequence {
+						return gen.NewCounterByteSequence("b-%s", 0, 1000)
+					},
+				},
+			},
+		}
+		spec := gen.Spec{
+			OrgID:    org,
+			BucketID: bucket,
+			Measurements: []gen.MeasurementSpec{
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f0",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: time.Minute,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							r := rand.New(rand.NewSource(10))
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatRandomValuesSequence(0, 90, r),
+							)
+						},
+					},
+				},
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f1",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: time.Minute,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							r := rand.New(rand.NewSource(11))
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatRandomValuesSequence(0, 180, r),
+							)
+						},
+					},
+				},
+				{
+					Name:     "m0",
+					TagsSpec: tagsSpec,
+					FieldValuesSpec: &gen.FieldValuesSpec{
+						Name: "f1",
+						TimeSequenceSpec: gen.TimeSequenceSpec{
+							Count: math.MaxInt32,
+							Delta: time.Minute,
+						},
+						DataType: models.Float,
+						Values: func(spec gen.TimeSequenceSpec) gen.TimeValuesSequence {
+							r := rand.New(rand.NewSource(12))
+							return gen.NewTimeFloatValuesSequence(
+								spec.Count,
+								gen.NewTimestampSequenceFromSpec(spec),
+								gen.NewFloatRandomValuesSequence(10, 10000, r),
+							)
+						},
+					},
+				},
+			},
+		}
+		tr := gen.TimeRange{
+			Start: mustParseTime("2019-11-25T00:00:00Z"),
+			End:   mustParseTime("2019-11-26T00:00:00Z"),
+		}
+		return gen.NewSeriesGeneratorFromSpec(&spec, tr), tr
+	}
+	benchmarkRead(b, setupFn, func(r *StorageReader) error {
 		mem := &memory.Allocator{}
 		tables, err := r.ReadFilter(context.Background(), query.ReadFilterSpec{
-			OrganizationID: spec.OrgID,
-			BucketID:       spec.BucketID,
-			Bounds: execute.Bounds{
-				Start: values.ConvertTime(tr.Start),
-				Stop:  values.ConvertTime(tr.End),
-			},
+			OrganizationID: r.Org,
+			BucketID:       r.Bucket,
+			Bounds:         r.Bounds,
 		}, mem)
 		if err != nil {
 			return err
@@ -134,27 +534,9 @@ func BenchmarkReadFilter(b *testing.B) {
 	})
 }
 
-func benchmarkRead(b *testing.B, sg gen.SeriesGenerator, f func(r query.StorageReader) error) {
-	logger := zaptest.NewLogger(b)
-	rootDir, err := ioutil.TempDir("", "storage-reads-test")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(rootDir) }()
-
-	generator := generate.Generator{}
-	if _, err := generator.Run(context.Background(), rootDir, sg); err != nil {
-		b.Fatal(err)
-	}
-
-	enginePath := filepath.Join(rootDir, "engine")
-	engine := storage.NewEngine(enginePath, storage.NewConfig())
-	engine.WithLogger(logger)
-
-	if err := engine.Open(context.Background()); err != nil {
-		b.Fatal(err)
-	}
-	reader := storageflux.NewReader(readservice.NewStore(engine))
+func benchmarkRead(b *testing.B, setupFn SetupFunc, f func(r *StorageReader) error) {
+	reader := NewStorageReader(b, setupFn)
+	defer reader.Close()
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -1,0 +1,183 @@
+package storageflux
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2"
+)
+
+// splitWindows will split a windowTable by creating a new table from each
+// row and modifying the group key to use the start and stop values from
+// that row.
+func splitWindows(ctx context.Context, in flux.Table, f func(t flux.Table) error) error {
+	wts := &windowTableSplitter{
+		ctx: ctx,
+		in:  in,
+	}
+	return wts.Do(f)
+}
+
+type windowTableSplitter struct {
+	ctx context.Context
+	in  flux.Table
+}
+
+func (w *windowTableSplitter) Do(f func(flux.Table) error) error {
+	defer w.in.Done()
+
+	startIdx, err := w.getTimeColumnIndex(execute.DefaultStartColLabel)
+	if err != nil {
+		return err
+	}
+
+	stopIdx, err := w.getTimeColumnIndex(execute.DefaultStopColLabel)
+	if err != nil {
+		return err
+	}
+
+	return w.in.Do(func(cr flux.ColReader) error {
+		// Retrieve the start and stop columns for splitting
+		// the windows.
+		start := cr.Times(startIdx)
+		stop := cr.Times(stopIdx)
+
+		// Iterate through each time to produce a table
+		// using the start and stop values.
+		arrs := make([]array.Interface, len(cr.Cols()))
+		for j := range cr.Cols() {
+			arrs[j] = getColumnValues(cr, j)
+		}
+
+		for i, n := 0, cr.Len(); i < n; i++ {
+			startT, stopT := start.Value(i), stop.Value(i)
+
+			// Rewrite the group key using the new time.
+			key := groupKeyForWindow(cr.Key(), startT, stopT)
+
+			// Produce a slice for each column into a new
+			// table buffer.
+			buffer := arrow.TableBuffer{
+				GroupKey: key,
+				Columns:  cr.Cols(),
+				Values:   make([]array.Interface, len(cr.Cols())),
+			}
+			for j, arr := range arrs {
+				buffer.Values[j] = arrow.Slice(arr, int64(i), int64(i+1))
+			}
+
+			// Wrap these into a single table and execute.
+			done := make(chan struct{})
+			table := &windowTableRow{
+				buffer: buffer,
+				done:   done,
+			}
+			if err := f(table); err != nil {
+				return err
+			}
+
+			select {
+			case <-done:
+			case <-w.ctx.Done():
+				return w.ctx.Err()
+			}
+		}
+		return nil
+	})
+}
+
+func (w *windowTableSplitter) getTimeColumnIndex(label string) (int, error) {
+	j := execute.ColIdx(label, w.in.Cols())
+	if j < 0 {
+		return -1, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  fmt.Sprintf("missing %q column from window splitter", label),
+		}
+	} else if c := w.in.Cols()[j]; c.Type != flux.TTime {
+		return -1, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  fmt.Sprintf("%q column must be of type time", label),
+		}
+	}
+	return j, nil
+}
+
+type windowTableRow struct {
+	used   int32
+	buffer arrow.TableBuffer
+	done   chan struct{}
+}
+
+func (w *windowTableRow) Key() flux.GroupKey {
+	return w.buffer.GroupKey
+}
+
+func (w *windowTableRow) Cols() []flux.ColMeta {
+	return w.buffer.Columns
+}
+
+func (w *windowTableRow) Do(f func(flux.ColReader) error) error {
+	if !atomic.CompareAndSwapInt32(&w.used, 0, 1) {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  "table already read",
+		}
+	}
+	defer close(w.done)
+
+	err := f(&w.buffer)
+	w.buffer.Release()
+	return err
+}
+
+func (w *windowTableRow) Done() {
+	if atomic.CompareAndSwapInt32(&w.used, 0, 1) {
+		w.buffer.Release()
+		close(w.done)
+	}
+}
+
+func (w *windowTableRow) Empty() bool {
+	return false
+}
+
+func groupKeyForWindow(key flux.GroupKey, start, stop int64) flux.GroupKey {
+	cols := key.Cols()
+	vs := make([]values.Value, len(cols))
+	for j, c := range cols {
+		if c.Label == execute.DefaultStartColLabel {
+			vs[j] = values.NewTime(values.Time(start))
+		} else if c.Label == execute.DefaultStopColLabel {
+			vs[j] = values.NewTime(values.Time(stop))
+		} else {
+			vs[j] = key.Value(j)
+		}
+	}
+	return execute.NewGroupKey(cols, vs)
+}
+
+// getColumnValues returns the array from the column reader as an array.Interface.
+func getColumnValues(cr flux.ColReader, j int) array.Interface {
+	switch typ := cr.Cols()[j].Type; typ {
+	case flux.TInt:
+		return cr.Ints(j)
+	case flux.TUInt:
+		return cr.UInts(j)
+	case flux.TFloat:
+		return cr.Floats(j)
+	case flux.TString:
+		return cr.Strings(j)
+	case flux.TBool:
+		return cr.Bools(j)
+	case flux.TTime:
+		return cr.Times(j)
+	default:
+		panic(fmt.Errorf("unimplemented column type: %s", typ))
+	}
+}


### PR DESCRIPTION
This implements create empty for the window table reader and allows this
table read function to be used when it is specified. It will pass down
the create empty flag from the original window call into the storage
read function.

This also fixes the window table reader so it properly creates
individual tables for each window. Previously, it was constructing one
table for an entire series instead of one table per window.

Tests have been added to verify three edge case behaviors. The first is
the normal read operation where all values are present. The second is
when create empty is specified so null values may be created. The third
is with truncated boundaries to ensure that storage is read from and the
start and stop timestamps get correctly truncated.