### PR TITLE
chore: move flagging location to lowest possible point - we safe now

### DIFF
--- a/ui/src/cloud/apis/reporting.ts
+++ b/ui/src/cloud/apis/reporting.ts
@@ -1,3 +1,5 @@
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 export interface Point {
   measurement: string
   fields: PointFields
@@ -19,6 +21,9 @@ export interface Points {
 }
 
 export const reportPoints = (points: Points) => {
+  if (!isFlagEnabled('appMetrics')) {
+    return
+  }
   try {
     const url = '/api/v2/app-metrics'
     return fetch(url, {

--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -1,7 +1,5 @@
 import {useState, useEffect} from 'react'
 
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 import {
   reportPoints as reportPointsAPI,
   Point,
@@ -21,10 +19,6 @@ export const updateReportingContext = (key: string, value: string) => {
 }
 
 export const reportEvent = ({timestamp, measurement, fields, tags}: Point) => {
-  if (!isFlagEnabled('appMetrics')) {
-    return
-  }
-
   reportingPoints.push({
     measurement,
     tags: {...reportingTags, ...tags},


### PR DESCRIPTION
`reportPoints` is the lowest level function in the reporting system we're setting up - all other calls must go through this function.

This PR moves the `appMetrics` flag / implicit cloud check to this function. Any function calling the reporting framework can now do so without needing to check if its in a cloud context or if `appMetrics` is flagged on.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
