### PR TITLE
chore(influx): disable failing when providing an unexpected error to influx CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [18331](https://github.com/influxdata/influxdb/pull/18331): Support organization name in addition to ID in DBRP operations
+1. [18335](https://github.com/influxdata/influxdb/pull/18335): Disable failing when providing an unexpected error to influx CLI
 
 ## v2.0.0-beta.11 [2020-05-26]
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -74,6 +74,11 @@ func (o genericCLIOpts) newCmd(use string, runE func(*cobra.Command, []string) e
 		Args: cobra.NoArgs,
 		Use:  use,
 		RunE: runE,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			// allows for unknown flags, parser does not crap the bed
+			// when providing a flag that doesn't exist/match.
+			UnknownFlags: true,
+		},
 	}
 
 	canWrapRunE := runE != nil && o.runEWrapFn != nil


### PR DESCRIPTION
closes: #18290

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass