### PR TITLE
feat(templates-ui): display template resources in accordion list

### DIFF
--- a/ui/src/templates/components/CommunityTemplateContents.tsx
+++ b/ui/src/templates/components/CommunityTemplateContents.tsx
@@ -2,9 +2,20 @@
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 
+// Types
 import {AppState, CommunityTemplate} from 'src/types'
 
-import {Heading, HeadingElement, Page, Panel} from '@influxdata/clockface'
+// Components
+import {
+  Panel,
+  FlexBox,
+  ComponentSize,
+  FlexDirection,
+  AlignItems,
+  Label,
+} from '@influxdata/clockface'
+import CommunityTemplateListItem from 'src/templates/components/CommunityTemplateListItem'
+import CommunityTemplateListGroup from 'src/templates/components/CommunityTemplateListGroup'
 
 interface StateProps {
   activeCommunityTemplate: CommunityTemplate
@@ -15,136 +26,132 @@ class CommunityTemplateContentsUnconnected extends PureComponent<StateProps> {
     const {activeCommunityTemplate} = this.props
     if (!Object.keys(activeCommunityTemplate).length) {
       return (
-        <Page>
-          <Panel>
-            <Panel.Header>Calculating template resource needs...</Panel.Header>
-          </Panel>
-        </Page>
+        <Panel>
+          <Panel.Header>Calculating template resource needs...</Panel.Header>
+        </Panel>
       )
     }
 
     return (
-      <Page className="community-templates-installer">
-        {Array.isArray(activeCommunityTemplate.dashboards) &&
-          activeCommunityTemplate.dashboards.map(dashboard => {
-            return (
-              <Panel key={dashboard.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>Dashboard</Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {dashboard.name}
-                  <br />
-                  {dashboard.description}
-                  <br />
+      <FlexBox
+        margin={ComponentSize.Small}
+        direction={FlexDirection.Column}
+        alignItems={AlignItems.Stretch}
+        className="community-templates-installer"
+      >
+        <CommunityTemplateListGroup
+          title="Dashboards"
+          count={activeCommunityTemplate.dashboards.length}
+        >
+          {Array.isArray(activeCommunityTemplate.dashboards) &&
+            activeCommunityTemplate.dashboards.map(dashboard => {
+              return (
+                <CommunityTemplateListItem
+                  key={dashboard.pkgName}
+                  title={dashboard.name}
+                  description={dashboard.description}
+                >
                   Charts: {dashboard.charts.length}
-                </Panel.Body>
-              </Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.telegrafConfigs) &&
-          activeCommunityTemplate.telegrafConfigs.map(telegrafConfig => {
-            return (
-              <Panel.Panel key={telegrafConfig.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>
-                    Telegraf Configuration
-                  </Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {telegrafConfig.pkgName}
-                  <br />
-                  {telegrafConfig.description}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.buckets) &&
-          activeCommunityTemplate.buckets.map(bucket => {
-            return (
-              <Panel.Panel key={bucket.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>Bucket</Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {bucket.name}
-                  <br />
-                  {bucket.description}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.checks) &&
-          activeCommunityTemplate.checks.map(check => {
-            return (
-              <Panel.Panel key={check.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>Check</Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {check.check.name}
-                  <br />
-                  {check.description}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.variables) &&
-          activeCommunityTemplate.variables.map(variable => {
-            return (
-              <Panel.Panel key={variable.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>Variable</Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {variable.name}
-                  <br />
+                </CommunityTemplateListItem>
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Telegraf Configurations"
+          count={activeCommunityTemplate.telegrafConfigs.length}
+        >
+          {Array.isArray(activeCommunityTemplate.telegrafConfigs) &&
+            activeCommunityTemplate.telegrafConfigs.map(telegrafConfig => {
+              return (
+                <CommunityTemplateListItem
+                  key={telegrafConfig.pkgName}
+                  title={telegrafConfig.pkgName}
+                  description={telegrafConfig.description}
+                />
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Buckets"
+          count={activeCommunityTemplate.buckets.length}
+        >
+          {Array.isArray(activeCommunityTemplate.buckets) &&
+            activeCommunityTemplate.buckets.map(bucket => {
+              return (
+                <CommunityTemplateListItem
+                  key={bucket.pkgName}
+                  title={bucket.name}
+                  description={bucket.description}
+                />
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Checks"
+          count={activeCommunityTemplate.checks.length}
+        >
+          {Array.isArray(activeCommunityTemplate.checks) &&
+            activeCommunityTemplate.checks.map(check => {
+              return (
+                <CommunityTemplateListItem
+                  key={check.pkgName}
+                  title={check.check.name}
+                  description={check.description}
+                />
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Variables"
+          count={activeCommunityTemplate.variables.length}
+        >
+          {Array.isArray(activeCommunityTemplate.variables) &&
+            activeCommunityTemplate.variables.map(variable => {
+              return (
+                <CommunityTemplateListItem
+                  key={variable.pkgName}
+                  title={variable.name}
+                  description={variable.description}
+                >
                   Type: {variable.arguments.type}
-                  <br />
-                  {variable.description}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.notificationRules) &&
-          activeCommunityTemplate.notificationRules.map(notificationRule => {
-            return (
-              <Panel.Panel key={notificationRule.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>
-                    Notification Rule
-                  </Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {notificationRule.name}
-                  <br />
-                  {notificationRule.description}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-        {Array.isArray(activeCommunityTemplate.labels) &&
-          activeCommunityTemplate.labels.map(label => {
-            return (
-              <Panel.Panel key={label.pkgName}>
-                <Panel.Header>
-                  <Heading element={HeadingElement.H4}>Label</Heading>
-                </Panel.Header>
-                <Panel.Body>
-                  Name: {label.name}
-                  <br />
-                  {Object.keys(label.properties).map(property => {
-                    return (
-                      <aside key={property}>
-                        {property}: {label.properties[property]}
-                      </aside>
-                    )
-                  })}
-                </Panel.Body>
-              </Panel.Panel>
-            )
-          })}
-      </Page>
+                </CommunityTemplateListItem>
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Notification Rules"
+          count={activeCommunityTemplate.notificationRules.length}
+        >
+          {Array.isArray(activeCommunityTemplate.notificationRules) &&
+            activeCommunityTemplate.notificationRules.map(notificationRule => {
+              return (
+                <CommunityTemplateListItem
+                  key={notificationRule.pkgName}
+                  title={notificationRule.name}
+                  description={notificationRule.description}
+                />
+              )
+            })}
+        </CommunityTemplateListGroup>
+        <CommunityTemplateListGroup
+          title="Labels"
+          count={activeCommunityTemplate.labels.length}
+        >
+          {Array.isArray(activeCommunityTemplate.labels) &&
+            activeCommunityTemplate.labels.map(label => {
+              return (
+                <CommunityTemplateListItem key={label.pkgName}>
+                  <Label
+                    description={label.properties.description}
+                    name={label.name}
+                    id={label.name}
+                    color={label.properties.color}
+                  />
+                </CommunityTemplateListItem>
+              )
+            })}
+        </CommunityTemplateListGroup>
+      </FlexBox>
     )
   }
 }

--- a/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
@@ -3,17 +3,9 @@ import React, {PureComponent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
-import {
-  Alignment,
-  Gradients,
-  Heading,
-  HeadingElement,
-  Orientation,
-  Overlay,
-  Panel,
-  Tabs,
-} from '@influxdata/clockface'
+import {Alignment, Orientation, Overlay, Tabs} from '@influxdata/clockface'
 
+import CommunityTemplateName from 'src/templates/components/CommunityTemplateName'
 import {CommunityTemplateReadme} from 'src/templates/components/CommunityTemplateReadme'
 import {CommunityTemplateContents} from 'src/templates/components/CommunityTemplateContents'
 
@@ -57,7 +49,7 @@ class CommunityTemplateInstallerOverlayUnconnected extends PureComponent<
   public render() {
     const {isVisible, templateName} = this.props
 
-    const resourceCount = 'some'
+    const resourceCount = 5
 
     return (
       <Overlay visible={isVisible}>
@@ -67,15 +59,11 @@ class CommunityTemplateInstallerOverlayUnconnected extends PureComponent<
             onDismiss={this.onDismiss}
           />
           <Overlay.Body>
-            <Panel border={true} gradient={Gradients.RebelAlliance}>
-              <Panel.Header>
-                <Heading element={HeadingElement.H3}>{templateName}</Heading>
-              </Panel.Header>
-              <Panel.Body>
-                Installing this template will create {resourceCount} resources
-                in your system
-              </Panel.Body>
-            </Panel>
+            <CommunityTemplateName
+              templateName={templateName}
+              resourceCount={resourceCount}
+              // onClickInstall={() => {}}
+            />
             <Tabs.Container orientation={Orientation.Horizontal}>
               <Tabs.Tabs alignment={Alignment.Center}>
                 <Tabs.Tab

--- a/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
@@ -4,7 +4,6 @@ import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Alignment, Orientation, Overlay, Tabs} from '@influxdata/clockface'
-
 import CommunityTemplateName from 'src/templates/components/CommunityTemplateName'
 import {CommunityTemplateReadme} from 'src/templates/components/CommunityTemplateReadme'
 import {CommunityTemplateContents} from 'src/templates/components/CommunityTemplateContents'

--- a/ui/src/templates/components/CommunityTemplateListGroup.tsx
+++ b/ui/src/templates/components/CommunityTemplateListGroup.tsx
@@ -1,0 +1,69 @@
+// Libraries
+import React, {FC, ReactNode, useState} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {
+  Heading,
+  HeadingElement,
+  Icon,
+  IconFont,
+  FlexBox,
+  ComponentSize,
+  AlignItems,
+  FlexDirection,
+} from '@influxdata/clockface'
+
+interface Props {
+  title: string
+  count?: string
+  children?: ReactNode
+}
+
+const CommunityTemplateListGroup: FC<Props> = ({title, count, children}) => {
+  const [mode, setMode] = useState<'expanded' | 'collapsed'>('collapsed')
+  const groupClassName = classnames('community-templates--list-group', {
+    [`community-templates--list-group__${mode}`]: mode,
+  })
+
+  const handleToggleMode = () => {
+    if (mode === 'expanded') {
+      setMode('collapsed')
+    } else {
+      setMode('expanded')
+    }
+  }
+
+  return (
+    <div className={groupClassName}>
+      <div
+        className="community-templates--list-header"
+        onClick={handleToggleMode}
+      >
+        <div className="community-templates--list-toggle">
+          <Icon glyph={IconFont.CaretRight} />
+        </div>
+        <Heading element={HeadingElement.H5}>{title}</Heading>
+        {count && (
+          <Heading
+            element={HeadingElement.Div}
+            appearance={HeadingElement.H6}
+            className="community-templates--list-counter"
+          >{`(${count})`}</Heading>
+        )}
+      </div>
+      {mode === 'expanded' && (
+        <FlexBox
+          margin={ComponentSize.Small}
+          direction={FlexDirection.Column}
+          alignItems={AlignItems.Stretch}
+          className="community-templates--list-group-items"
+        >
+          {children}
+        </FlexBox>
+      )}
+    </div>
+  )
+}
+
+export default CommunityTemplateListGroup

--- a/ui/src/templates/components/CommunityTemplateListItem.tsx
+++ b/ui/src/templates/components/CommunityTemplateListItem.tsx
@@ -1,0 +1,47 @@
+// Libraries
+import React, {FC, ReactNode} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {
+  Heading,
+  HeadingElement,
+  Panel,
+  ComponentSize,
+  AlignItems,
+} from '@influxdata/clockface'
+
+interface Props {
+  title?: string
+  description?: string
+  children?: ReactNode
+}
+
+const CommunityTemplateListItem: FC<Props> = ({
+  title,
+  children,
+  description,
+}) => {
+  const descriptionClassName = classnames(
+    'community-templates--item-description',
+    {
+      'community-templates--item-description__blank': !description,
+    }
+  )
+  return (
+    <Panel className="community-templates--item">
+      <Panel.Body
+        size={ComponentSize.ExtraSmall}
+        alignItems={AlignItems.FlexStart}
+      >
+        {title && <Heading element={HeadingElement.H6}>{title}</Heading>}
+        <p className={descriptionClassName}>
+          {description || 'No description'}
+        </p>
+        {children}
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default CommunityTemplateListItem

--- a/ui/src/templates/components/CommunityTemplateName.tsx
+++ b/ui/src/templates/components/CommunityTemplateName.tsx
@@ -1,0 +1,75 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  Gradients,
+  Heading,
+  HeadingElement,
+  Panel,
+  Button,
+  ComponentColor,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+  InfluxColors,
+} from '@influxdata/clockface'
+import CommunityTemplateNameIcon from 'src/templates/components/CommunityTemplateNameIcon'
+
+interface Props {
+  templateName: string
+  resourceCount?: number
+  onClickInstall?: () => void
+}
+
+const CommunityTemplateName: FC<Props> = ({
+  templateName,
+  resourceCount,
+  onClickInstall,
+}) => {
+  let installButton
+
+  if (onClickInstall) {
+    installButton = (
+      <Button
+        text="Install Template"
+        color={ComponentColor.Success}
+        size={ComponentSize.Medium}
+        onClick={onClickInstall}
+      />
+    )
+  }
+
+  return (
+    <Panel border={true} gradient={Gradients.SpirulinaSmoothie}>
+      <Panel.Body
+        margin={ComponentSize.Large}
+        direction={FlexDirection.Row}
+        alignItems={AlignItems.Center}
+      >
+        <CommunityTemplateNameIcon
+          strokeWidth={2}
+          strokeColor={InfluxColors.Neutrino}
+          width={54}
+          height={54}
+        />
+        <FlexBox.Child grow={1} shrink={0}>
+          <Heading
+            className="community-templates--template-name"
+            element={HeadingElement.H4}
+          >
+            {templateName}
+          </Heading>
+          <p className="community-templates--template-description">
+            Installing this template will create{' '}
+            <strong>{resourceCount} resources</strong> in your system
+          </p>
+        </FlexBox.Child>
+        {installButton}
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default CommunityTemplateName

--- a/ui/src/templates/components/CommunityTemplateNameIcon.tsx
+++ b/ui/src/templates/components/CommunityTemplateNameIcon.tsx
@@ -1,0 +1,77 @@
+import React, {FC, CSSProperties} from 'react'
+
+interface Props {
+  strokeColor: string
+  fillColor?: string
+  strokeWidth?: number
+  width: number
+  height: number
+}
+
+const CommunityTemplateNameIcon: FC<Props> = ({
+  strokeColor,
+  fillColor = 'none',
+  strokeWidth = 2,
+  width,
+  height,
+}) => {
+  const lineStyle: CSSProperties = {
+    strokeWidth,
+    stroke: strokeColor,
+    strokeLinecap: 'round',
+    strokeLinejoin: 'round',
+    strokeMiterlimit: 10,
+  }
+
+  const polygonStyle: CSSProperties = {
+    ...lineStyle,
+    fill: fillColor,
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      version="1.1"
+      id="Layer_1"
+      xmlns="http://www.w3.org/2000/svg"
+      x="0px"
+      y="0px"
+      viewBox="0 0 54 54"
+      preserveAspectRatio="xMidYMid meet"
+      xmlSpace="preserve"
+    >
+      <g>
+        <g>
+          <polygon
+            style={polygonStyle}
+            points="27,44.9 27,30.6 14.5,23.4 2,30.6 2,44.9 14.5,52 		"
+          />
+          <line style={lineStyle} x1="2.5" y1="30.8" x2="14.5" y2="37.7" />
+          <line style={lineStyle} x1="14.5" y1="37.7" x2="14.5" y2="51.6" />
+          <line style={lineStyle} x1="14.5" y1="37.7" x2="26.5" y2="30.8" />
+        </g>
+        <g>
+          <polygon
+            style={polygonStyle}
+            points="52,44.9 52,30.6 39.5,23.4 27,30.6 27,44.9 39.5,52 		"
+          />
+          <line style={lineStyle} x1="27.5" y1="30.8" x2="39.5" y2="37.7" />
+          <line style={lineStyle} x1="39.5" y1="37.7" x2="39.5" y2="51.6" />
+          <line style={lineStyle} x1="39.5" y1="37.7" x2="51.5" y2="30.8" />
+        </g>
+        <g>
+          <polygon
+            style={polygonStyle}
+            points="39.5,23.4 39.5,9.1 27,2 14.5,9.1 14.5,23.4 27,30.6 		"
+          />
+          <line style={lineStyle} x1="15" y1="9.4" x2="27" y2="16.3" />
+          <line style={lineStyle} x1="27" y1="16.3" x2="27" y2="30.1" />
+          <line style={lineStyle} x1="27" y1="16.3" x2="39" y2="9.4" />
+        </g>
+      </g>
+    </svg>
+  )
+}
+
+export default CommunityTemplateNameIcon

--- a/ui/src/templates/containers/CommunityTemplates.scss
+++ b/ui/src/templates/containers/CommunityTemplates.scss
@@ -13,7 +13,61 @@
 }
 
 .community-templates-installer {
-  grid-row-gap: $ix-marg-a;
-  grid-column-gap: $ix-marg-a;
-  margin: $ix-marg-b 0
+  margin-top: $ix-marg-c;
+}
+
+.community-templates--item-description {
+  color: $g13-mist;
+  margin: $cf-marg-a 0;
+  line-height: 1.125em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.community-templates--item-description__blank {
+  color: $g8-storm;
+  font-style: italic;
+}
+
+.community-templates--list-header {
+  display: flex;
+  align-items: center;
+  padding: $cf-marg-a 0;
+  transition: color 0.25s ease;
+  color: $g11-sidewalk;
+
+  &:hover,
+  .community-templates--list-group__expanded & {
+    cursor: pointer;
+    color: $g18-cloud;
+  }
+}
+
+.community-templates--list-counter {
+  margin-left: $cf-marg-b;
+  opacity: 0.6;
+}
+
+.community-templates--list-group-items {
+  padding-left: $cf-marg-d;
+}
+
+.community-templates--list-toggle {
+  width: $cf-marg-d;
+  height: $cf-marg-d;
+  position: relative;
+
+  > .cf-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transition: transform 0.25s ease;
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+
+  .community-templates--list-group__expanded & > .cf-icon {
+    transform: translate(-50%, -50%) rotate(90deg);
+  }
 }

--- a/ui/src/templates/containers/CommunityTemplates.scss
+++ b/ui/src/templates/containers/CommunityTemplates.scss
@@ -16,6 +16,30 @@
   margin-top: $ix-marg-c;
 }
 
+.community-templates--template-image {
+  width: 54px;
+  height: 54px;
+  background-color: #000;
+}
+
+.community-templates--template-name {
+  color: $g20-white;
+}
+
+.community-templates--template-description {
+  user-select: none;
+  color: $c-neutrino;
+  font-weight: $cf-font-weight--medium;
+  margin: 0;
+  margin-top: $cf-marg-b;
+  line-height: 1.125em;
+
+  strong {
+    color: $g20-white;
+    font-weight: $cf-font-weight--bold;
+  }
+}
+
 .community-templates--item-description {
   color: $g13-mist;
   margin: $cf-marg-a 0;


### PR DESCRIPTION
![Screen Shot 2020-06-23 at 11 55 46 AM](https://user-images.githubusercontent.com/2433762/85445916-ba887800-b548-11ea-894f-fee3648ea470.png)

- Create collapsible component for groups of items in resource list
- Create component for individual resources in list
- Create component for template name
  - Add SVG component for icon
- Tweak styling


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
