### PR TITLE
feat(pkger): extend pkgs with source identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [18387](https://github.com/influxdata/influxdb/pull/18387): Integrate query cancellation after queries have been submitted
+1. [18515](https://github.com/influxdata/influxdb/pull/18515): Extend templates with the source file|url|reader.
 
 ## v2.0.0-beta.12 [2020-06-12]
 

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -214,11 +214,12 @@ func (b *cmdPkgBuilder) pkgApplyRunEFn(cmd *cobra.Command, args []string) error 
 	}
 
 	opts := []pkger.ApplyOptFn{
+		pkger.ApplyWithPkg(pkg),
 		pkger.ApplyWithEnvRefs(providedEnvRefs),
 		pkger.ApplyWithStackID(stackID),
 	}
 
-	dryRunImpact, err := svc.DryRun(context.Background(), influxOrgID, 0, pkg, opts...)
+	dryRunImpact, err := svc.DryRun(context.Background(), influxOrgID, 0, opts...)
 	if err != nil {
 		return err
 	}
@@ -254,7 +255,7 @@ func (b *cmdPkgBuilder) pkgApplyRunEFn(cmd *cobra.Command, args []string) error 
 
 	opts = append(opts, pkger.ApplyWithSecrets(providedSecrets))
 
-	impact, err := svc.Apply(context.Background(), influxOrgID, 0, pkg, opts...)
+	impact, err := svc.Apply(context.Background(), influxOrgID, 0, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -708,8 +708,8 @@ func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args pkgFi
 type fakePkgSVC struct {
 	initStackFn func(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error)
 	createFn    func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
-	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg) (pkger.PkgImpactSummary, error)
-	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
+	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
+	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
 }
 
 var _ pkger.SVC = (*fakePkgSVC)(nil)
@@ -740,16 +740,16 @@ func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSe
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.dryRunFn != nil {
-		return f.dryRunFn(ctx, orgID, userID, pkg)
+		return f.dryRunFn(ctx, orgID, userID, opts...)
 	}
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *pkger.Pkg, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
 	if f.applyFn != nil {
-		return f.applyFn(ctx, orgID, userID, pkg, opts...)
+		return f.applyFn(ctx, orgID, userID, opts...)
 	}
 	panic("not implemented")
 }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4732,6 +4732,10 @@ paths:
                       type: string
                     description:
                       type: string
+                    sources:
+                      type: array
+                      items:
+                        type: string
                     urls:
                       type: array
                       items:
@@ -7647,11 +7651,29 @@ components:
         stackID:
           type: string
         package:
-          $ref: "#/components/schemas/Pkg"
+          type: object
+          properties:
+            contentType:
+              type: string
+            sources:
+              type: array
+              items:
+                type: string
+            package:
+              $ref: "#/components/schemas/Pkg"
         packages:
           type: array
           items:
-            $ref: "#/components/schemas/Pkg"
+            type: object
+            properties:
+              contentType:
+                type: string
+              sources:
+                type: array
+                items:
+                  type: string
+              package:
+                $ref: "#/components/schemas/Pkg"
         secrets:
           type: object
           additionalProperties:
@@ -7759,6 +7781,10 @@ components:
     PkgSummary:
       type: object
       properties:
+        sources:
+          type: array
+          items:
+            type: string
         stackID:
           type: string
         summary:

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -348,9 +348,6 @@ func (p *Pkg) Summary() Summary {
 	}
 
 	for _, c := range p.checks() {
-		if c.shouldRemove {
-			continue
-		}
 		sum.Checks = append(sum.Checks, c.summarize())
 	}
 
@@ -359,18 +356,12 @@ func (p *Pkg) Summary() Summary {
 	}
 
 	for _, l := range p.labels() {
-		if l.shouldRemove {
-			continue
-		}
 		sum.Labels = append(sum.Labels, l.summarize())
 	}
 
 	sum.LabelMappings = p.labelMappings()
 
 	for _, n := range p.notificationEndpoints() {
-		if n.shouldRemove {
-			continue
-		}
 		sum.NotificationEndpoints = append(sum.NotificationEndpoints, n.summarize())
 	}
 
