### PR TITLE
chore(pkger): fixup tracing span creation

### DIFF
--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -22,19 +22,19 @@ func MWTracing() SVCMiddleware {
 var _ SVC = (*traceMW)(nil)
 
 func (s *traceMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (Stack, error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "InitStack")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
 func (s *traceMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "DeleteStack")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
 func (s *traceMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "ExportStack")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogFields(log.String("org_id", orgID.String()))
 	span.LogFields(log.String("stack_id", stackID.String()))
 	defer span.Finish()
@@ -42,7 +42,7 @@ func (s *traceMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (
 }
 
 func (s *traceMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "ListStacks")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	stacks, err := s.next.ListStacks(ctx, orgID, f)
@@ -54,20 +54,20 @@ func (s *traceMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilte
 }
 
 func (s *traceMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (pkg *Pkg, err error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "CreatePkg")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	return s.next.CreatePkg(ctx, setters...)
 }
 
 func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "DryRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
 	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
 }
 
 func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
-	span, ctx := tracing.StartSpanFromContextWithOperationName(ctx, "Apply")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
 	return s.next.Apply(ctx, orgID, userID, pkg, opts...)


### PR DESCRIPTION
fallback to using the package.method(type).additional format.  The default is far superior than the one off names.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass