### PR TITLE
fix: uint overflow during setup on 32bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [18595](https://github.com/influxdata/influxdb/pull/18595): Add ability to skip resources in a template by kind or by metadata.name
 1. [18600](https://github.com/influxdata/influxdb/pull/18600): Extend influx apply with resource filter capabilities
 1. [18601](https://github.com/influxdata/influxdb/pull/18601): Provide active config  running influx config without args
+1. [18602](https://github.com/influxdata/influxdb/pull/18602): Fix uint overflow during setup on 32bit systems
 
 ## v2.0.0-beta.12 [2020-06-12]
 

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -316,7 +316,7 @@ func getConfirm(ui *input.UI, or *influxdb.OnboardingRequest) bool {
 	for {
 		rp := "infinite"
 		if or.RetentionPeriod > 0 {
-			rp = fmt.Sprintf("%d hrs", or.RetentionPeriod/uint(time.Hour))
+			rp = fmt.Sprintf("%d hrs", time.Duration(or.RetentionPeriod)/time.Hour)
 		}
 		ui.Writer.Write(promptWithColor(fmt.Sprintf(`
 You have entered:


### PR DESCRIPTION
Convert onboardingRequest RetentionPeriod to a Duration, rather than time.Hour to a uint.

Closes #18547

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
