### PR TITLE
fix(goreleaser): add separate influxctl archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,14 +42,14 @@ builds:
       pre: make generate
 
 archives:
-  - id: influxctl
+  - id: influxdb_client
     builds: ["influx"]
     format: tar.gz
     wrap_in_directory: true
     format_overrides:
       - goos: windows
         format: zip
-    name_template: 'influxdbctl_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: 'influxdb_client_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE
       - README.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,19 @@ builds:
       pre: make generate
 
 archives:
-  - format: tar.gz
+  - id: influxctl
+    builds: ["influx"]
+    format: tar.gz
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: 'influxdbctl_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - LICENSE
+      - README.md
+  - id: influxdb_single_binary
+    format: tar.gz
     wrap_in_directory: true
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17332

Attempts to add a separate influxctl archive to the build which contains only the `influx` cli tool

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
