### PR TITLE
fix(dbrp): Change DBRP mapping service to use Buckets resource permissions

### DIFF
--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -12,7 +12,7 @@ func AuthorizeFindDBRPs(ctx context.Context, rs []*influxdb.DBRPMappingV2) ([]*i
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 	rrs := rs[:0]
 	for _, r := range rs {
-		_, _, err := AuthorizeRead(ctx, influxdb.DBRPResourceType, r.ID, r.OrganizationID)
+		_, _, err := AuthorizeRead(ctx, influxdb.BucketsResourceType, r.BucketID, r.OrganizationID)
 		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
 			return nil, 0, err
 		}

--- a/dbrp/middleware_auth.go
+++ b/dbrp/middleware_auth.go
@@ -18,10 +18,14 @@ func NewAuthorizedService(s influxdb.DBRPMappingServiceV2) *AuthorizedService {
 }
 
 func (svc AuthorizedService) FindByID(ctx context.Context, orgID, id influxdb.ID) (*influxdb.DBRPMappingV2, error) {
-	if _, _, err := authorizer.AuthorizeRead(ctx, influxdb.DBRPResourceType, id, orgID); err != nil {
+	mapping, err := svc.DBRPMappingServiceV2.FindByID(ctx, orgID, id)
+	if err != nil {
 		return nil, err
 	}
-	return svc.DBRPMappingServiceV2.FindByID(ctx, orgID, id)
+	if _, _, err := authorizer.AuthorizeRead(ctx, influxdb.BucketsResourceType, mapping.BucketID, orgID); err != nil {
+		return nil, err
+	}
+	return mapping, nil
 }
 
 func (svc AuthorizedService) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilterV2, opts ...influxdb.FindOptions) ([]*influxdb.DBRPMappingV2, int, error) {
@@ -33,21 +37,25 @@ func (svc AuthorizedService) FindMany(ctx context.Context, filter influxdb.DBRPM
 }
 
 func (svc AuthorizedService) Create(ctx context.Context, t *influxdb.DBRPMappingV2) error {
-	if _, _, err := authorizer.AuthorizeCreate(ctx, influxdb.DBRPResourceType, t.OrganizationID); err != nil {
+	if _, _, err := authorizer.AuthorizeWrite(ctx, influxdb.BucketsResourceType, t.BucketID, t.OrganizationID); err != nil {
 		return err
 	}
 	return svc.DBRPMappingServiceV2.Create(ctx, t)
 }
 
 func (svc AuthorizedService) Update(ctx context.Context, u *influxdb.DBRPMappingV2) error {
-	if _, _, err := authorizer.AuthorizeWrite(ctx, influxdb.DBRPResourceType, u.ID, u.OrganizationID); err != nil {
+	if _, _, err := authorizer.AuthorizeWrite(ctx, influxdb.BucketsResourceType, u.BucketID, u.OrganizationID); err != nil {
 		return err
 	}
 	return svc.DBRPMappingServiceV2.Update(ctx, u)
 }
 
 func (svc AuthorizedService) Delete(ctx context.Context, orgID, id influxdb.ID) error {
-	if _, _, err := authorizer.AuthorizeWrite(ctx, influxdb.DBRPResourceType, id, orgID); err != nil {
+	mapping, err := svc.DBRPMappingServiceV2.FindByID(ctx, orgID, id)
+	if err != nil {
+		return err
+	}
+	if _, _, err := authorizer.AuthorizeWrite(ctx, influxdb.BucketsResourceType, mapping.BucketID, orgID); err != nil {
 		return err
 	}
 	return svc.DBRPMappingServiceV2.Delete(ctx, orgID, id)

--- a/dbrp/middleware_auth_test.go
+++ b/dbrp/middleware_auth_test.go
@@ -34,13 +34,20 @@ func TestAuth_FindByID(t *testing.T) {
 		{
 			name: "authorized to access id by org id",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(1),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -54,13 +61,20 @@ func TestAuth_FindByID(t *testing.T) {
 		{
 			name: "authorized to access id by id",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(1),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type: influxdb.DBRPResourceType,
+						Type: influxdb.BucketsResourceType,
 						ID:   influxdbtesting.IDPtr(1),
 					},
 				},
@@ -74,13 +88,20 @@ func TestAuth_FindByID(t *testing.T) {
 		{
 			name: "unauthorized to access id by org id",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(2),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -89,7 +110,7 @@ func TestAuth_FindByID(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:orgs/0000000000000002/dbrp/0000000000000001 is unauthorized",
+					Msg:  "read:orgs/0000000000000002/buckets/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -97,7 +118,14 @@ func TestAuth_FindByID(t *testing.T) {
 		{
 			name: "unauthorized to access id by id",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(1),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
@@ -112,7 +140,7 @@ func TestAuth_FindByID(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:orgs/0000000000000002/dbrp/0000000000000001 is unauthorized",
+					Msg:  "read:orgs/0000000000000002/buckets/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -230,7 +258,7 @@ func TestAuth_FindMany(t *testing.T) {
 				permissions: []influxdb.Permission{{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				}},
@@ -287,21 +315,21 @@ func TestAuth_FindMany(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type:  influxdb.DBRPResourceType,
+							Type:  influxdb.BucketsResourceType,
 							OrgID: influxdbtesting.IDPtr(1),
 						},
 					},
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type:  influxdb.DBRPResourceType,
+							Type:  influxdb.BucketsResourceType,
 							OrgID: influxdbtesting.IDPtr(2),
 						},
 					},
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type:  influxdb.DBRPResourceType,
+							Type:  influxdb.BucketsResourceType,
 							OrgID: influxdbtesting.IDPtr(3),
 						},
 					},
@@ -382,12 +410,14 @@ func TestAuth_Create(t *testing.T) {
 				m: influxdb.DBRPMappingV2{
 					ID:             1,
 					OrganizationID: 1,
+					BucketID:       2,
 				},
 				permission: influxdb.Permission{
 					Action: "write",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(2),
 					},
 				},
 			},
@@ -404,18 +434,20 @@ func TestAuth_Create(t *testing.T) {
 				m: influxdb.DBRPMappingV2{
 					ID:             1,
 					OrganizationID: 1,
+					BucketID:       2,
 				},
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(2),
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/0000000000000001/dbrp is unauthorized",
+					Msg:  "write:orgs/0000000000000001/buckets/0000000000000002 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -463,7 +495,7 @@ func TestAuth_Update(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "write",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -483,7 +515,7 @@ func TestAuth_Update(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -492,7 +524,7 @@ func TestAuth_Update(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/0000000000000001/dbrp/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/0000000000000001/buckets/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -535,13 +567,20 @@ func TestAuth_Delete(t *testing.T) {
 		{
 			name: "authorized",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(1),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
 					Action: "write",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -555,13 +594,20 @@ func TestAuth_Delete(t *testing.T) {
 		{
 			name: "unauthorized",
 			fields: fields{
-				service: &mock.DBRPMappingServiceV2{},
+				service: &mock.DBRPMappingServiceV2{
+					FindByIDFn: func(_ context.Context, _, _ influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+						return &influxdb.DBRPMappingV2{
+							OrganizationID: influxdb.ID(1),
+							BucketID:       influxdb.ID(1),
+						}, nil
+					},
+				},
 			},
 			args: args{
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.DBRPResourceType,
+						Type:  influxdb.BucketsResourceType,
 						OrgID: influxdbtesting.IDPtr(1),
 					},
 				},
@@ -570,7 +616,7 @@ func TestAuth_Delete(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/0000000000000001/dbrp/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/0000000000000001/buckets/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},


### PR DESCRIPTION
In order to improve the UX of the 1.x endpoint, we are auto-creating DBRP mappings and Buckets for users if they don't exist. The current DBRP mapping permissions checking has proved problematic, because Bucket write/read tokens generated in the UI only create permissions for Bucket resources. Currently, these tokens don't have permissions to deal with DBRP mappings.

In order to allow for normal Bucket read/write tokens (all buckets and specific buckets) to access this API, I've had to make some minor adjustments to the DBRP mapping service's authorization layer. These changes force the DBRP authorization layer to focus on Buckets resource permissions instead of those of the DBRP resource type.

A few examples to illustration what this means:

- Creating a DBRP mapping will require create permissions for Buckets
- Reading a DBRP mapping will require read access to the Bucket it points to.
- Deleting a DBRP mapping will require write permissions to the Bucket it points
  to.

This raises the question: Should DBRP mappings be publicly visible resources that have permissions of their own? I would argue they shouldn't be. The are an implementation detail of the Bucket resource to provide a mapping for 1.x DB/RP concepts. As such, they should rely on Bucket permissions.

📎 https://github.com/influxdata/influxdb/pull/18507
📎 influxdata/idpe#6948
