### PR TITLE
docs(clientLibs/js): use Point to write data

### DIFF
--- a/ui/src/clientLibraries/constants/index.ts
+++ b/ui/src/clientLibraries/constants/index.ts
@@ -258,11 +258,13 @@ queryApi.queryRows(query, {
     console.log('\\nFinished SUCCESS')
   },
 })`,
-  writingDataLineProtocolCodeSnippet: `const writeApi = client.getWriteApi(org, bucket)
-  
-const data = 'mem,host=host1 used_percent=23.43234543' // Line protocol string
-writeApi.writeRecord(data)
+  writingDataLineProtocolCodeSnippet: `const {Point} = require('@influxdata/influxdb-client')
+const writeApi = client.getWriteApi(org, bucket)
+writeApi.useDefaultTags({host: 'host1'})
 
+const point = new Point('mem')
+  .floatField('used_percent', 23.43234543)
+writeApi.writePoint(point)
 writeApi
     .close()
     .then(() => {


### PR DESCRIPTION
Closes influxdata/influxdb-client-js#190

This PR updates the node/JS example to use Point API.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
