### PR TITLE
feat(pkger): extend template Summary with discrete kinds for each summary type

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -2629,12 +2629,14 @@ spec:
 
 		labels := sum1.Labels
 		require.Len(t, labels, 2)
+		assert.Equal(t, pkger.KindLabel, labels[0].Kind)
 		assert.NotZero(t, labels[0].ID)
 		assert.Equal(t, "label-1", labels[0].Name)
 		assert.Equal(t, "the 2nd label", labels[1].Name)
 
 		bkts := sum1.Buckets
 		require.Len(t, bkts, 1)
+		assert.Equal(t, pkger.KindBucket, bkts[0].Kind)
 		assert.NotZero(t, bkts[0].ID)
 		assert.NotEmpty(t, bkts[0].MetaName)
 		assert.Equal(t, "rucketeer", bkts[0].Name)
@@ -2643,8 +2645,10 @@ spec:
 		checks := sum1.Checks
 		require.Len(t, checks, 2)
 		assert.Equal(t, "check 0 name", checks[0].Check.GetName())
+		assert.Equal(t, pkger.KindCheckThreshold, checks[0].Kind)
 		hasLabelAssociations(t, checks[0].LabelAssociations, 1, "label-1")
 		assert.Equal(t, "check-1", checks[1].Check.GetName())
