### PR TITLE
fix: remove urm create from task create request.

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -123,3 +123,10 @@
   default: false
   contact: Query Team
   lifetime: temporary
+
+- name: Urm Free Tasks
+  description: allow task system to operate without creating additional urms
+  key: urmFreeTasks
+  default: false
+  contact: Lyon Hill
+  lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -226,6 +226,20 @@ func MemoryOptimizedFill() BoolFlag {
 	return memoryOptimizedFill
 }
 
+var urmFreeTasks = MakeBoolFlag(
+	"Urm Free Tasks",
+	"urmFreeTasks",
+	"Lyon Hill",
+	false,
+	Temporary,
+	false,
+)
+
+// UrmFreeTasks - allow task system to operate without creating additional urms
+func UrmFreeTasks() BoolFlag {
+	return urmFreeTasks
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -243,6 +257,7 @@ var all = []Flag{
 	newLabels,
 	hydratevars,
 	memoryOptimizedFill,
+	urmFreeTasks,
 }
 
 var byKey = map[string]Flag{
@@ -262,4 +277,5 @@ var byKey = map[string]Flag{
 	"newLabels":                    newLabels,
 	"hydratevars":                  hydratevars,
 	"memoryOptimizedFill":          memoryOptimizedFill,
+	"urmFreeTasks":                 urmFreeTasks,
 }

--- a/kv/task.go
+++ b/kv/task.go
@@ -389,10 +389,10 @@ func (s *Service) findTasksByUserUrmFree(ctx context.Context, tx Tx, filter infl
 		return nil, 0, influxdb.ErrUnexpectedTaskBucketErr(err)
 	}
 
-	// free cursor resources
-	defer c.Close()
-
-	ps, _ := s.maxPermissions(ctx, tx, *filter.User)
+	ps, err := s.maxPermissions(ctx, tx, *filter.User)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	matchFn := newTaskMatchFn(filter, nil)
 
@@ -419,12 +419,11 @@ func (s *Service) findTasksByUserUrmFree(ctx context.Context, tx Tx, filter infl
 			}
 		}
 	}
-
 	if err := c.Err(); err != nil {
 		return nil, 0, err
 	}
 
-	return ts, len(ts), err
+	return ts, len(ts), c.Close()
 }
 
 // findTasksByOrg is a subset of the find tasks function. Used for cleanliness

--- a/kv/task.go
+++ b/kv/task.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/influxdata/influxdb/v2"
 	icontext "github.com/influxdata/influxdb/v2/context"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/resource"
 	"github.com/influxdata/influxdb/v2/task/options"
+	"go.uber.org/zap"
 )
 
 // Task Storage Schema
