### PR TITLE
fix: intermittent incorrect graph type

### DIFF
--- a/ui/src/shared/components/XYPlot.tsx
+++ b/ui/src/shared/components/XYPlot.tsx
@@ -80,8 +80,10 @@ const XYPlot: FunctionComponent<Props> = ({
 }) => {
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])
-  const xColumn = storedXColumn || defaultXColumn(table)
-  const yColumn = storedYColumn || defaultYColumn(table)
+  const xColumn = storedXColumn || defaultXColumn(table, '_time')
+  const yColumn =
+    (table.columnKeys.includes(storedYColumn) && storedYColumn) ||
+    defaultYColumn(table)
 
   const columnKeys = table.columnKeys
 

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -170,18 +170,32 @@ export const checkResultsLength = (giraffeResult: FromFluxResult): boolean => {
   return get(giraffeResult, 'table.length', 0) > 0
 }
 
-export const getNumericColumns = (table: Table): string[] => {
-  const numericColumnKeys = table.columnKeys.filter(k => {
+export const getTimeColumns = (table: Table): string[] => {
+  const timeColumns = table.columnKeys.filter(k => {
     if (k === 'result' || k === 'table') {
       return false
     }
 
     const columnType = table.getColumnType(k)
 
-    return columnType === 'time' || columnType === 'number'
+    return columnType === 'time'
   })
 
-  return numericColumnKeys
+  return timeColumns
+}
+
+export const getNumberColumns = (table: Table): string[] => {
+  const numberColumnKeys = table.columnKeys.filter(k => {
+    if (k === 'result' || k === 'table') {
+      return false
+    }
+
+    const columnType = table.getColumnType(k)
+
+    return columnType === 'number'
+  })
+
+  return numberColumnKeys
 }
 
 export const getGroupableColumns = (table: Table): string[] => {
@@ -213,7 +227,7 @@ export const defaultXColumn = (
   table: Table,
   preferredColumnKey?: string
 ): string | null => {
-  const validColumnKeys = getNumericColumns(table)
+  const validColumnKeys = getTimeColumns(table)
 
   if (validColumnKeys.includes(preferredColumnKey)) {
     return preferredColumnKey
@@ -239,7 +253,7 @@ export const defaultYColumn = (
   table: Table,
   preferredColumnKey?: string
 ): string | null => {
-  const validColumnKeys = getNumericColumns(table)
+  const validColumnKeys = getNumberColumns(table)
 
   if (validColumnKeys.includes(preferredColumnKey)) {
     return preferredColumnKey

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -170,6 +170,20 @@ export const checkResultsLength = (giraffeResult: FromFluxResult): boolean => {
   return get(giraffeResult, 'table.length', 0) > 0
 }
 
+export const getNumericColumns = (table: Table): string[] => {
+  const timeColumns = table.columnKeys.filter(k => {
+    if (k === 'result' || k === 'table') {
+      return false
+    }
+
+    const columnType = table.getColumnType(k)
+
+    return columnType === 'time' || columnType === 'number'
+  })
+
+  return timeColumns
+}
+
 export const getTimeColumns = (table: Table): string[] => {
   const timeColumns = table.columnKeys.filter(k => {
     if (k === 'result' || k === 'table') {


### PR DESCRIPTION
### The Problem
When a flux response returned with multiple tables with two different value column types i.e. `bool` in one table and `number` in the other.

see for example: [howdy.txt](https://github.com/influxdata/influxdb/files/4847331/howdy.txt)

The `XYPlot` would sometimes render "Incorrect graph type" and sometimes would display the line data. 

### The Solution
If there is renderable data, we display it.  We do this by selecting a sane default `yColumn` of type `number` if none is provided.  Previously, we could select a default for the y-axis of type `time`.  This didn't make sense for a default. 

