### PR TITLE
fix: tweak flagging structure of Community Templates

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -100,7 +100,6 @@ import NewEndpointOverlay from 'src/notifications/endpoints/components/NewEndpoi
 import EditEndpointOverlay from 'src/notifications/endpoints/components/EditEndpointOverlay'
 import NoOrgsPage from 'src/organizations/containers/NoOrgsPage'
 
-import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import {CommunityTemplateImportOverlay} from 'src/templates/components/CommunityTemplateImportOverlay'
 
 // Utilities
@@ -442,51 +441,31 @@ class Root extends PureComponent {
                                   component={UpdateVariableOverlay}
                                 />
                               </Route>
-                              {isFlagEnabled('communityTemplates') ? (
+                              <Route
+                                path="templates"
+                                component={TemplatesIndex}
+                              >
                                 <Route
-                                  path="templates"
-                                  component={CommunityTemplatesIndex}
-                                >
-                                  <Route
-                                    path="import/:templateName"
-                                    component={CommunityTemplateImportOverlay}
-                                  />
-                                  <Route
-                                    path=":id/export"
-                                    component={TemplateExportOverlay}
-                                  />
-                                  <Route
-                                    path=":id/view"
-                                    component={TemplateViewOverlay}
-                                  />
-                                  <Route
-                                    path=":id/static/view"
-                                    component={StaticTemplateViewOverlay}
-                                  />
-                                </Route>
-                              ) : (
+                                  path="import"
+                                  component={TemplateImportOverlay}
+                                />
                                 <Route
-                                  path="templates"
-                                  component={TemplatesIndex}
-                                >
-                                  <Route
-                                    path="import"
-                                    component={TemplateImportOverlay}
-                                  />
-                                  <Route
-                                    path=":id/export"
-                                    component={TemplateExportOverlay}
-                                  />
-                                  <Route
-                                    path=":id/view"
-                                    component={TemplateViewOverlay}
-                                  />
-                                  <Route
-                                    path=":id/static/view"
-                                    component={StaticTemplateViewOverlay}
-                                  />
-                                </Route>
-                              )}
+                                  path="import/:templateName"
+                                  component={CommunityTemplateImportOverlay}
+                                />
+                                <Route
+                                  path=":id/export"
+                                  component={TemplateExportOverlay}
+                                />
+                                <Route
+                                  path=":id/view"
+                                  component={TemplateViewOverlay}
+                                />
+                                <Route
+                                  path=":id/static/view"
+                                  component={StaticTemplateViewOverlay}
+                                />
+                              </Route>
                               <Route path="labels" component={LabelsIndex} />
                               <Route path="about" component={OrgProfilePage}>
                                 <Route

--- a/ui/src/shared/reducers/flags.ts
+++ b/ui/src/shared/reducers/flags.ts
@@ -28,10 +28,16 @@ export default (state = defaultState, action: Actions): FlagState => {
     case SET_FEATURE_FLAGS:
       // just setting the loading state
       if (!action.payload.flags) {
-        return {
+        const newState = {
           ...state,
           status: action.payload.status,
         }
+
+        if (!state.hasOwnProperty('original')) {
+          newState.original = defaultState.original
+        }
+
+        return newState
       }
       return {
         ...state,

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -9,6 +9,8 @@ import {CommunityTemplateInstallerOverlay} from 'src/templates/components/Commun
 import {createTemplate as createTemplateAction} from 'src/templates/actions/thunks'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
+import {FlagMap} from 'src/shared/reducers/flags'
+
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
 import {ComponentStatus} from '@influxdata/clockface'
@@ -26,6 +28,7 @@ interface DispatchProps {
 }
 
 interface StateProps {
+  flags: FlagMap
   org: Organization
   templateName: string
 }
@@ -42,6 +45,10 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   }
 
   public render() {
+    if (!this.props.flags.communityTemplates) {
+      return null
+    }
+
     return (
       <CommunityTemplateInstallerOverlay
         onDismissOverlay={this.onDismiss}
@@ -74,7 +81,11 @@ const mstp = (state: AppState, props: Props): StateProps => {
     props.params.orgID
   )
 
-  return {org, templateName: props.params.templateName}
+  return {
+    org,
+    templateName: props.params.templateName,
+    flags: state.flags.original,
+  }
 }
 
 const mdtp: DispatchProps = {

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -10,14 +10,18 @@ import SettingsHeader from 'src/settings/components/SettingsHeader'
 import TemplatesPage from 'src/templates/components/TemplatesPage'
 import GetResources from 'src/resources/components/GetResources'
 
+import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
+
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {getOrg} from 'src/organizations/selectors'
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
+import {FlagMap} from 'src/shared/reducers/flags'
 
 interface StateProps {
+  flags: FlagMap
   org: Organization
 }
 
@@ -26,7 +30,10 @@ type Props = WithRouterProps & StateProps
 @ErrorHandling
 class TemplatesIndex extends Component<Props> {
   public render() {
-    const {org, children} = this.props
+    const {org, children, flags} = this.props
+    if (flags.communityTemplates) {
+      return <CommunityTemplatesIndex>{children}</CommunityTemplatesIndex>
+    }
     return (
       <>
         <Page titleTag={pageTitleSuffixer(['Templates', 'Settings'])}>
@@ -51,6 +58,7 @@ class TemplatesIndex extends Component<Props> {
 const mstp = (state: AppState): StateProps => {
   return {
     org: getOrg(state),
+    flags: state.flags.original,
   }
 }
 


### PR DESCRIPTION
Tweaks community templates' structure around feature flagging

Previously the flagging occurred in `index.tsx`, but now the flagging is handled by `TemplatesIndex.tsx`, which either renders itself normally or conditionally renders the flagged template path.

#### Testing Instructions

to toggle the flag, start your local influxd process with:

```sh
go run ./cmd/influxd --assets-path=ui/build --feature-flags=communityTemplates=true
```


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
