### PR TITLE
fix(pkger): update handling of diff dashboard charts

### DIFF
--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -823,7 +823,7 @@ func DashboardToObject(name string, dash influxdb.Dashboard) Object {
 
 	charts := make([]Resource, 0, len(dash.Cells))
 	for _, cell := range dash.Cells {
-		if cell.ID == influxdb.ID(0) {
+		if cell.View == nil {
 			continue
 		}
 		ch := convertCellView(*cell)

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -260,6 +260,19 @@ type (
 // the SummaryChart is reused here.
 type DiffChart SummaryChart
 
+func (d *DiffChart) MarshalJSON() ([]byte, error) {
+	return json.Marshal((*SummaryChart)(d))
+}
+
+func (d *DiffChart) UnmarshalJSON(b []byte) error {
+	var sumChart SummaryChart
+	if err := json.Unmarshal(b, &sumChart); err != nil {
+		return err
+	}
+	*d = DiffChart(sumChart)
+	return nil
+}
+
 type (
 	// DiffLabel is a diff of an individual label.
 	DiffLabel struct {
@@ -519,7 +532,7 @@ func (s *SummaryChart) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// UnmarshalJSON unmarshals a view properities and other data.
+// UnmarshalJSON unmarshals a view properties and other data.
 func (s *SummaryChart) UnmarshalJSON(b []byte) error {
 	type alias SummaryChart
 	a := (*alias)(s)


### PR DESCRIPTION
backfilling a blind sopt in pkger. The diff dashboard charts were not working correctly across RPC boundaries. The marshal/unmarshal stuffs was off.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass