### PR TITLE
fix(codeowners): try user handle along with team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ http/swagger.yml @influxdata/monitoring-team
 /pkger/ @influxdata/tools-team
 
 # Storage code
-/storage/ @influxdata/storage-team
-/tsdb/ @influxdata/storage-team
+/storage/ @influxdata/storage-team-assigner @jacobmarble
+/tsdb/ @influxdata/storage-team-assigner @jacobmarble


### PR DESCRIPTION
Storage team isn't being marked as owner in PRs touching /storage/ and
/tsdb/. Let's make sure that a user can be an owner, then iterate.