### PR TITLE
feat(cmd/influx/write): allow to specify the number of workers to write data

### DIFF
--- a/write/batcher.go
+++ b/write/batcher.go
@@ -35,7 +35,7 @@ type Batcher struct {
 	MaxFlushInterval time.Duration         // MaxFlushInterval is the maximum amount of time to wait before flushing
 	MaxLineLength    int                   // MaxLineLength specifies the maximum length of a single line
 	Service          platform.WriteService // Service receives batches flushed from Batcher.
-	// Number of concurrent workers that write to service
+	// WriteWorkers is a number of concurrent workers that write to service
 	WriteWorkers int
 }
 

--- a/write/batcher_test.go
+++ b/write/batcher_test.go
@@ -331,7 +331,7 @@ func TestBatcher_Write(t *testing.T) {
 		name        string
 		fields      fields
 		args        args
-		want        string
+		want        []string
 		wantFlushes int
 		wantErr     bool
 	}{
@@ -345,7 +345,7 @@ func TestBatcher_Write(t *testing.T) {
 				bucket: platform.ID(2),
 				r:      strings.NewReader("m1,t1=v1 f1=1"),
 			},
-			want:        "m1,t1=v1 f1=1",
+			want:        []string{"m1,t1=v1 f1=1"},
 			wantFlushes: 1,
 		},
 		{
@@ -358,7 +358,7 @@ func TestBatcher_Write(t *testing.T) {
 				bucket: platform.ID(2),
 				r:      strings.NewReader("m1,t1=v1 f1=1\nm2,t2=v2 f2=2\nm3,t3=v3 f3=3"),
 			},
-			want:        "m3,t3=v3 f3=3",
+			want:        []string{"m1,t1=v1 f1=1\n", "m2,t2=v2 f2=2\n", "m3,t3=v3 f3=3"},
 			wantFlushes: 3,
 		},
 		{
@@ -377,7 +377,7 @@ func TestBatcher_Write(t *testing.T) {
 			// mocking the write service here to either return an error
 			// or get back all the bytes from the reader.
 			var (
-				got        string
+				got        []string
 				gotFlushes int
 			)
 			svc := &mock.WriteService{
@@ -386,7 +386,7 @@ func TestBatcher_Write(t *testing.T) {
 						return fmt.Errorf("error")
 					}
 					b, err := ioutil.ReadAll(r)
-					got = string(b)
+					got = append(got, string(b))
 					gotFlushes++
 					return err
 				},


### PR DESCRIPTION
Closes #17006

* added *workers* flag to influx write command
```bash
      --workers int          The number of concurrent workers to write data (default 1)
```
* the implementation uses multiple workers to send data to server

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
