### PR TITLE
chore: permanently remove authorizations from max permissions

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -52,8 +52,6 @@ type Service struct {
 	Migrator *Migrator
 
 	urmByUserIndex *Index
-
-	disableAuthorizationsForMaxPermissions func(context.Context) bool
 }
 
 // NewService returns an instance of a Service.
@@ -85,9 +83,6 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 				return id, nil
 			},
 		), WithIndexReadPathEnabled),
-		disableAuthorizationsForMaxPermissions: func(context.Context) bool {
-			return false
-		},
 	}
 
 	// kv service migrations
@@ -274,11 +269,4 @@ func (s *Service) WithStore(store Store) {
 // Should only be used in tests for mocking.
 func (s *Service) WithSpecialOrgBucketIDs(gen influxdb.IDGenerator) {
 	s.OrgBucketIDs = gen
-}
-
-// WithMaxPermissionFunc sets the useAuthorizationsForMaxPermissions function
-// which can trigger whether or not max permissions uses the users authorizations
-// to derive maximum permissions.
-func (s *Service) WithMaxPermissionFunc(fn func(context.Context) bool) {
-	s.disableAuthorizationsForMaxPermissions = fn
 }

--- a/kv/session.go
+++ b/kv/session.go
@@ -141,20 +141,8 @@ func (s *Service) maxPermissions(ctx context.Context, tx Tx, userID influxdb.ID)
 
 		ps = append(ps, p...)
 	}
-	ps = append(ps, influxdb.MePermissions(userID)...)
 
-	if !s.disableAuthorizationsForMaxPermissions(ctx) {
-		// TODO(desa): this is super expensive, we should keep a list of a users maximal privileges somewhere
-		// we did this so that the oper token would be used in a users permissions.
-		af := influxdb.AuthorizationFilter{UserID: &userID}
-		as, err := s.findAuthorizations(ctx, tx, af)
-		if err != nil {
-			return nil, err
-		}
-		for _, a := range as {
-			ps = append(ps, a.Permissions...)
-		}
-	}
+	ps = append(ps, influxdb.MePermissions(userID)...)
 
 	return ps, nil
 }


### PR DESCRIPTION
This is a clean-up PR.

I have built influxd locally and I don't think we need this now.
It was left in for OSS, under the speculation that something depended on it. It was suspected for bootstrapping a new cluster. However, I have managed to bootstrap a cluster with no problems and gone on to use the app successfully.

UPDATE:

There is a test using the initial users session to do an API call to perform a privileged action (create a user). Instead of using the onboarded initial users magical access all areas token.

So the question is... does this user really need those permissions in its session (not token)?
Since I don't believe any of the UI based operations allow this kind of management anyway.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
