### PR TITLE
feat: push down window first to storage

### DIFF
--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -447,6 +447,22 @@ func (tl *TestLauncher) Metrics(tb testing.TB) (metrics map[string]*dto.MetricFa
 	return metrics
 }
 
+func (tl *TestLauncher) NumReads(tb testing.TB, op string) uint64 {
+	const metricName = "query_influxdb_source_read_request_duration_seconds"
+	mf := tl.Metrics(tb)[metricName]
+	if mf != nil {
+		fmt.Printf("%v\n", mf)
+		for _, m := range mf.Metric {
+			for _, label := range m.Label {
+				if label.GetName() == "op" && label.GetValue() == op {
+					return m.Histogram.GetSampleCount()
+				}
+			}
+		}
+	}
+	return 0
+}
+
 // QueryResult wraps a single flux.Result with some helper methods.
 type QueryResult struct {
 	t *testing.T

--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -748,63 +748,226 @@ from(bucket: "%s")
 	}
 }
 
-func TestLauncher_Query_PushDownWindowAggregateAndBareAggregate(t *testing.T) {
-	l := launcher.RunTestLauncherOrFail(t, ctx, nil,
-		"--feature-flags", "pushDownWindowAggregateCount=true,pushDownWindowAggregateSum=true")
-	l.SetupOrFail(t)
-	defer l.ShutdownOrFail(t, ctx)
-
-	l.WritePointsOrFail(t, `
-m0,k=k0 f=0i 0
-m0,k=k0 f=1i 1000000000
-m0,k=k0 f=2i 2000000000
-m0,k=k0 f=3i 3000000000
-m0,k=k0 f=4i 4000000000
-m0,k=k0 f=5i 5000000000
-m0,k=k0 f=6i 6000000000
-m0,k=k0 f=5i 7000000000
-m0,k=k0 f=0i 8000000000
-m0,k=k0 f=6i 9000000000
-m0,k=k0 f=6i 10000000000
-m0,k=k0 f=7i 11000000000
-m0,k=k0 f=5i 12000000000
-m0,k=k0 f=8i 13000000000
-m0,k=k0 f=9i 14000000000
-m0,k=k0 f=5i 15000000000
-`)
-
-	getReadRequestCount := func(op string) uint64 {
-		const metricName = "query_influxdb_source_read_request_duration_seconds"
-		mf := l.Metrics(t)[metricName]
-		if mf != nil {
-			fmt.Printf("%v\n", mf)
-			for _, m := range mf.Metric {
-				for _, label := range m.Label {
-					if label.GetName() == "op" && label.GetValue() == op {
-						return m.Histogram.GetSampleCount()
-					}
-				}
-			}
-		}
-		return 0
-	}
-
-	for _, tt := range []struct {
-		name string
-		q    string
-		op   string
-		res  string
+func TestQueryPushDowns(t *testing.T) {
+	testcases := []struct {
+		name  string
+		data  []string
+		query string
+		op    string
+		want  string
 	}{
 		{
+			name: "window first",
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:05Z, stop: 1970-01-01T00:00:20Z)
+	|> window(every: 3s)
+	|> first()
+`,
+			op: "readWindow(first)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,k
+,,0,1970-01-01T00:00:05Z,1970-01-01T00:00:06Z,1970-01-01T00:00:05Z,5,f,m0,k0
+,,1,1970-01-01T00:00:06Z,1970-01-01T00:00:09Z,1970-01-01T00:00:06Z,6,f,m0,k0
+,,2,1970-01-01T00:00:09Z,1970-01-01T00:00:12Z,1970-01-01T00:00:09Z,6,f,m0,k0
+,,3,1970-01-01T00:00:12Z,1970-01-01T00:00:15Z,1970-01-01T00:00:12Z,5,f,m0,k0
+,,4,1970-01-01T00:00:15Z,1970-01-01T00:00:18Z,1970-01-01T00:00:15Z,5,f,m0,k0
+`,
+		},
+		{
+			name: "window first string",
+			data: []string{
+				"m,tag=a f=\"c\" 2000000000",
+				"m,tag=a f=\"d\" 3000000000",
+				"m,tag=a f=\"h\" 7000000000",
+				"m,tag=a f=\"i\" 8000000000",
+				"m,tag=a f=\"j\" 9000000000",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:10Z)
+	|> window(every: 5s)
+	|> first()
+`,
+			op: "readWindow(first)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,tag
+,,0,1970-01-01T00:00:00Z,1970-01-01T00:00:05Z,1970-01-01T00:00:02Z,c,f,m,a
+,,1,1970-01-01T00:00:05Z,1970-01-01T00:00:10Z,1970-01-01T00:00:07Z,h,f,m,a
+`,
+		},
+		{
+			name: "bare first",
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:05Z, stop: 1970-01-01T00:00:20Z)
+	|> first()
+`,
+			op: "readWindow(first)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,k
+,,0,1970-01-01T00:00:05Z,1970-01-01T00:00:20Z,1970-01-01T00:00:05Z,5,f,m0,k0
+`,
+		},
+		{
+			name: "window empty first",
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:02Z)
+	|> window(every: 500ms, createEmpty: true)
+	|> first()
+`,
+			op: "readWindow(first)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,_result,table,_start,_stop,_time,_value,_field,_measurement,k
+,_result,0,1970-01-01T00:00:00Z,1970-01-01T00:00:00.5Z,1970-01-01T00:00:00Z,0,f,m0,k0
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,1,1970-01-01T00:00:00.5Z,1970-01-01T00:00:01Z,,,f,m0,k0
+,_result,table,_start,_stop,_time,_value,_field,_measurement,k
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,_result,table,_start,_stop,_time,_value,_field,_measurement,k
+,_result,2,1970-01-01T00:00:01Z,1970-01-01T00:00:01.5Z,1970-01-01T00:00:01Z,1,f,m0,k0
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,3,1970-01-01T00:00:01.5Z,1970-01-01T00:00:02Z,,,f,m0,k0
+,_result,table,_start,_stop,_time,_value,_field,_measurement,k
+`,
+		},
+		{
+			name: "window aggregate first",
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:02Z)
+	|> aggregateWindow(every: 500ms, fn: first)
+`,
+			op: "readWindow(first)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,k
+,,0,1970-01-01T00:00:00Z,1970-01-01T00:00:02Z,1970-01-01T00:00:00.5Z,0,f,m0,k0
+,,0,1970-01-01T00:00:00Z,1970-01-01T00:00:02Z,1970-01-01T00:00:01.5Z,1,f,m0,k0
+`,
+		},
+		{
 			name: "count",
-			q: `
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> aggregateWindow(every: 5s, fn: count)
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readWindow(count)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long,string,string,string
 #group,false,false,false,false,true,true,true
 #default,_result,,,,,,
@@ -816,14 +979,32 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "bare count",
-			q: `
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> count()
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readWindow(count)",
-			res: `
+			want: `
 #group,false,false,false,true,true,true
 #datatype,string,long,long,string,string,string
 #default,_result,,,,,
@@ -833,14 +1014,32 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "sum",
-			q: `
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> aggregateWindow(every: 5s, fn: sum)
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readWindow(sum)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long,string,string,string
 #group,false,false,false,false,true,true,true
 #default,_result,,,,,,
@@ -852,14 +1051,32 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "bare sum",
-			q: `
+			data: []string{
+				"m0,k=k0 f=0i 0",
+				"m0,k=k0 f=1i 1000000000",
+				"m0,k=k0 f=2i 2000000000",
+				"m0,k=k0 f=3i 3000000000",
+				"m0,k=k0 f=4i 4000000000",
+				"m0,k=k0 f=5i 5000000000",
+				"m0,k=k0 f=6i 6000000000",
+				"m0,k=k0 f=5i 7000000000",
+				"m0,k=k0 f=0i 8000000000",
+				"m0,k=k0 f=6i 9000000000",
+				"m0,k=k0 f=6i 10000000000",
+				"m0,k=k0 f=7i 11000000000",
+				"m0,k=k0 f=5i 12000000000",
+				"m0,k=k0 f=8i 13000000000",
+				"m0,k=k0 f=9i 14000000000",
+				"m0,k=k0 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> sum()
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readWindow(sum)",
-			res: `
+			want: `
 #group,false,false,false,true,true,true
 #datatype,string,long,long,string,string,string
 #default,_result,,,,,
@@ -867,93 +1084,27 @@ from(bucket: v.bucket)
 ,,0,67,f,m0,k0
 `,
 		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			wantCount := getReadRequestCount(tt.op) + 1
-
-			prelude := fmt.Sprintf("v = {bucket: \"%s\", timeRangeStart: 1970-01-01T00:00:00Z, timeRangeStop: 1970-01-01T00:00:15Z}", l.Bucket.Name)
-			queryStr := prelude + "\n" + tt.q
-			res := l.MustExecuteQuery(queryStr)
-			defer res.Done()
-			got := flux.NewSliceResultIterator(res.Results)
-			defer got.Release()
-
-			dec := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
-			want, err := dec.Decode(ioutil.NopCloser(strings.NewReader(tt.res)))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer want.Release()
-
-			if err := executetest.EqualResultIterators(want, got); err != nil {
-				t.Fatal(err)
-			}
-
-			if want, got := wantCount, getReadRequestCount(tt.op); want != got {
-				t.Fatalf("unexpected sample count -want/+got:\n\t- %d\n\t+ %d", want, got)
-			}
-		})
-	}
-}
-
-func TestLauncher_Query_PushDownGroupAggregate(t *testing.T) {
-	l := launcher.RunTestLauncherOrFail(t, ctx, nil,
-		"--feature-flags",
-		"pushDownGroupAggregateCount=true",
-		"--feature-flags",
-		"pushDownGroupAggregateSum=true",
-		"--feature-flags",
-		"pushDownGroupAggregateFirst=true",
-		"--feature-flags",
-		"pushDownGroupAggregateLast=true",
-	)
-	l.SetupOrFail(t)
-	defer l.ShutdownOrFail(t, ctx)
-
-	l.WritePointsOrFail(t, `
-m0,k=k0,kk=kk0 f=0i 0
-m0,k=k0,kk=kk1 f=1i 1000000000
-m0,k=k0,kk=kk0 f=2i 2000000000
-m0,k=k0,kk=kk1 f=3i 3000000000
-m0,k=k0,kk=kk0 f=4i 4000000000
-m0,k=k0,kk=kk1 f=5i 5000000000
-m0,k=k0,kk=kk0 f=6i 6000000000
-m0,k=k0,kk=kk1 f=5i 7000000000
-m0,k=k0,kk=kk0 f=0i 8000000000
-m0,k=k0,kk=kk1 f=6i 9000000000
-m0,k=k0,kk=kk0 f=6i 10000000000
-m0,k=k0,kk=kk1 f=7i 11000000000
-m0,k=k0,kk=kk0 f=5i 12000000000
-m0,k=k0,kk=kk1 f=8i 13000000000
-m0,k=k0,kk=kk0 f=9i 14000000000
-m0,k=k0,kk=kk1 f=5i 15000000000
-`)
-
-	getReadRequestCount := func(op string) uint64 {
-		const metricName = "query_influxdb_source_read_request_duration_seconds"
-		mf := l.Metrics(t)[metricName]
-		if mf != nil {
-			fmt.Printf("%v\n", mf)
-			for _, m := range mf.Metric {
-				for _, label := range m.Label {
-					if label.GetName() == "op" && label.GetValue() == op {
-						return m.Histogram.GetSampleCount()
-					}
-				}
-			}
-		}
-		return 0
-	}
-
-	for _, tt := range []struct {
-		name string
-		q    string
-		op   string
-		res  string
-	}{
 		{
 			name: "group first",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 0)
 	|> group(columns: ["k"])
@@ -961,7 +1112,7 @@ from(bucket: v.bucket)
 	|> keep(columns: ["_time", "_value"])
 `,
 			op: "readGroup(first)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long
 #group,false,false,false,false
 #default,_result,,,
@@ -971,7 +1122,25 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "group none first",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 0)
 	|> group()
@@ -979,7 +1148,7 @@ from(bucket: v.bucket)
 	|> keep(columns: ["_time", "_value"])
 `,
 			op: "readGroup(first)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long
 #group,false,false,false,false
 #default,_result,,,
@@ -989,7 +1158,25 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "group last",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 0)
 	|> group(columns: ["k"])
@@ -997,7 +1184,7 @@ from(bucket: v.bucket)
 	|> keep(columns: ["_time", "_value"])
 `,
 			op: "readGroup(last)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long
 #group,false,false,false,false
 #default,_result,,,
@@ -1007,7 +1194,25 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "group none last",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 0)
 	|> group()
