### PR TITLE
feat: remove auto refresh from cloud instances

### DIFF
--- a/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -18,6 +18,7 @@ import autoRefreshOptions, {
 
 // Types
 import {AutoRefresh, AutoRefreshStatus} from 'src/types'
+import {CLOUD} from 'src/shared/constants'
 
 const DROPDOWN_WIDTH_COLLAPSED = 50
 const DROPDOWN_WIDTH_FULL = 84
@@ -46,6 +47,9 @@ export default class AutoRefreshDropdown extends Component<Props> {
   }
 
   public render() {
+    if (CLOUD) {
+      return false
+    }
     return (
       <div className={this.className}>
         <Dropdown

--- a/ui/src/utils/AutoRefresher.ts
+++ b/ui/src/utils/AutoRefresher.ts
@@ -1,3 +1,5 @@
+import {CLOUD} from 'src/shared/constants'
+
 type func = (...args: any[]) => any
 
 export class AutoRefresher {
@@ -35,6 +37,9 @@ export class AutoRefresher {
   }
 
   private refresh = () => {
+    if (CLOUD) {
+      return
+    }
     this.subscribers.forEach(fn => fn())
   }
 }


### PR DESCRIPTION
Closes influxdata/idpe#7409

this... removes the autorefresh interaction, and... stops sending data for client instances that already have auto refresh set up on their local state