### PR TITLE
feat(pkger): add initial outline of stack annotations and the ownerhship

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -1,0 +1,122 @@
+package influxdb
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// not exporting this so users are unable to create annotations.
+// this can change but for now want to keep this under lock and key.
+type annotation int
+
+const (
+	annotationUnknown annotation = iota
+	annotationStackOwner
+	annotationStackReference
+)
+
+type Annotations struct {
+	// Hide the internals so it can't be manipulated freely.
+	m map[annotation]interface{}
+}
+
+func (a Annotations) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.m)
+}
+
+func (a *Annotations) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &a.m)
+}
+
+func (a *Annotations) Stacks() struct {
+	Owner      ID
+	References []ID
+} {
+	var out struct {
+		Owner      ID
+		References []ID
+	}
+	if a == nil {
+		return out
+	}
+
+	ownerIDRaw, ok := a.m[annotationStackOwner].(string)
+	if ok {
+		if id, err := IDFromString(ownerIDRaw); err == nil {
+			out.Owner = *id
+		}
+	}
+
+	refs, _ := a.m[annotationStackReference].([]interface{})
+	for _, ref := range refs {
+		refIDRaw, ok := ref.(string)
+		if ok {
+			if id, err := IDFromString(refIDRaw); err == nil {
+				out.References = append(out.References, *id)
+			}
+		}
+	}
+
+	return out
+}
+
+type AnnotationSetFn func(a *Annotations)
+
+func (a *Annotations) Set(setFn AnnotationSetFn) {
+	if a.m == nil {
+		a.m = make(map[annotation]interface{})
+	}
+	setFn(a)
+}
+
+func (a *Annotations) Clone() Annotations {
+	m := make(map[annotation]interface{})
+	for k, v := range a.m {
+		m[k] = v
+	}
+	return Annotations{m: m}
+}
+
+func AnnotationSetStack(stackID ID) AnnotationSetFn {
+	return func(a *Annotations) {
+		stAnnot := a.Stacks()
+		if stackID == stAnnot.Owner {
+			return
+		}
+		if stAnnot.Owner == 0 {
+			AnnotationSetStackOwner(stackID)(a)
+			return
+		}
+		AnnotationSetStackReference(stackID)(a)
+	}
+}
+
+func AnnotationSetStackOwner(stackID ID) AnnotationSetFn {
+	return func(a *Annotations) {
+		a.m[annotationStackOwner] = stackID.String()
+	}
+}
+
+func AnnotationSetStackReference(stackID ID) AnnotationSetFn {
+	return func(a *Annotations) {
+		refs, _ := a.m[annotationStackReference].([]interface{})
+
+		m := map[string]bool{
+			stackID.String(): true,
+		}
+		for _, refRaw := range refs {
+			if id, ok := refRaw.(string); ok {
+				m[id] = true
+			}
+		}
+
+		var newRefs []interface{}
+		for ref := range m {
+			newRefs = append(newRefs, ref)
+		}
+		sort.Slice(newRefs, func(i, j int) bool {
+			return newRefs[i].(string) < newRefs[j].(string)
+		})
+		a.m[annotationStackReference] = newRefs
+	}
+}

--- a/kv/label.go
+++ b/kv/label.go
@@ -408,6 +408,10 @@ func (s *Service) updateLabel(ctx context.Context, tx Tx, id influxdb.ID, upd in
 		label.Properties = make(map[string]string)
 	}
 
+	if upd.Annotations != nil {
+		label.Annotations = *upd.Annotations
+	}
+
 	for k, v := range upd.Properties {
 		if v == "" {
 			delete(label.Properties, k)

--- a/label.go
+++ b/label.go
@@ -63,10 +63,11 @@ type LabelService interface {
 
 // Label is a tag set on a resource, typically used for filtering on a UI.
 type Label struct {
-	ID         ID                `json:"id,omitempty"`
-	OrgID      ID                `json:"orgID,omitempty"`
-	Name       string            `json:"name"`
-	Properties map[string]string `json:"properties,omitempty"`
+	ID          ID                `json:"id,omitempty"`
+	OrgID       ID                `json:"orgID,omitempty"`
+	Name        string            `json:"name"`
+	Properties  map[string]string `json:"properties,omitempty"`
+	Annotations Annotations       `json:"annotations"`
 }
 
 // Validate returns an error if the label is invalid.
@@ -123,8 +124,9 @@ func (l *LabelMapping) Validate() error {
 // LabelUpdate represents a changeset for a label.
 // Only the properties specified are updated.
 type LabelUpdate struct {
-	Name       string            `json:"name,omitempty"`
-	Properties map[string]string `json:"properties,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Properties  map[string]string `json:"properties,omitempty"`
+	Annotations *Annotations      `json:"annotations,omitempty"`
 }
 
 // LabelFilter represents a set of filters that restrict the returned results.


### PR DESCRIPTION
this a draft of the guardianship model as outlined with labels here.  The idea is this, we have stacks read the annotations on the individual resources, and if they are the owner, they can do whatever they want to the resource. if they are a reference, they can only read that resource. 

There are a lot of tests here... to acknowledge all the different state conditions for a label resource. I think I've covered all in the `pkger_test.go` tests 🤔.  This PR only touches on stacks ability to work with resources. Follow up work will build on this foundation is the plan. I'd liek to shoot as many holes in this idea as possible before marrying to it.


references: #18240

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass