### PR TITLE
refactor: remove feature flag for certain pushdowns

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
 	phttp "github.com/influxdata/influxdb/v2/http"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/kit/prom"
+	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/query"
 )
 
@@ -1596,24 +1598,12 @@ from(bucket: v.bucket)
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			l := launcher.RunTestLauncherOrFail(t, ctx, nil,
-				"--feature-flags",
-				"pushDownWindowAggregateCount=true",
-				"--feature-flags",
-				"pushDownWindowAggregateSum=true",
-				"--feature-flags",
-				"pushDownWindowAggregateFirst=true",
-				"--feature-flags",
-				"pushDownWindowAggregateLast=true",
-				"--feature-flags",
-				"pushDownGroupAggregateCount=true",
-				"--feature-flags",
-				"pushDownGroupAggregateSum=true",
-				"--feature-flags",
-				"pushDownGroupAggregateFirst=true",
-				"--feature-flags",
-				"pushDownGroupAggregateLast=true",
-			)
+			l := launcher.RunTestLauncherOrFail(t, ctx, mock.NewFlagger(map[feature.Flag]interface{}{
+				feature.PushDownWindowAggregateCount(): true,
+				feature.PushDownWindowAggregateSum():   true,
+				feature.PushDownWindowAggregateFirst(): true,
+				feature.PushDownWindowAggregateLast():  true,
+			}))
 
 			l.SetupOrFail(t)
 			defer l.ShutdownOrFail(t, ctx)

--- a/flags.yml
+++ b/flags.yml
@@ -96,34 +96,7 @@
   key: newAuth
   default: false
   contact: Alirie Gray
-  lifetime: temporary
-
-- name: Push Down Group Aggregate Count
-  description: Enable the count variant of PushDownGroupAggregate planner rule
-  key: pushDownGroupAggregateCount
-  default: false
-  contact: Query Team
-
-- name: Push Down Group Aggregate Sum
-  description: Enable the sum variant of PushDownGroupAggregate planner rule
-  key: pushDownGroupAggregateSum
-  default: false
-  contact: Query Team
-  lifetime: temporary
-
-- name: Push Down Group Aggregate First
-  description: Enable the first variant of PushDownGroupAggregate planner rule
-  key: pushDownGroupAggregateFirst
-  default: false
-  contact: Query Team
-  lifetime: temporary
-
-- name: Push Down Group Aggregate Last
-  description: Enable the last variant of PushDownGroupAggregate planner rule
-  key: pushDownGroupAggregateLast
-  default: false
-  contact: Query Team
-  lifetime: temporary
+  lifetime: temporaryc
 
 - name: New Label Package
   description: Enables the refactored labels api

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -184,62 +184,6 @@ func NewAuthPackage() BoolFlag {
 	return newAuth
 }
 
