### PR TITLE
feat(influx): extend influx export command with ability to export stack

### DIFF
--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmdPkg(t *testing.T) {
+func Test_Template_Commands(t *testing.T) {
 	fakeSVCFn := func(svc pkger.SVC) pkgSVCsFn {
 		return func() (pkger.SVC, influxdb.OrganizationService, error) {
 			return svc, &mock.OrganizationService{
@@ -46,11 +46,11 @@ func TestCmdPkg(t *testing.T) {
 		expectedOrgID := influxdb.ID(9000)
 
 		tests := []struct {
-			pkgFileArgs
+			templateFileArgs
 			assertFn func(t *testing.T, pkg *pkger.Pkg)
 		}{
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "yaml out with org id",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -58,7 +58,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "yaml out with org name",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -66,7 +66,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "yaml out with org name env var",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -74,7 +74,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "yaml out with org id env var",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -82,7 +82,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "with labelName filter",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -101,7 +101,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "with multiple labelName filters",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -122,7 +122,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "with resourceKind filter",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -139,7 +139,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "with multiple resourceKind filter",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -159,7 +159,7 @@ func TestCmdPkg(t *testing.T) {
 				},
 			},
 			{
-				pkgFileArgs: pkgFileArgs{
+				templateFileArgs: templateFileArgs{
 					name:     "with mixed resourceKind and labelName filters",
 					encoding: pkger.EncodingYAML,
 					filename: "pkg_0.yml",
@@ -228,204 +228,250 @@ func TestCmdPkg(t *testing.T) {
 					return &pkg, nil
 				},
 			}
-			return newCmdPkgBuilder(fakeSVCFn(pkgSVC), f, opt).cmdApply()
+			return newCmdPkgBuilder(fakeSVCFn(pkgSVC), f, opt).cmdExport()
 		}
 
 		for _, tt := range tests {
-			tt.pkgFileArgs.args = append([]string{"pkg", "export", "all"}, tt.pkgFileArgs.args...)
+			tt.templateFileArgs.args = append([]string{"export", "all"}, tt.templateFileArgs.args...)
 			assertFn := defaultAssertFn
 			if tt.assertFn != nil {
 				assertFn = tt.assertFn
 			}
-			testPkgWrites(t, cmdFn, tt.pkgFileArgs, assertFn)
+			testPkgWrites(t, cmdFn, tt.templateFileArgs, assertFn)
 		}
 	})
 
 	t.Run("export resources", func(t *testing.T) {
-		tests := []struct {
-			name string
-			pkgFileArgs
-			bucketIDs   []influxdb.ID
-			dashIDs     []influxdb.ID
-			endpointIDs []influxdb.ID
-			labelIDs    []influxdb.ID
-			ruleIDs     []influxdb.ID
-			taskIDs     []influxdb.ID
-			telegrafIDs []influxdb.ID
-			varIDs      []influxdb.ID
-		}{
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "buckets",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+		t.Run("by resource", func(t *testing.T) {
+			tests := []struct {
+				name string
+				templateFileArgs
+				bucketIDs   []influxdb.ID
+				dashIDs     []influxdb.ID
+				endpointIDs []influxdb.ID
+				labelIDs    []influxdb.ID
+				ruleIDs     []influxdb.ID
+				taskIDs     []influxdb.ID
+				telegrafIDs []influxdb.ID
+				varIDs      []influxdb.ID
+				stackID     influxdb.ID
+			}{
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "buckets",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					bucketIDs: []influxdb.ID{1, 2},
 				},
-				bucketIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "dashboards",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "dashboards",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					dashIDs: []influxdb.ID{1, 2},
 				},
-				dashIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "endpoints",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "endpoints",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					endpointIDs: []influxdb.ID{1, 2},
 				},
-				endpointIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "labels",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "labels",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					labelIDs: []influxdb.ID{1, 2},
 				},
-				labelIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "rules",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "rules",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					ruleIDs: []influxdb.ID{1, 2},
 				},
-				ruleIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "tasks",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "tasks",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					taskIDs: []influxdb.ID{1, 2},
 				},
-				taskIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "telegrafs",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "telegrafs",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					telegrafIDs: []influxdb.ID{1, 2},
 				},
-				telegrafIDs: []influxdb.ID{1, 2},
-			},
-			{
-				pkgFileArgs: pkgFileArgs{
-					name:     "variables",
-					encoding: pkger.EncodingYAML,
-					filename: "pkg_0.yml",
-				},
-				varIDs: []influxdb.ID{1, 2},
-			},
-		}
-
-		cmdFn := func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
-			pkgSVC := &fakePkgSVC{
-				exportFn: func(_ context.Context, opts ...pkger.ExportOptFn) (*pkger.Pkg, error) {
-					var opt pkger.ExportOpt
-					for _, o := range opts {
-						if err := o(&opt); err != nil {
-							return nil, err
-						}
-					}
-
-					var pkg pkger.Pkg
-					for _, rc := range opt.Resources {
-						if rc.Kind == pkger.KindNotificationEndpoint {
-							rc.Kind = pkger.KindNotificationEndpointHTTP
-						}
-						name := strings.ToLower(rc.Kind.String()) + strconv.Itoa(int(rc.ID))
-						pkg.Objects = append(pkg.Objects, pkger.Object{
-							APIVersion: pkger.APIVersion,
-							Kind:       rc.Kind,
-							Metadata:   pkger.Resource{"name": name},
-						})
-					}
-
-					return &pkg, nil
+				{
+					templateFileArgs: templateFileArgs{
+						name:     "variables",
+						encoding: pkger.EncodingYAML,
+						filename: "pkg_0.yml",
+					},
+					varIDs: []influxdb.ID{1, 2},
 				},
 			}
 
-			builder := newCmdPkgBuilder(fakeSVCFn(pkgSVC), f, opt)
-			return builder.cmdApply()
-		}
-		for _, tt := range tests {
-			tt.args = append(tt.args,
-				"pkg", "export",
-				"--buckets="+idsStr(tt.bucketIDs...),
-				"--endpoints="+idsStr(tt.endpointIDs...),
-				"--dashboards="+idsStr(tt.dashIDs...),
-				"--labels="+idsStr(tt.labelIDs...),
-				"--rules="+idsStr(tt.ruleIDs...),
-				"--tasks="+idsStr(tt.taskIDs...),
-				"--telegraf-configs="+idsStr(tt.telegrafIDs...),
-				"--variables="+idsStr(tt.varIDs...),
-			)
+			cmdFn := func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+				pkgSVC := &fakePkgSVC{
+					exportFn: func(_ context.Context, opts ...pkger.ExportOptFn) (*pkger.Pkg, error) {
+						var opt pkger.ExportOpt
+						for _, o := range opts {
+							if err := o(&opt); err != nil {
+								return nil, err
+							}
+						}
 
-			testPkgWrites(t, cmdFn, tt.pkgFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
+						var pkg pkger.Pkg
+						for _, rc := range opt.Resources {
+							if rc.Kind == pkger.KindNotificationEndpoint {
+								rc.Kind = pkger.KindNotificationEndpointHTTP
+							}
+							name := strings.ToLower(rc.Kind.String()) + strconv.Itoa(int(rc.ID))
+							pkg.Objects = append(pkg.Objects, pkger.Object{
+								APIVersion: pkger.APIVersion,
+								Kind:       rc.Kind,
+								Metadata:   pkger.Resource{"name": name},
+							})
+						}
+
+						return &pkg, nil
+					},
+				}
+
+				builder := newCmdPkgBuilder(fakeSVCFn(pkgSVC), f, opt)
+				return builder.cmdExport()
+			}
+			for _, tt := range tests {
+				tt.args = append(tt.args,
+					"export",
+					"--buckets="+idsStr(tt.bucketIDs...),
+					"--endpoints="+idsStr(tt.endpointIDs...),
+					"--dashboards="+idsStr(tt.dashIDs...),
+					"--labels="+idsStr(tt.labelIDs...),
+					"--rules="+idsStr(tt.ruleIDs...),
+					"--tasks="+idsStr(tt.taskIDs...),
+					"--telegraf-configs="+idsStr(tt.telegrafIDs...),
+					"--variables="+idsStr(tt.varIDs...),
+				)
+
+				testPkgWrites(t, cmdFn, tt.templateFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
+					sum := pkg.Summary()
+
+					kindToName := func(k pkger.Kind, id influxdb.ID) string {
+						return strings.ToLower(k.String()) + strconv.Itoa(int(id))
+					}
+
+					require.Len(t, sum.Buckets, len(tt.bucketIDs))
+					for i, id := range tt.bucketIDs {
+						actual := sum.Buckets[i]
+						assert.Equal(t, kindToName(pkger.KindBucket, id), actual.Name)
+					}
+					require.Len(t, sum.Dashboards, len(tt.dashIDs))
+					for i, id := range tt.dashIDs {
+						actual := sum.Dashboards[i]
+						assert.Equal(t, kindToName(pkger.KindDashboard, id), actual.Name)
+					}
+					require.Len(t, sum.NotificationEndpoints, len(tt.endpointIDs))
+					for i, id := range tt.endpointIDs {
+						actual := sum.NotificationEndpoints[i]
+						assert.Equal(t, kindToName(pkger.KindNotificationEndpointHTTP, id), actual.NotificationEndpoint.GetName())
+					}
+					require.Len(t, sum.Labels, len(tt.labelIDs))
+					for i, id := range tt.labelIDs {
+						actual := sum.Labels[i]
+						assert.Equal(t, kindToName(pkger.KindLabel, id), actual.Name)
+					}
+					require.Len(t, sum.NotificationRules, len(tt.ruleIDs))
+					for i, id := range tt.ruleIDs {
+						actual := sum.NotificationRules[i]
+						assert.Equal(t, kindToName(pkger.KindNotificationRule, id), actual.Name)
+					}
+					require.Len(t, sum.Tasks, len(tt.taskIDs))
+					for i, id := range tt.taskIDs {
+						actual := sum.Tasks[i]
+						assert.Equal(t, kindToName(pkger.KindTask, id), actual.Name)
+					}
+					require.Len(t, sum.TelegrafConfigs, len(tt.telegrafIDs))
+					for i, id := range tt.telegrafIDs {
+						actual := sum.TelegrafConfigs[i]
+						assert.Equal(t, kindToName(pkger.KindTelegraf, id), actual.TelegrafConfig.Name)
+					}
+					require.Len(t, sum.Variables, len(tt.varIDs))
+					for i, id := range tt.varIDs {
+						actual := sum.Variables[i]
+						assert.Equal(t, kindToName(pkger.KindVariable, id), actual.Name)
+					}
+				})
+			}
+		})
+
+		t.Run("by stack", func(t *testing.T) {
+			cmdFn := func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+				pkgSVC := &fakePkgSVC{
+					exportFn: func(_ context.Context, opts ...pkger.ExportOptFn) (*pkger.Pkg, error) {
+						var opt pkger.ExportOpt
+						for _, o := range opts {
+							if err := o(&opt); err != nil {
+								return nil, err
+							}
+						}
+
+						if opt.StackID != 1 {
+							return nil, errors.New("wrong stack ID, got: " + opt.StackID.String())
+						}
+						return &pkger.Pkg{
+							Objects: []pkger.Object{
+								pkger.LabelToObject("", influxdb.Label{
+									Name: "label-1",
+								}),
+							},
+						}, nil
+					},
+				}
+
+				builder := newCmdPkgBuilder(fakeSVCFn(pkgSVC), f, opt)
+				return builder.cmdExport()
+			}
+
+			tmplFileArgs := templateFileArgs{
+				name:     "stack",
+				encoding: pkger.EncodingYAML,
+				filename: "pkg_0.yml",
+				args:     []string{"export", "--stack-id=" + influxdb.ID(1).String()},
+			}
+
+			testPkgWrites(t, cmdFn, tmplFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
 				sum := pkg.Summary()
 
-				kindToName := func(k pkger.Kind, id influxdb.ID) string {
-					return strings.ToLower(k.String()) + strconv.Itoa(int(id))
-				}
-
-				require.Len(t, sum.Buckets, len(tt.bucketIDs))
-				for i, id := range tt.bucketIDs {
-					actual := sum.Buckets[i]
-					assert.Equal(t, kindToName(pkger.KindBucket, id), actual.Name)
-				}
-				require.Len(t, sum.Dashboards, len(tt.dashIDs))
-				for i, id := range tt.dashIDs {
-					actual := sum.Dashboards[i]
-					assert.Equal(t, kindToName(pkger.KindDashboard, id), actual.Name)
-				}
-				require.Len(t, sum.NotificationEndpoints, len(tt.endpointIDs))
-				for i, id := range tt.endpointIDs {
-					actual := sum.NotificationEndpoints[i]
-					assert.Equal(t, kindToName(pkger.KindNotificationEndpointHTTP, id), actual.NotificationEndpoint.GetName())
-				}
-				require.Len(t, sum.Labels, len(tt.labelIDs))
-				for i, id := range tt.labelIDs {
-					actual := sum.Labels[i]
-					assert.Equal(t, kindToName(pkger.KindLabel, id), actual.Name)
-				}
-				require.Len(t, sum.NotificationRules, len(tt.ruleIDs))
-				for i, id := range tt.ruleIDs {
-					actual := sum.NotificationRules[i]
-					assert.Equal(t, kindToName(pkger.KindNotificationRule, id), actual.Name)
-				}
-				require.Len(t, sum.Tasks, len(tt.taskIDs))
-				for i, id := range tt.taskIDs {
-					actual := sum.Tasks[i]
-					assert.Equal(t, kindToName(pkger.KindTask, id), actual.Name)
-				}
-				require.Len(t, sum.TelegrafConfigs, len(tt.telegrafIDs))
-				for i, id := range tt.telegrafIDs {
-					actual := sum.TelegrafConfigs[i]
-					assert.Equal(t, kindToName(pkger.KindTelegraf, id), actual.TelegrafConfig.Name)
-				}
-				require.Len(t, sum.Variables, len(tt.varIDs))
-				for i, id := range tt.varIDs {
-					actual := sum.Variables[i]
-					assert.Equal(t, kindToName(pkger.KindVariable, id), actual.Name)
-				}
+				require.Len(t, sum.Labels, 1)
+				assert.Equal(t, "label-1", sum.Labels[0].Name)
 			})
