### PR TITLE
chore(min-max/customtimerange): set min & max dates for start & vend time respectively

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -242,7 +242,7 @@ describe('DataExplorer', () => {
   })
 
   describe('select time range to query', () => {
-    it('can select different time ranges', () => {
+    it('can set a custom time range and restricts start & stop selections relative to start & stop dates', () => {
       // find initial value
       cy.get('.cf-dropdown--selected')
         .contains('Past 1')
@@ -261,6 +261,33 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('dropdown-item-customtimerange').click()
       cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
+
+      cy.getByTestID('timerange--input')
+        .first()
+        .clear()
+        .type('2019-10-29 08:00:00.000')
+
+      // Set the stop date to Oct 29, 2019
+      cy.getByTestID('timerange--input')
+        .last()
+        .clear()
+        .type('2019-10-29 09:00:00.000')
+
+      // click button and see if time range has been selected
+      cy.getByTestID('daterange--apply-btn').click()
+
+      cy.getByTestID('timerange-dropdown').click()
+      cy.getByTestID('dropdown-item-customtimerange').click()
+
+      // Select the 30th in the Start timerange
+      cy.get('.react-datepicker__day--030')
+        .first()
+        .should('be', 'disabled')
+
+      // Select the 28th in the Stop timerange
+      cy.get('.react-datepicker__day--028')
+        .last()
+        .should('be', 'disabled')
     })
 
     describe('should allow for custom time range selection', () => {
@@ -268,39 +295,6 @@ describe('DataExplorer', () => {
         cy.getByTestID('timerange-dropdown').click()
         cy.getByTestID('dropdown-item-customtimerange').click()
         cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
-      })
-
-      it('should not allow users to start dates after the stop date & stop dates before the start date', () => {
-        // Set the start date to Oct 29, 2019
-        cy.get('input[title="Start"]')
-          .should('have.length', 1)
-          .clear()
-          .type('2019-10-29 08:00:00.000')
-
-        // Set the stop date to Oct 29, 2019
-        cy.get('input[title="Stop"]')
-          .should('have.length', 1)
-          .clear()
-          .type('2019-10-29 09:00:00.000')
-
-        // click button and see if time range has been selected
-        cy.get('.cf-button--label')
-          .contains('Apply Time Range')
-          .should('have.length', 1)
-          .click()
-
-        cy.getByTestID('timerange-dropdown').click()
-        cy.getByTestID('dropdown-item-customtimerange').click()
-
-        // Select the 30th in the Start timerange
-        cy.get('.react-datepicker__day--030')
-          .first()
-          .should('be', 'disabled')
-
-        // Select the 28th in the Stop timerange
-        cy.get('.react-datepicker__day--028')
-          .last()
-          .should('be', 'disabled')
       })
 
       it.skip('should error when submitting stop dates that are before start dates', () => {
@@ -317,10 +311,7 @@ describe('DataExplorer', () => {
           .type('2019-10-29')
 
         // click button and see if time range has been selected
-        cy.get('.cf-button--label')
-          .contains('Apply Time Range')
-          .should('have.length', 1)
-          .click()
+        cy.getByTestID('daterange--apply-btn').click()
 
         // TODO: complete test once functionality is fleshed out
 
@@ -360,39 +351,13 @@ describe('DataExplorer', () => {
         cy.getByTestID('input-error').should('have.length', 1)
 
         // try submitting invalid date
-        cy.get('.cf-button--label')
-          .contains('Apply Time Range')
-          .should('have.length', 1)
-          .click()
+        cy.getByTestID('daterange--apply-btn').click()
 
         // TODO: complete test once functionality is fleshed out
 
         // cy.get('.cf-dropdown--selected')
         //   .contains('2019-10-01 00:00 - 2019-10-31 00:00')
         //   .should('have.length', 1)
-      })
-
-      it('can set a custom time range', () => {
-        // set the start and stop dates
-        cy.get('input[title="Start"]')
-          .should('have.length', 1)
-          .clear()
-          .type('2019-10-01')
-
-        cy.get('input[title="Stop"]')
-          .should('have.length', 1)
-          .clear()
-          .type('2019-10-31')
-
-        // click button and see if time range has been selected
-        cy.get('.cf-button--label')
-          .contains('Apply Time Range')
-          .should('have.length', 1)
-          .click()
-
-        cy.get('.cf-dropdown--selected')
-          .contains('2019-10-01 00:00 - 2019-10-31 00:00')
-          .should('have.length', 1)
       })
     })
   })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -270,6 +270,39 @@ describe('DataExplorer', () => {
         cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
       })
 
+      it('should not allow users to start dates after the stop date & stop dates before the start date', () => {
+        // Set the start date to Oct 29, 2019
+        cy.get('input[title="Start"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-29 08:00:00.000')
+
+        // Set the stop date to Oct 29, 2019
+        cy.get('input[title="Stop"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-29 09:00:00.000')
+
+        // click button and see if time range has been selected
+        cy.get('.cf-button--label')
+          .contains('Apply Time Range')
+          .should('have.length', 1)
+          .click()
+
+        cy.getByTestID('timerange-dropdown').click()
+        cy.getByTestID('dropdown-item-customtimerange').click()
+
+        // Select the 30th in the Start timerange
+        cy.get('.react-datepicker__day--030')
+          .first()
+          .should('be', 'disabled')
+
+        // Select the 28th in the Stop timerange
+        cy.get('.react-datepicker__day--028')
+          .last()
+          .should('be', 'disabled')
+      })
+
       it.skip('should error when submitting stop dates that are before start dates', () => {
         // TODO: complete with issue #15632
         // https://github.com/influxdata/influxdb/issues/15632

--- a/ui/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -15,6 +15,8 @@ import {Columns, ComponentSize, ComponentStatus} from '@influxdata/clockface'
 interface Props {
   label: string
   dateTime: string
+  maxDate?: string
+  minDate?: string
   onSelectDate: (date: string) => void
 }
 
@@ -56,7 +58,7 @@ export default class DatePicker extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {dateTime, label} = this.props
+    const {dateTime, label, maxDate, minDate} = this.props
 
     const date = new Date(dateTime)
 
@@ -89,6 +91,8 @@ export default class DatePicker extends PureComponent<Props, State> {
                 dayClassName={this.dayClassName}
                 timeIntervals={60}
                 fixedHeight={true}
+                minDate={new Date(minDate)}
+                maxDate={new Date(maxDate)}
               />
             </div>
           </Grid.Column>

--- a/ui/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -74,6 +74,7 @@ export default class DatePicker extends PureComponent<Props, State> {
                 value={this.inputValue}
                 onChange={this.handleChangeInput}
                 status={this.inputStatus}
+                testID="timerange--input"
               />
             </Form.Element>
             <div className="range-picker--popper-container">

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -54,11 +54,13 @@ class DateRangePicker extends PureComponent<Props, State> {
               dateTime={lower}
               onSelectDate={this.handleSelectLower}
               label="Start"
+              maxDate={upper}
             />
             <DatePicker
               dateTime={upper}
               onSelectDate={this.handleSelectUpper}
               label="Stop"
+              minDate={lower}
             />
           </div>
           <Button

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -69,6 +69,7 @@ class DateRangePicker extends PureComponent<Props, State> {
             size={ComponentSize.Small}
             onClick={this.handleSetTimeRange}
             text="Apply Time Range"
+            testID="daterange--apply-btn"
           />
         </div>
       </ClickOutside>


### PR DESCRIPTION
Sets min & max dates for max & min date picker (respectively). This means that users cannot select a start date that is after the end date, and users cannot select an end date that is after the start date.
Caveat to all of this is that these limitations are not respected when it comes to setting the time. This is an issue with the dependency that I filed here:

https://github.com/Hacker0x01/react-datepicker/issues/2184

This PR address some of the concerns listed here:

#15632

