### PR TITLE
fix(swagger): change dprps typo to dbrps

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -375,7 +375,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /dbrps:
     get:
-      operationId: GetDPRPs
+      operationId: GetDBRPs
       tags:
         - DBRPs
       summary: List all database retention policy mappings
@@ -464,7 +464,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  "/dprps/{dbrpID}":
+  "/dbrps/{dbrpID}":
     get:
       operationId: GetDBRPsID
       tags:


### PR DESCRIPTION
This PR fixes typo in swagger, *dprps* should be *dbrps* to match the go implementation. The swagger-generated clients look ugly with such typos, there is DprsAPI and methods dprs*.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
