### PR TITLE
feat(pkger): add ability to export by stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [18279](https://github.com/influxdata/influxdb/pull/18279): Make all pkg applications stateful via stacks
+1. [18322](https://github.com/influxdata/influxdb/pull/18322): Add ability to export a stack's existing (as they are in the platform) resource state as a pkg
 
 ## v2.0.0-beta.11 [2020-05-26]
 

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -729,6 +729,10 @@ func (f *fakePkgSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID,
 	panic("not implemented")
 }
 
+func (f *fakePkgSVC) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*pkger.Pkg, error) {
+	panic("not implemented")
+}
+
 func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
 	if f.createFn != nil {
 		return f.createFn(ctx, setters...)

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -1689,6 +1689,7 @@ func TestLauncher_Pkger(t *testing.T) {
 						Name:  "test-label-2",
 					}
 					require.NoError(t, l.kvService.CreateLabel(ctx, newLabel))
+					defer resourceCheck.mustDeleteLabel(t, newLabel.ID)
 
 					// TODO(jsteenb2): cannot figure out the issue with the http.LabelService returning
 					//				   the bad HTTP method error :-(. Revisit this and replace with the

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4728,6 +4728,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Pkg"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/Pkg"
         default:
           description: Unexpected error
           content:
@@ -4936,6 +4939,41 @@ paths:
       responses:
         "204":
           description: Stack and all its associated resources are deleted
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /packages/stacks/{stack_id}/export:
+    delete:
+      operationId: ExportStack
+      tags:
+        - InfluxPackages
+      summary: Export a stack's resources in the form of a package
+      parameters:
+        - in: path
+          name: stack_id
+          required: true
+          schema:
+            type: string
+          description: The stack id to be removed
+        - in: query
+          name: orgID
+          required: true
+          schema:
+            type: string
+          description: The organization id of the user
+      responses:
+        "200":
+          description: Stack and all its associated resources are deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pkg"
+            application/x-yaml:
+              schema:
+                $ref: "#/components/schemas/Pkg"
         default:
           description: Unexpected error
           content:

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -146,17 +146,7 @@ func (ex *resourceExporter) Objects() []Object {
 		objects = append(objects, obj)
 	}
 
-	sort.Slice(objects, func(i, j int) bool {
-		iName, jName := objects[i].Name(), objects[j].Name()
-		iKind, jKind := objects[i].Kind, objects[j].Kind
-
-		if iKind.is(jKind) {
-			return iName < jName
-		}
-		return kindPriorities[iKind] < kindPriorities[jKind]
-	})
-
-	return objects
+	return sortObjects(objects)
 }
 
 func (ex *resourceExporter) uniqByNameResID() influxdb.ID {

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -857,6 +857,10 @@ func (f *fakeSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 	panic("not implemented yet")
 }
 
+func (f *fakeSVC) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*pkger.Pkg, error) {
+	panic("not implemented")
+}
+
 func (f *fakeSVC) ListStacks(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error) {
 	if f.listStacksFn == nil {
 		panic("not implemented")

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -61,6 +62,7 @@ const ResourceTypeStack influxdb.ResourceType = "stack"
 type SVC interface {
 	InitStack(ctx context.Context, userID influxdb.ID, stack Stack) (Stack, error)
 	DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error
+	ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error)
 	ListStacks(ctx context.Context, orgID influxdb.ID, filter ListFilter) ([]Stack, error)
 
 	CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error)
@@ -331,6 +333,184 @@ func (s *Service) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 	}
 
 	return s.store.DeleteStack(ctx, identifiers.StackID)
+}
+
+func (s *Service) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
+	stack, err := s.store.ReadStackByID(ctx, stackID)
+	if err != nil {
+		return nil, err
+	}
+
+	labelObjs, availablePkgLabels, err := s.exportStackLabels(ctx, stack.Resources)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := Pkg{Objects: labelObjs}
+	for _, res := range stack.Resources {
+		var (
+			obj Object
+			err error
+		)
+
+		switch res.Kind {
+		case KindBucket:
+			bkt, err := s.bucketSVC.FindBucketByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find bucket[%s]", res.ID.String()))
+			}
+			obj = BucketToObject("", *bkt)
+		case KindCheck, KindCheckDeadman, KindCheckThreshold:
+			ch, err := s.checkSVC.FindCheckByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find check[%s]", res.ID.String()))
+			}
+			obj = CheckToObject("", ch)
+		case KindDashboard:
+			dash, err := s.dashSVC.FindDashboardByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find dashboard[%s]", res.ID.String()))
+			}
+			obj = DashboardToObject("", *dash)
+		case KindLabel:
+			// these labels have already been discovered. All valid associations with the
+			// labels to be exported will be added, those that are not, will not be added.
+			continue
+		case KindNotificationEndpoint,
+			KindNotificationEndpointHTTP,
+			KindNotificationEndpointPagerDuty,
+			KindNotificationEndpointSlack:
+			e, err := s.endpointSVC.FindNotificationEndpointByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find endpoint[%s]", res.ID.String()))
+			}
+			obj = NotificationEndpointToObject("", e)
+		case KindNotificationRule:
+			e, err := s.ruleSVC.FindNotificationRuleByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find rule[%s]", res.ID.String()))
+			}
+			var endpointName string
+			for _, ass := range res.Associations {
+				if ass.Kind.is(KindNotificationEndpoint) {
+					endpointName = ass.PkgName
+					break
+				}
+			}
+			// rule is invalid if the endpoint is deleted
+			if endpointName == "" {
+				continue
+			}
+			obj = NotificationRuleToObject("", endpointName, e)
+		case KindTask:
+			t, err := s.taskSVC.FindTaskByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find task[%s]", res.ID.String()))
+			}
+			obj = TaskToObject("", *t)
+		case KindTelegraf:
+			t, err := s.teleSVC.FindTelegrafConfigByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find telegraf config[%s]", res.ID.String()))
+			}
+			obj = TelegrafToObject("", *t)
+		case KindVariable:
+			v, err := s.varSVC.FindVariableByID(ctx, res.ID)
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				continue
+			}
+			if err != nil {
+				return nil, ierrors.Wrap(err, fmt.Sprintf("failed to find variable[%s]", res.ID.String()))
+			}
+			obj = VariableToObject("", *v)
+		default:
+			continue
+		}
+
+		labelAssociations, err := s.exportStackResourceLabelAssociations(ctx, res, availablePkgLabels)
+		if err != nil {
+			return nil, err
+		}
+		if len(labelAssociations) > 0 {
+			obj.AddAssociations(labelAssociations...)
+		}
+		obj.SetMetadataName(res.PkgName)
+		pkg.Objects = append(pkg.Objects, obj)
+	}
+
+	pkg.Objects = sortObjects(pkg.Objects)
+	return &pkg, nil
+}
+
+func (s *Service) exportStackLabels(ctx context.Context, resources []StackResource) ([]Object, map[string]string, error) {
+	var objects []Object
+	availablePkgLabels := make(map[string]string) // pkgName => label name
+	for _, res := range resources {
+		if !res.Kind.is(KindLabel) {
+			continue
+		}
+		label, err := s.labelSVC.FindLabelByID(ctx, res.ID)
+		if influxdb.ErrorCode(err) == influxdb.ENotFound {
+			continue
+		}
+		if err != nil {
+			return nil, nil, ierrors.Wrap(err, fmt.Sprintf("failed to find label[%s]", res.ID.String()))
+		}
+		obj := LabelToObject("", *label)
+		obj.SetMetadataName(res.PkgName)
+		objects = append(objects, obj)
+		availablePkgLabels[res.PkgName] = label.Name
+	}
+	return objects, availablePkgLabels, nil
+}
+
+func (s *Service) exportStackResourceLabelAssociations(ctx context.Context, res StackResource, availablePkgLabels map[string]string) ([]ObjectAssociation, error) {
+	labels, err := s.labelSVC.FindResourceLabels(ctx, influxdb.LabelMappingFilter{
+		ResourceID:   res.ID,
+		ResourceType: res.Kind.ResourceType(),
+	})
+	if err != nil {
+		wrapper := fmt.Sprintf("failed to find label mappings for %s[%s]", res.Kind, res.ID)
+		return nil, ierrors.Wrap(err, wrapper)
+	}
+
+	existingLabels := make(map[string]bool)
+	for _, l := range labels {
+		existingLabels[l.Name] = true
+	}
+
+	var associations []ObjectAssociation
+	for _, ass := range res.Associations {
+		// only labels that exist in the PKG AND PLATFORM will be exported as associations.
+		if ass.Kind.is(KindLabel) && existingLabels[availablePkgLabels[ass.PkgName]] {
+			associations = append(associations, ObjectAssociation{
+				Kind:    KindLabel,
+				PkgName: ass.PkgName,
+			})
+		}
+	}
+	return associations, nil
 }
 
 // ListFilter are filter options for filtering stacks from being returned.