@@ -387,9 +378,6 @@ func (p *Pkg) Summary() Summary {
 	}
 
 	for _, v := range p.variables() {
-		if v.shouldRemove {
-			continue
-		}
 		sum.Variables = append(sum.Variables, v.summarize())
 	}
 

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -17,9 +17,8 @@ import (
 )
 
 type identity struct {
-	name         *references
-	displayName  *references
-	shouldRemove bool
+	name        *references
+	displayName *references
 }
 
 func (i *identity) Name() string {

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3,6 +3,7 @@ package pkger
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -4255,7 +4256,14 @@ func nextField(t *testing.T, field string) (string, int) {
 
 func validParsedPkgFromFile(t *testing.T, path string, encoding Encoding) *Pkg {
 	t.Helper()
-	return newParsedPkg(t, FromFile(path), encoding)
+
+	pkg := newParsedPkg(t, FromFile(path), encoding)
+	u := url.URL{
+		Scheme: "file",
+		Path:   path,
+	}
+	require.Equal(t, []string{u.String()}, pkg.Sources())
+	return pkg
 }
 
 func newParsedPkg(t *testing.T, fn ReaderFn, encoding Encoding, opts ...ValidateOptFn) *Pkg {

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -64,10 +64,10 @@ func (s *authMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
-	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
-	return s.next.Apply(ctx, orgID, userID, pkg, opts...)
+func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+	return s.next.Apply(ctx, orgID, userID, opts...)
 }

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -113,7 +113,7 @@ func (s *loggingMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (p
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
+func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -138,10 +138,10 @@ func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *
 		fields = append(fields, dur)
 		s.logger.Info("pkg dry run successful", fields...)
 	}(time.Now())
-	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
+func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -163,7 +163,7 @@ func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *P
 		fields = append(fields, dur)
 		s.logger.Info("pkg apply successful", fields...)
 	}(time.Now())
-	return s.next.Apply(ctx, orgID, userID, pkg, opts...)
+	return s.next.Apply(ctx, orgID, userID, opts...)
 }
 
 func (s *loggingMW) summaryLogFields(sum Summary) []zap.Field {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -56,14 +56,14 @@ func (s *mwMetrics) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*
 	return pkg, rec(err)
 }
 
-func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	rec := s.rec.Record("dry_run")
-	impact, err := s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+	impact, err := s.next.DryRun(ctx, orgID, userID, opts...)
 	return impact, rec(err)
 }
 
-func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	rec := s.rec.Record("apply")
-	impact, err := s.next.Apply(ctx, orgID, userID, pkg, opts...)
+	impact, err := s.next.Apply(ctx, orgID, userID, opts...)
 	return impact, rec(err)
 }

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -1131,7 +1131,7 @@ func (r *stateRule) diffRule() DiffNotificationRule {
 	sum := DiffNotificationRule{
 		DiffIdentifier: DiffIdentifier{
 			ID:      SafeID(r.ID()),
-			Remove:  r.parserRule.shouldRemove,
+			Remove:  IsRemoval(r.stateStatus),
 			PkgName: r.parserRule.PkgName(),
 		},
 		New: DiffNotificationRuleValues{

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -95,7 +95,7 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					require.Len(t, impact.Diff.Buckets, 2)
@@ -130,7 +130,7 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					require.Len(t, impact.Diff.Buckets, 2)
@@ -171,7 +171,7 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithCheckSVC(fakeCheckSVC))
 
-				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 				require.NoError(t, err)
 
 				checks := impact.Diff.Checks
@@ -209,7 +209,7 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					require.Len(t, impact.Diff.Labels, 3)
@@ -250,7 +250,7 @@ func TestService(t *testing.T) {
 					}
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+					impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					labels := impact.Diff.Labels
@@ -299,7 +299,7 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithNotificationEndpointSVC(fakeEndpointSVC))
 
-				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 				require.NoError(t, err)
 
 				require.Len(t, impact.Diff.NotificationEndpoints, 5)
@@ -367,7 +367,7 @@ func TestService(t *testing.T) {
 
 				svc := newTestService(WithNotificationEndpointSVC(fakeEndpointSVC))
 
-				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 				require.NoError(t, err)
 
 				require.Len(t, impact.Diff.NotificationRules, 1)
@@ -403,7 +403,7 @@ func TestService(t *testing.T) {
 				}
 				svc := newTestService(WithSecretSVC(fakeSecretSVC))
 
-				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 				require.NoError(t, err)
 
 				assert.Equal(t, []string{"routing-key"}, impact.Summary.MissingSecrets)
@@ -424,7 +424,7 @@ func TestService(t *testing.T) {
 				}
 				svc := newTestService(WithVariableSVC(fakeVarSVC))
 
-				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, pkg)
+				impact, err := svc.DryRun(context.TODO(), influxdb.ID(100), 0, ApplyWithPkg(pkg))
 				require.NoError(t, err)
 
 				variables := impact.Diff.Variables
@@ -492,7 +492,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -544,7 +544,7 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithBucketSVC(fakeBktSVC))
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -584,7 +584,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeBktSVC.DeleteBucketCalls.Count(), 1)
@@ -605,7 +605,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -647,7 +647,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeCheckSVC.DeleteCheckCalls.Count(), 1)
@@ -672,7 +672,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -705,7 +705,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeLabelSVC.DeleteLabelCalls.Count(), 1)
@@ -760,7 +760,7 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithLabelSVC(fakeLabelSVC))
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -797,7 +797,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -839,7 +839,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.True(t, deletedDashs[1])
@@ -874,7 +874,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					assert.Equal(t, numExpected, fakeLabelSVC.CreateLabelMappingCalls.Count())
@@ -910,7 +910,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeLabelSVC.DeleteLabelMappingCalls.Count(), killCount)
@@ -1106,7 +1106,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -1155,7 +1155,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeEndpointSVC.DeleteNotificationEndpointCalls.Count(), 3)
@@ -1184,7 +1184,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -1227,7 +1227,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeRuleStore.DeleteNotificationRuleCalls.Count())
@@ -1261,7 +1261,7 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithTaskSVC(fakeTaskSVC))
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -1294,7 +1294,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeTaskSVC.DeleteTaskCalls.Count())
@@ -1315,7 +1315,7 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithTelegrafSVC(fakeTeleSVC))
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -1348,7 +1348,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.Equal(t, 1, fakeTeleSVC.DeleteTelegrafConfigCalls.Count())
@@ -1369,7 +1369,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary
@@ -1404,7 +1404,7 @@ func TestService(t *testing.T) {
 
 					orgID := influxdb.ID(9000)
 
-					_, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					_, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.Error(t, err)
 
 					assert.GreaterOrEqual(t, fakeVarSVC.DeleteVariableCalls.Count(), 1)
@@ -1445,7 +1445,7 @@ func TestService(t *testing.T) {
 
 					svc := newTestService(WithVariableSVC(fakeVarSVC))
 
-					impact, err := svc.Apply(context.TODO(), orgID, 0, pkg)
+					impact, err := svc.Apply(context.TODO(), orgID, 0, ApplyWithPkg(pkg))
 					require.NoError(t, err)
 
 					sum := impact.Summary

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -59,16 +59,16 @@ func (s *traceMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (pkg
 	return s.next.CreatePkg(ctx, setters...)
 }
 
-func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
-	return s.next.DryRun(ctx, orgID, userID, pkg, opts...)
+	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, pkg *Pkg, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
-	return s.next.Apply(ctx, orgID, userID, pkg, opts...)
+	return s.next.Apply(ctx, orgID, userID, opts...)
 }

--- a/pkger/store.go
+++ b/pkger/store.go
@@ -18,6 +18,7 @@ type (
 
 		Name        string             `json:"name"`
 		Description string             `json:"description"`
+		Sources     []string           `json:"sources,omitempty"`
 		URLs        []string           `json:"urls,omitempty"`
 		Resources   []entStackResource `json:"resources,omitempty"`
 
@@ -292,6 +293,7 @@ func convertStackToEnt(stack Stack) (kv.Entity, error) {
 		Description: stack.Description,
 		CreatedAt:   stack.CreatedAt,
 		UpdatedAt:   stack.UpdatedAt,
+		Sources:     stack.Sources,
 		URLs:        stack.URLs,
 	}
 
@@ -323,6 +325,7 @@ func convertStackEntToStack(ent *entStack) (Stack, error) {
 	stack := Stack{
 		Name:        ent.Name,
 		Description: ent.Description,
+		Sources:     ent.Sources,
 		URLs:        ent.URLs,
 		CRUDLog: influxdb.CRUDLog{
 			CreatedAt: ent.CreatedAt,

--- a/pkger/store_test.go
+++ b/pkger/store_test.go
@@ -17,6 +17,10 @@ func TestStoreKV(t *testing.T) {
 
 	stackStub := func(id, orgID influxdb.ID) pkger.Stack {
 		now := time.Time{}.Add(10 * 365 * 24 * time.Hour)
+		urls := []string{
+			"http://example.com",
+			"http://abc.gov",
+		}
 		return pkger.Stack{
 			ID:          id,
 			OrgID:       orgID,
@@ -26,10 +30,8 @@ func TestStoreKV(t *testing.T) {
 				CreatedAt: now,
 				UpdatedAt: now.Add(time.Hour),
 			},
-			URLs: []string{
-				"http://example.com",
-				"http://abc.gov",
-			},
+			Sources: urls,
+			URLs:    urls,
 			Resources: []pkger.StackResource{
 				{
 					APIVersion: pkger.APIVersion,


### PR DESCRIPTION
a good chunk of this PR is jiggling some bits to remove the high lvl Pkg from the svc interface.

references: #18243 

<details><summary>TODOs</summary>

- [x] add tests around different source types in Parser
- [x] add assertions to pkger_test.go
- [x] extend stack with sources
- [x] ensure API is backwards compatible (when OSS beta13 is released, we can let the axe split)

</details>


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass