### PR TITLE
feat(storage): Add logging points writer

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -951,7 +951,11 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		SessionRenewDisabled: m.sessionRenewDisabled,
 		NewBucketService:     source.NewBucketService,
 		NewQueryService:      source.NewQueryService,
-		PointsWriter:         pointsWriter,
+		PointsWriter: &storage.LoggingPointsWriter{
+			Underlying:    pointsWriter,
+			BucketService: bucketSvc,
+			LogBucketName: platform.MonitoringSystemBucketName,
+		},
 		DeleteService:        deleteService,
 		BackupService:        backupService,
 		KVBackupService:      m.kvService,

--- a/mock/points_writer.go
+++ b/mock/points_writer.go
@@ -13,6 +13,8 @@ type PointsWriter struct {
 	mu               sync.RWMutex
 	Points           []models.Point
 	Err              error
+
+	WritePointsFn func(ctx context.Context, points []models.Point) error
 }
 
 // ForceError is for error testing, if WritePoints is called after ForceError, it will return that error.
@@ -24,6 +26,10 @@ func (p *PointsWriter) ForceError(err error) {
 
 // WritePoints writes points to the PointsWriter that will be exposed in the Values.
 func (p *PointsWriter) WritePoints(ctx context.Context, points []models.Point) error {
+	if p.WritePointsFn != nil {
+		return p.WritePointsFn(ctx, points)
+	}
+
 	p.mu.Lock()
 	p.timesWriteCalled++
 	p.Points = append(p.Points, points...)

--- a/storage/points_writer.go
+++ b/storage/points_writer.go
@@ -2,13 +2,71 @@ package storage
 
 import (
 	"context"
+	"time"
 
+	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/tsdb"
 )
 
 // PointsWriter describes the ability to write points into a storage engine.
 type PointsWriter interface {
 	WritePoints(context.Context, []models.Point) error
+}
+
+// LoggingPointsWriter wraps an underlying points writer but writes logs to
+// another bucket when an error occurs.
+type LoggingPointsWriter struct {
+	// Wrapped points writer. Errored writes from here will be logged.
+	Underlying PointsWriter
+
+	// Service used to look up logging bucket.
+	BucketService influxdb.BucketService
+
+	// Name of the bucket to log to.
+	LogBucketName string
+}
+
+// WritePoints writes points to the underlying PointsWriter. Logs on error.
+func (w *LoggingPointsWriter) WritePoints(ctx context.Context, p []models.Point) error {
+	if len(p) == 0 {
+		return nil
+	}
+
+	// Write to underlying writer and exit immediately if successful.
+	err := w.Underlying.WritePoints(ctx, p)
+	if err == nil {
+		return nil
+	}
+
+	// Find organizationID from points
+	orgID, _ := tsdb.DecodeNameSlice(p[0].Name())
+
+	// Attempt to lookup log bucket.
+	bkt, e := w.BucketService.FindBucketByName(ctx, orgID, w.LogBucketName)
+	if e != nil {
+		return e
+	}
+
+	// Log error to bucket.
+	name := tsdb.EncodeName(orgID, bkt.ID)
+	pt, e := models.NewPoint(
+		string(name[:]),
+		models.NewTags(map[string]string{
+			models.MeasurementTagKey: "write_errors",
+			models.FieldKeyTagKey:    "error"},
+		),
+		models.Fields{"error": err.Error()},
+		time.Now(),
+	)
+	if e != nil {
+		return e
+	}
+	if e := w.Underlying.WritePoints(ctx, []models.Point{pt}); e != nil {
+		return e
+	}
+
+	return err
 }
 
 type BufferedPointsWriter struct {


### PR DESCRIPTION
## Overview 

This commit adds a LoggingPointsWriter which wraps a PointsWriter and provides logging when a write fails.


## Usage

Initial float write:

```sh
% influx write 'm v=1'                                        
```

Write to the same field but as an integer:

```sh
% influx write 'm v=1i'                                        
Error: Failed to write data: unexpected error writing points to database: partial write: series type mismatch: already Float but got Integer dropped=1.
See 'influx write -h' for help
```

Query logging from the `_monitoring` bucket:

```sh
% influx query 'from(bucket:"_monitoring") |> range(start:-1h)'
Result: _result
Table: keys: [_start, _stop, _field, _measurement]
                   _start:time                      _stop:time           _field:string     _measurement:string                      _time:time                                                                 _value:string  
------------------------------  ------------------------------  ----------------------  ----------------------  ------------------------------  ----------------------------------------------------------------------------  
2020-07-01T14:56:33.162539000Z  2020-07-01T15:56:33.162539000Z                   error            write_errors  2020-07-01T15:54:55.171442000Z  partial write: series type mismatch: already Float but got Integer dropped=1  
```

---

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