@@ -1015,7 +1220,7 @@ from(bucket: v.bucket)
 	|> keep(columns: ["_time", "_value"])
 `,
 			op: "readGroup(last)",
-			res: `
+			want: `
 #datatype,string,long,dateTime:RFC3339,long
 #group,false,false,false,false
 #default,_result,,,
@@ -1025,7 +1230,25 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "count group none",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> group()
@@ -1033,7 +1256,7 @@ from(bucket: v.bucket)
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readGroup(count)",
-			res: `
+			want: `
 #datatype,string,long,long
 #group,false,false,false
 #default,_result,,
@@ -1043,15 +1266,33 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "count group",
-			op:   "readGroup(count)",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			op: "readGroup(count)",
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> group(columns: ["kk"])
 	|> count()
 	|> drop(columns: ["_start", "_stop"])
 `,
-			res: `
+			want: `
 #datatype,string,long,string,long
 #group,false,false,true,false
 #default,_result,,,
@@ -1062,7 +1303,25 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "sum group none",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> group()
@@ -1070,7 +1329,7 @@ from(bucket: v.bucket)
 	|> drop(columns: ["_start", "_stop"])
 `,
 			op: "readGroup(sum)",
-			res: `
+			want: `
 #datatype,string,long,long
 #group,false,false,false
 #default,_result,,
@@ -1080,15 +1339,33 @@ from(bucket: v.bucket)
 		},
 		{
 			name: "sum group",
-			op:   "readGroup(sum)",
-			q: `
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			op: "readGroup(sum)",
+			query: `
 from(bucket: v.bucket)
 	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
 	|> group(columns: ["kk"])
 	|> sum()
 	|> drop(columns: ["_start", "_stop"])
 `,
