### PR TITLE
chore(flags): updated hydratevars to expose feature flag

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -109,6 +109,7 @@
   default: false
   contact: Ariel Salem / Monitoring Team
   lifetime: temporary
+  expose: true
 
 - name: Memory Optimized Fill
   description: Enable the memory optimized fill()

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -190,7 +190,7 @@ var hydratevars = MakeBoolFlag(
 	"Ariel Salem / Monitoring Team",
 	false,
 	Temporary,
-	false,
+	true,
 )
 
 // NewHydrateVarsFunctionality - Enables a minimalistic variable hydration


### PR DESCRIPTION
This PR sets the `expose` flag for the `hydratevars` feature flag so that it can be toggled on the UI