### PR TITLE
feat(pkger): extend SummaryLabel with its env references

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8486,10 +8486,15 @@ components:
           type: string
         name:
           type: string
-        description:
-          type: string
-        retentionPeriod:
-          type: string
+        properties:
+          type: object
+          properties:
+            color:
+              type: string
+            description:
+              type: string
+        envReferences:
+          $ref: "#/components/schemas/PkgEnvReferences"
     PkgChart:
       type: object
       properties:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -597,6 +597,7 @@ type SummaryLabel struct {
 		Color       string `json:"color"`
 		Description string `json:"description"`
 	} `json:"properties"`
+	EnvReferences []SummaryReference `json:"envReferences"`
 }
 
 // SummaryLabelMapping provides a summary of a label mapped with a single resource.

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1134,6 +1134,7 @@ func (l *label) summarize() SummaryLabel {
 			Color:       l.Color,
 			Description: l.Description,
 		},
+		EnvReferences: l.identity.summarizeReferences(),
 	}
 }
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -678,33 +678,15 @@ func TestService(t *testing.T) {
 					sum := impact.Summary
 					require.Len(t, sum.Labels, 3)
 
-					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:      1,
-						OrgID:   SafeID(orgID),
-						PkgName: "label-1",
-						Name:    "label-1",
-						Properties: struct {
-							Color       string `json:"color"`
-							Description string `json:"description"`
-						}{
-							Color:       "#FFFFFF",
-							Description: "label 1 description",
-						},
-					})
+					expectedLabel := sumLabelGen("label-1", "label-1", "#FFFFFF", "label 1 description")
+					expectedLabel.ID = 1
+					expectedLabel.OrgID = SafeID(orgID)
+					assert.Contains(t, sum.Labels, expectedLabel)
 
-					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:      2,
-						OrgID:   SafeID(orgID),
-						PkgName: "label-2",
-						Name:    "label-2",
-						Properties: struct {
-							Color       string `json:"color"`
-							Description string `json:"description"`
-						}{
-							Color:       "#000000",
-							Description: "label 2 description",
-						},
-					})
+					expectedLabel = sumLabelGen("label-2", "label-2", "#000000", "label 2 description")
+					expectedLabel.ID = 2
+					expectedLabel.OrgID = SafeID(orgID)
+					assert.Contains(t, sum.Labels, expectedLabel)
 				})
 			})
 
@@ -736,7 +718,6 @@ func TestService(t *testing.T) {
 
 					stubExisting := func(name string, id influxdb.ID) *influxdb.Label {
 						pkgLabel := pkg.mLabels[name]
-						fmt.Println(name, pkgLabel)
 						return &influxdb.Label{
 							// makes all pkg changes same as they are on the existing
 							ID:    id,
@@ -785,33 +766,15 @@ func TestService(t *testing.T) {
 					sum := impact.Summary
 					require.Len(t, sum.Labels, 3)
 
-					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:      1,
-						OrgID:   SafeID(orgID),
-						PkgName: "label-1",
-						Name:    "label-1",
-						Properties: struct {
-							Color       string `json:"color"`
-							Description string `json:"description"`
-						}{
-							Color:       "#FFFFFF",
-							Description: "label 1 description",
-						},
-					})
+					expectedLabel := sumLabelGen("label-1", "label-1", "#FFFFFF", "label 1 description")
+					expectedLabel.ID = 1
+					expectedLabel.OrgID = SafeID(orgID)
+					assert.Contains(t, sum.Labels, expectedLabel)
 
-					assert.Contains(t, sum.Labels, SummaryLabel{
-						ID:      2,
-						OrgID:   SafeID(orgID),
-						PkgName: "label-2",
-						Name:    "label-2",
-						Properties: struct {
-							Color       string `json:"color"`
-							Description string `json:"description"`
-						}{
-							Color:       "#000000",
-							Description: "label 2 description",
-						},
-					})
+					expectedLabel = sumLabelGen("label-2", "label-2", "#000000", "label 2 description")
+					expectedLabel.ID = 2
+					expectedLabel.OrgID = SafeID(orgID)
+					assert.Contains(t, sum.Labels, expectedLabel)
 
 					assert.Equal(t, 1, fakeLabelSVC.CreateLabelCalls.Count()) // only called for second label
 				})

--- a/pkger/testdata/label_ref.yml
+++ b/pkger/testdata/label_ref.yml
@@ -1,0 +1,10 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name


### PR DESCRIPTION
references: #18407

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)