### PR TITLE
chore(pkger): ensure sorting of axes on export of a dashboard's query

### DIFF
--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -633,6 +633,9 @@ func convertCellView(cell influxdb.Cell) chart {
 		ch.Position = p.Position
 	}
 
+	sort.Slice(ch.Axes, func(i, j int) bool {
+		return ch.Axes[i].Name < ch.Axes[j].Name
+	})
 	return ch
 }
 


### PR DESCRIPTION
forcing the sorting makes exports deterministic. The axes returned are a map, which don't guarantee any order. This forces that order every time. Makes exporting cleaner. Found this during demo prep


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass