### PR TITLE
fix: remove operation log system

### DIFF
--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -61,7 +61,6 @@ const (
 	dashboardsIDCellsIDPath     = "/api/v2/dashboards/:id/cells/:cellID"
 	dashboardsIDCellsIDViewPath = "/api/v2/dashboards/:id/cells/:cellID/view"
 	dashboardsIDMembersPath     = "/api/v2/dashboards/:id/members"
-	dashboardsIDLogPath         = "/api/v2/dashboards/:id/logs"
 	dashboardsIDMembersIDPath   = "/api/v2/dashboards/:id/members/:userID"
 	dashboardsIDOwnersPath      = "/api/v2/dashboards/:id/owners"
 	dashboardsIDOwnersIDPath    = "/api/v2/dashboards/:id/owners/:userID"
@@ -86,7 +85,6 @@ func NewDashboardHandler(log *zap.Logger, b *DashboardBackend) *DashboardHandler
 	h.HandlerFunc("POST", prefixDashboards, h.handlePostDashboard)
 	h.HandlerFunc("GET", prefixDashboards, h.handleGetDashboards)
 	h.HandlerFunc("GET", dashboardsIDPath, h.handleGetDashboard)
-	h.HandlerFunc("GET", dashboardsIDLogPath, h.handleGetDashboardLog)
 	h.HandlerFunc("DELETE", dashboardsIDPath, h.handleDeleteDashboard)
 	h.HandlerFunc("PATCH", dashboardsIDPath, h.handlePatchDashboard)
 
@@ -140,7 +138,6 @@ type dashboardLinks struct {
 	Members      string `json:"members"`
 	Owners       string `json:"owners"`
 	Cells        string `json:"cells"`
-	Logs         string `json:"logs"`
 	Labels       string `json:"labels"`
 	Organization string `json:"org"`
 }
@@ -181,7 +178,6 @@ func newDashboardResponse(d *influxdb.Dashboard, labels []*influxdb.Label) dashb
 			Members:      fmt.Sprintf("/api/v2/dashboards/%s/members", d.ID),
 			Owners:       fmt.Sprintf("/api/v2/dashboards/%s/owners", d.ID),
 			Cells:        fmt.Sprintf("/api/v2/dashboards/%s/cells", d.ID),
-			Logs:         fmt.Sprintf("/api/v2/dashboards/%s/logs", d.ID),
 			Labels:       fmt.Sprintf("/api/v2/dashboards/%s/labels", d.ID),
 			Organization: fmt.Sprintf("/api/v2/orgs/%s", d.OrganizationID),
 		},
@@ -307,40 +303,6 @@ func newDashboardCellViewResponse(dashID, cellID influxdb.ID, v *influxdb.View) 
 			Self: fmt.Sprintf("/api/v2/dashboards/%s/cells/%s", dashID, cellID),
 		},
 		View: *v,
-	}
-}
-
-type operationLogResponse struct {
-	Links map[string]string            `json:"links"`
-	Logs  []*operationLogEntryResponse `json:"logs"`
-}
-
-func newDashboardLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
-	logs := make([]*operationLogEntryResponse, 0, len(es))
-	for _, e := range es {
-		logs = append(logs, newOperationLogEntryResponse(e))
-	}
-	return &operationLogResponse{
-		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/dashboards/%s/logs", id),
-		},
-		Logs: logs,
-	}
-}
-
-type operationLogEntryResponse struct {
-	Links map[string]string `json:"links"`
-	*influxdb.OperationLogEntry
-}
-
-func newOperationLogEntryResponse(e *influxdb.OperationLogEntry) *operationLogEntryResponse {
-	links := map[string]string{}
-	if e.UserID.Valid() {
-		links["user"] = fmt.Sprintf("/api/v2/users/%s", e.UserID)
-	}
-	return &operationLogEntryResponse{
-		Links:             links,
-		OperationLogEntry: e,
 	}
 }
 
