### PR TITLE
fix: wrap flux validation

### DIFF
--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -24,6 +24,7 @@ import {
 // Utils
 import {getActiveTimeMachine, getActiveQuery} from 'src/timeMachine/selectors'
 import fromFlux from 'src/shared/utils/fromFlux'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {findNodes} from 'src/shared/utils/ast'
@@ -181,10 +182,12 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
         dispatch(notify(resultTooLarge(result.bytesRead)))
       }
 
-      // TODO: this is just here for validation. since we are already eating
-      // the cost of parsing the results, we should store the output instead
-      // of the raw input
-      fromFlux(result.csv)
+      if (isFlagEnabled('fluxParser')) {
+        // TODO: this is just here for validation. since we are already eating
+        // the cost of parsing the results, we should store the output instead
+        // of the raw input
+        fromFlux(result.csv)
+      }
     }
 
     const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
@@ -249,10 +252,12 @@ export const executeCheckQuery = () => async (dispatch, getState: GetState) => {
       dispatch(notify(resultTooLarge(result.bytesRead)))
     }
 
-    // TODO: this is just here for validation. since we are already eating
-    // the cost of parsing the results, we should store the output instead
-    // of the raw input
-    fromFlux(result.csv)
+    if (isFlagEnabled('fluxParser')) {
+      // TODO: this is just here for validation. since we are already eating
+      // the cost of parsing the results, we should store the output instead
+      // of the raw input
+      fromFlux(result.csv)
+    }
 
     const file = result.csv
 


### PR DESCRIPTION
these didn't get wrapped when reverting an experimental flux parser. Hoping that this'll fix:
influxdata/idpe#7100
and
influxdata/idpe#7365
as the errors referenced in those issues are generated at these lines. could not reproduce the errors locally, so i'm not sure if this'll fix those, but the code doesn't need to be in here all wild and free anyways