### PR TITLE
chore(flagged): update templates to use react router 5 hotness

### DIFF
--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -34,6 +34,7 @@ interface StateProps {
 type Props = RouteComponentProps & StateProps
 
 const templatesPath = '/orgs/:orgID/settings/templates'
+export const communityTemplatesImportPath = `${templatesPath}/import/:templateName`
 
 @ErrorHandling
 class TemplatesIndex extends Component<Props> {
@@ -44,7 +45,7 @@ class TemplatesIndex extends Component<Props> {
         <CommunityTemplatesIndex>
           <Switch>
             <Route
-              path={`${templatesPath}/import/:templateName`}
+              path={communityTemplatesImportPath}
               component={CommunityTemplateImportOverlay}
             />
           </Switch>

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -24,11 +24,17 @@ import {
   setResourceAtID,
 } from 'src/resources/reducers/helpers'
 
-export const defaultState = (): TemplatesState => ({
-  communityTemplateToInstall: {
+const defaultCommunityTemplate = (): CommunityTemplate => {
+  return {
+    sources: [],
+    stackID: '',
     summary: {},
     diff: {},
-  } as CommunityTemplate,
+  }
+}
+
+export const defaultState = (): TemplatesState => ({
+  communityTemplateToInstall: defaultCommunityTemplate(),
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
@@ -69,9 +75,9 @@ export const templatesReducer = (
       case SET_COMMUNITY_TEMPLATE_TO_INSTALL: {
         const {template} = action
 
-        const communityTemplateToInstall: CommunityTemplate = {
-          diff: template.diff || {},
-          summary: template.summary || {},
+        const communityTemplateToInstall = {
+          ...defaultCommunityTemplate(),
+          ...template,
         }
 
         communityTemplateToInstall.summary.dashboards = (

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -97,6 +97,12 @@ export const getGithubUrlFromTemplateName = (templateName: string): string => {
   return `https://github.com/influxdata/community-templates/tree/master/${templateName}`
 }
 
+export const getRawUrlFromGithub = repoUrl => {
+  return repoUrl
+    .replace('github.com', 'raw.githubusercontent.com')
+    .replace('tree/', '')
+}
+
 const applyTemplates = async params => {
   const resp = await postTemplatesApply(params)
   if (resp.status >= 300) {


### PR DESCRIPTION
Updates community templates to be compatible with react router 5 changes.

Mostly shuffling code around, [this](https://github.com/influxdata/influxdb/pull/18871/files#diff-b8bbbcc08236ad73ba323c538d2d3c51R53) is the only relevant change. 

See: https://codedaily.io/tutorials/48/Use-matchPath-to-Match-Nested-Route-Paths-in-Parent-Routes-with-React-Router

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