@@ -545,60 +507,6 @@ func decodeGetDashboardRequest(ctx context.Context, r *http.Request) (*getDashbo
 
 	return &getDashboardRequest{
 		DashboardID: i,
-	}, nil
-}
-
-// hanldeGetDashboardLog retrieves a dashboard log by the dashboards ID.
-func (h *DashboardHandler) handleGetDashboardLog(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	req, err := decodeGetDashboardLogRequest(ctx, r)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	log, _, err := h.DashboardOperationLogService.GetDashboardOperationLog(ctx, req.DashboardID, req.opts)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	h.log.Debug("Dashboard log retrieved", zap.String("log", fmt.Sprint(log)))
-
-	if err := encodeResponse(ctx, w, http.StatusOK, newDashboardLogResponse(req.DashboardID, log)); err != nil {
-		logEncodingError(h.log, r, err)
-		return
-	}
-}
-
-type getDashboardLogRequest struct {
-	DashboardID influxdb.ID
-	opts        influxdb.FindOptions
-}
-
-func decodeGetDashboardLogRequest(ctx context.Context, r *http.Request) (*getDashboardLogRequest, error) {
-	params := httprouter.ParamsFromContext(ctx)
-	id := params.ByName("id")
-	if id == "" {
-		return nil, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "url missing id",
-		}
-	}
-
-	var i influxdb.ID
-	if err := i.DecodeFromString(id); err != nil {
-		return nil, err
-	}
-
-	opts, err := influxdb.DecodeFindOptions(r)
-	if err != nil {
-		return nil, err
-	}
-
-	return &getDashboardLogRequest{
-		DashboardID: i,
-		opts:        *opts,
 	}, nil
 }
 

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -158,7 +158,6 @@ func TestService_handleGetDashboards(t *testing.T) {
         "members": "/api/v2/dashboards/da7aba5e5d81e550/members",
         "owners": "/api/v2/dashboards/da7aba5e5d81e550/owners",
         "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
-        "logs": "/api/v2/dashboards/da7aba5e5d81e550/logs",
         "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels"
       }
     },
@@ -186,7 +185,6 @@ func TestService_handleGetDashboards(t *testing.T) {
         "org": "/api/v2/orgs/0000000000000001",
         "members": "/api/v2/dashboards/0ca2204eca2204e0/members",
         "owners": "/api/v2/dashboards/0ca2204eca2204e0/owners",
-        "logs": "/api/v2/dashboards/0ca2204eca2204e0/logs",
         "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
         "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels"
       }
@@ -319,7 +317,6 @@ func TestService_handleGetDashboards(t *testing.T) {
         "members": "/api/v2/dashboards/da7aba5e5d81e550/members",
         "owners": "/api/v2/dashboards/da7aba5e5d81e550/owners",
         "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
-        "logs": "/api/v2/dashboards/da7aba5e5d81e550/logs",
         "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels"
       }
     }
@@ -481,7 +478,6 @@ func TestService_handleGetDashboard(t *testing.T) {
 	     "org": "/api/v2/orgs/0000000000000001",
 	     "members": "/api/v2/dashboards/020f755c3c082000/members",
 	     "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-	     "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 	     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 	     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 	}
@@ -562,7 +558,6 @@ func TestService_handleGetDashboard(t *testing.T) {
 	     "org": "/api/v2/orgs/0000000000000001",
 	     "members": "/api/v2/dashboards/020f755c3c082000/members",
 	     "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-	     "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 	     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 	     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 	}
@@ -641,7 +636,6 @@ func TestService_handleGetDashboard(t *testing.T) {
 	     "org": "/api/v2/orgs/0000000000000001",
 	     "members": "/api/v2/dashboards/020f755c3c082000/members",
 	     "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-	     "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 	     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 	     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 	}
