### PR TITLE
fix: guard against negative stats when non-fired events are 0

### DIFF
--- a/ui/src/cloud/utils/rum.ts
+++ b/ui/src/cloud/utils/rum.ts
@@ -34,10 +34,22 @@ export const buildFieldsFromTiming = function buildFieldsFromTiming(
   const totalServer = timing.responseEnd - timing.requestStart
 
   //  UI measurements
-  const domProcessing = timing.domComplete - timing.responseEnd
-  const domContentLoading = timing.domComplete - timing.domInteractive
-  const windowLoadEvent = timing.loadEventEnd - timing.loadEventStart
+  let domProcessing = timing.responseEnd
+  let domContentLoading = timing.domInteractive
+  let windowLoadEvent = timing.loadEventStart
 
+  // these values will be 0 if the event hasn't fired (e.g. because it's not finished) before the request is sent
+  if (timing.domComplete > 0) {
+    domProcessing = timing.domComplete - timing.responseEnd
+  }
+  if (timing.domComplete > 0) {
+    domContentLoading = timing.domComplete - timing.domInteractive
+  }
+  if (windowLoadEvent > 0) {
+    windowLoadEvent = timing.loadEventEnd - timing.loadEventStart
+  }
+
+  // tls and worker may not be set by the user agent - guard against that
   let tls = 0
   if (timing.secureConnectionStart > 0) {
     tls = timing.connectEnd - timing.secureConnectionStart


### PR DESCRIPTION
Some of the RUM metrics were reporting negative numbers.

The navigation timing api reports the times that certain events in a sequence happened. To calculate load times, later values are subtracted from earlier values to determine how long an event took. If the later event hasn't finished firing, its value will be 0, resulting in a subtraction looking like `0 - someEarlierValue` leading to a negative value for the metric.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass