### PR TITLE
fix: Fixes the dropdown width for variables

### DIFF
--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -46,7 +46,7 @@ class VariableDropdown extends PureComponent<Props> {
     const longestItemWidth = Math.floor(
       values.reduce(function(a, b) {
         return a.length > b.length ? a : b
-      }, '').length * 8.75
+      }, '').length * 9.5
     )
 
     const widthLength = Math.max(140, longestItemWidth)


### PR DESCRIPTION
The amount of spacing was too small for bucket names between 10-16 characters

No issue number 

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
