### PR TITLE
refactor(http): Simplify Authorizer (#17704)

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -111,6 +111,9 @@ func (a openAuthorizer) AuthorizeQuery(_ string, _ *influxql.Query) error { retu
 // function should be preferred over directly checking if an Authorizer is nil
 // or not.
 func AuthorizerIsOpen(a Authorizer) bool {
+	if u, ok := a.(interface{ AuthorizeUnrestricted() bool }); ok {
+		return u.AuthorizeUnrestricted()
+	}
 	return a == nil || a == OpenAuthorizer
 }
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -587,12 +587,8 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 	}
 
 	if h.Config.AuthEnabled {
-		if user != nil && user.AuthorizeUnrestricted() {
-			opts.Authorizer = query.OpenAuthorizer
-		} else {
-			// The current user determines the authorized actions.
-			opts.Authorizer = user
-		}
+		// The current user determines the authorized actions.
+		opts.Authorizer = user
 	} else {
 		// Auth is disabled, so allow everything.
 		opts.Authorizer = query.OpenAuthorizer


### PR DESCRIPTION
Have AuthorizerIsOpen() assert if a given authizer has an
AuthorizeUnrestricted() method and if so, call that to provide the
result of AuthorizerIsOpen().

Otherwise we check if the supplied Authorizer is nil.

This preserves the fast-path for checking tag-level (and other) tsdb
operations.

This simplifies how we handle such authorizers by handling this case in
only one place.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
