### PR TITLE
chore(flagged): rename variables

### DIFF
--- a/ui/src/templates/actions/creators.ts
+++ b/ui/src/templates/actions/creators.ts
@@ -11,7 +11,8 @@ export const ADD_TEMPLATE_SUMMARY = 'ADD_TEMPLATE_SUMMARY'
 export const GET_TEMPLATE_SUMMARIES_FOR_ORG = 'GET_TEMPLATE_SUMMARIES_FOR_ORG'
 export const POPULATE_TEMPLATE_SUMMARIES = 'POPULATE_TEMPLATE_SUMMARIES'
 export const REMOVE_TEMPLATE_SUMMARY = 'REMOVE_TEMPLATE_SUMMARY'
-export const SET_ACTIVE_COMMUNITY_TEMPLATE = 'SET_ACTIVE_COMMUNITY_TEMPLATE'
+export const SET_COMMUNITY_TEMPLATE_TO_INSTALL =
+  'SET_COMMUNITY_TEMPLATE_TO_INSTALL'
 export const SET_EXPORT_TEMPLATE = 'SET_EXPORT_TEMPLATE'
 export const SET_TEMPLATE_SUMMARY = 'SET_TEMPLATE_SUMMARY'
 export const SET_TEMPLATES_STATUS = 'SET_TEMPLATES_STATUS'
@@ -25,7 +26,7 @@ export type Action =
   | ReturnType<typeof setExportTemplate>
   | ReturnType<typeof setTemplatesStatus>
   | ReturnType<typeof setTemplateSummary>
-  | ReturnType<typeof setActiveCommunityTemplate>
+  | ReturnType<typeof setCommunityTemplateToInstall>
   | ReturnType<typeof toggleTemplateResourceInstall>
 
 type TemplateSummarySchema<R extends string | string[]> = NormalizedSchema<
@@ -83,9 +84,9 @@ export const setTemplateSummary = (
     schema,
   } as const)
 
-export const setActiveCommunityTemplate = (template: CommunityTemplate) =>
+export const setCommunityTemplateToInstall = (template: CommunityTemplate) =>
   ({
-    type: SET_ACTIVE_COMMUNITY_TEMPLATE,
+    type: SET_COMMUNITY_TEMPLATE_TO_INSTALL,
     template,
   } as const)
 

