### PR TITLE
fix: add support for macOS cross-compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,21 +20,36 @@ commands:
       This will install the cross compilers necessary to build release binaries.
     steps:
       - run:
-          name: Install cross compilers
+          name: Install linux cross compilers
           command: >
             sudo apt-get install -y --no-install-recommends
             gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
             gcc-aarch64-linux-gnu libc6-dev-arm64-cross
       - run:
+          name: Install macOS cross compilers
+          command: |
+            sudo apt-get install libxml2-dev libssl-dev zlib1g-dev
+            mkdir -p /opt/osxcross
+            cd /opt
+            git clone https://github.com/tpoechtrager/osxcross.git
+            cd osxcross
+            git checkout c2ad5e859d12a295c3f686a15bd7181a165bfa82
+            curl -L -o \
+              ./tarballs/MacOSX10.11.sdk.tar.xz \
+              https://macos-sdks.s3.amazonaws.com/MacOSX10.11.sdk.tar.xz
+            UNATTENDED=1 PORTABLE=true ./build.sh
+      - run:
           name: Install additional rust targets
           command: |
             rustup target add aarch64-unknown-linux-gnu \
                               arm-unknown-linux-gnueabihf \
-                              armv7-unknown-linux-gnueabihf
+                              armv7-unknown-linux-gnueabihf \
+                              x86_64-apple-darwin
             echo 'export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc' >> $HOME/.cargo/env
             echo 'export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $HOME/.cargo/env
             echo 'export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $HOME/.cargo/env
             echo 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $HOME/.cargo/env
+            echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=o64-clang' >> $HOME/.cargo/env
       - run:
           name: Install pkg-config wrapper
           command: go build -o /go/bin/pkg-config github.com/influxdata/pkg-config

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -3,10 +3,7 @@ builds:
   - id: influx
     goos:
       - linux
-      # Darwin cross compilation involves installing
-      # a compiler toolchain for it.
-      # https://github.com/influxdata/flux/issues/2654
-      # - darwin
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -16,15 +13,13 @@ builds:
       - CGO_ENABLED=1
       - CC=xcc
       - PKG_CONFIG=$GOPATH/bin/pkg-config
+      - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags: -s -w -X main.version=nightly -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: influx
   - id: influxd
     goos:
       - linux
-      # Darwin cross compilation involves installing
-      # a compiler toolchain for it.
-      # https://github.com/influxdata/flux/issues/2654
-      # - darwin
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -36,6 +31,7 @@ builds:
       - CGO_ENABLED=1
       - CC=xcc
       - PKG_CONFIG=$GOPATH/bin/pkg-config
+      - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags: -s -w -X main.version=nightly -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: influxd
     hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,10 +3,7 @@ builds:
   - id: influx
     goos:
       - linux
-    # Darwin cross compilation involves installing
-    # a compiler toolchain for it.
-    # https://github.com/influxdata/flux/issues/2654
-    # - darwin
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -16,15 +13,13 @@ builds:
       - CGO_ENABLED=1
       - CC=xcc
       - PKG_CONFIG=$GOPATH/bin/pkg-config
+      - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: influx
   - id: influxd
     goos:
       - linux
-    # Darwin cross compilation involves installing
-    # a compiler toolchain for it.
-    # https://github.com/influxdata/flux/issues/2654
-    # - darwin
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -36,6 +31,7 @@ builds:
       - CGO_ENABLED=1
       - CC=xcc
       - PKG_CONFIG=$GOPATH/bin/pkg-config
+      - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: influxd
     hooks:

--- a/xcc.sh
+++ b/xcc.sh
@@ -12,6 +12,7 @@ case "${GOOS}_${GOARCH}" in
   linux_amd64) CC=clang ;;
   linux_arm64) CC=aarch64-linux-gnu-gcc ;;
   linux_arm)   CC=arm-linux-gnueabihf-gcc ;;
+  darwin_amd64) CC=o64-clang ;;
   *) die "No cross-compiler set for ${GOOS}_${GOARCH}" ;;
 esac
 


### PR DESCRIPTION
This patch adds support for building macOS binaries via the release
system.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
