### PR TITLE
chore(gitignore): Re-order exclusion patterns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,23 +75,23 @@ cmd/influxd/version.go
 
 *.test
 
-!**/influx_tsm/
 **/influx_tsm
+!**/influx_tsm/
 
-!**/influx_stress/
 **/influx_stress
+!**/influx_stress/
 
-!**/influxd/
 **/influxd
+!**/influxd/
 
-!**/influx/
 **/influx
+!**/influx/
 
-!**/influxdb/
 **/influxdb
+!**/influxdb/
 
-!**/influx_inspect/
 **/influx_inspect
+!**/influx_inspect/
 
 /benchmark-tool
 /main


### PR DESCRIPTION
My original PR influxdata/influxdb#18207 attempted to address the aggressiveness of our `.gitignore` matches for known binary names.

Unfortunately, new directories with these names are now being ignored when they shouldn't (thanks @jsternberg). Upon further investigation, it looks like the only problematic patterns in the original code were the plain (non-globbed) patterns like `influxd` and `influxdb`.

Returning the globbed patterns to their original order fixes the problem while still holding onto the characteristic of being able to see directories like `cmd/influxd/launcher` via tools that use `.gitignore` for exclusion patterns. Below is an overview of how I've verified the changes.

Regular files matching know binary names should be ignored anywhere in the tree:

    $ echo "hello" > influxd
    $ echo "hello" > dbrp/influxd
    $ git status
    ## bb/reorder-exclusion

Directories matching known binary names should **not** be ignored anywhere in the tree:

    $ mkdir influxd
    $ echo "hello" > influxd/hello.txt
    $ mkdir dbrp/influxd
    $ echo "hello" > dbrp/influxd/hello.txt
    $ git status
    ## bb/reorder-exclusion
    ?? dbrp/influxd/
    ?? influxd/
    $ git status --untracked-files
    ## bb/reorder-exclusion
    ?? dbrp/influxd/hello.txt
    ?? influxd/hello.txt

New files in existing directories matching known binary names should **not** be ignored:

    $ echo "hello" > cmd/influx/hello.txt
    $ git status
    ## bb/reorder-exclusion
    ?? cmd/influx/hello.txt

I've also made changes to already indexed files like `cmd/influxd/launcher/engine.go` and those changes aren't ignored.