### PR TITLE
feat: Dashboards maintain sort order after navigating away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [18344](https://github.com/influxdata/influxdb/pull/18344): Extend influx CLI with version and User-Agent.
 1. [18355](https://github.com/influxdata/influxdb/pull/18355): Integrate RedirectTo functionality so CLOUD users now get navigated back to the originally linked page after login
 1. [18392](https://github.com/influxdata/influxdb/pull/18392): Consolidate pkg influx commands under templates. This removes some nesting of the CLI commands as part of that.
+1. [18400](https://github.com/influxdata/influxdb/pull/18400): Dashboards maintain sort order after navigating away
 
 ### Bug Fixes
 

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -32,6 +32,9 @@ import {
   Permission,
   PermissionResource,
 } from '@influxdata/influx'
+import {SortTypes} from 'src/shared/utils/sort'
+import {Sort} from '@influxdata/clockface'
+import {DashboardSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 export const links: Links = {
   authorizations: '/api/v2/authorizations',
@@ -147,6 +150,12 @@ export const query = {
   shifts: [],
 }
 
+const defaultSortOptions = {
+  sortDirection: Sort.Ascending,
+  sortType: SortTypes.String,
+  sortKey: 'name' as DashboardSortKey,
+}
+
 // Dashboards
 export const dashboard: Dashboard = {
   id: '1',
@@ -163,6 +172,7 @@ export const dashboard: Dashboard = {
   },
   labels: [],
   status: RemoteDataState.Done,
+  sortOptions: defaultSortOptions,
 }
 
 export const labels: Label[] = [
@@ -203,6 +213,7 @@ export const dashboardWithLabels: Dashboard = {
   },
   status: RemoteDataState.Done,
   labels: labelIDs,
+  sortOptions: defaultSortOptions,
 }
 
 export const cell: Cell = {

--- a/ui/src/dashboards/actions/creators.ts
+++ b/ui/src/dashboards/actions/creators.ts
@@ -1,5 +1,9 @@
 // Types
-import {RemoteDataState, DashboardEntities} from 'src/types'
+import {
+  RemoteDataState,
+  DashboardEntities,
+  DashboardSortParams,
+} from 'src/types'
 import {NormalizedSchema} from 'normalizr'
 import {setLabelOnResource} from 'src/labels/actions/creators'
 
@@ -10,6 +14,7 @@ export const REMOVE_DASHBOARD = 'REMOVE_DASHBOARD'
 export const REMOVE_DASHBOARD_LABEL = 'REMOVE_DASHBOARD_LABEL'
 export const SET_DASHBOARD = 'SET_DASHBOARD'
 export const SET_DASHBOARDS = 'SET_DASHBOARDS'
+export const SET_DASHBOARD_SORT = 'SET_DASHBOARD_SORT'
 
 export type Action =
   | ReturnType<typeof editDashboard>
@@ -18,6 +23,7 @@ export type Action =
   | ReturnType<typeof setDashboard>
   | ReturnType<typeof setDashboards>
   | ReturnType<typeof setLabelOnResource>
+  | ReturnType<typeof setDashboardSort>
 
 // R is the type of the value of the "result" key in normalizr's normalization
 type DashboardSchema<R extends string | string[]> = NormalizedSchema<
@@ -40,6 +46,12 @@ export const setDashboards = (
     type: SET_DASHBOARDS,
     status,
     schema,
+  } as const)
+
+export const setDashboardSort = (sortOptions: DashboardSortParams) =>
+  ({
+    type: SET_DASHBOARD_SORT,
+    sortOptions,
   } as const)
 
 export const setDashboard = (

--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -6,6 +6,10 @@ import {Cell, Dashboard, RemoteDataState} from 'src/types'
 import {DecimalPlaces} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
+import {SortTypes} from 'src/shared/utils/sort'
+import {Sort} from '@influxdata/clockface'
+import {DashboardSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
+
 export const UNTITLED_GRAPH: string = 'Untitled Graph'
 
 export const DEFAULT_DECIMAL_PLACES: DecimalPlaces = {
@@ -68,11 +72,18 @@ export type EmptyDefaultDashboard = Pick<
   cells: NewDefaultCell[]
 }
 
+export const DEFAULT_DASHBOARD_SORT_OPTIONS = {
+  sortDirection: Sort.Ascending,
+  sortType: SortTypes.String,
+  sortKey: 'name' as DashboardSortKey,
+}
+
 export const EMPTY_DASHBOARD: EmptyDefaultDashboard = {
   id: '0',
   name: '',
   cells: [NEW_DEFAULT_DASHBOARD_CELL],
   status: RemoteDataState.Done,
+  sortOptions: DEFAULT_DASHBOARD_SORT_OPTIONS,
 }
 
 export const DashboardTemplate: EmptyDefaultDashboard = {
@@ -80,6 +91,7 @@ export const DashboardTemplate: EmptyDefaultDashboard = {
   name: 'Create a New Dashboard',
   cells: [],
   status: RemoteDataState.Done,
+  sortOptions: DEFAULT_DASHBOARD_SORT_OPTIONS,
 }
 
 type NewDefaultDashboard = Pick<

--- a/ui/src/dashboards/reducers/dashboards.ts
+++ b/ui/src/dashboards/reducers/dashboards.ts
@@ -13,6 +13,7 @@ import {
 import {
   Action,
   SET_DASHBOARD,
+  SET_DASHBOARD_SORT,
   REMOVE_DASHBOARD,
   SET_DASHBOARDS,
   REMOVE_DASHBOARD_LABEL,
@@ -35,12 +36,15 @@ import {
   setRelation,
 } from 'src/resources/reducers/helpers'
 
+import {DEFAULT_DASHBOARD_SORT_OPTIONS} from 'src/dashboards/constants'
+
 type DashboardsState = ResourceState['dashboards']
 
 const initialState = () => ({
   byID: {},
   allIDs: [],
   status: RemoteDataState.NotStarted,
+  sortOptions: DEFAULT_DASHBOARD_SORT_OPTIONS,
 })
 
 export const dashboardsReducer = (
@@ -63,6 +67,14 @@ export const dashboardsReducer = (
 
       case SET_DASHBOARD: {
         setResourceAtID<Dashboard>(draftState, action, ResourceType.Dashboards)
+
+        return
+      }
+
+      case SET_DASHBOARD_SORT: {
+        const {sortOptions} = action
+
+        draftState['sortOptions'] = sortOptions
 
         return
       }

--- a/ui/src/dashboards/resources.ts
+++ b/ui/src/dashboards/resources.ts
@@ -9,6 +9,8 @@ import {
   RemoteDataState,
 } from 'src/types'
 
+import {DEFAULT_DASHBOARD_SORT_OPTIONS} from 'src/dashboards/constants'
+
 export const dbCell: Cell = {
   x: 1,
   y: 2,
@@ -34,6 +36,7 @@ export const dashboard: Dashboard = {
     self: '/v2/dashboards/1',
     cells: '/v2/dashboards/cells',
   },
+  sortOptions: DEFAULT_DASHBOARD_SORT_OPTIONS,
 }
 
 export const axes: Axes = {

--- a/ui/src/shared/utils/mocks/resourceToTemplate.ts
+++ b/ui/src/shared/utils/mocks/resourceToTemplate.ts
@@ -7,6 +7,8 @@ import {
   RemoteDataState,
 } from 'src/types'
 
+import {DEFAULT_DASHBOARD_SORT_OPTIONS} from 'src/dashboards/constants'
+
 export const myCell = {
   dashboardID: 'dash_1',
   id: 'cell_view_1',
@@ -25,6 +27,7 @@ export const myDashboard: Dashboard = {
   cells: [myCell.id],
   labels: [],
   status: RemoteDataState.NotStarted,
+  sortOptions: DEFAULT_DASHBOARD_SORT_OPTIONS,
 }
 
 export const myView: View = {

--- a/ui/src/types/dashboards.ts
+++ b/ui/src/types/dashboards.ts
@@ -7,12 +7,24 @@ import {
   BuilderConfig,
 } from 'src/client'
 import {RemoteDataState} from 'src/types'
+import {Sort} from '@influxdata/clockface'
+import {SortTypes} from 'src/shared/utils/sort'
+import {DashboardSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 export type FieldOption = RenamableField
 
 export interface SortOptions {
   field: string
   direction: string
+}
+
+export {Sort} from '@influxdata/clockface'
+export {SortTypes} from 'src/shared/utils/sort'
+
+export interface DashboardSortParams {
+  sortDirection: Sort
+  sortType: SortTypes
+  sortKey: DashboardSortKey
 }
 
 export interface DashboardDraftQuery extends DashboardQuery {
@@ -34,6 +46,7 @@ export interface Dashboard extends Omit<GenDashboard, 'cells' | 'labels'> {
   cells: string[]
   labels: string[]
   status: RemoteDataState
+  sortOptions: DashboardSortParams
 }
 
 export type Omit<K, V> = Pick<K, Exclude<keyof K, V>>


### PR DESCRIPTION
Closes #15292

Dashboard page remembers sort order when you go to a different page–does not save across page reloads.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass
