### PR TITLE
fix(ui): reset the loading spinner timer on error

### DIFF
--- a/ui/src/shared/components/ViewLoadingSpinner.tsx
+++ b/ui/src/shared/components/ViewLoadingSpinner.tsx
@@ -27,7 +27,7 @@ const ViewLoadingSpinner: FunctionComponent<Props> = ({loading}) => {
   }
 
   useEffect(() => {
-    if (loading === RemoteDataState.Done) {
+    if (loading === RemoteDataState.Done || RemoteDataState.Error) {
       resetTimer()
     }
 


### PR DESCRIPTION
Closes #18470 

Reset the timer when loading state is error.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
