### PR TITLE
fix(test): use go 1.13 in test scripts

### DIFF
--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -27,7 +27,7 @@ VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.12
+ENV GO_VERSION 1.13
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_go1.13
+++ b/Dockerfile_build_ubuntu64_go1.13
@@ -23,7 +23,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN gem install fpm
 
 # setup environment
-ENV GO_VERSION  1.12
+ENV GO_VERSION  1.13
 ENV GOARCH      amd64
 ENV GOROOT      /usr/local/go
 ENV GOPATH      /root/go

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 # Install go
 ENV GOCACHE=/tmp
 ENV GOPATH /go
-ENV GO_VERSION 1.12
+ENV GO_VERSION 1.13
 ENV GO_ARCH 386
 RUN wget --no-verbose -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 #      1: race enabled 64bit tests
 #      2: normal 32bit tests
 #      3: tsi build
-#      4: go 1.12
+#      4: go 1.13
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
 #
@@ -124,8 +124,8 @@ case $ENVIRONMENT_INDEX in
         rc=$?
         ;;
     4)
-        # go1.12
-        run_test_docker Dockerfile_build_ubuntu64_go1.12 test_64bit --test --junit-report
+        # go1.13
+        run_test_docker Dockerfile_build_ubuntu64_go1.13 test_64bit --test --junit-report
         rc=$?
         ;;
     "count")


### PR DESCRIPTION
With https://github.com/influxdata/influxdb/pull/17530, go 1.13 is required.
