### PR TITLE
tests(launcher): add a launcher test for read window aggregate push down

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	nethttp "net/http"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/lang"
@@ -743,5 +745,97 @@ from(bucket: "%s")
 	// Make sure that the data we stored matches the CSV
 	if err := executetest.EqualResultIterators(csvResultIterator, fromResultIterator); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestLauncher_Query_PushDownWindowAggregate(t *testing.T) {
+	l := launcher.RunTestLauncherOrFail(t, ctx,
+		"--feature-flags", "pushDownWindowAggregateCount=true")
+	l.SetupOrFail(t)
+	defer l.ShutdownOrFail(t, ctx)
+
+	l.WritePointsOrFail(t, `
+m0,k=k0 f=0i 0
+m0,k=k0 f=1i 1000000000
+m0,k=k0 f=2i 2000000000
+m0,k=k0 f=3i 3000000000
+m0,k=k0 f=4i 4000000000
+m0,k=k0 f=5i 5000000000
+m0,k=k0 f=6i 6000000000
+m0,k=k0 f=5i 7000000000
+m0,k=k0 f=0i 8000000000
+m0,k=k0 f=6i 9000000000
+m0,k=k0 f=6i 10000000000
+m0,k=k0 f=7i 11000000000
+m0,k=k0 f=5i 12000000000
+m0,k=k0 f=8i 13000000000
+m0,k=k0 f=9i 14000000000
+m0,k=k0 f=5i 15000000000
+`)
+
+	getReadRequestCount := func() uint64 {
+		const metricName = "query_influxdb_source_read_request_duration_seconds"
+		mf := l.Metrics(t)[metricName]
+		if mf != nil {
+			for _, m := range mf.Metric {
+				for _, label := range m.Label {
+					if label.GetName() == "op" && label.GetValue() == "readWindowAggregate" {
+						return m.Histogram.GetSampleCount()
+					}
+				}
+			}
+		}
+		return 0
+	}
+
+	for _, tt := range []struct {
+		name string
+		q    string
+		res  string
+	}{
+		{
+			name: "count",
+			q: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
+	|> aggregateWindow(every: 5s, fn: count)
+	|> drop(columns: ["_start", "_stop"])
+`,
+			res: `
+#datatype,string,long,long,string,string,string,dateTime:RFC3339
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_value,_field,_measurement,k,_time
+,,0,5,f,m0,k0,1970-01-01T00:00:05Z
+,,0,5,f,m0,k0,1970-01-01T00:00:10Z
+,,0,5,f,m0,k0,1970-01-01T00:00:15Z
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wantCount := getReadRequestCount() + 1
+
+			prelude := fmt.Sprintf("v = {bucket: \"%s\", timeRangeStart: 1970-01-01T00:00:00Z, timeRangeStop: 1970-01-01T00:00:15Z}", l.Bucket.Name)
+			queryStr := prelude + "\n" + tt.q
+			res := l.MustExecuteQuery(queryStr)
+			defer res.Done()
+			got := flux.NewSliceResultIterator(res.Results)
+			defer got.Release()
+
+			dec := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
+			want, err := dec.Decode(ioutil.NopCloser(strings.NewReader(tt.res)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer want.Release()
+
+			if err := executetest.EqualResultIterators(want, got); err != nil {
+				t.Fatal(err)
+			}
+
+			if want, got := wantCount, getReadRequestCount(); want != got {
+				t.Fatalf("unexpected sample count -want/+got:\n\t- %d\n\t+ %d", want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This adds a launcher test for the read window aggregate push down to
verify that it is done when a query is sent with the appropriate
pattern, the output is correct, and that the metric is incremented that
signals the push down happened.

Fixes #18184.