### PR TITLE
fix: build osxcross in $HOME rather than /opt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,15 +29,15 @@ commands:
           name: Install macOS cross compilers
           command: |
             sudo apt-get install libxml2-dev libssl-dev zlib1g-dev
-            mkdir -p /opt/osxcross
+            sudo mkdir -p /opt/osxcross
             cd /opt
-            git clone https://github.com/tpoechtrager/osxcross.git
+            sudo git clone https://github.com/tpoechtrager/osxcross.git
             cd osxcross
-            git checkout c2ad5e859d12a295c3f686a15bd7181a165bfa82
-            curl -L -o \
+            sudo git checkout c2ad5e859d12a295c3f686a15bd7181a165bfa82
+            sudo curl -L -o \
               ./tarballs/MacOSX10.11.sdk.tar.xz \
               https://macos-sdks.s3.amazonaws.com/MacOSX10.11.sdk.tar.xz
-            UNATTENDED=1 PORTABLE=true ./build.sh
+            UNATTENDED=1 PORTABLE=true sudo ./build.sh
       - run:
           name: Install additional rust targets
           command: |
@@ -49,7 +49,7 @@ commands:
             echo 'export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $HOME/.cargo/env
             echo 'export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc' >> $HOME/.cargo/env
             echo 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $HOME/.cargo/env
-            echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=o64-clang' >> $HOME/.cargo/env
+            echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/opt/osxcross/target/o64-clang' >> $HOME/.cargo/env
       - run:
           name: Install pkg-config wrapper
           command: go build -o /go/bin/pkg-config github.com/influxdata/pkg-config

--- a/xcc.sh
+++ b/xcc.sh
@@ -12,7 +12,7 @@ case "${GOOS}_${GOARCH}" in
   linux_amd64) CC=clang ;;
   linux_arm64) CC=aarch64-linux-gnu-gcc ;;
   linux_arm)   CC=arm-linux-gnueabihf-gcc ;;
-  darwin_amd64) CC=o64-clang ;;
+  darwin_amd64) CC=/opt/osxcross/target/bin/o64-clang ;;
   *) die "No cross-compiler set for ${GOOS}_${GOARCH}" ;;
 esac
 


### PR DESCRIPTION
Installing `osxcross` to `/opt` requires superuser permissions. This is
built as root in flux, but requires `sudo` for circleCI. Additionally,
there was a problem with `o64-clang` not being on the `PATH` that we
would have discovered the next time we tried to release.