### PR TITLE
feat(pkger): update remote http client to use new routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [18758](https://github.com/influxdata/influxdb/pull/18758): Extend influx stacks update cmd with ability to add resources without apply template
+1. [18793](https://github.com/influxdata/influxdb/pull/18793): Normalize InfluxDB templates under new /api/v2/templates and /api/v2/stacks public API 
 
 ### Bug Fixes
 

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -26,7 +26,7 @@ func (s *HTTPRemoteService) InitStack(ctx context.Context, userID influxdb.ID, s
 
 	var respBody RespStack
 	err := s.Client.
-		PostJSON(reqBody, RoutePrefixPackages, "/stacks").
+		PostJSON(reqBody, RoutePrefixStacks).
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -38,7 +38,7 @@ func (s *HTTPRemoteService) InitStack(ctx context.Context, userID influxdb.ID, s
 
 func (s *HTTPRemoteService) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	return s.Client.
-		Delete(RoutePrefixPackages, "stacks", identifiers.StackID.String()).
+		Delete(RoutePrefixStacks, identifiers.StackID.String()).
 		QueryParams([2]string{"orgID", identifiers.OrgID.String()}).
 		Do(ctx)
 }
@@ -54,7 +54,7 @@ func (s *HTTPRemoteService) ListStacks(ctx context.Context, orgID influxdb.ID, f
 
 	var resp RespListStacks
 	err := s.Client.
-		Get(RoutePrefixPackages, "/stacks").
+		Get(RoutePrefixStacks).
 		QueryParams(queryParams...).
 		DecodeJSON(&resp).
 		Do(ctx)
@@ -76,7 +76,7 @@ func (s *HTTPRemoteService) ListStacks(ctx context.Context, orgID influxdb.ID, f
 func (s *HTTPRemoteService) ReadStack(ctx context.Context, id influxdb.ID) (Stack, error) {
 	var respBody RespStack
 	err := s.Client.
-		Get(RoutePrefixPackages, "/stacks", id.String()).
+		Get(RoutePrefixStacks, id.String()).
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -101,7 +101,7 @@ func (s *HTTPRemoteService) UpdateStack(ctx context.Context, upd StackUpdate) (S
 
 	var respBody RespStack
 	err := s.Client.
-		PatchJSON(reqBody, RoutePrefixPackages, "/stacks", upd.ID.String()).
+		PatchJSON(reqBody, RoutePrefixStacks, upd.ID.String()).
 		DecodeJSON(&respBody).
 		Do(ctx)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *HTTPRemoteService) Export(ctx context.Context, opts ...ExportOptFn) (*P
 
 	var newPkg *Pkg
 	err = s.Client.
-		PostJSON(reqBody, RoutePrefixPackages).
+		PostJSON(reqBody, RoutePrefixTemplates, "/export").
 		Decode(func(resp *http.Response) error {
 			pkg, err := Parse(EncodingJSON, FromReader(resp.Body, "export"))
 			newPkg = pkg
@@ -220,7 +220,7 @@ func (s *HTTPRemoteService) apply(ctx context.Context, orgID influxdb.ID, dryRun
 
 	var resp RespApply
 	err := s.Client.
-		PostJSON(reqBody, RoutePrefixPackages, "/apply").
+		PostJSON(reqBody, RoutePrefixTemplates, "/apply").
 		DecodeJSON(&resp).
 		Do(ctx)
 	if err != nil {


### PR DESCRIPTION
this implicitly affects the CLI which uses that client. It will now hit the
new endpoints which will ship with the next release of OSS beta, and have
already landed in our upstream repos.

references: #18580

Closes #

Describe your proposed changes here.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass