### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/models/inline_strconv_parse.go
+++ b/models/inline_strconv_parse.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strconv"
 	"unsafe"
+	"runtime"
 )
 
 // parseIntBytes is a zero-alloc wrapper around strconv.ParseInt.
@@ -34,11 +35,11 @@ func parseBoolBytes(b []byte) (bool, error) {
 // It is unsafe, and is intended to prepare input to short-lived functions
 // that require strings.
 func unsafeBytesToString(in []byte) string {
+	s := ""
 	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
+	dst := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	dst.Data = src.Data
+	dst.Len = src.Len
+	runtime.KeepAlive(in)
 	return s
 }


### PR DESCRIPTION
I found an incorrect cast from `[]byte` to `string` in `models/inline_strconv_parse.go`. The problem is that when `reflect.StringHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `StringHeader` and casting it into the final, real string, then the underlying data might have been collected already, effectively making the returned string a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.StringHeader` from an actual slice by first instantiating the return value.
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
