### PR TITLE
refactor: remove org service from kv dashboard service

### DIFF
--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -241,14 +241,6 @@ func (s *Service) findDashboards(ctx context.Context, tx Tx, filter influxdb.Das
 		return s.findOrganizationDashboards(ctx, tx, *filter.OrganizationID)
 	}
 
-	if filter.Organization != nil {
-		o, err := s.findOrganizationByName(ctx, tx, *filter.Organization)
-		if err != nil {
-			return nil, err
-		}
-		return s.findOrganizationDashboards(ctx, tx, o.ID)
-	}
-
 	var offset, limit, count int
 	var descending bool
 	if len(opts) > 0 {


### PR DESCRIPTION
Closes #18503

This PR moves the lookup of an organization by its name from the kv dashboard service to the http layer. This is so that we can remove the outdated organization code from the kv package and switch to using the tenant service exclusively.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass