### PR TITLE
fix(dbrp): Wait until we know this bucket is default before writing value

### DIFF
--- a/dbrp/http_server_dbrp_test.go
+++ b/dbrp/http_server_dbrp_test.go
@@ -148,6 +148,9 @@ func Test_handlePostDBRP(t *testing.T) {
 				t.Fatalf("expected orgid %s got %s", tt.ExpectedDBRP.OrganizationID, dbrp.OrganizationID)
 			}
 
+			if !dbrp.Default {
+				t.Fatalf("expected dbrp to be marked as default")
+			}
 		})
 	}
 }

--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -370,17 +370,10 @@ func (s *Service) Create(ctx context.Context, dbrp *influxdb.DBRPMappingV2) erro
 	if err != nil {
 		return ErrInvalidDBRPID
 	}
-	b, err := json.Marshal(dbrp)
-	if err != nil {
-		return ErrInternalService(err)
-	}
 
 	return s.store.Update(ctx, func(tx kv.Tx) error {
 		bucket, err := tx.Bucket(bucket)
 		if err != nil {
-			return ErrInternalService(err)
-		}
-		if err := bucket.Put(encodedID, b); err != nil {
 			return ErrInternalService(err)
 		}
 		compKey := indexForeignKey(*dbrp)
@@ -394,6 +387,15 @@ func (s *Service) Create(ctx context.Context, dbrp *influxdb.DBRPMappingV2) erro
 		if !defSet {
 			dbrp.Default = true
 		}
+
+		b, err := json.Marshal(dbrp)
+		if err != nil {
+			return ErrInternalService(err)
+		}
+		if err := bucket.Put(encodedID, b); err != nil {
+			return ErrInternalService(err)
+		}
+
 		if dbrp.Default {
 			if err := s.setAsDefault(tx, compKey, encodedID); err != nil {
 				return err


### PR DESCRIPTION
DBRPs are currently being persisted with a `default` value of `false` even though they are the first DBRP mapping created for a DB. This fix defers writing the DBRP mapping record until after we've determined that it is indeed the default mapping for an Organization + DB. The index that refers to his default bucket is operating as expected.