### PR TITLE
feat: add communityTemplate feature flag and put copypasted container in it

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -28,6 +28,14 @@
   contact: Gavin Cabbage
   lifetime: permanent
 
+- name: Community Templates
+  description: Replace current template uploading functionality with community driven templates
+  key: communityTemplates
+  default: false
+  expose: true
+  contact: Bucky, Johnny Steenbergen (Berg)
+  lifetime: permanent
+
 - name: Frontend Example
   description: A temporary frontend example integer flag
   key: frontendExample

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -30,6 +30,20 @@ func BackendExample() BoolFlag {
 	return backendExample
 }
 
+var communityTemplates = MakeBoolFlag(
+	"Community Templates",
+	"communityTemplates",
+	"Bucky, Johnny Steenbergen (Berg)",
+	false,
+	Permanent,
+	true,
+)
+
+// CommunityTemplates - Replace current template uploading functionality with community driven templates
+func CommunityTemplates() BoolFlag {
+	return communityTemplates
+}
+
 var frontendExample = MakeIntFlag(
 	"Frontend Example",
 	"frontendExample",
@@ -131,6 +145,7 @@ func NewLabelPackage() BoolFlag {
 var all = []Flag{
 	appMetrics,
 	backendExample,
+	communityTemplates,
 	frontendExample,
 	pushDownWindowAggregateCount,
 	pushDownWindowAggregateRest,
@@ -143,6 +158,7 @@ var all = []Flag{
 var byKey = map[string]Flag{
 	"appMetrics":                   appMetrics,
 	"backendExample":               backendExample,
+	"communityTemplates":           communityTemplates,
 	"frontendExample":              frontendExample,
 	"pushDownWindowAggregateCount": pushDownWindowAggregateCount,
 	"pushDownWindowAggregateRest":  pushDownWindowAggregateRest,

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -48,6 +48,7 @@ import NewVEO from 'src/dashboards/components/NewVEO'
 import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage'
 import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
+import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
 import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
 import ClientCSharpOverlay from 'src/clientLibraries/components/ClientCSharpOverlay'
@@ -423,27 +424,51 @@ class Root extends PureComponent {
                                   component={UpdateVariableOverlay}
                                 />
                               </Route>
-                              <Route
-                                path="templates"
-                                component={TemplatesIndex}
-                              >
+                              {isFlagEnabled('communityTemplates') ? (
                                 <Route
-                                  path="import"
-                                  component={TemplateImportOverlay}
-                                />
+                                  path="templates"
+                                  component={CommunityTemplatesIndex}
+                                >
+                                  <Route
+                                    path="import"
+                                    component={TemplateImportOverlay}
+                                  />
+                                  <Route
+                                    path=":id/export"
+                                    component={TemplateExportOverlay}
+                                  />
+                                  <Route
+                                    path=":id/view"
+                                    component={TemplateViewOverlay}
+                                  />
+                                  <Route
+                                    path=":id/static/view"
+                                    component={StaticTemplateViewOverlay}
+                                  />
+                                </Route>
+                              ) : (
                                 <Route
-                                  path=":id/export"
-                                  component={TemplateExportOverlay}
-                                />
-                                <Route
-                                  path=":id/view"
-                                  component={TemplateViewOverlay}
-                                />
-                                <Route
-                                  path=":id/static/view"
-                                  component={StaticTemplateViewOverlay}
-                                />
-                              </Route>
+                                  path="templates"
+                                  component={TemplatesIndex}
+                                >
+                                  <Route
+                                    path="import"
+                                    component={TemplateImportOverlay}
+                                  />
+                                  <Route
+                                    path=":id/export"
+                                    component={TemplateExportOverlay}
+                                  />
+                                  <Route
+                                    path=":id/view"
+                                    component={TemplateViewOverlay}
+                                  />
+                                  <Route
+                                    path=":id/static/view"
+                                    component={StaticTemplateViewOverlay}
+                                  />
+                                </Route>
+                              )}
                               <Route path="labels" component={LabelsIndex} />
                               <Route path="about" component={OrgProfilePage}>
                                 <Route

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -1,0 +1,65 @@
+import React, {Component} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
+
+// Components
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {Page} from '@influxdata/clockface'
+import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
+import SettingsHeader from 'src/settings/components/SettingsHeader'
+import TemplatesPage from 'src/templates/components/TemplatesPage'
+import GetResources from 'src/resources/components/GetResources'
+
+// Utils
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {getOrg} from 'src/organizations/selectors'
+
+// Types
+import {AppState, Organization, ResourceType} from 'src/types'
+
+interface StateProps {
+  org: Organization
+}
+
+type Props = WithRouterProps & StateProps
+
+@ErrorHandling
+class CTI extends Component<Props> {
+  componentDidMount() {
+    // eslint-disable-next-line no-console
+    console.log('CommunityTemplatesIndex - the flag is working')
+  }
+
+  public render() {
+    const {org, children} = this.props
+    return (
+      <>
+        <Page titleTag={pageTitleSuffixer(['Templates', 'Settings'])}>
+          <SettingsHeader />
+          <SettingsTabbedPage activeTab="templates" orgID={org.id}>
+            <GetResources resources={[ResourceType.Templates]}>
+              <TemplatesPage onImport={this.handleImport} />
+            </GetResources>
+          </SettingsTabbedPage>
+        </Page>
+        {children}
+      </>
+    )
+  }
+
+  private handleImport = () => {
+    const {router, org} = this.props
+    router.push(`/orgs/${org.id}/settings/templates/import`)
+  }
+}
+
+const mstp = (state: AppState): StateProps => {
+  return {
+    org: getOrg(state),
+  }
+}
+
+export const CommunityTemplatesIndex = connect<StateProps, {}, {}>(
+  mstp,
+  null
+)(withRouter<{}>(CTI))


### PR DESCRIPTION
Closes #18238

Adds a feature flag and a simple copy-pasta component that logs that it's a flagged component and puts that nearly identical component behind the flag.

This is the foundational work for the whole of the Community Templates MVP work. If it looks like a copy/paste job, that's because that's the intent of it! We want this to carry as little risk as possible while we build confidence in the feature flag we've set up. If I managed to set up the flags incorrectly, the worst that will happen is a user will have a statement logged to their console. Once this gets out to prod and we confirm the flagging works the way we expect, we'll start in on the radical changes.

### Testing Instructions
* Run the binary with the following command:
    ```sh
    go run ./cmd/influxd/ --assets-path=ui/build --feature-flags=communityTemplates=true
    ```
* Start the frontend normally
* Go to Settings -> Templates
* you should see `CommunityTemplatesIndex - the flag is working` in the console.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
