### PR TITLE
feat(flagged): wireup simple url and name overlay

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -48,7 +48,6 @@ import NewVEO from 'src/dashboards/components/NewVEO'
 import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage'
 import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
-import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
 import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
 import ClientArduinoOverlay from 'src/clientLibraries/components/ClientArduinoOverlay'
@@ -99,6 +98,9 @@ import EditRuleOverlay from 'src/notifications/rules/components/EditRuleOverlay'
 import NewEndpointOverlay from 'src/notifications/endpoints/components/NewEndpointOverlay'
 import EditEndpointOverlay from 'src/notifications/endpoints/components/EditEndpointOverlay'
 import NoOrgsPage from 'src/organizations/containers/NoOrgsPage'
+
+import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
+import {CommunityTemplateImportOverlay} from 'src/templates/components/CommunityTemplateImportOverlay'
 
 // Utilities
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -435,8 +437,8 @@ class Root extends PureComponent {
                                   component={CommunityTemplatesIndex}
                                 >
                                   <Route
-                                    path="import"
-                                    component={TemplateImportOverlay}
+                                    path="import/:templateName"
+                                    component={CommunityTemplateImportOverlay}
                                   />
                                   <Route
                                     path=":id/export"

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -1,0 +1,92 @@
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
+
+// Components
+import {TemplateInstallerOverlay} from 'src/templates/components/TemplateInstallerOverlay'
+
+// Actions
+import {createTemplate as createTemplateAction} from 'src/templates/actions/thunks'
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+
+// Types
+import {AppState, Organization, ResourceType} from 'src/types'
+import {ComponentStatus} from '@influxdata/clockface'
+
+// Utils
+import {getByID} from 'src/resources/selectors'
+
+interface State {
+  status: ComponentStatus
+}
+
+interface DispatchProps {
+  createTemplate: typeof createTemplateAction
+  notify: typeof notifyAction
+}
+
+interface StateProps {
+  org: Organization
+  templateName: string
+}
+
+interface OwnProps extends WithRouterProps {
+  params: {orgID: string; templateName: string}
+}
+
+type Props = DispatchProps & OwnProps & StateProps
+
+class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
+  public state: State = {
+    status: ComponentStatus.Default,
+  }
+
+  public render() {
+    return (
+      <TemplateInstallerOverlay
+        onDismissOverlay={this.onDismiss}
+        onSubmit={this.handleInstallTemplate}
+        status={this.state.status}
+        templateName={this.props.templateName}
+        updateStatus={this.updateOverlayStatus}
+      />
+    )
+  }
+
+  private onDismiss = () => {
+    const {router} = this.props
+
+    router.goBack()
+  }
+
+  private updateOverlayStatus = (status: ComponentStatus) =>
+    this.setState(() => ({status}))
+
+  private handleInstallTemplate = (importString: string) => {
+    importString
+  }
+}
+
+const mstp = (state: AppState, props: Props): StateProps => {
+  const org = getByID<Organization>(
+    state,
+    ResourceType.Orgs,
+    props.params.orgID
+  )
+
+  return {org, templateName: props.params.templateName}
+}
+
+const mdtp: DispatchProps = {
+  createTemplate: createTemplateAction,
+  notify: notifyAction,
+}
+
+export const CommunityTemplateImportOverlay = connect<
+  StateProps,
+  DispatchProps,
+  Props
+>(
+  mstp,
+  mdtp
+)(withRouter(UnconnectedTemplateImportOverlay))

--- a/ui/src/templates/components/TemplateInstallerOverlay.tsx
+++ b/ui/src/templates/components/TemplateInstallerOverlay.tsx
@@ -1,0 +1,68 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+// Components
+import {
+  Gradients,
+  Heading,
+  HeadingElement,
+  Overlay,
+  Panel,
+} from '@influxdata/clockface'
+
+// Types
+import {ComponentStatus} from '@influxdata/clockface'
+
+interface OwnProps {
+  isVisible?: boolean
+  onDismissOverlay: () => void
+  onSubmit: (importString: string, orgID: string) => void
+  status?: ComponentStatus
+  templateName: string
+  updateStatus?: (status: ComponentStatus) => void
+}
+
+type Props = OwnProps & WithRouterProps
+
+class UnconnectedImportOverlay extends PureComponent<Props> {
+  public static defaultProps: {isVisible: boolean} = {
+    isVisible: true,
+  }
+
+  public render() {
+    const {isVisible, templateName} = this.props
+
+    const resourceCount = 0
+
+    return (
+      <Overlay visible={isVisible}>
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Header
+            title="Template Installer"
+            onDismiss={this.onDismiss}
+          />
+          <Overlay.Body>
+            <Panel border={true} gradient={Gradients.RebelAlliance}>
+              <Panel.Header>
+                <Heading element={HeadingElement.H3}>{templateName}</Heading>
+              </Panel.Header>
+              <Panel.Body>
+                Installing this template will create {resourceCount} resources
+                in your system
+              </Panel.Body>
+            </Panel>
+          </Overlay.Body>
+        </Overlay.Container>
+      </Overlay>
+    )
+  }
+
+  private onDismiss = () => {
+    this.props.onDismissOverlay()
+  }
+}
+
+export const TemplateInstallerOverlay = withRouter<OwnProps>(
+  UnconnectedImportOverlay
+)

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -73,3 +73,20 @@ export const getLabelRelationships = (resource: {
 
 export const getIncludedLabels = (included: {type: TemplateType}[]) =>
   included.filter((i): i is LabelIncluded => i.type === TemplateType.Label)
+
+// See https://github.com/influxdata/community-templates/
+// an example of a url that works with this function:
+// https://github.com/influxdata/community-templates/tree/master/csgo
+export const getTemplateNameFromGithubUrl = (url: string): string => {
+  if (!url.includes('https://github.com/influxdata/community-templates/')) {
+    throw new Error(
+      "We're only going to fetch from influxdb's github repo right now"
+    )
+  }
+  const [, name] = url.split('/tree/master/')
+  return name
+}
+
+export const getGithubUrlFromTemplateName = (templateName: string): string => {
+  return `https://github.com/influxdata/community-templates/tree/master/${templateName}`
+}


### PR DESCRIPTION
Connects #18234

Infers the name of the template from the github url, launches the first part of the new template overlay. It's still not functional, but it provides a starting point to work from.

It's behind feature flag `communityTemplates`.

To access this flag locally, start your app with:
```sh
go run ./cmd/influxd --assets-path=ui/build --feature-flags=communityTemplates=true
```

![Screen Shot 2020-06-10 at 4 20 04 PM](https://user-images.githubusercontent.com/146112/84328377-a602b380-ab36-11ea-98b1-ae801ef2801c.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