@@ -278,6 +280,89 @@ func (s *Service) findTasks(ctx context.Context, tx Tx, filter influxdb.TaskFilt
 
 // findTasksByUser is a subset of the find tasks function. Used for cleanliness
 func (s *Service) findTasksByUser(ctx context.Context, tx Tx, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
+	if feature.UrmFreeTasks().Enabled(ctx) {
+		return s.findTasksByUserUrmFree(ctx, tx, filter)
+	}
+	return s.findTasksByUserWithURM(ctx, tx, filter)
+}
+
+// findTasksByUser is a subset of the find tasks function. Used for cleanliness
+func (s *Service) findTasksByUserWithURM(ctx context.Context, tx Tx, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
+	if filter.User == nil {
+		return nil, 0, influxdb.ErrTaskNotFound
+	}
+	var org *influxdb.Organization
+	var err error
+	if filter.OrganizationID != nil {
+		org, err = s.findOrganizationByID(ctx, tx, *filter.OrganizationID)
+		if err != nil {
+			return nil, 0, err
+		}
+	} else if filter.Organization != "" {
+		org, err = s.findOrganizationByName(ctx, tx, filter.Organization)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	var ts []*influxdb.Task
+
+	maps, err := s.findUserResourceMappings(
+		ctx,
+		tx,
+		influxdb.UserResourceMappingFilter{
+			ResourceType: influxdb.TasksResourceType,
+			UserID:       *filter.User,
+			UserType:     influxdb.Owner,
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var (
+		afterSeen bool
+		after     = func(task *influxdb.Task) bool {
+			if filter.After == nil || afterSeen {
+				return true
+			}
+
+			if task.ID == *filter.After {
+				afterSeen = true
+			}
+
+			return false
+		}
+		matchFn = newTaskMatchFn(filter, org)
+	)
+
+	for _, m := range maps {
+		task, err := s.findTaskByIDWithAuth(ctx, tx, m.ResourceID)
+		if err != nil && err != influxdb.ErrTaskNotFound {
+			return nil, 0, err
+		}
+		if err == influxdb.ErrTaskNotFound {
+			continue
+		}
+
+		if matchFn == nil || matchFn(task) {
+			if !after(task) {
+				continue
+			}
+
+			ts = append(ts, task)
+
+			if len(ts) >= filter.Limit {
+				break
+			}
+		}
+
+	}
+
+	return ts, len(ts), nil
+}
+
+func (s *Service) findTasksByUserUrmFree(ctx context.Context, tx Tx, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 	var ts []*influxdb.Task
 
 	taskBucket, err := tx.Bucket(taskBucket)
@@ -664,6 +749,12 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 		return nil, influxdb.ErrUnexpectedTaskBucketErr(err)
 	}
 
+	if !feature.UrmFreeTasks().Enabled(ctx) {
+		if err := s.createTaskURM(ctx, tx, task); err != nil {
+			s.log.Info("Error creating user resource mapping for task", zap.Stringer("taskID", task.ID), zap.Error(err))
+		}
+	}
+
 	// populate permissions so the task can be used immediately
 	// if we cant populate here we shouldn't error.
 	ps, _ := s.maxPermissions(ctx, tx, task.OwnerID)
@@ -688,6 +779,22 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 	}
 
 	return task, nil
+}
+
+func (s *Service) createTaskURM(ctx context.Context, tx Tx, t *influxdb.Task) error {
+	// TODO(jsteenb2): should not be getting authorizer inside the store, should terminate at the
+	//  transport layer then pass user id everywhere else.
+	userAuth, err := icontext.GetAuthorizer(ctx)
+	if err != nil {
+		return err
+	}
+
+	return s.createUserResourceMapping(ctx, tx, &influxdb.UserResourceMapping{
+		ResourceType: influxdb.TasksResourceType,
+		ResourceID:   t.ID,
+		UserID:       userAuth.GetUserID(),
+		UserType:     influxdb.Owner,
+	})
 }
 
 // UpdateTask updates a single task with changeset.
@@ -909,6 +1016,12 @@ func (s *Service) deleteTask(ctx context.Context, tx Tx, id influxdb.ID) error {
 
 	if err := taskBucket.Delete(key); err != nil {
 		return influxdb.ErrUnexpectedTaskBucketErr(err)
+	}
+
+	if err := s.deleteUserResourceMapping(ctx, tx, influxdb.UserResourceMappingFilter{
+		ResourceID: task.ID,
+	}); err != nil {
+		s.log.Debug("Error deleting user resource mapping for task", zap.Stringer("taskID", task.ID), zap.Error(err))
 	}
 
 	uid, _ := icontext.GetUserID(ctx)

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -175,7 +175,7 @@ func TestRetrieveTaskWithBadAuth(t *testing.T) {
 		t.Fatal("miss matching taskID's")
 	}
 
-	tasks, _, err := ts.Service.FindTasks(ctx, influxdb.TaskFilter{})
+	tasks, _, err := ts.Service.FindTasks(context.Background(), influxdb.TaskFilter{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestRetrieveTaskWithBadAuth(t *testing.T) {
 
 	// test status filter
 	active := string(influxdb.TaskActive)
-	tasksWithActiveFilter, _, err := ts.Service.FindTasks(ctx, influxdb.TaskFilter{Status: &active})
+	tasksWithActiveFilter, _, err := ts.Service.FindTasks(context.Background(), influxdb.TaskFilter{Status: &active})
 	if err != nil {
 		t.Fatal("could not find tasks")
 	}


### PR DESCRIPTION
This will greatly reduce the amount of urms created in the system. To make this change to the system we need to also remove our direct reliance on the urm's in tasks.
Remove the create and delete portion of the task actions that are creating and deleting urms
Remove reliance on urm's when we are doing FindTaskByUser and instead rely on the user filter matching the task.OwnerID

One test had to be changed because the test was explicitly hacking the task to remove the owner ID and then trying to successfully look up the task by ownerID