--- a/ui/src/templates/components/CommunityTemplateContents.tsx
+++ b/ui/src/templates/components/CommunityTemplateContents.tsx
@@ -21,7 +21,7 @@ import {toggleTemplateResourceInstall} from 'src/templates/actions/creators'
 import {getResourceInstallCount} from 'src/templates/selectors'
 
 interface StateProps {
-  activeCommunityTemplate: CommunityTemplate
+  summary: CommunityTemplate
 }
 
 interface DispatchProps {
@@ -32,8 +32,8 @@ type Props = StateProps & DispatchProps
 
 class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
   render() {
-    const {activeCommunityTemplate} = this.props
-    if (!Object.keys(activeCommunityTemplate).length) {
+    const {summary} = this.props
+    if (!Object.keys(summary).length) {
       return (
         <Panel>
           <Panel.Header>Calculating template resource needs...</Panel.Header>
@@ -50,10 +50,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
       >
         <CommunityTemplateListGroup
           title="Dashboards"
-          count={getResourceInstallCount(activeCommunityTemplate.dashboards)}
+          count={getResourceInstallCount(summary.dashboards)}
         >
-          {Array.isArray(activeCommunityTemplate.dashboards) &&
-            activeCommunityTemplate.dashboards.map(dashboard => {
+          {Array.isArray(summary.dashboards) &&
+            summary.dashboards.map(dashboard => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={dashboard.shouldInstall}
@@ -75,12 +75,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Telegraf Configurations"
-          count={getResourceInstallCount(
-            activeCommunityTemplate.telegrafConfigs
-          )}
+          count={getResourceInstallCount(summary.telegrafConfigs)}
         >
-          {Array.isArray(activeCommunityTemplate.telegrafConfigs) &&
-            activeCommunityTemplate.telegrafConfigs.map(telegrafConfig => {
+          {Array.isArray(summary.telegrafConfigs) &&
+            summary.telegrafConfigs.map(telegrafConfig => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={telegrafConfig.shouldInstall}
@@ -100,10 +98,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Buckets"
-          count={getResourceInstallCount(activeCommunityTemplate.buckets)}
+          count={getResourceInstallCount(summary.buckets)}
         >
-          {Array.isArray(activeCommunityTemplate.buckets) &&
-            activeCommunityTemplate.buckets.map(bucket => {
+          {Array.isArray(summary.buckets) &&
+            summary.buckets.map(bucket => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={bucket.shouldInstall}
@@ -123,10 +121,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Checks"
-          count={getResourceInstallCount(activeCommunityTemplate.checks)}
+          count={getResourceInstallCount(summary.checks)}
         >
-          {Array.isArray(activeCommunityTemplate.checks) &&
-            activeCommunityTemplate.checks.map(check => {
+          {Array.isArray(summary.checks) &&
+            summary.checks.map(check => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={check.shouldInstall}
@@ -146,10 +144,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Variables"
-          count={getResourceInstallCount(activeCommunityTemplate.variables)}
+          count={getResourceInstallCount(summary.variables)}
         >
-          {Array.isArray(activeCommunityTemplate.variables) &&
-            activeCommunityTemplate.variables.map(variable => {
+          {Array.isArray(summary.variables) &&
+            summary.variables.map(variable => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={variable.shouldInstall}
@@ -171,12 +169,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Notification Rules"
-          count={getResourceInstallCount(
-            activeCommunityTemplate.notificationRules
-          )}
+          count={getResourceInstallCount(summary.notificationRules)}
         >
-          {Array.isArray(activeCommunityTemplate.notificationRules) &&
-            activeCommunityTemplate.notificationRules.map(notificationRule => {
+          {Array.isArray(summary.notificationRules) &&
+            summary.notificationRules.map(notificationRule => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={notificationRule.shouldInstall}
@@ -196,10 +192,10 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
         </CommunityTemplateListGroup>
         <CommunityTemplateListGroup
           title="Labels"
-          count={getResourceInstallCount(activeCommunityTemplate.labels)}
+          count={getResourceInstallCount(summary.labels)}
         >
-          {Array.isArray(activeCommunityTemplate.labels) &&
-            activeCommunityTemplate.labels.map(label => {
+          {Array.isArray(summary.labels) &&
+            summary.labels.map(label => {
               return (
                 <CommunityTemplateListItem
                   shouldInstall={label.shouldInstall}
@@ -228,9 +224,7 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
 }
 
 const mstp = (state: AppState): StateProps => {
-  const {activeCommunityTemplate} = state.resources.templates
-
-  return {activeCommunityTemplate}
+  return {summary: state.resources.templates.communityTemplateToInstall.summary}
 }
 
 const mdtp = {

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -89,7 +89,9 @@ const mstp = (state: AppState, props: Props): StateProps => {
     org,
     templateName: props.params.templateName,
     flags: state.flags.original,
-    resourceCount: getTotalResourceCount(state),
+    resourceCount: getTotalResourceCount(
+      state.resources.templates.communityTemplateToInstall.summary
+    ),
   }
 }
 

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -28,13 +28,8 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {
   getGithubUrlFromTemplateName,
   getTemplateNameFromGithubUrl,
+  reviewTemplate,
 } from 'src/templates/utils'
-
-import {
-  Error as PkgError,
-  TemplateSummary,
-  postTemplatesApply,
-} from 'src/client'
 
 // Types
 import {AppState, Organization} from 'src/types'
@@ -77,7 +72,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       )
 
       this.setState({currentTemplate}, () => {
-        this.applyTemplates(
+        this.reviewTemplateResources(
           this.props.org.id,
           getTemplateNameFromGithubUrl(currentTemplate)
         )
@@ -148,24 +143,13 @@ class UnconnectedTemplatesIndex extends Component<Props> {
     )
   }
 
-  private applyTemplates = async (orgID, templateName) => {
+  private reviewTemplateResources = async (orgID, templateName) => {
     const yamlLocation =
       getRawYamlFromGithub(this.state.currentTemplate) + `/${templateName}.yml`
 
-    const params = {
-      data: {
-        dryRun: true,
-        orgID,
-        remotes: [{url: yamlLocation}],
-      },
-    }
     try {
-      const resp = await postTemplatesApply(params)
-      if (resp.status >= 300) {
-        throw new Error((resp.data as PkgError).message)
-      }
+      const summary = await reviewTemplate(orgID, yamlLocation)
 
-      const summary = (resp.data as TemplateSummary).summary
       this.props.setActiveCommunityTemplate(summary)
       return summary
     } catch (err) {
@@ -181,7 +165,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
 
     const name = getTemplateNameFromGithubUrl(this.state.currentTemplate)
     this.showInstallerOverlay(name)
-    this.applyTemplates(this.props.org.id, name)
+    this.reviewTemplateResources(this.props.org.id, name)
   }
 
   private showInstallerOverlay = templateName => {

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -20,7 +20,7 @@ import {
 import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
 import SettingsHeader from 'src/settings/components/SettingsHeader'
 
-import {setActiveCommunityTemplate} from 'src/templates/actions/creators'
+import {setCommunityTemplateToInstall} from 'src/templates/actions/creators'
 import {getOrg} from 'src/organizations/selectors'
 
 // Utils
@@ -46,7 +46,7 @@ interface OwnProps extends WithRouterProps {
 }
 
 interface DispatchProps {
-  setActiveCommunityTemplate: typeof setActiveCommunityTemplate
+  setCommunityTemplateToInstall: typeof setCommunityTemplateToInstall
 }
 
 type Props = DispatchProps & OwnProps & StateProps
@@ -150,7 +150,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
     try {
       const summary = await reviewTemplate(orgID, yamlLocation)
 
-      this.props.setActiveCommunityTemplate(summary)
+      this.props.setCommunityTemplateToInstall(summary)
       return summary
     } catch (err) {
       console.error(err)
@@ -186,7 +186,7 @@ const mstp = (state: AppState): StateProps => {
 }
 
 const mdtp = {
-  setActiveCommunityTemplate,
+  setCommunityTemplateToInstall,
 }
 
 export const CommunityTemplatesIndex = connect<StateProps, {}, {}>(

--- a/ui/src/templates/reducers/index.test.ts
+++ b/ui/src/templates/reducers/index.test.ts
@@ -42,10 +42,10 @@ const templateSummary = {
 
 const exportTemplate = {status, item: null}
 
-const activeCommunityTemplate: CommunityTemplate = {}
+const communityTemplateToInstall: CommunityTemplate = {}
 
 const initialState = () => ({
-  activeCommunityTemplate,
+  communityTemplateToInstall,
   status,
   byID: {
     ['1']: templateSummary,
@@ -97,7 +97,7 @@ describe('templates reducer', () => {
       byID,
       allIDs,
       exportTemplate,
-      activeCommunityTemplate,
+      communityTemplateToInstall,
     }
     const actual = reducer(state, removeTemplateSummary(state.allIDs[1]))
 

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -4,7 +4,7 @@ import {
   ADD_TEMPLATE_SUMMARY,
   POPULATE_TEMPLATE_SUMMARIES,
   REMOVE_TEMPLATE_SUMMARY,
-  SET_ACTIVE_COMMUNITY_TEMPLATE,
+  SET_COMMUNITY_TEMPLATE_TO_INSTALL,
   SET_EXPORT_TEMPLATE,
   SET_TEMPLATE_SUMMARY,
   SET_TEMPLATES_STATUS,
@@ -25,7 +25,10 @@ import {
 } from 'src/resources/reducers/helpers'
 
 export const defaultState = (): TemplatesState => ({
-  activeCommunityTemplate: {} as CommunityTemplate,
+  communityTemplateToInstall: {
+    summary: {},
+    diff: {},
+  } as CommunityTemplate,
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
@@ -63,22 +66,25 @@ export const templatesReducer = (
         return
       }
 
-      case SET_ACTIVE_COMMUNITY_TEMPLATE: {
+      case SET_COMMUNITY_TEMPLATE_TO_INSTALL: {
         const {template} = action
 
-        const activeCommunityTemplate: CommunityTemplate = {}
+        const communityTemplateToInstall: CommunityTemplate = {
+          diff: template.diff || {},
+          summary: template.summary || {},
+        }
 
-        activeCommunityTemplate.dashboards = (template.dashboards || []).map(
-          dashboard => {
-            if (!dashboard.hasOwnProperty('shouldInstall')) {
-              dashboard.shouldInstall = true
-            }
-            return dashboard
+        communityTemplateToInstall.summary.dashboards = (
+          template.summary.dashboards || []
+        ).map(dashboard => {
+          if (!dashboard.hasOwnProperty('shouldInstall')) {
+            dashboard.shouldInstall = true
           }
-        )
+          return dashboard
+        })
 
-        activeCommunityTemplate.telegrafConfigs = (
-          template.telegrafConfigs || []
+        communityTemplateToInstall.summary.telegrafConfigs = (
+          template.summary.telegrafConfigs || []
         ).map(telegrafConfig => {
           if (!telegrafConfig.hasOwnProperty('shouldInstall')) {
             telegrafConfig.shouldInstall = true
@@ -86,48 +92,70 @@ export const templatesReducer = (
           return telegrafConfig
         })
 
-        activeCommunityTemplate.buckets = (template.buckets || []).map(
-          bucket => {
-            if (!bucket.hasOwnProperty('shouldInstall')) {
-              bucket.shouldInstall = true
-            }
-            return bucket
+        communityTemplateToInstall.summary.buckets = (
+          template.summary.buckets || []
+        ).map(bucket => {
+          if (!bucket.hasOwnProperty('shouldInstall')) {
+            bucket.shouldInstall = true
           }
-        )
+          return bucket
+        })
 
-        activeCommunityTemplate.checks = (template.checks || []).map(check => {
+        communityTemplateToInstall.summary.checks = (
+          template.summary.checks || []
+        ).map(check => {
           if (!check.hasOwnProperty('shouldInstall')) {
             check.shouldInstall = true
           }
           return check
         })
 
-        activeCommunityTemplate.variables = (template.variables || []).map(
-          variable => {
-            if (!variable.hasOwnProperty('shouldInstall')) {
-              variable.shouldInstall = true
-            }
-            return variable
+        communityTemplateToInstall.summary.variables = (
+          template.summary.variables || []
+        ).map(variable => {
+          if (!variable.hasOwnProperty('shouldInstall')) {
+            variable.shouldInstall = true
           }
-        )
-
-        activeCommunityTemplate.notificationRules = (
-          template.notificationRules || []
-        ).map(noritifcationRule => {
-          if (!noritifcationRule.hasOwnProperty('shouldInstall')) {
-            noritifcationRule.shouldInstall = true
-          }
-          return noritifcationRule
+          return variable
         })
 
-        activeCommunityTemplate.labels = (template.labels || []).map(label => {
+        communityTemplateToInstall.summary.notificationRules = (
+          template.summary.notificationRules || []
+        ).map(notificationRule => {
+          if (!notificationRule.hasOwnProperty('shouldInstall')) {
+            notificationRule.shouldInstall = true
+          }
+          return notificationRule
+        })
+
+        communityTemplateToInstall.summary.notificationEndpoints = (
+          template.summary.notificationEndpoints || []
+        ).map(notificationEndpoint => {
+          if (!notificationEndpoint.hasOwnProperty('shouldInstall')) {
+            notificationEndpoint.shouldInstall = true
+          }
+          return notificationEndpoint
+        })
+
+        communityTemplateToInstall.summary.labels = (
+          template.summary.labels || []
+        ).map(label => {
           if (!label.hasOwnProperty('shouldInstall')) {
             label.shouldInstall = true
           }
           return label
         })
 
-        draftState.activeCommunityTemplate = activeCommunityTemplate
+        communityTemplateToInstall.summary.summaryTask = (
+          template.summary.summaryTask || []
+        ).map(summaryTask => {
+          if (!summaryTask.hasOwnProperty('shouldInstall')) {
+            summaryTask.shouldInstall = true
+          }
+          return summaryTask
+        })
+
+        draftState.communityTemplateToInstall = communityTemplateToInstall
         return
       }
 
@@ -158,15 +186,15 @@ export const templatesReducer = (
       case TOGGLE_TEMPLATE_RESOURCE_INSTALL: {
         const {resourceType, shouldInstall, templateMetaName} = action
 
-        const activeCommTempl = {...draftState.activeCommunityTemplate}
+        const templateToInstall = {...draftState.communityTemplateToInstall}
 
-        activeCommTempl[resourceType].forEach(resource => {
+        templateToInstall.summary[resourceType].forEach(resource => {
           if (resource.templateMetaName === templateMetaName) {
             resource.shouldInstall = shouldInstall
           }
         })
 
-        draftState.activeCommunityTemplate = activeCommTempl
+        draftState.communityTemplateToInstall = templateToInstall
       }
     }
   })

--- a/ui/src/templates/selectors/index.ts
+++ b/ui/src/templates/selectors/index.ts
@@ -1,4 +1,4 @@
-import {AppState} from 'src/types'
+import {CommunityTemplate} from 'src/types'
 
 const isResourceSelected = resource => resource.shouldInstall
 
@@ -6,14 +6,10 @@ export const getResourceInstallCount = (collection: any[]): number => {
   return collection.filter(isResourceSelected).length
 }
 
-export const getTotalResourceCount = (appState: AppState): number => {
-  const {activeCommunityTemplate} = appState.resources.templates
-
+export const getTotalResourceCount = (summary: CommunityTemplate): number => {
   let resourceCount = 0
-  Object.keys(activeCommunityTemplate).forEach(resourceType => {
-    resourceCount += getResourceInstallCount(
-      activeCommunityTemplate[resourceType]
-    )
+  Object.keys(summary).forEach(resourceType => {
+    resourceCount += getResourceInstallCount(summary[resourceType])
   })
 
   return resourceCount

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -97,13 +97,13 @@ export const getGithubUrlFromTemplateName = (templateName: string): string => {
   return `https://github.com/influxdata/community-templates/tree/master/${templateName}`
 }
 
-const applyTemplates = async (params) => {
+const applyTemplates = async params => {
   const resp = await postTemplatesApply(params)
   if (resp.status >= 300) {
     throw new Error((resp.data as PkgError).message)
   }
 
-  const summary = (resp.data as TemplateSummary).summary
+  const summary = resp.data as TemplateSummary
   return summary
 }
 

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -8,6 +8,12 @@ import {
   Variable,
 } from 'src/types'
 
+import {
+  Error as PkgError,
+  postTemplatesApply,
+  TemplateSummary,
+} from 'src/client'
+
 export function findIncludedsFromRelationships<
   T extends {id: string; type: TemplateType}
 >(
@@ -89,4 +95,38 @@ export const getTemplateNameFromGithubUrl = (url: string): string => {
 
 export const getGithubUrlFromTemplateName = (templateName: string): string => {
   return `https://github.com/influxdata/community-templates/tree/master/${templateName}`
+}
+
+const applyTemplates = async (params) => {
+  const resp = await postTemplatesApply(params)
+  if (resp.status >= 300) {
+    throw new Error((resp.data as PkgError).message)
+  }
+
+  const summary = (resp.data as TemplateSummary).summary
+  return summary
+}
+
+export const reviewTemplate = async (orgID: string, templateUrl: string) => {
+  const params = {
+    data: {
+      dryRun: true,
+      orgID,
+      remotes: [{url: templateUrl}],
+    },
+  }
+
+  return applyTemplates(params)
+}
+
+export const installTemplate = async (orgID: string, templateUrl: string) => {
+  const params = {
+    data: {
+      dryRun: false,
+      orgID,
+      remotes: [{url: templateUrl}],
+    },
+  }
+
+  return applyTemplates(params)
 }

--- a/ui/src/types/templates.ts
+++ b/ui/src/types/templates.ts
@@ -26,7 +26,7 @@ export type CommunityTemplate = any
 
 export interface TemplatesState extends NormalizedState<TemplateSummary> {
   exportTemplate: {status: RemoteDataState; item: DocumentCreate}
-  activeCommunityTemplate: CommunityTemplate
+  communityTemplateToInstall: CommunityTemplate
 }
 
 interface KeyValuePairs {


### PR DESCRIPTION
Community Templates background work. Changes our internal representation of templates to match pkgr's model.

When we send a yaml, json, or jsonnet template file to the pkgr API, it returns an object with a `summary` of the template, and a `diff` of the changes, among other things. Previously, our redux store used `summary` and discarded everything else. Now it's storing the entire object returned from the API. The frontend still only uses `summary` at the moment, but that will change in the future.

These commits were split off of work to install templates which is still underway.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
