### PR TITLE
feat: adding a bucket provider

### DIFF
--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -1,7 +1,7 @@
 // Funcs
 import {
   isSystemBucket,
-  getSortedBucketNames,
+  getSortedBuckets,
   SYSTEM,
 } from 'src/buckets/selectors/index'
 
@@ -164,7 +164,7 @@ describe('Bucket Selector', () => {
       },
     ]
 
-    const results = getSortedBucketNames(buckets)
+    const results = getSortedBuckets(buckets).map(bucket => bucket.name)
     const expectedResult = [
       'alpha',
       'buck2',

--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/buckets/selectors/index'
 
 // Types
-import {Bucket} from 'src/types'
+import {AppState, Bucket} from 'src/types'
 
 describe('Bucket Selector', () => {
   it('should return true when a default bucket is passed', () => {
@@ -164,7 +164,17 @@ describe('Bucket Selector', () => {
       },
     ]
 
-    const results = getSortedBuckets(buckets).map(bucket => bucket.name)
+    const results = getSortedBuckets({
+      resources: {
+        buckets: {
+          status: 'Done',
+          byID: buckets.reduce((prev, curr) => {
+            prev[curr.id] = curr
+          }, {}),
+          allIDs: buckets.map(bucket => bucket.id),
+        },
+      },
+    } as AppState).map(bucket => bucket.name)
     const expectedResult = [
       'alpha',
       'buck2',

--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -170,6 +170,7 @@ describe('Bucket Selector', () => {
           status: 'Done',
           byID: buckets.reduce((prev, curr) => {
             prev[curr.id] = curr
+            return prev
           }, {}),
           allIDs: buckets.map(bucket => bucket.id),
         },

--- a/ui/src/buckets/selectors/index.ts
+++ b/ui/src/buckets/selectors/index.ts
@@ -32,9 +32,11 @@ const sortFunc = (a: Bucket, b: Bucket) => {
   return 0
 }
 
-export const getSortedBucketNames = (buckets: Bucket[]) => {
+export const getSortedBuckets = (state: AppState) => {
   const systemBuckets = []
   const otherBuckets = []
+  const buckets = getAll<Bucket>(state, ResourceType.Buckets)
+
   buckets.forEach(bucket => {
     // separate system buckets from the rest
     if (isSystemBucket(bucket.type)) {
@@ -47,6 +49,6 @@ export const getSortedBucketNames = (buckets: Bucket[]) => {
   systemBuckets.sort(sortFunc)
   // alphabetize other buckets
   otherBuckets.sort(sortFunc)
-  // concat the system buckets to the end of the other buckets and map results
-  return otherBuckets.concat(systemBuckets).map(bucket => bucket.name)
+  // concat the system buckets to the end of the other buckets
+  return otherBuckets.concat(systemBuckets)
 }

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import React, {FC, useEffect} from 'react'
 import {connect} from 'react-redux'
 
 // Actions
@@ -38,17 +38,25 @@ export const BucketContext = React.createContext<BucketContextType>(
 
 let GLOBAL_LOADING = false
 
-const lockAndLoad = async () => {
+const lockAndLoad = async grabber => {
   GLOBAL_LOADING = true
-  await getBuckets()
+  await grabber()
   GLOBAL_LOADING = false
 }
 
 export const BucketProvider: FC<Props> = React.memo(
   ({loading, getBuckets, buckets, children}) => {
-    if (!GLOBAL_LOADING && loading === RemoteDataState.NotStarted) {
-      lockAndLoad()
-    }
+    useEffect(() => {
+      if (loading !== RemoteDataState.NotStarted) {
+        return
+      }
+
+      if (GLOBAL_LOADING) {
+        return
+      }
+
+      lockAndLoad(getBuckets)
+    }, [loading])
 
     return (
       <BucketContext.Provider

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -1,0 +1,72 @@
+import React, {FC} from 'react'
+import {connect} from 'react-redux'
+
+// Actions
+import {getBuckets} from 'src/buckets/actions/thunks'
+
+// Selectors
+import {getSortedBuckets} from 'src/buckets/selectors'
+import {getStatus} from 'src/resources/selectors'
+
+// Types
+import {AppState, Bucket, ResourceType, RemoteDataState} from 'src/types'
+
+export interface StateProps {
+  loading: RemoteDataState
+  buckets: Bucket[]
+}
+
+export interface DispatchProps {
+  getBuckets: typeof getBuckets
+}
+
+export type Props = StateProps & DispatchProps
+
+export interface BucketContextType {
+  loading: RemoteDataState
+  buckets: Bucket[]
+}
+
+export const DEFAULT_CONTEXT: BucketContextType = {
+  loading: RemoteDataState.NotStarted,
+  buckets: [],
+}
+
+export const BucketContext = React.createContext<BucketContextType>(
+  DEFAULT_CONTEXT
+)
+
+export const BucketProvider: FC<Props> = React.memo(
+  ({loading, getBuckets, buckets, children}) => {
+    if (loading === RemoteDataState.NotStarted) {
+      getBuckets()
+    }
+
+    return (
+      <BucketContext.Provider
+        value={{
+          loading,
+          buckets,
+        }}
+      >
+        {children}
+      </BucketContext.Provider>
+    )
+  }
+)
+
+const mstp = (state: AppState): StateProps => {
+  const buckets = getSortedBuckets(state)
+  const loading = getStatus(state, ResourceType.Buckets)
+
+  return {
+    loading,
+    buckets,
+  }
+}
+
+const mdtp: DispatchProps = {
+  getBuckets: getBuckets,
+}
+
+export default connect<StateProps, DispatchProps>(mstp, mdtp)(BucketProvider)

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -36,10 +36,15 @@ export const BucketContext = React.createContext<BucketContextType>(
   DEFAULT_CONTEXT
 )
 
+let GLOBAL_LOADING = false
+
 export const BucketProvider: FC<Props> = React.memo(
   ({loading, getBuckets, buckets, children}) => {
-    if (loading === RemoteDataState.NotStarted) {
-      getBuckets()
+    if (!GLOBAL_LOADING && loading === RemoteDataState.NotStarted) {
+      GLOBAL_LOADING = true
+      getBuckets().then(() => {
+        GLOBAL_LOADING = false
+      })
     }
 
     return (

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -38,15 +38,16 @@ export const BucketContext = React.createContext<BucketContextType>(
 
 let GLOBAL_LOADING = false
 
+const lockAndLoad = async () => {
+  GLOBAL_LOADING = true
+  await getBuckets()
+  GLOBAL_LOADING = false
+}
+
 export const BucketProvider: FC<Props> = React.memo(
   ({loading, getBuckets, buckets, children}) => {
     if (!GLOBAL_LOADING && loading === RemoteDataState.NotStarted) {
-      new Promise(async resolve => {
-        GLOBAL_LOADING = true
-        await getBuckets()
-        GLOBAL_LOADING = false
-        resolve()
-      })
+      lockAndLoad()
     }
 
     return (

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -41,9 +41,11 @@ let GLOBAL_LOADING = false
 export const BucketProvider: FC<Props> = React.memo(
   ({loading, getBuckets, buckets, children}) => {
     if (!GLOBAL_LOADING && loading === RemoteDataState.NotStarted) {
-      GLOBAL_LOADING = true
-      getBuckets().then(() => {
+      new Promise(async resolve => {
+        GLOBAL_LOADING = true
+        await getBuckets()
         GLOBAL_LOADING = false
+        resolve()
       })
     }
 

--- a/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
@@ -4,11 +4,10 @@ import {connect} from 'react-redux'
 import {SelectDropdown} from '@influxdata/clockface'
 
 // Types
-import {AppState, Bucket, ResourceType} from 'src/types'
+import {AppState} from 'src/types'
 
 // Selectors
-import {getSortedBucketNames} from 'src/buckets/selectors'
-import {getAll} from 'src/resources/selectors'
+import {getSortedBuckets} from 'src/buckets/selectors'
 
 interface StateProps {
   bucketNames: string[]
@@ -37,12 +36,10 @@ const BucketsDropdown: FunctionComponent<Props> = ({
 
 const mstp = (state: AppState): StateProps => {
   // map names and sort via a selector
-  const buckets = getSortedBucketNames(
-    getAll<Bucket>(state, ResourceType.Buckets)
-  )
+  const buckets = getSortedBuckets(state)
 
   return {
-    bucketNames: buckets,
+    bucketNames: buckets.map(bucket => bucket.name),
   }
 }
 


### PR DESCRIPTION
i got real stoked about reimplementing resources within the system, then realized that the only issue with GetResources is that it merges the request for data with the display of data. So this PR turned into separating concerns. Wrap it around any component that needs bucket information, redux should handle the singleton mechanism required to decouple the resource fetching from the number of things requesting data.

in the same vein, removed display / formatting logic that was defined outside of the view layer to open up default sorting on buckets