### PR TITLE
feat(pkger): extend summary resource types with env refs

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8105,6 +8105,8 @@ components:
                     type: string
                   status:
                     type: string
+                  envReferences:
+                    $ref: "#/components/schemas/PkgEnvReferences"
             telegrafConfigs:
               type: array
               items:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8120,6 +8120,8 @@ components:
                         type: array
                         items:
                           $ref: "#/components/schemas/PkgSummaryLabel"
+                      envReferences:
+                        $ref: "#/components/schemas/PkgEnvReferences"
             variables:
               type: array
               items:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8143,6 +8143,8 @@ components:
                     type: array
                     items:
                       $ref: "#/components/schemas/PkgSummaryLabel"
+                  envReferences:
+                    $ref: "#/components/schemas/PkgEnvReferences"
         diff:
           type: object
           properties:

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -643,7 +643,8 @@ type SummaryTask struct {
 	Query       string          `json:"query"`
 	Status      influxdb.Status `json:"status"`
 
-	LabelAssociations []SummaryLabel `json:"labelAssociations"`
+	EnvReferences     []SummaryReference `json:"envReferences"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 }
 
 // SummaryTelegraf provides a summary of a pkg telegraf config.

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -649,9 +649,11 @@ type SummaryTask struct {
 
 // SummaryTelegraf provides a summary of a pkg telegraf config.
 type SummaryTelegraf struct {
-	PkgName           string                  `json:"pkgName"`
-	TelegrafConfig    influxdb.TelegrafConfig `json:"telegrafConfig"`
-	LabelAssociations []SummaryLabel          `json:"labelAssociations"`
+	PkgName        string                  `json:"pkgName"`
+	TelegrafConfig influxdb.TelegrafConfig `json:"telegrafConfig"`
+
+	EnvReferences     []SummaryReference `json:"envReferences"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 }
 
 // SummaryVariable provides a summary of a pkg variable.

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -658,11 +658,13 @@ type SummaryTelegraf struct {
 
 // SummaryVariable provides a summary of a pkg variable.
 type SummaryVariable struct {
-	ID                SafeID                      `json:"id,omitempty"`
-	PkgName           string                      `json:"pkgName"`
-	OrgID             SafeID                      `json:"orgID,omitempty"`
-	Name              string                      `json:"name"`
-	Description       string                      `json:"description"`
-	Arguments         *influxdb.VariableArguments `json:"arguments"`
-	LabelAssociations []SummaryLabel              `json:"labelAssociations"`
+	ID          SafeID                      `json:"id,omitempty"`
+	PkgName     string                      `json:"pkgName"`
+	OrgID       SafeID                      `json:"orgID,omitempty"`
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Arguments   *influxdb.VariableArguments `json:"arguments"`
+
+	EnvReferences     []SummaryReference `json:"envReferences"`
+	LabelAssociations []SummaryLabel     `json:"labelAssociations"`
 }

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1910,6 +1910,7 @@ func (v *variable) summarize() SummaryVariable {
 		Description:       v.Description,
 		Arguments:         v.influxVarArgs(),
 		LabelAssociations: toSummaryLabels(v.labels...),
+		EnvReferences:     summarizeCommonReferences(v.identity, v.labels),
 	}
 }
 

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1851,6 +1851,7 @@ func (t *telegraf) summarize() SummaryTelegraf {
 		PkgName:           t.PkgName(),
 		TelegrafConfig:    cfg,
 		LabelAssociations: toSummaryLabels(t.labels...),
+		EnvReferences:     summarizeCommonReferences(t.identity, t.labels),
 	}
 }
 

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1188,8 +1188,12 @@ type sortedLabels []*label
 
 func (s sortedLabels) summarizeReferences() []SummaryReference {
 	refs := make([]SummaryReference, 0)
-	for _, l := range s {
-		refs = append(refs, l.summarizeReferences()...)
+	for i, l := range s {
+		if !l.name.hasEnvRef() {
+			continue
+		}
+		field := fmt.Sprintf("spec.%s[%d].name", fieldAssociations, i)
+		refs = append(refs, convertRefToRefSummary(field, l.name))
 	}
 	return refs
 }

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -35,10 +35,10 @@ func (i *identity) PkgName() string {
 
 func (i *identity) summarizeReferences() []SummaryReference {
 	refs := make([]SummaryReference, 0)
-	if i.name != nil && i.name.EnvRef != "" {
+	if i.name.hasEnvRef() {
 		refs = append(refs, convertRefToRefSummary("metadata.name", i.name))
 	}
-	if i.displayName != nil && i.displayName.EnvRef != "" {
+	if i.displayName.hasEnvRef() {
 		refs = append(refs, convertRefToRefSummary("spec.name", i.displayName))
 	}
 	return refs
@@ -1474,7 +1474,7 @@ func (r *notificationRule) summarize() SummaryNotificationRule {
 	}
 
 	envRefs := summarizeCommonReferences(r.identity, r.labels)
-	if r.endpointName != nil && r.endpointName.EnvRef != "" {
+	if r.endpointName.hasEnvRef() {
 		envRefs = append(envRefs, convertRefToRefSummary("spec.endpointName", r.endpointName))
 	}
 
@@ -1722,6 +1722,7 @@ func (t *task) summarize() SummaryTask {
 		Query:       t.query,
 		Status:      t.Status(),
 
+		EnvReferences:     summarizeCommonReferences(t.identity, t.labels),
 		LabelAssociations: toSummaryLabels(t.labels...),
 	}
 }
@@ -1993,6 +1994,10 @@ type references struct {
 
 func (r *references) hasValue() bool {
 	return r.EnvRef != "" || r.Secret != "" || r.val != nil
+}
+
+func (r *references) hasEnvRef() bool {
+	return r != nil && r.EnvRef != ""
 }
 
 func (r *references) String() string {

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3342,8 +3342,8 @@ spec:
 		})
 	})
 
-	t.Run("pkg with telegraf and label associations", func(t *testing.T) {
-		t.Run("with valid fields", func(t *testing.T) {
+	t.Run("pkg with telegraf config", func(t *testing.T) {
+		t.Run("and associated labels should be successful", func(t *testing.T) {
 			testfileRunner(t, "testdata/telegraf", func(t *testing.T, pkg *Pkg) {
 				sum := pkg.Summary()
 				require.Len(t, sum.TelegrafConfigs, 2)
@@ -3373,6 +3373,27 @@ spec:
 				expectedMapping.LabelPkgName = "label-2"
 				expectedMapping.LabelName = "label-2"
 				assert.Equal(t, expectedMapping, sum.LabelMappings[1])
+			})
+		})
+
+		t.Run("with env refs should be valid", func(t *testing.T) {
+			testfileRunner(t, "testdata/telegraf_ref.yml", func(t *testing.T, pkg *Pkg) {
+				actual := pkg.Summary().TelegrafConfigs
+				require.Len(t, actual, 1)
+
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+				}
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
 			})
 		})
 

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -50,28 +50,27 @@ func TestParse(t *testing.T) {
 
 		t.Run("with env refs should be valid", func(t *testing.T) {
 			testfileRunner(t, "testdata/bucket_ref.yml", func(t *testing.T, pkg *Pkg) {
-				buckets := pkg.Summary().Buckets
-				require.Len(t, buckets, 1)
+				actual := pkg.Summary().Buckets
+				require.Len(t, actual, 1)
 
-				actual := buckets[0]
-				expectedBucket := SummaryBucket{
-					PkgName:           "env-meta-name",
-					Name:              "env-spec-name",
-					LabelAssociations: []SummaryLabel{},
-					EnvReferences: []SummaryReference{
-						{
-							Field:        "metadata.name",
-							EnvRefKey:    "meta-name",
-							DefaultValue: "env-meta-name",
-						},
-						{
-							Field:        "spec.name",
-							EnvRefKey:    "spec-name",
-							DefaultValue: "env-spec-name",
-						},
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 				}
-				assert.Equal(t, expectedBucket, actual)
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
 			})
 		})
 
@@ -586,6 +585,11 @@ spec:
 						Field:        "spec.name",
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -2270,24 +2274,24 @@ spec:
 				actual := pkg.Summary().Dashboards
 				require.Len(t, actual, 1)
 
-				expected := SummaryDashboard{
-					PkgName:           "env-meta-name",
-					Name:              "env-spec-name",
-					LabelAssociations: []SummaryLabel{},
-					EnvReferences: []SummaryReference{
-						{
-							Field:        "metadata.name",
-							EnvRefKey:    "meta-name",
-							DefaultValue: "env-meta-name",
-						},
-						{
-							Field:        "spec.name",
-							EnvRefKey:    "spec-name",
-							DefaultValue: "env-spec-name",
-						},
+				expected := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 				}
-				assert.Equal(t, expected, actual[0])
+				assert.Equal(t, expected, actual[0].EnvReferences)
 			})
 		})
 
@@ -2527,6 +2531,11 @@ spec:
 						Field:        "spec.name",
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -2846,6 +2855,11 @@ spec:
 						Field:        "spec.name",
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 					{
 						Field:        "spec.endpointName",
@@ -3179,6 +3193,11 @@ spec:
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
 					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
+					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
 			})
@@ -3392,6 +3411,11 @@ spec:
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
 					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
+					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
 			})
@@ -3506,6 +3530,11 @@ spec:
 						Field:        "spec.name",
 						EnvRefKey:    "spec-name",
 						DefaultValue: "env-spec-name",
+					},
+					{
+						Field:        "spec.associations[0].name",
+						EnvRefKey:    "label-meta-name",
+						DefaultValue: "env-label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3163,6 +3163,27 @@ spec:
 			})
 		})
 
