### PR TITLE
fix(timeseries-map-bug): prevents random racecondition bug from erroring cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@
 1. [18573](https://github.com/influxdata/influxdb/pull/18573): Extend influx stacks cmd with new influx stacks update cmd
 1. [18595](https://github.com/influxdata/influxdb/pull/18595): Add ability to skip resources in a template by kind or by metadata.name
 1. [18600](https://github.com/influxdata/influxdb/pull/18600): Extend influx apply with resource filter capabilities
-1. [18601](https://github.com/influxdata/influxdb/pull/18601): Provide active config  running influx config without args
+1. [18601](https://github.com/influxdata/influxdb/pull/18601): Provide active config running influx config without args
 1. [18606](https://github.com/influxdata/influxdb/pull/18606): Enable influxd binary to look for a config file on startup
 
 ### Bug Fixes
+
 1. [18602](https://github.com/influxdata/influxdb/pull/18602): Fix uint overflow during setup on 32bit systems
 1. [18623](https://github.com/influxdata/influxdb/pull/18623): Drop support for --local flag within influx CLI
+1. [18632](https://github.com/influxdata/influxdb/pull/18632): Prevents undefined queries in cells from erroring out in dashboards
 
 ## v2.0.0-beta.12 [2020-06-12]
 

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -325,7 +325,9 @@ const mstp = (state: AppState, props: OwnProps): StateProps => {
   // component appends it automatically. That should be fixed
   // NOTE: limit the variables returned to those that are used,
   // as this prevents resending when other queries get sent
-  const queries = props.queries.map(q => q.text).filter(t => !!t.trim())
+  const queries = props.queries
+    ? props.queries.map(q => q.text).filter(t => !!t.trim())
+    : []
   const vars = getVariables(state).filter(v =>
     queries.some(t => isInQuery(t, v))
   )


### PR DESCRIPTION
Closes #18312 

### Problem

Cells would randomly error out after creation because the query that was created was undefined

### Solution

After some investigating, it seems like this issue is a race condition that makes it hard to reproduce consistently. I investigated the origin of the queries property that's being passed in and everything seems to indicate that queries should be there. As such, I'm not quite sure where this bug actually exists (that queries are undefined in the map dispatch to props), but adding this statement should allow us to prevent the cell from erroring out.


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