+		assert.Equal(t, pkger.KindCheckDeadman, checks[1].Kind)
 		hasLabelAssociations(t, checks[1].LabelAssociations, 1, "label-1")
 		for _, ch := range checks {
 			assert.NotZero(t, ch.Check.GetID())
@@ -2652,6 +2656,7 @@ spec:
 
 		dashs := sum1.Dashboards
 		require.Len(t, dashs, 1)
+		assert.Equal(t, pkger.KindDashboard, dashs[0].Kind)
 		assert.NotZero(t, dashs[0].ID)
 		assert.NotEmpty(t, dashs[0].Name)
 		assert.Equal(t, "dash_1", dashs[0].Name)
@@ -2662,6 +2667,7 @@ spec:
 
 		endpoints := sum1.NotificationEndpoints
 		require.Len(t, endpoints, 1)
+		assert.Equal(t, pkger.KindNotificationEndpointHTTP, endpoints[0].Kind)
 		assert.NotZero(t, endpoints[0].NotificationEndpoint.GetID())
 		assert.Equal(t, "no auth endpoint", endpoints[0].NotificationEndpoint.GetName())
 		assert.Equal(t, "http none auth desc", endpoints[0].NotificationEndpoint.GetDescription())
@@ -2670,6 +2676,7 @@ spec:
 
 		require.Len(t, sum1.NotificationRules, 1)
 		rule := sum1.NotificationRules[0]
+		assert.Equal(t, pkger.KindNotificationRule, rule.Kind)
 		assert.NotZero(t, rule.ID)
 		assert.Equal(t, "rule_0", rule.Name)
 		assert.Equal(t, pkger.SafeID(endpoints[0].NotificationEndpoint.GetID()), rule.EndpointID)
@@ -2678,12 +2685,14 @@ spec:
 
 		require.Len(t, sum1.Tasks, 1)
 		task := sum1.Tasks[0]
+		assert.Equal(t, pkger.KindTask, task.Kind)
 		assert.NotZero(t, task.ID)
 		assert.Equal(t, "task_1", task.Name)
 		assert.Equal(t, "desc_1", task.Description)
 
 		teles := sum1.TelegrafConfigs
 		require.Len(t, teles, 1)
+		assert.Equal(t, pkger.KindTelegraf, teles[0].Kind)
 		assert.NotZero(t, teles[0].TelegrafConfig.ID)
 		assert.Equal(t, l.Org.ID, teles[0].TelegrafConfig.OrgID)
 		assert.Equal(t, "first tele config", teles[0].TelegrafConfig.Name)
@@ -2692,6 +2701,7 @@ spec:
 
 		vars := sum1.Variables
 		require.Len(t, vars, 1)
+		assert.Equal(t, pkger.KindVariable, vars[0].Kind)
 		assert.NotZero(t, vars[0].ID)
 		assert.Equal(t, "query var", vars[0].Name)
 		assert.Equal(t, []string{"rucketeer"}, vars[0].Selected)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7801,6 +7801,8 @@ components:
                     type: string
                   orgID:
                     type: string
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   templateMetaName:
                     type: string
                   name:
@@ -7822,6 +7824,8 @@ components:
                   - $ref: "#/components/schemas/CheckDiscriminator"
                   - type: object
                     properties:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
                       templateMetaName:
                         type: string
                       labelAssociations:
@@ -7830,10 +7834,6 @@ components:
                           $ref: "#/components/schemas/TemplateSummaryLabel"
                       envReferences:
                         $ref: "#/components/schemas/TemplateEnvReferences"
-            labels:
-              type: array
-              items:
-                $ref: "#/components/schemas/TemplateSummaryLabel"
             dashboards:
               type: array
               items:
@@ -7843,6 +7843,8 @@ components:
                     type: "string"
                   orgID:
                     type: "string"
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   templateMetaName:
                     type: string
                   name:
@@ -7859,6 +7861,10 @@ components:
                       $ref: "#/components/schemas/TemplateChart"
                   envReferences:
                     $ref: "#/components/schemas/TemplateEnvReferences"
+            labels:
+              type: array
+              items:
+                $ref: "#/components/schemas/TemplateSummaryLabel"
             labelMappings:
               type: array
               items:
@@ -7895,6 +7901,8 @@ components:
                   - $ref: "#/components/schemas/NotificationEndpointDiscrimator"
                   - type: object
                     properties:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
                       templateMetaName:
                         type: string
                       labelAssociations:
@@ -7908,6 +7916,8 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   templateMetaName:
                     type: string
                   name:
@@ -7959,6 +7969,8 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   templateMetaName:
                     type: string
                   id:
@@ -7986,6 +7998,8 @@ components:
                   - $ref: "#/components/schemas/TelegrafRequest"
                   - type: object
                     properties:
+                      kind:
+                        $ref: "#/components/schemas/TemplateKind"
                       templateMetaName:
                         type: string
                       labelAssociations:
@@ -7999,6 +8013,8 @@ components:
               items:
                 type: object
                 properties:
+                  kind:
+                    $ref: "#/components/schemas/TemplateKind"
                   templateMetaName:
                     type: string
                   id:
@@ -8368,6 +8384,8 @@ components:
           type: string
         orgID:
           type: string
+        kind:
+          $ref: "#/components/schemas/TemplateKind"
         templateMetaName:
           type: string
         name:

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -30,22 +30,28 @@ func TestParse(t *testing.T) {
 
 				actual := buckets[0]
 				expectedBucket := SummaryBucket{
-					MetaName:          "rucket-11",
+					SummaryIdentifier: SummaryIdentifier{
+						Kind:          KindBucket,
+						MetaName:      "rucket-11",
+						EnvReferences: []SummaryReference{},
+					},
 					Name:              "rucket-11",
 					Description:       "bucket 1 description",
 					RetentionPeriod:   time.Hour,
 					LabelAssociations: []SummaryLabel{},
-					EnvReferences:     []SummaryReference{},
 				}
 				assert.Equal(t, expectedBucket, actual)
 
 				actual = buckets[1]
 				expectedBucket = SummaryBucket{
-					MetaName:          "rucket-22",
+					SummaryIdentifier: SummaryIdentifier{
+						Kind:          KindBucket,
+						MetaName:      "rucket-22",
+						EnvReferences: []SummaryReference{},
+					},
 					Name:              "display name",
 					Description:       "bucket 2 description",
 					LabelAssociations: []SummaryLabel{},
-					EnvReferences:     []SummaryReference{},
 				}
 				assert.Equal(t, expectedBucket, actual)
 			})
@@ -483,6 +489,7 @@ spec:
 				require.Len(t, sum.Checks, 2)
 
 				check1 := sum.Checks[0]
+				assert.Equal(t, KindCheckThreshold, check1.Kind)
 				thresholdCheck, ok := check1.Check.(*icheck.Threshold)
 				require.Truef(t, ok, "got: %#v", check1)
 
@@ -529,6 +536,7 @@ spec:
 				assert.Len(t, check1.LabelAssociations, 1)
 
 				check2 := sum.Checks[1]
+				assert.Equal(t, KindCheckDeadman, check2.Kind)
 				deadmanCheck, ok := check2.Check.(*icheck.Deadman)
 				require.Truef(t, ok, "got: %#v", check2)
 
@@ -951,6 +959,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-1", actual.Name)
 						assert.Equal(t, "desc1", actual.Description)
 
@@ -1035,6 +1044,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-0", actual.Name)
 						assert.Equal(t, "a dashboard w/ heatmap chart", actual.Description)
 
@@ -1153,6 +1163,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-0", actual.Name)
 						assert.Equal(t, "a dashboard w/ single histogram chart", actual.Description)
 
