### PR TITLE
feat(query): add test and feature flag for pushing down sum

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -49,8 +49,14 @@
   default: false
   contact: Query Team
 
+- name: Push Down Window Aggregate Sum
+  description: Enable Sum variant of PushDownWindowAggregateRule and PushDownBareAggregateRule
+  key: pushDownWindowAggregateSum
+  default: false
+  contact: Query Team
+
 - name: Push Down Window Aggregate Rest
-  description: Enable non-Count variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
+  description: Enable non-Count, non-Sum variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
   key: pushDownWindowAggregateRest
   default: false
   contact: Query Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -72,6 +72,20 @@ func PushDownWindowAggregateCount() BoolFlag {
 	return pushDownWindowAggregateCount
 }
 
+var pushDownWindowAggregateSum = MakeBoolFlag(
+	"Push Down Window Aggregate Sum",
+	"pushDownWindowAggregateSum",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownWindowAggregateSum - Enable Sum variant of PushDownWindowAggregateRule and PushDownBareAggregateRule
+func PushDownWindowAggregateSum() BoolFlag {
+	return pushDownWindowAggregateSum
+}
+
 var pushDownWindowAggregateRest = MakeBoolFlag(
 	"Push Down Window Aggregate Rest",
 	"pushDownWindowAggregateRest",
@@ -81,7 +95,7 @@ var pushDownWindowAggregateRest = MakeBoolFlag(
 	false,
 )
 
-// PushDownWindowAggregateRest - Enable non-Count variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
+// PushDownWindowAggregateRest - Enable non-Count, non-Sum variants of PushDownWindowAggregateRule and PushDownWindowAggregateRule (stage 2)
 func PushDownWindowAggregateRest() BoolFlag {
 	return pushDownWindowAggregateRest
 }
@@ -218,6 +232,7 @@ var all = []Flag{
 	communityTemplates,
 	frontendExample,
 	pushDownWindowAggregateCount,
+	pushDownWindowAggregateSum,
 	pushDownWindowAggregateRest,
 	newAuth,
 	sessionService,
@@ -236,6 +251,7 @@ var byKey = map[string]Flag{
 	"communityTemplates":           communityTemplates,
 	"frontendExample":              frontendExample,
 	"pushDownWindowAggregateCount": pushDownWindowAggregateCount,
+	"pushDownWindowAggregateSum":   pushDownWindowAggregateSum,
 	"pushDownWindowAggregateRest":  pushDownWindowAggregateRest,
 	"newAuth":                      newAuth,
 	"sessionService":               sessionService,

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -684,7 +684,7 @@ func canPushWindowedAggregate(ctx context.Context, fnNode plan.Node) bool {
 	}
 
 	// Check the aggregate function spec. Require operation on _value. There
-	// are two feature flags covering all cases. One specifically for Count,
+	// are two feature flags covering all cases. One specifically for Count, one for Sum,
 	// and another for the rest. There are individual capability tests for all
 	// cases.
 	switch fnNode.Kind() {
@@ -725,7 +725,7 @@ func canPushWindowedAggregate(ctx context.Context, fnNode plan.Node) bool {
 			return false
 		}
 	case universe.SumKind:
-		if !feature.PushDownWindowAggregateRest().Enabled(ctx) || !caps.HaveSum() {
+		if !feature.PushDownWindowAggregateSum().Enabled(ctx) || !caps.HaveSum() {
 			return false
 		}
 

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -683,10 +683,8 @@ func canPushWindowedAggregate(ctx context.Context, fnNode plan.Node) bool {
 		return false
 	}
 
-	// Check the aggregate function spec. Require operation on _value. There
-	// are two feature flags covering all cases. One specifically for Count, one for Sum,
-	// and another for the rest. There are individual capability tests for all
-	// cases.
+	// Check the aggregate function spec. Require the operation on _value
+	// and check the feature flag associated with the aggregate function.
 	switch fnNode.Kind() {
 	case universe.MinKind:
 		if !feature.PushDownWindowAggregateRest().Enabled(ctx) || !caps.HaveMin() {

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1169,7 +1169,7 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 	// Turn on all variants.
 	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
 		feature.PushDownWindowAggregateCount(): true,
-		feature.PushDownWindowAggregateSum(): true,
+		feature.PushDownWindowAggregateSum():   true,
 		feature.PushDownWindowAggregateRest():  true,
 	})
 
@@ -1961,7 +1961,7 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 	// Turn on support for window aggregate count
 	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
 		feature.PushDownWindowAggregateCount(): true,
-		feature.PushDownWindowAggregateSum(): true,
+		feature.PushDownWindowAggregateSum():   true,
 	})
 
 	withFlagger, _ := feature.Annotate(context.Background(), flagger)

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1169,6 +1169,7 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 	// Turn on all variants.
 	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
 		feature.PushDownWindowAggregateCount(): true,
+		feature.PushDownWindowAggregateSum(): true,
 		feature.PushDownWindowAggregateRest():  true,
 	})
 
@@ -1960,6 +1961,7 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 	// Turn on support for window aggregate count
 	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
 		feature.PushDownWindowAggregateCount(): true,
+		feature.PushDownWindowAggregateSum(): true,
 	})
 
 	withFlagger, _ := feature.Annotate(context.Background(), flagger)
@@ -1985,10 +1987,12 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 		},
 	}
 
-	readWindowAggregate := &influxdb.ReadWindowAggregatePhysSpec{
-		ReadRangePhysSpec: *(readRange.Copy().(*influxdb.ReadRangePhysSpec)),
-		WindowEvery:       math.MaxInt64,
-		Aggregates:        []plan.ProcedureKind{universe.CountKind},
+	readWindowAggregate := func(proc plan.ProcedureKind) *influxdb.ReadWindowAggregatePhysSpec {
+		return &influxdb.ReadWindowAggregatePhysSpec{
+			ReadRangePhysSpec: *(readRange.Copy().(*influxdb.ReadRangePhysSpec)),
+			WindowEvery:       math.MaxInt64,
+			Aggregates:        []plan.ProcedureKind{proc},
+		}
 	}
 
 	minProcedureSpec := func() *universe.MinProcedureSpec {
@@ -1998,6 +2002,11 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 	}
 	countProcedureSpec := func() *universe.CountProcedureSpec {
 		return &universe.CountProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value"}},
+		}
+	}
+	sumProcedureSpec := func() *universe.SumProcedureSpec {
+		return &universe.SumProcedureSpec{
 			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value"}},
 		}
 	}
@@ -2019,7 +2028,27 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 			},
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate),
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate("count")),
+				},
+			},
+		},
+		{
+			// successful push down
+			Context: haveCaps,
+			Name:    "push down sum",
+			Rules:   []plan.Rule{influxdb.PushDownBareAggregateRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", readRange),
+					plan.CreatePhysicalNode("sum", sumProcedureSpec()),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate("sum")),
 				},
 			},
 		},

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -29,6 +29,7 @@ func NewStore(viewer reads.Viewer) reads.Store {
 		},
 		windowCap: WindowAggregateCapability{
 			Count: true,
+			Sum:   true,
 		},
 	}
 }


### PR DESCRIPTION
This adds the storage capability in OSS for pushing down `sum` in `ReadWindowAggregate`, and associated tests and feature flag.