### PR TITLE
feat(query): register bare aggregate

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -748,7 +748,7 @@ from(bucket: "%s")
 	}
 }
 
-func TestLauncher_Query_PushDownWindowAggregate(t *testing.T) {
+func TestLauncher_Query_PushDownWindowAggregateAndBareAggregate(t *testing.T) {
 	l := launcher.RunTestLauncherOrFail(t, ctx,
 		"--feature-flags", "pushDownWindowAggregateCount=true")
 	l.SetupOrFail(t)
@@ -809,6 +809,22 @@ from(bucket: v.bucket)
 ,,0,5,f,m0,k0,1970-01-01T00:00:05Z
 ,,0,5,f,m0,k0,1970-01-01T00:00:10Z
 ,,0,5,f,m0,k0,1970-01-01T00:00:15Z
+`,
+		},
+		{
+			name: "bare count",
+			q: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
+	|> count()
+	|> drop(columns: ["_start", "_stop"])
+`,
+			res: `
+#group,false,false,false,true,true,true
+#datatype,string,long,long,string,string,string
+#default,_result,,,,,
+,result,table,_value,_field,_measurement,k
+,,0,15,f,m0,k0
 `,
 		},
 	} {

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -25,10 +25,8 @@ func init() {
 		PushDownReadTagKeysRule{},
 		PushDownReadTagValuesRule{},
 		SortedPivotRule{},
-		// For the following two rules to take effect the appropriate capabilities must be
-		// added AND feature flags must be enabled.
 		PushDownWindowAggregateRule{},
-		// PushDownBareAggregateRule{},
+		PushDownBareAggregateRule{},
 		PushDownGroupAggregateRule{},
 	)
 }
@@ -781,7 +779,7 @@ func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 type PushDownBareAggregateRule struct{}
 
 func (p PushDownBareAggregateRule) Name() string {
-	return "PushDownWindowAggregateRule"
+	return "PushDownBareAggregateRule"
 }
 
 func (p PushDownBareAggregateRule) Pattern() plan.Pattern {


### PR DESCRIPTION
This PR enables the `PushDownBareAggregateRule` and adds testing to cover `count()` as a bare aggregate. 

It also makes a small fix to `PushDownBareAggregateRule.Name()`. 