### PR TITLE
feat(starter): add starter service to run scripts on events

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,0 +1,22 @@
+package influxdb
+
+type Event struct {
+	Type EventType
+	Auth Authorization
+}
+
+type EventType uint
+
+const (
+	EventUnknown EventType = iota
+	EventSetupComplete
+	EventStartupComplete
+)
+
+func (s EventType) String() string {
+	return [...]string{
+		EventUnknown:         "unknown",
+		EventSetupComplete:   "setup_complete",
+		EventStartupComplete: "startup_complete",
+	}[s]
+}

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	google.golang.org/api v0.17.0
 	google.golang.org/grpc v1.27.1
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	honnef.co/go/tools v0.0.1-2019.2.3.0.20190904154718-afd67930eec2
 	istio.io/pkg v0.0.0-20200606170016-70c5172b9cdf

--- a/on_setup.yml
+++ b/on_setup.yml
@@ -1,0 +1,1 @@
+template: pkger/testdata/bucket.yml

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -95,6 +95,28 @@ func Parse(encoding Encoding, readerFn ReaderFn, opts ...ValidateOptFn) (*Pkg, e
 	return pkg, nil
 }
 
+func ParseFromURL(rawURL string) (*Pkg, error) {
+	enc := EncodingSource
+	switch path.Ext(rawURL) {
+	case ".jsonnet":
+		enc = EncodingJsonnet
+	case ".json":
+		enc = EncodingJSON
+	case ".yml", ".yaml":
+		enc = EncodingYAML
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.HasPrefix(u.Scheme, "http") {
+		return Parse(enc, FromHTTPRequest(rawURL))
+	}
+	return Parse(enc, FromFile(rawURL))
+}
+
 // FromFile reads a file from disk and provides a reader from it.
 func FromFile(filePath string) ReaderFn {
 	return func() (io.Reader, string, error) {

--- a/starter/service.go
+++ b/starter/service.go
@@ -1,0 +1,63 @@
+package starter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/influxdb/v2"
+	icontext "github.com/influxdata/influxdb/v2/context"
+	"github.com/influxdata/influxdb/v2/pkger"
+)
+
+type Service struct {
+	scripts []ScriptTemplate
+
+	eventConsumer chan influxdb.Event
+	tmplSVC       pkger.SVC
+}
+
+type ScriptTemplate struct {
+	Template string `yaml:"template"`
+}
+
+func NewService(tmplSVC pkger.SVC, scripts ...ScriptTemplate) *Service {
+	return &Service{
+		scripts:       scripts,
+		eventConsumer: make(chan influxdb.Event, 1), // nonblocking sends to this consumer
+		tmplSVC:       tmplSVC,
+	}
+}
+
+func (s *Service) EventConsumer() chan<- influxdb.Event {
+	return s.eventConsumer
+}
+
+func (s *Service) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-s.eventConsumer:
+			s.handleEvent(ctx, ev)
+		}
+	}
+}
+
+func (s *Service) handleEvent(ctx context.Context, ev influxdb.Event) {
+	switch ev.Type {
+	case influxdb.EventSetupComplete:
+		for _, scr := range s.scripts {
+			tmpl, err := pkger.ParseFromURL(scr.Template)
+			if err != nil {
+				fmt.Println("error parsing template: ", err.Error())
+				continue
+			}
+
+			ctx := icontext.SetAuthorizer(ctx, &ev.Auth)
+			_, err = s.tmplSVC.Apply(ctx, ev.Auth.OrgID, ev.Auth.UserID, pkger.ApplyWithPkg(tmpl))
+			if err != nil {
+				fmt.Println("error applying template: ", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
events here are SetupComplete and StartupComplte. This example
code is an hour of coding something together. Not at all a
final product. It is a strawman to understand the basics of what
events can do for OSS.

What's missing here? a whole lot. The following would need to be addressed:

  * event service, single place to publish events to, decoupling pub/sub
  * simpler and more extensive events, likely an evnet type and properties
    root lvl of event struct
  * there is more things like tests and the like to make this production ready
