### PR TITLE
fix(tsm1): delimit tsmKeyPrefix with appended comma

### DIFF
--- a/tsdb/tsm1/engine_measurement_schema.go
+++ b/tsdb/tsm1/engine_measurement_schema.go
@@ -348,6 +348,7 @@ func (e *Engine) fieldsPredicate(ctx context.Context, orgID influxdb.ID, bucketI
 
 	mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 	tsmKeyPrefix := mt.AppendHashKey(orgBucketEsc)
+	tsmKeyPrefix = append(tsmKeyPrefix, ',')
 
 	var canceled bool
 
@@ -453,6 +454,7 @@ func (e *Engine) fieldsNoPredicate(ctx context.Context, orgID influxdb.ID, bucke
 
 	mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 	tsmKeyPrefix := mt.AppendHashKey(orgBucketEsc)
+	tsmKeyPrefix = append(tsmKeyPrefix, ',')
 
 	var stats cursors.CursorStats
 	var canceled bool

--- a/tsdb/tsm1/engine_measurement_schema_test.go
+++ b/tsdb/tsm1/engine_measurement_schema_test.go
@@ -532,6 +532,29 @@ memB,host=EB,os=macOS value=1.3 201`)
 			exp:      nil,
 			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
 		},
+		{
+			name: "prefix substring without predicate",
+			args: args{
+				org: 1,
+				m:   "cpu",
+				key: "host",
+				min: 0,
+				max: 1000,
+			},
+			expStats: cursors.CursorStats{},
+		},
+		{
+			name: "prefix substring with predicate",
+			args: args{
+				org:  1,
+				m:    "cpu",
+				key:  "host",
+				min:  0,
+				max:  1000,
+				expr: `os = 'linux'`,
+			},
+			expStats: cursors.CursorStats{},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -792,6 +815,27 @@ mem,mem1=v,mem2=v        f=1 201`)
 			},
 			exp:      nil,
 			expStats: cursors.CursorStats{ScannedValues: 0, ScannedBytes: 0},
+		},
+		{
+			name: "prefix substring without predicate",
+			args: args{
+				org: 0,
+				m:   "cp",
+				min: 0,
+				max: 1000,
+			},
+			expStats: cursors.CursorStats{},
+		},
+		{
+			name: "prefix substring with predicate",
+			args: args{
+				org:  0,
+				m:    "cp",
+				min:  0,
+				max:  1000,
+				expr: `cpu = 'v'`,
+			},
+			expStats: cursors.CursorStats{},
 		},
 	}
 	for _, tc := range tests {
@@ -1062,6 +1106,29 @@ m10,foo=v barS="60" 501
 				min:  0,
 				max:  1000,
 				expr: `foo = 'nonexistent'`,
+			},
+			exp:      nil,
+			expStats: makeStats(0),
+		},
+		{
+			name: "prefix substring without predicate",
+			args: args{
+				org: 0,
+				m:   "m0",
+				min: 0,
+				max: 1000,
+			},
+			exp:      nil,
+			expStats: makeStats(0),
+		},
+		{
+			name: "prefix substring with predicate",
+			args: args{
+				org:  0,
+				m:    "m0",
+				min:  0,
+				max:  1000,
+				expr: `tag10 = 'v10'`,
 			},
 			exp:      nil,
 			expStats: makeStats(0),

--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -53,6 +53,7 @@ func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgID, bucketID influ
 		// append the measurement tag key to the prefix
 		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+		tsmKeyPrefix = append(tsmKeyPrefix, ',')
 	}
 
 	// TODO(sgc): extend prefix when filtering by \x00 == <measurement>
@@ -181,6 +182,7 @@ func (e *Engine) tagValuesPredicate(ctx context.Context, orgID, bucketID influxd
 		// append the measurement tag key to the prefix
 		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+		tsmKeyPrefix = append(tsmKeyPrefix, ',')
 	}
 
 	var canceled bool
@@ -349,6 +351,7 @@ func (e *Engine) tagKeysNoPredicate(ctx context.Context, orgID, bucketID influxd
 		// append the measurement tag key to the prefix
 		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+		tsmKeyPrefix = append(tsmKeyPrefix, ',')
 	}
 
 	var keyset models.TagKeysSet
@@ -474,6 +477,7 @@ func (e *Engine) tagKeysPredicate(ctx context.Context, orgID, bucketID influxdb.
 		// append the measurement tag key to the prefix
 		mt := models.Tags{models.NewTag(models.MeasurementTagKeyBytes, measurement)}
 		tsmKeyPrefix = mt.AppendHashKey(tsmKeyPrefix)
+		tsmKeyPrefix = append(tsmKeyPrefix, ',')
 	}
 
 	var canceled bool


### PR DESCRIPTION
Fixes #7589.

Append a comma to the TSM key prefix when matching a full measurement name to avoid erroneously matching other measurement names that include the prefix in their own name. For example, this prevents matching a measurement "cpu1" when targeting "cpu" by updating the prefix to "cpu,". This relies on the fact that tag key-value pairs are separated by commas.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
