### PR TITLE
feat(query/stdlib): add a rule to reorder group and window

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -85,6 +85,12 @@
   default: false
   contact: Query Team
 
+- name: Group Window Aggregate Transpose
+  description: Enables the GroupWindowAggregateTransposeRule for all enabled window aggregates
+  key: groupWindowAggregateTranspose
+  default: false
+  contact: Query Team
+
 - name: New Auth Package
   description: Enables the refactored authorization api
   key: newAuth

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -156,6 +156,20 @@ func PushDownWindowAggregateLast() BoolFlag {
 	return pushDownWindowAggregateLast
 }
 
+var groupWindowAggregateTranspose = MakeBoolFlag(
+	"Group Window Aggregate Transpose",
+	"groupWindowAggregateTranspose",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// GroupWindowAggregateTranspose - Enables the GroupWindowAggregateTransposeRule for all enabled window aggregates
+func GroupWindowAggregateTranspose() BoolFlag {
+	return groupWindowAggregateTranspose
+}
+
 var newAuth = MakeBoolFlag(
 	"New Auth Package",
 	"newAuth",
@@ -294,6 +308,7 @@ var all = []Flag{
 	pushDownWindowAggregateMean,
 	pushDownWindowAggregateFirst,
 	pushDownWindowAggregateLast,
+	groupWindowAggregateTranspose,
 	newAuth,
 	pushDownGroupAggregateCount,
 	pushDownGroupAggregateSum,
@@ -306,24 +321,25 @@ var all = []Flag{
 }
 
 var byKey = map[string]Flag{
-	"appMetrics":                   appMetrics,
-	"backendExample":               backendExample,
-	"communityTemplates":           communityTemplates,
-	"frontendExample":              frontendExample,
-	"pushDownWindowAggregateCount": pushDownWindowAggregateCount,
-	"pushDownWindowAggregateSum":   pushDownWindowAggregateSum,
-	"pushDownWindowAggregateMin":   pushDownWindowAggregateMin,
-	"pushDownWindowAggregateMax":   pushDownWindowAggregateMax,
-	"pushDownWindowAggregateMean":  pushDownWindowAggregateMean,
-	"pushDownWindowAggregateFirst": pushDownWindowAggregateFirst,
-	"pushDownWindowAggregateLast":  pushDownWindowAggregateLast,
-	"newAuth":                      newAuth,
-	"pushDownGroupAggregateCount":  pushDownGroupAggregateCount,
-	"pushDownGroupAggregateSum":    pushDownGroupAggregateSum,
-	"pushDownGroupAggregateFirst":  pushDownGroupAggregateFirst,
-	"pushDownGroupAggregateLast":   pushDownGroupAggregateLast,
-	"newLabels":                    newLabels,
-	"hydratevars":                  hydratevars,
-	"memoryOptimizedFill":          memoryOptimizedFill,
-	"urmFreeTasks":                 urmFreeTasks,
+	"appMetrics":                    appMetrics,
+	"backendExample":                backendExample,
+	"communityTemplates":            communityTemplates,
+	"frontendExample":               frontendExample,
+	"pushDownWindowAggregateCount":  pushDownWindowAggregateCount,
+	"pushDownWindowAggregateSum":    pushDownWindowAggregateSum,
+	"pushDownWindowAggregateMin":    pushDownWindowAggregateMin,
+	"pushDownWindowAggregateMax":    pushDownWindowAggregateMax,
+	"pushDownWindowAggregateMean":   pushDownWindowAggregateMean,
+	"pushDownWindowAggregateFirst":  pushDownWindowAggregateFirst,
+	"pushDownWindowAggregateLast":   pushDownWindowAggregateLast,
+	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
+	"newAuth":                       newAuth,
+	"pushDownGroupAggregateCount":   pushDownGroupAggregateCount,
+	"pushDownGroupAggregateSum":     pushDownGroupAggregateSum,
+	"pushDownGroupAggregateFirst":   pushDownGroupAggregateFirst,
+	"pushDownGroupAggregateLast":    pushDownGroupAggregateLast,
+	"newLabels":                     newLabels,
+	"hydratevars":                   hydratevars,
+	"memoryOptimizedFill":           memoryOptimizedFill,
+	"urmFreeTasks":                  urmFreeTasks,
 }

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -29,6 +29,7 @@ func init() {
 		PushDownWindowAggregateRule{},
 		PushDownWindowAggregateByTimeRule{},
 		PushDownBareAggregateRule{},
+		GroupWindowAggregateTransposeRule{},
 		PushDownGroupAggregateRule{},
 		SwitchFillImplRule{},
 	)
@@ -740,6 +741,26 @@ func canPushWindowedAggregate(ctx context.Context, fnNode plan.Node) bool {
 	return true
 }
 
+func isPushableWindow(windowSpec *universe.WindowProcedureSpec) bool {
+	// every and period must be equal
+	// every.months must be zero
+	// every.isNegative must be false
+	// offset: must be zero
+	// timeColumn: must be "_time"
+	// startColumn: must be "_start"
+	// stopColumn: must be "_stop"
+	// createEmpty: must be false
+	window := windowSpec.Window
+	return window.Every.Equal(window.Period) &&
+		window.Every.Months() == 0 &&
+		!window.Every.IsNegative() &&
+		!window.Every.IsZero() &&
+		window.Offset.IsZero() &&
+		windowSpec.TimeColumn == "_time" &&
+		windowSpec.StartColumn == "_start" &&
+		windowSpec.StopColumn == "_stop"
+}
+
 func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	fnNode := pn
 	if !canPushWindowedAggregate(ctx, fnNode) {
@@ -751,23 +772,7 @@ func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 	fromNode := windowNode.Predecessors()[0]
 	fromSpec := fromNode.ProcedureSpec().(*ReadRangePhysSpec)
 
-	// every and period must be equal
-	// every.months must be zero
-	// every.isNegative must be false
-	// offset: must be zero
-	// timeColumn: must be "_time"
-	// startColumn: must be "_start"
-	// stopColumn: must be "_stop"
-	// createEmpty: must be false
-	window := windowSpec.Window
-	if !window.Every.Equal(window.Period) ||
-		window.Every.Months() != 0 ||
-		window.Every.IsNegative() ||
-		window.Every.IsZero() ||
-		!window.Offset.IsZero() ||
-		windowSpec.TimeColumn != "_time" ||
-		windowSpec.StartColumn != "_start" ||
-		windowSpec.StopColumn != "_stop" {
+	if !isPushableWindow(windowSpec) {
 		return pn, false, nil
 	}
 
@@ -775,7 +780,7 @@ func (PushDownWindowAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 	return plan.CreatePhysicalNode("ReadWindowAggregate", &ReadWindowAggregatePhysSpec{
 		ReadRangePhysSpec: *fromSpec.Copy().(*ReadRangePhysSpec),
 		Aggregates:        []plan.ProcedureKind{fnNode.Kind()},
-		WindowEvery:       window.Every.Nanoseconds(),
+		WindowEvery:       windowSpec.Window.Every.Nanoseconds(),
 		CreateEmpty:       windowSpec.CreateEmpty,
 	}), true, nil
 }
@@ -871,6 +876,107 @@ func (p PushDownBareAggregateRule) Rewrite(ctx context.Context, pn plan.Node) (p
 		Aggregates:        []plan.ProcedureKind{fnNode.Kind()},
 		WindowEvery:       math.MaxInt64,
 	}), true, nil
+}
+
+// GroupWindowAggregateTransposeRule will match the given pattern.
+// ReadGroupPhys |> window |> { min, max, count, sum }
+//
+// This pattern will use the PushDownWindowAggregateRule to determine
+// if the ReadWindowAggregatePhys operation is available before it will
+// rewrite the above. This rewrites the above to:
+//
+// ReadWindowAggregatePhys |> group(columns: ["_start", "_stop", ...]) |> { min, max, sum }
+//
+// The count aggregate uses sum to merge the results.
+type GroupWindowAggregateTransposeRule struct{}
+
+func (p GroupWindowAggregateTransposeRule) Name() string {
+	return "GroupWindowAggregateTransposeRule"
+}
+
+var windowMergeablePushAggs = []plan.ProcedureKind{
+	universe.MinKind,
+	universe.MaxKind,
+	universe.CountKind,
+	universe.SumKind,
+}
+
+func (p GroupWindowAggregateTransposeRule) Pattern() plan.Pattern {
+	return plan.OneOf(windowMergeablePushAggs,
+		plan.Pat(universe.WindowKind, plan.Pat(ReadGroupPhysKind)))
+}
+
+func (p GroupWindowAggregateTransposeRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
+	if !feature.GroupWindowAggregateTranspose().Enabled(ctx) {
+		return pn, false, nil
+	}
+
+	fnNode := pn
+	if !canPushWindowedAggregate(ctx, fnNode) {
+		return pn, false, nil
+	}
+
+	windowNode := fnNode.Predecessors()[0]
+	windowSpec := windowNode.ProcedureSpec().(*universe.WindowProcedureSpec)
+
+	if !isPushableWindow(windowSpec) {
+		return pn, false, nil
+	}
+
+	fromNode := windowNode.Predecessors()[0]
+	fromSpec := fromNode.ProcedureSpec().(*ReadGroupPhysSpec)
+
+	// This only works with GroupModeBy. It is the case
+	// that ReadGroup, which we depend on as a predecessor,
+	// only works with GroupModeBy so it should be impossible
+	// to fail this condition, but we add this here for extra
+	// protection.
+	if fromSpec.GroupMode != flux.GroupModeBy {
+		return pn, false, nil
+	}
+
+	// Perform the rewrite by replacing each of the nodes.
+	newFromNode := plan.CreatePhysicalNode("ReadWindowAggregate", &ReadWindowAggregatePhysSpec{
+		ReadRangePhysSpec: *fromSpec.ReadRangePhysSpec.Copy().(*ReadRangePhysSpec),
+		Aggregates:        []plan.ProcedureKind{fnNode.Kind()},
+		WindowEvery:       windowSpec.Window.Every.Nanoseconds(),
+		CreateEmpty:       windowSpec.CreateEmpty,
+	})
+
+	// Replace the window node with a group node first.
+	groupKeys := make([]string, len(fromSpec.GroupKeys), len(fromSpec.GroupKeys)+2)
+	copy(groupKeys, fromSpec.GroupKeys)
+	if !execute.ContainsStr(groupKeys, execute.DefaultStartColLabel) {
+		groupKeys = append(groupKeys, execute.DefaultStartColLabel)
+	}
+	if !execute.ContainsStr(groupKeys, execute.DefaultStopColLabel) {
+		groupKeys = append(groupKeys, execute.DefaultStopColLabel)
+	}
+	newGroupNode := plan.CreatePhysicalNode("group", &universe.GroupProcedureSpec{
+		GroupMode: flux.GroupModeBy,
+		GroupKeys: groupKeys,
+	})
+	newFromNode.AddSuccessors(newGroupNode)
+	newGroupNode.AddPredecessors(newFromNode)
+
+	// Attach the existing function node to the new group node.
+	fnNode.ClearPredecessors()
+	newGroupNode.AddSuccessors(fnNode)
+	fnNode.AddPredecessors(newGroupNode)
+
+	// Replace the spec for the function if needed.
+	switch spec := fnNode.ProcedureSpec().(type) {
+	case *universe.CountProcedureSpec:
+		newFnNode := plan.CreatePhysicalNode("sum", &universe.SumProcedureSpec{
+			AggregateConfig: spec.AggregateConfig,
+		})
+		plan.ReplaceNode(fnNode, newFnNode)
+		fnNode = newFnNode
+	default:
+		// No replacement required. The procedure is idempotent so
+		// we can use it over and over again and get the same result.
+	}
+	return fnNode, true, nil
 }
 
 //

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1917,6 +1917,522 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 	}
 }
 
+func TestTransposeGroupToWindowAggregateRule(t *testing.T) {
+	// Turn on all variants.
+	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
+		feature.GroupWindowAggregateTranspose(): true,
+		feature.PushDownWindowAggregateCount():  true,
+		feature.PushDownWindowAggregateSum():    true,
+		feature.PushDownWindowAggregateMin():    true,
+		feature.PushDownWindowAggregateMax():    true,
+		feature.PushDownWindowAggregateMean():   true,
+		feature.PushDownWindowAggregateFirst():  true,
+		feature.PushDownWindowAggregateLast():   true,
+	})
+
+	rules := []plan.Rule{
+		influxdb.PushDownGroupRule{},
+		influxdb.PushDownWindowAggregateRule{},
+		influxdb.PushDownWindowAggregateByTimeRule{},
+		influxdb.GroupWindowAggregateTransposeRule{},
+	}
+
+	withFlagger, _ := feature.Annotate(context.Background(), flagger)
+
+	// Construct dependencies either with or without aggregate window caps.
+	deps := func(have bool) influxdb.StorageDependencies {
+		return influxdb.StorageDependencies{
+			FromDeps: influxdb.FromDependencies{
+				Reader:  mockReaderCaps{Have: have},
+				Metrics: influxdb.NewMetrics(nil),
+			},
+		}
+	}
+
+	haveCaps := deps(true).Inject(withFlagger)
+	noCaps := deps(false).Inject(withFlagger)
+
+	readRange := influxdb.ReadRangePhysSpec{
+		Bucket: "my-bucket",
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+
+	group := func(mode flux.GroupMode, keys ...string) *universe.GroupProcedureSpec {
+		return &universe.GroupProcedureSpec{
+			GroupMode: mode,
+			GroupKeys: keys,
+		}
+	}
+
+	groupResult := func(keys ...string) *universe.GroupProcedureSpec {
+		keys = append(keys, execute.DefaultStartColLabel, execute.DefaultStopColLabel)
+		return group(flux.GroupModeBy, keys...)
+	}
+
+	dur1m := values.ConvertDuration(60 * time.Second)
+	dur2m := values.ConvertDuration(120 * time.Second)
+	dur0 := values.ConvertDuration(0)
+	durNeg, _ := values.ParseDuration("-60s")
+	dur1y, _ := values.ParseDuration("1y")
+	durInf := values.ConvertDuration(math.MaxInt64)
+
+	window := func(dur values.Duration) universe.WindowProcedureSpec {
+		return universe.WindowProcedureSpec{
+			Window: plan.WindowSpec{
+				Every:  dur,
+				Period: dur,
+				Offset: dur0,
+			},
+			TimeColumn:  "_time",
+			StartColumn: "_start",
+			StopColumn:  "_stop",
+			CreateEmpty: false,
+		}
+	}
+
+	window1m := window(dur1m)
+	window1mCreateEmpty := window1m
+	window1mCreateEmpty.CreateEmpty = true
+	window2m := window(dur2m)
+	windowNeg := window(durNeg)
+	window1y := window(dur1y)
+	windowInf := window(durInf)
+	windowInfCreateEmpty := windowInf
+	windowInfCreateEmpty.CreateEmpty = true
+
+	tests := make([]plantest.RuleTestCase, 0)
+
+	// construct a simple plan with a specific window and aggregate function
+	simplePlan := func(window universe.WindowProcedureSpec, agg plan.NodeID, spec plan.ProcedureSpec, successors ...plan.Node) *plantest.PlanSpec {
+		pspec := &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("group", group(flux.GroupModeBy)),
+				plan.CreateLogicalNode("window", &window),
+				plan.CreateLogicalNode(agg, spec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		}
+		for i, successor := range successors {
+			pspec.Nodes = append(pspec.Nodes, successor)
+			pspec.Edges = append(pspec.Edges, [2]int{i + 3, i + 4})
+		}
+		return pspec
+	}
+
+	// construct a simple result
+	simpleResult := func(proc plan.ProcedureKind, every values.Duration, createEmpty bool, successors ...plan.Node) *plantest.PlanSpec {
+		spec := &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{proc},
+					WindowEvery:       every.Nanoseconds(),
+					CreateEmpty:       createEmpty,
+				}),
+			},
+		}
+		for i, successor := range successors {
+			spec.Nodes = append(spec.Nodes, successor)
+			spec.Edges = append(spec.Edges, [2]int{i, i + 1})
+		}
+		return spec
+	}
+
+	duplicateSpec := func(column, as string) *universe.SchemaMutationProcedureSpec {
+		return &universe.SchemaMutationProcedureSpec{
+			Mutations: []universe.SchemaMutation{
+				&universe.DuplicateOpSpec{
+					Column: execute.DefaultStopColLabel,
+					As:     execute.DefaultTimeColLabel,
+				},
+			},
+		}
+	}
+
+	// ReadRange -> group -> window -> min => ReadWindowAggregate -> group -> min
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "SimplePassMin",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "min", minProcedureSpec()),
+		After: simpleResult("min", dur1m, false,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("min", minProcedureSpec()),
+		),
+	})
+
+	// ReadRange -> group -> window -> max => ReadWindowAggregate -> group -> max
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "SimplePassMax",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "max", maxProcedureSpec()),
+		After: simpleResult("max", dur1m, false,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("max", maxProcedureSpec()),
+		),
+	})
+
+	// ReadRange -> group -> window -> mean => ReadGroup -> mean
+	// TODO(jsternberg): When we begin pushing down mean calls,
+	// this test will need to be updated to the appropriate pattern.
+	// The reason why this is included is because we cannot rewrite
+	// a grouped mean to use read window aggregate with mean. We
+	// will need this plan to be something different that doesn't
+	// exist yet so this is testing that we don't attempt to use
+	// this planner rule for mean.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "SimplePassMean",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "mean", meanProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("mean", meanProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		},
+	})
+
+	// ReadRange -> group -> window -> count => ReadWindowAggregate -> group -> sum
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "SimplePassCount",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "count", countProcedureSpec()),
+		After: simpleResult("count", dur1m, false,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("sum", sumProcedureSpec()),
+		),
+	})
+
+	// ReadRange -> group -> window -> sum => ReadWindowAggregate -> group -> sum
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "SimplePassSum",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "sum", sumProcedureSpec()),
+		After: simpleResult("sum", dur1m, false,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("sum", sumProcedureSpec()),
+		),
+	})
+
+	// Rewrite with aggregate window
+	// ReadRange -> group -> window -> min -> duplicate -> window
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "WithSuccessor",
+		Rules:   rules,
+		Before: simplePlan(window1mCreateEmpty, "min", minProcedureSpec(),
+			plan.CreateLogicalNode("duplicate", duplicateSpec("_stop", "_time")),
+			plan.CreateLogicalNode("window", &windowInf),
+		),
+		After: simpleResult("min", dur1m, true,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("min", minProcedureSpec()),
+			plan.CreatePhysicalNode("duplicate", duplicateSpec("_stop", "_time")),
+			plan.CreatePhysicalNode("window", &windowInf),
+		),
+	})
+
+	// ReadRange -> group(host) -> window -> min => ReadWindowAggregate -> group(host, _start, _stop) -> min
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "GroupByHostPassMin",
+		Rules:   rules,
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("group", group(flux.GroupModeBy, "host")),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		},
+		After: simpleResult("min", dur1m, false,
+			plan.CreatePhysicalNode("group", groupResult("host")),
+			plan.CreatePhysicalNode("min", minProcedureSpec()),
+		),
+	})
+
+	// ReadRange -> group(_start, host) -> window -> min => ReadWindowAggregate -> group(_start, host, _stop) -> min
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "GroupByStartPassMin",
+		Rules:   rules,
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("group", group(flux.GroupModeBy, "_start", "host")),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		},
+		After: simpleResult("min", dur1m, false,
+			plan.CreatePhysicalNode("group", group(flux.GroupModeBy, "_start", "host", "_stop")),
+			plan.CreatePhysicalNode("min", minProcedureSpec()),
+		),
+	})
+
+	// Helper that adds a test with a simple plan that does not pass due to a
+	// specified bad window
+	simpleMinUnchanged := func(name string, window universe.WindowProcedureSpec) {
+		tests = append(tests, plantest.RuleTestCase{
+			Context: haveCaps,
+			Name:    name,
+			Rules:   rules,
+			Before:  simplePlan(window, "min", minProcedureSpec()),
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+						ReadRangePhysSpec: readRange,
+						GroupMode:         flux.GroupModeBy,
+					}),
+					plan.CreatePhysicalNode("window", &window),
+					plan.CreatePhysicalNode("min", minProcedureSpec()),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+		})
+	}
+
+	// Condition not met: period not equal to every
+	badWindow1 := window1m
+	badWindow1.Window.Period = dur2m
+	simpleMinUnchanged("BadPeriod", badWindow1)
+
+	// Condition not met: offset non-zero
+	badWindow2 := window1m
+	badWindow2.Window.Offset = dur1m
+	simpleMinUnchanged("BadOffset", badWindow2)
+
+	// Condition not met: non-standard _time column
+	badWindow3 := window1m
+	badWindow3.TimeColumn = "_timmy"
+	simpleMinUnchanged("BadTime", badWindow3)
+
+	// Condition not met: non-standard start column
+	badWindow4 := window1m
+	badWindow4.StartColumn = "_stooort"
+	simpleMinUnchanged("BadStart", badWindow4)
+
+	// Condition not met: non-standard stop column
+	badWindow5 := window1m
+	badWindow5.StopColumn = "_stappp"
+	simpleMinUnchanged("BadStop", badWindow5)
+
+	// Condition met: createEmpty is true.
+	windowCreateEmpty1m := window1m
+	windowCreateEmpty1m.CreateEmpty = true
+	tests = append(tests, plantest.RuleTestCase{
+		Context: haveCaps,
+		Name:    "CreateEmptyPassMin",
+		Rules:   rules,
+		Before:  simplePlan(window1mCreateEmpty, "min", minProcedureSpec()),
+		After: simpleResult("min", dur1m, true,
+			plan.CreatePhysicalNode("group", groupResult()),
+			plan.CreatePhysicalNode("min", minProcedureSpec()),
+		),
+	})
+
+	// Condition not met: duration too long.
+	simpleMinUnchanged("WindowTooLarge", window1y)
+
+	// Condition not met: neg duration.
+	simpleMinUnchanged("WindowNeg", windowNeg)
+
+	// Bad min column
+	// ReadRange -> group -> window -> min => ReadGroup -> window -> min
+	badMinSpec := universe.MinProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: "_valmoo"},
+	}
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMinCol",
+		Context: haveCaps,
+		Rules:   rules,
+		Before:  simplePlan(window1m, "min", &badMinSpec),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("min", &badMinSpec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		},
+	})
+
+	// Bad max column
+	// ReadRange -> group -> window -> max => ReadGroup -> window -> max
+	badMaxSpec := universe.MaxProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: "_valmoo"},
+	}
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMaxCol",
+		Context: haveCaps,
+		Rules:   rules,
+		Before:  simplePlan(window1m, "max", &badMaxSpec),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("max", &badMaxSpec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		},
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> group -> window -> min
+	//                             \-> min
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "CollapsedWithSuccessor1",
+		Context: haveCaps,
+		Rules:   rules,
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("group", group(flux.GroupModeBy)),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{2, 4},
+			},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("min", minProcedureSpec()),
+				plan.CreatePhysicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{1, 3},
+			},
+		},
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> group -> window -> min
+	//                   \-> window
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "CollapsedWithSuccessor2",
+		Context: haveCaps,
+		Rules:   rules,
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("group", group(flux.GroupModeBy)),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+				plan.CreateLogicalNode("window", &window2m),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{1, 4},
+			},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("min", minProcedureSpec()),
+				plan.CreatePhysicalNode("window", &window2m),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{0, 3},
+			},
+		},
+	})
+
+	// Fail due to no capabilities present.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: noCaps,
+		Name:    "FailNoCaps",
+		Rules:   rules,
+		Before:  simplePlan(window1m, "count", countProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadGroup", &influxdb.ReadGroupPhysSpec{
+					ReadRangePhysSpec: readRange,
+					GroupMode:         flux.GroupModeBy,
+				}),
+				plan.CreatePhysicalNode("window", &window1m),
+				plan.CreatePhysicalNode("count", countProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		},
+	})
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
 func TestPushDownBareAggregateRule(t *testing.T) {
 	// Turn on support for window aggregate count
 	flagger := mock.NewFlagger(map[feature.Flag]interface{}{


### PR DESCRIPTION
This rule reorders group and window so it will switch from using
`ReadGroup` to using `ReadWindowAggregate` when the intent is to
aggregate a grouped window. It will then add a group node that groups by
the given columns and the start and stop columns and then reperform the
aggregate. This is more performant than performing the group first.

Fixes #17895.