### PR TITLE
refactor: remove urms from new label service

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -876,7 +876,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 			m.log.Error("Failed creating new labels store", zap.Error(err))
 			return err
 		}
-		ls := label.NewService(labelsStore, m.kvService)
+		ls := label.NewService(labelsStore)
 		labelSvc = label.NewLabelController(flagger, m.kvService, ls)
 	}
 

--- a/label/service_test.go
+++ b/label/service_test.go
@@ -59,9 +59,7 @@ func initLabelService(s kv.Store, f influxdbtesting.LabelFields, t *testing.T) (
 		t.Fatalf("failed to create label store: %v", err)
 	}
 
-	kvSvc := kv.NewService(zaptest.NewLogger(t), s)
-
-	svc := label.NewService(st, kvSvc)
+	svc := label.NewService(st)
 	ctx := context.Background()
 
 	for _, l := range f.Labels {


### PR DESCRIPTION
This PR removes the creation of URMs from the new label service. I looked with @GeorgeMac and we found no place where these URMs are actually use, they are just created when a label is created. Removing their creation should have no side effects.

This code change is only within the new label service, so it will fall under the same feature flag that controls whether the new or old label service is being used ("newLabels").

This PR also removes some debugging fmt.prints that I forgot to remove yesterday. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
