### PR TITLE
feat(cmdClick-task): Added command click functionality to tasks names to open in separate tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0-beta.13 [unreleased]
+
+### Features
+
+1. [18480](https://github.com/influxdata/influxdb/pull/18480): Allows tasks to open in new tabs
+
 ## v2.0.0-beta.12 [2020-06-11]
 
 ### Features

--- a/ui/src/tasks/actions/thunks.ts
+++ b/ui/src/tasks/actions/thunks.ts
@@ -282,13 +282,17 @@ export const setAllTaskOptionsByID = (taskID: string) => async (
   }
 }
 
-export const selectTask = (taskID: string) => (
+export const selectTask = (taskID: string, commandClick?: boolean) => (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
   const org = getOrg(getState())
 
-  dispatch(push(`/orgs/${org.id}/tasks/${taskID}`))
+  if (commandClick) {
+    window.open(`/orgs/${org.id}/tasks/${taskID}`, '_blank')
+  } else {
+    dispatch(push(`/orgs/${org.id}/tasks/${taskID}`))
+  }
 }
 
 export const goToTasks = () => (

--- a/ui/src/tasks/actions/thunks.ts
+++ b/ui/src/tasks/actions/thunks.ts
@@ -282,19 +282,6 @@ export const setAllTaskOptionsByID = (taskID: string) => async (
   }
 }
 
-export const selectTask = (taskID: string, commandClick?: boolean) => (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const org = getOrg(getState())
-
-  if (commandClick) {
-    window.open(`/orgs/${org.id}/tasks/${taskID}`, '_blank')
-  } else {
-    dispatch(push(`/orgs/${org.id}/tasks/${taskID}`))
-  }
-}
-
 export const goToTasks = () => (
   dispatch: Dispatch<Action>,
   getState: GetState

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -19,11 +19,7 @@ import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTaskStatus'
 
 // Actions
-import {
-  addTaskLabel,
-  deleteTaskLabel,
-  selectTask,
-} from 'src/tasks/actions/thunks'
+import {addTaskLabel, deleteTaskLabel} from 'src/tasks/actions/thunks'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
@@ -36,7 +32,6 @@ interface PassedProps {
   task: Task
   onActivate: (task: Task) => void
   onDelete: (task: Task) => void
-  onSelect: typeof selectTask
   onClone: (task: Task) => void
   onRunTask: (taskID: string) => void
   onUpdate: (name: string, taskID: string) => void
@@ -140,10 +135,16 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
   }
 
   private handleNameClick = (event: MouseEvent) => {
+    const {
+      params: {orgID},
+      router,
+      task,
+    } = this.props
+    const url = `/orgs/${orgID}/tasks/${task.id}`
     if (event.metaKey) {
-      this.props.onSelect(this.props.task.id, true)
+      window.open(url, '_blank')
     } else {
-      this.props.onSelect(this.props.task.id)
+      router.push(url)
     }
   }
 

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -139,10 +139,12 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     )
   }
 
-  private handleNameClick = (e: MouseEvent) => {
-    e.preventDefault()
-
-    this.props.onSelect(this.props.task.id)
+  private handleNameClick = (event: MouseEvent) => {
+    if (event.metaKey) {
+      this.props.onSelect(this.props.task.id, true)
+    } else {
+      this.props.onSelect(this.props.task.id)
+    }
   }
 
   private handleViewRuns = () => {

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -99,7 +99,6 @@ export default class TasksList extends PureComponent<Props, State> {
       sortType,
       onActivate,
       onDelete,
-      onSelectTask,
       onClone,
       onUpdate,
       onRunTask,

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -11,7 +11,7 @@ import EmptyTasksList from 'src/tasks/components/EmptyTasksList'
 import {Task} from 'src/types'
 import {SortTypes} from 'src/shared/utils/sort'
 import {Sort} from '@influxdata/clockface'
-import {selectTask, addTaskLabel, runTask} from 'src/tasks/actions/thunks'
+import {addTaskLabel, runTask} from 'src/tasks/actions/thunks'
 import {checkTaskLimits as checkTaskLimitsAction} from 'src/cloud/actions/limits'
 import {TaskSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
@@ -27,7 +27,6 @@ interface Props {
   onClone: (task: Task) => void
   onFilterChange: (searchTerm: string) => void
   totalCount: number
-  onSelect: typeof selectTask
   onAddTaskLabel: typeof addTaskLabel
   onRunTask: typeof runTask
   onUpdate: (name: string, taskID: string) => void
@@ -100,7 +99,7 @@ export default class TasksList extends PureComponent<Props, State> {
       sortType,
       onActivate,
       onDelete,
-      onSelect,
+      onSelectTask,
       onClone,
       onUpdate,
       onRunTask,
@@ -121,7 +120,6 @@ export default class TasksList extends PureComponent<Props, State> {
         onActivate={onActivate}
         onDelete={onDelete}
         onClone={onClone}
-        onSelect={onSelect}
         onUpdate={onUpdate}
         onRunTask={onRunTask}
         onFilterChange={onFilterChange}

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -20,7 +20,6 @@ import {
   updateTaskStatus,
   updateTaskName,
   deleteTask,
-  selectTask,
   cloneTask,
   addTaskLabel,
   runTask,
@@ -56,7 +55,6 @@ interface ConnectedDispatchProps {
   updateTaskName: typeof updateTaskName
   deleteTask: typeof deleteTask
   cloneTask: typeof cloneTask
-  selectTask: typeof selectTask
   setSearchTerm: typeof setSearchTermAction
   setShowInactive: typeof setShowInactiveAction
   onAddTaskLabel: typeof addTaskLabel
@@ -109,7 +107,6 @@ class TasksPage extends PureComponent<Props, State> {
   public render(): JSX.Element {
     const {sortKey, sortDirection, sortType} = this.state
     const {
-      selectTask,
       setSearchTerm,
       updateTaskName,
       searchTerm,
@@ -160,7 +157,6 @@ class TasksPage extends PureComponent<Props, State> {
                       onDelete={this.handleDelete}
                       onCreate={this.handleCreateTask}
                       onClone={this.handleClone}
-                      onSelect={selectTask}
                       onAddTaskLabel={onAddTaskLabel}
                       onRunTask={onRunTask}
                       onFilterChange={setSearchTerm}
@@ -293,7 +289,6 @@ const mdtp: ConnectedDispatchProps = {
   updateTaskStatus,
   updateTaskName,
   deleteTask,
-  selectTask,
   cloneTask,
   setSearchTerm: setSearchTermAction,
   setShowInactive: setShowInactiveAction,


### PR DESCRIPTION
### Problem

Working with tasks requires a lot of back and forth

### Solution

Integrate command+click functionality on task names so that users can open and browse multiple tasks in different tabs

![command-click-task](https://user-images.githubusercontent.com/19984220/84503303-d188b980-ac6e-11ea-995d-79e04c643444.gif)


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