-var pushDownGroupAggregateCount = MakeBoolFlag(
-	"Push Down Group Aggregate Count",
-	"pushDownGroupAggregateCount",
-	"Query Team",
-	false,
-	Temporary,
-	false,
-)
-
-// PushDownGroupAggregateCount - Enable the count variant of PushDownGroupAggregate planner rule
-func PushDownGroupAggregateCount() BoolFlag {
-	return pushDownGroupAggregateCount
-}
-
-var pushDownGroupAggregateSum = MakeBoolFlag(
-	"Push Down Group Aggregate Sum",
-	"pushDownGroupAggregateSum",
-	"Query Team",
-	false,
-	Temporary,
-	false,
-)
-
-// PushDownGroupAggregateSum - Enable the sum variant of PushDownGroupAggregate planner rule
-func PushDownGroupAggregateSum() BoolFlag {
-	return pushDownGroupAggregateSum
-}
-
-var pushDownGroupAggregateFirst = MakeBoolFlag(
-	"Push Down Group Aggregate First",
-	"pushDownGroupAggregateFirst",
-	"Query Team",
-	false,
-	Temporary,
-	false,
-)
-
-// PushDownGroupAggregateFirst - Enable the first variant of PushDownGroupAggregate planner rule
-func PushDownGroupAggregateFirst() BoolFlag {
-	return pushDownGroupAggregateFirst
-}
-
-var pushDownGroupAggregateLast = MakeBoolFlag(
-	"Push Down Group Aggregate Last",
-	"pushDownGroupAggregateLast",
-	"Query Team",
-	false,
-	Temporary,
-	false,
-)
-
-// PushDownGroupAggregateLast - Enable the last variant of PushDownGroupAggregate planner rule
-func PushDownGroupAggregateLast() BoolFlag {
-	return pushDownGroupAggregateLast
-}
-
 var newLabels = MakeBoolFlag(
 	"New Label Package",
 	"newLabels",
@@ -338,10 +282,6 @@ var all = []Flag{
 	pushDownWindowAggregateLast,
 	groupWindowAggregateTranspose,
 	newAuth,
-	pushDownGroupAggregateCount,
-	pushDownGroupAggregateSum,
-	pushDownGroupAggregateFirst,
-	pushDownGroupAggregateLast,
 	newLabels,
 	hydratevars,
 	memoryOptimizedFill,
@@ -364,10 +304,6 @@ var byKey = map[string]Flag{
 	"pushDownWindowAggregateLast":   pushDownWindowAggregateLast,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
 	"newAuth":                       newAuth,
-	"pushDownGroupAggregateCount":   pushDownGroupAggregateCount,
-	"pushDownGroupAggregateSum":     pushDownGroupAggregateSum,
-	"pushDownGroupAggregateFirst":   pushDownGroupAggregateFirst,
-	"pushDownGroupAggregateLast":    pushDownGroupAggregateLast,
 	"newLabels":                     newLabels,
 	"hydratevars":                   hydratevars,
 	"memoryOptimizedFill":           memoryOptimizedFill,

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -1106,26 +1106,16 @@ func canPushGroupedAggregate(ctx context.Context, pn plan.Node) bool {
 	switch pn.Kind() {
 	case universe.CountKind:
 		agg := pn.ProcedureSpec().(*universe.CountProcedureSpec)
-		return caps.HaveCount() &&
-			feature.PushDownGroupAggregateCount().Enabled(ctx) &&
-			len(agg.Columns) == 1 &&
-			agg.Columns[0] == execute.DefaultValueColLabel
+		return caps.HaveCount() && len(agg.Columns) == 1 && agg.Columns[0] == execute.DefaultValueColLabel
 	case universe.SumKind:
 		agg := pn.ProcedureSpec().(*universe.SumProcedureSpec)
-		return caps.HaveSum() &&
-			feature.PushDownGroupAggregateSum().Enabled(ctx) &&
-			len(agg.Columns) == 1 &&
-			agg.Columns[0] == execute.DefaultValueColLabel
+		return caps.HaveSum() && len(agg.Columns) == 1 && agg.Columns[0] == execute.DefaultValueColLabel
 	case universe.FirstKind:
 		agg := pn.ProcedureSpec().(*universe.FirstProcedureSpec)
-		return caps.HaveFirst() &&
-			feature.PushDownGroupAggregateFirst().Enabled(ctx) &&
-			agg.Column == execute.DefaultValueColLabel
+		return caps.HaveFirst() && agg.Column == execute.DefaultValueColLabel
 	case universe.LastKind:
 		agg := pn.ProcedureSpec().(*universe.LastProcedureSpec)
-		return caps.HaveLast() &&
-			feature.PushDownGroupAggregateLast().Enabled(ctx) &&
-			agg.Column == execute.DefaultValueColLabel
+		return caps.HaveLast() && agg.Column == execute.DefaultValueColLabel
 	}
 	return false
 }

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -2602,12 +2602,7 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 //
 func TestPushDownGroupAggregateRule(t *testing.T) {
 	// Turn on all flags
-	ctx, _ := feature.Annotate(context.Background(), mock.NewFlagger(map[feature.Flag]interface{}{
-		feature.PushDownGroupAggregateCount(): true,
-		feature.PushDownGroupAggregateSum():   true,
-		feature.PushDownGroupAggregateFirst(): true,
-		feature.PushDownGroupAggregateLast():  true,
-	}))
+	ctx, _ := feature.Annotate(context.Background(), mock.NewFlagger(map[feature.Flag]interface{}{}))
 
 	caps := func(c query.GroupCapability) context.Context {
 		deps := influxdb.StorageDependencies{

--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -166,11 +166,5 @@ var FluxEndToEndFeatureFlags = PerTestFeatureFlagMap{
 		"bare_sum_push": {
 			"pushDownWindowAggregateSum": "true",
 		},
-		"group_count_push": {
-			"pushDownGroupAggregateCount": "true",
-		},
-		"group_sum_push": {
-			"pushDownGroupAggregateSum": "true",
-		},
 	},
 }


### PR DESCRIPTION
This PR turns pushdown optimizations on by default for
```
|> group |> count
|> group |> sum
|> group |> first
|> group |> last
```
