### PR TITLE
feat: add error metric writing method. call it during honeybadger errors

### DIFF
--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -7,7 +7,8 @@ import {
   PointTags,
   PointFields,
 } from 'src/cloud/apis/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+export {Point, PointTags, PointFields} from 'src/cloud/apis/reporting'
 
 let reportingTags = {}
 let reportingPoints = []
@@ -25,10 +26,6 @@ export const updateReportingContext = (key: string, value: string) => {
 }
 
 export const reportEvent = ({timestamp, measurement, fields, tags}: Point) => {
-  if (!isFlagEnabled('appMetrics')) {
-    return
-  }
-
   if (isEmpty(fields)) {
     fields = {source: 'ui'}
   }

--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -3,7 +3,7 @@ import HoneyBadger from 'honeybadger-js'
 import {CLOUD, GIT_SHA} from 'src/shared/constants'
 
 import {getUserFlags} from 'src/shared/utils/featureFlag'
-import {reportPoints, PointTags, PointFields} from 'src/cloud/apis/reporting'
+import {reportEvent, PointTags, PointFields} from 'src/cloud/utils/reporting'
 
 if (CLOUD) {
   HoneyBadger.configure({
@@ -19,10 +19,8 @@ export const reportSingleErrorMetric = (
   measurement = 'ui_error'
 ) => {
   if (CLOUD) {
-    const points = {
-      points: [{measurement, tags, fields: {errorCount: 1, ...fields}}],
-    }
-    reportPoints(points)
+    const point = {measurement, tags, fields: {errorCount: 1, ...fields}}
+    reportEvent(point)
   }
 }
 

--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -3,6 +3,7 @@ import HoneyBadger from 'honeybadger-js'
 import {CLOUD, GIT_SHA} from 'src/shared/constants'
 
 import {getUserFlags} from 'src/shared/utils/featureFlag'
+import {reportPoints, PointTags, PointFields} from 'src/cloud/apis/reporting'
 
 if (CLOUD) {
   HoneyBadger.configure({
@@ -10,6 +11,19 @@ if (CLOUD) {
     revision: GIT_SHA,
     environment: process.env.HONEYBADGER_ENV,
   })
+}
+
+export const reportSingleErrorMetric = (
+  tags: PointTags = {},
+  fields: PointFields = {},
+  measurement = 'ui_error'
+) => {
+  if (CLOUD) {
+    const points = {
+      points: [{measurement, tags, fields: {errorCount: 1, ...fields}}],
+    }
+    reportPoints(points)
+  }
 }
 
 // See https://docs.honeybadger.io/lib/javascript/guides/reporting-errors.html#additional-options
@@ -44,6 +58,15 @@ export const reportError = (
 
   if (CLOUD) {
     HoneyBadger.notify(error, {context, ...options})
+
+    let errorType = 'generic (untagged) error'
+    if (options.name) {
+      errorType = options.name
+    } else if (options.component) {
+      errorType = options.component
+    }
+
+    reportSingleErrorMetric({errorType})
   } else {
     const honeyBadgerContext = (HoneyBadger as any).context
     /* eslint-disable no-console */


### PR DESCRIPTION
Connects IDPE 7432. Doesn't completely finish the task.

* Adds a method that reports a single error metric to tools
  * Calls this method on HoneyBadger errors
* Goal: every time we have an error, we report it, then graph each error over time to establish a baseline error rate. If the rate spikes suddenly, we have good indication that something is up.

* Todo: Start sensibly replacing calls to `console.error`. I say sensibly because in the short time I looked around, it seemed clear that there were areas where this isn't appropriate, but we're logging an error with `console.error`

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass