### PR TITLE
fix(influx): normalize output of template task diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 1. [18601](https://github.com/influxdata/influxdb/pull/18601): Provide active config running influx config without args
 1. [18606](https://github.com/influxdata/influxdb/pull/18606): Enable influxd binary to look for a config file on startup
 1. [18647](https://github.com/influxdata/influxdb/pull/18647): Add support for env ref default values to the template parser
-1. [18655](https://github.com/influxdata/influxdb/pull/18655): Add support for platfrom variable selected field to templates
+1. [18655](https://github.com/influxdata/influxdb/pull/18655): Add support for platform variable selected field to templates
 
 ### Bug Fixes
 

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -1461,6 +1461,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 		appendValues := func(id pkger.SafeID, pkgName string, v pkger.DiffTaskValues) []string {
 			timing := v.Cron
 			if v.Cron == "" {
+				if v.Offset == "" {
+					v.Offset = time.Duration(0).String()
+				}
 				timing = fmt.Sprintf("every: %s offset: %s", v.Every, v.Offset)
 			}
 			return []string{pkgName, id.String(), v.Name, v.Description, timing}


### PR DESCRIPTION
noticed a discrepancy where tasks with a `Offset` value of nil are converted into `""` instead of `0sec`. Tiny fix to clean it up

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass