### PR TITLE
feat(notebooks): display raw data within query pipes

### DIFF
--- a/ui/src/notebooks/components/Pipe.tsx
+++ b/ui/src/notebooks/components/Pipe.tsx
@@ -12,7 +12,7 @@ const Pipe: FC<PipeProp> = props => {
 
   return useMemo(
     () => createElement(PIPE_DEFINITIONS[data.type].component, props),
-    [props.data]
+    [props.data, props.results]
   )
 }
 

--- a/ui/src/notebooks/components/PipeList.tsx
+++ b/ui/src/notebooks/components/PipeList.tsx
@@ -11,7 +11,7 @@ import EmptyPipeList from 'src/notebooks/components/EmptyPipeList'
 import {DapperScrollbars} from '@influxdata/clockface'
 
 const PipeList: FC = () => {
-  const {id, pipes, updatePipe} = useContext(NotebookContext)
+  const {id, pipes, updatePipe, results} = useContext(NotebookContext)
   const {scrollPosition} = useContext(ScrollContext)
   const update = useCallback(updatePipe, [id])
 
@@ -26,6 +26,7 @@ const PipeList: FC = () => {
         index={index}
         data={pipes[index]}
         onUpdate={update}
+        results={results[index]}
       />
     )
   })

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useState, useCallback, RefObject} from 'react'
 import {RemoteDataState} from 'src/types'
 import {PipeData} from 'src/notebooks'
