### PR TITLE
feat(storage): Add option to disable WritePoints() validation.

### DIFF
--- a/models/points_test.go
+++ b/models/points_test.go
@@ -3230,3 +3230,11 @@ func BenchmarkParsePointsWithOptions(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkValidToken(b *testing.B) {
+	token := []byte("Hello世界")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		models.ValidToken(token)
+	}
+}


### PR DESCRIPTION
This commit adds the `WithWritePointsValidationEnabled()` option to disable validation in `Engine.WritePoints()` as the same validation is performed earlier in the call stack by cloud.