### PR TITLE
feat(flag-redirectTo): using old UI feature flag to flag redirectTo

### DIFF
--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -93,7 +93,7 @@ export class Signin extends PureComponent<Props, State> {
 
       clearInterval(this.intervalID)
 
-      if (CLOUD && isFlagEnabled('redirectto')) {
+      if (CLOUD && isFlagEnabled('redirectToCloud')) {
         const url = new URL(
           `${window.location.origin}${CLOUD_SIGNIN_PATHNAME}?redirectTo=${
             window.location.href

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -64,7 +64,7 @@ class LoginPageContents extends PureComponent<DispatchProps> {
   public async componentDidMount() {
     try {
       let config
-      if (isFlagEnabled('redirectto')) {
+      if (isFlagEnabled('redirectToCloud')) {
         const redirectTo = getFromLocalStorage('redirectTo') || '/'
         config = await getAuth0Config(redirectTo)
       } else {

--- a/ui/src/shared/selectors/flags.ts
+++ b/ui/src/shared/selectors/flags.ts
@@ -11,6 +11,7 @@ export const OSS_FLAGS = {
   fluxParser: false,
   matchingNotificationRules: false,
   notebooks: false,
+  redirectToCloud: false,
   telegrafEditor: false,
 }
 
@@ -24,6 +25,7 @@ export const CLOUD_FLAGS = {
   fluxParser: false,
   matchingNotificationRules: false,
   notebooks: false,
+  redirectToCloud: false,
   telegrafEditor: false,
 }
 


### PR DESCRIPTION
This is a temporary solution to a problem that is being addressed elsewhere. This PR aims to add a UI feature flag that can be toggled from the console, rather than using the existing configCat setup since that currently doesn't support unauthenticated requests.
