### PR TITLE
fix(variable-hydration): fixed variable overhydration issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@
 1. [18331](https://github.com/influxdata/influxdb/pull/18331): Support organization name in addition to ID in DBRP operations
 1. [18335](https://github.com/influxdata/influxdb/pull/18335): Disable failing when providing an unexpected error to influx CLI
 1. [18345](https://github.com/influxdata/influxdb/pull/18345): Have influx delete cmd respect the config
-   <<<<<<< HEAD
 1. [18385](https://github.com/influxdata/influxdb/pull/18385): Store initialization for pkger enforced on reads
 
 ### UI Improvements
 
 1. [18319](https://github.com/influxdata/influxdb/pull/18319): Display bucket ID in bucket list and enable 1 click copying
 1. [18361](https://github.com/influxdata/influxdb/pull/18361): Tokens list is now consistent with the other resource lists
+1. [18346](https://github.com/influxdata/influxdb/pull/18346): Reduce the number of variables being hydrated when toggling variables
 
 ## v2.0.0-beta.11 [2020-05-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@
 1. [18331](https://github.com/influxdata/influxdb/pull/18331): Support organization name in addition to ID in DBRP operations
 1. [18335](https://github.com/influxdata/influxdb/pull/18335): Disable failing when providing an unexpected error to influx CLI
 1. [18345](https://github.com/influxdata/influxdb/pull/18345): Have influx delete cmd respect the config
+   <<<<<<< HEAD
 1. [18385](https://github.com/influxdata/influxdb/pull/18385): Store initialization for pkger enforced on reads
 
 ### UI Improvements
 
 1. [18319](https://github.com/influxdata/influxdb/pull/18319): Display bucket ID in bucket list and enable 1 click copying
 1. [18361](https://github.com/influxdata/influxdb/pull/18361): Tokens list is now consistent with the other resource lists
-
 
 ## v2.0.0-beta.11 [2020-05-26]
 

--- a/flags.yml
+++ b/flags.yml
@@ -106,6 +106,6 @@
 - name: New Hydrate Vars Functionality
   description: Enables a minimalistic variable hydration
   key: hydratevars
-  default: true
+  default: false
   contact: Ariel Salem / Monitoring Team
   lifetime: temporary

--- a/flags.yml
+++ b/flags.yml
@@ -103,3 +103,9 @@
   contact: Alirie Gray
   lifetime: temporary
 
+- name: New Hydrate Vars Functionality
+  description: Enables a minimalistic variable hydration
+  key: hydratevars
+  default: false
+  contact: Ariel Salem / Monitoring Team
+  lifetime: temporary

--- a/flags.yml
+++ b/flags.yml
@@ -106,6 +106,6 @@
 - name: New Hydrate Vars Functionality
   description: Enables a minimalistic variable hydration
   key: hydratevars
-  default: false
+  default: true
   contact: Ariel Salem / Monitoring Team
   lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -188,7 +188,7 @@ var hydratevars = MakeBoolFlag(
 	"New Hydrate Vars Functionality",
 	"hydratevars",
 	"Ariel Salem / Monitoring Team",
-	false,
+	true,
 	Temporary,
 	false,
 )

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -184,6 +184,20 @@ func NewLabelPackage() BoolFlag {
 	return newLabels
 }
 
+var hydratevars = MakeBoolFlag(
+	"New Hydrate Vars Functionality",
+	"hydratevars",
+	"Ariel Salem / Monitoring Team",
+	false,
+	Temporary,
+	false,
+)
+
+// NewHydrateVarsFunctionality - Enables a minimalistic variable hydration
+func NewHydrateVarsFunctionality() BoolFlag {
+	return hydratevars
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -198,6 +212,7 @@ var all = []Flag{
 	pushDownGroupAggregateFirst,
 	pushDownGroupAggregateLast,
 	newLabels,
+	hydratevars,
 }
 
 var byKey = map[string]Flag{
@@ -214,4 +229,5 @@ var byKey = map[string]Flag{
 	"pushDownGroupAggregateFirst":  pushDownGroupAggregateFirst,
 	"pushDownGroupAggregateLast":   pushDownGroupAggregateLast,
 	"newLabels":                    newLabels,
+	"hydratevars":                  hydratevars,
 }

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -188,7 +188,7 @@ var hydratevars = MakeBoolFlag(
 	"New Hydrate Vars Functionality",
 	"hydratevars",
 	"Ariel Salem / Monitoring Team",
-	true,
+	false,
 	Temporary,
 	false,
 )

--- a/ui/src/shared/utils/filterUnusedVars.ts
+++ b/ui/src/shared/utils/filterUnusedVars.ts
@@ -20,6 +20,8 @@ export const filterUnusedVars = (variables: Variable[], views: View[]) => {
     (acc, vp) => [...acc, ...vp.queries.map(query => query.text)],
     [] as Array<string>
   )
+  // TODO: make sure to parse out variables for other used variables
+  // console.log('queryTexts: ', queryTexts)
 
   const varsInUse = variables.filter(variable =>
     queryTexts.some(text => isInQuery(text, variable))

--- a/ui/src/shared/utils/filterUnusedVars.ts
+++ b/ui/src/shared/utils/filterUnusedVars.ts
@@ -20,8 +20,6 @@ export const filterUnusedVars = (variables: Variable[], views: View[]) => {
     (acc, vp) => [...acc, ...vp.queries.map(query => query.text)],
     [] as Array<string>
   )
-  // TODO: make sure to parse out variables for other used variables
-  // console.log('queryTexts: ', queryTexts)
 
   const varsInUse = variables.filter(variable =>
     queryTexts.some(text => isInQuery(text, variable))

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -33,6 +33,7 @@ import {findDependentVariables} from 'src/variables/utils/exportVariables'
 import {getOrg} from 'src/organizations/selectors'
 import {getLabels, getStatus} from 'src/resources/selectors'
 import {currentContext} from 'src/shared/selectors/currentContext'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -433,6 +434,10 @@ export const selectValue = (variableID: string, selected: string) => async (
 
   await dispatch(selectValueInState(contextID, variableID, selected))
   // only hydrate the changedVariable
-  dispatch(hydrateChangedVariable(variableID))
+  if (isFlagEnabled('hydratevars')) {
+    dispatch(hydrateChangedVariable(variableID))
+  } else {
+    dispatch(hydrateVariables(true))
+  }
   dispatch(updateQueryVars({[variable.name]: selected}))
 }

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -433,7 +433,6 @@ export const selectValue = (variableID: string, selected: string) => async (
 
   await dispatch(selectValueInState(contextID, variableID, selected))
   // only hydrate the changedVariable
-  dispatch(hydrateVariables(true))
-  // dispatch(hydrateChangedVariable(variableID))
+  dispatch(hydrateChangedVariable(variableID))
   dispatch(updateQueryVars({[variable.name]: selected}))
 }

--- a/ui/src/variables/mocks/index.ts
+++ b/ui/src/variables/mocks/index.ts
@@ -639,7 +639,7 @@ export const defaultVariable: Variable = {
   id: '05b73f4bffe8e000',
   orgID: '05b73f49a1d1b000',
   name: 'static',
-  description: '',
+  description: 'defaultVariable',
   selected: ['defbuck'],
   arguments: {type: 'constant', values: ['beans', 'defbuck']},
   createdAt: '2020-05-19T05:54:20.927477-07:00',
@@ -657,7 +657,7 @@ export const associatedVariable: Variable = {
   id: '05b740974228e000',
   orgID: '05b740945a91b000',
   name: 'dependent',
-  description: '',
+  description: 'associatedVariable',
   selected: [],
   arguments: {
     type: 'query',
@@ -699,32 +699,36 @@ export const timeRangeStartVariable: Variable = {
   selected: [],
 }
 
+export const timeRangeStopVariable: Variable = {
+  orgID: '',
+  id: 'timeRangeStop',
+  name: 'timeRangeStop',
+  arguments: {
+    type: 'system',
+    values: ['now()'],
+  },
+  status: RemoteDataState.Done,
+  labels: [],
+  selected: [],
+}
+
+export const windowPeriodVariable: Variable = {
+  orgID: '',
+  id: 'windowPeriod',
+  name: 'windowPeriod',
+  arguments: {
+    type: 'system',
+    values: [10000],
+  },
+  status: RemoteDataState.Done,
+  labels: [],
+  selected: [],
+}
+
 export const defaultVariables: Variable[] = [
   defaultVariable,
   associatedVariable,
   timeRangeStartVariable,
-  {
-    orgID: '',
-    id: 'timeRangeStop',
-    name: 'timeRangeStop',
-    arguments: {
-      type: 'system',
-      values: ['now()'],
-    },
-    status: RemoteDataState.Done,
-    labels: [],
-    selected: [],
-  },
-  {
-    orgID: '',
-    id: 'windowPeriod',
-    name: 'windowPeriod',
-    arguments: {
-      type: 'system',
-      values: [10000],
-    },
-    status: RemoteDataState.Done,
-    labels: [],
-    selected: [],
-  },
+  timeRangeStopVariable,
+  windowPeriodVariable,
 ]

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -394,9 +394,13 @@ describe('hydrate vars', () => {
       selections: {},
       fetcher,
     }).promise
-
-    expect(actual.length).toEqual(1)
-    expect(actual).toEqual([defaultVariable])
+    if (isFlagEnabled('hydratevars')) {
+      expect(actual.length).toEqual(1)
+      expect(actual).toEqual([defaultVariable])
+    }
+    // TODO(ariel): remove the if condition above when feature is good
+    // Also remove the following tests:
+    expect(actual.length).toEqual(2)
   })
 })
 

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -126,15 +126,44 @@ describe('hydrate vars', () => {
     */
     if (isFlagEnabled('hydratevars')) {
       expect(actual.length).toEqual(2)
+      expect(
+        actual.filter(v => v.id === 'e')[0].arguments.values.results
+      ).toEqual(['eVal'])
+      expect(actual.filter(v => v.id === 'e')[0].selected).toEqual(['eVal'])
+      expect(
+        actual.filter(v => v.id === 'g')[0].arguments.values.results
+      ).toEqual(['gVal'])
+      expect(actual.filter(v => v.id === 'g')[0].selected).toEqual(['gVal'])
     }
+    // TODO(ariel): remove the if condition above when feature is good
+    // Also remove the following tests:
+    expect(
+      actual.filter(v => v.id === 'a')[0].arguments.values.results
+    ).toBeFalsy()
+    expect(
+      actual.filter(v => v.id === 'b')[0].arguments.values.results
+    ).toBeFalsy()
+    expect(
+      actual.filter(v => v.id === 'c')[0].arguments.values.results
+    ).toBeFalsy()
+    expect(
+      actual.filter(v => v.id === 'd')[0].arguments.values.results
+    ).toBeFalsy()
+
     expect(
       actual.filter(v => v.id === 'e')[0].arguments.values.results
     ).toEqual(['eVal'])
     expect(actual.filter(v => v.id === 'e')[0].selected).toEqual(['eVal'])
+
     expect(
       actual.filter(v => v.id === 'g')[0].arguments.values.results
     ).toEqual(['gVal'])
     expect(actual.filter(v => v.id === 'g')[0].selected).toEqual(['gVal'])
+
+    expect(
+      actual.filter(v => v.id === 'f')[0].arguments.values.results
+    ).toEqual(['fVal'])
+    expect(actual.filter(v => v.id === 'f')[0].selected).toEqual(['fVal'])
   })
 
   test('should invalidate all ancestors of a node when it fails', async () => {
@@ -182,10 +211,23 @@ describe('hydrate vars', () => {
     //     }
     if (isFlagEnabled('hydratevars')) {
       expect(actual.length).toEqual(1)
+      const [cResult] = actual
+      expect(cResult.arguments.values.results).toEqual(['cVal'])
+      expect(cResult.selected).toEqual(['cVal'])
     }
-    const [cResult] = actual
-    expect(cResult.arguments.values.results).toEqual(['cVal'])
-    expect(cResult.selected).toEqual(['cVal'])
+    // TODO(ariel): remove the if condition above when feature is good
+    // Also remove the following tests:
+    expect(
+      actual.filter(v => v.id === 'a')[0].arguments.values.results
+    ).toEqual([])
+    expect(
+      actual.filter(v => v.id === 'b')[0].arguments.values.results
+    ).toEqual([])
+
+    expect(
+      actual.filter(v => v.id === 'c')[0].arguments.values.results
+    ).toEqual(['cVal'])
+    expect(actual.filter(v => v.id === 'c')[0].selected).toEqual(['cVal'])
   })
 
   test('works with map template variables', async () => {
@@ -229,9 +271,18 @@ describe('hydrate vars', () => {
     // appropriate substitution is actually taking place
     if (isFlagEnabled('hydratevars')) {
       expect(actual.length).toEqual(1)
+      const [bResult] = actual
+      expect(bResult.arguments.values).toEqual({
+        k: 'v',
+      })
     }
-    const [bResult] = actual
-    expect(bResult.arguments.values).toEqual({
+    // TODO(ariel): remove the if condition above when feature is good
+    // Also remove the following tests:
+    expect(
+      actual.filter(v => v.id === 'a')[0].arguments.values.results
+    ).toEqual(['aVal'])
+    expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
+    expect(actual.filter(v => v.id === 'b')[0].arguments.values).toEqual({
       k: 'v',
     })
   })
@@ -275,9 +326,20 @@ describe('hydrate vars', () => {
 
     if (isFlagEnabled('hydratevars')) {
       expect(actual.length).toEqual(1)
+      const [bResult] = actual
+      expect(bResult.arguments.values).toEqual(['v1', 'v2'])
     }
-    const [bResult] = actual
-    expect(bResult.arguments.values).toEqual(['v1', 'v2'])
+    // TODO(ariel): remove the if condition above when feature is good
+    // Also remove the following tests:
+    expect(
+      actual.filter(v => v.id === 'a')[0].arguments.values.results
+    ).toEqual(['aVal'])
+    expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
+
+    expect(actual.filter(v => v.id === 'b')[0].arguments.values).toEqual([
+      'v1',
+      'v2',
+    ])
   })
 
   test('should be cancellable', done => {

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -5,6 +5,7 @@ import {
   createVariableGraph,
   findSubgraphFeature,
 } from 'src/variables/utils/hydrateVars'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Mocks
 import {
@@ -123,7 +124,9 @@ describe('hydrate vars', () => {
       We expect the final outcome to be the two associated variables as the parents,
       Since those are the bottom-most children of the graph cycle
     */
-    expect(actual.length).toEqual(2)
+    if (isFlagEnabled('hydratevars')) {
+      expect(actual.length).toEqual(2)
+    }
     expect(
       actual.filter(v => v.id === 'e')[0].arguments.values.results
     ).toEqual(['eVal'])
@@ -177,7 +180,9 @@ describe('hydrate vars', () => {
     //       b [fontcolor = "red"]
     //       c [fontcolor = "green"]
     //     }
-    expect(actual.length).toEqual(1)
+    if (isFlagEnabled('hydratevars')) {
+      expect(actual.length).toEqual(1)
+    }
     const [cResult] = actual
     expect(cResult.arguments.values.results).toEqual(['cVal'])
     expect(cResult.selected).toEqual(['cVal'])
@@ -222,7 +227,9 @@ describe('hydrate vars', () => {
 
     // Basic test for now, we would need an icky mock to assert that the
     // appropriate substitution is actually taking place
-    expect(actual.length).toEqual(1)
+    if (isFlagEnabled('hydratevars')) {
+      expect(actual.length).toEqual(1)
+    }
     const [bResult] = actual
     expect(bResult.arguments.values).toEqual({
       k: 'v',
@@ -266,7 +273,9 @@ describe('hydrate vars', () => {
       fetcher,
     }).promise
 
-    expect(actual.length).toEqual(1)
+    if (isFlagEnabled('hydratevars')) {
+      expect(actual.length).toEqual(1)
+    }
     const [bResult] = actual
     expect(bResult.arguments.values).toEqual(['v1', 'v2'])
   })

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -119,16 +119,15 @@ describe('hydrate vars', () => {
     //       f [fontcolor = "green"]
     //       g [fontcolor = "green"]
     //     }
-    expect(actual.length).toEqual(3)
-    expect(
-      actual.filter(v => v.id === 'b')[0].arguments.values.results
-    ).toBeFalsy()
-
+    /*
+      We expect the final outcome to be the two associated variables as the parents,
+      Since those are the bottom-most children of the graph cycle
+    */
+    expect(actual.length).toEqual(2)
     expect(
       actual.filter(v => v.id === 'e')[0].arguments.values.results
     ).toEqual(['eVal'])
     expect(actual.filter(v => v.id === 'e')[0].selected).toEqual(['eVal'])
-
     expect(
       actual.filter(v => v.id === 'g')[0].arguments.values.results
     ).toEqual(['gVal'])
@@ -179,7 +178,9 @@ describe('hydrate vars', () => {
     //       c [fontcolor = "green"]
     //     }
     expect(actual.length).toEqual(1)
-    expect(actual).toEqual([c])
+    const [cResult] = actual
+    expect(cResult.arguments.values.results).toEqual(['cVal'])
+    expect(cResult.selected).toEqual(['cVal'])
   })
 
   test('works with map template variables', async () => {
@@ -222,7 +223,10 @@ describe('hydrate vars', () => {
     // Basic test for now, we would need an icky mock to assert that the
     // appropriate substitution is actually taking place
     expect(actual.length).toEqual(1)
-    expect(actual).toEqual([b])
+    const [bResult] = actual
+    expect(bResult.arguments.values).toEqual({
+      k: 'v',
+    })
   })
 
   // This ensures that the update of a dependant variable updates the
@@ -263,7 +267,8 @@ describe('hydrate vars', () => {
     }).promise
 
     expect(actual.length).toEqual(1)
-    expect(actual).toEqual([b])
+    const [bResult] = actual
+    expect(bResult.arguments.values).toEqual(['v1', 'v2'])
   })
 
   test('should be cancellable', done => {
@@ -325,11 +330,11 @@ describe('hydrate vars', () => {
 })
 
 describe('findSubgraphFeature', () => {
-  const getParentNodes = (node, acc: Set<string> = new Set()): string[] => {
+  const getParentNodeIDs = (node, acc: Set<string> = new Set()): string[] => {
     for (const parent of node.parents) {
       if (!acc.has(parent)) {
         acc.add(parent.variable.id)
-        getParentNodes(parent, acc)
+        getParentNodeIDs(parent, acc)
       }
     }
     return [...acc]
@@ -407,6 +412,14 @@ describe('findSubgraphFeature', () => {
           variable: defaultVariable,
           parent: [associatedVariable]
         },
+
+          variable: timeRangeStart,
+          parent: []
+        },
+        {
+          variable: timeRangeStop,
+          parent: []
+        },
         {
           variable: a,
           children: [],
@@ -424,19 +437,25 @@ describe('findSubgraphFeature', () => {
       associatedVariable,
       a,
     ])
-    // returns the two subgraph results
-    expect(actual.length).toEqual(2)
-    const resultIDs = actual.map(v => v.variable.id)
-    // expect the two variables with no children to be output
-    expect(resultIDs).toEqual([defaultVariable.id, a.id])
-    expect(actual[0].children).toEqual([])
-    expect(actual[1].children).toEqual([])
+    // returns the four subgraph results
+    expect(actual.length).toEqual(4)
+    const [defaultVarInResult] = actual.filter(
+      vn => vn.variable.id === defaultVariable.id
+    )
+    expect(defaultVarInResult.variable).toEqual(defaultVariable)
     // expect the subgraph to return the passed in variable
-    const parents = getParentNodes(actual[0])
-    expect(parents.length).toEqual(1)
-    const [parent] = parents
+    const parentIDs = getParentNodeIDs(defaultVarInResult)
+    expect(parentIDs.length).toEqual(1)
+    const [parentID] = parentIDs
     // expect the defaultVariable to have the associatedVariable as a parent
-    expect(parent).toEqual(associatedVariable.id)
+    expect(parentID).toEqual(associatedVariable.id)
+    const [timeRangeResult] = actual.filter(
+      vn => vn.variable.id === timeRangeStartVariable.id
+    )
+    expect(timeRangeResult).toEqual(timeRangeResult)
+    // expect the subgraph to return the passed in variable
+    const rents = getParentNodeIDs(timeRangeResult)
+    expect(rents).toEqual([])
   })
   test('should return the child node (defaultVariable) with associated parents of the input (associatedVariable) when the child node is passed in', async () => {
     /*
@@ -467,28 +486,37 @@ describe('findSubgraphFeature', () => {
     expect(resultIDs).toEqual([defaultVariable.id])
     expect(actual[0].children).toEqual([])
     // expect the subgraph to return the passed in variable
-    const parents = getParentNodes(actual[0])
-    expect(parents.length).toEqual(1)
-    const [parent] = parents
+    const parentIDs = getParentNodeIDs(actual[0])
+    expect(parentIDs.length).toEqual(1)
+    const [parentID] = parentIDs
     // expect the defaultVariable to have the associatedVariable as a parent
-    expect(parent).toEqual(associatedVariable.id)
+    expect(parentID).toEqual(associatedVariable.id)
   })
-  test('should return the child node (defaultVariable) with associated parents of the input (associatedVariable) when the parent node is passed in', async () => {
+  test('should return all the child nodes if the input variable has children', async () => {
     /*
-     This example deals with the following situation where a parent with a child has been passed in.
+     This example deals with the following situation where a parent with multiple children has been passed in.
      Practically speaking, this looks like:
 
-              associatedVariable
-                    |
-                    |
-                defaultVariable
+                    associatedVariable
+                  /          |         \
+                /           |          \
+      timeRangeStart  defaultVariable   timeRangeStop
 
-      By passing in the associatedVariable, we expect the child to be returned with a reference to the parent:
+      By passing in the associatedVariable, we expect the first to be returned with a reference to the parent,
+      while the subsequent children should not include a reference to the parent:
 
       [
         {
           variable: defaultVariable,
           parent: [associatedVariable]
+        },
+        {
+          variable: timeRangeStart,
+          parent: []
+        },
+        {
+          variable: timeRangeStop,
+          parent: []
         },
       ]
       The reason for this is because we want the youngest child node (end of the LL tail) to load first, followed by its parents.
@@ -498,27 +526,36 @@ describe('findSubgraphFeature', () => {
       associatedVariable,
     ])
     // returns the subgraph result
-    expect(actual.length).toEqual(1)
-    const resultIDs = actual.map(v => v.variable.id)
+    expect(actual.length).toEqual(3)
     // expect the one variables with no children to be output
-    expect(resultIDs).toEqual([defaultVariable.id])
-    expect(actual[0].children).toEqual([])
+    const [defaultVarInResult] = actual.filter(
+      vn => vn.variable.id === defaultVariable.id
+    )
+    expect(defaultVarInResult.variable).toEqual(defaultVariable)
     // expect the subgraph to return the passed in variable
-    const parents = getParentNodes(actual[0])
+    const parents = getParentNodeIDs(defaultVarInResult)
     expect(parents.length).toEqual(1)
     const [parent] = parents
     // expect the defaultVariable to have the associatedVariable as a parent
     expect(parent).toEqual(associatedVariable.id)
+    const [timeRangeResult] = actual.filter(
+      vn => vn.variable.id === timeRangeStartVariable.id
+    )
+    expect(timeRangeResult).toEqual(timeRangeResult)
+    // expect the subgraph to return the passed in variable
+    const rents = getParentNodeIDs(timeRangeResult)
+    expect(rents).toEqual([])
   })
-  test('should only return the child nodes (defaultVariable, timeRangeStart) with the like parents filtered out of the second variable (timeRangeStart) when the multiple common parents are passed in', async () => {
+  test('should only return the child nodes (defaultVariable, timeRangeStart, timeRangeStop) with the like parents filtered out of the second variable (timeRangeStart) when the multiple common parents are passed in', async () => {
     /*
      This example deals with the following situation where a parent has two children.
      In this case, both the defaultVariable and timeRangeStart are children to associatedVariable.
      Practically speaking, this looks like:
 
-                         associatedVariable
-                        /                  \
-                    defaultVariable     timeRangeStart
+                    associatedVariable
+                  /          |         \
+                /           |          \
+      timeRangeStart  defaultVariable   timeRangeStop
 
       By passing in the associatedVariable and the timeRangeStart, the output should be:
 
@@ -529,6 +566,10 @@ describe('findSubgraphFeature', () => {
         },
         {
           variable: timeRangeStart,
+          parent: [],
+        },
+        {
+          variable: timeRangeStop,
           parent: [],
         },
       ]
@@ -542,21 +583,23 @@ describe('findSubgraphFeature', () => {
       associatedVariable,
     ])
     // returns the subgraph result
-    expect(actual.length).toEqual(2)
-    const resultIDs = actual.map(v => v.variable.id)
-    // expect the one variables with no children to be output
-    expect(resultIDs).toEqual([defaultVariable.id, timeRangeStartVariable.id])
-    expect(actual[0].children).toEqual([])
-    expect(actual[1].children).toEqual([])
+    expect(actual.length).toEqual(3)
+    const [defaultVarInResult] = actual.filter(
+      vn => vn.variable.id === defaultVariable.id
+    )
+    expect(defaultVarInResult.variable).toEqual(defaultVariable)
     // expect the subgraph to return the passed in variable
-    const parents = getParentNodes(actual[0])
-    expect(parents.length).toEqual(1)
-    const [parent] = parents
+    const parentIDs = getParentNodeIDs(defaultVarInResult)
+    expect(parentIDs.length).toEqual(1)
+    const [parentID] = parentIDs
     // expect the defaultVariable to have the associatedVariable as a parent
-    expect(parent).toEqual(associatedVariable.id)
-    // since the expected parent is the associatedVariable, we expect that
-    // the subgraph to filter out the parent before it is added onto the subgraph
-    const timeRangeParents = getParentNodes(actual[1])
-    expect(timeRangeParents).toEqual([])
+    expect(parentID).toEqual(associatedVariable.id)
+    const [timeRangeResult] = actual.filter(
+      vn => vn.variable.id === timeRangeStartVariable.id
+    )
+    expect(timeRangeResult).toEqual(timeRangeResult)
+    // expect the subgraph to return the passed in variable
+    const rents = getParentNodeIDs(timeRangeResult)
+    expect(rents).toEqual([])
   })
 })

--- a/ui/src/variables/utils/hydrateVars.test.ts
+++ b/ui/src/variables/utils/hydrateVars.test.ts
@@ -119,18 +119,19 @@ describe('hydrate vars', () => {
     //       f [fontcolor = "green"]
     //       g [fontcolor = "green"]
     //     }
-    expect(
-      actual.filter(v => v.id === 'a')[0].arguments.values.results
-    ).toBeFalsy()
+    // TODO(ariel): figured out if these tests are necessary
+    // expect(
+    //   actual.filter(v => v.id === 'a')[0].arguments.values.results
+    // ).toBeFalsy()
     expect(
       actual.filter(v => v.id === 'b')[0].arguments.values.results
     ).toBeFalsy()
-    expect(
-      actual.filter(v => v.id === 'c')[0].arguments.values.results
-    ).toBeFalsy()
-    expect(
-      actual.filter(v => v.id === 'd')[0].arguments.values.results
-    ).toBeFalsy()
+    // expect(
+    //   actual.filter(v => v.id === 'c')[0].arguments.values.results
+    // ).toBeFalsy()
+    // expect(
+    //   actual.filter(v => v.id === 'd')[0].arguments.values.results
+    // ).toBeFalsy()
 
     expect(
       actual.filter(v => v.id === 'e')[0].arguments.values.results
@@ -142,10 +143,10 @@ describe('hydrate vars', () => {
     ).toEqual(['gVal'])
     expect(actual.filter(v => v.id === 'g')[0].selected).toEqual(['gVal'])
 
-    expect(
-      actual.filter(v => v.id === 'f')[0].arguments.values.results
-    ).toEqual(['fVal'])
-    expect(actual.filter(v => v.id === 'f')[0].selected).toEqual(['fVal'])
+    // expect(
+    //   actual.filter(v => v.id === 'f')[0].arguments.values.results
+    // ).toEqual(['fVal'])
+    // expect(actual.filter(v => v.id === 'f')[0].selected).toEqual(['fVal'])
   })
 
   test('should invalidate all ancestors of a node when it fails', async () => {
@@ -192,12 +193,13 @@ describe('hydrate vars', () => {
     //       c [fontcolor = "green"]
     //     }
     //
-    expect(
-      actual.filter(v => v.id === 'a')[0].arguments.values.results
-    ).toEqual([])
-    expect(
-      actual.filter(v => v.id === 'b')[0].arguments.values.results
-    ).toEqual([])
+    // TODO(ariel): determine if these are still relevant
+    // expect(
+    //   actual.filter(v => v.id === 'a')[0].arguments.values.results
+    // ).toEqual([])
+    // expect(
+    //   actual.filter(v => v.id === 'b')[0].arguments.values.results
+    // ).toEqual([])
 
     expect(
       actual.filter(v => v.id === 'c')[0].arguments.values.results
@@ -244,10 +246,11 @@ describe('hydrate vars', () => {
 
     // Basic test for now, we would need an icky mock to assert that the
     // appropriate substitution is actually taking place
-    expect(
-      actual.filter(v => v.id === 'a')[0].arguments.values.results
-    ).toEqual(['aVal'])
-    expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
+    // TODO(ariel): determine if these are still necessary checks
+    // expect(
+    //   actual.filter(v => v.id === 'a')[0].arguments.values.results
+    // ).toEqual(['aVal'])
+    // expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
     expect(actual.filter(v => v.id === 'b')[0].arguments.values).toEqual({
       k: 'v',
     })
@@ -289,11 +292,11 @@ describe('hydrate vars', () => {
       selections: {},
       fetcher,
     }).promise
-
-    expect(
-      actual.filter(v => v.id === 'a')[0].arguments.values.results
-    ).toEqual(['aVal'])
-    expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
+    // TODO(ariel): determine if these are still necessary checks
+    // expect(
+    //   actual.filter(v => v.id === 'a')[0].arguments.values.results
+    // ).toEqual(['aVal'])
+    // expect(actual.filter(v => v.id === 'a')[0].selected).toEqual(['aVal'])
 
     expect(actual.filter(v => v.id === 'b')[0].arguments.values).toEqual([
       'v1',

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -74,7 +74,7 @@ export const createVariableGraph = (
   return Object.values(nodesByID)
 }
 
-export const isInQuery = (query: string, v: Variable) => {
+export const isInQuery = (query: string, v: Variable): boolean => {
   const regexp = new RegExp(
     `${BOUNDARY_GROUP}${OPTION_NAME}.${v.name}${BOUNDARY_GROUP}`
   )
@@ -194,6 +194,7 @@ const getDeduplicatedRootChild = (
   - The node for one of the passed variables depends on this node
 
 */
+// TODO(ariel): rename this back to findSubgraph & update tests once feature flag is removed
 export const findSubgraphFeature = (
   graph: VariableNode[],
   variables: Variable[]
@@ -513,8 +514,7 @@ export const hydrateVars = (
   options: HydrateVarsOptions
 ): EventedCancelBox<Variable[]> => {
   let findSubgraphFunction = findSubgraph
-  if (true) {
-    // if (isFlagEnabled('hydratevars')) {
+  if (isFlagEnabled('hydratevars')) {
     findSubgraphFunction = findSubgraphFeature
   }
 

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -513,6 +513,7 @@ export const hydrateVars = (
   options: HydrateVarsOptions
 ): EventedCancelBox<Variable[]> => {
   let findSubgraphFunction = findSubgraph
+  // if (true) {
   if (isFlagEnabled('hydratevars')) {
     findSubgraphFunction = findSubgraphFeature
   }
@@ -529,7 +530,6 @@ export const hydrateVars = (
     if (isCancelled) {
       return
     }
-
     try {
       // TODO: terminate the concept of node.values at the fetcher and just use variables
       node.values = await hydrateVarsHelper(node, options, on)


### PR DESCRIPTION
Closes #18192 

### Problem
This PR aims to address the issue of overly hydrating variables when a variable selection is made.

#### Solution
The solution is as follows:

- Only pass in the variable that has been selected to hydrate that specific variable
- Create a subgraph of the variables that are being used by performing an in order tree traversal of the parent's child nodes in order to first load children, then their parents

This solution will help reduce the amount of unnecessary query requests made from the UI post order to hydrate variables. However, since it involves a lot of moving parts that currently work, I've set it behind a feature flag in order to make sure that variables are still going to work correctly

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
