### PR TITLE
feat(pkger): extend SummaryCheck with its env references

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8029,6 +8029,8 @@ components:
                         type: array
                         items:
                           $ref: "#/components/schemas/PkgSummaryLabel"
+                      envReferences:
+                        $ref: "#/components/schemas/PkgEnvReferences"
             notificationRules:
               type: array
               items:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7956,6 +7956,8 @@ components:
                         type: array
                         items:
                           $ref: "#/components/schemas/PkgSummaryLabel"
+                      envReferences:
+                        $ref: "#/components/schemas/PkgEnvReferences"
             labels:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -535,7 +535,9 @@ func (s *SummaryChart) UnmarshalJSON(b []byte) error {
 type SummaryNotificationEndpoint struct {
 	PkgName              string                        `json:"pkgName"`
 	NotificationEndpoint influxdb.NotificationEndpoint `json:"notificationEndpoint"`
-	LabelAssociations    []SummaryLabel                `json:"labelAssociations"`
+
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
+	EnvReferences     []SummaryReference `json:"envReferences"`
 }
 
 // UnmarshalJSON unmarshals the notificatio endpoint. This is necessary b/c of

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -442,10 +442,12 @@ type SummaryBucket struct {
 
 // SummaryCheck provides a summary of a pkg check.
 type SummaryCheck struct {
-	PkgName           string          `json:"pkgName"`
-	Check             influxdb.Check  `json:"check"`
-	Status            influxdb.Status `json:"status"`
-	LabelAssociations []SummaryLabel  `json:"labelAssociations"`
+	PkgName string          `json:"pkgName"`
+	Check   influxdb.Check  `json:"check"`
+	Status  influxdb.Status `json:"status"`
+
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
+	EnvReferences     []SummaryReference `json:"envReferences"`
 }
 
 func (s *SummaryCheck) UnmarshalJSON(b []byte) error {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1278,6 +1278,7 @@ func (n *notificationEndpoint) summarize() SummaryNotificationEndpoint {
 	sum := SummaryNotificationEndpoint{
 		PkgName:           n.PkgName(),
 		LabelAssociations: toSummaryLabels(n.labels...),
+		EnvReferences:     summarizeCommonReferences(n.identity, n.labels),
 	}
 
 	switch n.kind {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -251,6 +251,7 @@ func (c *check) summarize() SummaryCheck {
 		PkgName:           c.PkgName(),
 		Status:            c.Status(),
 		LabelAssociations: toSummaryLabels(c.labels...),
+		EnvReferences:     summarizeCommonReferences(c.identity, c.labels),
 	}
 	switch c.kind {
 	case checkKindThreshold:

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -571,6 +571,27 @@ spec:
 			})
 		})
 
+		t.Run("with env refs should be successful", func(t *testing.T) {
+			testfileRunner(t, "testdata/checks_ref.yml", func(t *testing.T, pkg *Pkg) {
+				actual := pkg.Summary().Checks
+				require.Len(t, actual, 1)
+
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+				}
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
+			})
+		})
+
 		t.Run("handles bad config", func(t *testing.T) {
 			tests := []struct {
 				kind   Kind

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -2417,8 +2417,8 @@ spec:
 		})
 	})
 
-	t.Run("pkg with notification endpoints and labels associated", func(t *testing.T) {
-		t.Run("happy path", func(t *testing.T) {
+	t.Run("pkg with notification endpoints", func(t *testing.T) {
+		t.Run("and labels associated should be successful", func(t *testing.T) {
 			testfileRunner(t, "testdata/notification_endpoint", func(t *testing.T, pkg *Pkg) {
 				expectedEndpoints := []SummaryNotificationEndpoint{
 					{
@@ -2509,6 +2509,27 @@ spec:
 						LabelName:       "label-1",
 					})
 				}
+			})
+		})
+
+		t.Run("with env refs should be valid", func(t *testing.T) {
+			testfileRunner(t, "testdata/notification_endpoint_ref.yml", func(t *testing.T, pkg *Pkg) {
+				actual := pkg.Summary().NotificationEndpoints
+				require.Len(t, actual, 1)
+
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+				}
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
 			})
 		})
 

--- a/pkger/testdata/checks_ref.yml
+++ b/pkger/testdata/checks_ref.yml
@@ -1,0 +1,19 @@
+apiVersion: influxdata.com/v2alpha1
+kind: CheckThreshold
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  every: 1m
+  offset: 15s
+  query:  |
+    from(bucket: "rucket_1")
+  statusMessageTemplate: "Check: ${ r._check_name } is: ${ r._level }"
+  thresholds:
+    - type: greater
+      level: CRIT
+      value: 50.0

--- a/pkger/testdata/notification_endpoint_ref.yml
+++ b/pkger/testdata/notification_endpoint_ref.yml
@@ -1,0 +1,13 @@
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationEndpointSlack
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  url: https://hooks.slack.com/services/bip/piddy/boppidy
+  token: tokenval
+


### PR DESCRIPTION
references: #18407

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)