### PR TITLE
fix: reportEvent has a default timestamp

### DIFF
--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -25,7 +25,12 @@ export const updateReportingContext = (key: string, value: string) => {
   reportingTags = {...reportingTags, [key]: value}
 }
 
-export const reportEvent = ({timestamp, measurement, fields, tags}: Point) => {
+export const reportEvent = ({
+  timestamp = toNano(Date.now()),
+  measurement,
+  fields,
+  tags,
+}: Point) => {
   if (isEmpty(fields)) {
     fields = {source: 'ui'}
   }


### PR DESCRIPTION
Default timestamp on `reportEvent` was clobbered in a merge.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass