### PR TITLE
chore(influx): remove client timeout on write cmd's retriever

### DIFF
--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -134,7 +134,8 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 		"join": "unbounded test",
 	},
 	"testing/chronograf": {
-		"buckets": "unbounded test",
+		"buckets":                "unbounded test",
+		"aggregate_window_count": "flakey test: https://github.com/influxdata/influxdb/issues/18463",
 	},
 	"testing/kapacitor": {
 		"fill_default": "unknown field type for f1",


### PR DESCRIPTION
also adds skip for flakey test identified in issue: #18463
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass