### PR TITLE
fix(ui): ensure bold cell note text is legible in light mode dashboards

### DIFF
--- a/ui/src/dashboards/components/DashboardLightMode.scss
+++ b/ui/src/dashboards/components/DashboardLightMode.scss
@@ -37,7 +37,7 @@
     background-color: $c-pool;
   }
 
-  .cell--context  {
+  .cell--context {
     color: $g13-mist;
   }
   .cell:hover .cell--context {
@@ -61,6 +61,10 @@
 
   .markdown-format {
     color: $g7-graphite;
+
+    strong {
+      color: $g6-smoke;
+    }
 
     code {
       background-color: $g19-ghost;


### PR DESCRIPTION
Before:
![Screen Shot 2020-06-04 at 2 32 14 PM](https://user-images.githubusercontent.com/2433762/83812463-705e5600-a670-11ea-8782-8f6a9986c38e.png)

After:
![Screen Shot 2020-06-04 at 2 32 30 PM](https://user-images.githubusercontent.com/2433762/83812475-76543700-a670-11ea-8d02-0116437542ae.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