-		}
+		})
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		t.Run("pkg is valid returns no error", func(t *testing.T) {
+		t.Run("template is valid returns no error", func(t *testing.T) {
 			builder := newInfluxCmdBuilder(
 				in(new(bytes.Buffer)),
 				out(ioutil.Discard),
 			)
 			cmd := builder.cmd(func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
-				return newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), f, opt).cmdApply()
+				return newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), f, opt).cmdTemplate()
 			})
 
 			cmd.SetArgs([]string{
-				"pkg",
+				"template",
 				"validate",
 				"--file=../../pkger/testdata/bucket.yml",
 				"-f=../../pkger/testdata/label.yml",
@@ -433,7 +479,7 @@ func TestCmdPkg(t *testing.T) {
 			require.NoError(t, cmd.Execute())
 		})
 
-		t.Run("pkg is invalid returns error", func(t *testing.T) {
+		t.Run("template is invalid returns error", func(t *testing.T) {
 			// pkgYml is invalid because it is missing a name and wrong apiVersion
 			const pkgYml = `apiVersion: 0.1.0
 	kind: Bucket
@@ -444,9 +490,9 @@ func TestCmdPkg(t *testing.T) {
 				out(ioutil.Discard),
 			)
 			cmd := builder.cmd(func(f *globalFlags, opt genericCLIOpts) *cobra.Command {
-				return newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), f, opt).cmdApply()
+				return newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), f, opt).cmdTemplate()
 			})
-			cmd.SetArgs([]string{"pkg", "validate"})
+			cmd.SetArgs([]string{"template", "validate"})
 
 			require.Error(t, cmd.Execute())
 		})
@@ -542,10 +588,10 @@ func TestCmdPkg(t *testing.T) {
 								return stack, nil
 							},
 						}
-						return newCmdPkgBuilder(fakeSVCFn(echoSVC), f, opt).cmdApply()
+						return newCmdPkgBuilder(fakeSVCFn(echoSVC), f, opt).cmdStacks()
 					})
 
-					baseArgs := []string{"pkg", "stack", "init", "--json"}
+					baseArgs := []string{"stacks", "init", "--json"}
 
 					rootCmd.SetArgs(append(baseArgs, tt.args...))
 
@@ -640,7 +686,7 @@ func Test_readFilesFromPath(t *testing.T) {
 	})
 }
 
-type pkgFileArgs struct {
+type templateFileArgs struct {
 	name     string
 	filename string
 	encoding pkger.Encoding
@@ -648,7 +694,7 @@ type pkgFileArgs struct {
 	envVars  map[string]string
 }
 
-func testPkgWrites(t *testing.T, newCmdFn func(*globalFlags, genericCLIOpts) *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) {
+func testPkgWrites(t *testing.T, newCmdFn func(*globalFlags, genericCLIOpts) *cobra.Command, args templateFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) {
 	t.Helper()
 
 	defer addEnvVars(t, args.envVars)()
@@ -667,7 +713,7 @@ func testPkgWrites(t *testing.T, newCmdFn func(*globalFlags, genericCLIOpts) *co
 	t.Run(path.Join(args.name, "buffer"), testPkgWritesToBuffer(wrappedCmdFn, args, assertFn))
 }
 
-func testPkgWritesFile(newCmdFn func(w io.Writer) *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
+func testPkgWritesFile(newCmdFn func(w io.Writer) *cobra.Command, args templateFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
@@ -688,7 +734,7 @@ func testPkgWritesFile(newCmdFn func(w io.Writer) *cobra.Command, args pkgFileAr
 	}
 }
 
-func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
+func testPkgWritesToBuffer(newCmdFn func(w io.Writer) *cobra.Command, args templateFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -1773,7 +1773,7 @@ func TestLauncher_Pkger(t *testing.T) {
 			}
 		})
 
-		t.Run("exporting the existing state of stack resources to a pkg", func(t *testing.T) {
+		t.Run("exporting the existing state of stack resources as template", func(t *testing.T) {
 			testStackApplyFn := func(t *testing.T) (pkger.Summary, pkger.Stack, func()) {
 				t.Helper()
 
@@ -2109,6 +2109,139 @@ func TestLauncher_Pkger(t *testing.T) {
 					assert.Contains(t, exportedSum.Buckets[0].LabelAssociations, expectedAssociation)
 				})
 			})
+		})
+
+		t.Run("exporting the existing state of plus others will update stack with template", func(t *testing.T) {
+			testStackApplyFn := func(t *testing.T) (pkger.Summary, pkger.Stack, func()) {
+				t.Helper()
+
+				stack, cleanup := newStackFn(t, pkger.Stack{})
+				defer func() {
+					if t.Failed() {
+						cleanup()
+					}
+				}()
+
+				var (
+					initialBucketPkgName = "rucketeer-1"
+					initialLabelPkgName  = "labelino"
+				)
+
+				labelObj := newLabelObject(initialLabelPkgName, "label 1", "init desc", "#222eee")
+				bktObj := newBucketObject(initialBucketPkgName, "display name", "init desc")
+				bktObj.AddAssociations(pkger.ObjectAssociation{
+					Kind:     pkger.KindLabel,
+					MetaName: labelObj.Name(),
+				})
+
+				initialPkg := newPkg(bktObj, labelObj)
+
+				impact, err := svc.Apply(ctx, l.Org.ID, l.User.ID,
+					pkger.ApplyWithPkg(initialPkg),
+					pkger.ApplyWithStackID(stack.ID),
+				)
+				require.NoError(t, err)
+
+				return impact.Summary, stack, cleanup
+			}
+
+			newLabel := &influxdb.Label{
+				OrgID: l.Org.ID,
+				Name:  "test-label-2",
+			}
+			require.NoError(t, l.kvService.CreateLabel(ctx, newLabel))
+
+			tests := []struct {
+				name string
+				opts []pkger.ExportOptFn
+			}{
+				{
+					name: "with resource kind",
+					opts: []pkger.ExportOptFn{
+						pkger.ExportWithExistingResources(pkger.ResourceToClone{
+							Kind: pkger.KindLabel,
+							ID:   newLabel.ID,
+						}),
+					},
+				},
+				{
+					name: "with org id",
+					opts: []pkger.ExportOptFn{
+						pkger.ExportWithAllOrgResources(pkger.ExportByOrgIDOpt{
+							OrgID: l.Org.ID,
+						}),
+					},
+				},
+				{
+					name: "with both resource and an org id",
+					opts: []pkger.ExportOptFn{
+						pkger.ExportWithExistingResources(pkger.ResourceToClone{
+							Kind: pkger.KindLabel,
+							ID:   newLabel.ID,
+						}),
+						pkger.ExportWithAllOrgResources(pkger.ExportByOrgIDOpt{
+							OrgID: l.Org.ID,
+						}),
+					},
+				},
+			}
+
+			initialSum, stack, cleanup := testStackApplyFn(t)
+
+			var cleanups []func()
+			cleanups = append(cleanups, cleanup)
+
+			for _, tt := range tests {
+				fn := func(t *testing.T) {
+					exportedTemplate, err := svc.Export(ctx,
+						append(tt.opts, pkger.ExportWithStackID(stack.ID), pkger.ExportWithStackUpdate())...,
+					)
+					require.NoError(t, err)
+
+					hasAssociation := func(t *testing.T, actual []pkger.SummaryLabel) {
+						t.Helper()
+						assert.Len(t, actual, 1, "unexpected number of label mappings")
+						if len(actual) != 1 {
+							return
+						}
+						assert.Equal(t, actual[0].PkgName, initialSum.Labels[0].PkgName)
+					}
+
+					sum := exportedTemplate.Summary()
+
+					require.Len(t, sum.Buckets, 1, "missing required buckets")
+					assert.Equal(t, initialSum.Buckets[0].PkgName, sum.Buckets[0].PkgName)
+					assert.Equal(t, initialSum.Buckets[0].Name, sum.Buckets[0].Name)
+					hasAssociation(t, sum.Buckets[0].LabelAssociations)
+
+					require.Len(t, sum.Labels, 2, "missing required labels")
+					assert.Contains(t, sum.Labels, pkger.SummaryLabel{
+						PkgName:       initialSum.Labels[0].PkgName,
+						Name:          initialSum.Labels[0].Name,
+						Properties:    initialSum.Labels[0].Properties,
+						EnvReferences: initialSum.Labels[0].EnvReferences,
+					})
+
+					func() {
+						for _, l := range sum.Labels {
+							if l.Name == "test-label-2" {
+								return
+							}
+						}
+						require.Fail(t, "failed to find test-label-2 label")
+					}()
+
+					updatedStack, err := svc.ReadStack(ctx, stack.ID)
+					require.NoError(t, err)
+
+					require.Len(t, updatedStack.Resources, 3)
+				}
+
+				t.Run(tt.name, fn)
+			}
+			for _, cleanup := range cleanups {
+				cleanup()
+			}
 		})
 	})
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7704,6 +7704,8 @@ components:
     PkgCreate:
       type: object
       properties:
+        shouldUpdateStack:
+          type: boolean
         stackID:
           type: string
         orgIDs:
@@ -8417,7 +8419,7 @@ components:
                   properties:
                     kind:
                       $ref: "#/components/schemas/TemplateKind"
-                    pkgName:
+                    metaName:
                       type: string
         urls:
           type: array

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -126,9 +126,10 @@ func (s *HTTPRemoteService) Export(ctx context.Context, opts ...ExportOptFn) (*P
 	}
 
 	reqBody := ReqExport{
-		StackID:   opt.StackID.String(),
-		OrgIDs:    orgIDs,
-		Resources: opt.Resources,
+		UpdateStack: opt.UpdateStack,
+		StackID:     opt.StackID.String(),
+		OrgIDs:      orgIDs,
+		Resources:   opt.Resources,
 	}
 
 	var newPkg *Pkg
@@ -244,10 +245,19 @@ func convertRespStackToStack(respStack RespStack) (Stack, error) {
 	}
 	for _, r := range respStack.Resources {
 		sr := StackResource{
-			APIVersion:   r.APIVersion,
-			MetaName:     r.MetaName,
-			Kind:         r.Kind,
-			Associations: r.Associations,
+			APIVersion: r.APIVersion,
+			MetaName:   r.MetaName,
+			Kind:       r.Kind,
+		}
+		for _, a := range r.Associations {
+			sra := StackResourceAssociation{
+				Kind:     a.Kind,
+				MetaName: a.MetaName,
+			}
+			if sra.MetaName == "" && a.PkgName != nil {
+				sra.MetaName = *a.PkgName
+			}
+			sr.Associations = append(sr.Associations, sra)
 		}
 
 		resID, err := influxdb.IDFromString(r.ID)

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -111,9 +111,9 @@ func (s *HTTPRemoteService) Export(ctx context.Context, opts ...ExportOptFn) (*P
 		return nil, err
 	}
 
-	var orgIDs []ReqCreateOrgIDOpt
+	var orgIDs []ReqExportOrgIDOpt
 	for _, org := range opt.OrgIDs {
-		orgIDs = append(orgIDs, ReqCreateOrgIDOpt{
+		orgIDs = append(orgIDs, ReqExportOrgIDOpt{
 			OrgID: org.OrgID.String(),
 			Filters: struct {
 				ByLabel        []string `json:"byLabel"`
@@ -125,7 +125,7 @@ func (s *HTTPRemoteService) Export(ctx context.Context, opts ...ExportOptFn) (*P
 		})
 	}
 
-	reqBody := ReqCreatePkg{
+	reqBody := ReqExport{
 		StackID:   opt.StackID.String(),
 		OrgIDs:    orgIDs,
 		Resources: opt.Resources,
@@ -167,7 +167,7 @@ func (s *HTTPRemoteService) Apply(ctx context.Context, orgID, userID influxdb.ID
 func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun bool, opts ...ApplyOptFn) (ImpactSummary, error) {
 	opt := applyOptFromOptFns(opts...)
 
-	var rawPkg ReqRawPkg
+	var rawPkg ReqRawTemplate
 	for _, pkg := range opt.Pkgs {
 		b, err := pkg.Encode(EncodingJSON)
 		if err != nil {
@@ -178,7 +178,7 @@ func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun
 		rawPkg.ContentType = EncodingJSON.String()
 	}
 
-	reqBody := ReqApplyPkg{
+	reqBody := ReqApply{
 		OrgID:       orgID.String(),
 		DryRun:      dryRun,
 		EnvRefs:     opt.EnvRefs,
@@ -211,7 +211,7 @@ func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun
 		})
 	}
 
-	var resp RespApplyPkg
+	var resp RespApply
 	err := s.Client.
 		PostJSON(reqBody, RoutePrefix, "/apply").
 		DecodeJSON(&resp).

--- a/pkger/http_server_test.go
+++ b/pkger/http_server_test.go
@@ -791,7 +791,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 								ID:           influxdb.ID(3).String(),
 								Kind:         pkger.KindBucket,
 								MetaName:     "rucketeer",
-								Associations: []pkger.StackResourceAssociation{},
+								Associations: []pkger.RespStackResourceAssoc{},
 							},
 						},
 					},

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -299,6 +299,10 @@ type ObjectAssociation struct {
 
 // AddAssociations adds an association to the object.
 func (k Object) AddAssociations(associations ...ObjectAssociation) {
+	if len(associations) == 0 {
+		return
+	}
+
 	if k.Spec == nil {
 		k.Spec = make(Resource)
 	}

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -471,8 +471,8 @@ func (s *stateCoordinator) reconcileLabelMappings(stackResources []StackResource
 		for _, l := range labels {
 			// we want to keep associations that are from previous application and are not changing
 			delete(mStackAss, StackResourceAssociation{
-				Kind:    KindLabel,
-				PkgName: l.parserLabel.PkgName(),
+				Kind:     KindLabel,
+				MetaName: l.parserLabel.PkgName(),
 			})
 		}
 
@@ -480,8 +480,8 @@ func (s *stateCoordinator) reconcileLabelMappings(stackResources []StackResource
 		// state fall into here and are marked for removal.
 		for assForRemoval := range mStackAss {
 			s.labelMappingsToRemove = append(s.labelMappingsToRemove, stateLabelMappingForRemoval{
-				LabelPkgName:    assForRemoval.PkgName,
-				LabelID:         mLabelPkgNameToID[assForRemoval.PkgName],
+				LabelPkgName:    assForRemoval.MetaName,
+				LabelID:         mLabelPkgNameToID[assForRemoval.MetaName],
 				ResourceID:      r.ID,
 				ResourcePkgName: r.MetaName,
 				ResourceType:    r.Kind.ResourceType(),
@@ -495,7 +495,7 @@ func (s *stateCoordinator) reconcileNotificationDependencies(stackResources []St
 		if r.Kind.is(KindNotificationRule) {
 			for _, ass := range r.Associations {
 				if ass.Kind.is(KindNotificationEndpoint) {
-					s.mRules[r.MetaName].associatedEndpoint = s.mEndpoints[ass.PkgName]
+					s.mRules[r.MetaName].associatedEndpoint = s.mEndpoints[ass.MetaName]
 					break
 				}
 			}
@@ -1193,8 +1193,8 @@ func (r *stateRule) endpointAssociation() StackResourceAssociation {
 		return StackResourceAssociation{}
 	}
 	return StackResourceAssociation{
-		Kind:    KindNotificationEndpoint,
-		PkgName: r.endpointPkgName(),
+		Kind:     KindNotificationEndpoint,
+		MetaName: r.endpointPkgName(),
 	}
 }
 

--- a/pkger/store.go
+++ b/pkger/store.go
@@ -302,7 +302,7 @@ func convertStackToEnt(stack Stack) (kv.Entity, error) {
 		for _, ass := range res.Associations {
 			associations = append(associations, entStackAssociation{
 				Kind: ass.Kind.String(),
-				Name: ass.PkgName,
+				Name: ass.MetaName,
 			})
 		}
 		stEnt.Resources = append(stEnt.Resources, entStackResource{
@@ -352,8 +352,8 @@ func convertStackEntToStack(ent *entStack) (Stack, error) {
 
 		for _, ass := range res.Associations {
 			stackRes.Associations = append(stackRes.Associations, StackResourceAssociation{
-				Kind:    Kind(ass.Kind),
-				PkgName: ass.Name,
+				Kind:     Kind(ass.Kind),
+				MetaName: ass.Name,
 			})
 		}
 

--- a/pkger/store_test.go
+++ b/pkger/store_test.go
@@ -39,8 +39,8 @@ func TestStoreKV(t *testing.T) {
 					Kind:       pkger.KindBucket,
 					MetaName:   "buzz lightyear",
 					Associations: []pkger.StackResourceAssociation{{
-						Kind:    pkger.KindLabel,
-						PkgName: "foo_label",
+						Kind:     pkger.KindLabel,
+						MetaName: "foo_label",
 					}},
 				},
 				{


### PR DESCRIPTION
this extends the export command with the ability to export by stack with additional resources that are not part of the stack as part of the template.  An example:

```
$ influx export --stack-id $STACK_ID --labels $UNASSOCIATED_LABEL_ID
# output is
# template that includes all of the stack plus the additional label
```

references: #18646


tip: ignore whitespace changes

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
