### PR TITLE
fix(metric): enable metrics collection for requests call count in RED client

### DIFF
--- a/kit/metric/client.go
+++ b/kit/metric/client.go
@@ -56,7 +56,7 @@ func New(reg prometheus.Registerer, service string) *REDClient {
 func (c *REDClient) Record(method string) func(error) error {
 	start := time.Now()
 	return func(err error) error {
-		c.reqs.With(prometheus.Labels{"method": method})
+		c.reqs.With(prometheus.Labels{"method": method}).Inc()
 
 		if err != nil {
 			c.errs.With(prometheus.Labels{


### PR DESCRIPTION
found this issue trying to find metrics in data explorer. We never captured the reqs metrics until we add the `Inc` call.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass