### PR TITLE
feat(reporting): Silence reporting errors

### DIFF
--- a/ui/src/cloud/apis/reporting.ts
+++ b/ui/src/cloud/apis/reporting.ts
@@ -30,7 +30,6 @@ export const reportPoints = (points: Points) => {
       credentials: 'include',
     })
   } catch (e) {
-    console.error(e)
     // don't want reporting errors to effect user experience
   }
 }


### PR DESCRIPTION
reporting errors were being logged on the console as errors. There is no need for these errors to be reflected to the user. 