### PR TITLE
fix(pkger): fix flaky test caused by merge race condition

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -346,7 +346,8 @@ func TestLauncher_Pkger(t *testing.T) {
 			})
 
 			t.Run("that has already been deleted should be successful", func(t *testing.T) {
-				newStack, _ := newStackFn(t, pkger.Stack{})
+				newStack, cleanup := newStackFn(t, pkger.Stack{})
+				defer cleanup()
 
 				err := svc.DeleteStack(ctx, struct{ OrgID, UserID, StackID influxdb.ID }{
 					OrgID:   l.Org.ID,
@@ -1539,11 +1540,7 @@ func TestLauncher_Pkger(t *testing.T) {
 
 		t.Run("apply with actions", func(t *testing.T) {
 			stack, cleanup := newStackFn(t, pkger.Stack{})
-			defer func() {
-				if t.Failed() {
-					cleanup()
-				}
-			}()
+			defer cleanup()
 
 			var (
 				bucketPkgName   = "rucketeer-1"


### PR DESCRIPTION
one PR got merged, then the other without rebase/rerunning tests. That
is what resulted in this broken test.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass