### PR TITLE
fix(storage/reads): fix off-by-one error in WindowCountArrayCursor

### DIFF
--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -247,12 +247,13 @@ func (c *integerFloatWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -263,6 +264,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++
@@ -521,12 +525,13 @@ func (c *integerIntegerWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -537,6 +542,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++
@@ -795,12 +803,13 @@ func (c *integerUnsignedWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -811,6 +820,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++
@@ -1029,12 +1041,13 @@ func (c *integerStringWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -1045,6 +1058,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++
@@ -1263,12 +1279,13 @@ func (c *integerBooleanWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -1279,6 +1296,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -254,12 +254,13 @@ func (c *integer{{.Name}}WindowCountArrayCursor) Next() *cursors.IntegerArray {
 	rowIdx := 0
 	var acc int64 = 0
 
+	firstTimestamp := a.Timestamps[rowIdx]
+	windowStart := firstTimestamp - firstTimestamp%c.every
+	windowEnd := windowStart + c.every
+
 	// enumerate windows
 WINDOWS:
 	for {
-		firstTimestamp := a.Timestamps[rowIdx]
-		windowStart := firstTimestamp - firstTimestamp%c.every
-		windowEnd := windowStart + c.every
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
 			if ts >= windowEnd {
@@ -270,6 +271,9 @@ WINDOWS:
 				}
 				// start the new window
 				acc = 0
+				firstTimestamp = a.Timestamps[rowIdx]
+				windowStart = firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
 				continue WINDOWS
 			} else {
 				acc++

--- a/storage/reads/array_cursor_test.go
+++ b/storage/reads/array_cursor_test.go
@@ -1,8 +1,11 @@
 package reads
 
 import (
+	"math"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
 )
 
@@ -36,6 +39,193 @@ func TestIntegerFilterArrayCursor(t *testing.T) {
 		t.Fatalf("len(Next())=%d, want %d", got, want)
 	} else if got, want := len(c.Next().Timestamps), 350; got != want {
 		t.Fatalf("len(Next())=%d, want %d", got, want)
+	}
+}
+
+func makeIntegerArray(n int64, tsStart time.Time, tsStep time.Duration, vStart, vStep int64) *cursors.IntegerArray {
+	ia := &cursors.IntegerArray{
+		Timestamps: make([]int64, n),
+		Values:     make([]int64, n),
+	}
+
+	for i := int64(0); i < n; i++ {
+		ia.Timestamps[i] = tsStart.UnixNano() + i*int64(tsStep)
+		ia.Values[i] = vStart + i*vStep
+	}
+
+	return ia
+}
+
+func mustParseTime(ts string) time.Time {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestIntegerIntegerCountArrayCursor(t *testing.T) {
+	maxTimestamp := time.Unix(0, math.MaxInt64)
+
+	testcases := []struct {
+		name        string
+		every       time.Duration
+		inputArrays []*cursors.IntegerArray
+		want        []*cursors.IntegerArray
+	}{
+		{
+			name:  "window",
+			every: 15 * time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(4, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, 15, 0),
+			},
+		},
+		{
+			name:  "window two input arrays",
+			every: 15 * time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
+					200, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(8, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, 15, 0),
+			},
+		},
+		{
+			name:  "window spans input arrays",
+			every: 40 * time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
+					200, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(3, mustParseTime("2010-01-01T00:40:00Z"), 40*time.Minute, 40, 0),
+			},
+		},
+		{
+			name:  "window max int every",
+			every: time.Duration(math.MaxInt64),
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 60, 0),
+			},
+		},
+		{
+			name:  "window max int every two arrays",
+			every: time.Duration(math.MaxInt64),
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
+					100, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+			},
+		},
+		{
+			name:  "window max int span epoch",
+			every: time.Duration(math.MaxInt64),
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					120,
+					mustParseTime("1969-12-31T23:00:00Z"), time.Minute,
+					100, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+			},
+		},
+		{
+			name:  "window max int span epoch two arrays",
+			every: time.Duration(math.MaxInt64),
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("1969-12-31T23:00:00Z"), time.Minute,
+					100, 1,
+				),
+				makeIntegerArray(
+					60,
+					mustParseTime("1970-01-01T00:00:00Z"), time.Minute,
+					100, 1,
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resultN int
+			mc := &MockIntegerArrayCursor{
+				CloseFunc: func() {},
+				ErrFunc:   func() error { return nil },
+				StatsFunc: func() cursors.CursorStats { return cursors.CursorStats{} },
+				NextFunc: func() *cursors.IntegerArray {
+					if resultN < len(tc.inputArrays) {
+						a := tc.inputArrays[resultN]
+						resultN++
+						return a
+					}
+					return &cursors.IntegerArray{}
+				},
+			}
+			var countArrayCursor cursors.IntegerArrayCursor
+			if tc.every != 0 {
+				countArrayCursor = &integerIntegerWindowCountArrayCursor{
+					IntegerArrayCursor: mc,
+					every:              int64(tc.every),
+				}
+			} else {
+				countArrayCursor = newCountArrayCursor(mc).(cursors.IntegerArrayCursor)
+			}
+			got := make([]*cursors.IntegerArray, 0, len(tc.want))
+			for a := countArrayCursor.Next(); a.Len() != 0; a = countArrayCursor.Next() {
+				got = append(got, a)
+			}
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("did not get expected result from count array cursor; -got/+want:\n%v", diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I found a bug in `WindowCountArrayCursor` while working on https://github.com/influxdata/flux/issues/2855 where if a window boundary happens to land on an array boundary, we get a wrong answer.

The wrong answer was that we would inadvertently skip creation of a new window, so we would end up with one window of double the `every` duration where there should have been two windows. The test case `window two input arrays` below covers this case.

This could cause us to get incorrect answers when pushing down window+count or a bare count in Flux, so I opted to merge this fix ahead of the refactoring for influxdata/flux#2855.
