### PR TITLE
Update CODEOWNERS storage team names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ http/swagger.yml @influxdata/monitoring-team
 /pkger/ @influxdata/tools-team
 
 # Storage code
-/storage/ @influxdata/storage-team-assigner
-/tsdb/ @influxdata/storage-team-assigner
+/storage/ @influxdata/storage-team
+/tsdb/ @influxdata/storage-team


### PR DESCRIPTION
This GitHub feature isn't working, so try a different team name.