### PR TITLE
fix: don't re-fetch variables if their loading status is done

### DIFF
--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -126,12 +126,20 @@ export const hydrateVariables = (skipCache?: boolean) => async (
 ) => {
   const state = getState()
   const org = getOrg(state)
-  const vars = getVariablesFromState(state)
+  const vars = getVariablesFromState(state).filter(
+    v => v.status && v.status !== RemoteDataState.Done
+  )
+
+  if (!vars.length) {
+    return
+  }
+
   const hydration = hydrateVars(vars, getAllVariablesFromState(state), {
     orgID: org.id,
     url: state.links.query.self,
     skipCache,
   })
+
   hydration.on('status', (variable, status) => {
     if (status === RemoteDataState.Loading) {
       dispatch(setVariable(variable.id, status))


### PR DESCRIPTION
Connects #18296

Checks if variables have been loaded and skips the hydration process for any variables that have already been hydrated.

**previously** _note the delay between double clicking the Submit/Cancel button and the cancel notification firing_
![old](https://user-images.githubusercontent.com/146112/85345647-d7b93a00-b4a7-11ea-993f-45d565d6c90d.gif)

**now** _cancel button fires immediately_*
![new](https://user-images.githubusercontent.com/146112/85345688-fcadad00-b4a7-11ea-9618-1ebec585aca6.gif)

\* I know we're planning on changing it so it doesn't flash, but the flash is actually the indicator that the ui is responsive.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
