### PR TITLE
refactor: remove user id check from find authorizations

### DIFF
--- a/authorization/middleware_auth.go
+++ b/authorization/middleware_auth.go
@@ -44,9 +44,6 @@ func (s *AuthedAuthorizationService) FindAuthorizationByToken(ctx context.Contex
 	if _, _, err := authorizer.AuthorizeRead(ctx, influxdb.AuthorizationsResourceType, a.ID, a.OrgID); err != nil {
 		return nil, err
 	}
-	if _, _, err := authorizer.AuthorizeReadResource(ctx, influxdb.UsersResourceType, a.UserID); err != nil {
-		return nil, err
-	}
 	return a, nil
 }
 
@@ -56,9 +53,6 @@ func (s *AuthedAuthorizationService) FindAuthorizationByID(ctx context.Context, 
 		return nil, err
 	}
 	if _, _, err := authorizer.AuthorizeRead(ctx, influxdb.AuthorizationsResourceType, a.ID, a.OrgID); err != nil {
-		return nil, err
-	}
-	if _, _, err := authorizer.AuthorizeReadResource(ctx, influxdb.UsersResourceType, a.UserID); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/authorization/middleware_auth_test.go
+++ b/authorization/middleware_auth_test.go
@@ -75,6 +75,29 @@ func TestAuthorizationService_ReadAuthorization(t *testing.T) {
 			},
 		},
 		{
+			name: "authorized to access id - no user",
+			args: args{
+				permissions: []influxdb.Permission{
+					{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type:  influxdb.AuthorizationsResourceType,
+							OrgID: influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				authorizations: []*influxdb.Authorization{
+					{
+						ID:     10,
+						UserID: 1,
+						OrgID:  1,
+					},
+				},
+			},
+		},
+		{
 			name: "unauthorized to access id - wrong org",
 			args: args{
 				permissions: []influxdb.Permission{
@@ -97,34 +120,6 @@ func TestAuthorizationService_ReadAuthorization(t *testing.T) {
 			wants: wants{
 				err: &influxdb.Error{
 					Msg:  "read:orgs/0000000000000001/authorizations/000000000000000a is unauthorized",
-					Code: influxdb.EUnauthorized,
-				},
-				authorizations: []*influxdb.Authorization{},
-			},
-		},
-		{
-			name: "unauthorized to access id - wrong user",
-			args: args{
-				permissions: []influxdb.Permission{
-					{
-						Action: influxdb.ReadAction,
-						Resource: influxdb.Resource{
-							Type:  influxdb.AuthorizationsResourceType,
-							OrgID: influxdbtesting.IDPtr(1),
-						},
-					},
-					{
-						Action: influxdb.ReadAction,
-						Resource: influxdb.Resource{
-							Type: influxdb.UsersResourceType,
-							ID:   influxdbtesting.IDPtr(2),
-						},
-					},
-				},
-			},
-			wants: wants{
-				err: &influxdb.Error{
-					Msg:  "read:users/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 				authorizations: []*influxdb.Authorization{},

--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -37,13 +37,6 @@ func AuthorizeFindAuthorizations(ctx context.Context, rs []*influxdb.Authorizati
 		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
 			continue
 		}
-		_, _, err = AuthorizeReadResource(ctx, influxdb.UsersResourceType, r.UserID)
-		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
-			return nil, 0, err
-		}
-		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
-			continue
-		}
 		rrs = append(rrs, r)
 	}
 	return rrs, len(rrs), nil


### PR DESCRIPTION
This PR removes the check for read user permission when finding Authorizations. This is to fix an issue where Authorizations sometime return empty from a curl request even when the user has permission to view those Authorizations.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