+		t.Run("with env refs should be valid", func(t *testing.T) {
+			testfileRunner(t, "testdata/task_ref.yml", func(t *testing.T, pkg *Pkg) {
+				actual := pkg.Summary().Tasks
+				require.Len(t, actual, 1)
+
+				expectedEnvRefs := []SummaryReference{
+					{
+						Field:        "metadata.name",
+						EnvRefKey:    "meta-name",
+						DefaultValue: "env-meta-name",
+					},
+					{
+						Field:        "spec.name",
+						EnvRefKey:    "spec-name",
+						DefaultValue: "env-spec-name",
+					},
+				}
+				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
+			})
+		})
+
 		t.Run("handles bad config", func(t *testing.T) {
 			tests := []struct {
 				kind   Kind

--- a/pkger/testdata/bucket_ref.yml
+++ b/pkger/testdata/bucket_ref.yml
@@ -8,3 +8,15 @@ spec:
   name:
     envRef:
       key: spec-name
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name

--- a/pkger/testdata/checks_ref.yml
+++ b/pkger/testdata/checks_ref.yml
@@ -17,3 +17,15 @@ spec:
     - type: greater
       level: CRIT
       value: 50.0
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name

--- a/pkger/testdata/dashboard_ref.yml
+++ b/pkger/testdata/dashboard_ref.yml
@@ -8,3 +8,15 @@ spec:
   name:
     envRef:
       key: spec-name
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name

--- a/pkger/testdata/notification_endpoint_ref.yml
+++ b/pkger/testdata/notification_endpoint_ref.yml
@@ -10,4 +10,15 @@ spec:
       key: spec-name
   url: https://hooks.slack.com/services/bip/piddy/boppidy
   token: tokenval
-
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name

--- a/pkger/testdata/notification_rule_ref.yml
+++ b/pkger/testdata/notification_rule_ref.yml
@@ -16,6 +16,18 @@ spec:
   messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
   statusRules:
     - currentLevel: WARN
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name
 ---
 apiVersion: influxdata.com/v2alpha1
 kind: NotificationEndpointSlack

--- a/pkger/testdata/task_ref.yml
+++ b/pkger/testdata/task_ref.yml
@@ -1,0 +1,14 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Task
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  every: 10m
+  offset: 15s
+  query:  >
+    from(bucket: "rucket_1")

--- a/pkger/testdata/task_ref.yml
+++ b/pkger/testdata/task_ref.yml
@@ -12,3 +12,15 @@ spec:
   offset: 15s
   query:  >
     from(bucket: "rucket_1")
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name

--- a/pkger/testdata/telegraf_ref.yml
+++ b/pkger/testdata/telegraf_ref.yml
@@ -56,3 +56,15 @@ spec:
 
      hostname = ""
      omit_hostname = false
+  associations:
+   - kind: Label
+     name:
+      envRef:
+       key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+ name:
+  envRef:
+   key: label-meta-name

--- a/pkger/testdata/telegraf_ref.yml
+++ b/pkger/testdata/telegraf_ref.yml
@@ -1,0 +1,58 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Telegraf
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  config: |
+   # Configuration for telegraf agent
+   [agent]
+     ## Default data collection interval for all inputs
+     interval = "10s"
+     ## Rounds collection interval to 'interval'
+     ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+     round_interval = true
+
+     ## Telegraf will send metrics to outputs in batches of at most
+     ## metric_batch_size metrics.
+     ## This controls the size of writes that Telegraf sends to output plugins.
+     metric_batch_size = 1000
+
+     ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+     ## output, and will flush this buffer on a successful write. Oldest metrics
+     ## are dropped first when this buffer fills.
+     ## This buffer only fills when writes fail to output plugin(s).
+     metric_buffer_limit = 10000
+
+     ## Collection jitter is used to jitter the collection by a random amount.
+     ## Each plugin will sleep for a random time within jitter before collecting.
+     ## This can be used to avoid many plugins querying things like sysfs at the
+     ## same time, which can have a measurable effect on the system.
+     collection_jitter = "0s"
+
+     ## Default flushing interval for all outputs. Maximum flush_interval will be
+     ## flush_interval + flush_jitter
+     flush_interval = "10s"
+     ## Jitter the flush interval by a random amount. This is primarily to avoid
+     ## large write spikes for users running a large number of telegraf instances.
+     ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+     flush_jitter = "0s"
+
+     ## By default or when set to "0s", precision will be set to the same
+     ## timestamp order as the collection interval, with the maximum being 1s.
+     ##   ie, when interval = "10s", precision will be "1s"
+     ##       when interval = "250ms", precision will be "1ms"
+     ## Precision will NOT be used for service inputs. It is up to each individual
+     ## service input to set the timestamp at the appropriate precision.
+     ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+     precision = ""
+     debug = false
+     quiet = false
+     logfile = ""
+
+     hostname = ""
+     omit_hostname = false

--- a/pkger/testdata/variable_ref.yml
+++ b/pkger/testdata/variable_ref.yml
@@ -1,0 +1,13 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Variable
+metadata:
+  name:
+    envRef:
+      key: meta-name
+spec:
+  name:
+    envRef:
+      key: spec-name
+  type: constant
+  values:
+    - first val

--- a/pkger/testdata/variable_ref.yml
+++ b/pkger/testdata/variable_ref.yml
@@ -11,3 +11,15 @@ spec:
   type: constant
   values:
     - first val
+  associations:
+    - kind: Label
+      name:
+        envRef:
+          key: label-meta-name
+---
+apiVersion: influxdata.com/v2alpha1
+kind: Label
+metadata:
+  name:
+    envRef:
+      key: label-meta-name


### PR DESCRIPTION
closes: #18407

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)