### PR TITLE
refactor(storage/reads): refactor and add unit tests for *WindowCountArrayCursor

### DIFF
--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -201,19 +201,19 @@ func (c floatArraySumCursor) Next() *cursors.FloatArray {
 	}
 }
 
-type integerFloatWindowCountArrayCursor struct {
+type floatWindowCountArrayCursor struct {
 	cursors.FloatArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   *cursors.FloatArray
 }
 
-func newIntegerFloatWindowCountArrayCursor(cur cursors.FloatArrayCursor, every int64) *integerFloatWindowCountArrayCursor {
+func newFloatWindowCountArrayCursor(cur cursors.FloatArrayCursor, every int64) *floatWindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integerFloatWindowCountArrayCursor{
+	return &floatWindowCountArrayCursor{
 		FloatArrayCursor: cur,
 		every:            every,
 		res:              cursors.NewIntegerArrayLen(resLen),
@@ -221,16 +221,16 @@ func newIntegerFloatWindowCountArrayCursor(cur cursors.FloatArrayCursor, every i
 	}
 }
 
-func newIntegerFloatCountArrayCursor(cur cursors.FloatArrayCursor) *integerFloatWindowCountArrayCursor {
+func newFloatCountArrayCursor(cur cursors.FloatArrayCursor) *floatWindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newIntegerFloatWindowCountArrayCursor(cur, 0)
+	return newFloatWindowCountArrayCursor(cur, 0)
 }
 
-func (c *integerFloatWindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *floatWindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.FloatArrayCursor.Stats()
 }
 
-func (c *integerFloatWindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *floatWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]
@@ -511,19 +511,19 @@ func (c integerArraySumCursor) Next() *cursors.IntegerArray {
 	}
 }
 
-type integerIntegerWindowCountArrayCursor struct {
+type integerWindowCountArrayCursor struct {
 	cursors.IntegerArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   *cursors.IntegerArray
 }
 
-func newIntegerIntegerWindowCountArrayCursor(cur cursors.IntegerArrayCursor, every int64) *integerIntegerWindowCountArrayCursor {
+func newIntegerWindowCountArrayCursor(cur cursors.IntegerArrayCursor, every int64) *integerWindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integerIntegerWindowCountArrayCursor{
+	return &integerWindowCountArrayCursor{
 		IntegerArrayCursor: cur,
 		every:              every,
 		res:                cursors.NewIntegerArrayLen(resLen),
@@ -531,16 +531,16 @@ func newIntegerIntegerWindowCountArrayCursor(cur cursors.IntegerArrayCursor, eve
 	}
 }
 
-func newIntegerIntegerCountArrayCursor(cur cursors.IntegerArrayCursor) *integerIntegerWindowCountArrayCursor {
+func newIntegerCountArrayCursor(cur cursors.IntegerArrayCursor) *integerWindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newIntegerIntegerWindowCountArrayCursor(cur, 0)
+	return newIntegerWindowCountArrayCursor(cur, 0)
 }
 
-func (c *integerIntegerWindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *integerWindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.IntegerArrayCursor.Stats()
 }
 
-func (c *integerIntegerWindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *integerWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]
@@ -821,19 +821,19 @@ func (c unsignedArraySumCursor) Next() *cursors.UnsignedArray {
 	}
 }
 
-type integerUnsignedWindowCountArrayCursor struct {
+type unsignedWindowCountArrayCursor struct {
 	cursors.UnsignedArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   *cursors.UnsignedArray
 }
 
-func newIntegerUnsignedWindowCountArrayCursor(cur cursors.UnsignedArrayCursor, every int64) *integerUnsignedWindowCountArrayCursor {
+func newUnsignedWindowCountArrayCursor(cur cursors.UnsignedArrayCursor, every int64) *unsignedWindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integerUnsignedWindowCountArrayCursor{
+	return &unsignedWindowCountArrayCursor{
 		UnsignedArrayCursor: cur,
 		every:               every,
 		res:                 cursors.NewIntegerArrayLen(resLen),
@@ -841,16 +841,16 @@ func newIntegerUnsignedWindowCountArrayCursor(cur cursors.UnsignedArrayCursor, e
 	}
 }
 
-func newIntegerUnsignedCountArrayCursor(cur cursors.UnsignedArrayCursor) *integerUnsignedWindowCountArrayCursor {
+func newUnsignedCountArrayCursor(cur cursors.UnsignedArrayCursor) *unsignedWindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newIntegerUnsignedWindowCountArrayCursor(cur, 0)
+	return newUnsignedWindowCountArrayCursor(cur, 0)
 }
 
-func (c *integerUnsignedWindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *unsignedWindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.UnsignedArrayCursor.Stats()
 }
 
-func (c *integerUnsignedWindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *unsignedWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]
@@ -1091,19 +1091,19 @@ func (c *stringArrayCursor) nextArrayCursor() bool {
 	return ok
 }
 
-type integerStringWindowCountArrayCursor struct {
+type stringWindowCountArrayCursor struct {
 	cursors.StringArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   *cursors.StringArray
 }
 
-func newIntegerStringWindowCountArrayCursor(cur cursors.StringArrayCursor, every int64) *integerStringWindowCountArrayCursor {
+func newStringWindowCountArrayCursor(cur cursors.StringArrayCursor, every int64) *stringWindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integerStringWindowCountArrayCursor{
+	return &stringWindowCountArrayCursor{
 		StringArrayCursor: cur,
 		every:             every,
 		res:               cursors.NewIntegerArrayLen(resLen),
@@ -1111,16 +1111,16 @@ func newIntegerStringWindowCountArrayCursor(cur cursors.StringArrayCursor, every
 	}
 }
 
-func newIntegerStringCountArrayCursor(cur cursors.StringArrayCursor) *integerStringWindowCountArrayCursor {
+func newStringCountArrayCursor(cur cursors.StringArrayCursor) *stringWindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newIntegerStringWindowCountArrayCursor(cur, 0)
+	return newStringWindowCountArrayCursor(cur, 0)
 }
 
-func (c *integerStringWindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *stringWindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.StringArrayCursor.Stats()
 }
 
-func (c *integerStringWindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *stringWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]
@@ -1361,19 +1361,19 @@ func (c *booleanArrayCursor) nextArrayCursor() bool {
 	return ok
 }
 
-type integerBooleanWindowCountArrayCursor struct {
+type booleanWindowCountArrayCursor struct {
 	cursors.BooleanArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   *cursors.BooleanArray
 }
 
-func newIntegerBooleanWindowCountArrayCursor(cur cursors.BooleanArrayCursor, every int64) *integerBooleanWindowCountArrayCursor {
+func newBooleanWindowCountArrayCursor(cur cursors.BooleanArrayCursor, every int64) *booleanWindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integerBooleanWindowCountArrayCursor{
+	return &booleanWindowCountArrayCursor{
 		BooleanArrayCursor: cur,
 		every:              every,
 		res:                cursors.NewIntegerArrayLen(resLen),
@@ -1381,16 +1381,16 @@ func newIntegerBooleanWindowCountArrayCursor(cur cursors.BooleanArrayCursor, eve
 	}
 }
 
-func newIntegerBooleanCountArrayCursor(cur cursors.BooleanArrayCursor) *integerBooleanWindowCountArrayCursor {
+func newBooleanCountArrayCursor(cur cursors.BooleanArrayCursor) *booleanWindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newIntegerBooleanWindowCountArrayCursor(cur, 0)
+	return newBooleanWindowCountArrayCursor(cur, 0)
 }
 
-func (c *integerBooleanWindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *booleanWindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.BooleanArrayCursor.Stats()
 }
 
-func (c *integerBooleanWindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *booleanWindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -2,6 +2,7 @@ package reads
 
 import (
 	"errors"
+	"math"
 
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
 )
@@ -207,37 +208,29 @@ func (c {{$type}}) Next() {{$arrayType}} {
 
 {{end}}
 
-type integer{{.Name}}CountArrayCursor struct {
-	cursors.{{.Name}}ArrayCursor
-}
-
-func (c *integer{{.Name}}CountArrayCursor) Stats() cursors.CursorStats {
-	return c.{{.Name}}ArrayCursor.Stats()
-}
-
-func (c *integer{{.Name}}CountArrayCursor) Next() *cursors.IntegerArray {
-	a := c.{{.Name}}ArrayCursor.Next()
-	if len(a.Timestamps) == 0 {
-		return &cursors.IntegerArray{}
-	}
-
-	ts := a.Timestamps[0]
-	var acc int64
-	for {
-		acc += int64(len(a.Timestamps))
-		a = c.{{.Name}}ArrayCursor.Next()
-		if len(a.Timestamps) == 0 {
-			res := cursors.NewIntegerArrayLen(1)
-			res.Timestamps[0] = ts
-			res.Values[0] = acc
-			return res
-		}
-	}
-}
-
 type integer{{.Name}}WindowCountArrayCursor struct {
 	cursors.{{.Name}}ArrayCursor
 	every int64
+	res   *cursors.IntegerArray
+	tmp   {{$arrayType}}
+}
+
+func newInteger{{.Name}}WindowCountArrayCursor(cur cursors.{{.Name}}ArrayCursor, every int64) *integer{{.Name}}WindowCountArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &integer{{.Name}}WindowCountArrayCursor{
+		{{.Name}}ArrayCursor: cur,
+		every: every,
+		res: cursors.NewIntegerArrayLen(resLen),
+		tmp: &cursors.{{.Name}}Array{},
+	}
+}
+
+func newInteger{{.Name}}CountArrayCursor(cur cursors.{{.Name}}ArrayCursor) *integer{{.Name}}WindowCountArrayCursor {
+	// zero means aggregate over the whole series
+	return newInteger{{.Name}}WindowCountArrayCursor(cur, 0)
 }
 
 func (c *integer{{.Name}}WindowCountArrayCursor) Stats() cursors.CursorStats {
@@ -245,52 +238,92 @@ func (c *integer{{.Name}}WindowCountArrayCursor) Stats() cursors.CursorStats {
 }
 
 func (c *integer{{.Name}}WindowCountArrayCursor) Next() *cursors.IntegerArray {
-	a := c.{{.Name}}ArrayCursor.Next()
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.{{.Name}}Array
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.{{.Name}}ArrayCursor.Next()
+	}
+
 	if a.Len() == 0 {
 		return &cursors.IntegerArray{}
 	}
 
-	res := cursors.NewIntegerArrayLen(0)
 	rowIdx := 0
 	var acc int64 = 0
 
-	firstTimestamp := a.Timestamps[rowIdx]
-	windowStart := firstTimestamp - firstTimestamp%c.every
-	windowEnd := windowStart + c.every
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
 
 	// enumerate windows
 WINDOWS:
 	for {
 		for ; rowIdx < a.Len(); rowIdx++ {
 			ts := a.Timestamps[rowIdx]
-			if ts >= windowEnd {
+			if c.every != 0 && ts >= windowEnd {
 				// new window detected, close the current window
+				// do not generate a point for empty windows
 				if acc > 0 {
-					res.Timestamps = append(res.Timestamps, windowEnd)
-					res.Values = append(res.Values, acc)
+					c.res.Timestamps[pos] = windowEnd
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
 				}
+
 				// start the new window
 				acc = 0
-				firstTimestamp = a.Timestamps[rowIdx]
-				windowStart = firstTimestamp - firstTimestamp%c.every
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
 				windowEnd = windowStart + c.every
+
 				continue WINDOWS
 			} else {
 				acc++
 			}
 		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
 		// get the next chunk
 		a = c.{{.Name}}ArrayCursor.Next()
 		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
 			if acc > 0 {
-				res.Timestamps = append(res.Timestamps, windowEnd)
-				res.Values = append(res.Values, acc)
+				c.res.Timestamps[pos] = windowEnd
+				c.res.Values[pos] = acc
+				pos++
 			}
-			break
+			break WINDOWS
 		}
 		rowIdx = 0
 	}
-	return res
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
 }
 
 type {{.name}}EmptyArrayCursor struct {
@@ -304,4 +337,4 @@ func (c *{{.name}}EmptyArrayCursor) Close() {}
 func (c *{{.name}}EmptyArrayCursor) Stats() cursors.CursorStats { return cursors.CursorStats{} }
 func (c *{{.name}}EmptyArrayCursor) Next() {{$arrayType}} { return &c.res }
 
-{{end}}
+{{end}}{{/* range . */}}

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -208,19 +208,19 @@ func (c {{$type}}) Next() {{$arrayType}} {
 
 {{end}}
 
-type integer{{.Name}}WindowCountArrayCursor struct {
+type {{.name}}WindowCountArrayCursor struct {
 	cursors.{{.Name}}ArrayCursor
 	every int64
 	res   *cursors.IntegerArray
 	tmp   {{$arrayType}}
 }
 
-func newInteger{{.Name}}WindowCountArrayCursor(cur cursors.{{.Name}}ArrayCursor, every int64) *integer{{.Name}}WindowCountArrayCursor {
+func new{{.Name}}WindowCountArrayCursor(cur cursors.{{.Name}}ArrayCursor, every int64) *{{.name}}WindowCountArrayCursor {
 	resLen := MaxPointsPerBlock
 	if every == 0 {
 		resLen = 1
 	}
-	return &integer{{.Name}}WindowCountArrayCursor{
+	return &{{.name}}WindowCountArrayCursor{
 		{{.Name}}ArrayCursor: cur,
 		every: every,
 		res: cursors.NewIntegerArrayLen(resLen),
@@ -228,16 +228,16 @@ func newInteger{{.Name}}WindowCountArrayCursor(cur cursors.{{.Name}}ArrayCursor,
 	}
 }
 
-func newInteger{{.Name}}CountArrayCursor(cur cursors.{{.Name}}ArrayCursor) *integer{{.Name}}WindowCountArrayCursor {
+func new{{.Name}}CountArrayCursor(cur cursors.{{.Name}}ArrayCursor) *{{.name}}WindowCountArrayCursor {
 	// zero means aggregate over the whole series
-	return newInteger{{.Name}}WindowCountArrayCursor(cur, 0)
+	return new{{.Name}}WindowCountArrayCursor(cur, 0)
 }
 
-func (c *integer{{.Name}}WindowCountArrayCursor) Stats() cursors.CursorStats {
+func (c *{{.name}}WindowCountArrayCursor) Stats() cursors.CursorStats {
 	return c.{{.Name}}ArrayCursor.Stats()
 }
 
-func (c *integer{{.Name}}WindowCountArrayCursor) Next() *cursors.IntegerArray {
+func (c *{{.name}}WindowCountArrayCursor) Next() *cursors.IntegerArray {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]

--- a/storage/reads/array_cursor.go
+++ b/storage/reads/array_cursor.go
@@ -63,15 +63,15 @@ func newSumArrayCursor(cur cursors.Cursor) cursors.Cursor {
 func newCountArrayCursor(cur cursors.Cursor) cursors.Cursor {
 	switch cur := cur.(type) {
 	case cursors.FloatArrayCursor:
-		return newIntegerFloatCountArrayCursor(cur)
+		return newFloatCountArrayCursor(cur)
 	case cursors.IntegerArrayCursor:
-		return newIntegerIntegerCountArrayCursor(cur)
+		return newIntegerCountArrayCursor(cur)
 	case cursors.UnsignedArrayCursor:
-		return newIntegerUnsignedCountArrayCursor(cur)
+		return newUnsignedCountArrayCursor(cur)
 	case cursors.StringArrayCursor:
-		return newIntegerStringCountArrayCursor(cur)
+		return newStringCountArrayCursor(cur)
 	case cursors.BooleanArrayCursor:
-		return newIntegerBooleanCountArrayCursor(cur)
+		return newBooleanCountArrayCursor(cur)
 	default:
 		panic(fmt.Sprintf("unreachable: %T", cur))
 	}
@@ -85,15 +85,15 @@ func newWindowCountArrayCursor(cur cursors.Cursor, req *datatypes.ReadWindowAggr
 	}
 	switch cur := cur.(type) {
 	case cursors.FloatArrayCursor:
-		return newIntegerFloatWindowCountArrayCursor(cur, req.WindowEvery)
+		return newFloatWindowCountArrayCursor(cur, req.WindowEvery)
 	case cursors.IntegerArrayCursor:
-		return newIntegerIntegerWindowCountArrayCursor(cur, req.WindowEvery)
+		return newIntegerWindowCountArrayCursor(cur, req.WindowEvery)
 	case cursors.UnsignedArrayCursor:
-		return newIntegerUnsignedWindowCountArrayCursor(cur, req.WindowEvery)
+		return newUnsignedWindowCountArrayCursor(cur, req.WindowEvery)
 	case cursors.StringArrayCursor:
-		return newIntegerStringWindowCountArrayCursor(cur, req.WindowEvery)
+		return newStringWindowCountArrayCursor(cur, req.WindowEvery)
 	case cursors.BooleanArrayCursor:
-		return newIntegerBooleanWindowCountArrayCursor(cur, req.WindowEvery)
+		return newBooleanWindowCountArrayCursor(cur, req.WindowEvery)
 	default:
 		panic(fmt.Sprintf("unreachable: %T", cur))
 	}

--- a/storage/reads/array_cursor_test.go
+++ b/storage/reads/array_cursor_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb/v2/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
 )
 
@@ -42,15 +43,15 @@ func TestIntegerFilterArrayCursor(t *testing.T) {
 	}
 }
 
-func makeIntegerArray(n int64, tsStart time.Time, tsStep time.Duration, vStart, vStep int64) *cursors.IntegerArray {
+func makeIntegerArray(n int, tsStart time.Time, tsStep time.Duration, valueFn func(i int64) int64) *cursors.IntegerArray {
 	ia := &cursors.IntegerArray{
 		Timestamps: make([]int64, n),
 		Values:     make([]int64, n),
 	}
 
-	for i := int64(0); i < n; i++ {
-		ia.Timestamps[i] = tsStart.UnixNano() + i*int64(tsStep)
-		ia.Values[i] = vStart + i*vStep
+	for i := 0; i < n; i++ {
+		ia.Timestamps[i] = tsStart.UnixNano() + int64(i)*int64(tsStep)
+		ia.Values[i] = valueFn(int64(i))
 	}
 
 	return ia
@@ -62,6 +63,13 @@ func mustParseTime(ts string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+func copyIntegerArray(src *cursors.IntegerArray) *cursors.IntegerArray {
+	dst := cursors.NewIntegerArrayLen(src.Len())
+	copy(dst.Timestamps, src.Timestamps)
+	copy(dst.Values, src.Values)
+	return dst
 }
 
 func TestIntegerIntegerCountArrayCursor(t *testing.T) {
@@ -80,11 +88,74 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(4, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, 15, 0),
+				makeIntegerArray(4, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, func(int64) int64 { return 15 }),
+			},
+		},
+		{
+			name:  "empty windows",
+			every: time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					4,
+					mustParseTime("2010-01-01T00:00:00Z"), 15*time.Minute,
+					func(i int64) int64 { return 100 + i },
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(
+					4,
+					mustParseTime("2010-01-01T00:01:00Z"), 15*time.Minute,
+					func(i int64) int64 { return 1 },
+				),
+			},
+		},
+		{
+			name:  "unaligned window",
+			every: 15 * time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:00:30Z"), time.Minute,
+					func(i int64) int64 { return 100 + i },
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(
+					4,
+					mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute,
+					func(i int64) int64 {
+						return 15
+					}),
+			},
+		},
+		{
+			name:  "more unaligned window",
+			every: 15 * time.Minute,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray(
+					60,
+					mustParseTime("2010-01-01T00:01:30Z"), time.Minute,
+					func(i int64) int64 { return 100 + i },
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(
+					5,
+					mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute,
+					func(i int64) int64 {
+						switch i {
+						case 0:
+							return 14
+						case 4:
+							return 1
+						default:
+							return 15
+						}
+					}),
 			},
 		},
 		{
@@ -94,16 +165,16 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
-					200, 1,
+					func(i int64) int64 { return 200 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(8, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, 15, 0),
+				makeIntegerArray(8, mustParseTime("2010-01-01T00:15:00Z"), 15*time.Minute, func(int64) int64 { return 15 }),
 			},
 		},
 		{
@@ -113,82 +184,116 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
-					200, 1,
+					func(i int64) int64 { return 200 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(3, mustParseTime("2010-01-01T00:40:00Z"), 40*time.Minute, 40, 0),
+				makeIntegerArray(3, mustParseTime("2010-01-01T00:40:00Z"), 40*time.Minute, func(int64) int64 { return 40 }),
 			},
 		},
 		{
-			name:  "window max int every",
-			every: time.Duration(math.MaxInt64),
+			name:  "more windows than MaxPointsPerBlock",
+			every: 2 * time.Millisecond,
+			inputArrays: []*cursors.IntegerArray{
+				makeIntegerArray( // 1 second, one point per ms
+					1000,
+					mustParseTime("2010-01-01T00:00:00Z"), time.Millisecond,
+					func(i int64) int64 { return i },
+				),
+				makeIntegerArray( // 1 second, one point per ms
+					1000,
+					mustParseTime("2010-01-01T00:00:01Z"), time.Millisecond,
+					func(i int64) int64 { return i },
+				),
+				makeIntegerArray( // 1 second, one point per ms
+					1000,
+					mustParseTime("2010-01-01T00:00:02Z"), time.Millisecond,
+					func(i int64) int64 { return i },
+				),
+			},
+			want: []*cursors.IntegerArray{
+				makeIntegerArray(
+					1000,
+					mustParseTime("2010-01-01T00:00:00.002Z"), 2*time.Millisecond,
+					func(i int64) int64 { return 2 },
+				),
+				makeIntegerArray(
+					500,
+					mustParseTime("2010-01-01T00:00:02.002Z"), 2*time.Millisecond,
+					func(i int64) int64 { return 2 },
+				),
+			},
+		},
+		{
+			name: "whole series",
 			inputArrays: []*cursors.IntegerArray{
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 60, 0),
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, func(i int64) int64 { return 60 }),
 			},
 		},
 		{
-			name:  "window max int every two arrays",
-			every: time.Duration(math.MaxInt64),
+			name:        "whole series no points",
+			inputArrays: []*cursors.IntegerArray{{}},
+			want:        []*cursors.IntegerArray{},
+		},
+		{
+			name: "whole series two arrays",
 			inputArrays: []*cursors.IntegerArray{
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 				makeIntegerArray(
 					60,
 					mustParseTime("2010-01-01T01:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, func(int64) int64 { return 120 }),
 			},
 		},
 		{
-			name:  "window max int span epoch",
-			every: time.Duration(math.MaxInt64),
+			name: "whole series span epoch",
 			inputArrays: []*cursors.IntegerArray{
 				makeIntegerArray(
 					120,
 					mustParseTime("1969-12-31T23:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, func(int64) int64 { return 120 }),
 			},
 		},
 		{
-			name:  "window max int span epoch two arrays",
-			every: time.Duration(math.MaxInt64),
+			name: "whole series span epoch two arrays",
 			inputArrays: []*cursors.IntegerArray{
 				makeIntegerArray(
 					60,
 					mustParseTime("1969-12-31T23:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 				makeIntegerArray(
 					60,
 					mustParseTime("1970-01-01T00:00:00Z"), time.Minute,
-					100, 1,
+					func(i int64) int64 { return 100 + i },
 				),
 			},
 			want: []*cursors.IntegerArray{
-				makeIntegerArray(1, maxTimestamp, 40*time.Minute, 120, 0),
+				makeIntegerArray(1, maxTimestamp, 40*time.Minute, func(int64) int64 { return 120 }),
 			},
 		},
 	}
@@ -208,18 +313,10 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 					return &cursors.IntegerArray{}
 				},
 			}
-			var countArrayCursor cursors.IntegerArrayCursor
-			if tc.every != 0 {
-				countArrayCursor = &integerIntegerWindowCountArrayCursor{
-					IntegerArrayCursor: mc,
-					every:              int64(tc.every),
-				}
-			} else {
-				countArrayCursor = newCountArrayCursor(mc).(cursors.IntegerArrayCursor)
-			}
+			countArrayCursor := newIntegerIntegerWindowCountArrayCursor(mc, int64(tc.every))
 			got := make([]*cursors.IntegerArray, 0, len(tc.want))
 			for a := countArrayCursor.Next(); a.Len() != 0; a = countArrayCursor.Next() {
-				got = append(got, a)
+				got = append(got, copyIntegerArray(a))
 			}
 
 			if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -227,6 +324,58 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewCountArrayCursor(t *testing.T) {
+	want := &integerIntegerWindowCountArrayCursor{
+		IntegerArrayCursor: &MockIntegerArrayCursor{},
+		res:                cursors.NewIntegerArrayLen(1),
+		tmp:                &cursors.IntegerArray{},
+	}
+
+	got := newCountArrayCursor(&MockIntegerArrayCursor{})
+
+	if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+		t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+	}
+}
+
+func TestNewWindowCountArrayCursor(t *testing.T) {
+	t.Run("hour window", func(t *testing.T) {
+		want := &integerIntegerWindowCountArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			every:              int64(time.Hour),
+			res:                cursors.NewIntegerArrayLen(MaxPointsPerBlock),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		req := &datatypes.ReadWindowAggregateRequest{
+			WindowEvery: int64(time.Hour),
+		}
+		got := newWindowCountArrayCursor(&MockIntegerArrayCursor{}, req)
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("count whole series", func(t *testing.T) {
+		want := &integerIntegerWindowCountArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			every:              0,
+			res:                cursors.NewIntegerArrayLen(1),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		req := &datatypes.ReadWindowAggregateRequest{
+			WindowEvery: math.MaxInt64,
+		}
+		got := newWindowCountArrayCursor(&MockIntegerArrayCursor{}, req)
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
 }
 
 type MockIntegerArrayCursor struct {

--- a/storage/reads/array_cursor_test.go
+++ b/storage/reads/array_cursor_test.go
@@ -296,6 +296,21 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 				makeIntegerArray(1, maxTimestamp, 40*time.Minute, func(int64) int64 { return 120 }),
 			},
 		},
+		{
+			name: "whole series, with max int64 timestamp",
+			inputArrays: []*cursors.IntegerArray{
+				{
+					Timestamps: []int64{math.MaxInt64},
+					Values:     []int64{0},
+				},
+			},
+			want: []*cursors.IntegerArray{
+				{
+					Timestamps: []int64{math.MaxInt64},
+					Values:     []int64{1},
+				},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -313,7 +328,7 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 					return &cursors.IntegerArray{}
 				},
 			}
-			countArrayCursor := newIntegerIntegerWindowCountArrayCursor(mc, int64(tc.every))
+			countArrayCursor := newIntegerWindowCountArrayCursor(mc, int64(tc.every))
 			got := make([]*cursors.IntegerArray, 0, len(tc.want))
 			for a := countArrayCursor.Next(); a.Len() != 0; a = countArrayCursor.Next() {
 				got = append(got, copyIntegerArray(a))
@@ -327,7 +342,7 @@ func TestIntegerIntegerCountArrayCursor(t *testing.T) {
 }
 
 func TestNewCountArrayCursor(t *testing.T) {
-	want := &integerIntegerWindowCountArrayCursor{
+	want := &integerWindowCountArrayCursor{
 		IntegerArrayCursor: &MockIntegerArrayCursor{},
 		res:                cursors.NewIntegerArrayLen(1),
 		tmp:                &cursors.IntegerArray{},
@@ -335,14 +350,14 @@ func TestNewCountArrayCursor(t *testing.T) {
 
 	got := newCountArrayCursor(&MockIntegerArrayCursor{})
 
-	if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+	if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowCountArrayCursor{})); diff != "" {
 		t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 	}
 }
 
 func TestNewWindowCountArrayCursor(t *testing.T) {
 	t.Run("hour window", func(t *testing.T) {
-		want := &integerIntegerWindowCountArrayCursor{
+		want := &integerWindowCountArrayCursor{
 			IntegerArrayCursor: &MockIntegerArrayCursor{},
 			every:              int64(time.Hour),
 			res:                cursors.NewIntegerArrayLen(MaxPointsPerBlock),
@@ -354,13 +369,13 @@ func TestNewWindowCountArrayCursor(t *testing.T) {
 		}
 		got := newWindowCountArrayCursor(&MockIntegerArrayCursor{}, req)
 
-		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowCountArrayCursor{})); diff != "" {
 			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 		}
 	})
 
 	t.Run("count whole series", func(t *testing.T) {
-		want := &integerIntegerWindowCountArrayCursor{
+		want := &integerWindowCountArrayCursor{
 			IntegerArrayCursor: &MockIntegerArrayCursor{},
 			every:              0,
 			res:                cursors.NewIntegerArrayLen(1),
@@ -372,7 +387,7 @@ func TestNewWindowCountArrayCursor(t *testing.T) {
 		}
 		got := newWindowCountArrayCursor(&MockIntegerArrayCursor{}, req)
 
-		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerIntegerWindowCountArrayCursor{})); diff != "" {
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowCountArrayCursor{})); diff != "" {
 			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 		}
 	})


### PR DESCRIPTION
This is the first part of a refactoring that makes merges code `integer<type>WindowCountArrayCursor` with `integer<type>CountArrayCursor`. The intent here is that we only want to have to implement aggregate functions in cursors one time (e.g., first, last, max, min) rather than have to implement them once for windowed aggregation and once for aggregation over a whole range. This will let us more easily push down new aggregate functions moving forward.

I also refactored the code in `integer<type>WindowCountArrayCursor` to send out arrays no larger than `MaxPointsPerBlock` (1000) so that we get bounded memory usage and better streaming properties.

This is all part of the issue influxdata/flux#2855. This just handles `count`.  I will do `sum` in a separate PR.
