### PR TITLE
chore(flagged): add active template to redux

### DIFF
--- a/ui/src/templates/actions/creators.ts
+++ b/ui/src/templates/actions/creators.ts
@@ -1,5 +1,9 @@
 // Types
-import {RemoteDataState, TemplateSummaryEntities} from 'src/types'
+import {
+  CommunityTemplate,
+  RemoteDataState,
+  TemplateSummaryEntities,
+} from 'src/types'
 import {DocumentCreate} from '@influxdata/influx'
 import {NormalizedSchema} from 'normalizr'
 
@@ -7,6 +11,7 @@ export const ADD_TEMPLATE_SUMMARY = 'ADD_TEMPLATE_SUMMARY'
 export const GET_TEMPLATE_SUMMARIES_FOR_ORG = 'GET_TEMPLATE_SUMMARIES_FOR_ORG'
 export const POPULATE_TEMPLATE_SUMMARIES = 'POPULATE_TEMPLATE_SUMMARIES'
 export const REMOVE_TEMPLATE_SUMMARY = 'REMOVE_TEMPLATE_SUMMARY'
+export const SET_ACTIVE_COMMUNITY_TEMPLATE = 'SET_ACTIVE_COMMUNITY_TEMPLATE'
 export const SET_EXPORT_TEMPLATE = 'SET_EXPORT_TEMPLATE'
 export const SET_TEMPLATE_SUMMARY = 'SET_TEMPLATE_SUMMARY'
 export const SET_TEMPLATES_STATUS = 'SET_TEMPLATES_STATUS'
@@ -18,6 +23,7 @@ export type Action =
   | ReturnType<typeof setExportTemplate>
   | ReturnType<typeof setTemplatesStatus>
   | ReturnType<typeof setTemplateSummary>
+  | ReturnType<typeof setActiveCommunityTemplate>
 
 type TemplateSummarySchema<R extends string | string[]> = NormalizedSchema<
   TemplateSummaryEntities,
@@ -72,4 +78,10 @@ export const setTemplateSummary = (
     id,
     status,
     schema,
+  } as const)
+
+export const setActiveCommunityTemplate = (template: CommunityTemplate) =>
+  ({
+    type: SET_ACTIVE_COMMUNITY_TEMPLATE,
+    template,
   } as const)

--- a/ui/src/templates/reducers/index.test.ts
+++ b/ui/src/templates/reducers/index.test.ts
@@ -17,6 +17,7 @@ import {
 
 // Types
 import {
+  CommunityTemplate,
   RemoteDataState,
   TemplateSummaryEntities,
   TemplateSummary,
@@ -41,7 +42,10 @@ const templateSummary = {
 
 const exportTemplate = {status, item: null}
 
+const activeCommunityTemplate: CommunityTemplate = {}
+
 const initialState = () => ({
+  activeCommunityTemplate,
   status,
   byID: {
     ['1']: templateSummary,
@@ -88,7 +92,13 @@ describe('templates reducer', () => {
     const byID = {[templateSummary.id]: templateSummary}
 
     const state = initialState()
-    const expected = {status, byID, allIDs, exportTemplate}
+    const expected = {
+      status,
+      byID,
+      allIDs,
+      exportTemplate,
+      activeCommunityTemplate,
+    }
     const actual = reducer(state, removeTemplateSummary(state.allIDs[1]))
 
     expect(actual).toEqual(expected)

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -4,11 +4,13 @@ import {
   ADD_TEMPLATE_SUMMARY,
   POPULATE_TEMPLATE_SUMMARIES,
   REMOVE_TEMPLATE_SUMMARY,
+  SET_ACTIVE_COMMUNITY_TEMPLATE,
   SET_EXPORT_TEMPLATE,
   SET_TEMPLATE_SUMMARY,
   SET_TEMPLATES_STATUS,
 } from 'src/templates/actions/creators'
 import {
+  CommunityTemplate,
   ResourceType,
   RemoteDataState,
   TemplateSummary,
@@ -22,6 +24,7 @@ import {
 } from 'src/resources/reducers/helpers'
 
 export const defaultState = (): TemplatesState => ({
+  activeCommunityTemplate: {} as CommunityTemplate,
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
@@ -56,6 +59,13 @@ export const templatesReducer = (
           ResourceType.Templates
         )
 
+        return
+      }
+
+      case SET_ACTIVE_COMMUNITY_TEMPLATE: {
+        const {template} = action
+
+        draftState.activeCommunityTemplate = template
         return
       }
 

--- a/ui/src/types/templates.ts
+++ b/ui/src/types/templates.ts
@@ -22,8 +22,11 @@ export interface TemplateSummary extends Omit<GenTemplateSummary, 'labels'> {
   status: RemoteDataState
 }
 
+export type CommunityTemplate = any
+
 export interface TemplatesState extends NormalizedState<TemplateSummary> {
   exportTemplate: {status: RemoteDataState; item: DocumentCreate}
+  activeCommunityTemplate: CommunityTemplate
 }
 
 interface KeyValuePairs {


### PR DESCRIPTION
Closes #18525 

Adds community template structure to redux. This is all hidden behind the flag `communityTemplates`

Pasting 
```
https://github.com/influxdata/community-templates/tree/master/csgo
```

into the file field results in the template being added to redux. Next part of the iteration will take the data this puts into redux and populate the modal with it.

![Screen Shot 2020-06-15 at 6 18 01 PM](https://user-images.githubusercontent.com/146112/84721069-9e774c00-af34-11ea-9648-febc7a713ee0.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass