### PR TITLE
fix(dbrpv2): lookup by org name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [18279](https://github.com/influxdata/influxdb/pull/18279): Make all pkg applications stateful via stacks
 
+### Bug Fixes
+
+1. [18331](https://github.com/influxdata/influxdb/pull/18331): Support organization name in addition to ID in DBRP operations
+
 ## v2.0.0-beta.11 [2020-05-26]
 
 ### Features

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -203,7 +203,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 	backupBackend.BackupService = authorizer.NewBackupService(backupBackend.BackupService)
 	h.Mount(prefixBackup, NewBackupHandler(backupBackend))
 
-	h.Mount(dbrp.PrefixDBRP, dbrp.NewHTTPHandler(b.Logger, b.DBRPService))
+	h.Mount(dbrp.PrefixDBRP, dbrp.NewHTTPHandler(b.Logger, b.DBRPService, b.OrganizationService))
 
 	writeBackend := NewWriteBackend(b.Logger.With(zap.String("handler", "write")), b)
 	h.Mount(prefixWrite, NewWriteHandler(b.Logger, writeBackend,

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -11683,6 +11683,7 @@ components:
     DBRP:
       required:
         - orgID
+        - org
         - bucketID
         - database
         - retention_policy
@@ -11694,6 +11695,9 @@ components:
         orgID:
           type: string
           description: the organization ID that owns this mapping.
+        org:
+          type: string
+          description: the organization that owns this mapping.
         bucketID:
           type: string
           description: the bucket ID used as target for the translation.


### PR DESCRIPTION
This change adds support for the `org` name parameter in addition to `orgID` for organization lookup when interacting with the DBRP HTTP APIs for reading, updating and deleting DBRP mappings. It also enhances the DBRP mapping creation operation to consider `organization` in the request body, if `organization_id` is missing 

The logic is enhanced to fallback to look up the org ID from the org name if the ID is not present. If both are provided, the name will be ignored in favor of the ID.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
