### PR TITLE
chore(pkger): drop remove diff field no longer in use

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -1286,9 +1286,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(l.ID, l.PkgName, l.New)
 			switch {
-			case l.IsNew():
+			case pkger.IsNew(l.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case l.Remove:
+			case pkger.IsRemoval(l.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1312,9 +1312,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(b.ID, b.PkgName, b.New)
 			switch {
-			case b.IsNew():
+			case pkger.IsNew(b.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case b.Remove:
+			case pkger.IsRemoval(b.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1342,9 +1342,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(c.ID, c.PkgName, c.New)
 			switch {
-			case c.IsNew():
+			case pkger.IsNew(c.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case c.Remove:
+			case pkger.IsRemoval(c.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1368,9 +1368,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(d.ID, d.PkgName, d.New)
 			switch {
-			case d.IsNew():
+			case pkger.IsNew(d.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case d.Remove:
+			case pkger.IsRemoval(d.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1398,9 +1398,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(e.ID, e.PkgName, e.New)
 			switch {
-			case e.IsNew():
+			case pkger.IsNew(e.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case e.Remove:
+			case pkger.IsRemoval(e.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1440,9 +1440,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(e.ID, e.PkgName, e.New)
 			switch {
-			case e.IsNew():
+			case pkger.IsNew(e.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case e.Remove:
+			case pkger.IsRemoval(e.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1465,9 +1465,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(e.ID, e.PkgName, e.New)
 			switch {
-			case e.IsNew():
+			case pkger.IsNew(e.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case e.Remove:
+			case pkger.IsRemoval(e.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1497,9 +1497,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(e.ID, e.PkgName, e.New)
 			switch {
-			case e.IsNew():
+			case pkger.IsNew(e.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case e.Remove:
+			case pkger.IsRemoval(e.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)
@@ -1527,9 +1527,9 @@ func (b *cmdPkgBuilder) printPkgDiff(diff pkger.Diff) error {
 
 			newRow := appendValues(v.ID, v.PkgName, v.New)
 			switch {
-			case v.IsNew():
+			case pkger.IsNew(v.StateStatus):
 				printer.AppendDiff(nil, newRow)
-			case v.Remove:
+			case pkger.IsRemoval(v.StateStatus):
 				printer.AppendDiff(oldRow, nil)
 			default:
 				printer.AppendDiff(oldRow, newRow)

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -140,7 +140,6 @@ func (s SafeID) String() string {
 // dictates if the resource is new, to be removed, or will remain.
 type DiffIdentifier struct {
 	ID          SafeID      `json:"id"`
-	Remove      bool        `json:"bool"`
 	StateStatus StateStatus `json:"stateStatus"`
 	PkgName     string      `json:"pkgName"`
 }

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -725,7 +725,6 @@ func (b *stateBucket) diffBucket() DiffBucket {
 	diff := DiffBucket{
 		DiffIdentifier: DiffIdentifier{
 			ID:          SafeID(b.ID()),
-			Remove:      IsRemoval(b.stateStatus),
 			StateStatus: b.stateStatus,
 			PkgName:     b.parserBkt.PkgName(),
 		},
@@ -834,7 +833,6 @@ func (c *stateCheck) diffCheck() DiffCheck {
 	diff := DiffCheck{
 		DiffIdentifier: DiffIdentifier{
 			ID:          SafeID(c.ID()),
-			Remove:      IsRemoval(c.stateStatus),
 			StateStatus: c.stateStatus,
 			PkgName:     c.parserCheck.PkgName(),
 		},
@@ -899,7 +897,6 @@ func (d *stateDashboard) diffDashboard() DiffDashboard {
 	diff := DiffDashboard{
 		DiffIdentifier: DiffIdentifier{
 			ID:          SafeID(d.ID()),
-			Remove:      IsRemoval(d.stateStatus),
 			StateStatus: d.stateStatus,
 			PkgName:     d.parserDash.PkgName(),
 		},
@@ -967,9 +964,7 @@ type stateLabel struct {
 func (l *stateLabel) diffLabel() DiffLabel {
 	diff := DiffLabel{
 		DiffIdentifier: DiffIdentifier{
-			ID: SafeID(l.ID()),
-			// TODO: axe Remove field when StateStatus is adopted
-			Remove:      IsRemoval(l.stateStatus),
+			ID:          SafeID(l.ID()),
 			StateStatus: l.stateStatus,
 			PkgName:     l.parserLabel.PkgName(),
 		},
@@ -1121,7 +1116,6 @@ func (e *stateEndpoint) diffEndpoint() DiffNotificationEndpoint {
 	diff := DiffNotificationEndpoint{
 		DiffIdentifier: DiffIdentifier{
 			ID:          SafeID(e.ID()),
-			Remove:      IsRemoval(e.stateStatus),
 			StateStatus: e.stateStatus,
 			PkgName:     e.parserEndpoint.PkgName(),
 		},
@@ -1201,9 +1195,9 @@ func (r *stateRule) endpointAssociation() StackResourceAssociation {
 func (r *stateRule) diffRule() DiffNotificationRule {
 	sum := DiffNotificationRule{
 		DiffIdentifier: DiffIdentifier{
-			ID:      SafeID(r.ID()),
-			Remove:  IsRemoval(r.stateStatus),
-			PkgName: r.parserRule.PkgName(),
+			ID:          SafeID(r.ID()),
+			StateStatus: r.stateStatus,
+			PkgName:     r.parserRule.PkgName(),
 		},
 		New: DiffNotificationRuleValues{
 			Name:            r.parserRule.Name(),
@@ -1356,9 +1350,9 @@ func (t *stateTask) ID() influxdb.ID {
 func (t *stateTask) diffTask() DiffTask {
 	diff := DiffTask{
 		DiffIdentifier: DiffIdentifier{
-			ID:      SafeID(t.ID()),
-			Remove:  IsRemoval(t.stateStatus),
-			PkgName: t.parserTask.PkgName(),
+			ID:          SafeID(t.ID()),
+			StateStatus: t.stateStatus,
+			PkgName:     t.parserTask.PkgName(),
 		},
 		New: DiffTaskValues{
 			Name:        t.parserTask.Name(),
@@ -1432,9 +1426,9 @@ func (t *stateTelegraf) ID() influxdb.ID {
 func (t *stateTelegraf) diffTelegraf() DiffTelegraf {
 	return DiffTelegraf{
 		DiffIdentifier: DiffIdentifier{
-			ID:      SafeID(t.ID()),
-			Remove:  IsRemoval(t.stateStatus),
-			PkgName: t.parserTelegraf.PkgName(),
+			ID:          SafeID(t.ID()),
+			StateStatus: t.stateStatus,
+			PkgName:     t.parserTelegraf.PkgName(),
 		},
 		New: t.parserTelegraf.config,
 		Old: t.existing,
@@ -1487,7 +1481,6 @@ func (v *stateVariable) diffVariable() DiffVariable {
 	diff := DiffVariable{
 		DiffIdentifier: DiffIdentifier{
 			ID:          SafeID(v.ID()),
-			Remove:      IsRemoval(v.stateStatus),
 			StateStatus: v.stateStatus,
 			PkgName:     v.parserVar.PkgName(),
 		},


### PR DESCRIPTION
this was missed in a previous PR wehre we added the status in place of the
remove boolean flag

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass