### PR TITLE
refactor: move name lookup to auth http

### DIFF
--- a/authorization/http_server_test.go
+++ b/authorization/http_server_test.go
@@ -32,7 +32,6 @@ func TestService_handlePostAuthorization(t *testing.T) {
 	type fields struct {
 		AuthorizationService influxdb.AuthorizationService
 		TenantService        TenantService
-		LookupService        influxdb.LookupService
 	}
 	type args struct {
 		session       *influxdb.Authorization
@@ -72,16 +71,11 @@ func TestService_handlePostAuthorization(t *testing.T) {
 							Name: "o1",
 						}, nil
 					},
-				},
-				LookupService: &mock.LookupService{
-					NameFn: func(ctx context.Context, resource influxdb.ResourceType, id influxdb.ID) (string, error) {
-						switch resource {
-						case influxdb.BucketsResourceType:
-							return "b1", nil
-						case influxdb.OrgsResourceType:
-							return "o1", nil
-						}
-						return "", fmt.Errorf("bad resource type %s", resource)
+					FindBucketByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+						return &influxdb.Bucket{
+							ID:   id,
+							Name: "b1",
+						}, nil
 					},
 				},
 			},
@@ -168,7 +162,7 @@ func TestService_handlePostAuthorization(t *testing.T) {
 
 			svc := NewService(storage, tt.fields.TenantService)
 
-			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), svc, tt.fields.TenantService, mock.NewLookupService())
+			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), svc, tt.fields.TenantService)
 			router := chi.NewRouter()
 			router.Mount(handler.Prefix(), handler)
 
@@ -223,7 +217,6 @@ func TestService_handleGetAuthorization(t *testing.T) {
 	type fields struct {
 		AuthorizationService influxdb.AuthorizationService
 		TenantService        TenantService
-		LookupService        influxdb.LookupService
 	}
 	type args struct {
 		id string
@@ -283,16 +276,11 @@ func TestService_handleGetAuthorization(t *testing.T) {
 							Name: "o1",
 						}, nil
 					},
-				},
-				LookupService: &mock.LookupService{
-					NameFn: func(ctx context.Context, resource influxdb.ResourceType, id influxdb.ID) (string, error) {
-						switch resource {
-						case influxdb.BucketsResourceType:
-							return "b1", nil
-						case influxdb.OrgsResourceType:
-							return "o1", nil
-						}
-						return "", fmt.Errorf("bad resource type %s", resource)
+					FindBucketByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+						return &influxdb.Bucket{
+							ID:   id,
+							Name: "b1",
+						}, nil
 					},
 				},
 			},
@@ -361,7 +349,7 @@ func TestService_handleGetAuthorization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
 
-			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), tt.fields.AuthorizationService, tt.fields.TenantService, mock.NewLookupService())
+			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), tt.fields.AuthorizationService, tt.fields.TenantService)
 			router := chi.NewRouter()
 			router.Mount(handler.Prefix(), handler)
 
@@ -700,7 +688,7 @@ func TestService_handleGetAuthorizations(t *testing.T) {
 
 			svc := NewService(storage, tt.fields.TenantService)
 
-			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), svc, tt.fields.TenantService, mock.NewLookupService())
+			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), svc, tt.fields.TenantService)
 			router := chi.NewRouter()
 			router.Mount(handler.Prefix(), handler)
 
@@ -806,7 +794,7 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
 
-			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), tt.fields.AuthorizationService, tt.fields.TenantService, mock.NewLookupService())
+			handler := NewHTTPAuthHandler(zaptest.NewLogger(t), tt.fields.AuthorizationService, tt.fields.TenantService)
 			router := chi.NewRouter()
 			router.Mount(handler.Prefix(), handler)
 

--- a/authorization/mock_tenant.go
+++ b/authorization/mock_tenant.go
@@ -12,6 +12,7 @@ type tenantService struct {
 	FindUserFn            func(context.Context, influxdb.UserFilter) (*influxdb.User, error)
 	FindOrganizationByIDF func(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error)
 	FindOrganizationF     func(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error)
+	FindBucketByIDFn      func(context.Context, influxdb.ID) (*influxdb.Bucket, error)
 }
 
 // FindUserByID returns a single User by ID.
@@ -32,4 +33,8 @@ func (s *tenantService) FindOrganizationByID(ctx context.Context, id influxdb.ID
 //FindOrganization calls FindOrganizationF.
 func (s *tenantService) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
 	return s.FindOrganizationF(ctx, filter)
+}
+
+func (s *tenantService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+	return s.FindBucketByIDFn(ctx, id)
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -1055,7 +1055,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		authService = authorization.NewAuthMetrics(m.reg, authService)
 		authService = authorization.NewAuthLogger(authLogger, authService)
 
-		newHandler := authorization.NewHTTPAuthHandler(m.log, authService, ts, lookupSvc)
+		newHandler := authorization.NewHTTPAuthHandler(m.log, authService, ts)
 		authHTTPServer = kithttp.NewFeatureHandler(feature.NewAuthPackage(), m.flagger, oldHandler, newHandler, newHandler.Prefix())
 	}
 


### PR DESCRIPTION
Addresses #18498

This PR moves the name lookup function that is used by the Authorization service from the kv lookup service to be a function of the Authorization service itself. This will allow us to remove the lookup service from the kv package when the new Authorization service feature flag is fully turned on, which is one of the steps to fully migrate to the tenant service.

This change does remove the functionality of looking up the name of a Telegraf, Dashboard, and Source. However, it doesn't appear that this code path was actually being used. The `Name` property is optional on the `Resource` definition in the swagger, and so I have left the swagger unchanged. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass