### PR TITLE
feat(pkger): add ability to skip a resource within a template

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7691,6 +7691,23 @@ components:
               contentType:
                 type: string
             required: ["url"]
+        actions:
+          type: array
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  action:
+                    type: string
+                    enum: ["skipResource"]
+                  properties:
+                    type: object
+                    properties:
+                      kind:
+                        type: string
+                      resourceTemplateName:
+                        type: string
+                    required: ["kind", "resourceTemplateName"]
     PkgCreateKind:
       type: string
       enum:

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -2,6 +2,7 @@ package pkger
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/influxdata/influxdb/v2"
@@ -212,6 +213,17 @@ func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun
 	if opt.StackID != 0 {
 		stackID := opt.StackID.String()
 		reqBody.StackID = &stackID
+	}
+
+	for act := range opt.ResourcesToSkip {
+		b, err := json.Marshal(act)
+		if err != nil {
+			return PkgImpactSummary{}, influxErr(influxdb.EInvalid, err)
+		}
+		reqBody.RawActions = append(reqBody.RawActions, ReqRawAction{
+			Action:     string(ActionTypeSkipResource),
+			Properties: b,
+		})
 	}
 
 	var resp RespApplyPkg


### PR DESCRIPTION
tie it together e2e

references: #18490

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
