### PR TITLE
feat(loadBuckets): loadBuckets sets buckets after req and removed Buckets fetching from DataExplorerPage

### DIFF
--- a/ui/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/ui/src/dataExplorer/components/DataExplorerPage.tsx
@@ -25,7 +25,7 @@ const DataExplorerPage: FC = ({children}) => {
   return (
     <Page titleTag={pageTitleSuffixer(['Data Explorer'])}>
       {children}
-      <GetResources resources={[ResourceType.Variables, ResourceType.Buckets]}>
+      <GetResources resources={[ResourceType.Variables]}>
         <Page.Header fullWidth={true}>
           <Page.Title title="Data Explorer" />
           <CloudUpgradeButton />


### PR DESCRIPTION
Closes #18510

### Problem

Navigating to the DataExplorer was making two query requests for buckets

### Solution

Removed Buckets from GetResources wrapper around DataExplorerPage and updated the loadBuckets function to set the loaded buckets once they are returned from the API and normalized.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] Rebased/mergeable