-import {FromFluxResult} from '@influxdata/giraffe'
+import {BothResults} from 'src/notebooks/context/query'
 
 export interface PipeMeta {
   title: string
@@ -16,11 +16,11 @@ export interface NotebookContextType {
   id: string
   pipes: PipeData[]
   meta: PipeMeta[] // data only used for the view layer for Notebooks
-  results: FromFluxResult[]
+  results: BothResults[]
   addPipe: (pipe: PipeData) => void
   updatePipe: (idx: number, pipe: PipeData) => void
   updateMeta: (idx: number, pipe: PipeMeta) => void
-  updateResult: (idx: number, result: FromFluxResult) => void
+  updateResult: (idx: number, result: BothResults) => void
   movePipe: (currentIdx: number, newIdx: number) => void
   removePipe: (idx: number) => void
 }
@@ -115,11 +115,11 @@ export const NotebookProvider: FC = ({children}) => {
   )
 
   const updateResult = useCallback(
-    (idx: number, results: FromFluxResult) => {
+    (idx: number, results: BothResults) => {
       _setResults(pipes => {
         pipes[idx] = {
           ...results,
-        } as FromFluxResult
+        } as BothResults
         return pipes.slice()
       })
     },

--- a/ui/src/notebooks/context/query.tsx
+++ b/ui/src/notebooks/context/query.tsx
@@ -11,12 +11,17 @@ import {NotebookContext} from 'src/notebooks/context/notebook'
 import {TimeContext} from 'src/notebooks/context/time'
 import {fromFlux as parse, FromFluxResult} from '@influxdata/giraffe'
 
+export interface BothResults {
+  parsed: FromFluxResult
+  raw: string
+}
+
 export interface QueryContextType {
-  query: (text: string) => Promise<FromFluxResult>
+  query: (text: string) => Promise<BothResults>
 }
 
 export const DEFAULT_CONTEXT: QueryContextType = {
-  query: () => Promise.resolve({} as FromFluxResult),
+  query: () => Promise.resolve({} as BothResults),
 }
 
 export const QueryContext = React.createContext<QueryContextType>(
@@ -48,7 +53,10 @@ export const QueryProvider: FC<Props> = ({children, variables, org}) => {
         return raw
       })
       .then(raw => {
-        return parse(raw.csv)
+        return {
+          raw: raw.csv,
+          parsed: parse(raw.csv),
+        }
       })
   }
 

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -1,5 +1,5 @@
 import {FunctionComponent, ComponentClass, ReactNode} from 'react'
-import {FromFluxResult} from '@influxdata/giraffe'
+import {BothResults} from 'src/notebooks/context/query'
 
 export interface PipeContextProps {
   children?: ReactNode
@@ -11,7 +11,7 @@ export type PipeData = any
 export interface PipeProp {
   data: PipeData
   onUpdate: (data: PipeData) => void
-  results?: FromFluxResult
+  results?: BothResults
 
   Context:
     | FunctionComponent<PipeContextProps>

--- a/ui/src/notebooks/pipes/Query/Results.tsx
+++ b/ui/src/notebooks/pipes/Query/Results.tsx
@@ -1,0 +1,63 @@
+// Libraries
+import React, {FC} from 'react'
+import {BothResults} from 'src/notebooks/context/query'
+import {AutoSizer} from 'react-virtualized'
+import classnames from 'classnames'
+
+// Components
+import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
+import ResultsHeader from 'src/notebooks/pipes/Query/ResultsHeader'
+
+// Types
+import {RawDataSize} from 'src/notebooks/pipes/Query'
+
+interface Props {
+  results: BothResults
+  size: RawDataSize
+  onUpdateSize: (size: RawDataSize) => void
+}
+
+const Results: FC<Props> = ({results, size, onUpdateSize}) => {
+  const resultsExist = !!results.raw
+  const className = classnames('notebook-raw-data', {
+    [`notebook-raw-data__${size}`]: resultsExist && size,
+  })
+
+  let resultsBody = (
+    <div className="notebook-raw-data--empty">
+      Run the Notebook to see results
+    </div>
+  )
+
+  if (resultsExist) {
+    resultsBody = (
+      <div className="notebook-raw-data--body">
+        <AutoSizer>
+          {({width, height}) =>
+            width &&
+            height && (
+              <RawFluxDataTable
+                files={[results.raw]}
+                width={width}
+                height={height}
+              />
+            )
+          }
+        </AutoSizer>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className}>
+      <ResultsHeader
+        resultsExist={resultsExist}
+        size={size}
+        onUpdateSize={onUpdateSize}
+      />
+      {resultsBody}
+    </div>
+  )
+}
+
+export default Results

--- a/ui/src/notebooks/pipes/Query/ResultsHeader.tsx
+++ b/ui/src/notebooks/pipes/Query/ResultsHeader.tsx
@@ -1,0 +1,55 @@
+// Libraries
+import React, {FC} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {Icon, IconFont} from '@influxdata/clockface'
+
+// Types
+import {RawDataSize} from 'src/notebooks/pipes/Query'
+
+interface Props {
+  resultsExist: boolean
+  size: RawDataSize
+  onUpdateSize: (size: RawDataSize) => void
+}
+
+const ResultsHeader: FC<Props> = ({resultsExist, size, onUpdateSize}) => {
+  if (!resultsExist) {
+    return (
+      <div className="notebook-raw-data--header">
+        <Icon glyph={IconFont.DashF} />
+      </div>
+    )
+  }
+
+  const handleClick = (newSize: RawDataSize) => (): void => {
+    onUpdateSize(newSize)
+  }
+
+  const generateClassName = (buttonSize: RawDataSize): string => {
+    return classnames('notebook-raw-data--size-toggle', {
+      [`notebook-raw-data--size-toggle__${buttonSize}`]: buttonSize,
+      'notebook-raw-data--size-toggle__active': buttonSize === size,
+    })
+  }
+
+  return (
+    <div className="notebook-raw-data--header">
+      <div
+        className={generateClassName('small')}
+        onClick={handleClick('small')}
+      />
+      <div
+        className={generateClassName('medium')}
+        onClick={handleClick('medium')}
+      />
+      <div
+        className={generateClassName('large')}
+        onClick={handleClick('large')}
+      />
+    </div>
+  )
+}
+
+export default ResultsHeader

--- a/ui/src/notebooks/pipes/Query/index.ts
+++ b/ui/src/notebooks/pipes/Query/index.ts
@@ -2,11 +2,14 @@ import {register} from 'src/notebooks'
 import View from './view'
 import './style.scss'
 
+export type RawDataSize = 'small' | 'medium' | 'large'
+
 register({
   type: 'query',
   component: View,
   button: 'Custom Script',
   initial: {
+    rawDataSize: 'small',
     activeQuery: 0,
     queries: [
       {

--- a/ui/src/notebooks/pipes/Query/style.scss
+++ b/ui/src/notebooks/pipes/Query/style.scss
@@ -1,8 +1,114 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+$notebook-results-header: 47px;
+$notebook-results-small: 200px;
+$notebook-results-medium: 400px;
+$notebook-results-large: 600px;
+
 .notebook-panel--body .flux-editor--monaco {
   position: relative;
 
   .react-monaco-editor-container {
-      min-height: 100px;
+    min-height: 100px;
   }
 }
 
+.notebook-raw-data {
+  margin-top: $cf-marg-a;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  border: $cf-border solid $g2-kevlar;
+  background-color: $g2-kevlar;
+  border-radius: $cf-radius 0 0 $cf-radius;
+}
+
+.notebook-raw-data__small {
+  height: $notebook-results-small;
+}
+
+.notebook-raw-data__medium {
+  height: $notebook-results-medium;
+}
+
+.notebook-raw-data__large {
+  height: $notebook-results-large;
+}
+
+.notebook-raw-data--header {
+  color: $g8-storm;
+  width: $notebook-results-header;
+  flex: 0 0 $notebook-results-header;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: $cf-marg-b 0;
+}
+
+.notebook-raw-data--body,
+.notebook-raw-data--empty {
+  position: relative;
+  flex: 1 0 0;
+}
+
+.notebook-raw-data--empty {
+  color: $g8-storm;
+  user-select: none;
+  padding: $cf-marg-b 0;
+  font-weight: $cf-font-weight--medium;
+}
+
+.notebook-raw-data__success {
+  height: 200px;
+}
+
+.notebook-raw-data--size-toggle {
+  border-radius: 50%;
+  position: relative;
+  width: 24px;
+  height: 24px;
+  margin-bottom: $cf-marg-a;
+  border: $cf-border solid $g3-castle;
+  background-color: $g1-raven;
+  transition: background-color 0.25s ease;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    border-radius: 50%;
+    transition: width 0.25s ease, height 0.25s ease, background-color 0.25s ease;
+    transform: translate(-50%, -50%);
+    background-color: $g5-pepper;
+  }
+
+  &:hover {
+    cursor: pointer;
+
+    &:after {
+      background-color: $g7-graphite;
+    }
+  }
+}
+
+.notebook-raw-data--size-toggle__active:after,
+.notebook-raw-data--size-toggle__active:hover:after {
+  background-color: $c-pool;
+}
+
+.notebook-raw-data--size-toggle__small:after {
+  width: 8px;
+  height: 8px;
+}
+
+.notebook-raw-data--size-toggle__medium:after {
+  width: 12px;
+  height: 12px;
+}
+
+.notebook-raw-data--size-toggle__large:after {
+  width: 16px;
+  height: 16px;
+}

--- a/ui/src/notebooks/pipes/Query/view.tsx
+++ b/ui/src/notebooks/pipes/Query/view.tsx
@@ -1,8 +1,15 @@
+// Libraries
 import React, {FC, useMemo} from 'react'
-import {PipeProp} from 'src/notebooks'
-import FluxMonacoEditor from 'src/shared/components/FluxMonacoEditor'
+import {get} from 'lodash'
 
-const Query: FC<PipeProp> = ({data, onUpdate, Context}) => {
+// Types
+import {PipeProp} from 'src/notebooks'
+
+// Components
+import FluxMonacoEditor from 'src/shared/components/FluxMonacoEditor'
+import Results from 'src/notebooks/pipes/Query/Results'
+
+const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
   const {queries, activeQuery} = data
   const query = queries[activeQuery]
 

--- a/ui/src/notebooks/pipes/Query/view.tsx
+++ b/ui/src/notebooks/pipes/Query/view.tsx
@@ -29,7 +29,6 @@ const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
   }
 
   const onUpdateSize = (rawDataSize: RawDataSize): void => {
-    console.log('onUpdateSize Query')
     onUpdate({rawDataSize})
   }
 

--- a/ui/src/notebooks/pipes/Query/view.tsx
+++ b/ui/src/notebooks/pipes/Query/view.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useMemo} from 'react'
-import {get} from 'lodash'
 
 // Types
 import {PipeProp} from 'src/notebooks'
@@ -16,7 +15,7 @@ import 'src/notebooks/pipes/Query/style.scss'
 const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
   const {queries, activeQuery} = data
   const query = queries[activeQuery]
-  const size = get(data, 'rawDataSize', 'small')
+  const size = data.rawDataSize || 'small'
 
   function updateText(text) {
     const _queries = queries.slice()

--- a/ui/src/notebooks/pipes/Query/view.tsx
+++ b/ui/src/notebooks/pipes/Query/view.tsx
@@ -4,14 +4,19 @@ import {get} from 'lodash'
 
 // Types
 import {PipeProp} from 'src/notebooks'
+import {RawDataSize} from 'src/notebooks/pipes/Query'
 
 // Components
 import FluxMonacoEditor from 'src/shared/components/FluxMonacoEditor'
 import Results from 'src/notebooks/pipes/Query/Results'
 
+// Styles
+import 'src/notebooks/pipes/Query/style.scss'
+
 const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
   const {queries, activeQuery} = data
   const query = queries[activeQuery]
+  const size = get(data, 'rawDataSize', 'small')
 
   function updateText(text) {
     const _queries = queries.slice()
@@ -23,6 +28,11 @@ const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
     onUpdate({queries: _queries})
   }
 
+  const onUpdateSize = (rawDataSize: RawDataSize): void => {
+    console.log('onUpdateSize Query')
+    onUpdate({rawDataSize})
+  }
+
   return useMemo(
     () => (
       <Context>
@@ -32,9 +42,10 @@ const Query: FC<PipeProp> = ({data, onUpdate, Context, results}) => {
           onSubmitScript={() => {}}
           autogrow
         />
+        <Results results={results} size={size} onUpdateSize={onUpdateSize} />
       </Context>
     ),
-    [query.text]
+    [query.text, results, data.rawDataSize]
   )
 }
 

--- a/ui/src/notebooks/pipes/markdown/style.scss
+++ b/ui/src/notebooks/pipes/markdown/style.scss
@@ -1,7 +1,5 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
-$notebook-panel--bg: mix($g1-raven, $g2-kevlar, 50%);
-
 .notebook-panel--markdown {
   font-size: 14px;
   line-height: 16px;

--- a/ui/src/notebooks/style.scss
+++ b/ui/src/notebooks/style.scss
@@ -133,6 +133,7 @@
 .notebook-panel--body {
   border-radius: 0 0 $cf-radius $cf-radius;
   padding: $cf-marg-b;
+  padding-left: $cf-marg-d;
   padding-top: 0;
   position: relative;
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/7138

- Create new type `BothResults` that contains both raw data and parsed results
  - Using this temporarily until `RawDataTable` is included in Giraffe and accepts parsed results
- Create `Results` components as part of the `Query` pipe type
- Allow results to be rendered in 3 sizes
  - Small `200px`
  - Medium `400px`
  - Large `600px`

![notebook-raw-data-sizes](https://user-images.githubusercontent.com/2433762/83575179-d10c5800-a4e3-11ea-8544-3c434b37a91a.gif)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
