### PR TITLE
feat(pkger): extend SummaryBucket with its env references

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7894,6 +7894,24 @@ components:
                 type: string
           spec:
             type: object
+    PkgEnvReferences:
+      type: array
+      items:
+        type: object
+        properties:
+          resourceField:
+            type: string
+            description: Field the environment reference corresponds too
+          envRefKey:
+            type: string
+            description: Key identified as environment reference and is the key identified in the template
+          value:
+            type: string
+            description: Value provided to fulfill reference
+          defaultValue:
+            type: string
+            description: Default value that will be provided for the reference when no value is provided
+        required: [resourceField, envRefKey, defaultValue]
     PkgSummary:
       type: object
       properties:
@@ -7923,6 +7941,8 @@ components:
                     type: array
                     items:
                       $ref: "#/components/schemas/PkgSummaryLabel"
+                  envReferences:
+                    $ref: "#/components/schemas/PkgEnvReferences"
             checks:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -434,8 +434,9 @@ type SummaryBucket struct {
 	PkgName     string `json:"pkgName"`
 	Description string `json:"description"`
 	// TODO: return retention rules?
-	RetentionPeriod   time.Duration  `json:"retentionPeriod"`
-	LabelAssociations []SummaryLabel `json:"labelAssociations"`
+	RetentionPeriod   time.Duration      `json:"retentionPeriod"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
+	EnvReferences     []SummaryReference `json:"envReferences"`
 }
 
 // SummaryCheck provides a summary of a pkg check.
@@ -609,6 +610,15 @@ type SummaryLabelMapping struct {
 	LabelPkgName    string                `json:"labelPkgName"`
 	LabelName       string                `json:"labelName"`
 	LabelID         SafeID                `json:"labelID"`
+}
+
+// SummaryReference informs the consumer of required references for
+// this resource.
+type SummaryReference struct {
+	Field        string `json:"resourceField"`
+	EnvRefKey    string `json:"envRefKey"`
+	Value        string `json:"value"`
+	DefaultValue string `json:"defaultValue"`
 }
 
 // SummaryTask provides a summary of a task.

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -32,6 +32,7 @@ func TestParse(t *testing.T) {
 					Description:       "bucket 1 description",
 					RetentionPeriod:   time.Hour,
 					LabelAssociations: []SummaryLabel{},
+					EnvReferences:     []SummaryReference{},
 				}
 				assert.Equal(t, expectedBucket, actual)
 
@@ -41,12 +42,40 @@ func TestParse(t *testing.T) {
 					Name:              "display name",
 					Description:       "bucket 2 description",
 					LabelAssociations: []SummaryLabel{},
+					EnvReferences:     []SummaryReference{},
 				}
 				assert.Equal(t, expectedBucket, actual)
 			})
 		})
 
-		t.Run("handles bad config", func(t *testing.T) {
+		t.Run("with env refs should be valid", func(t *testing.T) {
+			testfileRunner(t, "testdata/bucket_ref.yml", func(t *testing.T, pkg *Pkg) {
+				buckets := pkg.Summary().Buckets
+				require.Len(t, buckets, 1)
+
+				actual := buckets[0]
+				expectedBucket := SummaryBucket{
+					PkgName:           "env-meta-name",
+					Name:              "env-spec-name",
+					LabelAssociations: []SummaryLabel{},
+					EnvReferences: []SummaryReference{
+						{
+							Field:        "metadata.name",
+							EnvRefKey:    "meta-name",
+							DefaultValue: "env-meta-name",
+						},
+						{
+							Field:        "spec.name",
+							EnvRefKey:    "spec-name",
+							DefaultValue: "env-spec-name",
+						},
+					},
+				}
+				assert.Equal(t, expectedBucket, actual)
+			})
+		})
+
+		t.Run("should handle bad config", func(t *testing.T) {
 			tests := []testPkgResourceError{
 				{
 					name:           "missing name",
@@ -3648,6 +3677,7 @@ spec:
 				Description:       "desc_1",
 				RetentionPeriod:   10000 * time.Second,
 				LabelAssociations: labels,
+				EnvReferences:     []SummaryReference{},
 			},
 			{
 				PkgName:           "rucket-2",
@@ -3655,6 +3685,7 @@ spec:
 				Description:       "desc-2",
 				RetentionPeriod:   20000 * time.Second,
 				LabelAssociations: labels,
+				EnvReferences:     []SummaryReference{},
 			},
 			{
 				PkgName:           "rucket-3",
@@ -3662,6 +3693,7 @@ spec:
 				Description:       "desc_3",
 				RetentionPeriod:   30000 * time.Second,
 				LabelAssociations: labels,
+				EnvReferences:     []SummaryReference{},
 			},
 		}
 		assert.Equal(t, bkts, sum.Buckets)

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -506,6 +506,7 @@ func TestService(t *testing.T) {
 						Description:       "bucket 1 description",
 						RetentionPeriod:   time.Hour,
 						LabelAssociations: []SummaryLabel{},
+						EnvReferences:     []SummaryReference{},
 					}
 					assert.Contains(t, sum.Buckets, expected)
 				})
@@ -557,6 +558,7 @@ func TestService(t *testing.T) {
 						Description:       "bucket 1 description",
 						RetentionPeriod:   time.Hour,
 						LabelAssociations: []SummaryLabel{},
+						EnvReferences:     []SummaryReference{},
 					}
 					assert.Contains(t, sum.Buckets, expected)
 					assert.Zero(t, fakeBktSVC.CreateBucketCalls.Count())

--- a/pkger/testdata/bucket_ref.yml
+++ b/pkger/testdata/bucket_ref.yml
@@ -1,0 +1,10 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Bucket
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name


### PR DESCRIPTION
references: #18407 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)