### PR TITLE
chore(influx): add support for week duration

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -552,7 +552,10 @@ func rawDurationToTimeDuration(raw string) (time.Duration, error) {
 		return 0, err
 	}
 
-	const day = 24 * time.Hour
+	const (
+		day  = 24 * time.Hour
+		week = 7 * day
+	)
 
 	var dur time.Duration
 	for _, d := range retention.Values {
@@ -561,8 +564,10 @@ func rawDurationToTimeDuration(raw string) (time.Duration, error) {
 		}
 		mag := time.Duration(d.Magnitude)
 		switch d.Unit {
+		case "w":
+			dur += mag * week
 		case "d":
-			dur += mag * (day)
+			dur += mag * day
 		case "m":
 			dur += mag * time.Minute
 		case "s":


### PR DESCRIPTION
small example from setup run:

```sh
> influx setup -b $BUCKET_NAME -o $ORG -u $USER_NAME -p $USER_PASSWORD -r 1w -f
>influx bucket ls
ID			Name		Retention	Organization ID
05e3d28141308001	bucket1		168h0m0s	05e3d28141308000
# 168h == 1 week
```

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass