### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The project also requires a recent stable version of Rust. We recommend using [r
 
 If you are getting an `error loading module requirements` error with `bzr executable file not found in $PATH”` on `make`, then you need to ensure you have `bazaar`, `protobuf`, and `yarn` installed.
 
-- OSX: `brew install bazaar yarn`
+- OSX: `brew install bazaar yarn protobuf`
 - Linux (Arch): `pacman -S bzr protobuf yarn`
 - Linux (Ubuntu): `apt install bzr protobuf-compiler yarnpkg`
 


### PR DESCRIPTION
Simply adds protobuf to the OSX "Build From Source" section as it was missing.

