### PR TITLE
fix: update formatStatValue to correctly handle trailing zeroes in all cases

### DIFF
--- a/ui/src/shared/utils/formatStatValue.test.ts
+++ b/ui/src/shared/utils/formatStatValue.test.ts
@@ -1,0 +1,231 @@
+import {formatStatValue} from './formatStatValue'
+
+describe('formatStatValue', () => {
+  let prefix: string
+  let value: number | string
+  let suffix: string
+
+  describe('handles bad input gracefully', () => {
+    test('does not throw an error when decimal places is greater than 100', () => {
+      expect(() =>
+        formatStatValue('2.00', {
+          decimalPlaces: {isEnforced: true, digits: 101},
+        })
+      ).not.toThrow()
+    })
+
+    test('handles undefined', () => {
+      prefix = 'LOL'
+      value = undefined
+      suffix = ' is funny'
+
+      const errorResult = formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+      expect(typeof errorResult === 'string').toEqual(true)
+      expect(errorResult).not.toEqual(`${prefix}${value}${suffix}`)
+    })
+
+    test('handles null', () => {
+      prefix = ':-('
+      value = null
+      suffix = ' is not funny'
+
+      const errorResult = formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+      expect(typeof errorResult === 'string').toEqual(true)
+      expect(errorResult).not.toEqual(`${prefix}${value}${suffix}`)
+    })
+  })
+
+  test('formats NaN', () => {
+    prefix = 'My nanny is '
+    value = NaN
+    suffix = ''
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+
+  test('formats Infinity', () => {
+    prefix = 'To '
+    value = Infinity
+    suffix = ' and beyond'
+
+    const INFINITY_SYMBOL = '∞'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${INFINITY_SYMBOL}${suffix}`)
+  })
+
+  test('formats negative Infinity', () => {
+    prefix = 'To '
+    value = -Infinity
+    suffix = ' and beyond'
+
+    const INFINITY_SYMBOL = '∞'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}-${INFINITY_SYMBOL}${suffix}`)
+  })
+
+  test('formats 0 with trailing decimal 0s', () => {
+    prefix = ''
+    value = 0
+    let trailingDecimals = 2
+    suffix = ''
+
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: trailingDecimals},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}0.00${suffix}`)
+
+    trailingDecimals = 10
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: trailingDecimals},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}0.0000000000${suffix}`)
+  })
+
+  test('formats an integer value', () => {
+    prefix = 'we have '
+    value = 123
+    suffix = ' abc'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = -1
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = 123456789
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}123,456,789${suffix}`)
+  })
+
+  test('formats a float value', () => {
+    prefix = 'abc '
+    value = 123.456789
+    suffix = ' yoyoyo'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 6},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = -9.012345678911111111111111111111111111111111111
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 20},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}-9.0123456789${suffix}`)
+  })
+
+  test('formats an empty string value', () => {
+    prefix = ''
+    value = ''
+    suffix = ''
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 3},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+
+  test('formats a non-empty string value', () => {
+    prefix = 'Negative '
+    value = '-666.666'
+    suffix = ' is Evil'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 3},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+
+  test('keeps trailing zeroes for the required number of decimal places', () => {
+    value = '2.000'
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    value = '2.00000000000000000000000000'
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    value = '2.0'
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    value = '2'
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    /* prettier-ignore */
+    value = 2
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    /* prettier-ignore */
+    value = 2.0
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+
+    /* prettier-ignore */
+    value = 2.00000000
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
+    ).toEqual('2.000')
+  })
+})


### PR DESCRIPTION
Closes #18493 

The util responsible for handling the formatting of single stat values has some logic holes in it. Trailing zeroes were being truncated. This addresses the issue with unit tests.

<img width="1680" alt="Screen Shot 2020-06-12 at 2 48 45 PM" src="https://user-images.githubusercontent.com/10736577/84549652-5dc1cd80-acbd-11ea-8fe6-cfc6b1b78a04.png">

