### PR TITLE
chore(docs): update documentation links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,7 +93,7 @@ Your browser should reload the page after you save your changes (sometimes this 
 
 ## Getting some Graphs
 
-If you haven't set up telegraf yet, [following the official telegraf documentation](https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/) is the quickest and most straightforward and hassle-free way of getting some data into your local instance. The documentation there will be kept fresher and and more current than this tutorial.
+If you haven't set up telegraf yet, [following the official telegraf documentation](https://v2.docs.influxdata.com/v2.0/write-data/no-code/use-telegraf/) is the quickest and most straightforward and hassle-free way of getting some data into your local instance. The documentation there will be kept fresher and and more current than this tutorial.
 
 Learning how to input Line protocol data is a great tool if you need to debug with arbitrary adhoc data. Check out a quick intro to the [Line protocol](https://v2.docs.influxdata.com/v2.0/write-data/#what-you-ll-need), and learn how to [input it via the ui.](https://v2.docs.influxdata.com/v2.0/write-data/#user-interface) *Since we're running `influxd` locally, you can skip step 1.*
 

--- a/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -79,7 +79,7 @@ export class SelectCollectorsStep extends PureComponent<Props> {
             </a>
             &nbsp; and how to &nbsp;
             <a
-              href="https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/manual-config/"
+              href="https://v2.docs.influxdata.com/v2.0/write-data/no-code/use-telegraf/manual-config/"
               target="_blank"
             >
               Configure these Plugins

--- a/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolHelperText.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolHelperText.tsx
@@ -6,7 +6,7 @@ const LineProtocolHelperText: FC<{}> = () => {
     <p>
       Need help writing InfluxDB Line Protocol?{' '}
       <a
-        href="https://v2.docs.influxdata.com/v2.0/write-data/#write-data-in-the-influxdb-ui"
+        href="https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/"
         target="_blank"
       >
         See Documentation

--- a/ui/src/telegrafs/components/TelegrafExplainer.tsx
+++ b/ui/src/telegrafs/components/TelegrafExplainer.tsx
@@ -40,7 +40,7 @@ const TelegrafExplainer: FunctionComponent<Props> = ({
       <br />
       Here's a handy guide for{' '}
       <a
-        href="https://v2.docs.influxdata.com/v2.0/write-data/use-telegraf/"
+        href="https://v2.docs.influxdata.com/v2.0/write-data/no-code/use-telegraf/"
         target="_blank"
       >
         Getting Started with Telegraf


### PR DESCRIPTION
The "Write Data" section of the v2 documentation was restructured. Although redirects were put in place for all the modified docs, we're adding new functionality that will automatically select and update cloud URLs if users visit the docs from Cloud. 301 redirects lose the referrer. I updated the links to prevent the need for redirects.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