-			res: `
+			want: `
 #datatype,string,long,string,long
 #group,false,false,true,false
 #default,_result,,,
@@ -1097,29 +1374,50 @@ from(bucket: v.bucket)
 ,,1,kk1,35
 `,
 		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			wantCount := getReadRequestCount(tt.op) + 1
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			l := launcher.RunTestLauncherOrFail(t, ctx, nil,
+				"--feature-flags",
+				"pushDownWindowAggregateCount=true",
+				"--feature-flags",
+				"pushDownWindowAggregateSum=true",
+				"--feature-flags",
+				"pushDownWindowAggregateFirst=true",
+				"--feature-flags",
+				"pushDownGroupAggregateCount=true",
+				"--feature-flags",
+				"pushDownGroupAggregateSum=true",
+				"--feature-flags",
+				"pushDownGroupAggregateFirst=true",
+				"--feature-flags",
+				"pushDownGroupAggregateLast=true",
+			)
 
-			prelude := fmt.Sprintf("v = {bucket: \"%s\", timeRangeStart: 1970-01-01T00:00:00Z, timeRangeStop: 1970-01-01T00:00:15Z}", l.Bucket.Name)
-			queryStr := prelude + "\n" + tt.q
+			l.SetupOrFail(t)
+			defer l.ShutdownOrFail(t, ctx)
+
+			l.WritePointsOrFail(t, strings.Join(tc.data, "\n"))
+
+			queryStr := "v = {bucket: " + "\"" + l.Bucket.Name + "\"" + "}\n" + tc.query
+
 			res := l.MustExecuteQuery(queryStr)
 			defer res.Done()
 			got := flux.NewSliceResultIterator(res.Results)
 			defer got.Release()
 
 			dec := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
-			want, err := dec.Decode(ioutil.NopCloser(strings.NewReader(tt.res)))
+			want, err := dec.Decode(ioutil.NopCloser(strings.NewReader(tc.want)))
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer want.Release()
 
 			if err := executetest.EqualResultIterators(want, got); err != nil {
-				t.Error(err)
+				t.Fatal(err)
 			}
-
-			if want, got := wantCount, getReadRequestCount(tt.op); want != got {
+			if want, got := uint64(1), l.NumReads(t, tc.op); want != got {
 				t.Fatalf("unexpected sample count -want/+got:\n\t- %d\n\t+ %d", want, got)
 			}
 		})

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -733,8 +733,16 @@ func canPushWindowedAggregate(ctx context.Context, fnNode plan.Node) bool {
 		if !feature.PushDownWindowAggregateFirst().Enabled(ctx) || !caps.HaveFirst() {
 			return false
 		}
+		firstSpec := fnNode.ProcedureSpec().(*universe.FirstProcedureSpec)
+		if firstSpec.Column != execute.DefaultValueColLabel {
+			return false
+		}
 	case universe.LastKind:
 		if !feature.PushDownWindowAggregateLast().Enabled(ctx) || !caps.HaveLast() {
+			return false
+		}
+		lastSpec := fnNode.ProcedureSpec().(*universe.LastProcedureSpec)
+		if lastSpec.Column != execute.DefaultValueColLabel {
 			return false
 		}
 	}

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -9,6 +9,8 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/v2/kit/errors"
 	"github.com/influxdata/influxdb/v2/models"
@@ -616,14 +618,22 @@ func (wai *windowAggregateIterator) Do(f func(flux.Table) error) error {
 	return wai.handleRead(f, rs)
 }
 
+// isSelector returns true if given a procedure kind that represents a selector operator.
+func isSelector(kind plan.ProcedureKind) bool {
+	return kind == universe.FirstKind || kind == universe.LastKind || kind == universe.MinKind || kind == universe.MaxKind
+}
+
 func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs storage.ResultSet) error {
 	windowEvery := wai.spec.WindowEvery
 	createEmpty := wai.spec.CreateEmpty
+
+	selector := len(wai.spec.Aggregates) > 0 && isSelector(wai.spec.Aggregates[0])
+
 	timeColumn := wai.spec.TimeColumn
 	if timeColumn == "" {
 		tableFn := f
 		f = func(table flux.Table) error {
-			return splitWindows(wai.ctx, table, tableFn)
+			return splitWindows(wai.ctx, wai.alloc, table, selector, tableFn)
 		}
 	}
 
@@ -658,20 +668,75 @@ READ:
 		hasTimeCol := timeColumn != ""
 		switch typedCur := cur.(type) {
 		case cursors.IntegerArrayCursor:
-			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TInt, hasTimeCol)
-			table = newIntegerWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			if !selector {
+				cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TInt, hasTimeCol)
+				table = newIntegerWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else if createEmpty && !hasTimeCol {
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TInt)
+				table = newIntegerEmptyWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else {
+				// Note hasTimeCol == true means that aggregateWindow() was called.
+				// Because aggregateWindow() ultimately removes empty tables we
+				// don't bother creating them here.
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TInt)
+				table = newIntegerWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			}
 		case cursors.FloatArrayCursor:
-			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TFloat, hasTimeCol)
-			table = newFloatWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			if !selector {
+				cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TFloat, hasTimeCol)
+				table = newFloatWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else if createEmpty && !hasTimeCol {
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TFloat)
+				table = newFloatEmptyWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else {
+				// Note hasTimeCol == true means that aggregateWindow() was called.
+				// Because aggregateWindow() ultimately removes empty tables we
+				// don't bother creating them here.
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TFloat)
+				table = newFloatWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			}
 		case cursors.UnsignedArrayCursor:
-			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TUInt, hasTimeCol)
-			table = newUnsignedWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			if !selector {
+				cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TUInt, hasTimeCol)
+				table = newUnsignedWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else if createEmpty && !hasTimeCol {
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TUInt)
+				table = newUnsignedEmptyWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else {
+				// Note hasTimeCol == true means that aggregateWindow() was called.
+				// Because aggregateWindow() ultimately removes empty tables we
+				// don't bother creating them here.
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TUInt)
+				table = newUnsignedWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			}
 		case cursors.BooleanArrayCursor:
-			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TBool, hasTimeCol)
-			table = newBooleanWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			if !selector {
+				cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TBool, hasTimeCol)
+				table = newBooleanWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else if createEmpty && !hasTimeCol {
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TBool)
+				table = newBooleanEmptyWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else {
+				// Note hasTimeCol == true means that aggregateWindow() was called.
+				// Because aggregateWindow() ultimately removes empty tables we
+				// don't bother creating them here.
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TBool)
+				table = newBooleanWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			}
 		case cursors.StringArrayCursor:
-			cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TString, hasTimeCol)
-			table = newStringWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			if !selector {
+				cols, defs := determineTableColsForWindowAggregate(rs.Tags(), flux.TString, hasTimeCol)
+				table = newStringWindowTable(done, typedCur, bnds, windowEvery, createEmpty, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else if createEmpty && !hasTimeCol {
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TString)
+				table = newStringEmptyWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			} else {
+				// Note hasTimeCol == true means that aggregateWindow() was called.
+				// Because aggregateWindow() ultimately removes empty tables we
+				// don't bother creating them here.
+				cols, defs := determineTableColsForSeries(rs.Tags(), flux.TString)
+				table = newStringWindowSelectorTable(done, typedCur, bnds, windowEvery, timeColumn, key, cols, rs.Tags(), defs, wai.cache, wai.alloc)
+			}
 		default:
 			panic(fmt.Sprintf("unreachable: %T", typedCur))
 		}

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -7,6 +7,7 @@
 package storageflux
 
 import (
+	"math"
 	"sync"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -134,7 +135,7 @@ func newFloatWindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start%every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -303,6 +304,352 @@ func (t *floatWindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type floatWindowSelectorTable struct {
+	floatTable
+	windowEvery int64
+	timeColumn  string
+}
+
+func newFloatWindowSelectorTable(
+	done chan struct{},
+	cur cursors.FloatArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *floatWindowSelectorTable {
+	t := &floatWindowSelectorTable{
+		floatTable: floatTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *floatWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *floatWindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx] = t.stopTimes(arr)
+		cr.cols[timeColIdx] = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type floatEmptyWindowSelectorTable struct {
+	floatTable
+	arr         *cursors.FloatArray
+	idx         int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func newFloatEmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.FloatArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *floatEmptyWindowSelectorTable {
+	rangeStart := int64(bounds.Start)
+	rangeStop := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop := windowStart + windowEvery
+
+	t := &floatEmptyWindowSelectorTable{
+		floatTable: floatTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr:         cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *floatEmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *floatEmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx] = stop
+		cr.cols[timeColIdx] = time
+	}
+
+	cr.cols[valueColIdx] = values.NewFloat64Array()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.Float64Builder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.Float64Builder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.Float64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table
@@ -532,7 +879,7 @@ func newIntegerWindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start%every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -701,6 +1048,352 @@ func (t *integerWindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type integerWindowSelectorTable struct {
+	integerTable
+	windowEvery int64
+	timeColumn  string
+}
+
+func newIntegerWindowSelectorTable(
+	done chan struct{},
+	cur cursors.IntegerArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *integerWindowSelectorTable {
+	t := &integerWindowSelectorTable{
+		integerTable: integerTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *integerWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *integerWindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx] = t.stopTimes(arr)
+		cr.cols[timeColIdx] = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type integerEmptyWindowSelectorTable struct {
+	integerTable
+	arr         *cursors.IntegerArray
+	idx         int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func newIntegerEmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.IntegerArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *integerEmptyWindowSelectorTable {
+	rangeStart := int64(bounds.Start)
+	rangeStop := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop := windowStart + windowEvery
+
+	t := &integerEmptyWindowSelectorTable{
+		integerTable: integerTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr:         cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *integerEmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *integerEmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx] = stop
+		cr.cols[timeColIdx] = time
+	}
+
+	cr.cols[valueColIdx] = values.NewInt64Array()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.Int64Builder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.Int64Builder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.Int64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table
@@ -930,7 +1623,7 @@ func newUnsignedWindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start%every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -1099,6 +1792,352 @@ func (t *unsignedWindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type unsignedWindowSelectorTable struct {
+	unsignedTable
+	windowEvery int64
+	timeColumn  string
+}
+
+func newUnsignedWindowSelectorTable(
+	done chan struct{},
+	cur cursors.UnsignedArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *unsignedWindowSelectorTable {
+	t := &unsignedWindowSelectorTable{
+		unsignedTable: unsignedTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *unsignedWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *unsignedWindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx] = t.stopTimes(arr)
+		cr.cols[timeColIdx] = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type unsignedEmptyWindowSelectorTable struct {
+	unsignedTable
+	arr         *cursors.UnsignedArray
+	idx         int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func newUnsignedEmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.UnsignedArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *unsignedEmptyWindowSelectorTable {
+	rangeStart := int64(bounds.Start)
+	rangeStop := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop := windowStart + windowEvery
+
+	t := &unsignedEmptyWindowSelectorTable{
+		unsignedTable: unsignedTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr:         cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *unsignedEmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *unsignedEmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx] = stop
+		cr.cols[timeColIdx] = time
+	}
+
+	cr.cols[valueColIdx] = values.NewUint64Array()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.Uint64Builder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.Uint64Builder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.Uint64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table
@@ -1328,7 +2367,7 @@ func newStringWindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start%every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -1497,6 +2536,352 @@ func (t *stringWindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type stringWindowSelectorTable struct {
+	stringTable
+	windowEvery int64
+	timeColumn  string
+}
+
+func newStringWindowSelectorTable(
+	done chan struct{},
+	cur cursors.StringArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *stringWindowSelectorTable {
+	t := &stringWindowSelectorTable{
+		stringTable: stringTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *stringWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *stringWindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx] = t.stopTimes(arr)
+		cr.cols[timeColIdx] = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type stringEmptyWindowSelectorTable struct {
+	stringTable
+	arr         *cursors.StringArray
+	idx         int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func newStringEmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.StringArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *stringEmptyWindowSelectorTable {
+	rangeStart := int64(bounds.Start)
+	rangeStop := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop := windowStart + windowEvery
+
+	t := &stringEmptyWindowSelectorTable{
+		stringTable: stringTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr:         cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *stringEmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *stringEmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx] = stop
+		cr.cols[timeColIdx] = time
+	}
+
+	cr.cols[valueColIdx] = values.NewBinaryArray()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.BinaryBuilder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.BinaryBuilder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.BinaryBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table
@@ -1726,7 +3111,7 @@ func newBooleanWindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start%every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -1895,6 +3280,352 @@ func (t *booleanWindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type booleanWindowSelectorTable struct {
+	booleanTable
+	windowEvery int64
+	timeColumn  string
+}
+
+func newBooleanWindowSelectorTable(
+	done chan struct{},
+	cur cursors.BooleanArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *booleanWindowSelectorTable {
+	t := &booleanWindowSelectorTable{
+		booleanTable: booleanTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *booleanWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *booleanWindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx] = t.stopTimes(arr)
+		cr.cols[timeColIdx] = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type booleanEmptyWindowSelectorTable struct {
+	booleanTable
+	arr         *cursors.BooleanArray
+	idx         int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func newBooleanEmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.BooleanArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *booleanEmptyWindowSelectorTable {
+	rangeStart := int64(bounds.Start)
+	rangeStop := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop := windowStart + windowEvery
+
+	t := &booleanEmptyWindowSelectorTable{
+		booleanTable: booleanTable{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr:         cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *booleanEmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *booleanEmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx] = stop
+		cr.cols[timeColIdx] = time
+	}
+
+	cr.cols[valueColIdx] = values.NewBooleanArray()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuilder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -1,6 +1,7 @@
 package storageflux 
 
 import (
+	"math"
 	"sync"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -128,7 +129,7 @@ func new{{.Name}}WindowTable(
 	}
 	if t.createEmpty {
 		start := int64(bounds.Start)
-		t.nextTS = start + (every - start % every)
+		t.nextTS = start + (every - offset(start, every))
 	}
 	t.readTags(tags)
 	t.init(t.advance)
@@ -297,6 +298,352 @@ func (t *{{.name}}WindowTable) advance() bool {
 	}
 	t.appendTags(cr)
 	return true
+}
+
+// This table implementation will not have any empty windows.
+type {{.name}}WindowSelectorTable struct {
+	{{.name}}Table
+	windowEvery int64
+	timeColumn  string
+}
+
+func new{{.Name}}WindowSelectorTable(
+	done chan struct{},
+	cur cursors.{{.Name}}ArrayCursor,
+	bounds execute.Bounds,
+	every int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *{{.name}}WindowSelectorTable {
+	t := &{{.name}}WindowSelectorTable{
+		{{.name}}Table: {{.name}}Table{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		windowEvery: every,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *{{.name}}WindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *{{.name}}WindowSelectorTable) advance() bool {
+	arr := t.cur.Next()
+	if arr.Len() == 0 {
+		return false
+	}
+
+	cr := t.allocateBuffer(arr.Len())
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		cr.cols[timeColIdx] = t.startTimes(arr)
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		cr.cols[timeColIdx] = t.stopTimes(arr)
+		t.appendBounds(cr)
+	default:
+		cr.cols[startColIdx] = t.startTimes(arr)
+		cr.cols[stopColIdx]  = t.stopTimes(arr)
+		cr.cols[timeColIdx]  = arrow.NewInt(arr.Timestamps, t.alloc)
+	}
+
+	cr.cols[valueColIdx] = t.toArrowBuffer(arr.Values)
+	t.appendTags(cr)
+	return true
+}
+
+func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(arr.Len())
+
+	rangeStart := int64(t.bounds.Start)
+
+	for _, v := range arr.Timestamps {
+		if windowStart := v - offset(v, t.windowEvery); windowStart < rangeStart {
+			start.Append(rangeStart)
+		} else {
+			start.Append(windowStart)
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(arr.Len())
+
+	rangeStop := int64(t.bounds.Stop)
+
+	for _, v := range arr.Timestamps {
+		if windowStop := v - offset(v, t.windowEvery) + t.windowEvery; windowStop > rangeStop {
+			stop.Append(rangeStop)
+		} else {
+			stop.Append(windowStop)
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+// This table implementation may contain empty windows
+// in addition to non-empty windows.
+type {{.name}}EmptyWindowSelectorTable struct {
+	{{.name}}Table
+	arr *cursors.{{.Name}}Array
+	idx int
+	rangeStart  int64
+	rangeStop   int64
+	windowStart int64
+	windowStop  int64
+	windowEvery int64
+	timeColumn  string
+}
+
+func new{{.Name}}EmptyWindowSelectorTable(
+	done chan struct{},
+	cur cursors.{{.Name}}ArrayCursor,
+	bounds execute.Bounds,
+	windowEvery int64,
+	timeColumn string,
+	key flux.GroupKey,
+	cols []flux.ColMeta,
+	tags models.Tags,
+	defs [][]byte,
+	cache *tagsCache,
+	alloc *memory.Allocator,
+) *{{.name}}EmptyWindowSelectorTable {
+	rangeStart  := int64(bounds.Start)
+	rangeStop   := int64(bounds.Stop)
+	windowStart := rangeStart - offset(rangeStart, windowEvery)
+	windowStop  := windowStart + windowEvery
+
+	t := &{{.name}}EmptyWindowSelectorTable{
+		{{.name}}Table: {{.name}}Table{
+			table: newTable(done, bounds, key, cols, defs, cache, alloc),
+			cur:   cur,
+		},
+		arr: cur.Next(),
+		rangeStart:  rangeStart,
+		rangeStop:   rangeStop,
+		windowStart: windowStart,
+		windowStop:  windowStop,
+		windowEvery: windowEvery,
+		timeColumn:  timeColumn,
+	}
+	t.readTags(tags)
+	t.init(t.advance)
+	return t
+}
+
+func (t *{{.name}}EmptyWindowSelectorTable) Do(f func(flux.ColReader) error) error {
+	return t.do(f, t.advance)
+}
+
+func (t *{{.name}}EmptyWindowSelectorTable) advance() bool {
+	if t.arr.Len() == 0 {
+		return false
+	}
+
+	values := t.arrowBuilder()
+	values.Resize(storage.MaxPointsPerBlock)
+
+	var cr *colReader
+
+	switch t.timeColumn {
+	case execute.DefaultStartColLabel:
+		start := t.startTimes(values)
+		cr = t.allocateBuffer(start.Len())
+		cr.cols[timeColIdx] = start
+		t.appendBounds(cr)
+	case execute.DefaultStopColLabel:
+		stop := t.stopTimes(values)
+		cr = t.allocateBuffer(stop.Len())
+		cr.cols[timeColIdx] = stop
+		t.appendBounds(cr)
+	default:
+		start, stop, time := t.startStopTimes(values)
+		cr = t.allocateBuffer(time.Len())
+		cr.cols[startColIdx] = start
+		cr.cols[stopColIdx]  = stop
+		cr.cols[timeColIdx]  = time
+	}
+
+	cr.cols[valueColIdx] = values.New{{.ArrowType}}Array()
+	t.appendTags(cr)
+	return true
+}
+
+func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop  += t.windowEvery
+
+		if start.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array()
+}
+
+func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop  += t.windowEvery
+
+		if stop.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return stop.NewInt64Array()
+}
+
+func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.ArrowType}}Builder) (*array.Int64, *array.Int64, *array.Int64) {
+	start := arrow.NewIntBuilder(t.alloc)
+	start.Resize(storage.MaxPointsPerBlock)
+
+	stop := arrow.NewIntBuilder(t.alloc)
+	stop.Resize(storage.MaxPointsPerBlock)
+
+	time := arrow.NewIntBuilder(t.alloc)
+	time.Resize(storage.MaxPointsPerBlock)
+
+	for t.windowStart < t.rangeStop {
+
+		// If the current array is non-empty and has
+		// been read in its entirety, call Next().
+		if t.arr.Len() > 0 && t.idx == t.arr.Len() {
+			t.arr = t.cur.Next()
+			t.idx = 0
+		}
+
+		// The first window should start at the
+		// beginning of the time range.
+		if t.windowStart < t.rangeStart {
+			start.Append(t.rangeStart)
+		} else {
+			start.Append(t.windowStart)
+		}
+
+		// The last window should stop at the end of
+		// the time range.
+		if t.windowStop > t.rangeStop {
+			stop.Append(t.rangeStop)
+		} else {
+			stop.Append(t.windowStop)
+		}
+
+		var v int64
+
+		if t.arr.Len() == 0 {
+			v = math.MaxInt64
+		} else {
+			v = t.arr.Timestamps[t.idx]
+		}
+
+		// If the current timestamp falls within the
+		// current window, append the value to the
+		// builder, otherwise append a null value.
+		if t.windowStart <= v && v < t.windowStop {
+			time.Append(v)
+			t.append(builder, t.arr.Values[t.idx])
+			t.idx++
+		} else {
+			time.AppendNull()
+			builder.AppendNull()
+		}
+
+		t.windowStart += t.windowEvery
+		t.windowStop  += t.windowEvery
+
+		if time.Len() == storage.MaxPointsPerBlock {
+			break
+		}
+	}
+	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
 }
 
 // group table

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -14,6 +14,15 @@ import (
 	"github.com/influxdata/influxdb/v2/models"
 )
 
+// offset returns a non-negative equivalent to t % windowEvery.
+func offset(t, windowEvery int64) int64 {
+	r := t % windowEvery
+	if r < 0 {
+		r += windowEvery
+	}
+	return r
+}
+
 type table struct {
 	bounds execute.Bounds
 	key    flux.GroupKey
@@ -229,13 +238,25 @@ func (t *floatTable) toArrowBuffer(vs []float64) *array.Float64 {
 func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float64 {
 	return arrow.NewFloat(vs, t.alloc)
 }
+func (t *floatWindowSelectorTable) toArrowBuffer(vs []float64) *array.Float64 {
+	return arrow.NewFloat(vs, t.alloc)
+}
 func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float64 {
 	b := arrow.NewFloatBuilder(t.alloc)
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
 	return b.NewFloat64Array()
 }
+func (t *floatEmptyWindowSelectorTable) arrowBuilder() *array.Float64Builder {
+	return arrow.NewFloatBuilder(t.alloc)
+}
+func (t *floatEmptyWindowSelectorTable) append(builder *array.Float64Builder, v float64) {
+	builder.Append(v)
+}
 func (t *integerTable) toArrowBuffer(vs []int64) *array.Int64 {
+	return arrow.NewInt(vs, t.alloc)
+}
+func (t *integerWindowSelectorTable) toArrowBuffer(vs []int64) *array.Int64 {
 	return arrow.NewInt(vs, t.alloc)
 }
 func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int64 {
@@ -247,10 +268,19 @@ func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
 	t.appendValues(intervals, b.Append, b.AppendNull)
 	return b.NewInt64Array()
 }
+func (t *integerEmptyWindowSelectorTable) arrowBuilder() *array.Int64Builder {
+	return arrow.NewIntBuilder(t.alloc)
+}
+func (t *integerEmptyWindowSelectorTable) append(builder *array.Int64Builder, v int64) {
+	builder.Append(v)
+}
 func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint64 {
 	return arrow.NewUint(vs, t.alloc)
 }
 func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+	return arrow.NewUint(vs, t.alloc)
+}
+func (t *unsignedWindowSelectorTable) toArrowBuffer(vs []uint64) *array.Uint64 {
 	return arrow.NewUint(vs, t.alloc)
 }
 func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint64 {
@@ -259,10 +289,19 @@ func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint64 {
 	t.appendValues(intervals, b.Append, b.AppendNull)
 	return b.NewUint64Array()
 }
+func (t *unsignedEmptyWindowSelectorTable) arrowBuilder() *array.Uint64Builder {
+	return arrow.NewUintBuilder(t.alloc)
+}
+func (t *unsignedEmptyWindowSelectorTable) append(builder *array.Uint64Builder, v uint64) {
+	builder.Append(v)
+}
 func (t *stringTable) toArrowBuffer(vs []string) *array.Binary {
 	return arrow.NewString(vs, t.alloc)
 }
 func (t *stringGroupTable) toArrowBuffer(vs []string) *array.Binary {
+	return arrow.NewString(vs, t.alloc)
+}
+func (t *stringWindowSelectorTable) toArrowBuffer(vs []string) *array.Binary {
 	return arrow.NewString(vs, t.alloc)
 }
 func (t *stringWindowTable) mergeValues(intervals []int64) *array.Binary {
@@ -271,10 +310,19 @@ func (t *stringWindowTable) mergeValues(intervals []int64) *array.Binary {
 	t.appendValues(intervals, b.AppendString, b.AppendNull)
 	return b.NewBinaryArray()
 }
+func (t *stringEmptyWindowSelectorTable) arrowBuilder() *array.BinaryBuilder {
+	return arrow.NewStringBuilder(t.alloc)
+}
+func (t *stringEmptyWindowSelectorTable) append(builder *array.BinaryBuilder, v string) {
+	builder.AppendString(v)
+}
 func (t *booleanTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)
 }
 func (t *booleanGroupTable) toArrowBuffer(vs []bool) *array.Boolean {
+	return arrow.NewBool(vs, t.alloc)
+}
+func (t *booleanWindowSelectorTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)
 }
 func (t *booleanWindowTable) mergeValues(intervals []int64) *array.Boolean {
@@ -282,4 +330,10 @@ func (t *booleanWindowTable) mergeValues(intervals []int64) *array.Boolean {
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
 	return b.NewBooleanArray()
+}
+func (t *booleanEmptyWindowSelectorTable) arrowBuilder() *array.BooleanBuilder {
+	return arrow.NewBoolBuilder(t.alloc)
+}
+func (t *booleanEmptyWindowSelectorTable) append(builder *array.BooleanBuilder, v bool) {
+	builder.Append(v)
 }

--- a/storage/flux/types.tmpldata
+++ b/storage/flux/types.tmpldata
@@ -2,26 +2,31 @@
 	{
 		"Name":"Float",
 		"name":"float",
-		"Type":"float64"
+		"Type":"float64",
+		"ArrowType":"Float64"
 	},
 	{
 		"Name":"Integer",
 		"name":"integer",
-		"Type":"int64"
+		"Type":"int64",
+		"ArrowType":"Int64"
 	},
 	{
 		"Name":"Unsigned",
 		"name":"unsigned",
-		"Type":"uint64"
+		"Type":"uint64",
+		"ArrowType":"Uint64"
 	},
 	{
 		"Name":"String",
 		"name":"string",
-		"Type":"string"
+		"Type":"string",
+		"ArrowType":"Binary"
 	},
 	{
 		"Name":"Boolean",
 		"name":"boolean",
-		"Type":"bool"
+		"Type":"bool",
+		"ArrowType":"Boolean"
 	}
 ]

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -32,6 +32,7 @@ func NewStore(viewer reads.Viewer) reads.Store {
 		windowCap: WindowAggregateCapability{
 			Count: true,
 			Sum:   true,
+			First: true,
 		},
 	}
 }


### PR DESCRIPTION
- Adds launcher tests for windowed first, bare first, and `aggregateWindow(fn: first)`
- Turns on the storage capability for first selection
- Adds a table iterator for windowed selectors
