### PR TITLE
fix(swagger): PostBucketRequest.orgID is required

### DIFF
--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -457,6 +457,34 @@ func TestService_handlePostBucket(t *testing.T) {
 				statusCode: http.StatusUnprocessableEntity,
 			},
 		},
+		{
+			name: "create a new bucket without orgId",
+			fields: fields{
+				BucketService: &mock.BucketService{
+					CreateBucketFn: func(ctx context.Context, c *influxdb.Bucket) error {
+						c.ID = platformtesting.MustIDBase16("020f755c3c082000")
+						return nil
+					},
+				},
+				OrganizationService: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, f influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+						return &influxdb.Organization{ID: platformtesting.MustIDBase16("6f626f7274697320")}, nil
+					},
+				},
+			},
+			args: args{
+				bucket: &influxdb.Bucket{
+					Name: "hello",
+				},
+			},
+			wants: wants{
+				statusCode: http.StatusBadRequest,
+				body: `{
+	"code": "invalid",
+	"message": "organization id must be provided"
+}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7430,7 +7430,7 @@ components:
           type: string
         retentionRules:
           $ref: "#/components/schemas/RetentionRules"
-      required: [name, retentionRules]
+      required: [orgID, name, retentionRules]
     Bucket:
       properties:
         links:


### PR DESCRIPTION
This PR set `orgID` from `PostBucketRequest` as a required field. 

See sources:

https://github.com/influxdata/influxdb/blob/af1119304d7130606235eeec73144c8212b54598/http/bucket_service.go#L345

https://github.com/influxdata/influxdb/blob/5776350a5396b1f5b5f25f8c5b81582d536a35c2/tenant/http_server_bucket.go#L297

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

https://github.com/influxdata/influxdb-client-python/issues/119
