### PR TITLE
fix: Flakey explorer test wrong test id

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -516,7 +516,7 @@ describe('DataExplorer', () => {
     })
 
     it('can filter aggregation functions by name from script editor mode', () => {
-      cy.get('.cf-input-field').type('covariance')
+      cy.getByTestID('input-field').type('covariance')
       cy.get('.flux-toolbar--list-item').should('have.length', 1)
     })
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -516,7 +516,9 @@ describe('DataExplorer', () => {
     })
 
     it('can filter aggregation functions by name from script editor mode', () => {
-      cy.getByTestID('input-field').type('covariance').should('have.length', 10)
+      cy.getByTestID('input-field')
+        .type('covariance')
+        .should('have.length', 10)
       cy.get('.flux-toolbar--list-item').should('have.length', 1)
     })
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -518,7 +518,7 @@ describe('DataExplorer', () => {
     it('can filter aggregation functions by name from script editor mode', () => {
       cy.getByTestID('input-field')
         .type('covariance')
-        .should('have.length', 10)
+        .should('have.value', 'covariance')
       cy.get('.flux-toolbar--list-item').should('have.length', 1)
     })
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -516,7 +516,7 @@ describe('DataExplorer', () => {
     })
 
     it('can filter aggregation functions by name from script editor mode', () => {
-      cy.getByTestID('input-field').type('covariance')
+      cy.getByTestID('input-field').type('covariance').should('have.length', 10)
       cy.get('.flux-toolbar--list-item').should('have.length', 1)
     })
 


### PR DESCRIPTION
specifcally the 'can filter aggregation functions by name from script editor mode'

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
