### PR TITLE
feat(cmd/influx/write): add new processing options and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 
 ### Features
 
+1. [18779](https://github.com/influxdata/influxdb/pull/18779): Add new processing options and enhancements to influx write.
 1. [19246](https://github.com/influxdata/influxdb/pull/19246): Redesign load data page to increase discovery and ease of use
 1. [19334](https://github.com/influxdata/influxdb/pull/19334): Add --active-config flag to influx to set config for single command
 1. [19219](https://github.com/influxdata/influxdb/pull/19219): List buckets via the API now supports after (ID) parameter as an alternative to offset.

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -88,7 +88,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&writeFlags.IgnoreDataTypeInColumnName, "xIgnoreDataTypeInColumnName", false, "Ignores dataType which could be specified after ':' in column name")
 	cmd.PersistentFlags().MarkHidden("xIgnoreDataTypeInColumnName") // should be used only upon explicit advice
 	cmd.PersistentFlags().StringVar(&writeFlags.Encoding, "encoding", "UTF-8", "Character encoding of input files or stdin")
-	cmd.PersistentFlags().StringVar(&writeFlags.ErrorsFile, "errors-file", "", "The path to the file to write rejected rows")
+	cmd.PersistentFlags().StringVar(&writeFlags.ErrorsFile, "errors-file", "", "The path to the file to write rejected rows to")
 
 	cmdDryRun := opt.newCmd("dryrun", fluxWriteDryrunF, false)
 	cmdDryRun.Args = cobra.MaximumNArgs(1)

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -56,6 +56,7 @@ func readLines(reader io.Reader) []string {
 
 func createTempFile(suffix string, contents []byte) string {
 	file, err := ioutil.TempFile("", "influx_writeTest*."+suffix)
+	file.Close() // Close immediatelly, since we need only a file name
 	if err != nil {
 		log.Fatal(err)
 		return "unknown.file"
@@ -544,4 +545,20 @@ func Test_fluxWriteF(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, "stdin3 i=stdin1,j=stdin2,k=stdin4", strings.Trim(string(lineData), "\n"))
 	})
+}
+
+// Test_writeFlags_errorsFile tests that rejected rows are written to errors file
+func Test_writeFlags_errorsFile(t *testing.T) {
+	defer removeTempFiles()
+	errorsFile := createTempFile("errors", []byte{})
+	stdInContents := "_measurement,a|long:strict\nm,1\nm,1.1"
+	out := bytes.Buffer{}
+	command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
+	command.SetArgs([]string{"dryrun", "--format", "csv", "--errors-file", errorsFile})
+	err := command.Execute()
+	require.Nil(t, err)
+	require.Equal(t, "m a=1i", strings.Trim(out.String(), "\n"))
+	errorLines, err := ioutil.ReadFile(errorsFile)
+	require.Nil(t, err)
+	require.Equal(t, "# error : line 3: column 'a': '1.1' cannot fit into long data type\nm,1.1", strings.Trim(string(errorLines), "\n"))
 }

--- a/pkg/csv2lp/README.md
+++ b/pkg/csv2lp/README.md
@@ -139,6 +139,11 @@ Existing [data types](https://v2.docs.influxdata.com/v2.0/reference/syntax/annot
 - `#constant` annotation adds a constant column to the data, so you can set measurement, time, field or tag of every row you import 
    - the format of a constant annotation row is `#constant,datatype,name,value`', it contains supported datatype, a column name, and a constant value
    - _column name_ can be omitted for _dateTime_ or _measurement_ columns, so the annotation can be simply `#constant,measurement,cpu`
+- `#concat` annotation adds a new column that is concatenated from existing columns according to a template
+   - the format of a concat annotation row is `#concat,datatype,name,template`', it contains supported datatype, a column name, and a template value
+   - the `template` is a string with `${columnName}` placeholders, in which the placeholders are replaced by values of existing columns
+      - for example: `#concat,string,fullName,${firstName} ${lastName}`
+   - _column name_ can be omitted for _dateTime_ or _measurement_ columns
 - `#timezone` annotation specifies the time zone of the data using an offset, which is either `+hhmm` or `-hhmm` or `Local` to use the local/computer time zone. Examples:  _#timezone,+0100_  _#timezone -0500_ _#timezone Local_
 
 #### Data type with data format

--- a/pkg/csv2lp/README.md
+++ b/pkg/csv2lp/README.md
@@ -158,6 +158,9 @@ All data types can include the format that is used to parse column data. It is t
    - note that you have to quote column delimiters whenever they appear in a CSV column value, for example:
       - `#constant,"double:,.",myColumn,"1.234,011"`
 - `long:format` and `unsignedLong:format` support the same format as `double`, but everything after and including a fraction character is ignored
+   - the format can be prepended with `strict` to fail when a fraction digit is present, for example:
+      - `1000.000` is `1000` when parsed as `long`, but fails when parsed as `long:strict`
+      - `1_000,000` is `1000` when parsed as `long:,_`, but fails when parsed as `long:strict,_`
 - `boolean:truthy:falsy`
    - `truthy` and `falsy` are comma-separated lists of values, they can be empty to assume all values as truthy/falsy; for example `boolean:sí,yes,ja,oui,ano,да:no,nein,non,ne,нет` 
    - a  `boolean` data type (without the format) parses column values that start with any of _tTyY1_ as `true` values, _fFnN0_ as `false` values and fails on other values

--- a/pkg/csv2lp/csv2lp.go
+++ b/pkg/csv2lp/csv2lp.go
@@ -23,7 +23,7 @@ func (e CsvLineError) Error() string {
 	return fmt.Sprintf("%v", e.Err)
 }
 
-// CreateRowColumnError creates adds row number and column name to the error supplied
+// CreateRowColumnError wraps an existing error to add line and column coordinates
 func CreateRowColumnError(line int, columnLabel string, err error) CsvLineError {
 	return CsvLineError{
 		Line: line,

--- a/pkg/csv2lp/csv2lp_test.go
+++ b/pkg/csv2lp/csv2lp_test.go
@@ -218,6 +218,10 @@ func Test_CsvLineError(t *testing.T) {
 			CsvLineError{Line: 2, Err: CsvColumnError{"a", errors.New("cause")}},
 			"line 2: column 'a': cause",
 		},
+		{
+			CsvLineError{Line: -1, Err: CsvColumnError{"a", errors.New("cause")}},
+			"column 'a': cause",
+		},
 	}
 	for _, test := range tests {
 		require.Equal(t, test.value, test.err.Error())

--- a/pkg/csv2lp/csv2lp_test.go
+++ b/pkg/csv2lp/csv2lp_test.go
@@ -204,38 +204,66 @@ func Test_CsvToLineProtocol_SkipRowOnError(t *testing.T) {
 	require.Equal(t, messages, 2)
 }
 
-// Test_CsvToLineProtocol_RowSkipped tests that error rows are reported to configured RowSkippedListener
+// Test_CsvToLineProtocol_RowSkipped tests that error rows are reported to configured RowSkipped listener
 func Test_CsvToLineProtocol_RowSkipped(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	oldFlags := log.Flags()
 	log.SetFlags(0)
-	oldPrefix := log.Prefix()
-	prefix := "::PREFIX::"
-	log.SetPrefix(prefix)
 	defer func() {
 		log.SetOutput(os.Stderr)
 		log.SetFlags(oldFlags)
-		log.SetPrefix(oldPrefix)
 	}()
 
+	type ActualArguments = struct {
+		src *CsvToLineReader
+		err error
+		row []string
+	}
+	type ExpectedArguments = struct {
+		errorString string
+		row         []string
+	}
+
 	csv := "sep=;\n_measurement;a|long:strict\n;1\ncpu;2.1\ncpu;3a\n"
+	calledArgs := []ActualArguments{}
+	expectedArgs := []ExpectedArguments{
+		{
+			"line 3: column '_measurement': no measurement supplied",
+			[]string{"", "1"},
+		},
+		{
+			"line 4: column 'a': '2.1' cannot fit into long data type",
+			[]string{"cpu", "2.1"},
+		},
+		{
+			"line 5: column 'a': strconv.ParseInt:",
+			[]string{"cpu", "3a"},
+		},
+	}
 
 	reader := CsvToLineProtocol(strings.NewReader(csv)).SkipRowOnError(true)
 	reader.RowSkipped = func(src *CsvToLineReader, err error, _row []string) {
-		log.Println(err, string(src.Comma()))
+		// make a copy of _row
+		row := make([]string, len(_row))
+		copy(row, _row)
+		// remember for comparison
+		calledArgs = append(calledArgs, ActualArguments{
+			src, err, row,
+		})
 	}
 	// read all the data
 	ioutil.ReadAll(reader)
 
 	out := buf.String()
-	// fmt.Println(out, string(';'))
-	// ::PREFIX::line 3: column '_measurement': no measurement supplied
-	// ::PREFIX::line 4: column 'a': '2.1' cannot fit into long data type
-	// ::PREFIX::line 5: column 'a': strconv.ParseInt: parsing "3a": invalid syntax
-	messages := strings.Count(out, prefix)
-	require.Equal(t, 3, messages)
-	require.Equal(t, 3, strings.Count(out, ";"))
+	require.Empty(t, out, "No log messages expected because RowSkipped handler is set")
+
+	require.Len(t, calledArgs, 3)
+	for i, expected := range expectedArgs {
+		require.Equal(t, reader, calledArgs[i].src)
+		require.Contains(t, calledArgs[i].err.Error(), expected.errorString)
+		require.Equal(t, expected.row, calledArgs[i].row)
+	}
 }
 
 // Test_CsvLineError tests CsvLineError error format

--- a/pkg/csv2lp/csv_annotations.go
+++ b/pkg/csv2lp/csv_annotations.go
@@ -112,7 +112,7 @@ func concatSetupTable(table *CsvTable, row []string) error {
 	}
 	// add a virtual column to the table
 	table.extraColumns = append(table.extraColumns, &col)
-	// add validator to report error when no placeholder column is not available
+	// add validator to report error when no placeholder column is available
 	table.validators = append(table.validators, func(table *CsvTable) error {
 		placeholders := computedReplacer.FindAllString(template, len(template))
 		for _, placeholder := range placeholders {

--- a/pkg/csv2lp/csv_annotations.go
+++ b/pkg/csv2lp/csv_annotations.go
@@ -114,9 +114,6 @@ func concatSetupTable(table *CsvTable, row []string) error {
 		placeholders := computedReplacer.FindAllString(template, len(template))
 		for _, placeholder := range placeholders {
 			columnLabel := placeholder[2 : len(placeholder)-1] // ${columnLabel}
-			if columnLabel == "$" {
-				return nil
-			}
 			if placeholderColumn := table.Column(columnLabel); placeholderColumn == nil {
 				return CsvColumnError{
 					Column: col.Label,

--- a/pkg/csv2lp/csv_annotations_test.go
+++ b/pkg/csv2lp/csv_annotations_test.go
@@ -169,7 +169,7 @@ func Test_ConcatAnnotation(t *testing.T) {
 		{[]string{"dateTime", "3", ""}, "_", "3", linePartTime},
 		{[]string{"long", "fN", "fV"}, "fN", "fV", 0},
 		// concat values
-		{[]string{"string", "fN", "${$}-${b}-${a}"}, "fN", "$-2-1", 0},
+		{[]string{"string", "fN", "$-${b}-${a}"}, "fN", "$-2-1", 0},
 	}
 	exampleRow := []string{"1", "2"}
 	for i, test := range tests {

--- a/pkg/csv2lp/csv_table.go
+++ b/pkg/csv2lp/csv_table.go
@@ -46,7 +46,7 @@ type CsvTableColumn struct {
 	// TimeZone of dateTime column, applied when parsing dateTime DataType
 	TimeZone *time.Location
 	// ParseF is an optional function used to convert column's string value to interface{}
-	ParseF func(string) (interface{}, error)
+	ParseF func(value string, lineNumber int) (interface{}, error)
 
 	// escapedLabel contains escaped label that can be directly used in line protocol
 	escapedLabel string

--- a/pkg/csv2lp/csv_table.go
+++ b/pkg/csv2lp/csv_table.go
@@ -46,7 +46,7 @@ type CsvTableColumn struct {
 	// TimeZone of dateTime column, applied when parsing dateTime DataType
 	TimeZone *time.Location
 	// ParseF is an optional function used to convert column's string value to interface{}
-	ParseF func(value string, lineNumber int) (interface{}, error)
+	ParseF func(value string) (interface{}, error)
 
 	// escapedLabel contains escaped label that can be directly used in line protocol
 	escapedLabel string
@@ -126,9 +126,18 @@ func (c *CsvTableColumn) setupDataType(columnValue string) {
 	// setup column data type
 	c.DataType = columnValue
 
-	// setup custom parsing of bool data type
+	// setup custom parsing
 	if c.DataType == boolDatatype && c.DataFormat != "" {
 		c.ParseF = createBoolParseFn(c.DataFormat)
+		return
+	}
+	if c.DataType == longDatatype && strings.HasPrefix(c.DataFormat, "strict") {
+		c.ParseF = createStrictLongParseFn(c.DataFormat[6:])
+		return
+	}
+	if c.DataType == uLongDatatype && strings.HasPrefix(c.DataFormat, "strict") {
+		c.ParseF = createStrictUnsignedLongParseFn(c.DataFormat[6:])
+		return
 	}
 }
 

--- a/pkg/csv2lp/csv_table.go
+++ b/pkg/csv2lp/csv_table.go
@@ -391,7 +391,7 @@ func (t *CsvTable) recomputeLineProtocolColumns() {
 // CreateLine produces a protocol line out of the supplied row or returns error
 func (t *CsvTable) CreateLine(row []string) (line string, err error) {
 	buffer := make([]byte, 100)[:0]
-	buffer, err = t.AppendLine(buffer, row)
+	buffer, err = t.AppendLine(buffer, row, -1)
 	if err != nil {
 		return "", err
 	}
@@ -399,7 +399,7 @@ func (t *CsvTable) CreateLine(row []string) (line string, err error) {
 }
 
 // AppendLine appends a protocol line to the supplied buffer using a CSV row and returns appended buffer or an error if any
-func (t *CsvTable) AppendLine(buffer []byte, row []string) ([]byte, error) {
+func (t *CsvTable) AppendLine(buffer []byte, row []string, lineNumber int) ([]byte, error) {
 	if t.computeLineProtocolColumns() {
 		// validate column data types
 		if t.cachedFieldValue != nil && !IsTypeSupported(t.cachedFieldValue.DataType) {
@@ -447,7 +447,7 @@ func (t *CsvTable) AppendLine(buffer []byte, row []string) ([]byte, error) {
 			buffer = append(buffer, escapeTag(field)...)
 			buffer = append(buffer, '=')
 			var err error
-			buffer, err = appendConverted(buffer, value, t.cachedFieldValue)
+			buffer, err = appendConverted(buffer, value, t.cachedFieldValue, lineNumber)
 			if err != nil {
 				return buffer, CsvColumnError{
 					t.cachedFieldName.Label,
@@ -468,7 +468,7 @@ func (t *CsvTable) AppendLine(buffer []byte, row []string) ([]byte, error) {
 			buffer = append(buffer, field.LineLabel()...)
 			buffer = append(buffer, '=')
 			var err error
-			buffer, err = appendConverted(buffer, value, field)
+			buffer, err = appendConverted(buffer, value, field, lineNumber)
 			if err != nil {
 				return buffer, CsvColumnError{
 					field.Label,
@@ -491,7 +491,7 @@ func (t *CsvTable) AppendLine(buffer []byte, row []string) ([]byte, error) {
 			}
 			buffer = append(buffer, ' ')
 			var err error
-			buffer, err = appendConverted(buffer, timeVal, t.cachedTime)
+			buffer, err = appendConverted(buffer, timeVal, t.cachedTime, lineNumber)
 			if err != nil {
 				return buffer, CsvColumnError{
 					t.cachedTime.Label,

--- a/pkg/csv2lp/data_conversion.go
+++ b/pkg/csv2lp/data_conversion.go
@@ -133,7 +133,7 @@ func toTypedValue(val string, column *CsvTableColumn, lineNumber int) (interface
 	dataType := column.DataType
 	dataFormat := column.DataFormat
 	if column.ParseF != nil {
-		return column.ParseF(val)
+		return column.ParseF(val, lineNumber)
 	}
 	switch dataType {
 	case stringDatatype:
@@ -267,7 +267,7 @@ func CreateDecoder(encoding string) (func(io.Reader) io.Reader, error) {
 }
 
 // createBoolParseFn returns a function that converts a string value to boolean according to format "true,yes,1:false,no,0"
-func createBoolParseFn(format string) func(string) (interface{}, error) {
+func createBoolParseFn(format string) func(string, int) (interface{}, error) {
 	var err error = nil
 	truthy := []string{}
 	falsy := []string{}
@@ -284,7 +284,7 @@ func createBoolParseFn(format string) func(string) (interface{}, error) {
 			falsy = strings.Split(f, ",")
 		}
 	}
-	return func(val string) (interface{}, error) {
+	return func(val string, _lineNumber int) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/csv2lp/data_conversion.go
+++ b/pkg/csv2lp/data_conversion.go
@@ -93,7 +93,7 @@ func escapeString(val string) string {
 //
 // For example, to get a strconv-parseable float from a Spanish value '3.494.826.157,123', use format ",." .
 func normalizeNumberString(value string, format string, removeFraction bool) (normalized string, truncated bool) {
-	if format == "" {
+	if len(format) == 0 {
 		format = ". \n\t\r_"
 	}
 	if strings.ContainsAny(value, format) {

--- a/pkg/csv2lp/data_conversion_test.go
+++ b/pkg/csv2lp/data_conversion_test.go
@@ -336,7 +336,7 @@ func Test_CreateBoolParseFn(t *testing.T) {
 		fn := createBoolParseFn(test.format)
 		for j, pair := range test.pair {
 			t.Run(fmt.Sprint(i)+"_"+fmt.Sprint(j), func(t *testing.T) {
-				result, err := fn(pair.value)
+				result, err := fn(pair.value, 1)
 				switch pair.expect {
 				case "true":
 					require.Equal(t, true, result)


### PR DESCRIPTION
Closes #18744 : **indicate a loss of precision when parsing long/unsignedLong data types**

When parsing `long` or `unsignedLong` value from a string value with fraction digits, the whole CSV row fails when in a strict mode, which is turned on using a column dataFormat that starts with `strict`, such as `long:strict`. A warning is printed when not in a strict mode, saying `line x: column y: '1.2' truncated to '1' to fit into long data type`.  [Package documentation](https://github.com/influxdata/influxdb/compare/18744/csv2lp?expand=1#diff-845cb71dbfa49b093ae411b57e24e057R161) explains strict parsing.

Closes #18742 : **add the ability to write rejected records to a specific file**

There is a new --error-file option in `influx write`
```
   --errors-file string   The path to the file to write rejected rows to
```
The file then contains rows than cannot be imported because of data quality issues, CSV comments are also written to let the user know of what was wrong, for example:
```
# error : line 3: column 'a': '1.1' cannot fit into long data type
cpu,1.1
```

Closes #18741: **add the ability to construct a timestamp from multiple columns**

A new `#concat` annotation adds a new column that is concatenated from existing columns according to bash-like string interpolation literal with variables referencing existing column labels. For example: `#concat,string,fullName,${firstName} ${lastName}`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
