### PR TITLE
feat(influxd): refactor run command to use cli.Program to respect config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 1. [18595](https://github.com/influxdata/influxdb/pull/18595): Add ability to skip resources in a template by kind or by metadata.name
 1. [18600](https://github.com/influxdata/influxdb/pull/18600): Extend influx apply with resource filter capabilities
 1. [18601](https://github.com/influxdata/influxdb/pull/18601): Provide active config  running influx config without args
+1. [18606](https://github.com/influxdata/influxdb/pull/18606): Enable influxd binary to look for a config file on startup
+
+### Bug Fixes
 1. [18602](https://github.com/influxdata/influxdb/pull/18602): Fix uint overflow during setup on 32bit systems
 
 ## v2.0.0-beta.12 [2020-06-12]

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -84,59 +84,91 @@ const (
 	JaegerTracing = "jaeger"
 )
 
-// NewCommand creates the command to run influxdb.
-func NewCommand() *cobra.Command {
+func NewInfluxdCommand(ctx context.Context, subCommands ...*cobra.Command) *cobra.Command {
 	l := NewLauncher()
-	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Start the influxd server (default)",
-		Run: func(cmd *cobra.Command, args []string) {
-			// exit with SIGINT and SIGTERM
-			ctx := context.Background()
-			ctx = signals.WithStandardSignals(ctx)
 
-			if err := l.run(ctx); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			} else if !l.Running() {
-				os.Exit(1)
-			}
-
-			var wg sync.WaitGroup
-			if !l.ReportingDisabled() {
-				reporter := telemetry.NewReporter(l.Log(), l.Registry())
-				reporter.Interval = 8 * time.Hour
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					reporter.Report(ctx)
-				}()
-			}
-
-			<-ctx.Done()
-
-			// Attempt clean shutdown.
-			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			defer cancel()
-			l.Shutdown(ctx)
-			wg.Wait()
-		},
+	prog := cli.Program{
+		Name: "influxd",
+		Run:  cmdRunE(ctx, l),
 	}
 
-	buildLauncherCommand(l, cmd)
+	assignDescs := func(cmd *cobra.Command) {
+		cmd.Short = "Start the influxd server (default)"
+		cmd.Long = `
+	Start up the daemon configured with flags/env vars/config file.
+
+	The order of precedence for config options are as follows (1 highest, 3 lowest):
+		1. flags
+		2. env vars
+		3. config file
+
+	A config file can be provided via the INFLUXD_CONFIG_FILE env var. If a file is
+	not provided via an env var, influxd will look in the current directory for a
+	config.yaml file. If one does not exist, then it will continue unchanged.`
+	}
+
+	cmd := cli.NewCommand(&prog)
+	runCmd := &cobra.Command{
+		Use:  "run",
+		RunE: cmd.RunE,
+	}
+	for _, c := range []*cobra.Command{cmd, runCmd} {
+		assignDescs(c)
+		setLauncherCMDOpts(l, c)
+	}
+	cmd.AddCommand(append(subCommands, runCmd)...)
 
 	return cmd
 }
 
+func cmdRunE(ctx context.Context, l *Launcher) func() error {
+	return func() error {
+		// exit with SIGINT and SIGTERM
+		ctx = signals.WithStandardSignals(ctx)
+
+		if err := l.run(ctx); err != nil {
+			return err
+		} else if !l.Running() {
+			return errors.New("the daemon is already running")
+		}
+
+		var wg sync.WaitGroup
+		if !l.ReportingDisabled() {
+			reporter := telemetry.NewReporter(l.Log(), l.Registry())
+			reporter.Interval = 8 * time.Hour
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				reporter.Report(ctx)
+			}()
+		}
+
+		<-ctx.Done()
+
+		// Attempt clean shutdown.
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		l.Shutdown(ctx)
+		wg.Wait()
+
+		return nil
+	}
+}
+
 var vaultConfig vault.Config
 
-func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
+func setLauncherCMDOpts(l *Launcher, cmd *cobra.Command) {
+	cli.BindOptions(cmd, launcherOpts(l))
+	cmd.AddCommand(inspect.NewCommand())
+}
+
+func launcherOpts(l *Launcher) []cli.Opt {
 	dir, err := fs.InfluxDir()
 	if err != nil {
 		panic(fmt.Errorf("failed to determine influx directory: %v", err))
 	}
 
-	opts := []cli.Opt{
+	return []cli.Opt{
 		{
 			DestP:   &l.logLevel,
 			Flag:    "log-level",
@@ -312,8 +344,6 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 			Desc:  "feature flag overrides",
 		},
 	}
-	cli.BindOptions(cmd, opts)
-	cmd.AddCommand(inspect.NewCommand())
 }
 
 // Launcher represents the main program execution.
@@ -479,7 +509,7 @@ func (m *Launcher) Run(ctx context.Context, args ...string) error {
 		},
 	}
 
-	buildLauncherCommand(m, cmd)
+	setLauncherCMDOpts(m, cmd)
 
 	cmd.SetArgs(args)
 	return cmd.Execute()

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -1,16 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	_ "net/http/pprof"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/generate"
-	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/migrate"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/restore"
@@ -18,7 +17,6 @@ import (
 	_ "github.com/influxdata/influxdb/v2/tsdb/tsi1"
 	_ "github.com/influxdata/influxdb/v2/tsdb/tsm1"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -27,52 +25,28 @@ var (
 	date    = fmt.Sprint(time.Now().UTC().Format(time.RFC3339))
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "influxd",
-	Short: "Influx Server",
-}
-
-func init() {
+func main() {
 	influxdb.SetBuildInfo(version, commit, date)
-	viper.SetEnvPrefix("INFLUXD")
-	viper.AutomaticEnv()
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	rootCmd.InitDefaultHelpCmd()
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "version",
-		Short: "Print the influxd server version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("InfluxDB %s (git: %s) build_date: %s\n", version, commit, date)
+
+	rootCmd := launcher.NewInfluxdCommand(context.Background(),
+		generate.Command,
+		restore.Command,
+		migrate.Command,
+		&cobra.Command{
+			Use:   "version",
+			Short: "Print the influxd server version",
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Printf("InfluxDB %s (git: %s) build_date: %s\n", version, commit, date)
+			},
 		},
-	})
-	rootCmd.AddCommand(launcher.NewCommand())
-	rootCmd.AddCommand(generate.Command)
-	rootCmd.AddCommand(inspect.NewCommand())
-	rootCmd.AddCommand(restore.Command)
-	rootCmd.AddCommand(migrate.Command)
+	)
 
 	// TODO: this should be removed in the future: https://github.com/influxdata/influxdb/issues/16220
 	if os.Getenv("QUERY_TRACING") == "1" {
 		flux.EnableExperimentalTracing()
 	}
-}
 
-// find determines the default behavior when running influxd.
-// Specifically, find will return the influxd run command if no sub-command
-// was specified.
-func find(args []string) *cobra.Command {
-	cmd, _, err := rootCmd.Find(args)
-	if err == nil && cmd == rootCmd {
-		// Execute the run command if no sub-command is specified
-		return launcher.NewCommand()
-	}
-
-	return rootCmd
-}
-
-func main() {
-	cmd := find(os.Args[1:])
-	if err := cmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
example config:

```yaml
# config.yaml file in same dir as running daemon
http-bind-address: ":8888"
log-level: debug
```

logs from startup:

```
2020-06-18T17:45:59.482500Z	info	Listening	{"log_id": "0NU8Rsnl000", "transport": "http", "addr": ":8888", "port": 8888}
```

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
