### PR TITLE
fix: update templates contents to handle empty collections

### DIFF
--- a/ui/src/templates/components/CommunityTemplateListGroup.tsx
+++ b/ui/src/templates/components/CommunityTemplateListGroup.tsx
@@ -16,7 +16,7 @@ import {
 
 interface Props {
   title: string
-  count?: string
+  count: number
   children?: ReactNode
 }
 
@@ -44,13 +44,11 @@ const CommunityTemplateListGroup: FC<Props> = ({title, count, children}) => {
           <Icon glyph={IconFont.CaretRight} />
         </div>
         <Heading element={HeadingElement.H5}>{title}</Heading>
-        {count && (
-          <Heading
-            element={HeadingElement.Div}
-            appearance={HeadingElement.H6}
-            className="community-templates--list-counter"
-          >{`(${count})`}</Heading>
-        )}
+        <Heading
+          element={HeadingElement.Div}
+          appearance={HeadingElement.H6}
+          className="community-templates--list-counter"
+        >{`(${count})`}</Heading>
       </div>
       {mode === 'expanded' && (
         <FlexBox

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -65,7 +65,17 @@ export const templatesReducer = (
       case SET_ACTIVE_COMMUNITY_TEMPLATE: {
         const {template} = action
 
-        draftState.activeCommunityTemplate = template
+        const activeCommunityTemplate: CommunityTemplate = {}
+        activeCommunityTemplate.dashboards = template.dashboards || []
+        activeCommunityTemplate.telegrafConfigs = template.telegrafConfigs || []
+        activeCommunityTemplate.buckets = template.buckets || []
+        activeCommunityTemplate.checks = template.checks || []
+        activeCommunityTemplate.variables = template.variables || []
+        activeCommunityTemplate.notificationRules =
+          template.notificationRules || []
+        activeCommunityTemplate.labels = template.labels || []
+
+        draftState.activeCommunityTemplate = activeCommunityTemplate
         return
       }
 


### PR DESCRIPTION
Template resource collections are made into empty arrays.

Guards against empty or `null` collections coming back from the API.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
