### PR TITLE
fix: loads function writeNavigationTimingMetrics after window.load runs

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -546,6 +546,6 @@ if (rootNode) {
   render(<Root />, rootNode)
 }
 
-window.addEventListener('load', _event => {
+window.addEventListener('load', () => {
   writeNavigationTimingMetrics()
 })

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -546,4 +546,6 @@ if (rootNode) {
   render(<Root />, rootNode)
 }
 
-writeNavigationTimingMetrics()
+window.addEventListener('load', _event => {
+  writeNavigationTimingMetrics()
+})


### PR DESCRIPTION
Closes #18421

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
