### PR TITLE
feat: adding more segmentation vectors

### DIFF
--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -81,6 +81,7 @@ export class Signin extends PureComponent<Props, State> {
   private checkForLogin = async () => {
     try {
       await client.users.me()
+
       const redirectIsSet = !!getFromLocalStorage('redirectTo')
       if (redirectIsSet) {
         removeFromLocalStorage('redirectTo')

--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -1,22 +1,26 @@
 // Libraries
 import {FunctionComponent, useEffect, useState} from 'react'
 import {connect} from 'react-redux'
-import {get} from 'lodash'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
 // Types
-import {AppState, Organization} from 'src/types'
+import {AppState, Organization, OrgSetting} from 'src/types'
 
 // Actions
 import {getOrgSettings as getOrgSettingsAction} from 'src/cloud/actions/orgsettings'
+
+import {getOrg} from 'src/organizations/selectors'
+import {getOrgSettings} from 'src/cloud/selectors/orgsettings'
+import {updateReportingContext} from 'src/cloud/utils/reporting'
 
 interface PassedInProps {
   children: React.ReactElement<any>
 }
 interface StateProps {
   org: Organization
+  settings: OrgSetting[]
 }
 interface DispatchProps {
   getOrgSettings: typeof getOrgSettingsAction
@@ -27,6 +31,7 @@ type Props = StateProps & DispatchProps & PassedInProps
 const OrgSettings: FunctionComponent<Props> = ({
   org,
   getOrgSettings,
+  settings,
   children,
 }) => {
   const [hasFetchedOrgSettings, setHasFetchedOrgSettings] = useState<boolean>(
@@ -39,11 +44,21 @@ const OrgSettings: FunctionComponent<Props> = ({
     }
   }, [org])
 
+  useEffect(() => {
+    updateReportingContext(
+      Object.entries(settings).reduce((prev, [key, val]) => {
+        prev[`org (${key})`] = val
+        return prev
+      }, {})
+    )
+  }, [settings])
+
   return children
 }
 
 const mstp = (state: AppState): StateProps => ({
-  org: get(state, 'resources.orgs.org', null),
+  org: getOrg(state),
+  settings: getOrgSettings(state),
 })
 
 const mdtp: DispatchProps = {

--- a/ui/src/cloud/selectors/orgsettings.ts
+++ b/ui/src/cloud/selectors/orgsettings.ts
@@ -1,0 +1,6 @@
+import {AppState} from 'src/types'
+import {get} from 'lodash'
+
+export const getOrgSettings = (state: AppState) => {
+  return get(state, 'cloud.orgSettings.settings', [])
+}

--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -16,8 +16,12 @@ const reportingInterval = 5 // seconds
 
 const toNano = (ms: number) => ms * 1000000
 
-export const updateReportingContext = (key: string, value: string) => {
-  reportingTags = {...reportingTags, [key]: value}
+interface KeyValue {
+  [key: string]: string
+}
+
+export const updateReportingContext = (properties: KeyValue) => {
+  reportingTags = {...reportingTags, ...properties}
 }
 
 export const reportEvent = ({timestamp, measurement, fields, tags}: Point) => {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -13,6 +13,7 @@ import {loadLocalStorage} from 'src/localStorage'
 
 import {getRootNode} from 'src/utils/nodes'
 import {getBrowserBasepath} from 'src/utils/basepath'
+import {updateReportingContext} from 'src/cloud/utils/reporting'
 
 // Components
 import App from 'src/App'
@@ -158,6 +159,16 @@ import '@influxdata/clockface/dist/index.css'
 
 const rootNode = getRootNode()
 const basepath = getBrowserBasepath()
+
+const SESSION_KEY = 'session'
+
+const cookieSession = document.cookie.match(
+  new RegExp('(^| )' + SESSION_KEY + '=([^;]+)')
+)
+
+updateReportingContext({
+  session: cookieSession ? cookieSession[2] : '',
+})
 
 declare global {
   interface Window {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -167,7 +167,7 @@ const cookieSession = document.cookie.match(
 )
 
 updateReportingContext({
-  session: cookieSession ? cookieSession[2] : '',
+  session: cookieSession ? cookieSession[2].slice(5) : '',
 })
 
 declare global {

--- a/ui/src/shared/actions/me.ts
+++ b/ui/src/shared/actions/me.ts
@@ -23,9 +23,11 @@ export const getMe = () => async dispatch => {
 
     if (CLOUD) {
       fireUserDataReady(user.id, user.name)
-      updateReportingContext('userID', user.id)
     }
 
+    updateReportingContext({
+      userID: user.id,
+    })
     HoneyBadger.setContext({
       user_id: user.id,
     })

--- a/ui/src/shared/containers/SetOrg.tsx
+++ b/ui/src/shared/containers/SetOrg.tsx
@@ -52,10 +52,11 @@ const SetOrg: FC<Props> = ({
     const foundOrg = orgs.find(o => o.id === orgID)
     if (foundOrg) {
       setOrg(foundOrg)
-      updateReportingContext('orgID', orgID)
+      updateReportingContext({orgID: orgID})
       setLoading(RemoteDataState.Done)
       return
     }
+    updateReportingContext({orgID: null})
 
     if (!orgs.length) {
       router.push(`/no-orgs`)


### PR DESCRIPTION
wanted to double check our user segmentation vectors were in here.

added session, for when we decouple session ids from user ids

added flags, so we can compare funnels across changes there

added org settings, to reduce cross domain lookups against the datasets