### PR TITLE
feat: migrate task records to always have an owner id

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -107,7 +107,7 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 
 		NewAnonymousMigration(
 			"migrate task owner id",
-			s.taskOwnerIDUpMigration,
+			s.TaskOwnerIDUpMigration,
 			func(context.Context, Store) error {
 				return nil
 			},

--- a/kv/service.go
+++ b/kv/service.go
@@ -104,6 +104,14 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		),
 		// add index user resource mappings by user id
 		s.urmByUserIndex.Migration(),
+
+		NewAnonymousMigration(
+			"migrate task owner id",
+			s.taskOwnerIDUpMigration,
+			func(context.Context, Store) error {
+				return nil
+			},
+		),
 		// and new migrations below here (and move this comment down):
 	)
 

--- a/kv/task.go
+++ b/kv/task.go
@@ -1778,7 +1778,7 @@ func taskRunKey(taskID, runID influxdb.ID) ([]byte, error) {
 	return []byte(string(encodedID) + "/" + string(encodedRunID)), nil
 }
 
-func (s *Service) taskOwnerIDUpMigration(ctx context.Context, store Store) error {
+func (s *Service) TaskOwnerIDUpMigration(ctx context.Context, store Store) error {
 	var ownerlessTasks []*influxdb.Task
 	// loop through the tasks and collect a set of tasks that are missing the owner id.
 	err := store.View(ctx, func(tx Tx) error {

--- a/kv/task.go
+++ b/kv/task.go
@@ -1807,7 +1807,11 @@ func (s *Service) taskOwnerIDUpMigration(ctx context.Context, store Store) error
 				ownerlessTasks = append(ownerlessTasks, t)
 			}
 		}
-		return c.Err()
+if err := c.Err(); err != nil {
+    return err
+}
+
+return c.Close()
 	})
 	if err != nil {
 		return err

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -313,5 +314,76 @@ func TestTaskRunCancellation(t *testing.T) {
 
 	if canceled.Status != influxdb.RunCanceled.String() {
 		t.Fatalf("expected task run to be cancelled")
+	}
+}
+
+func TestTaskMigrate(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	ts := newService(t, ctx, nil)
+	defer ts.Close()
+
+	id := "05da585043e02000"
+	// create a task that has auth set and no ownerID
+	err := ts.Store.Update(context.Background(), func(tx kv.Tx) error {
+		b, err := tx.Bucket([]byte("tasksv1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		taskBody := fmt.Sprintf(`{"id":"05da585043e02000","type":"system","orgID":"05d3ae3492c9c000","org":"whos","authorizationID":"%s","name":"asdf","status":"active","flux":"option v = {\n  bucket: \"bucks\",\n  timeRangeStart: -1h,\n  timeRangeStop: now()\n}\n\noption task = { \n  name: \"asdf\",\n  every: 5m,\n}\n\nfrom(bucket: \"_monitoring\")\n  |\u003e range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |\u003e filter(fn: (r) =\u003e r[\"_measurement\"] == \"boltdb_reads_total\")\n  |\u003e filter(fn: (r) =\u003e r[\"_field\"] == \"counter\")\n  |\u003e to(bucket: \"bucks\", org: \"whos\")","every":"5m","latestCompleted":"2020-06-16T17:01:26.083319Z","latestScheduled":"2020-06-16T17:01:26.083319Z","lastRunStatus":"success","createdAt":"2020-06-15T19:10:29Z","updatedAt":"0001-01-01T00:00:00Z"}`, ts.Auth.ID.String())
+		err = b.Put([]byte(id), []byte(taskBody))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ts.Service.TaskOwnerIDUpMigration(context.Background(), ts.Store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idType, _ := influxdb.IDFromString(id)
+	task, err := ts.Service.FindTaskByID(context.Background(), *idType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.OwnerID != ts.User.ID {
+		t.Fatal("failed to fill in ownerID")
+	}
+
+	// create a task that has no auth or owner id but a urm exists
+	err = ts.Store.Update(context.Background(), func(tx kv.Tx) error {
+		b, err := tx.Bucket([]byte("tasksv1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		taskBody := fmt.Sprintf(`{"id":"05da585043e02000","type":"system","orgID":"%s","org":"whos","name":"asdf","status":"active","flux":"option v = {\n  bucket: \"bucks\",\n  timeRangeStart: -1h,\n  timeRangeStop: now()\n}\n\noption task = { \n  name: \"asdf\",\n  every: 5m,\n}\n\nfrom(bucket: \"_monitoring\")\n  |\u003e range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |\u003e filter(fn: (r) =\u003e r[\"_measurement\"] == \"boltdb_reads_total\")\n  |\u003e filter(fn: (r) =\u003e r[\"_field\"] == \"counter\")\n  |\u003e to(bucket: \"bucks\", org: \"whos\")","every":"5m","latestCompleted":"2020-06-16T17:01:26.083319Z","latestScheduled":"2020-06-16T17:01:26.083319Z","lastRunStatus":"success","createdAt":"2020-06-15T19:10:29Z","updatedAt":"0001-01-01T00:00:00Z"}`, ts.Org.ID.String())
+		err = b.Put([]byte(id), []byte(taskBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ts.Service.TaskOwnerIDUpMigration(context.Background(), ts.Store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	task, err = ts.Service.FindTaskByID(context.Background(), *idType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.OwnerID != ts.User.ID {
+		t.Fatal("failed to fill in ownerID")
 	}
 }


### PR DESCRIPTION
Co-authored-by: Alirie Gray <alirie.gray@gmail.com>

