### PR TITLE
fix: remove leftover .tmp folders after backup/snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 v1.8.1 [unreleased]
 -------------------
 
+### Bugfixes
+
+- [#18329](https://github.com/influxdata/influxdb/pull/18329): Remove leftover .tmp folders after backup/snapshot
+
 v1.8.0 [2020-04-11]
 -------------------
 


### PR DESCRIPTION
Closes #16289

When creating a backup on an installation with a large database the leftover .tmp folders created during the backup/snapshot will fill up the disk. See #16289 for details.
This PR will cleanup the leftover .tmp folders if there is no concurrent backup/snapshot running.

If there is a better idea on how to cleanup .tmp folders I'm open for other solutions.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