@@ -3046,6 +3226,19 @@ func getLabelIDMap(ctx context.Context, labelSVC influxdb.LabelService, labelNam
 		}
 	}
 	return mLabelIDs, nil
+}
+
+func sortObjects(objects []Object) []Object {
+	sort.Slice(objects, func(i, j int) bool {
+		iName, jName := objects[i].Name(), objects[j].Name()
+		iKind, jKind := objects[i].Kind, objects[j].Kind
+
+		if iKind.is(jKind) {
+			return iName < jName
+		}
+		return kindPriorities[iKind] < kindPriorities[jKind]
+	})
+	return objects
 }
 
 type doMutex struct {

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -44,6 +44,14 @@ func (s *authMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Use
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
+func (s *authMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
+	err := s.authAgent.OrgPermissions(ctx, orgID, influxdb.ReadAction)
+	if err != nil {
+		return nil, err
+	}
+	return s.next.ExportStack(ctx, orgID, stackID)
+}
+
 func (s *authMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	err := s.authAgent.OrgPermissions(ctx, orgID, influxdb.ReadAction)
 	if err != nil {

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -61,6 +61,23 @@ func (s *loggingMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, 
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
+func (s *loggingMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (pkg *Pkg, err error) {
+	defer func(start time.Time) {
+		if err == nil {
+			return
+		}
+
+		s.logger.Error(
+			"failed to export stack",
+			zap.Error(err),
+			zap.Stringer("orgID", orgID),
+			zap.Stringer("stackID", stackID),
+			zap.Duration("took", time.Since(start)),
+		)
+	}(time.Now())
+	return s.next.ExportStack(ctx, orgID, stackID)
+}
+
 func (s *loggingMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) (stacks []Stack, err error) {
 	defer func(start time.Time) {
 		if err == nil {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -38,6 +38,12 @@ func (s *mwMetrics) DeleteStack(ctx context.Context, identifiers struct{ OrgID, 
 	return rec(s.next.DeleteStack(ctx, identifiers))
 }
 
+func (s *mwMetrics) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
+	rec := s.rec.Record("export_stack")
+	pkg, err := s.next.ExportStack(ctx, orgID, stackID)
+	return pkg, rec(err)
+}
+
 func (s *mwMetrics) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	rec := s.rec.Record("list_stacks")
 	stacks, err := s.next.ListStacks(ctx, orgID, f)

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -33,6 +33,14 @@ func (s *traceMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
+func (s *traceMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
+	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "ExportStack")
+	span.LogFields(log.String("org_id", orgID.String()))
+	span.LogFields(log.String("stack_id", stackID.String()))
+	defer span.Finish()
+	return s.next.ExportStack(ctx, orgID, stackID)
+}
+
 func (s *traceMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "ListStacks")
 	defer span.Finish()


### PR DESCRIPTION
this ability exports all resources associated with a stack by the same
metadata.name fields as the original application had done it. This can
be used as a means to snapshot the current state of the stack. This can
be used for source control or other means.

closes: #18271

---
**Acceptance Criteria**
- [x] exporting a pkg with a stack id exports the pkg using the existing
- [x] deleted resources, are no exported (there is nothing to export)
- [x] extend CLI with `influx pkg export stack $STACK_ID`

---
- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)