### PR TITLE
chore: move flux testing notebook to feature flag

### DIFF
--- a/ui/src/notebooks/pipes/TestFlux/index.ts
+++ b/ui/src/notebooks/pipes/TestFlux/index.ts
@@ -5,7 +5,7 @@ register({
   type: 'test',
   component: View,
   priority: -1,
-  disabled: true,
+  featureFlag: 'notebook-panel--test-flux',
   button: 'Flux Result Tester',
   initial: {
     panelVisibility: 'visible',

--- a/ui/src/shared/selectors/flags.ts
+++ b/ui/src/shared/selectors/flags.ts
@@ -14,6 +14,7 @@ export const OSS_FLAGS = {
   telegrafEditor: false,
   streamEvents: false,
   'notebook-panel--spotify': false,
+  'notebook-panel--test-flux': false,
 }
 
 export const CLOUD_FLAGS = {
@@ -29,6 +30,7 @@ export const CLOUD_FLAGS = {
   telegrafEditor: false,
   streamEvents: false,
   'notebook-panel--spotify': false,
+  'notebook-panel--test-flux': false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {


### PR DESCRIPTION
this moves the flux testing panel type introduced here: https://github.com/influxdata/influxdb/pull/18554 to using the feature flag based toggles