### PR TITLE
chore: cleanup bucket auth and to transform dependencies

### DIFF
--- a/query/stdlib/experimental/to.go
+++ b/query/stdlib/experimental/to.go
@@ -176,9 +176,7 @@ func createToTransformation(id execute.DatasetID, mode execute.AccumulationMode,
 // ToTransformation is the transformation for the `to` flux function.
 type ToTransformation struct {
 	ctx      context.Context
-	bucket   string
 	bucketID platform.ID
-	org      string
 	orgID    platform.ID
 	d        execute.Dataset
 	cache    execute.TableBuilderCache

--- a/query/stdlib/experimental/to.go
+++ b/query/stdlib/experimental/to.go
@@ -197,7 +197,6 @@ func NewToTransformation(ctx context.Context, d execute.Dataset, cache execute.T
 	var err error
 
 	var orgID platform.ID
-	var org string
 	// Get organization name and ID
 	if spec.Spec.Org != "" {
 		oID, ok := deps.OrganizationLookup.Lookup(ctx, spec.Spec.Org)
@@ -205,7 +204,6 @@ func NewToTransformation(ctx context.Context, d execute.Dataset, cache execute.T
 			return nil, fmt.Errorf("failed to look up organization %q", spec.Spec.Org)
 		}
 		orgID = oID
-		org = spec.Spec.Org
 	} else if spec.Spec.OrgID != "" {
 		if oid, err := platform.IDFromString(spec.Spec.OrgID); err != nil {
 			return nil, err
@@ -220,15 +218,8 @@ func NewToTransformation(ctx context.Context, d execute.Dataset, cache execute.T
 		}
 		orgID = req.OrganizationID
 	}
-	if org == "" {
-		org = deps.OrganizationLookup.LookupName(ctx, orgID)
-		if org == "" {
-			return nil, fmt.Errorf("failed to look up organization name for ID %q", orgID.String())
-		}
-	}
 
 	var bucketID *platform.ID
-	var bucket string
 	// Get bucket name and ID
 	// User will have specified exactly one in the ToOpSpec.
 	if spec.Spec.Bucket != "" {
@@ -237,21 +228,14 @@ func NewToTransformation(ctx context.Context, d execute.Dataset, cache execute.T
 			return nil, fmt.Errorf("failed to look up bucket %q in org %q", spec.Spec.Bucket, spec.Spec.Org)
 		}
 		bucketID = &bID
-		bucket = spec.Spec.Bucket
 	} else {
 		if bucketID, err = platform.IDFromString(spec.Spec.BucketID); err != nil {
 			return nil, err
 		}
-		bucket = deps.BucketLookup.LookupName(ctx, orgID, *bucketID)
-		if bucket == "" {
-			return nil, fmt.Errorf("failed to look up bucket with ID %q in org %q", bucketID, org)
-		}
 	}
 	return &ToTransformation{
 		ctx:      ctx,
-		bucket:   bucket,
 		bucketID: *bucketID,
-		org:      org,
 		orgID:    orgID,
 		d:        d,
 		cache:    cache,

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -17,12 +17,10 @@ type HostLookup interface {
 
 type BucketLookup interface {
 	Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool)
-	LookupName(ctx context.Context, orgID platform.ID, id platform.ID) string
 }
 
 type OrganizationLookup interface {
 	Lookup(ctx context.Context, name string) (platform.ID, bool)
-	LookupName(ctx context.Context, id platform.ID) string
 }
 
 type FromDependencies struct {


### PR DESCRIPTION
This is just a small clean-up PR.

1. ~Tenant bucket auth middleware doesn't need a URM service (It doesn't use it).~ (doing this in another PR)
2. The `to()` related pieces don't need to resolve a bucket or orgs name from an ID in order to function.
