### PR TITLE
feat(cmd/influx/write): write data from url

### DIFF
--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	platform "github.com/influxdata/influxdb/v2"
-	"github.com/influxdata/influxdb/v2/http"
+	ihttp "github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/kit/signals"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/pkg/csv2lp"
@@ -28,8 +31,9 @@ type writeFlagsType struct {
 	Bucket                     string
 	Precision                  string
 	Format                     string
-	Files                      []string
 	Headers                    []string
+	Files                      []string
+	URLs                       []string
 	Debug                      bool
 	SkipRowOnError             bool
 	SkipHeader                 int
@@ -72,8 +76,9 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	}
 	opts.mustRegister(cmd)
 	cmd.PersistentFlags().StringVar(&writeFlags.Format, "format", "", "Input format, either lp (Line Protocol) or csv (Comma Separated Values). Defaults to lp unless '.csv' extension")
-	cmd.PersistentFlags().StringArrayVarP(&writeFlags.Files, "file", "f", []string{}, "The path to the file to import")
 	cmd.PersistentFlags().StringArrayVar(&writeFlags.Headers, "header", []string{}, "Header prepends lines to input data; Example --header HEADER1 --header HEADER2")
+	cmd.PersistentFlags().StringArrayVarP(&writeFlags.Files, "file", "f", []string{}, "The path to the file to import")
+	cmd.PersistentFlags().StringArrayVarP(&writeFlags.URLs, "url", "u", []string{}, "The url with data to import")
 	cmd.PersistentFlags().BoolVar(&writeFlags.Debug, "debug", false, "Log CSV columns to stderr before reading data rows")
 	cmd.PersistentFlags().BoolVar(&writeFlags.SkipRowOnError, "skipRowOnError", false, "Log CSV data errors to stderr and continue with CSV processing")
 	cmd.PersistentFlags().IntVar(&writeFlags.SkipHeader, "skipHeader", 0, "Skip the first <n> rows from input data")
@@ -98,15 +103,15 @@ func (writeFlags *writeFlagsType) dump(args []string) {
 
 // createLineReader uses writeFlags and cli arguments to create a reader that produces line protocol
 func (writeFlags *writeFlagsType) createLineReader(cmd *cobra.Command, args []string) (io.Reader, io.Closer, error) {
-	readers := make([]io.Reader, 0, 2*len(writeFlags.Headers)+2*len(writeFlags.Files)+1)
-	closers := make([]io.Closer, 0, len(writeFlags.Files))
-
 	files := writeFlags.Files
 	if len(args) > 0 && len(args[0]) > 1 && args[0][0] == '@' {
 		// backward compatibility: @ in arg denotes a file
 		files = append(files, args[0][1:])
 		args = args[:0]
 	}
+
+	readers := make([]io.Reader, 0, 2*len(writeFlags.Headers)+2*len(files)+2*len(writeFlags.URLs)+1)
+	closers := make([]io.Closer, 0, len(files)+len(writeFlags.URLs))
 
 	// validate input format
 	if len(writeFlags.Format) > 0 && writeFlags.Format != inputFormatLineProtocol && writeFlags.Format != inputFormatCsv {
@@ -139,6 +144,30 @@ func (writeFlags *writeFlagsType) createLineReader(cmd *cobra.Command, args []st
 			closers = append(closers, f)
 			readers = append(readers, decode(f), strings.NewReader("\n"))
 			if len(writeFlags.Format) == 0 && strings.HasSuffix(file, ".csv") {
+				writeFlags.Format = inputFormatCsv
+			}
+		}
+	}
+
+	// #18349 allow URL data sources, a simple alternative to `curl -f -s http://... | influx write ...`
+	if len(writeFlags.URLs) > 0 {
+		client := http.Client{Timeout: 5 * time.Minute}
+		for _, addr := range writeFlags.URLs {
+			u, err := url.Parse(addr)
+			if err != nil {
+				return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to open %q: %v", addr, err)
+			}
+			resp, err := client.Get(addr)
+			if err != nil {
+				return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to open %q: %v", addr, err)
+			}
+			closers = append(closers, resp.Body)
+			if resp.StatusCode/100 != 2 {
+				return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to open %q: response status_code=%d", addr, resp.StatusCode)
+			}
+			readers = append(readers, decode(resp.Body), strings.NewReader("\n"))
+			if len(writeFlags.Format) == 0 &&
+				(strings.HasSuffix(u.Path, ".csv") || strings.HasPrefix(resp.Header.Get("Content-Type"), "text/csv")) {
 				writeFlags.Format = inputFormatCsv
 			}
 		}
@@ -253,7 +282,7 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 
 	// write to InfluxDB
 	s := write.Batcher{
-		Service: &http.WriteService{
+		Service: &ihttp.WriteService{
 			Addr:               flags.Host,
 			Token:              flags.Token,
 			Precision:          writeFlags.Precision,

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -78,7 +78,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&writeFlags.Format, "format", "", "Input format, either lp (Line Protocol) or csv (Comma Separated Values). Defaults to lp unless '.csv' extension")
 	cmd.PersistentFlags().StringArrayVar(&writeFlags.Headers, "header", []string{}, "Header prepends lines to input data; Example --header HEADER1 --header HEADER2")
 	cmd.PersistentFlags().StringArrayVarP(&writeFlags.Files, "file", "f", []string{}, "The path to the file to import")
-	cmd.PersistentFlags().StringArrayVarP(&writeFlags.URLs, "url", "u", []string{}, "The url with data to import")
+	cmd.PersistentFlags().StringArrayVarP(&writeFlags.URLs, "url", "u", []string{}, "The URL to import data from")
 	cmd.PersistentFlags().BoolVar(&writeFlags.Debug, "debug", false, "Log CSV columns to stderr before reading data rows")
 	cmd.PersistentFlags().BoolVar(&writeFlags.SkipRowOnError, "skipRowOnError", false, "Log CSV data errors to stderr and continue with CSV processing")
 	cmd.PersistentFlags().IntVar(&writeFlags.SkipHeader, "skipHeader", 0, "Skip the first <n> rows from input data")


### PR DESCRIPTION
Closes #18349 

This PR allows using http(s) URL as a source of data for `influx write` as requested by #18349 

`influx write --help` adds:
```bash
-u, --url stringArray      The URL to import data from
```

The data format detection was also enhanced. If URL's path ends with ".csv" or the URL resource content type is `text/csv`, the input data format is assumed to be `csv`

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
