### PR TITLE
refactor: move checks service to new package

### DIFF
--- a/checks/service.go
+++ b/checks/service.go
@@ -1,0 +1,566 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/tracing"
+	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/notification/check"
+	"github.com/influxdata/influxdb/v2/query/fluxlang"
+	"github.com/influxdata/influxdb/v2/snowflake"
+	"go.uber.org/zap"
+)
+
+var _ influxdb.CheckService = (*Service)(nil)
+
+// Service is a check service
+// It provides all the operations needed to manage checks
+type Service struct {
+	kv kv.Store
+
+	log *zap.Logger
+
+	orgs  influxdb.OrganizationService
+	tasks influxdb.TaskService
+
+	timeGenerator influxdb.TimeGenerator
+	idGenerator   influxdb.IDGenerator
+
+	checkStore *kv.IndexStore
+}
+
+// NewService constructs and configures a new checks.Service
+func NewService(logger *zap.Logger, store kv.Store, orgs influxdb.OrganizationService, tasks influxdb.TaskService) *Service {
+	return &Service{
+		kv:    store,
+		log:   logger,
+		orgs:  orgs,
+		tasks: tasks,
+
+		timeGenerator: influxdb.RealTimeGenerator{},
+		idGenerator:   snowflake.NewIDGenerator(),
+		checkStore:    newCheckStore(),
+	}
+}
+
+func newCheckStore() *kv.IndexStore {
+	const resource = "check"
+
+	var decEndpointEntFn kv.DecodeBucketValFn = func(key, val []byte) ([]byte, interface{}, error) {
+		ch, err := check.UnmarshalJSON(val)
+		return key, ch, err
+	}
+
+	var decValToEntFn kv.ConvertValToEntFn = func(_ []byte, v interface{}) (kv.Entity, error) {
+		ch, ok := v.(influxdb.Check)
+		if err := kv.IsErrUnexpectedDecodeVal(ok); err != nil {
+			return kv.Entity{}, err
+		}
+		return kv.Entity{
+			PK: kv.EncID(ch.GetID()),
+			UniqueKey: kv.Encode(
+				kv.EncID(ch.GetOrgID()),
+				kv.EncString(ch.GetName()),
+			),
+			Body: ch,
+		}, nil
+	}
+
+	return &kv.IndexStore{
+		Resource: resource,
+		EntStore: kv.NewStoreBase(
+			resource,
+			[]byte("checksv1"),
+			kv.EncIDKey,
+			kv.EncBodyJSON,
+			decEndpointEntFn,
+			decValToEntFn,
+		),
+		IndexStore: kv.NewOrgNameKeyStore(resource, []byte("checkindexv1"), false),
+	}
+}
+
+// FindCheckByID retrieves a check by id.
+func (s *Service) FindCheckByID(ctx context.Context, id influxdb.ID) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	var c influxdb.Check
+	err := s.kv.View(ctx, func(tx kv.Tx) error {
+		chkVal, err := s.findCheckByID(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		c = chkVal
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (s *Service) findCheckByID(ctx context.Context, tx kv.Tx, id influxdb.ID) (influxdb.Check, error) {
+	chkVal, err := s.checkStore.FindEnt(ctx, tx, kv.Entity{PK: kv.EncID(id)})
+	if err != nil {
+		return nil, err
+	}
+	return chkVal.(influxdb.Check), nil
+}
+
+func (s *Service) findCheckByName(ctx context.Context, tx kv.Tx, orgID influxdb.ID, name string) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	chVal, err := s.checkStore.FindEnt(ctx, tx, kv.Entity{
+		UniqueKey: kv.Encode(kv.EncID(orgID), kv.EncString(name)),
+	})
+	if kv.IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Err:  err,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return chVal.(influxdb.Check), nil
+}
+
+// FindCheck retrives a check using an arbitrary check filter.
+// Filters using ID, or OrganizationID and check Name should be efficient.
+// Other filters will do a linear scan across checks until it finds a match.
+func (s *Service) FindCheck(ctx context.Context, filter influxdb.CheckFilter) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if filter.ID != nil {
+		return s.FindCheckByID(ctx, *filter.ID)
+	}
+
+	if filter.Org != nil {
+		o, err := s.orgs.FindOrganization(ctx, influxdb.OrganizationFilter{Name: filter.Org})
+		if err != nil {
+			return nil, err
+		}
+		filter.OrgID = &o.ID
+	}
+
+	var c influxdb.Check
+	err := s.kv.View(ctx, func(tx kv.Tx) error {
+		if filter.OrgID != nil && filter.Name != nil {
+			ch, err := s.findCheckByName(ctx, tx, *filter.OrgID, *filter.Name)
+			c = ch
+			return err
+		}
+
+		var prefix []byte
+		if filter.OrgID != nil {
+			ent := kv.Entity{UniqueKey: kv.EncID(*filter.OrgID)}
+			prefix, _ = s.checkStore.IndexStore.EntKey(ctx, ent)
+		}
+
+		filterFn := filterChecksFn(filter)
+		return s.checkStore.Find(ctx, tx, kv.FindOpts{
+			Prefix: prefix,
+			Limit:  1,
+			FilterEntFn: func(k []byte, v interface{}) bool {
+				ch, ok := v.(influxdb.Check)
+				if err := kv.IsErrUnexpectedDecodeVal(ok); err != nil {
+					return false
+				}
+				return filterFn(ch)
+			},
+			CaptureFn: func(key []byte, decodedVal interface{}) error {
+				c, _ = decodedVal.(influxdb.Check)
+				return nil
+			},
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if c == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "check not found",
+		}
+	}
+	return c, nil
+}
+
+func filterChecksFn(filter influxdb.CheckFilter) func(c influxdb.Check) bool {
+	return func(c influxdb.Check) bool {
+		if filter.ID != nil && c.GetID() != *filter.ID {
+			return false
+		}
+		if filter.OrgID != nil && c.GetOrgID() != *filter.OrgID {
+			return false
+		}
+		if filter.Name != nil && c.GetName() != *filter.Name {
+			return false
+		}
+		return true
+	}
+}
+
+// FindChecks retrieves all checks that match an arbitrary check filter.
+// Filters using ID, or OrganizationID and check Name should be efficient.
+// Other filters will do a linear scan across all checks searching for a match.
+func (s *Service) FindChecks(ctx context.Context, filter influxdb.CheckFilter, opts ...influxdb.FindOptions) ([]influxdb.Check, int, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if filter.ID != nil {
+		c, err := s.FindCheckByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, 0, err
+		}
+		return []influxdb.Check{c}, 1, nil
+	}
+
+	if filter.Org != nil {
+		o, err := s.orgs.FindOrganization(ctx, influxdb.OrganizationFilter{Name: filter.Org})
+		if err != nil {
+			return nil, 0, &influxdb.Error{Err: err}
+		}
+
+		filter.OrgID = &o.ID
+	}
+
+	var checks []influxdb.Check
+	err := s.kv.View(ctx, func(tx kv.Tx) error {
+		var opt influxdb.FindOptions
+		if len(opts) > 0 {
+			opt = opts[0]
+		}
+
+		filterFn := filterChecksFn(filter)
+		return s.checkStore.Find(ctx, tx, kv.FindOpts{
+			Descending: opt.Descending,
+			Offset:     opt.Offset,
+			Limit:      opt.Limit,
+			FilterEntFn: func(k []byte, v interface{}) bool {
+				ch, ok := v.(influxdb.Check)
+				if err := kv.IsErrUnexpectedDecodeVal(ok); err != nil {
+					return false
+				}
+				return filterFn(ch)
+			},
+			CaptureFn: func(key []byte, decodedVal interface{}) error {
+				c, ok := decodedVal.(influxdb.Check)
+				if err := kv.IsErrUnexpectedDecodeVal(ok); err != nil {
+					return err
+				}
+				checks = append(checks, c)
+				return nil
+			},
+		})
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return checks, len(checks), nil
+}
+
+// CreateCheck creates a influxdb check and sets ID.
+func (s *Service) CreateCheck(ctx context.Context, c influxdb.CheckCreate, userID influxdb.ID) (err error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := c.Status.Valid(); err != nil {
+		return err
+	}
+
+	if c.GetOrgID().Valid() {
+		if _, err := s.orgs.FindOrganizationByID(ctx, c.GetOrgID()); err != nil {
+			return &influxdb.Error{
+				Code: influxdb.ENotFound,
+				Op:   influxdb.OpCreateCheck,
+				Err:  err,
+			}
+		}
+	}
+
+	c.SetID(s.idGenerator.ID())
+	c.SetOwnerID(userID)
+	now := s.timeGenerator.Now()
+	c.SetCreatedAt(now)
+	c.SetUpdatedAt(now)
+
+	if err := c.Valid(fluxlang.DefaultService); err != nil {
+		return err
+	}
+
+	// create task initially in inactive state
+	t, err := s.createCheckTask(ctx, c)
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "Could not create task from check",
+			Err:  err,
+		}
+	}
+
+	c.SetTaskID(t.ID)
+
+	err = s.kv.Update(ctx, func(tx kv.Tx) error {
+		return s.putCheck(ctx, tx, c, kv.PutNew())
+	})
+
+	// something went wrong persisting new check
+	// so remove associated task
+	if err != nil {
+		if derr := s.tasks.DeleteTask(ctx, t.ID); derr != nil {
+			msg := fmt.Sprintf("error removing task %q for check %q in org %q", t.ID, c.GetName(), c.GetOrgID())
+			s.log.Error(msg, zap.Error(derr))
+		}
+
+		return err
+	}
+
+	// update task to be in matching state to check
+	if influxdb.Status(t.Status) != c.Status {
+		_, err = s.tasks.UpdateTask(ctx, t.ID, influxdb.TaskUpdate{
+			Status: strPtr(string(c.Status)),
+		})
+	}
+
+	return err
+}
+
+func (s *Service) createCheckTask(ctx context.Context, c influxdb.CheckCreate) (*influxdb.Task, error) {
+	script, err := c.GenerateFlux(fluxlang.DefaultService)
+	if err != nil {
+		return nil, err
+	}
+
+	tc := influxdb.TaskCreate{
+		Type:           c.Type(),
+		Flux:           script,
+		OwnerID:        c.GetOwnerID(),
+		OrganizationID: c.GetOrgID(),
+		// task initially in inactive state to ensure it isn't
+		// scheduled until check is persisted and active
+		Status: string(influxdb.Inactive),
+	}
+
+	t, err := s.tasks.CreateTask(ctx, tc)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// PutCheck will put a check without setting an ID.
+func (s *Service) PutCheck(ctx context.Context, c influxdb.Check) error {
+	if err := c.Valid(fluxlang.DefaultService); err != nil {
+		return err
+	}
+	return s.kv.Update(ctx, func(tx kv.Tx) error {
+		return s.putCheck(ctx, tx, c)
+	})
+}
+
+func (s *Service) putCheck(ctx context.Context, tx kv.Tx, c influxdb.Check, opts ...kv.PutOptionFn) error {
+	return s.checkStore.Put(ctx, tx, kv.Entity{
+		PK:        kv.EncID(c.GetID()),
+		UniqueKey: kv.Encode(kv.EncID(c.GetOrgID()), kv.EncString(c.GetName())),
+		Body:      c,
+	}, opts...)
+}
+
+// PatchCheck updates a check according the parameters set on upd.
+func (s *Service) PatchCheck(ctx context.Context, id influxdb.ID, upd influxdb.CheckUpdate) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	var check influxdb.Check
+	if err := s.kv.Update(ctx, func(tx kv.Tx) error {
+		c, err := s.findCheckByID(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+
+		c, err = s.patchCheck(ctx, tx, c, upd)
+		if err != nil {
+			return err
+		}
+
+		check = c
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := s.patchCheckTask(ctx, check.GetTaskID(), upd); err != nil {
+		return nil, err
+	}
+
+	return check, nil
+}
+
+// UpdateCheck updates the check.
+func (s *Service) UpdateCheck(ctx context.Context, id influxdb.ID, chk influxdb.CheckCreate) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	var check influxdb.Check
+	if err := s.kv.Update(ctx, func(tx kv.Tx) error {
+		c, err := s.updateCheck(ctx, tx, id, chk)
+		if err != nil {
+			return err
+		}
+		check = c
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := s.updateCheckTask(ctx, chk); err != nil {
+		return nil, err
+	}
+
+	return check, nil
+}
+
+func (s *Service) updateCheckTask(ctx context.Context, chk influxdb.CheckCreate) error {
+	flux, err := chk.GenerateFlux(fluxlang.DefaultService)
+	if err != nil {
+		return err
+	}
+
+	tu := influxdb.TaskUpdate{
+		Flux:        &flux,
+		Description: strPtr(chk.GetDescription()),
+	}
+
+	if chk.Status != "" {
+		tu.Status = strPtr(string(chk.Status))
+	}
+
+	if _, err := s.tasks.UpdateTask(ctx, chk.GetTaskID(), tu); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (s *Service) patchCheckTask(ctx context.Context, taskID influxdb.ID, upd influxdb.CheckUpdate) error {
+	tu := influxdb.TaskUpdate{
+		Description: upd.Description,
+	}
+
+	if upd.Status != nil {
+		tu.Status = strPtr(string(*upd.Status))
+	}
+
+	if _, err := s.tasks.UpdateTask(ctx, taskID, tu); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) updateCheck(ctx context.Context, tx kv.Tx, id influxdb.ID, chk influxdb.CheckCreate) (influxdb.Check, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	current, err := s.findCheckByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	chk.SetTaskID(current.GetTaskID())
+
+	if chk.GetName() != current.GetName() {
+		c0, err := s.findCheckByName(ctx, tx, current.GetOrgID(), chk.GetName())
+		if err == nil && c0.GetID() != id {
+			return nil, &influxdb.Error{
+				Code: influxdb.EConflict,
+				Msg:  "check name is not unique",
+			}
+		}
+
+		ent := kv.Entity{
+			UniqueKey: kv.Encode(kv.EncID(current.GetOrgID()), kv.EncString(current.GetName())),
+		}
+		if err := s.checkStore.IndexStore.DeleteEnt(ctx, tx, ent); err != nil {
+			return nil, err
+		}
+	}
+
+	// ID and OrganizationID can not be updated
+	chk.SetID(current.GetID())
+	chk.SetOrgID(current.GetOrgID())
+	chk.SetOwnerID(current.GetOwnerID())
+	chk.SetCreatedAt(current.GetCRUDLog().CreatedAt)
+	chk.SetUpdatedAt(s.timeGenerator.Now())
+
+	if err := chk.Valid(fluxlang.DefaultService); err != nil {
+		return nil, err
+	}
+
+	if err := chk.Status.Valid(); err != nil {
+		return nil, err
+	}
+
+	if err := s.putCheck(ctx, tx, chk.Check); err != nil {
+		return nil, err
+	}
+
+	return chk.Check, nil
+}
+
+func (s *Service) patchCheck(ctx context.Context, tx kv.Tx, check influxdb.Check, upd influxdb.CheckUpdate) (influxdb.Check, error) {
+	if upd.Name != nil {
+		check.SetName(*upd.Name)
+	}
+
+	if upd.Description != nil {
+		check.SetDescription(*upd.Description)
+	}
+
+	check.SetUpdatedAt(s.timeGenerator.Now())
+
+	if err := check.Valid(fluxlang.DefaultService); err != nil {
+		return nil, err
+	}
+
+	if err := s.putCheck(ctx, tx, check, kv.PutUpdate()); err != nil {
+		return nil, err
+	}
+
+	return check, nil
+}
+
+// DeleteCheck deletes a check and prunes it from the index.
+func (s *Service) DeleteCheck(ctx context.Context, id influxdb.ID) error {
+	ch, err := s.FindCheckByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := s.tasks.DeleteTask(ctx, ch.GetTaskID()); err != nil {
+		return err
+	}
+
+	return s.kv.Update(ctx, func(tx kv.Tx) error {
+		return s.checkStore.DeleteEnt(ctx, tx, kv.Entity{
+			PK: kv.EncID(id),
+		})
+	})
+}
+
+func strPtr(s string) *string {
+	ss := new(string)
+	*ss = s
+	return ss
+}

--- a/checks/service_external_test.go
+++ b/checks/service_external_test.go
@@ -1,0 +1,1979 @@
+package checks
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/influxdata/influxdb/v2/notification"
+	"github.com/influxdata/influxdb/v2/notification/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	orgOneID = "020f755c3c083000"
+	orgTwoID = "020f755c3c083001"
+
+	oneID   = "020f755c3c082000"
+	twoID   = "020f755c3c082001"
+	threeID = "020f755c3c082002"
+	fourID  = "020f755c3c082003"
+	fiveID  = "020f755c3c082004"
+	sixID   = "020f755c3c082005"
+
+	checkOneID = "020f755c3c082000"
+	checkTwoID = "020f755c3c082001"
+)
+
+var script = `data = from(bucket: "telegraf") |> range(start: -1m) |> filter(fn: (r) => r._field == "usage_user")`
+
+var deadman1 = &check.Deadman{
+	Base: check.Base{
+		Name:        "name1",
+		ID:          MustIDBase16(checkOneID),
+		OrgID:       MustIDBase16(orgOneID),
+		OwnerID:     MustIDBase16(sixID),
+		Description: "desc1",
+		TaskID:      1,
+		Query: influxdb.DashboardQuery{
+			Text: script,
+			BuilderConfig: influxdb.BuilderConfig{
+				Buckets: []string{},
+				Tags: []struct {
+					Key                   string   `json:"key"`
+					Values                []string `json:"values"`
+					AggregateFunctionType string   `json:"aggregateFunctionType"`
+				}{
+					{
+						Key:                   "_field",
+						Values:                []string{"usage_user"},
+						AggregateFunctionType: "filter",
+					},
+				},
+				Functions: []struct {
+					Name string `json:"name"`
+				}{},
+			},
+		},
+		Every:                 mustDuration("1m"),
+		StatusMessageTemplate: "msg1",
+		Tags: []influxdb.Tag{
+			{Key: "k1", Value: "v1"},
+			{Key: "k2", Value: "v2"},
+		},
+		CRUDLog: influxdb.CRUDLog{
+			CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+			UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+		},
+	},
+	TimeSince:  mustDuration("21s"),
+	StaleTime:  mustDuration("1h"),
+	ReportZero: true,
+	Level:      notification.Critical,
+}
+
+var threshold1 = &check.Threshold{
+	Base: check.Base{
+		Name:                  "name2",
+		ID:                    MustIDBase16(checkTwoID),
+		OrgID:                 MustIDBase16(orgTwoID),
+		OwnerID:               MustIDBase16(sixID),
+		TaskID:                1,
+		Description:           "desc2",
+		StatusMessageTemplate: "msg2",
+		Every:                 mustDuration("1m"),
+		Query: influxdb.DashboardQuery{
+			Text: script,
+			BuilderConfig: influxdb.BuilderConfig{
+				Buckets: []string{},
+				Tags: []struct {
+					Key                   string   `json:"key"`
+					Values                []string `json:"values"`
+					AggregateFunctionType string   `json:"aggregateFunctionType"`
+				}{},
+				Functions: []struct {
+					Name string `json:"name"`
+				}{},
+			},
+		},
+		Tags: []influxdb.Tag{
+			{Key: "k11", Value: "v11"},
+		},
+		CRUDLog: influxdb.CRUDLog{
+			CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+			UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+		},
+	},
+	Thresholds: []check.ThresholdConfig{
+		&check.Lesser{
+			ThresholdConfigBase: check.ThresholdConfigBase{
+				Level: notification.Ok,
+			},
+			Value: 1000,
+		},
+		&check.Greater{
+			ThresholdConfigBase: check.ThresholdConfigBase{
+				Level: notification.Warn,
+			},
+			Value: 2000,
+		},
+		&check.Range{
+			ThresholdConfigBase: check.ThresholdConfigBase{
+				Level: notification.Info,
+			},
+			Min:    1500,
+			Max:    1900,
+			Within: true,
+		},
+	},
+}
+
+var checkCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmpopts.IgnoreFields(check.Base{}, "TaskID"),
+	cmp.Transformer("Sort", func(in []influxdb.Check) []influxdb.Check {
+		out := append([]influxdb.Check(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].GetID() > out[j].GetID()
+		})
+		return out
+	}),
+}
+
+var taskCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	// skip comparing permissions
+	cmpopts.IgnoreFields(
+		influxdb.Task{},
+		"Authorization",
+		"LatestCompleted",
+		"LatestScheduled",
+		"CreatedAt",
+		"UpdatedAt",
+	),
+	cmp.Transformer("Sort", func(in []*influxdb.Task) []*influxdb.Task {
+		out := append([]*influxdb.Task{}, in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID > out[j].ID
+		})
+		return out
+	}),
+}
+
+// CheckFields will include the IDGenerator, and checks
+type CheckFields struct {
+	IDGenerator          influxdb.IDGenerator
+	TimeGenerator        influxdb.TimeGenerator
+	TaskService          influxdb.TaskService
+	Checks               []influxdb.Check
+	Organizations        []*influxdb.Organization
+	UserResourceMappings []*influxdb.UserResourceMapping
+	Tasks                []influxdb.TaskCreate
+}
+
+type checkServiceFactory func(CheckFields, *testing.T) (influxdb.CheckService, influxdb.TaskService, string, func())
+
+type checkServiceF func(
+	init checkServiceFactory,
+	t *testing.T,
+)
+
+// CheckService tests all the service functions.
+func CheckService(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	tests := []struct {
+		name string
+		fn   checkServiceF
+	}{
+		{
+			name: "CreateCheck",
+			fn:   CreateCheck,
+		},
+		{
+			name: "FindCheckByID",
+			fn:   FindCheckByID,
+		},
+		{
+			name: "FindChecks",
+			fn:   FindChecks,
+		},
+		{
+			name: "FindCheck",
+			fn:   FindCheck,
+		},
+		{
+			name: "PatchCheck",
+			fn:   PatchCheck,
+		},
+		{
+			name: "UpdateCheck",
+			fn:   UpdateCheck,
+		},
+		{
+			name: "DeleteCheck",
+			fn:   DeleteCheck,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn(init, t)
+		})
+	}
+}
+
+// CreateCheck testing
+func CreateCheck(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		userID influxdb.ID
+		check  influxdb.Check
+	}
+	type wants struct {
+		err    *influxdb.Error
+		checks []influxdb.Check
+		tasks  []*influxdb.Task
+	}
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "create checks with empty set",
+			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator(checkOneID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Checks:        []influxdb.Check{},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(fiveID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(twoID),
+						UserType:     influxdb.Member,
+					},
+				},
+			},
+			args: args{
+				userID: MustIDBase16(twoID),
+				check: &check.Deadman{
+					Base: check.Base{
+						Name:        "name1",
+						OrgID:       MustIDBase16(orgOneID),
+						Description: "desc1",
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						Every:                 mustDuration("1m"),
+						StatusMessageTemplate: "msg1",
+						Tags: []influxdb.Tag{
+							{Key: "k1", Value: "v1"},
+							{Key: "k2", Value: "v2"},
+						},
+					},
+					TimeSince:  mustDuration("21s"),
+					StaleTime:  mustDuration("1h"),
+					ReportZero: true,
+					Level:      notification.Critical,
+				},
+			},
+			wants: wants{
+				tasks: []*influxdb.Task{
+					{
+						ID:             MustIDBase16("020f755c3c082000"),
+						Name:           "name1",
+						Type:           "deadman",
+						OrganizationID: MustIDBase16("020f755c3c083000"),
+						Organization:   "theorg",
+						OwnerID:        MustIDBase16("020f755c3c082001"),
+						Status:         "active",
+						Flux:           "package main\nimport \"influxdata/influxdb/monitor\"\nimport \"experimental\"\nimport \"influxdata/influxdb/v1\"\n\ndata = from(bucket: \"telegraf\")\n\t|> range(start: -1h)\n\t|> filter(fn: (r) =>\n\t\t(r._field == \"usage_user\"))\n\noption task = {name: \"name1\", every: 1m}\n\ncheck = {\n\t_check_id: \"020f755c3c082000\",\n\t_check_name: \"name1\",\n\t_type: \"deadman\",\n\ttags: {k1: \"v1\", k2: \"v2\"},\n}\ncrit = (r) =>\n\t(r[\"dead\"])\nmessageFn = (r) =>\n\t(\"msg1\")\n\ndata\n\t|> v1[\"fieldsAsCols\"]()\n\t|> monitor[\"deadman\"](t: experimental[\"subDuration\"](from: now(), d: 21s))\n\t|> monitor[\"check\"](data: check, messageFn: messageFn, crit: crit)",
+						Every:          "1m",
+					},
+				},
+				checks: []influxdb.Check{
+					&check.Deadman{
+						Base: check.Base{
+							Name:    "name1",
+							ID:      MustIDBase16(checkOneID),
+							OrgID:   MustIDBase16(orgOneID),
+							OwnerID: MustIDBase16(twoID),
+							Query: influxdb.DashboardQuery{
+								Text: script,
+								BuilderConfig: influxdb.BuilderConfig{
+									Buckets: []string{},
+									Tags: []struct {
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
+									}{
+										{
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
+										},
+									},
+									Functions: []struct {
+										Name string `json:"name"`
+									}{},
+								},
+							},
+							Every:                 mustDuration("1m"),
+							Description:           "desc1",
+							StatusMessageTemplate: "msg1",
+							Tags: []influxdb.Tag{
+								{Key: "k1", Value: "v1"},
+								{Key: "k2", Value: "v2"},
+							},
+							CRUDLog: influxdb.CRUDLog{
+								CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+								UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							},
+						},
+						TimeSince:  mustDuration("21s"),
+						StaleTime:  mustDuration("1h"),
+						ReportZero: true,
+						Level:      notification.Critical,
+					},
+				},
+			},
+		},
+		{
+			name: "basic create check",
+			fields: CheckFields{
+				IDGenerator: &mock.IDGenerator{
+					IDFn: func() influxdb.ID {
+						return MustIDBase16(checkTwoID)
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(checkOneID),
+						ResourceType: influxdb.ChecksResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+				},
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Checks: []influxdb.Check{
+					deadman1,
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				check: &check.Threshold{
+					Base: check.Base{
+						Name:                  "name2",
+						OrgID:                 MustIDBase16(orgTwoID),
+						OwnerID:               MustIDBase16(twoID),
+						Description:           "desc2",
+						StatusMessageTemplate: "msg2",
+						Every:                 mustDuration("1m"),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+						},
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+						},
+					},
+					Thresholds: []check.ThresholdConfig{
+						&check.Lesser{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Ok,
+							},
+							Value: 1000,
+						},
+						&check.Greater{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Warn,
+							},
+							Value: 2000,
+						},
+						&check.Range{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Info,
+							},
+							Min:    1500,
+							Max:    1900,
+							Within: true,
+						},
+					},
+				},
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+				tasks: []*influxdb.Task{
+					{
+						ID:             MustIDBase16("020f755c3c082001"),
+						Name:           "name2",
+						Type:           "threshold",
+						OrganizationID: MustIDBase16("020f755c3c083001"),
+						Organization:   "otherorg",
+						OwnerID:        MustIDBase16("020f755c3c082005"),
+						Status:         "active",
+						Every:          "1m",
+						Flux:           "package main\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\n\ndata = from(bucket: \"telegraf\")\n\t|> range(start: -1m)\n\t|> filter(fn: (r) =>\n\t\t(r._field == \"usage_user\"))\n\noption task = {name: \"name2\", every: 1m}\n\ncheck = {\n\t_check_id: \"020f755c3c082001\",\n\t_check_name: \"name2\",\n\t_type: \"threshold\",\n\ttags: {k11: \"v11\"},\n}\nok = (r) =>\n\t(r[\"usage_user\"] < 1000.0)\nwarn = (r) =>\n\t(r[\"usage_user\"] > 2000.0)\ninfo = (r) =>\n\t(r[\"usage_user\"] < 1900.0 and r[\"usage_user\"] > 1500.0)\nmessageFn = (r) =>\n\t(\"msg2\")\n\ndata\n\t|> v1[\"fieldsAsCols\"]()\n\t|> monitor[\"check\"](\n\t\tdata: check,\n\t\tmessageFn: messageFn,\n\t\tok: ok,\n\t\twarn: warn,\n\t\tinfo: info,\n\t)",
+					},
+				},
+			},
+		},
+		{
+			name: "names should be unique within an organization",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(checkOneID),
+						ResourceType: influxdb.ChecksResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+				},
+				IDGenerator: &mock.IDGenerator{
+					IDFn: func() influxdb.ID {
+						return MustIDBase16(checkTwoID)
+					},
+				},
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Checks: []influxdb.Check{
+					deadman1,
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+			},
+			args: args{
+				userID: MustIDBase16(twoID),
+				check: &check.Threshold{
+					Base: check.Base{
+						Name:        "name1",
+						OrgID:       MustIDBase16(orgOneID),
+						Description: "desc1",
+						Every:       mustDuration("1m"),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						StatusMessageTemplate: "msg1",
+						Tags: []influxdb.Tag{
+							{Key: "k1", Value: "v1"},
+							{Key: "k2", Value: "v2"},
+						},
+					},
+				},
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					deadman1,
+				},
+				err: &influxdb.Error{
+					Code: influxdb.EConflict,
+					Op:   influxdb.OpCreateCheck,
+					Msg:  "check is not unique",
+				},
+			},
+		},
+		{
+			name: "names should not be unique across organizations",
+			fields: CheckFields{
+				IDGenerator: &mock.IDGenerator{
+					IDFn: func() influxdb.ID {
+						return MustIDBase16(checkTwoID)
+					},
+				},
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(twoID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(orgOneID),
+						ResourceType: influxdb.OrgsResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(checkOneID),
+						ResourceType: influxdb.ChecksResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+				},
+			},
+			args: args{
+				userID: MustIDBase16(twoID),
+				check: &check.Threshold{
+					Base: check.Base{
+						Name:        "name1",
+						OrgID:       MustIDBase16(orgTwoID),
+						Description: "desc2",
+						Every:       mustDuration("1m"),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						StatusMessageTemplate: "msg2",
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+							{Key: "k22", Value: "v22"},
+						},
+					},
+				},
+			},
+			wants: wants{
+				tasks: []*influxdb.Task{
+					{
+						ID:             MustIDBase16("020f755c3c082001"),
+						Name:           "name1",
+						Type:           "threshold",
+						OrganizationID: MustIDBase16("020f755c3c083001"),
+						Organization:   "otherorg",
+						OwnerID:        MustIDBase16("020f755c3c082001"),
+						Status:         "active",
+						Every:          "1m",
+						Flux:           "package main\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\n\ndata = from(bucket: \"telegraf\")\n\t|> range(start: -1m)\n\t|> filter(fn: (r) =>\n\t\t(r._field == \"usage_user\"))\n\noption task = {name: \"name1\", every: 1m}\n\ncheck = {\n\t_check_id: \"020f755c3c082001\",\n\t_check_name: \"name1\",\n\t_type: \"threshold\",\n\ttags: {k11: \"v11\", k22: \"v22\"},\n}\nmessageFn = (r) =>\n\t(\"msg2\")\n\ndata\n\t|> v1[\"fieldsAsCols\"]()\n\t|> monitor[\"check\"](data: check, messageFn: messageFn)",
+					},
+				},
+				checks: []influxdb.Check{
+					deadman1,
+					&check.Threshold{
+						Base: check.Base{
+							ID:    MustIDBase16(checkTwoID),
+							Name:  "name1",
+							OrgID: MustIDBase16(orgTwoID),
+							Every: mustDuration("1m"),
+							Query: influxdb.DashboardQuery{
+								Text: script,
+								BuilderConfig: influxdb.BuilderConfig{
+									Buckets: []string{},
+									Tags: []struct {
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
+									}{
+										{
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
+										},
+									},
+									Functions: []struct {
+										Name string `json:"name"`
+									}{},
+								},
+							},
+							OwnerID:               MustIDBase16(twoID),
+							Description:           "desc2",
+							StatusMessageTemplate: "msg2",
+							Tags: []influxdb.Tag{
+								{Key: "k11", Value: "v11"},
+								{Key: "k22", Value: "v22"},
+							},
+							CRUDLog: influxdb.CRUDLog{
+								CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+								UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create check with orgID not exist",
+			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator(checkOneID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Checks:        []influxdb.Check{},
+				Organizations: []*influxdb.Organization{},
+			},
+			args: args{
+				userID: MustIDBase16(twoID),
+				check: &check.Threshold{
+					Base: check.Base{
+						Name:  "name1",
+						OrgID: MustIDBase16(orgOneID),
+						Every: mustDuration("1m"),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						Description:           "desc2",
+						StatusMessageTemplate: "msg2",
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+							{Key: "k22", Value: "v22"},
+						},
+					},
+				},
+			},
+			wants: wants{
+				checks: []influxdb.Check{},
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Msg:  "organization not found",
+					Op:   influxdb.OpCreateCheck,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, tasks, _, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+			createCheck := influxdb.CheckCreate{Check: tt.args.check, Status: influxdb.Active}
+			err := s.CreateCheck(ctx, createCheck, tt.args.userID)
+			influxErrsEqual(t, tt.wants.err, err)
+
+			defer s.DeleteCheck(ctx, tt.args.check.GetID())
+
+			checks, _, err := s.FindChecks(ctx, influxdb.CheckFilter{})
+			if err != nil {
+				t.Fatalf("failed to retrieve checks: %v", err)
+			}
+			if diff := cmp.Diff(checks, tt.wants.checks, checkCmpOptions...); diff != "" {
+				t.Errorf("checks are different -got/+want\ndiff %s", diff)
+			}
+
+			foundTasks, _, err := tasks.FindTasks(ctx, influxdb.TaskFilter{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(foundTasks, tt.wants.tasks, taskCmpOptions); diff != "" {
+				t.Errorf("tasks are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// FindCheckByID testing
+func FindCheckByID(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		id influxdb.ID
+	}
+	type wants struct {
+		err   *influxdb.Error
+		check influxdb.Check
+	}
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "basic find check by id",
+			fields: CheckFields{
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(checkTwoID),
+			},
+			wants: wants{
+				check: threshold1,
+			},
+		},
+		{
+			name: "find check by id not exist",
+			fields: CheckFields{
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(threeID),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpFindCheckByID,
+					Msg:  "check not found",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+
+			check, err := s.FindCheckByID(ctx, tt.args.id)
+			influxErrsEqual(t, tt.wants.err, err)
+
+			if diff := cmp.Diff(check, tt.wants.check, checkCmpOptions...); diff != "" {
+				t.Errorf("check is different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// FindChecks testing
+func FindChecks(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		ID           influxdb.ID
+		name         string
+		organization string
+		OrgID        influxdb.ID
+		userID       influxdb.ID
+		findOptions  influxdb.FindOptions
+	}
+
+	type wants struct {
+		checks []influxdb.Check
+		err    error
+	}
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "find all checks",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "find all checks by offset and limit",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				findOptions: influxdb.FindOptions{
+					Offset: 1,
+					Limit:  1,
+				},
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "find all checks by descending",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				findOptions: influxdb.FindOptions{
+					Limit:      1,
+					Descending: true,
+				},
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "find checks by organization name",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				userID:       MustIDBase16(sixID),
+				organization: "theorg",
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					deadman1,
+				},
+			},
+		},
+		{
+			name: "find checks by organization id",
+			fields: CheckFields{
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "otherorg",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				OrgID:  MustIDBase16(orgTwoID),
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "find check by name",
+			fields: CheckFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				name:   "name2",
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "missing check returns no checks",
+			fields: CheckFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				name:   "xyz",
+			},
+			wants: wants{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, opPrefix, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+
+			filter := influxdb.CheckFilter{
+				UserResourceMappingFilter: influxdb.UserResourceMappingFilter{
+					UserID:       tt.args.userID,
+					ResourceType: influxdb.ChecksResourceType,
+				},
+			}
+			if tt.args.ID.Valid() {
+				filter.ID = &tt.args.ID
+			}
+			if tt.args.OrgID.Valid() {
+				filter.OrgID = &tt.args.OrgID
+			}
+			if tt.args.organization != "" {
+				filter.Org = &tt.args.organization
+			}
+			if tt.args.name != "" {
+				filter.Name = &tt.args.name
+			}
+
+			checks, _, err := s.FindChecks(ctx, filter, tt.args.findOptions)
+			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+
+			if diff := cmp.Diff(checks, tt.wants.checks, checkCmpOptions...); diff != "" {
+				t.Errorf("checks are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// DeleteCheck testing
+func DeleteCheck(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		ID     string
+		userID influxdb.ID
+	}
+	type wants struct {
+		err    *influxdb.Error
+		checks []influxdb.Check
+	}
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "delete checks using exist id",
+			fields: CheckFields{
+				IDGenerator: mock.NewIDGenerator("0000000000000001", t),
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				ID:     checkOneID,
+				userID: MustIDBase16(sixID),
+			},
+			wants: wants{
+				checks: []influxdb.Check{
+					threshold1,
+				},
+			},
+		},
+		{
+			name: "delete checks using id that does not exist",
+			fields: CheckFields{
+				IDGenerator: mock.NewIDGenerator("0000000000000001", t),
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+						ResourceType: influxdb.ChecksResourceType,
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+		data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				ID:     "1234567890654321",
+				userID: MustIDBase16(sixID),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Op:   influxdb.OpDeleteCheck,
+					Msg:  "check not found",
+					Code: influxdb.ENotFound,
+				},
+				checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+			err := s.DeleteCheck(ctx, MustIDBase16(tt.args.ID))
+			influxErrsEqual(t, tt.wants.err, err)
+
+			filter := influxdb.CheckFilter{
+				UserResourceMappingFilter: influxdb.UserResourceMappingFilter{
+					UserID:       tt.args.userID,
+					ResourceType: influxdb.ChecksResourceType,
+				},
+			}
+			checks, _, err := s.FindChecks(ctx, filter)
+			if err != nil {
+				t.Fatalf("failed to retrieve checks: %v", err)
+			}
+			if diff := cmp.Diff(checks, tt.wants.checks, checkCmpOptions...); diff != "" {
+				t.Errorf("checks are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// FindCheck testing
+func FindCheck(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		name  string
+		OrgID influxdb.ID
+	}
+
+	type wants struct {
+		check influxdb.Check
+		err   *influxdb.Error
+	}
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "find check by name",
+			fields: CheckFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+					{
+						Name: "theorg2",
+						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					threshold1,
+				},
+			},
+			args: args{
+				name:  "name1",
+				OrgID: MustIDBase16(orgOneID),
+			},
+			wants: wants{
+				check: deadman1,
+			},
+		},
+		{
+			name: "mixed filter",
+			fields: CheckFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{},
+			},
+			args: args{
+				name:  "name2",
+				OrgID: MustIDBase16(orgOneID),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpFindCheck,
+					Msg:  "check not found",
+				},
+			},
+		},
+		{
+			name: "missing check returns error",
+			fields: CheckFields{
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{},
+			},
+			args: args{
+				name:  "xyz",
+				OrgID: MustIDBase16(orgOneID),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpFindCheck,
+					Msg:  "check not found",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _, done := init(tt.fields, t)
+			defer done()
+
+			var filter influxdb.CheckFilter
+			if tt.args.name != "" {
+				filter.Name = &tt.args.name
+			}
+			if tt.args.OrgID.Valid() {
+				filter.OrgID = &tt.args.OrgID
+			}
+
+			check, err := s.FindCheck(context.Background(), filter)
+			influxErrsEqual(t, tt.wants.err, err)
+
+			if diff := cmp.Diff(check, tt.wants.check, checkCmpOptions...); diff != "" {
+				t.Errorf("checks are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// UpdateCheck testing
+func UpdateCheck(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		id    influxdb.ID
+		check influxdb.Check
+	}
+	type wants struct {
+		err   error
+		check influxdb.Check
+	}
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "mixed update",
+			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator("0000000000000001", t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2007, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+				},
+			},
+			args: args{
+				id: MustIDBase16(checkOneID),
+				check: &check.Threshold{
+					Base: check.Base{
+						ID:      MustIDBase16(checkTwoID),
+						OrgID:   MustIDBase16(orgOneID),
+						OwnerID: MustIDBase16(twoID),
+						Every:   mustDuration("1m"),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						Name:                  "changed",
+						Description:           "desc changed",
+						StatusMessageTemplate: "msg2",
+						TaskID:                1,
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+							{Key: "k22", Value: "v22"},
+							{Key: "k33", Value: "v33"},
+						},
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: time.Date(2001, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2002, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					Thresholds: []check.ThresholdConfig{
+						&check.Lesser{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Ok,
+							},
+							Value: 1000,
+						},
+						&check.Greater{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Warn,
+							},
+							Value: 2000,
+						},
+						&check.Range{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Info,
+							},
+							Min:    1500,
+							Max:    1900,
+							Within: true,
+						},
+					},
+				},
+			},
+			wants: wants{
+				check: &check.Threshold{
+					Base: check.Base{
+						ID:      MustIDBase16(checkOneID),
+						OrgID:   MustIDBase16(orgOneID),
+						Name:    "changed",
+						Every:   mustDuration("1m"),
+						OwnerID: MustIDBase16(sixID),
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+							},
+						},
+						Description:           "desc changed",
+						StatusMessageTemplate: "msg2",
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+							{Key: "k22", Value: "v22"},
+							{Key: "k33", Value: "v33"},
+						},
+						TaskID: 1,
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2007, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					Thresholds: []check.ThresholdConfig{
+						&check.Lesser{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Ok,
+							},
+							Value: 1000,
+						},
+						&check.Greater{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Warn,
+							},
+							Value: 2000,
+						},
+						&check.Range{
+							ThresholdConfigBase: check.ThresholdConfigBase{
+								Level: notification.Info,
+							},
+							Min:    1500,
+							Max:    1900,
+							Within: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update name unique",
+			fields: CheckFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					&check.Deadman{
+						Base: check.Base{
+							ID:    MustIDBase16(checkTwoID),
+							OrgID: MustIDBase16(orgOneID),
+							Every: mustDuration("1m"),
+							Query: influxdb.DashboardQuery{
+								Text: script,
+								BuilderConfig: influxdb.BuilderConfig{
+									Tags: []struct {
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
+									}{
+										{
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
+										},
+									},
+								},
+							},
+							TaskID:                1,
+							Name:                  "check2",
+							OwnerID:               MustIDBase16(twoID),
+							StatusMessageTemplate: "msg1",
+						},
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(checkOneID),
+				check: &check.Deadman{
+					Base: check.Base{
+						OrgID:                 MustIDBase16(orgOneID),
+						OwnerID:               MustIDBase16(twoID),
+						Name:                  "check2",
+						Description:           "desc changed",
+						TaskID:                1,
+						Every:                 mustDuration("1m"),
+						StatusMessageTemplate: "msg2",
+						Tags: []influxdb.Tag{
+							{Key: "k11", Value: "v11"},
+							{Key: "k22", Value: "v22"},
+							{Key: "k33", Value: "v33"},
+						},
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: time.Date(2001, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2002, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					TimeSince:  mustDuration("12s"),
+					StaleTime:  mustDuration("1h"),
+					ReportZero: false,
+					Level:      notification.Warn,
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.EConflict,
+					Msg:  "check name is not unique",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, opPrefix, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+
+			checkCreate := influxdb.CheckCreate{Check: tt.args.check, Status: influxdb.Active}
+
+			check, err := s.UpdateCheck(ctx, tt.args.id, checkCreate)
+			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+
+			if diff := cmp.Diff(check, tt.wants.check, checkCmpOptions...); diff != "" {
+				t.Errorf("check is different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// PatchCheck testing
+func PatchCheck(
+	init checkServiceFactory,
+	t *testing.T,
+) {
+	type args struct {
+		id  influxdb.ID
+		upd influxdb.CheckUpdate
+	}
+	type wants struct {
+		err   *influxdb.Error
+		check influxdb.Check
+	}
+
+	inactive := influxdb.Inactive
+
+	tests := []struct {
+		name   string
+		fields CheckFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "mixed patch",
+			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator("0000000000000001", t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2007, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+				},
+			},
+			args: args{
+				id: MustIDBase16(checkOneID),
+				upd: influxdb.CheckUpdate{
+					Name:        strPtr("changed"),
+					Description: strPtr("desc changed"),
+					Status:      &inactive,
+				},
+			},
+			wants: wants{
+				check: &check.Deadman{
+					Base: check.Base{
+						ID:          MustIDBase16(checkOneID),
+						OrgID:       MustIDBase16(orgOneID),
+						Name:        "changed",
+						OwnerID:     MustIDBase16(sixID),
+						Every:       mustDuration("1m"),
+						Description: "desc changed",
+						Query: influxdb.DashboardQuery{
+							Text: script,
+							BuilderConfig: influxdb.BuilderConfig{
+								Buckets: []string{},
+								Tags: []struct {
+									Key                   string   `json:"key"`
+									Values                []string `json:"values"`
+									AggregateFunctionType string   `json:"aggregateFunctionType"`
+								}{
+									{
+										Key:                   "_field",
+										Values:                []string{"usage_user"},
+										AggregateFunctionType: "filter",
+									},
+								},
+								Functions: []struct {
+									Name string `json:"name"`
+								}{},
+							},
+						},
+						StatusMessageTemplate: "msg1",
+						Tags: []influxdb.Tag{
+							{Key: "k1", Value: "v1"},
+							{Key: "k2", Value: "v2"},
+						},
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2007, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					TimeSince:  mustDuration("21s"),
+					StaleTime:  mustDuration("1h"),
+					ReportZero: true,
+					Level:      notification.Critical,
+				},
+			},
+		},
+		{
+			name: "update name unique",
+			fields: CheckFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Checks: []influxdb.Check{
+					deadman1,
+					&check.Deadman{
+						Base: check.Base{
+							ID:      MustIDBase16(checkTwoID),
+							OrgID:   MustIDBase16(orgOneID),
+							Every:   mustDuration("1m"),
+							Name:    "check2",
+							OwnerID: MustIDBase16(sixID),
+							Query: influxdb.DashboardQuery{
+								Text: script,
+								BuilderConfig: influxdb.BuilderConfig{
+									Tags: []struct {
+										Key                   string   `json:"key"`
+										Values                []string `json:"values"`
+										AggregateFunctionType string   `json:"aggregateFunctionType"`
+									}{
+										{
+											Key:                   "_field",
+											Values:                []string{"usage_user"},
+											AggregateFunctionType: "filter",
+										},
+									},
+								},
+							},
+							StatusMessageTemplate: "msg1",
+						},
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(checkOneID),
+				upd: influxdb.CheckUpdate{
+					Name: strPtr("check2"),
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.EConflict,
+					Msg:  "check entity update conflicts with an existing entity",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+
+			check, err := s.PatchCheck(ctx, tt.args.id, tt.args.upd)
+			influxErrsEqual(t, tt.wants.err, err)
+
+			if diff := cmp.Diff(check, tt.wants.check, checkCmpOptions...); diff != "" {
+				t.Errorf("check is different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// MustIDBase16 is an helper to ensure a correct ID is built during testing.
+func MustIDBase16(s string) influxdb.ID {
+	id, err := influxdb.IDFromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return *id
+}
+
+func diffPlatformErrors(name string, actual, expected error, opPrefix string, t *testing.T) {
+	t.Helper()
+	ErrorsEqual(t, actual, expected)
+}
+
+// ErrorsEqual checks to see if the provided errors are equivalent.
+func ErrorsEqual(t *testing.T, actual, expected error) {
+	t.Helper()
+	if expected == nil && actual == nil {
+		return
+	}
+
+	if expected == nil && actual != nil {
+		t.Errorf("unexpected error %s", actual.Error())
+	}
+
+	if expected != nil && actual == nil {
+		t.Errorf("expected error %s but received nil", expected.Error())
+	}
+
+	if influxdb.ErrorCode(expected) != influxdb.ErrorCode(actual) {
+		t.Logf("\nexpected: %v\nactual: %v\n\n", expected, actual)
+		t.Errorf("expected error code %q but received %q", influxdb.ErrorCode(expected), influxdb.ErrorCode(actual))
+	}
+
+	if influxdb.ErrorMessage(expected) != influxdb.ErrorMessage(actual) {
+		t.Logf("\nexpected: %v\nactual: %v\n\n", expected, actual)
+		t.Errorf("expected error message %q but received %q", influxdb.ErrorMessage(expected), influxdb.ErrorMessage(actual))
+	}
+}
+
+func influxErrsEqual(t *testing.T, expected *influxdb.Error, actual error) {
+	t.Helper()
+
+	if expected != nil {
+		require.Error(t, actual)
+	}
+
+	if actual == nil {
+		return
+	}
+
+	if expected == nil {
+		require.NoError(t, actual)
+		return
+	}
+	iErr, ok := actual.(*influxdb.Error)
+	require.True(t, ok)
+	assert.Equal(t, expected.Code, iErr.Code)
+	assert.Truef(t, strings.HasPrefix(iErr.Error(), expected.Error()), "expected: %s got err: %s", expected.Error(), actual.Error())
+}
+
+func mustDuration(d string) *notification.Duration {
+	dur, err := time.ParseDuration(d)
+	if err != nil {
+		panic(err)
+	}
+
+	ndur, err := notification.FromTimeDuration(dur)
+	if err != nil {
+		panic(err)
+	}
+
+	// Filter out the zero values from the duration.
+	durs := make([]ast.Duration, 0, len(ndur.Values))
+	for _, d := range ndur.Values {
+		if d.Magnitude != 0 {
+			durs = append(durs, d)
+		}
+	}
+	ndur.Values = durs
+	return &ndur
+}

--- a/checks/service_test.go
+++ b/checks/service_test.go
@@ -1,0 +1,84 @@
+package checks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/inmem"
+	"github.com/influxdata/influxdb/v2/kv"
+	_ "github.com/influxdata/influxdb/v2/query/builtin"
+	"github.com/influxdata/influxdb/v2/query/fluxlang"
+	"go.uber.org/zap/zaptest"
+)
+
+func NewKVTestStore(t *testing.T) (kv.Store, func()) {
+	return inmem.NewKVStore(), func() {}
+}
+
+func TestCheckService(t *testing.T) {
+	CheckService(initCheckService, t)
+}
+
+func initCheckService(f CheckFields, t *testing.T) (influxdb.CheckService, influxdb.TaskService, string, func()) {
+	store, closeKVStore := NewKVTestStore(t)
+	logger := zaptest.NewLogger(t)
+	svc := kv.NewService(logger, store, kv.ServiceConfig{
+		FluxLanguageService: fluxlang.DefaultService,
+	})
+	svc.IDGenerator = f.IDGenerator
+	svc.TimeGenerator = f.TimeGenerator
+	if f.TimeGenerator == nil {
+		svc.TimeGenerator = influxdb.RealTimeGenerator{}
+	}
+
+	checkService := NewService(logger, store, svc, svc)
+	checkService.idGenerator = f.IDGenerator
+	if f.TimeGenerator != nil {
+		checkService.timeGenerator = f.TimeGenerator
+	}
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing check service: %v", err)
+	}
+	for _, m := range f.UserResourceMappings {
+		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate user resource mapping: %v", err)
+		}
+	}
+	for _, o := range f.Organizations {
+		if err := svc.PutOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to populate organizations")
+		}
+	}
+	for _, c := range f.Checks {
+		if err := checkService.PutCheck(ctx, c); err != nil {
+			t.Fatalf("failed to populate checks")
+		}
+	}
+	for _, tc := range f.Tasks {
+		if _, err := svc.CreateTask(ctx, tc); err != nil {
+			t.Fatalf("failed to populate tasks: %v", err)
+		}
+	}
+	return checkService, svc, kv.OpPrefix, func() {
+		for _, o := range f.Organizations {
+			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {
+				t.Logf("failed to remove organization: %v", err)
+			}
+		}
+		for _, urm := range f.UserResourceMappings {
+			if err := svc.DeleteUserResourceMapping(ctx, urm.ResourceID, urm.UserID); err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
+				t.Logf("failed to remove urm rule: %v", err)
+			}
+		}
+		for _, c := range f.Checks {
+			if err := checkService.DeleteCheck(ctx, c.GetID()); err != nil {
+				t.Logf("failed to remove check: %v", err)
+			}
+		}
+
+		closeKVStore()
+	}
+}

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/influxdb/v2/authorization"
 	"github.com/influxdata/influxdb/v2/authorizer"
 	"github.com/influxdata/influxdb/v2/bolt"
+	"github.com/influxdata/influxdb/v2/checks"
 	"github.com/influxdata/influxdb/v2/chronograf/server"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/v2/dbrp"
@@ -801,7 +802,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	var checkSvc platform.CheckService
 	{
 		coordinator := coordinator.NewCoordinator(m.log, m.scheduler, m.executor)
-		checkSvc = middleware.NewCheckService(m.kvService, m.kvService, coordinator)
+		checkSvc = checks.NewService(m.log.With(zap.String("svc", "checks")), m.kvStore, m.kvService, m.kvService)
+		checkSvc = middleware.NewCheckService(checkSvc, m.kvService, coordinator)
 	}
 
 	var notificationRuleSvc platform.NotificationRuleStore


### PR DESCRIPTION
Part of #18498

This change copies @GeorgeMac's checks service. This change should not affect any functionality. This will allow us to remove the checks file from the kv package which is the last step to removing all references to orgs and urms from kv so that we can switch entirely to the tenant service remove the dead code from kv.

Blocking https://github.com/influxdata/influxdb/pull/18551

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
