### PR TITLE
feat: perform final aggregation of grouped aggregates on flux side

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -75,6 +75,27 @@
   default: false
   contact: Query Team
 
+- name: Push Down Group Aggregate Sum
+  description: Enable the sum variant of PushDownGroupAggregate planner rule
+  key: pushDownGroupAggregateSum
+  default: false
+  contact: Query Team
+  lifetime: temporary
+
+- name: Push Down Group Aggregate First
+  description: Enable the first variant of PushDownGroupAggregate planner rule
+  key: pushDownGroupAggregateFirst
+  default: false
+  contact: Query Team
+  lifetime: temporary
+
+- name: Push Down Group Aggregate Last
+  description: Enable the last variant of PushDownGroupAggregate planner rule
+  key: pushDownGroupAggregateLast
+  default: false
+  contact: Query Team
+  lifetime: temporary
+
 - name: New Label Package
   description: Enables the refactored labels api
   key: newLabels

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -128,6 +128,48 @@ func PushDownGroupAggregateCount() BoolFlag {
 	return pushDownGroupAggregateCount
 }
 
+var pushDownGroupAggregateSum = MakeBoolFlag(
+	"Push Down Group Aggregate Sum",
+	"pushDownGroupAggregateSum",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownGroupAggregateSum - Enable the sum variant of PushDownGroupAggregate planner rule
+func PushDownGroupAggregateSum() BoolFlag {
+	return pushDownGroupAggregateSum
+}
+
+var pushDownGroupAggregateFirst = MakeBoolFlag(
+	"Push Down Group Aggregate First",
+	"pushDownGroupAggregateFirst",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownGroupAggregateFirst - Enable the first variant of PushDownGroupAggregate planner rule
+func PushDownGroupAggregateFirst() BoolFlag {
+	return pushDownGroupAggregateFirst
+}
+
+var pushDownGroupAggregateLast = MakeBoolFlag(
+	"Push Down Group Aggregate Last",
+	"pushDownGroupAggregateLast",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownGroupAggregateLast - Enable the last variant of PushDownGroupAggregate planner rule
+func PushDownGroupAggregateLast() BoolFlag {
+	return pushDownGroupAggregateLast
+}
+
 var newLabels = MakeBoolFlag(
 	"New Label Package",
 	"newLabels",
@@ -152,6 +194,9 @@ var all = []Flag{
 	newAuth,
 	sessionService,
 	pushDownGroupAggregateCount,
+	pushDownGroupAggregateSum,
+	pushDownGroupAggregateFirst,
+	pushDownGroupAggregateLast,
 	newLabels,
 }
 
@@ -165,5 +210,8 @@ var byKey = map[string]Flag{
 	"newAuth":                      newAuth,
 	"sessionService":               sessionService,
 	"pushDownGroupAggregateCount":  pushDownGroupAggregateCount,
+	"pushDownGroupAggregateSum":    pushDownGroupAggregateSum,
+	"pushDownGroupAggregateFirst":  pushDownGroupAggregateFirst,
+	"pushDownGroupAggregateLast":   pushDownGroupAggregateLast,
 	"newLabels":                    newLabels,
 }

--- a/mock/reader.go
+++ b/mock/reader.go
@@ -40,6 +40,18 @@ func (s *StorageReader) Close() {
 	}
 }
 
+type GroupStoreReader struct {
+	*StorageReader
+	GroupCapabilityFn func(ctx context.Context) query.GroupCapability
+}
+
+func (s *GroupStoreReader) GetGroupCapability(ctx context.Context) query.GroupCapability {
+	if s.GroupCapabilityFn != nil {
+		return s.GroupCapabilityFn(ctx)
+	}
+	return nil
+}
+
 type WindowAggregateStoreReader struct {
 	*StorageReader
 	GetWindowAggregateCapabilityFn func(ctx context.Context) query.WindowAggregateCapability

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -873,7 +873,9 @@ func (PushDownGroupAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (pl
 	case universe.FirstKind:
 		// ReadGroup() -> first => ReadGroup(first) -> min
 		root := plan.CreatePhysicalNode("min", &universe.MinProcedureSpec{
-			SelectorConfig: execute.DefaultSelectorConfig,
+			SelectorConfig: execute.SelectorConfig{
+				Column: execute.DefaultTimeColLabel,
+			},
 		})
 
 		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{
@@ -889,7 +891,9 @@ func (PushDownGroupAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (pl
 	case universe.LastKind:
 		// ReadGroup() -> last => ReadGroup(last) -> max
 		root := plan.CreatePhysicalNode("max", &universe.MaxProcedureSpec{
-			SelectorConfig: execute.DefaultSelectorConfig,
+			SelectorConfig: execute.SelectorConfig{
+				Column: execute.DefaultTimeColLabel,
+			},
 		})
 
 		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -29,10 +29,7 @@ func init() {
 		// added AND feature flags must be enabled.
 		PushDownWindowAggregateRule{},
 		// PushDownBareAggregateRule{},
-
-		// For this rule to take effect the corresponding feature flags must be
-		// enabled.
-		// PushDownGroupAggregateRule{},
+		PushDownGroupAggregateRule{},
 	)
 }
 
@@ -822,37 +819,126 @@ func (rule PushDownGroupAggregateRule) Pattern() plan.Pattern {
 	return plan.OneOf(
 		[]plan.ProcedureKind{
 			universe.CountKind,
+			universe.SumKind,
+			universe.FirstKind,
+			universe.LastKind,
 		},
 		plan.Pat(ReadGroupPhysKind))
 }
 
 func (PushDownGroupAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
-	// Check the aggregate function spec. Require operation on _value.
-	var aggregateMethod string
-	fnNode := pn
-	switch fnNode.Kind() {
-	case universe.CountKind:
-		if !feature.PushDownGroupAggregateCount().Enabled(ctx) {
-			return pn, false, nil
-		}
-
-		countSpec := fnNode.ProcedureSpec().(*universe.CountProcedureSpec)
-		if len(countSpec.Columns) != 1 || countSpec.Columns[0] != execute.DefaultValueColLabel {
-			return pn, false, nil
-		}
-		aggregateMethod = universe.CountKind
-	}
-
-	groupNode := fnNode.Predecessors()[0]
-	groupSpec := groupNode.ProcedureSpec().(*ReadGroupPhysSpec)
-
-	// Group spec must not already have an aggregate method.
-	if len(groupSpec.AggregateMethod) > 0 {
+	group := pn.Predecessors()[0].ProcedureSpec().(*ReadGroupPhysSpec)
+	// Cannot push down multiple aggregates
+	if len(group.AggregateMethod) > 0 {
 		return pn, false, nil
 	}
 
-	// Rule passes.
-	rewrite := *groupSpec.Copy().(*ReadGroupPhysSpec)
-	rewrite.AggregateMethod = aggregateMethod
-	return plan.CreatePhysicalNode("ReadGroup", &rewrite), true, nil
+	if !canPushGroupedAggregate(ctx, pn) {
+		return pn, false, nil
+	}
+
+	switch pn.Kind() {
+	case universe.CountKind:
+		// ReadGroup() -> count => ReadGroup(count) -> sum
+		root := plan.CreatePhysicalNode("sum", &universe.SumProcedureSpec{
+			AggregateConfig: execute.DefaultAggregateConfig,
+		})
+
+		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{
+			ReadRangePhysSpec: group.ReadRangePhysSpec,
+			GroupMode:         group.GroupMode,
+			GroupKeys:         group.GroupKeys,
+			AggregateMethod:   universe.CountKind,
+		})
+
+		root.AddPredecessors(leaf)
+		leaf.AddSuccessors(root)
+		return root, true, nil
+	case universe.SumKind:
+		// ReadGroup() -> sum => ReadGroup(sum) -> sum
+		root := plan.CreatePhysicalNode("sum", &universe.SumProcedureSpec{
+			AggregateConfig: execute.DefaultAggregateConfig,
+		})
+
+		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{
+			ReadRangePhysSpec: group.ReadRangePhysSpec,
+			GroupMode:         group.GroupMode,
+			GroupKeys:         group.GroupKeys,
+			AggregateMethod:   universe.SumKind,
+		})
+
+		root.AddPredecessors(leaf)
+		leaf.AddSuccessors(root)
+		return root, true, nil
+	case universe.FirstKind:
+		// ReadGroup() -> first => ReadGroup(first) -> min
+		root := plan.CreatePhysicalNode("min", &universe.MinProcedureSpec{
+			SelectorConfig: execute.DefaultSelectorConfig,
+		})
+
+		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{
+			ReadRangePhysSpec: group.ReadRangePhysSpec,
+			GroupMode:         group.GroupMode,
+			GroupKeys:         group.GroupKeys,
+			AggregateMethod:   universe.FirstKind,
+		})
+
+		root.AddPredecessors(leaf)
+		leaf.AddSuccessors(root)
+		return root, true, nil
+	case universe.LastKind:
+		// ReadGroup() -> last => ReadGroup(last) -> max
+		root := plan.CreatePhysicalNode("max", &universe.MaxProcedureSpec{
+			SelectorConfig: execute.DefaultSelectorConfig,
+		})
+
+		leaf := plan.CreatePhysicalNode("ReadGroupAggregate", &ReadGroupPhysSpec{
+			ReadRangePhysSpec: group.ReadRangePhysSpec,
+			GroupMode:         group.GroupMode,
+			GroupKeys:         group.GroupKeys,
+			AggregateMethod:   universe.LastKind,
+		})
+
+		root.AddPredecessors(leaf)
+		leaf.AddSuccessors(root)
+		return root, true, nil
+	}
+	return pn, false, nil
+}
+
+func canPushGroupedAggregate(ctx context.Context, pn plan.Node) bool {
+	reader := GetStorageDependencies(ctx).FromDeps.Reader
+	aggregator, ok := reader.(query.GroupAggregator)
+	if !ok {
+		return false
+	}
+	caps := aggregator.GetGroupCapability(ctx)
+	if caps == nil {
+		return false
+	}
+	switch pn.Kind() {
+	case universe.CountKind:
+		agg := pn.ProcedureSpec().(*universe.CountProcedureSpec)
+		return caps.HaveCount() &&
+			feature.PushDownGroupAggregateCount().Enabled(ctx) &&
+			len(agg.Columns) == 1 &&
+			agg.Columns[0] == execute.DefaultValueColLabel
+	case universe.SumKind:
+		agg := pn.ProcedureSpec().(*universe.SumProcedureSpec)
+		return caps.HaveSum() &&
+			feature.PushDownGroupAggregateSum().Enabled(ctx) &&
+			len(agg.Columns) == 1 &&
+			agg.Columns[0] == execute.DefaultValueColLabel
+	case universe.FirstKind:
+		agg := pn.ProcedureSpec().(*universe.FirstProcedureSpec)
+		return caps.HaveFirst() &&
+			feature.PushDownGroupAggregateFirst().Enabled(ctx) &&
+			agg.Column == execute.DefaultValueColLabel
+	case universe.LastKind:
+		agg := pn.ProcedureSpec().(*universe.LastProcedureSpec)
+		return caps.HaveLast() &&
+			feature.PushDownGroupAggregateLast().Enabled(ctx) &&
+			agg.Column == execute.DefaultValueColLabel
+	}
+	return false
 }

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1757,12 +1757,16 @@ func TestPushDownGroupAggregateRule(t *testing.T) {
 
 	minProcedureSpec := func() *universe.MinProcedureSpec {
 		return &universe.MinProcedureSpec{
-			SelectorConfig: execute.DefaultSelectorConfig,
+			SelectorConfig: execute.SelectorConfig{
+				Column: execute.DefaultTimeColLabel,
+			},
 		}
 	}
 	maxProcedureSpec := func() *universe.MaxProcedureSpec {
 		return &universe.MaxProcedureSpec{
-			SelectorConfig: execute.DefaultSelectorConfig,
+			SelectorConfig: execute.SelectorConfig{
+				Column: execute.DefaultTimeColLabel,
+			},
 		}
 	}
 	countProcedureSpec := func() *universe.CountProcedureSpec {

--- a/query/stdlib/influxdata/influxdb/source.go
+++ b/query/stdlib/influxdata/influxdb/source.go
@@ -211,7 +211,7 @@ func ReadGroupSource(id execute.DatasetID, r query.StorageReader, readSpec query
 
 	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
 	src.orgID = readSpec.OrganizationID
-	src.op = "readGroup"
+	src.op = readSpec.Name()
 
 	src.runner = src
 	return src

--- a/query/storage.go
+++ b/query/storage.go
@@ -71,6 +71,10 @@ type ReadGroupSpec struct {
 	AggregateMethod string
 }
 
+func (spec *ReadGroupSpec) Name() string {
+	return fmt.Sprintf("readGroup(%s)", spec.AggregateMethod)
+}
+
 type ReadTagKeysSpec struct {
 	ReadFilterSpec
 }

--- a/query/storage.go
+++ b/query/storage.go
@@ -24,6 +24,17 @@ type StorageReader interface {
 	Close()
 }
 
+type GroupCapability interface {
+	HaveCount() bool
+	HaveSum() bool
+	HaveFirst() bool
+	HaveLast() bool
+}
+
+type GroupAggregator interface {
+	GetGroupCapability(ctx context.Context) GroupCapability
+}
+
 // WindowAggregateCapability describes what is supported by WindowAggregateReader.
 type WindowAggregateCapability interface {
 	HaveMin() bool

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -70,6 +70,13 @@ func (r *storeReader) ReadFilter(ctx context.Context, spec query.ReadFilterSpec,
 	}, nil
 }
 
+func (r *storeReader) GetGroupCapability(ctx context.Context) query.GroupCapability {
+	if aggStore, ok := r.s.(storage.GroupStore); ok {
+		return aggStore.GetGroupCapability(ctx)
+	}
+	return nil
+}
+
 func (r *storeReader) ReadGroup(ctx context.Context, spec query.ReadGroupSpec, alloc *memory.Allocator) (query.TableIterator, error) {
 	return &groupIterator{
 		ctx:   ctx,

--- a/storage/reads/store.go
+++ b/storage/reads/store.go
@@ -84,6 +84,14 @@ type Store interface {
 	GetSource(orgID, bucketID uint64) proto.Message
 }
 
+type GroupCapability interface {
+	query.GroupCapability
+}
+
+type GroupStore interface {
+	GetGroupCapability(ctx context.Context) GroupCapability
+}
+
 // WindowAggregateCapability describes what is supported by WindowAggregateStore.
 type WindowAggregateCapability interface {
 	query.WindowAggregateCapability


### PR DESCRIPTION
When pushing down a group followed by an aggregate, storage will aggregate per series (not per group). Therefore a final aggregation is needed on the query side. This PR modifies the planner's rewrite rules for grouped aggregates accordingly.

Note, this PR adds rewrite rules for `group() |> first()` and `group() |> last()`. Because storage does not yet support these operations, I've updated it to expose its current capabilities.