### PR TITLE
feat: adding helper text to cells

### DIFF
--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -74,6 +74,11 @@ export const NotebookProvider: FC = ({children}) => {
           return pipes.slice()
         }
       }
+
+      if(pipe.type === 'query' && pipes.filter(p => p.type === 'query').length) {
+          pipe.queries[0].text = '// tip: use the __PREVIOUS_RESULT__ variable to link your queries\n\n' + pipe.queries[0].text
+      }
+
       if (pipes.length && pipe.type !== 'query') {
         _setResults(add({...results[results.length - 1]}))
         _setMeta(

--- a/ui/src/notebooks/context/notebook.tsx
+++ b/ui/src/notebooks/context/notebook.tsx
@@ -75,8 +75,13 @@ export const NotebookProvider: FC = ({children}) => {
         }
       }
 
-      if(pipe.type === 'query' && pipes.filter(p => p.type === 'query').length) {
-          pipe.queries[0].text = '// tip: use the __PREVIOUS_RESULT__ variable to link your queries\n\n' + pipe.queries[0].text
+      if (
+        pipe.type === 'query' &&
+        pipes.filter(p => p.type === 'query').length
+      ) {
+        pipe.queries[0].text =
+          '// tip: use the __PREVIOUS_RESULT__ variable to link your queries\n\n' +
+          pipe.queries[0].text
       }
 
       if (pipes.length && pipe.type !== 'query') {


### PR DESCRIPTION

![Kapture 2020-06-05 at 9 52 55](https://user-images.githubusercontent.com/1434802/83903677-6c374480-a713-11ea-8790-acdcd8538839.gif)

Just adds a little context aware helper test for notebooks so that the user can learn about linking queries together. the location of the code feels a bit weird, but it's because notebooks are allowed to know about queries, but queries arent allowed to know about notebooks. maybe there needs to be an "onAdd" function that gets added to a notebook specific register function? it all gets a little spicy too quick