### PR TITLE
feat(influx): extend CLI with versoin and user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [18279](https://github.com/influxdata/influxdb/pull/18279): Make all pkg applications stateful via stacks
 1. [18322](https://github.com/influxdata/influxdb/pull/18322): Add ability to export a stack's existing (as they are in the platform) resource state as a pkg
 1. [18334](https://github.com/influxdata/influxdb/pull/18334): Update influx pkg commands with improved usage and examples in long form.
+1. [18344](https://github.com/influxdata/influxdb/pull/18344): Extend influx CLI with version and User-Agent.
 
 ### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ $(CMDS): $(SOURCES)
 # Ease of use build for just the go binary
 influxd: bin/$(GOOS)/influxd
 
+influx: bin/$(GOOS)/influx
+
 #
 # Define targets for the web ui
 #

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/bolt"
@@ -26,6 +27,12 @@ import (
 )
 
 const maxTCPConnections = 10
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = time.Now().UTC().Format(time.RFC3339)
+)
 
 func main() {
 	influxCmd := influxCmd()
@@ -218,8 +225,21 @@ func (b *cmdInfluxBuilder) cmd(childCmdFns ...func(f *globalFlags, opt genericCL
 
 	// completion command goes last, after the walk, so that all
 	// commands have every flag listed in the bash|zsh completions.
-	cmd.AddCommand(completionCmd(cmd))
+	cmd.AddCommand(
+		completionCmd(cmd),
+		cmdVersion(),
+	)
 	return cmd
+}
+
+func cmdVersion() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the influx CLI version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Influx CLI %s (git: %s) build_date: %s\n", version, commit, date)
+		},
+	}
 }
 
 func influxCmd(opts ...genericCLIOptFn) *cobra.Command {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -51,7 +52,17 @@ func newHTTPClient() (*httpc.Client, error) {
 		return httpClient, nil
 	}
 
-	c, err := http.NewHTTPClient(flags.Host, flags.Token, flags.skipVerify)
+	userAgent := fmt.Sprintf(
+		"influx/%s (%s) Sha/%s Date/%s",
+		version, runtime.GOOS, commit, date,
+	)
+
+	c, err := http.NewHTTPClient(
+		flags.Host,
+		flags.Token,
+		flags.skipVerify,
+		httpc.WithUserAgentHeader(userAgent),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes: #18336 
Closes: #14821

---
Acceptance Criteria

- [x] all http calls from influx CLI have a `User-Agent` header
- [x] `User-Agent` header should look like `User-Agent: influx/$VERSION (<system-information>) Sha/$SHA Date/$BUILD_DATE`

---
- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
