### PR TITLE
chore(pkger): convert packages endpoints into new naming convention

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -1019,10 +1019,10 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		pkgSVC = pkger.MWAuth(authAgent)(pkgSVC)
 	}
 
-	var pkgHTTPServer *pkger.HTTPServer
+	var pkgHTTPServer *pkger.HTTPServerPackages
 	{
 		pkgServerLogger := m.log.With(zap.String("handler", "pkger"))
-		pkgHTTPServer = pkger.NewHTTPServer(pkgServerLogger, pkgSVC)
+		pkgHTTPServer = pkger.NewHTTPServerPackages(pkgServerLogger, pkgSVC)
 	}
 
 	var userHTTPServer *tenant.UserHandler

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -26,7 +26,7 @@ func (s *HTTPRemoteService) InitStack(ctx context.Context, userID influxdb.ID, s
 
 	var respBody RespStack
 	err := s.Client.
-		PostJSON(reqBody, RoutePrefix, "/stacks").
+		PostJSON(reqBody, RoutePrefixPackages, "/stacks").
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -38,7 +38,7 @@ func (s *HTTPRemoteService) InitStack(ctx context.Context, userID influxdb.ID, s
 
 func (s *HTTPRemoteService) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	return s.Client.
-		Delete(RoutePrefix, "stacks", identifiers.StackID.String()).
+		Delete(RoutePrefixPackages, "stacks", identifiers.StackID.String()).
 		QueryParams([2]string{"orgID", identifiers.OrgID.String()}).
 		Do(ctx)
 }
@@ -54,7 +54,7 @@ func (s *HTTPRemoteService) ListStacks(ctx context.Context, orgID influxdb.ID, f
 
 	var resp RespListStacks
 	err := s.Client.
-		Get(RoutePrefix, "/stacks").
+		Get(RoutePrefixPackages, "/stacks").
 		QueryParams(queryParams...).
 		DecodeJSON(&resp).
 		Do(ctx)
@@ -76,7 +76,7 @@ func (s *HTTPRemoteService) ListStacks(ctx context.Context, orgID influxdb.ID, f
 func (s *HTTPRemoteService) ReadStack(ctx context.Context, id influxdb.ID) (Stack, error) {
 	var respBody RespStack
 	err := s.Client.
-		Get(RoutePrefix, "/stacks", id.String()).
+		Get(RoutePrefixPackages, "/stacks", id.String()).
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -101,7 +101,7 @@ func (s *HTTPRemoteService) UpdateStack(ctx context.Context, upd StackUpdate) (S
 
 	var respBody RespStack
 	err := s.Client.
-		PatchJSON(reqBody, RoutePrefix, "/stacks", upd.ID.String()).
+		PatchJSON(reqBody, RoutePrefixPackages, "/stacks", upd.ID.String()).
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *HTTPRemoteService) Export(ctx context.Context, opts ...ExportOptFn) (*P
 
 	var newPkg *Pkg
 	err = s.Client.
-		PostJSON(reqBody, RoutePrefix).
+		PostJSON(reqBody, RoutePrefixPackages).
 		Decode(func(resp *http.Response) error {
 			pkg, err := Parse(EncodingJSON, FromReader(resp.Body, "export"))
 			newPkg = pkg
@@ -220,7 +220,7 @@ func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun
 
 	var resp RespApply
 	err := s.Client.
-		PostJSON(reqBody, RoutePrefix, "/apply").
+		PostJSON(reqBody, RoutePrefixPackages, "/apply").
 		DecodeJSON(&resp).
 		Do(ctx)
 	if err != nil {

--- a/pkger/http_server_packages_deprecated_test.go
+++ b/pkger/http_server_packages_deprecated_test.go
@@ -64,7 +64,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 				}, nil
 			}
 			svc := pkger.NewService(pkger.WithLabelSVC(fakeLabelSVC))
-			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+			pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			testttp.
@@ -94,7 +94,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 		})
 
 		t.Run("should be invalid if not org ids or resources provided", func(t *testing.T) {
-			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), nil)
+			pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), nil)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			testttp.
@@ -183,7 +183,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -251,7 +251,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					body := newReqApplyYMLBody(t, influxdb.ID(9000), true)
@@ -372,7 +372,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -442,7 +442,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						},
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -491,7 +491,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 			},
 		}
 
-		pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+		pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 		svr := newMountedHandler(pkgHandler, 1)
 
 		testttp.
@@ -523,7 +523,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 					return stack, nil
 				},
 			}
-			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+			pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			reqBody := pkger.ReqCreateStack{
@@ -607,7 +607,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						}
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -662,7 +662,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 					}}, nil
 				},
 			}
-			pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+			pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 			svr := newMountedHandler(pkgHandler, 1)
 
 			tests := []struct {
@@ -837,7 +837,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 							return tt.stub, nil
 						},
 					}
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -891,7 +891,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						}
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -1001,7 +1001,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 							return st, nil
 						},
 					}
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.
@@ -1055,7 +1055,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 						}
 					}
 
-					pkgHandler := pkger.NewHTTPServer(zap.NewNop(), svc)
+					pkgHandler := pkger.NewHTTPServerPackages(zap.NewNop(), svc)
 					svr := newMountedHandler(pkgHandler, 1)
 
 					testttp.


### PR DESCRIPTION
note: going to make this evolution in two steps so that we have a simple
rollback to get back to a working state. We'll be maintaining both packages
and the new templates and stacks endpoints for a while as users start to
move onto a newer CLI version. Sunsetting by end of July.

references: #18580

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