@@ -1227,6 +1238,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-0", actual.Name)
 						assert.Equal(t, "a dashboard w/ single markdown chart", actual.Description)
 
@@ -1248,6 +1260,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-0", actual.Name)
 						assert.Equal(t, "a dashboard w/ single scatter chart", actual.Description)
 
@@ -1525,6 +1538,7 @@ spec:
 						require.Len(t, sum.Dashboards, 2)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-1", actual.MetaName)
 						assert.Equal(t, "display name", actual.Name)
 						assert.Equal(t, "desc1", actual.Description)
@@ -1692,6 +1706,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-1", actual.Name)
 						assert.Equal(t, "desc1", actual.Description)
 
@@ -1970,6 +1985,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-1", actual.Name)
 						assert.Equal(t, "desc1", actual.Description)
 
@@ -2147,6 +2163,7 @@ spec:
 						require.Len(t, sum.Dashboards, 1)
 
 						actual := sum.Dashboards[0]
+						assert.Equal(t, KindDashboard, actual.Kind)
 						assert.Equal(t, "dash-1", actual.Name)
 						assert.Equal(t, "desc1", actual.Description)
 
@@ -2432,7 +2449,10 @@ spec:
 			testfileRunner(t, "testdata/notification_endpoint", func(t *testing.T, template *Template) {
 				expectedEndpoints := []SummaryNotificationEndpoint{
 					{
-						MetaName: "http-basic-auth-notification-endpoint",
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:     KindNotificationEndpointHTTP,
+							MetaName: "http-basic-auth-notification-endpoint",
+						},
 						NotificationEndpoint: &endpoint.HTTP{
 							Base: endpoint.Base{
 								Name:        "basic endpoint name",
@@ -2447,7 +2467,10 @@ spec:
 						},
 					},
 					{
-						MetaName: "http-bearer-auth-notification-endpoint",
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:     KindNotificationEndpointHTTP,
+							MetaName: "http-bearer-auth-notification-endpoint",
+						},
 						NotificationEndpoint: &endpoint.HTTP{
 							Base: endpoint.Base{
 								Name:        "http-bearer-auth-notification-endpoint",
@@ -2461,7 +2484,10 @@ spec:
 						},
 					},
 					{
-						MetaName: "http-none-auth-notification-endpoint",
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:     KindNotificationEndpointHTTP,
+							MetaName: "http-none-auth-notification-endpoint",
+						},
 						NotificationEndpoint: &endpoint.HTTP{
 							Base: endpoint.Base{
 								Name:        "http-none-auth-notification-endpoint",
@@ -2474,7 +2500,10 @@ spec:
 						},
 					},
 					{
-						MetaName: "pager-duty-notification-endpoint",
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:     KindNotificationEndpointPagerDuty,
+							MetaName: "pager-duty-notification-endpoint",
+						},
 						NotificationEndpoint: &endpoint.PagerDuty{
 							Base: endpoint.Base{
 								Name:        "pager duty name",
@@ -2486,7 +2515,10 @@ spec:
 						},
 					},
 					{
-						MetaName: "slack-notification-endpoint",
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:     KindNotificationEndpointHTTP,
+							MetaName: "slack-notification-endpoint",
+						},
 						NotificationEndpoint: &endpoint.Slack{
 							Base: endpoint.Base{
 								Name:        "slack name",
@@ -2818,6 +2850,7 @@ spec:
 				require.Len(t, rules, 1)
 
 				rule := rules[0]
+				assert.Equal(t, KindNotificationRule, rule.Kind)
 				assert.Equal(t, "rule_0", rule.Name)
 				assert.Equal(t, "endpoint-0", rule.EndpointMetaName)
 				assert.Equal(t, "desc_0", rule.Description)
@@ -3152,6 +3185,11 @@ spec:
 				sum := template.Summary()
 				tasks := sum.Tasks
 				require.Len(t, tasks, 2)
+
+				for _, ta := range tasks {
+					assert.Equal(t, KindTask, ta.Kind)
+				}
+
 				sort.Slice(tasks, func(i, j int) bool {
 					return tasks[i].MetaName < tasks[j].MetaName
 				})
@@ -3374,6 +3412,7 @@ spec:
 				require.Len(t, sum.TelegrafConfigs, 2)
 
 				actual := sum.TelegrafConfigs[0]
+				assert.Equal(t, KindTelegraf, actual.Kind)
 				assert.Equal(t, "display name", actual.TelegrafConfig.Name)
 				assert.Equal(t, "desc", actual.TelegrafConfig.Description)
 
@@ -3473,6 +3512,9 @@ spec:
 				sum := template.Summary()
 
 				require.Len(t, sum.Variables, 4)
+				for _, v := range sum.Variables {
+					assert.Equal(t, KindVariable, v.Kind)
+				}
 
 				varEquals := func(t *testing.T, name, vType string, vals interface{}, selected []string, v SummaryVariable) {
 					t.Helper()
@@ -3869,28 +3911,37 @@ spec:
 
 		bkts := []SummaryBucket{
 			{
-				MetaName:          "rucket-1",
+				SummaryIdentifier: SummaryIdentifier{
+					Kind:          KindBucket,
+					MetaName:      "rucket-1",
+					EnvReferences: []SummaryReference{},
+				},
 				Name:              "rucket-1",
 				Description:       "desc_1",
 				RetentionPeriod:   10000 * time.Second,
 				LabelAssociations: labels,
-				EnvReferences:     []SummaryReference{},
 			},
 			{
-				MetaName:          "rucket-2",
+				SummaryIdentifier: SummaryIdentifier{
+					Kind:          KindBucket,
+					MetaName:      "rucket-2",
+					EnvReferences: []SummaryReference{},
+				},
 				Name:              "rucket-2",
 				Description:       "desc-2",
 				RetentionPeriod:   20000 * time.Second,
 				LabelAssociations: labels,
-				EnvReferences:     []SummaryReference{},
 			},
 			{
-				MetaName:          "rucket-3",
+				SummaryIdentifier: SummaryIdentifier{
+					Kind:          KindBucket,
+					MetaName:      "rucket-3",
+					EnvReferences: []SummaryReference{},
+				},
 				Name:              "rucket-3",
 				Description:       "desc_3",
 				RetentionPeriod:   30000 * time.Second,
 				LabelAssociations: labels,
-				EnvReferences:     []SummaryReference{},
 			},
 		}
 		assert.Equal(t, bkts, sum.Buckets)
@@ -4424,8 +4475,12 @@ func sumLabelGen(metaName, name, color, desc string, envRefs ...SummaryReference
 		envRefs = make([]SummaryReference, 0)
 	}
 	return SummaryLabel{
-		MetaName: metaName,
-		Name:     name,
+		SummaryIdentifier: SummaryIdentifier{
+			Kind:          KindLabel,
+			MetaName:      metaName,
+			EnvReferences: envRefs,
+		},
+		Name: name,
 		Properties: struct {
 			Color       string `json:"color"`
 			Description string `json:"description"`
@@ -4433,7 +4488,6 @@ func sumLabelGen(metaName, name, color, desc string, envRefs ...SummaryReference
 			Color:       color,
 			Description: desc,
 		},
-		EnvReferences: envRefs,
 	}
 }
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -785,14 +785,17 @@ func TestService(t *testing.T) {
 					require.Len(t, sum.Buckets, 2)
 
 					expected := SummaryBucket{
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:          KindBucket,
+							MetaName:      "rucket-11",
+							EnvReferences: []SummaryReference{},
+						},
 						ID:                SafeID(time.Hour),
 						OrgID:             SafeID(orgID),
-						MetaName:          "rucket-11",
 						Name:              "rucket-11",
 						Description:       "bucket 1 description",
 						RetentionPeriod:   time.Hour,
 						LabelAssociations: []SummaryLabel{},
-						EnvReferences:     []SummaryReference{},
 					}
 					assert.Contains(t, sum.Buckets, expected)
 				})
@@ -837,14 +840,17 @@ func TestService(t *testing.T) {
 					require.Len(t, sum.Buckets, 2)
 
 					expected := SummaryBucket{
+						SummaryIdentifier: SummaryIdentifier{
+							Kind:          KindBucket,
+							MetaName:      "rucket-11",
+							EnvReferences: []SummaryReference{},
+						},
 						ID:                SafeID(3),
 						OrgID:             SafeID(orgID),
-						MetaName:          "rucket-11",
 						Name:              "rucket-11",
 						Description:       "bucket 1 description",
 						RetentionPeriod:   time.Hour,
 						LabelAssociations: []SummaryLabel{},
-						EnvReferences:     []SummaryReference{},
 					}
 					assert.Contains(t, sum.Buckets, expected)
 					assert.Zero(t, fakeBktSVC.CreateBucketCalls.Count())


### PR DESCRIPTION
references: #18804

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)