### PR TITLE
chore(pkger): refactor indpendent stack export functionality out of existence

### DIFF
--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -185,8 +185,8 @@ func TestCmdPkg(t *testing.T) {
 
 		cmdFn := func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 			pkgSVC := &fakePkgSVC{
-				createFn: func(_ context.Context, opts ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
-					opt := pkger.CreateOpt{}
+				exportFn: func(_ context.Context, opts ...pkger.ExportOptFn) (*pkger.Pkg, error) {
+					opt := pkger.ExportOpt{}
 					for _, o := range opts {
 						if err := o(&opt); err != nil {
 							return nil, err
@@ -322,8 +322,8 @@ func TestCmdPkg(t *testing.T) {
 
 		cmdFn := func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 			pkgSVC := &fakePkgSVC{
-				createFn: func(_ context.Context, opts ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
-					var opt pkger.CreateOpt
+				exportFn: func(_ context.Context, opts ...pkger.ExportOptFn) (*pkger.Pkg, error) {
+					var opt pkger.ExportOpt
 					for _, o := range opts {
 						if err := o(&opt); err != nil {
 							return nil, err
@@ -707,7 +707,7 @@ func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args pkgFi
 
 type fakePkgSVC struct {
 	initStackFn func(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error)
-	createFn    func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
+	exportFn    func(ctx context.Context, setters ...pkger.ExportOptFn) (*pkger.Pkg, error)
 	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
 	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
 }
@@ -741,9 +741,9 @@ func (f *fakePkgSVC) UpdateStack(ctx context.Context, upd pkger.StackUpdate) (pk
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
-	if f.createFn != nil {
-		return f.createFn(ctx, setters...)
+func (f *fakePkgSVC) Export(ctx context.Context, setters ...pkger.ExportOptFn) (*pkger.Pkg, error) {
+	if f.exportFn != nil {
+		return f.exportFn(ctx, setters...)
 	}
 	panic("not implemented")
 }

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -708,8 +708,8 @@ func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args pkgFi
 type fakePkgSVC struct {
 	initStackFn func(ctx context.Context, userID influxdb.ID, stack pkger.Stack) (pkger.Stack, error)
 	exportFn    func(ctx context.Context, setters ...pkger.ExportOptFn) (*pkger.Pkg, error)
-	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
-	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
+	dryRunFn    func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error)
+	applyFn     func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error)
 }
 
 var _ pkger.SVC = (*fakePkgSVC)(nil)
@@ -748,14 +748,14 @@ func (f *fakePkgSVC) Export(ctx context.Context, setters ...pkger.ExportOptFn) (
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakePkgSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 	if f.dryRunFn != nil {
 		return f.dryRunFn(ctx, orgID, userID, opts...)
 	}
 	panic("not implemented")
 }
 
-func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 	if f.applyFn != nil {
 		return f.applyFn(ctx, orgID, userID, opts...)
 	}

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -470,7 +470,7 @@ func TestLauncher_Pkger(t *testing.T) {
 			})
 			defer cleanup()
 
-			sumEquals := func(t *testing.T, impact pkger.PkgImpactSummary) {
+			sumEquals := func(t *testing.T, impact pkger.ImpactSummary) {
 				t.Helper()
 
 				assert.Equal(t, expectedURLs, impact.Sources)
@@ -1597,7 +1597,7 @@ func TestLauncher_Pkger(t *testing.T) {
 				name      string
 				pkgFn     func(t *testing.T) *pkger.Pkg
 				applyOpts []pkger.ApplyOptFn
-				assertFn  func(t *testing.T, impact pkger.PkgImpactSummary)
+				assertFn  func(t *testing.T, impact pkger.ImpactSummary)
 			}{
 				{
 					name:  "skip resource",
@@ -1640,7 +1640,7 @@ func TestLauncher_Pkger(t *testing.T) {
 							MetaName: variablePkgName,
 						}),
 					},
-					assertFn: func(t *testing.T, impact pkger.PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact pkger.ImpactSummary) {
 						summary := impact.Summary
 						assert.Empty(t, summary.Buckets)
 						assert.Empty(t, summary.Checks)
@@ -1685,7 +1685,7 @@ func TestLauncher_Pkger(t *testing.T) {
 							Kind: pkger.KindVariable,
 						}),
 					},
-					assertFn: func(t *testing.T, impact pkger.PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact pkger.ImpactSummary) {
 						summary := impact.Summary
 						assert.Empty(t, summary.Buckets)
 						assert.Empty(t, summary.Checks)
@@ -1727,7 +1727,7 @@ func TestLauncher_Pkger(t *testing.T) {
 							Kind: pkger.KindLabel,
 						}),
 					},
-					assertFn: func(t *testing.T, impact pkger.PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact pkger.ImpactSummary) {
 						summary := impact.Summary
 						assert.Empty(t, summary.Labels, 0)
 						assert.Empty(t, summary.LabelMappings)

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -1920,7 +1920,7 @@ func TestLauncher_Pkger(t *testing.T) {
 				initialSum, stack, cleanup := testStackApplyFn(t)
 				defer cleanup()
 
-				exportedPkg, err := svc.ExportStack(ctx, l.Org.ID, stack.ID)
+				exportedTemplate, err := svc.Export(ctx, pkger.ExportWithStackID(stack.ID))
 				require.NoError(t, err)
 
 				hasAssociation := func(t *testing.T, actual []pkger.SummaryLabel) {
@@ -1932,7 +1932,7 @@ func TestLauncher_Pkger(t *testing.T) {
 					assert.Equal(t, actual[0].PkgName, initialSum.Labels[0].PkgName)
 				}
 
-				sum := exportedPkg.Summary()
+				sum := exportedTemplate.Summary()
 
 				require.Len(t, sum.Buckets, 1, "missing required buckets")
 				assert.Equal(t, initialSum.Buckets[0].PkgName, sum.Buckets[0].PkgName)
@@ -2008,10 +2008,10 @@ func TestLauncher_Pkger(t *testing.T) {
 
 				require.Len(t, impact.Summary.Dashboards, 1)
 
-				exportedPkg, err := svc.ExportStack(ctx, l.Org.ID, impact.StackID)
+				exportedTemplate, err := svc.Export(ctx, pkger.ExportWithStackID(impact.StackID))
 				require.NoError(t, err)
 
-				summary := exportedPkg.Summary()
+				summary := exportedTemplate.Summary()
 				require.Len(t, summary.Dashboards, 1)
 
 				exportedDash := summary.Dashboards[0]
@@ -2065,10 +2065,10 @@ func TestLauncher_Pkger(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					exportedPkg, err := svc.ExportStack(ctx, l.Org.ID, stack.ID)
+					exportedTemplate, err := svc.Export(ctx, pkger.ExportWithStackID(stack.ID))
 					require.NoError(t, err)
 
-					exportedSum := exportedPkg.Summary()
+					exportedSum := exportedTemplate.Summary()
 					require.Len(t, exportedSum.Labels, 1)
 					require.Len(t, exportedSum.Buckets, 1)
 					require.Empty(t, exportedSum.Buckets[0].LabelAssociations, "received unexpected label associations")
@@ -2096,10 +2096,10 @@ func TestLauncher_Pkger(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					exportedPkg, err := svc.ExportStack(ctx, l.Org.ID, stack.ID)
+					exportedTemplate, err := svc.Export(ctx, pkger.ExportWithStackID(stack.ID))
 					require.NoError(t, err)
 
-					exportedSum := exportedPkg.Summary()
+					exportedSum := exportedTemplate.Summary()
 					assert.Len(t, exportedSum.Labels, 2)
 					require.Len(t, exportedSum.Buckets, 1)
 					require.Len(t, exportedSum.Buckets[0].LabelAssociations, 2)
@@ -2471,8 +2471,8 @@ spec:
 
 		t.Run("exporting all resources for an org", func(t *testing.T) {
 			t.Run("getting everything", func(t *testing.T) {
-				newPkg, err := svc.CreatePkg(ctx, pkger.CreateWithAllOrgResources(
-					pkger.CreateByOrgIDOpt{
+				newPkg, err := svc.Export(ctx, pkger.ExportWithAllOrgResources(
+					pkger.ExportByOrgIDOpt{
 						OrgID: l.Org.ID,
 					},
 				))
@@ -2579,8 +2579,8 @@ spec:
 			})
 
 			t.Run("filtered by resource types", func(t *testing.T) {
-				newPkg, err := svc.CreatePkg(ctx, pkger.CreateWithAllOrgResources(
-					pkger.CreateByOrgIDOpt{
+				newPkg, err := svc.Export(ctx, pkger.ExportWithAllOrgResources(
+					pkger.ExportByOrgIDOpt{
 						OrgID:         l.Org.ID,
 						ResourceKinds: []pkger.Kind{pkger.KindCheck, pkger.KindTask},
 					},
@@ -2600,8 +2600,8 @@ spec:
 			})
 
 			t.Run("filtered by label resource type", func(t *testing.T) {
-				newPkg, err := svc.CreatePkg(ctx, pkger.CreateWithAllOrgResources(
-					pkger.CreateByOrgIDOpt{
+				newPkg, err := svc.Export(ctx, pkger.ExportWithAllOrgResources(
+					pkger.ExportByOrgIDOpt{
 						OrgID:         l.Org.ID,
 						ResourceKinds: []pkger.Kind{pkger.KindLabel},
 					},
@@ -2621,8 +2621,8 @@ spec:
 			})
 
 			t.Run("filtered by label name", func(t *testing.T) {
-				newPkg, err := svc.CreatePkg(ctx, pkger.CreateWithAllOrgResources(
-					pkger.CreateByOrgIDOpt{
+				newPkg, err := svc.Export(ctx, pkger.ExportWithAllOrgResources(
+					pkger.ExportByOrgIDOpt{
 						OrgID:      l.Org.ID,
 						LabelNames: []string{"the 2nd label"},
 					},
@@ -2641,8 +2641,8 @@ spec:
 			})
 
 			t.Run("filtered by label name and resource type", func(t *testing.T) {
-				newPkg, err := svc.CreatePkg(ctx, pkger.CreateWithAllOrgResources(
-					pkger.CreateByOrgIDOpt{
+				newPkg, err := svc.Export(ctx, pkger.ExportWithAllOrgResources(
+					pkger.ExportByOrgIDOpt{
 						OrgID:         l.Org.ID,
 						LabelNames:    []string{"the 2nd label"},
 						ResourceKinds: []pkger.Kind{pkger.KindDashboard},
@@ -2782,8 +2782,8 @@ spec:
 				},
 			}
 
-			newPkg, err := svc.CreatePkg(ctx,
-				pkger.CreateWithExistingResources(append(resToClone, resWithNewName...)...),
+			newPkg, err := svc.Export(ctx,
+				pkger.ExportWithExistingResources(append(resToClone, resWithNewName...)...),
 			)
 			require.NoError(t, err)
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4862,41 +4862,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /packages/stacks/{stack_id}/export:
-    delete:
-      operationId: ExportStack
-      tags:
-        - InfluxPackages
-      summary: Export a stack's resources in the form of a package
-      parameters:
-        - in: path
-          name: stack_id
-          required: true
-          schema:
-            type: string
-          description: The stack id to be removed
-        - in: query
-          name: orgID
-          required: true
-          schema:
-            type: string
-          description: The organization id of the user
-      responses:
-        "200":
-          description: Stack and all its associated resources are deleted
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Pkg"
-            application/x-yaml:
-              schema:
-                $ref: "#/components/schemas/Pkg"
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /tasks:
     get:
       operationId: GetTasks
@@ -7739,6 +7704,8 @@ components:
     PkgCreate:
       type: object
       properties:
+        stackID:
+          type: string
         orgIDs:
           type: array
           items:

--- a/pkger/doc.go
+++ b/pkger/doc.go
@@ -101,13 +101,13 @@ have the ability to do so using the following:
 	}
 
 	svc := NewService(serviceOpts...)
-	newPkg, err := svc.CreatePkg(ctx,
+	newPkg, err := svc.Export(ctx,
 		CreateWithMetadata(Metadata{
 			Name: 		 "pkg name",
 			Description: "stand up desc",
 			Version: 	 "v1.0.0",
 		}),
-		CreateWithExistingResources(resourcesToClone...),
+		ExportWithExistingResources(resourcesToClone...),
 	)
 	if err != nil {
 		panic(err) // handle error as you see fit

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -1174,10 +1174,6 @@ func (f *fakeSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 	panic("not implemented yet")
 }
 
-func (f *fakeSVC) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*pkger.Pkg, error) {
-	panic("not implemented")
-}
-
 func (f *fakeSVC) ListStacks(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error) {
 	if f.listStacksFn == nil {
 		panic("not implemented")
@@ -1199,7 +1195,7 @@ func (f *fakeSVC) UpdateStack(ctx context.Context, upd pkger.StackUpdate) (pkger
 	panic("not implemented")
 }
 
-func (f *fakeSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
+func (f *fakeSVC) Export(ctx context.Context, setters ...pkger.ExportOptFn) (*pkger.Pkg, error) {
 	panic("not implemented")
 }
 

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -154,18 +154,18 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 							var opt pkger.ApplyOpt
 							for _, o := range opts {
 								o(&opt)
 							}
 							pkg, err := pkger.Combine(opt.Pkgs)
 							if err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 
 							if err := pkg.Validate(); err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -176,7 +176,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 									},
 								})
 							}
-							return pkger.PkgImpactSummary{
+							return pkger.ImpactSummary{
 								Summary: sum,
 								Diff:    diff,
 							}, nil
@@ -222,18 +222,18 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 							var opt pkger.ApplyOpt
 							for _, o := range opts {
 								o(&opt)
 							}
 							pkg, err := pkger.Combine(opt.Pkgs)
 							if err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 
 							if err := pkg.Validate(); err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -244,7 +244,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 									},
 								})
 							}
-							return pkger.PkgImpactSummary{
+							return pkger.ImpactSummary{
 								Diff:    diff,
 								Summary: sum,
 							}, nil
@@ -342,18 +342,18 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 							var opt pkger.ApplyOpt
 							for _, o := range opts {
 								o(&opt)
 							}
 							pkg, err := pkger.Combine(opt.Pkgs)
 							if err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 
 							if err := pkg.Validate(); err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
 							sum := pkg.Summary()
 							var diff pkger.Diff
@@ -365,7 +365,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 								})
 							}
 
-							return pkger.PkgImpactSummary{
+							return pkger.ImpactSummary{
 								Diff:    diff,
 								Summary: sum,
 							}, nil
@@ -427,16 +427,16 @@ func TestPkgerHTTPServer(t *testing.T) {
 			for _, tt := range tests {
 				fn := func(t *testing.T) {
 					svc := &fakeSVC{
-						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+						dryRunFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 							var opt pkger.ApplyOpt
 							for _, o := range opts {
 								o(&opt)
 							}
 							pkg, err := pkger.Combine(opt.Pkgs)
 							if err != nil {
-								return pkger.PkgImpactSummary{}, err
+								return pkger.ImpactSummary{}, err
 							}
-							return pkger.PkgImpactSummary{
+							return pkger.ImpactSummary{
 								Summary: pkg.Summary(),
 							}, nil
 						},
@@ -459,7 +459,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 
 	t.Run("apply a pkg", func(t *testing.T) {
 		svc := &fakeSVC{
-			applyFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+			applyFn: func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 				var opt pkger.ApplyOpt
 				for _, o := range opts {
 					o(&opt)
@@ -467,7 +467,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 
 				pkg, err := pkger.Combine(opt.Pkgs)
 				if err != nil {
-					return pkger.PkgImpactSummary{}, err
+					return pkger.ImpactSummary{}, err
 				}
 
 				sum := pkg.Summary()
@@ -484,7 +484,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 					sum.MissingSecrets = append(sum.MissingSecrets, key)
 				}
 
-				return pkger.PkgImpactSummary{
+				return pkger.ImpactSummary{
 					Diff:    diff,
 					Summary: sum,
 				}, nil
@@ -1157,8 +1157,8 @@ type fakeSVC struct {
 	listStacksFn  func(ctx context.Context, orgID influxdb.ID, filter pkger.ListFilter) ([]pkger.Stack, error)
 	readStackFn   func(ctx context.Context, id influxdb.ID) (pkger.Stack, error)
 	updateStackFn func(ctx context.Context, upd pkger.StackUpdate) (pkger.Stack, error)
-	dryRunFn      func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
-	applyFn       func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error)
+	dryRunFn      func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error)
+	applyFn       func(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error)
 }
 
 var _ pkger.SVC = (*fakeSVC)(nil)
@@ -1199,7 +1199,7 @@ func (f *fakeSVC) Export(ctx context.Context, setters ...pkger.ExportOptFn) (*pk
 	panic("not implemented")
 }
 
-func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 	if f.dryRunFn == nil {
 		panic("not implemented")
 	}
@@ -1207,7 +1207,7 @@ func (f *fakeSVC) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ..
 	return f.dryRunFn(ctx, orgID, userID, opts...)
 }
 
-func (f *fakeSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.PkgImpactSummary, error) {
+func (f *fakeSVC) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...pkger.ApplyOptFn) (pkger.ImpactSummary, error) {
 	if f.applyFn == nil {
 		panic("not implemented")
 	}

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -91,10 +91,10 @@ func (s *authMW) Export(ctx context.Context, opts ...ExportOptFn) (*Pkg, error) 
 	return s.next.Export(ctx, opts...)
 }
 
-func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *authMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	return s.next.Apply(ctx, orgID, userID, opts...)
 }

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -44,14 +44,6 @@ func (s *authMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Use
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
-func (s *authMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
-	err := s.authAgent.OrgPermissions(ctx, orgID, influxdb.ReadAction)
-	if err != nil {
-		return nil, err
-	}
-	return s.next.ExportStack(ctx, orgID, stackID)
-}
-
 func (s *authMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	err := s.authAgent.OrgPermissions(ctx, orgID, influxdb.ReadAction)
 	if err != nil {
@@ -86,8 +78,17 @@ func (s *authMW) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, error
 	return s.next.UpdateStack(ctx, upd)
 }
 
-func (s *authMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error) {
-	return s.next.CreatePkg(ctx, setters...)
+func (s *authMW) Export(ctx context.Context, opts ...ExportOptFn) (*Pkg, error) {
+	opt, err := exportOptFromOptFns(opts)
+	if err != nil {
+		return nil, err
+	}
+	if opt.StackID != 0 {
+		if _, err := s.ReadStack(ctx, opt.StackID); err != nil {
+			return nil, err
+		}
+	}
+	return s.next.Export(ctx, opts...)
 }
 
 func (s *authMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -135,7 +135,7 @@ func (s *loggingMW) Export(ctx context.Context, opts ...ExportOptFn) (pkg *Pkg, 
 	return s.next.Export(ctx, opts...)
 }
 
-func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
+func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact ImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -163,7 +163,7 @@ func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts 
 	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {
+func (s *loggingMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact ImpactSummary, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -61,23 +61,6 @@ func (s *loggingMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, 
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
-func (s *loggingMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (pkg *Pkg, err error) {
-	defer func(start time.Time) {
-		if err == nil {
-			return
-		}
-
-		s.logger.Error(
-			"failed to export stack",
-			zap.Error(err),
-			zap.Stringer("orgID", orgID),
-			zap.Stringer("stackID", stackID),
-			zap.Duration("took", time.Since(start)),
-		)
-	}(time.Now())
-	return s.next.ExportStack(ctx, orgID, stackID)
-}
-
 func (s *loggingMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) (stacks []Stack, err error) {
 	defer func(start time.Time) {
 		if err == nil {
@@ -140,7 +123,7 @@ func (s *loggingMW) UpdateStack(ctx context.Context, upd StackUpdate) (_ Stack, 
 	return s.next.UpdateStack(ctx, upd)
 }
 
-func (s *loggingMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (pkg *Pkg, err error) {
+func (s *loggingMW) Export(ctx context.Context, opts ...ExportOptFn) (pkg *Pkg, err error) {
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
@@ -149,7 +132,7 @@ func (s *loggingMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (p
 		}
 		s.logger.Info("pkg create", append(s.summaryLogFields(pkg.Summary()), dur)...)
 	}(time.Now())
-	return s.next.CreatePkg(ctx, setters...)
+	return s.next.Export(ctx, opts...)
 }
 
 func (s *loggingMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (impact PkgImpactSummary, err error) {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -42,12 +42,6 @@ func (s *mwMetrics) DeleteStack(ctx context.Context, identifiers struct{ OrgID, 
 	return rec(s.next.DeleteStack(ctx, identifiers))
 }
 
-func (s *mwMetrics) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
-	rec := s.rec.Record("export_stack")
-	pkg, err := s.next.ExportStack(ctx, orgID, stackID)
-	return pkg, rec(err)
-}
-
 func (s *mwMetrics) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	rec := s.rec.Record("list_stacks")
 	stacks, err := s.next.ListStacks(ctx, orgID, f)
@@ -66,9 +60,9 @@ func (s *mwMetrics) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, er
 	return stack, rec(err)
 }
 
-func (s *mwMetrics) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error) {
+func (s *mwMetrics) Export(ctx context.Context, opts ...ExportOptFn) (*Pkg, error) {
 	rec := s.rec.Record("create_pkg")
-	pkg, err := s.next.CreatePkg(ctx, setters...)
+	pkg, err := s.next.Export(ctx, opts...)
 	return pkg, rec(err)
 }
 

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -66,13 +66,13 @@ func (s *mwMetrics) Export(ctx context.Context, opts ...ExportOptFn) (*Pkg, erro
 	return pkg, rec(err)
 }
 
-func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	rec := s.rec.Record("dry_run")
 	impact, err := s.next.DryRun(ctx, orgID, userID, opts...)
 	return impact, rec(err, applyMetricAdditions(orgID, userID, impact.Sources))
 }
 
-func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *mwMetrics) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	rec := s.rec.Record("apply")
 	impact, err := s.next.Apply(ctx, orgID, userID, opts...)
 	return impact, rec(err, applyMetricAdditions(orgID, userID, impact.Sources))

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/influxdata/influxdb/v2"
@@ -25,7 +26,7 @@ var _ SVC = (*mwMetrics)(nil)
 func MWMetrics(reg *prom.Registry) SVCMiddleware {
 	return func(svc SVC) SVC {
 		return &mwMetrics{
-			rec:  metric.New(reg, "pkger", metric.WithVec(templateVec())),
+			rec:  metric.New(reg, "pkger", metric.WithVec(templateVec()), metric.WithVec(exportVec())),
 			next: svc,
 		}
 	}
@@ -62,8 +63,21 @@ func (s *mwMetrics) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, er
 
 func (s *mwMetrics) Export(ctx context.Context, opts ...ExportOptFn) (*Pkg, error) {
 	rec := s.rec.Record("create_pkg")
+	opt, err := exportOptFromOptFns(opts)
+	if err != nil {
+		return nil, rec(err)
+	}
+
 	pkg, err := s.next.Export(ctx, opts...)
-	return pkg, rec(err)
+	if err != nil {
+		return nil, err
+	}
+
+	return pkg, rec(err, metric.RecordAdditional(map[string]interface{}{
+		"num_org_ids": len(opt.OrgIDs),
+		"summary":     pkg.Summary(),
+		"by_stack":    opt.StackID != 0,
+	}))
 }
 
 func (s *mwMetrics) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
@@ -84,6 +98,70 @@ func applyMetricAdditions(orgID, userID influxdb.ID, sources []string) func(*met
 		"sources": sources,
 		"user_id": userID.String(),
 	})
+}
+
+func exportVec() metric.VecOpts {
+	const (
+		byStack         = "by_stack"
+		numOrgIDs       = "num_org_ids"
+		bkts            = "buckets"
+		checks          = "checks"
+		dashes          = "dashboards"
+		endpoints       = "endpoints"
+		labels          = "labels"
+		labelMappings   = "label_mappings"
+		rules           = "rules"
+		tasks           = "tasks"
+		telegrafConfigs = "telegraf_configs"
+		variables       = "variables"
+	)
+	return metric.VecOpts{
+		Name: "template_export",
+		Help: "Metrics for resources being exported",
+		LabelNames: []string{
+			"method",
+			byStack,
+			numOrgIDs,
+			bkts,
+			checks,
+			dashes,
+			endpoints,
+			labels,
+			labelMappings,
+			rules,
+			tasks,
+			telegrafConfigs,
+			variables,
+		},
+		CounterFn: func(vec *prometheus.CounterVec, o metric.CollectFnOpts) {
+			if o.Err != nil {
+				return
+			}
+
+			orgID, _ := o.AdditionalProps[numOrgIDs].(int)
+			sum, _ := o.AdditionalProps["sum"].(Summary)
+			st, _ := o.AdditionalProps[byStack].(bool)
+
+			vec.
+				With(prometheus.Labels{
+					"method":        o.Method,
+					byStack:         strconv.FormatBool(st),
+					numOrgIDs:       strconv.Itoa(orgID),
+					bkts:            strconv.Itoa(len(sum.Buckets)),
+					checks:          strconv.Itoa(len(sum.Checks)),
+					dashes:          strconv.Itoa(len(sum.Dashboards)),
+					endpoints:       strconv.Itoa(len(sum.NotificationEndpoints)),
+					labels:          strconv.Itoa(len(sum.Labels)),
+					labelMappings:   strconv.Itoa(len(sum.LabelMappings)),
+					rules:           strconv.Itoa(len(sum.NotificationRules)),
+					tasks:           strconv.Itoa(len(sum.Tasks)),
+					telegrafConfigs: strconv.Itoa(len(sum.TelegrafConfigs)),
+					variables:       strconv.Itoa(len(sum.TelegrafConfigs)),
+				}).
+				Inc()
+		},
+		HistogramFn: nil,
+	}
 }
 
 func templateVec() metric.VecOpts {

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -85,7 +85,7 @@ func TestService(t *testing.T) {
 			path          string
 			kinds         []Kind
 			skipResources []ActionSkipResource
-			assertFn      func(*testing.T, PkgImpactSummary)
+			assertFn      func(*testing.T, ImpactSummary)
 		}
 
 		testDryRunActions := func(t *testing.T, fields dryRunTestFields) {
@@ -231,7 +231,7 @@ func TestService(t *testing.T) {
 							MetaName: "rucket-11",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Buckets)
 					},
 				})
@@ -293,7 +293,7 @@ func TestService(t *testing.T) {
 							MetaName: "check-1",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Checks)
 					},
 				})
@@ -315,7 +315,7 @@ func TestService(t *testing.T) {
 							MetaName: "dash-2",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Dashboards)
 					},
 				})
@@ -426,7 +426,7 @@ func TestService(t *testing.T) {
 							MetaName: "label-3",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Labels)
 					},
 				})
@@ -532,7 +532,7 @@ func TestService(t *testing.T) {
 							MetaName: "pager-duty-notification-endpoint",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.NotificationEndpoints)
 					},
 				})
@@ -600,7 +600,7 @@ func TestService(t *testing.T) {
 							MetaName: "rule-uuid",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.NotificationRules)
 					},
 				})
@@ -637,7 +637,7 @@ func TestService(t *testing.T) {
 							MetaName: "task-1",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Tasks)
 					},
 				})
@@ -659,7 +659,7 @@ func TestService(t *testing.T) {
 							MetaName: "tele-2",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Telegrafs)
 					},
 				})
@@ -749,7 +749,7 @@ func TestService(t *testing.T) {
 							MetaName: "var-map-4",
 						},
 					},
-					assertFn: func(t *testing.T, impact PkgImpactSummary) {
+					assertFn: func(t *testing.T, impact ImpactSummary) {
 						require.Empty(t, impact.Diff.Variables)
 					},
 				})

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -1749,7 +1749,7 @@ func TestService(t *testing.T) {
 		})
 	})
 
-	t.Run("CreatePkg", func(t *testing.T) {
+	t.Run("Export", func(t *testing.T) {
 		newThresholdBase := func(i int) icheck.Base {
 			return icheck.Base{
 				ID:          influxdb.ID(i),
@@ -1826,7 +1826,7 @@ func TestService(t *testing.T) {
 							ID:   expected.ID,
 							Name: tt.newName,
 						}
-						pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+						pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 						require.NoError(t, err)
 
 						newPkg := encodeAndDecode(t, pkg)
@@ -1926,7 +1926,7 @@ func TestService(t *testing.T) {
 							ID:   tt.expected.GetID(),
 							Name: tt.newName,
 						}
-						pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+						pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 						require.NoError(t, err)
 
 						newPkg := encodeAndDecode(t, pkg)
@@ -2311,7 +2311,7 @@ func TestService(t *testing.T) {
 								ID:   expected.ID,
 								Name: tt.newName,
 							}
-							pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+							pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 							require.NoError(t, err)
 
 							newPkg := encodeAndDecode(t, pkg)
@@ -2361,7 +2361,7 @@ func TestService(t *testing.T) {
 							ID:   2,
 						},
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resourcesToClone...))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resourcesToClone...))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -2417,7 +2417,7 @@ func TestService(t *testing.T) {
 							ID:   expectedLabel.ID,
 							Name: tt.newName,
 						}
-						pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+						pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 						require.NoError(t, err)
 
 						newPkg := encodeAndDecode(t, pkg)
@@ -2545,7 +2545,7 @@ func TestService(t *testing.T) {
 							ID:   tt.expected.GetID(),
 							Name: tt.newName,
 						}
-						pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+						pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 						require.NoError(t, err)
 
 						newPkg := encodeAndDecode(t, pkg)
@@ -2672,7 +2672,7 @@ func TestService(t *testing.T) {
 								ID:   tt.rule.GetID(),
 								Name: tt.newName,
 							}
-							pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+							pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 							require.NoError(t, err)
 
 							newPkg := encodeAndDecode(t, pkg)
@@ -2773,7 +2773,7 @@ func TestService(t *testing.T) {
 							ID:   2,
 						},
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resourcesToClone...))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resourcesToClone...))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -2845,7 +2845,7 @@ func TestService(t *testing.T) {
 								ID:   tt.task.ID,
 								Name: tt.newName,
 							}
-							pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+							pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 							require.NoError(t, err)
 
 							newPkg := encodeAndDecode(t, pkg)
@@ -2899,7 +2899,7 @@ func TestService(t *testing.T) {
 							ID:   2,
 						},
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resourcesToClone...))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resourcesToClone...))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -2944,7 +2944,7 @@ func TestService(t *testing.T) {
 							ID:   2,
 						},
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resourcesToClone...))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resourcesToClone...))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -3044,7 +3044,7 @@ func TestService(t *testing.T) {
 							ID:   tt.expectedVar.ID,
 							Name: tt.newName,
 						}
-						pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+						pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 						require.NoError(t, err)
 
 						newPkg := encodeAndDecode(t, pkg)
@@ -3099,7 +3099,7 @@ func TestService(t *testing.T) {
 						Kind: KindBucket,
 						ID:   expected.ID,
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -3147,7 +3147,7 @@ func TestService(t *testing.T) {
 							ID:   20,
 						},
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resourcesToClone...))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resourcesToClone...))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -3189,7 +3189,7 @@ func TestService(t *testing.T) {
 						Kind: KindLabel,
 						ID:   1,
 					}
-					pkg, err := svc.CreatePkg(context.TODO(), CreateWithExistingResources(resToClone))
+					pkg, err := svc.Export(context.TODO(), ExportWithExistingResources(resToClone))
 					require.NoError(t, err)
 
 					newPkg := encodeAndDecode(t, pkg)
@@ -3370,9 +3370,9 @@ func TestService(t *testing.T) {
 				WithVariableSVC(varSVC),
 			)
 
-			pkg, err := svc.CreatePkg(
+			pkg, err := svc.Export(
 				context.TODO(),
-				CreateWithAllOrgResources(CreateByOrgIDOpt{
+				ExportWithAllOrgResources(ExportByOrgIDOpt{
 					OrgID: orgID,
 				}),
 			)

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -63,14 +63,14 @@ func (s *traceMW) Export(ctx context.Context, opts ...ExportOptFn) (pkg *Pkg, er
 	return s.next.Export(ctx, opts...)
 }
 
-func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()
 	return s.next.DryRun(ctx, orgID, userID, opts...)
 }
 
-func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {
+func (s *traceMW) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (ImpactSummary, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	span.LogKV("orgID", orgID.String(), "userID", userID.String())
 	defer span.Finish()

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -33,14 +33,6 @@ func (s *traceMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 	return s.next.DeleteStack(ctx, identifiers)
 }
 
-func (s *traceMW) ExportStack(ctx context.Context, orgID, stackID influxdb.ID) (*Pkg, error) {
-	span, ctx := tracing.StartSpanFromContext(ctx)
-	span.LogFields(log.String("org_id", orgID.String()))
-	span.LogFields(log.String("stack_id", stackID.String()))
-	defer span.Finish()
-	return s.next.ExportStack(ctx, orgID, stackID)
-}
-
 func (s *traceMW) ListStacks(ctx context.Context, orgID influxdb.ID, f ListFilter) ([]Stack, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
@@ -65,10 +57,10 @@ func (s *traceMW) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, erro
 	return s.next.UpdateStack(ctx, upd)
 }
 
-func (s *traceMW) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (pkg *Pkg, err error) {
+func (s *traceMW) Export(ctx context.Context, opts ...ExportOptFn) (pkg *Pkg, err error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
-	return s.next.CreatePkg(ctx, setters...)
+	return s.next.Export(ctx, opts...)
 }
 
 func (s *traceMW) DryRun(ctx context.Context, orgID, userID influxdb.ID, opts ...ApplyOptFn) (PkgImpactSummary, error) {


### PR DESCRIPTION
the Export behavior (renamed from CreatePkg) now provides for stackID as
another input. With this we are able to remove the additional endpoint
/api/v2/packages/stacks/:stack_id/export. It now fits into the
/api/v2/packages/export endpoint as another req body parameter. This also
makes all export functionality in teh same space, encapsulated both in the
endpoint and within the service layer :-).

references: #18646

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)