@@ -716,7 +710,6 @@ func TestService_handleGetDashboard(t *testing.T) {
 		    "org": "/api/v2/orgs/0000000000000001",
 		    "members": "/api/v2/dashboards/020f755c3c082000/members",
 		    "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-		    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 		    "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 		    "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 		  }
@@ -878,7 +871,6 @@ func TestService_handlePostDashboard(t *testing.T) {
 							"org": "/api/v2/orgs/0000000000000001",
 							"members": "/api/v2/dashboards/020f755c3c082000/members",
 							"owners": "/api/v2/dashboards/020f755c3c082000/owners",
-							"logs": "/api/v2/dashboards/020f755c3c082000/logs",
 							"cells": "/api/v2/dashboards/020f755c3c082000/cells",
 							"labels": "/api/v2/dashboards/020f755c3c082000/labels"
 						}
@@ -1003,7 +995,6 @@ func TestService_handlePostDashboard(t *testing.T) {
 						"org": "/api/v2/orgs/0000000000000001",
 						"members": "/api/v2/dashboards/020f755c3c082000/members",
 						"owners": "/api/v2/dashboards/020f755c3c082000/owners",
-						"logs": "/api/v2/dashboards/020f755c3c082000/logs",
 						"cells": "/api/v2/dashboards/020f755c3c082000/cells",
 						"labels": "/api/v2/dashboards/020f755c3c082000/labels"
 					}
@@ -1246,7 +1237,6 @@ func TestService_handlePatchDashboard(t *testing.T) {
 		    "org": "/api/v2/orgs/0000000000000001",
 		    "members": "/api/v2/dashboards/020f755c3c082000/members",
 		    "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-		    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 		    "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 		    "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 		  }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3126,36 +3126,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  "/dashboards/{dashboardID}/logs":
-    get:
-      operationId: GetDashboardsIDLogs
-      tags:
-        - Dashboards
-        - OperationLogs
-      summary: Retrieve operation logs for a dashboard
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - $ref: "#/components/parameters/Offset"
-        - $ref: "#/components/parameters/Limit"
-        - in: path
-          name: dashboardID
-          required: true
-          description: The dashboard ID.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Operation logs for the dashboard
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OperationLogs"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /query/ast:
     post:
       operationId: PostQueryAst
@@ -3962,36 +3932,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  "/buckets/{bucketID}/logs":
-    get:
-      operationId: GetBucketsIDLogs
-      tags:
-        - Buckets
-        - OperationLogs
-      summary: Retrieve operation logs for a bucket
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - $ref: "#/components/parameters/Offset"
-        - $ref: "#/components/parameters/Limit"
-        - in: path
-          name: bucketID
-          required: true
-          description: The bucket ID.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Operation logs for the bucket
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OperationLogs"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /orgs:
     get:
       operationId: GetOrgs
@@ -4672,36 +4612,6 @@ paths:
       responses:
         "204":
           description: Owner removed
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/logs":
-    get:
-      operationId: GetOrgsIDLogs
-      tags:
-        - Organizations
-        - OperationLogs
-      summary: Retrieve operation logs for an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - $ref: "#/components/parameters/Offset"
-        - $ref: "#/components/parameters/Limit"
-        - in: path
-          name: orgID
-          required: true
-          description: The organization ID.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Operation logs for the organization
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OperationLogs"
         default:
           description: Unexpected error
           content:
@@ -5894,36 +5804,6 @@ paths:
           description: Password successfully updated
         default:
           description: Unsuccessful authentication
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/users/{userID}/logs":
-    get:
-      operationId: GetUsersIDLogs
-      tags:
-        - Users
-        - OperationLogs
-      summary: Retrieve operation logs for a user
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - $ref: "#/components/parameters/Offset"
-        - $ref: "#/components/parameters/Limit"
-        - in: path
-          name: userID
-          required: true
-          description: The user ID.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Operation logs for the user
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/OperationLogs"
-        default:
-          description: Unexpected error
           content:
             application/json:
               schema:
@@ -7574,7 +7454,6 @@ components:
           readOnly: true
           example:
             labels: "/api/v2/buckets/1/labels"
-            logs: "/api/v2/buckets/1/logs"
             members: "/api/v2/buckets/1/members"
             org: "/api/v2/orgs/2"
             owners: "/api/v2/buckets/1/owners"
@@ -7583,9 +7462,6 @@ components:
           properties:
             labels:
               description: URL to retrieve labels for this bucket
-              $ref: "#/components/schemas/Link"
-            logs:
-              description: URL to retrieve operation logs for this bucket
               $ref: "#/components/schemas/Link"
             members:
               description: URL to retrieve members that can read this bucket
@@ -7698,35 +7574,6 @@ components:
           description: A description of the event that occurred.
           type: string
           example: Halt and catch fire
-    OperationLog:
-      type: object
-      readOnly: true
-      properties:
-        description:
-          type: string
-          description: A description of the event that occurred.
-          example: Bucket Created
-        time:
-          type: string
-          description: Time event occurred, RFC3339Nano.
-          format: date-time
-        userID:
-          type: string
-          description: ID of the user who operated the event.
-        links:
-          type: object
-          properties:
-            user:
-              $ref: "#/components/schemas/Link"
-    OperationLogs:
-      type: object
-      properties:
-        logs:
-          type: array
-          items:
-            $ref: "#/components/schemas/OperationLog"
-        links:
-          $ref: "#/components/schemas/Links"
     Organization:
       properties:
         links:
@@ -7741,7 +7588,6 @@ components:
             buckets: "/api/v2/buckets?org=myorg"
             tasks: "/api/v2/tasks?org=myorg"
             dashboards: "/api/v2/dashboards?org=myorg"
-            logs: "/api/v2/orgs/1/logs"
           properties:
             self:
               $ref: "#/components/schemas/Link"
@@ -7758,8 +7604,6 @@ components:
             tasks:
               $ref: "#/components/schemas/Link"
             dashboards:
-              $ref: "#/components/schemas/Link"
-            logs:
               $ref: "#/components/schemas/Link"
         id:
           readOnly: true
@@ -8573,15 +8417,11 @@ components:
             self: "/api/v2/tasks/1/runs/1"
             task: "/api/v2/tasks/1"
             retry: "/api/v2/tasks/1/runs/1/retry"
-            logs: "/api/v2/tasks/1/runs/1/logs"
           properties:
             self:
               type: string
               format: uri
             task:
-              type: string
-              format: uri
-            logs:
               type: string
               format: uri
             retry:
@@ -8794,12 +8634,8 @@ components:
           readOnly: true
           example:
             self: "/api/v2/users/1"
-            logs: "/api/v2/users/1/logs"
           properties:
             self:
-              type: string
-              format: uri
-            logs:
               type: string
               format: uri
       required: [name]
@@ -10064,7 +9900,6 @@ components:
                 cells: "/api/v2/dashboards/1/cells"
                 owners: "/api/v2/dashboards/1/owners"
                 members: "/api/v2/dashboards/1/members"
-                logs: "/api/v2/dashboards/1/logs"
                 labels: "/api/v2/dashboards/1/labels"
                 org: "/api/v2/labels/1"
               properties:
@@ -10075,8 +9910,6 @@ components:
                 members:
                   $ref: "#/components/schemas/Link"
                 owners:
-                  $ref: "#/components/schemas/Link"
-                logs:
                   $ref: "#/components/schemas/Link"
                 labels:
                   $ref: "#/components/schemas/Link"
@@ -10111,7 +9944,6 @@ components:
                 cells: "/api/v2/dashboards/1/cells"
                 owners: "/api/v2/dashboards/1/owners"
                 members: "/api/v2/dashboards/1/members"
-                logs: "/api/v2/dashboards/1/logs"
                 labels: "/api/v2/dashboards/1/labels"
                 org: "/api/v2/labels/1"
               properties:
@@ -10122,8 +9954,6 @@ components:
                 members:
                   $ref: "#/components/schemas/Link"
                 owners:
-                  $ref: "#/components/schemas/Link"
-                logs:
                   $ref: "#/components/schemas/Link"
                 labels:
                   $ref: "#/components/schemas/Link"

--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -30,7 +30,6 @@ describe('Bucket Selector', () => {
         updatedAt: '2019-11-05T08:58:09.593805-08:00',
         links: {
           labels: '/api/v2/buckets/7902bd683453c00c/labels',
-          logs: '/api/v2/buckets/7902bd683453c00c/logs',
           members: '/api/v2/buckets/7902bd683453c00c/members',
           org: '/api/v2/orgs/e483753c9bdb47bf',
           owners: '/api/v2/buckets/7902bd683453c00c/owners',
@@ -50,7 +49,6 @@ describe('Bucket Selector', () => {
         updatedAt: '2019-10-15T11:10:27.970567-07:00',
         links: {
           labels: '/api/v2/buckets/7f44462ac794c7c1/labels',
-          logs: '/api/v2/buckets/7f44462ac794c7c1/logs',
           members: '/api/v2/buckets/7f44462ac794c7c1/members',
           org: '/api/v2/orgs/e483753c9bdb47bf',
           owners: '/api/v2/buckets/7f44462ac794c7c1/owners',
@@ -70,7 +68,6 @@ describe('Bucket Selector', () => {
         updatedAt: '2019-11-05T08:57:59.280486-08:00',
         links: {
           labels: '/api/v2/buckets/a8fee6b433c16f86/labels',
-          logs: '/api/v2/buckets/a8fee6b433c16f86/logs',
           members: '/api/v2/buckets/a8fee6b433c16f86/members',
           org: '/api/v2/orgs/e483753c9bdb47bf',
           owners: '/api/v2/buckets/a8fee6b433c16f86/owners',
@@ -90,7 +87,6 @@ describe('Bucket Selector', () => {
         updatedAt: '2019-10-18T14:05:24.838292-07:00',
         links: {
           labels: '/api/v2/buckets/adbb0107da2d7d38/labels',
-          logs: '/api/v2/buckets/adbb0107da2d7d38/logs',
           members: '/api/v2/buckets/adbb0107da2d7d38/members',
           org: '/api/v2/orgs/e483753c9bdb47bf',
           owners: '/api/v2/buckets/adbb0107da2d7d38/owners',
@@ -110,7 +106,6 @@ describe('Bucket Selector', () => {
         updatedAt: '2019-11-05T08:58:16.873502-08:00',
         links: {
           labels: '/api/v2/buckets/e2871ad8f92e752a/labels',
-          logs: '/api/v2/buckets/e2871ad8f92e752a/logs',
           members: '/api/v2/buckets/e2871ad8f92e752a/members',
           org: '/api/v2/orgs/e483753c9bdb47bf',
           owners: '/api/v2/buckets/e2871ad8f92e752a/owners',
@@ -135,7 +130,6 @@ describe('Bucket Selector', () => {
         updatedAt: '0001-01-01T00:00:00Z',
         links: {
           labels: '/api/v2/buckets/000000000000000a/labels',
-          logs: '/api/v2/buckets/000000000000000a/logs',
           members: '/api/v2/buckets/000000000000000a/members',
           org: '/api/v2/orgs/',
           owners: '/api/v2/buckets/000000000000000a/owners',
@@ -160,7 +154,6 @@ describe('Bucket Selector', () => {
         updatedAt: '0001-01-01T00:00:00Z',
         links: {
           labels: '/api/v2/buckets/000000000000000b/labels',
-          logs: '/api/v2/buckets/000000000000000b/logs',
           members: '/api/v2/buckets/000000000000000b/members',
           org: '/api/v2/orgs/',
           owners: '/api/v2/buckets/000000000000000b/owners',


### PR DESCRIPTION
Work had started on a operation log but was never fully implemented and was later partially removed. The plan here is to remove the partially defunct logs and then build a new robust op log system that will replace it in the future.

closes #18423
closes #18389