### PR TITLE
fix(pkger): stop swallowing parser errors from pkger parser in http remote service

### DIFF
--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1849,8 +1849,16 @@ type (
 
 // Error implements the error interface.
 func (e *parseErr) Error() string {
-	var errMsg []string
+	var (
+		errMsg   []string
+		seenErrs = make(map[string]bool)
+	)
 	for _, ve := range append(e.ValidationErrs(), e.rawErrs...) {
+		msg := ve.Error()
+		if seenErrs[msg] {
+			continue
+		}
+		seenErrs[msg] = true
 		errMsg = append(errMsg, ve.Error())
 	}
 


### PR DESCRIPTION
this PR also deduplicates error messages in the CLI.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass