### PR TITLE
feat: Add initial OSS-Fuzz testing integration

### DIFF
--- a/FUZZ.md
+++ b/FUZZ.md
@@ -1,0 +1,25 @@
+# Fuzzing InfluxDB
+
+## Continuous fuzzing
+
+The InfluxDB repository contains testing targets for InfluxDB's integration with
+[OSS-Fuzz](https://google.github.io/oss-fuzz/).
+
+The build scripts for this integration are contained [in the OSS-Fuzz repo](https://github.com/google/oss-fuzz/tree/master/projects/influxdb).
+
+## Local fuzzing
+
+For local fuzzing, install [go-fuzz](https://github.com/dvyukov/go-fuzz):
+
+```
+$ go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+```
+
+Below is an example of building and running a fuzz test.
+In this case, the test is located at `./jsonweb/fuzz.go`.
+
+```
+$ cd go/src/github.com/influxdata/influxdb/jsonweb
+$ go-fuzz-build github.com/influxdata/influxdb/v2/jsonweb
+$ go-fuzz -bin jsonweb-fuzz.zip
+```

--- a/jsonweb/fuzz.go
+++ b/jsonweb/fuzz.go
@@ -1,0 +1,24 @@
+// +build gofuzz
+
+package jsonweb
+
+// FuzzJsonWeb is the entry point for fuzzing when built with go-fuzz-build.
+func FuzzJsonWeb(data []byte) int {
+	var keyStore = KeyStoreFunc(func(kid string) ([]byte, error) {
+		if kid != "some-key" {
+			return nil, ErrKeyNotFound
+		}
+
+		return []byte("correct-key"), nil
+	})
+
+	parser := NewTokenParser(keyStore)
+	if _, err := parser.Parse(string(data)); err != nil {
+		// An error here means this input is not interesting
+		// to the fuzzer.
+		return 0
+	}
+	// The input valid, and the fuzzer should increase priority
+	// along these lines.
+	return 1
+}


### PR DESCRIPTION
For a basic overview of our fuzzing initiative and [OSS-Fuzz](https://google.github.io/oss-fuzz/) integration, see ~the README~ FUZZ.md included in this PR.

There are many ways to integrate fuzz tests into a project. Instead of the structure proposed here, we might prefer to do things [the way Golang does](https://github.com/golang/go/tree/master/src/html), with fuzz tests included in the packages themselves. This can evolve over time as we find something that works for us.