### PR TITLE
fix: org setting causing 400 errors on app metrics

### DIFF
--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -46,8 +46,8 @@ const OrgSettings: FunctionComponent<Props> = ({
 
   useEffect(() => {
     updateReportingContext(
-      Object.entries(settings).reduce((prev, [key, val]) => {
-        prev[`org (${key})`] = val
+      settings.reduce((prev, curr) => {
+        prev[`org (${curr.key})`] = curr.value
         return prev
       }, {})
     )


### PR DESCRIPTION
fixes an issue where we are unable to unmarshal an app metrics post because of a malformed json schema. no idea where i got the previous shape from, but i am curious why typescript wasn't screaming about it.