### PR TITLE
feat(flows): redesign minimap and rename to "Table of Contents"

### DIFF
--- a/ui/src/notebooks/NotebookVariables.scss
+++ b/ui/src/notebooks/NotebookVariables.scss
@@ -7,3 +7,5 @@ $notebook-panel--bg: mix($g1-raven, $g2-kevlar, 50%);
 
 $notebook-divider-height: ($cf-marg-a * 2) + $cf-border;
 $notebook-divider-color: $g2-kevlar;
+
+$notebook-minimap--expanded: 270px;

--- a/ui/src/notebooks/components/header/index.tsx
+++ b/ui/src/notebooks/components/header/index.tsx
@@ -3,7 +3,6 @@ import React, {FC} from 'react'
 import {Page} from '@influxdata/clockface'
 import AddButtons from 'src/notebooks/components/AddButtons'
 import Buttons from 'src/notebooks/components/header/Buttons'
-import MiniMapToggle from 'src/notebooks/components/minimap/MiniMapToggle'
 
 const FULL_WIDTH = true
 
@@ -18,7 +17,6 @@ const Header: FC = () => (
         <AddButtons />
       </Page.ControlBarLeft>
       <Page.ControlBarRight>
-        <MiniMapToggle />
         <Buttons />
       </Page.ControlBarRight>
     </Page.ControlBar>

--- a/ui/src/notebooks/components/minimap/MiniMap.scss
+++ b/ui/src/notebooks/components/minimap/MiniMap.scss
@@ -1,13 +1,74 @@
 @import '@influxdata/clockface/dist/variables.scss';
 @import '~src/notebooks/NotebookVariables.scss';
 
-.notebook-minimap {
-  flex: 0 0 200px;
+$notebook-minimap--left-gutter: $cf-marg-d;
+$notebook-minimap--collapsed: $cf-marg-d + $cf-marg-a;
+$notebook-minimap--item-padding: $cf-marg-b;
+
+.notebook-minimap,
+.notebook-minimap__collapsed {
   border-right: $cf-border solid $notebook-divider-color;
 }
 
+.notebook-minimap {
+  flex: 0 0 $notebook-minimap--expanded;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.notebook-minimap--scroll {
+  flex: 1 0 0;
+}
+
+.notebook-minimap__collapsed {
+  flex: 0 0 ($notebook-minimap--collapsed + $notebook-minimap--left-gutter);
+}
+
+.notebook-minimap--header {
+  margin-left: $notebook-minimap--left-gutter;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: $cf-marg-d + $cf-marg-c;
+  border: none;
+  border-bottom: $cf-border solid $notebook-divider-color;
+  margin-bottom: $cf-marg-b;
+  background-color: transparent;
+  outline: none;
+  color: $g15-platinum;
+  transition: color 0.25s ease, background-color 0.25s ease;
+  padding: 0 $notebook-minimap--item-padding;
+
+  &:hover {
+    color: $g20-white;
+    background-color: $g2-kevlar;
+    cursor: pointer;
+  }
+
+  .notebook-minimap__collapsed & {
+    padding: 0;
+    width: $notebook-minimap--collapsed;
+  }
+}
+
+.notebook-minimap--title {
+  font-family: $cf-text-font;
+  font-size: 14px;
+  font-weight: $cf-font-weight--medium;
+  user-select: none;
+  flex: 1 0 0;
+  text-align: left;
+  margin: 0;
+}
+
+.notebook-minimap--icon {
+  opacity: 0.5;
+  font-size: 1.125em;
+}
+
 .notebook-minimap--list {
-  padding-left: $cf-marg-d;
+  padding-left: $notebook-minimap--left-gutter;
   padding-right: $cf-marg-b;
 }
 
@@ -19,7 +80,7 @@
   margin-bottom: $cf-border;
   height: $cf-marg-d;
   line-height: $cf-marg-d;
-  padding: 0 $cf-marg-b;
+  padding: 0 $notebook-minimap--item-padding;
   border-radius: $cf-radius;
   user-select: none;
 

--- a/ui/src/notebooks/components/minimap/MiniMap.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMap.tsx
@@ -8,6 +8,7 @@ import {ScrollContext} from 'src/notebooks/context/scroll'
 
 // Components
 import {DapperScrollbars} from '@influxdata/clockface'
+import MiniMapToggle from 'src/notebooks/components/minimap/MiniMapToggle'
 import MiniMapItem from 'src/notebooks/components/minimap/MiniMapItem'
 
 // Types
@@ -25,7 +26,11 @@ const MiniMap: FC<StateProps> = ({notebookMiniMapState}) => {
   const {scrollToPipe} = useContext(ScrollContext)
 
   if (notebookMiniMapState === 'collapsed') {
-    return null
+    return (
+      <div className="notebook-minimap__collapsed">
+        <MiniMapToggle />
+      </div>
+    )
   }
 
   const handleClick = (idx: number): void => {
@@ -46,9 +51,12 @@ const MiniMap: FC<StateProps> = ({notebookMiniMapState}) => {
   ))
 
   return (
-    <DapperScrollbars className="notebook-minimap" autoHide={true}>
-      <div className="notebook-minimap--list">{pipes}</div>
-    </DapperScrollbars>
+    <div className="notebook-minimap">
+      <MiniMapToggle />
+      <DapperScrollbars className="notebook-minimap--scroll" autoHide={true}>
+        <div className="notebook-minimap--list">{pipes}</div>
+      </DapperScrollbars>
+    </div>
   )
 }
 

--- a/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
@@ -3,7 +3,7 @@ import React, {FC} from 'react'
 import {connect} from 'react-redux'
 
 // Components
-import {SlideToggle, InputLabel} from '@influxdata/clockface'
+import {Icon, IconFont} from '@influxdata/clockface'
 
 // Actions
 import {setNotebookMiniMapState} from 'src/shared/actions/app'
@@ -31,7 +31,9 @@ const MiniMapToggle: FC<Props> = ({
   const active = notebookMiniMapState === 'expanded'
 
   const handleChange = (): void => {
-    event('Toggled Mini Map', {state: active ? 'collapsed' : 'expanded'})
+    event('Notebook Toggled Table of Contents', {
+      state: active ? 'collapsed' : 'expanded',
+    })
 
     if (active) {
       handleSetNotebookMiniMapState('collapsed')
@@ -40,11 +42,20 @@ const MiniMapToggle: FC<Props> = ({
     }
   }
 
+  const glyph = active ? IconFont.Minimize : IconFont.Maximize
+  const title = active
+    ? 'Click to minimize Table of Contents'
+    : 'Click to maximize Table of Contents'
+
   return (
-    <>
-      <SlideToggle active={active} onChange={handleChange} />
-      <InputLabel>Minimap</InputLabel>
-    </>
+    <button
+      className="notebook-minimap--header"
+      onClick={handleChange}
+      title={title}
+    >
+      {active && <h6 className="notebook-minimap--title">Table of Contents</h6>}
+      <Icon className="notebook-minimap--icon" glyph={glyph} />
+    </button>
   )
 }
 


### PR DESCRIPTION
![redesigned-toc-component](https://user-images.githubusercontent.com/2433762/86044821-81944b80-b9ff-11ea-888e-a9b2997797d9.gif)

- Rename (in UI) "Minimap" to "Table of Contents" to make the component more intuitive
- Move toggle to be contained within the component it is toggling
- Redesign component to have a header and more consistent expand/collapse icons

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
