### PR TITLE
fix(kv): Install feature-flag for switching between normal and simplified options parsing

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -153,3 +153,10 @@
   default: false
   contact: Lyon Hill
   lifetime: temporary
+
+- name: Simple Task Options Extraction
+  description: Simplified task options extraction to avoid undefined functions when saving tasks
+  key: simpleTaskOptionsExtraction
+  default: false
+  contact: Brett Buddin
+  lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -296,6 +296,20 @@ func UrmFreeTasks() BoolFlag {
 	return urmFreeTasks
 }
 
+var simpleTaskOptionsExtraction = MakeBoolFlag(
+	"Simple Task Options Extraction",
+	"simpleTaskOptionsExtraction",
+	"Brett Buddin",
+	false,
+	Temporary,
+	false,
+)
+
+// SimpleTaskOptionsExtraction - Simplified task options extraction to avoid undefined functions when saving tasks
+func SimpleTaskOptionsExtraction() BoolFlag {
+	return simpleTaskOptionsExtraction
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -318,6 +332,7 @@ var all = []Flag{
 	hydratevars,
 	memoryOptimizedFill,
 	urmFreeTasks,
+	simpleTaskOptionsExtraction,
 }
 
 var byKey = map[string]Flag{
@@ -342,4 +357,5 @@ var byKey = map[string]Flag{
 	"hydratevars":                   hydratevars,
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"urmFreeTasks":                  urmFreeTasks,
+	"simpleTaskOptionsExtraction":   simpleTaskOptionsExtraction,
 }


### PR DESCRIPTION
This installs a feature-flag to switch between normal options parsing and a simplified variant. In this simplified version, we are doing a naive extraction of the content `option task = { ... }` and passing that through the options extractor on its own. This allows for tasks that use functions like `tableFind` to be saved correctly.

An obvious drawback of this approach is that functions cannot be used to create the RHS of the assignment. Since most people don't do this, we should be safe until the Flux team provides some APIs for us to consume that do this extraction in a static manner.