### PR TITLE
feat(influx): provide means to provide trace debug ids to httpc client

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -57,12 +57,15 @@ func newHTTPClient() (*httpc.Client, error) {
 		version, runtime.GOOS, commit, date,
 	)
 
-	c, err := http.NewHTTPClient(
-		flags.Host,
-		flags.Token,
-		flags.skipVerify,
+	opts := []httpc.ClientOptFn{
 		httpc.WithUserAgentHeader(userAgent),
-	)
+	}
+	// This is useful for forcing tracing on a given endpoint.
+	if flags.traceDebugID != "" {
+		opts = append(opts, httpc.WithHeader("jaeger-debug-id", flags.traceDebugID))
+	}
+
+	c, err := http.NewHTTPClient(flags.Host, flags.Token, flags.skipVerify, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +149,9 @@ func runEMiddlware(mw cobraRunEMiddleware) genericCLIOptFn {
 
 type globalFlags struct {
 	config.Config
-	local      bool
-	skipVerify bool
+	local        bool
+	skipVerify   bool
+	traceDebugID string
 }
 
 var flags globalFlags
@@ -201,6 +205,12 @@ func (b *cmdInfluxBuilder) cmd(childCmdFns ...func(f *globalFlags, opt genericCL
 			DestP:      &flags.Host,
 			Flag:       "host",
 			Desc:       "HTTP address of Influx",
+			Persistent: true,
+		},
+		{
+			DestP:      &flags.traceDebugID,
+			Flag:       "trace-debug-id",
+			Hidden:     true,
 			Persistent: true,
 		},
 	}

--- a/kit/cli/viper.go
+++ b/kit/cli/viper.go
@@ -16,6 +16,7 @@ type Opt struct {
 
 	EnvVar     string
 	Flag       string
+	Hidden     bool
 	Persistent bool
 	Required   bool
 	Short      rune // using rune b/c it guarantees correctness. a short must always be a string of length 1
@@ -177,6 +178,12 @@ func BindOptions(cmd *cobra.Command, opts []Opt) {
 			// if you get a panic here, sorry about that!
 			// anyway, go ahead and make a PR and add another type.
 			panic(fmt.Errorf("unknown destination type %t", o.DestP))
+		}
+
+		// so weirdness with the flagset her, the flag must be set before marking it
+		// hidden. This is in contrast to the MarkRequired, which can be set before...
+		if o.Hidden {
+			flagset.MarkHidden(o.Flag)
 		}
 	}
 }


### PR DESCRIPTION
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass