### PR TITLE
feat(pkger): extend SummaryNotifcationRules with its env references

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8080,6 +8080,8 @@ components:
                     type: array
                     items:
                       $ref: "#/components/schemas/PkgSummaryLabel"
+                  envReferences:
+                    $ref: "#/components/schemas/PkgEnvReferences"
             tasks:
               type: array
               items:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -446,8 +446,8 @@ type SummaryCheck struct {
 	Check   influxdb.Check  `json:"check"`
 	Status  influxdb.Status `json:"status"`
 
-	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 	EnvReferences     []SummaryReference `json:"envReferences"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 }
 
 func (s *SummaryCheck) UnmarshalJSON(b []byte) error {
@@ -536,8 +536,8 @@ type SummaryNotificationEndpoint struct {
 	PkgName              string                        `json:"pkgName"`
 	NotificationEndpoint influxdb.NotificationEndpoint `json:"notificationEndpoint"`
 
-	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 	EnvReferences     []SummaryReference `json:"envReferences"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 }
 
 // UnmarshalJSON unmarshals the notificatio endpoint. This is necessary b/c of
@@ -572,13 +572,15 @@ type (
 		EndpointPkgName string `json:"endpointPkgName"`
 		EndpointType    string `json:"endpointType"`
 
-		Every             string              `json:"every"`
-		LabelAssociations []SummaryLabel      `json:"labelAssociations"`
-		Offset            string              `json:"offset"`
-		MessageTemplate   string              `json:"messageTemplate"`
-		Status            influxdb.Status     `json:"status"`
-		StatusRules       []SummaryStatusRule `json:"statusRules"`
-		TagRules          []SummaryTagRule    `json:"tagRules"`
+		Every           string              `json:"every"`
+		Offset          string              `json:"offset"`
+		MessageTemplate string              `json:"messageTemplate"`
+		Status          influxdb.Status     `json:"status"`
+		StatusRules     []SummaryStatusRule `json:"statusRules"`
+		TagRules        []SummaryTagRule    `json:"tagRules"`
+
+		EnvReferences     []SummaryReference `json:"envReferences"`
+		LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 	}
 
 	SummaryStatusRule struct {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1473,6 +1473,11 @@ func (r *notificationRule) summarize() SummaryNotificationRule {
 		endpointType = r.associatedEndpoint.kind.String()
 	}
 
+	envRefs := summarizeCommonReferences(r.identity, r.labels)
+	if r.endpointName != nil && r.endpointName.EnvRef != "" {
+		envRefs = append(envRefs, convertRefToRefSummary("spec.endpointName", r.endpointName))
+	}
+
 	return SummaryNotificationRule{
 		PkgName:           r.PkgName(),
 		Name:              r.Name(),
@@ -1481,6 +1486,7 @@ func (r *notificationRule) summarize() SummaryNotificationRule {
 		Description:       r.description,
 		Every:             r.every.String(),
 		LabelAssociations: toSummaryLabels(r.labels...),
+		EnvReferences:     envRefs,
 		Offset:            r.offset.String(),
 		MessageTemplate:   r.msgTemplate,
 		Status:            r.Status(),

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -2831,6 +2831,32 @@ spec:
 			})
 		})
 
+		t.Run("with env refs should be valid", func(t *testing.T) {
+			testfileRunner(t, "testdata/notification_rule_ref.yml", func(t *testing.T, pkg *Pkg) {
+				actual := pkg.Summary().NotificationRules
+				require.Len(t, actual, 1)
+
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.endpointName",
+						EnvRefKey:    "endpoint-meta-name",
+						DefaultValue: "env-endpoint-meta-name",
+					},
+				}
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
+			})
+		})
+
 		t.Run("handles bad config", func(t *testing.T) {
 			pkgWithValidEndpint := func(resource string) string {
 				return fmt.Sprintf(`

--- a/pkger/testdata/notification_rule_ref.yml
+++ b/pkger/testdata/notification_rule_ref.yml
@@ -1,0 +1,27 @@
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationRule
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  endpointName:
+    envRef:
+      key: endpoint-meta-name
+  every: 10m
+  offset: 30s
+  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
+  statusRules:
+    - currentLevel: WARN
+---
+apiVersion: influxdata.com/v2alpha1
+kind: NotificationEndpointSlack
+metadata:
+  name:
+    envRef:
+      key: endpoint-meta-name
+spec:
+  url: https://hooks.slack.com/services/bip/piddy/boppidy


### PR DESCRIPTION
references: #18407

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)