### PR TITLE
chore: upgrade @types/react-redux

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -72,7 +72,7 @@
     "@types/react-dnd-html5-backend": "^2.1.9",
     "@types/react-dom": "^16.8.1",
     "@types/react-grid-layout": "^0.16.5",
-    "@types/react-redux": "^6.0.9",
+    "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
     "@types/react-virtualized": "^9.18.3",
     "@types/text-encoding": "^0.0.32",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,14 +16,11 @@ import SetOrg from 'src/shared/containers/SetOrg'
 import CreateOrgOverlay from './organizations/components/CreateOrgOverlay'
 
 // Types
-import {AppState, CurrentPage, Theme} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  inPresentationMode: boolean
-  currentPage: CurrentPage
-  theme: Theme
-}
-type Props = StateProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps
+type Props = ReduxProps & RouterProps
 
 const App: SFC<Props> = ({inPresentationMode, currentPage, theme}) => {
   const appWrapperClass = classnames('', {
@@ -60,4 +57,6 @@ const mstp = (state: AppState) => {
   return {inPresentationMode, currentPage, theme}
 }
 
-export default connect<StateProps, {}>(mstp, null)(withRouter(App))
+const connector = connect(mstp)
+
+export default connector(withRouter(App))

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {SFC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import classnames from 'classnames'
 import {Switch, Route} from 'react-router-dom'
 
@@ -48,7 +48,7 @@ const App: SFC<Props> = ({inPresentationMode, currentPage, theme}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     app: {
       ephemeral: {inPresentationMode},

--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // APIs
@@ -12,11 +12,8 @@ import {CLOUD, CLOUD_URL, CLOUD_LOGOUT_PATH} from 'src/shared/constants'
 // Components
 import {reset} from 'src/shared/actions/flags'
 
-interface DispatchProps {
-  resetFeatureFlags: typeof reset
-}
-
-type Props = DispatchProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps
 
 const Logout: FC<Props> = ({history, resetFeatureFlags}) => {
   const handleSignOut = async () => {
@@ -45,4 +42,6 @@ const mdtp = {
   resetFeatureFlags: reset,
 }
 
-export default connect<{}, DispatchProps>(null, mdtp)(withRouter(Logout))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(Logout))

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {ReactElement, PureComponent} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 import {client} from 'src/utils/api'
 
@@ -36,11 +36,8 @@ interface OwnProps {
   children: ReactElement<any>
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-}
-
-type Props = OwnProps & RouteComponentProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & RouteComponentProps & ReduxProps
 
 const FETCH_WAIT = 60000
 
@@ -77,7 +74,7 @@ export class Signin extends PureComponent<Props, State> {
       <SpinnerContainer loading={loading} spinnerComponent={<TechnoSpinner />}>
         {auth && (
           <Switch>
-            <Route render={props => <GetMe {...props} />} />
+            <Route component={GetMe} />
           </Switch>
         )}
       </SpinnerContainer>
@@ -126,8 +123,10 @@ export class Signin extends PureComponent<Props, State> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
 }
 
-export default connect(null, mdtp)(Signin)
+const connector = connect(null, mdtp)
+
+export default connector(Signin)

--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useState} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 //Components
@@ -159,4 +159,4 @@ const mstp = ({cloud: {limits}}: AppState) => {
   }
 }
 
-export default connect(mstp, null)(AlertingIndex)
+export default connect(mstp)(AlertingIndex)

--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 //Components
@@ -152,7 +152,7 @@ const AlertingIndex: FunctionComponent<StateProps> = ({
   )
 }
 
-const mstp = ({cloud: {limits}}: AppState): StateProps => {
+const mstp = ({cloud: {limits}}: AppState) => {
   return {
     limitStatus: extractMonitoringLimitStatus(limits),
     limitedResources: extractLimitedMonitoringResources(limits),

--- a/ui/src/alerting/components/builder/DeadmanConditions.tsx
+++ b/ui/src/alerting/components/builder/DeadmanConditions.tsx
@@ -22,22 +22,11 @@ import {
 } from 'src/alerting/actions/alertBuilder'
 
 // Types
-import {CheckStatusLevel, AppState} from 'src/types'
+import {AppState} from 'src/types'
 import DurationInput from 'src/shared/components/DurationInput'
 import {CHECK_OFFSET_OPTIONS} from 'src/alerting/constants'
 
-interface DispatchProps {
-  onSetStaleTime: typeof setStaleTime
-  onSetTimeSince: typeof setTimeSince
-  onSetLevel: typeof setLevel
-}
-
-interface StateProps {
-  staleTime: string
-  timeSince: string
-  level: CheckStatusLevel
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const DeadmanConditions: FC<Props> = ({
@@ -128,5 +117,7 @@ const mdtp = {
   onSetTimeSince: setTimeSince,
   onSetLevel: setLevel,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DeadmanConditions)

--- a/ui/src/alerting/components/builder/DeadmanConditions.tsx
+++ b/ui/src/alerting/components/builder/DeadmanConditions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -38,7 +38,7 @@ interface StateProps {
   level: CheckStatusLevel
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const DeadmanConditions: FC<Props> = ({
   staleTime,
@@ -117,17 +117,16 @@ const DeadmanConditions: FC<Props> = ({
   )
 }
 
-const mstp = ({
-  alertBuilder: {staleTime, timeSince, level},
-}: AppState): StateProps => ({staleTime, timeSince, level})
+const mstp = ({alertBuilder: {staleTime, timeSince, level}}: AppState) => ({
+  staleTime,
+  timeSince,
+  level,
+})
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetStaleTime: setStaleTime,
   onSetTimeSince: setTimeSince,
   onSetLevel: setLevel,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(DeadmanConditions)
+export default connector(DeadmanConditions)

--- a/ui/src/alerting/components/builder/MatchingRuleCard.tsx
+++ b/ui/src/alerting/components/builder/MatchingRuleCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'

--- a/ui/src/alerting/components/builder/MatchingRuleCard.tsx
+++ b/ui/src/alerting/components/builder/MatchingRuleCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
@@ -41,7 +41,7 @@ const MatchingRuleCard: FC<Props> = ({rule, endpoints}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const endpoints = getAll<NotificationEndpoint>(
     state,
     ResourceType.NotificationEndpoints

--- a/ui/src/alerting/components/builder/ThresholdCondition.tsx
+++ b/ui/src/alerting/components/builder/ThresholdCondition.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useState, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -45,7 +45,7 @@ interface OwnProps {
   level: CheckStatusLevel
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type Props = ReduxProps & OwnProps
 
 const defaultThreshold = {
   type: 'greater' as 'greater',
@@ -148,7 +148,7 @@ const ThresholdCondition: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const giraffeResult = getVisTable(state)
 
   return {
@@ -156,14 +156,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateThreshold: updateThreshold,
   onRemoveThreshold: removeThreshold,
 }
 
 export {ThresholdCondition}
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(ThresholdCondition)
+export default connector(ThresholdCondition)

--- a/ui/src/alerting/components/builder/ThresholdCondition.tsx
+++ b/ui/src/alerting/components/builder/ThresholdCondition.tsx
@@ -28,23 +28,16 @@ import {
   CheckStatusLevel,
 } from 'src/types'
 import {ComponentSize} from '@influxdata/clockface'
-import {Table} from '@influxdata/giraffe'
+
+// Constants
 import {LEVEL_COMPONENT_COLORS} from 'src/alerting/constants'
-
-interface StateProps {
-  table: Table
-}
-
-interface DispatchProps {
-  onUpdateThreshold: typeof updateThreshold
-  onRemoveThreshold: typeof removeThreshold
-}
 
 interface OwnProps {
   threshold: Threshold
   level: CheckStatusLevel
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 const defaultThreshold = {
@@ -162,5 +155,7 @@ const mdtp = {
 }
 
 export {ThresholdCondition}
+
+const connector = connect(mstp, mdtp)
 
 export default connector(ThresholdCondition)

--- a/ui/src/alerting/components/builder/ThresholdConditions.tsx
+++ b/ui/src/alerting/components/builder/ThresholdConditions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ThresholdCondition from 'src/alerting/components/builder/ThresholdCondition'
@@ -23,9 +23,7 @@ const ThresholdConditions: FC<StateProps> = ({thresholds}) => {
   )
 }
 
-const mstp = ({
-  alertBuilder: {thresholds: thresholdsArray},
-}: AppState): StateProps => {
+const mstp = ({alertBuilder: {thresholds: thresholdsArray}}: AppState) => {
   const thresholds = {}
   thresholdsArray.forEach(t => {
     thresholds[t.level] = t

--- a/ui/src/alerting/components/builder/ThresholdConditions.tsx
+++ b/ui/src/alerting/components/builder/ThresholdConditions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ThresholdCondition from 'src/alerting/components/builder/ThresholdCondition'
@@ -31,4 +31,4 @@ const mstp = ({alertBuilder: {thresholds: thresholdsArray}}: AppState) => {
   return {thresholds}
 }
 
-export default connect<StateProps, {}, {}>(mstp, null)(ThresholdConditions)
+export default connect<StateProps>(mstp)(ThresholdConditions)

--- a/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -46,7 +46,7 @@ interface State {
   description: string
 }
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 class AllAccessTokenOverlay extends PureComponent<Props, State> {
@@ -129,17 +129,14 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     orgID: getOrg(state).id,
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateAuthorization: createAuthorization,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(AllAccessTokenOverlay)
+export default connector(AllAccessTokenOverlay)

--- a/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -34,18 +34,11 @@ interface OwnProps {
   onClose: () => void
 }
 
-interface StateProps {
-  orgID: string
-}
-
-interface DispatchProps {
-  onCreateAuthorization: typeof createAuthorization
-}
-
 interface State {
   description: string
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
 @ErrorHandling
@@ -138,5 +131,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onCreateAuthorization: createAuthorization,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(AllAccessTokenOverlay)

--- a/ui/src/authorizations/components/BucketsTokenOverlay.tsx
+++ b/ui/src/authorizations/components/BucketsTokenOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -67,7 +67,7 @@ interface State {
   activeTabWrite: BucketTab
 }
 
-type Props = OwnProps & DispatchProps & StateProps
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 class BucketsTokenOverlay extends PureComponent<Props, State> {
@@ -278,18 +278,15 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     orgID: getOrg(state).id,
     buckets: getAll<Bucket>(state, ResourceType.Buckets),
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateAuthorization: createAuthorization,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(BucketsTokenOverlay)
+export default connector(BucketsTokenOverlay)

--- a/ui/src/authorizations/components/BucketsTokenOverlay.tsx
+++ b/ui/src/authorizations/components/BucketsTokenOverlay.tsx
@@ -50,15 +50,6 @@ interface OwnProps {
   onClose: () => void
 }
 
-interface StateProps {
-  buckets: Bucket[]
-  orgID: string
-}
-
-interface DispatchProps {
-  onCreateAuthorization: typeof createAuthorization
-}
-
 interface State {
   description: string
   readBuckets: string[]
@@ -67,6 +58,7 @@ interface State {
   activeTabWrite: BucketTab
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
 @ErrorHandling
@@ -288,5 +280,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onCreateAuthorization: createAuthorization,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(BucketsTokenOverlay)

--- a/ui/src/authorizations/components/TokenRow.tsx
+++ b/ui/src/authorizations/components/TokenRow.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {
@@ -35,7 +35,7 @@ interface DispatchProps {
   onUpdate: typeof updateAuthorization
 }
 
-type Props = DispatchProps & OwnProps
+type Props = ReduxProps & OwnProps
 
 class TokenRow extends PureComponent<Props> {
   public render() {
@@ -115,4 +115,4 @@ const mdtp = {
   onUpdate: updateAuthorization,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(TokenRow)
+export default connector(TokenRow)

--- a/ui/src/authorizations/components/TokenRow.tsx
+++ b/ui/src/authorizations/components/TokenRow.tsx
@@ -30,10 +30,7 @@ interface OwnProps {
   onClickDescription: (authID: string) => void
 }
 
-interface DispatchProps {
-  onDelete: typeof deleteAuthorization
-  onUpdate: typeof updateAuthorization
-}
+type ReduxProps = ConnectedProps<typeof connector>
 
 type Props = ReduxProps & OwnProps
 
@@ -114,5 +111,7 @@ const mdtp = {
   onDelete: deleteAuthorization,
   onUpdate: updateAuthorization,
 }
+
+const connector = connect(null, mdtp)
 
 export default connector(TokenRow)

--- a/ui/src/authorizations/components/TokensTab.tsx
+++ b/ui/src/authorizations/components/TokensTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {isEmpty} from 'lodash'
 
@@ -157,4 +157,4 @@ const mstp = (state: AppState) => ({
   tokens: getAll<Authorization>(state, ResourceType.Authorizations),
 })
 
-export default connect<StateProps, {}, {}>(mstp, null)(withRouter(TokensTab))
+export default connect<StateProps>(mstp)(withRouter(TokensTab))

--- a/ui/src/authorizations/components/TokensTab.tsx
+++ b/ui/src/authorizations/components/TokensTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {isEmpty} from 'lodash'
 

--- a/ui/src/authorizations/containers/TokensIndex.tsx
+++ b/ui/src/authorizations/containers/TokensIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -61,4 +61,4 @@ class TokensIndex extends Component<StateProps> {
 
 const mstp = (state: AppState) => ({org: getOrg(state)})
 
-export default connect<StateProps>(mstp, null)(TokensIndex)
+export default connector(TokensIndex)

--- a/ui/src/authorizations/containers/TokensIndex.tsx
+++ b/ui/src/authorizations/containers/TokensIndex.tsx
@@ -20,17 +20,17 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 
-interface StateProps {
-  org: Organization
-}
 import {ORGS, ORG_ID, TOKENS} from 'src/shared/constants/routes'
 
 const tokensPath = `/${ORGS}/${ORG_ID}/load-data/${TOKENS}/generate`
 
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
+
 @ErrorHandling
-class TokensIndex extends Component<StateProps> {
+class TokensIndex extends Component<Props> {
   public render() {
     const {org} = this.props
 
@@ -60,5 +60,7 @@ class TokensIndex extends Component<StateProps> {
 }
 
 const mstp = (state: AppState) => ({org: getOrg(state)})
+
+const connector = connect(mstp)
 
 export default connector(TokensIndex)

--- a/ui/src/buckets/components/BucketCardActions.tsx
+++ b/ui/src/buckets/components/BucketCardActions.tsx
@@ -2,7 +2,6 @@
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
 
 // Components
 import {
@@ -24,14 +23,7 @@ import {setDataLoadersType} from 'src/dataLoaders/actions/dataLoaders'
 import {Label, OwnBucket} from 'src/types'
 import {DataLoaderType} from 'src/types/dataLoaders'
 
-interface DispatchProps {
-  onAddBucketLabel: typeof addBucketLabel
-  onDeleteBucketLabel: typeof deleteBucketLabel
-  onSetDataLoadersBucket: typeof setBucketInfo
-  onSetDataLoadersType: typeof setDataLoadersType
-}
-
-interface Props {
+interface OwnProps {
   bucket: OwnBucket
   bucketType: 'user' | 'system'
   orgID: string
@@ -39,9 +31,11 @@ interface Props {
   onFilterChange: (searchTerm: string) => void
 }
 
-const BucketCardActions: FC<Props &
-  RouteComponentProps<{orgID: string}> &
-  DispatchProps> = ({
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps & RouterProps
+
+const BucketCardActions: FC<Props> = ({
   bucket,
   bucketType,
   orgID,
@@ -141,5 +135,7 @@ const mdtp = {
   onSetDataLoadersBucket: setBucketInfo,
   onSetDataLoadersType: setDataLoadersType,
 }
+
+const connector = connect(null, mdtp)
 
 export default connector(withRouter(BucketCardActions))

--- a/ui/src/buckets/components/BucketCardActions.tsx
+++ b/ui/src/buckets/components/BucketCardActions.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -135,14 +135,11 @@ const BucketCardActions: FC<Props &
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddBucketLabel: addBucketLabel,
   onDeleteBucketLabel: deleteBucketLabel,
   onSetDataLoadersBucket: setBucketInfo,
   onSetDataLoadersType: setDataLoadersType,
 }
 
-export default connect<{}, DispatchProps>(
-  null,
-  mdtp
-)(withRouter(BucketCardActions))
+export default connector(withRouter(BucketCardActions))

--- a/ui/src/buckets/components/BucketCardMeta.tsx
+++ b/ui/src/buckets/components/BucketCardMeta.tsx
@@ -2,7 +2,7 @@
 import React, {FC} from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import {capitalize} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Constants
 import {
@@ -19,15 +19,12 @@ import {ResourceCard} from '@influxdata/clockface'
 // Types
 import {OwnBucket} from 'src/types'
 
-interface DispatchProps {
-  notify: typeof notifyAction
-}
-
 interface OwnProps {
   bucket: OwnBucket
 }
 
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   const handleCopyAttempt = (
@@ -77,8 +74,10 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(BucketCardMeta)
+const connector = connect(null, mdtp)
+
+export default connector(BucketCardMeta)

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {isEmpty} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -62,7 +62,7 @@ interface State {
   sortType: SortTypes
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const FilterBuckets = FilterList<Bucket>()
 
@@ -202,7 +202,7 @@ class BucketsTab extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const buckets = getAll<Bucket>(state, ResourceType.Buckets)
   return {
     buckets,
@@ -210,11 +210,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createBucket,
   updateBucket,
   deleteBucket,
   checkBucketLimits: checkBucketLimitsAction,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(BucketsTab)
+export default connector(BucketsTab)

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -29,10 +29,7 @@ import {
   updateBucket,
   deleteBucket,
 } from 'src/buckets/actions/thunks'
-import {
-  checkBucketLimits as checkBucketLimitsAction,
-  LimitStatus,
-} from 'src/cloud/actions/limits'
+import {checkBucketLimits as checkBucketLimitsAction} from 'src/cloud/actions/limits'
 
 // Utils
 import {extractBucketLimits} from 'src/cloud/utils/limits'
@@ -43,18 +40,6 @@ import {SortTypes} from 'src/shared/utils/sort'
 import {AppState, Bucket, ResourceType, OwnBucket} from 'src/types'
 import {BucketSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
-interface StateProps {
-  buckets: Bucket[]
-  limitStatus: LimitStatus
-}
-
-interface DispatchProps {
-  createBucket: typeof createBucket
-  updateBucket: typeof updateBucket
-  deleteBucket: typeof deleteBucket
-  checkBucketLimits: typeof checkBucketLimitsAction
-}
-
 interface State {
   searchTerm: string
   sortKey: BucketSortKey
@@ -62,6 +47,7 @@ interface State {
   sortType: SortTypes
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const FilterBuckets = FilterList<Bucket>()
@@ -216,5 +202,7 @@ const mdtp = {
   deleteBucket,
   checkBucketLimits: checkBucketLimitsAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(BucketsTab)

--- a/ui/src/buckets/components/CreateBucketButton.tsx
+++ b/ui/src/buckets/components/CreateBucketButton.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -35,7 +35,7 @@ interface DispatchProps {
 
 interface OwnProps {}
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 const CreateBucketButton: FC<Props> = ({
   limitStatus,
@@ -79,19 +79,16 @@ const CreateBucketButton: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     limitStatus: extractBucketLimits(state.cloud.limits),
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onShowOverlay: showOverlay,
   onDismissOverlay: dismissOverlay,
   checkBucketLimits: checkBucketLimitsAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(CreateBucketButton)
+export default connector(CreateBucketButton)

--- a/ui/src/buckets/components/CreateBucketButton.tsx
+++ b/ui/src/buckets/components/CreateBucketButton.tsx
@@ -23,19 +23,8 @@ import {extractBucketLimits} from 'src/cloud/utils/limits'
 // Types
 import {AppState} from 'src/types'
 
-interface StateProps {
-  limitStatus: LimitStatus
-}
-
-interface DispatchProps {
-  onShowOverlay: typeof showOverlay
-  onDismissOverlay: typeof dismissOverlay
-  checkBucketLimits: typeof checkBucketLimitsAction
-}
-
-interface OwnProps {}
-
-type Props = OwnProps & ReduxProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const CreateBucketButton: FC<Props> = ({
   limitStatus,
@@ -90,5 +79,7 @@ const mdtp = {
   onDismissOverlay: dismissOverlay,
   checkBucketLimits: checkBucketLimitsAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(CreateBucketButton)

--- a/ui/src/buckets/components/CreateBucketOverlay.tsx
+++ b/ui/src/buckets/components/CreateBucketOverlay.tsx
@@ -13,7 +13,7 @@ import {extractBucketMaxRetentionSeconds} from 'src/cloud/utils/limits'
 import {createBucket} from 'src/buckets/actions/thunks'
 
 // Types
-import {Organization, AppState} from 'src/types'
+import {AppState} from 'src/types'
 import {
   createBucketReducer,
   RuleType,
@@ -24,19 +24,11 @@ import {
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 
-interface StateProps {
-  org: Organization
-  isRetentionLimitEnforced: boolean
-}
-
-interface DispatchProps {
-  createBucket: typeof createBucket
-}
-
 interface OwnProps {
   onClose: () => void
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
 const CreateBucketOverlay: FC<Props> = ({
@@ -124,5 +116,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   createBucket,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(CreateBucketOverlay)

--- a/ui/src/buckets/components/CreateBucketOverlay.tsx
+++ b/ui/src/buckets/components/CreateBucketOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, ChangeEvent, FormEvent, useReducer} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -37,7 +37,7 @@ interface OwnProps {
   onClose: () => void
 }
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 const CreateBucketOverlay: FC<Props> = ({
   org,
@@ -109,7 +109,7 @@ const CreateBucketOverlay: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const org = getOrg(state)
   const isRetentionLimitEnforced = !!extractBucketMaxRetentionSeconds(
     state.cloud.limits
@@ -121,11 +121,8 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createBucket,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(CreateBucketOverlay)
+export default connector(CreateBucketOverlay)

--- a/ui/src/buckets/components/DemoDataBucketCard.tsx
+++ b/ui/src/buckets/components/DemoDataBucketCard.tsx
@@ -32,18 +32,14 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 // Types
 import {DemoBucket} from 'src/types'
 
-interface DispatchProps {
-  removeBucket: typeof deleteDemoDataBucketMembership
-  notify: typeof notifyAction
-}
-
-interface Props {
+interface OwnProps {
   bucket: DemoBucket
 }
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps & RouterProps
 
-const DemoDataBucketCard: FC<Props &
-  RouteComponentProps<{orgID: string}> &
-  DispatchProps> = ({
+const DemoDataBucketCard: FC<Props> = ({
   bucket,
   history,
   match: {
@@ -142,7 +138,6 @@ const mdtp = {
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, {}>(
-  null,
-  mdtp
-)(withRouter(DemoDataBucketCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(DemoDataBucketCard))

--- a/ui/src/buckets/components/DemoDataBucketCard.tsx
+++ b/ui/src/buckets/components/DemoDataBucketCard.tsx
@@ -2,7 +2,7 @@
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import CopyToClipboard from 'react-copy-to-clipboard'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Constants
 import {
@@ -137,7 +137,7 @@ const DemoDataBucketCard: FC<Props &
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   removeBucket: deleteDemoDataBucketMembership,
   notify: notifyAction,
 }

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get, sortBy} from 'lodash'
 
 // Actions
@@ -25,7 +25,7 @@ interface DispatchProps {
   getDemoDataBuckets: typeof getDemoDataBucketsAction
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const DemoDataDropdown: FC<Props> = ({
   ownBucketsByID,
@@ -111,17 +111,14 @@ const DemoDataDropdown: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   ownBucketsByID: state.resources[ResourceType.Buckets].byID,
   demoDataBuckets: get(state, 'cloud.demoData.buckets', []) as Bucket[],
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getDemoDataBucketMembership: getDemoDataBucketMembershipAction,
   getDemoDataBuckets: getDemoDataBucketsAction,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(DemoDataDropdown)
+export default connector(DemoDataDropdown)

--- a/ui/src/buckets/components/DemoDataDropdown.tsx
+++ b/ui/src/buckets/components/DemoDataDropdown.tsx
@@ -15,16 +15,7 @@ import {ComponentColor, Dropdown, Icon, IconFont} from '@influxdata/clockface'
 // Types
 import {AppState, Bucket, ResourceType} from 'src/types'
 
-interface StateProps {
-  ownBucketsByID: {[id: string]: Bucket}
-  demoDataBuckets: Bucket[]
-}
-
-interface DispatchProps {
-  getDemoDataBucketMembership: typeof getDemoDataBucketMembershipAction
-  getDemoDataBuckets: typeof getDemoDataBucketsAction
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const DemoDataDropdown: FC<Props> = ({
@@ -120,5 +111,7 @@ const mdtp = {
   getDemoDataBucketMembership: getDemoDataBucketMembershipAction,
   getDemoDataBuckets: getDemoDataBucketsAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DemoDataDropdown)

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ComponentStatus} from 'src/clockface'
@@ -40,7 +40,7 @@ interface DispatchProps {
 }
 
 type Props = StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{bucketID: string; orgID: string}>
 
 class RenameBucketForm extends PureComponent<Props, State> {
@@ -141,7 +141,7 @@ class RenameBucketForm extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, props: Props): StateProps => {
+const mstp = (state: AppState, props: Props) => {
   const {bucketID} = props.match.params
 
   const startBucket = getByID<OwnBucket>(state, ResourceType.Buckets, bucketID)
@@ -155,11 +155,9 @@ const mstp = (state: AppState, props: Props): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onRenameBucket: renameBucket,
 }
 
 // state mapping requires router
-export default withRouter(
-  connect<StateProps, DispatchProps>(mstp, mdtp)(RenameBucketForm)
-)
+export default withRouter(connector(RenameBucketForm))

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -30,18 +30,9 @@ interface State {
   bucket: OwnBucket
 }
 
-interface StateProps {
-  startBucket: OwnBucket
-  buckets: Bucket[]
-}
-
-interface DispatchProps {
-  onRenameBucket: typeof renameBucket
-}
-
-type Props = StateProps &
-  ReduxProps &
-  RouteComponentProps<{bucketID: string; orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{bucketID: string; orgID: string}>
+type Props = ReduxProps & RouterProps
 
 class RenameBucketForm extends PureComponent<Props, State> {
   public state = {bucket: this.props.startBucket}
@@ -141,7 +132,7 @@ class RenameBucketForm extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, props: Props) => {
+const mstp = (state: AppState, props: RouterProps) => {
   const {bucketID} = props.match.params
 
   const startBucket = getByID<OwnBucket>(state, ResourceType.Buckets, bucketID)
@@ -158,6 +149,8 @@ const mstp = (state: AppState, props: Props) => {
 const mdtp = {
   onRenameBucket: renameBucket,
 }
+
+const connector = connect(mstp, mdtp)
 
 // state mapping requires router
 export default withRouter(connector(RenameBucketForm))

--- a/ui/src/buckets/components/Retention.tsx
+++ b/ui/src/buckets/components/Retention.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SelectGroup, ButtonShape} from '@influxdata/clockface'
@@ -117,7 +117,7 @@ class Retention extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   maxRetentionSeconds: extractBucketMaxRetentionSeconds(state.cloud.limits),
 })
 

--- a/ui/src/buckets/components/Retention.tsx
+++ b/ui/src/buckets/components/Retention.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {SelectGroup, ButtonShape} from '@influxdata/clockface'

--- a/ui/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/ui/src/buckets/components/UpdateBucketOverlay.tsx
@@ -38,6 +38,7 @@ interface DispatchProps {
   onNotify: typeof notify
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{bucketID: string; orgID: string}>
 
 const UpdateBucketOverlay: FunctionComponent<Props> = ({
@@ -159,7 +160,9 @@ const mdtp = {
   onNotify: notify,
 }
 
-export default connect<{}, DispatchProps, {}>(
+const connector = connect(null, mdtp)
+
+export default connect<{}, DispatchProps>(
   null,
   mdtp
 )(withRouter(UpdateBucketOverlay))

--- a/ui/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/ui/src/buckets/components/UpdateBucketOverlay.tsx
@@ -7,7 +7,7 @@ import React, {
   FormEvent,
 } from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -38,8 +38,7 @@ interface DispatchProps {
   onNotify: typeof notify
 }
 
-type Props = DispatchProps &
-  RouteComponentProps<{bucketID: string; orgID: string}>
+type Props = ReduxProps & RouteComponentProps<{bucketID: string; orgID: string}>
 
 const UpdateBucketOverlay: FunctionComponent<Props> = ({
   onUpdateBucket,
@@ -155,7 +154,7 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateBucket: updateBucket,
   onNotify: notify,
 }

--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components

--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components

--- a/ui/src/checks/components/CheckCard.tsx
+++ b/ui/src/checks/components/CheckCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -51,7 +51,7 @@ interface OwnProps {
   check: Check
 }
 
-type Props = OwnProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const CheckCard: FC<Props> = ({
   onRemoveCheckLabel,
@@ -190,7 +190,7 @@ const CheckCard: FC<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateCheckDisplayProperties: updateCheckDisplayProperties,
   deleteCheck: deleteCheck,
   onAddCheckLabel: addCheckLabel,

--- a/ui/src/checks/components/CheckCard.tsx
+++ b/ui/src/checks/components/CheckCard.tsx
@@ -38,19 +38,11 @@ import {Check, Label} from 'src/types'
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 
-interface DispatchProps {
-  onUpdateCheckDisplayProperties: typeof updateCheckDisplayProperties
-  deleteCheck: typeof deleteCheck
-  onAddCheckLabel: typeof addCheckLabel
-  onRemoveCheckLabel: typeof deleteCheckLabel
-  onCloneCheck: typeof cloneCheck
-  onNotify: typeof notify
-}
-
 interface OwnProps {
   check: Check
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const CheckCard: FC<Props> = ({
@@ -199,4 +191,6 @@ const mdtp = {
   onNotify: notify,
 }
 
-export default connect<{}, DispatchProps>(null, mdtp)(withRouter(CheckCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(CheckCard))

--- a/ui/src/checks/components/CheckConditionsCard.tsx
+++ b/ui/src/checks/components/CheckConditionsCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -55,7 +55,7 @@ const CheckConditionsCard: FC<Props> = ({checkType}) => {
   )
 }
 
-const mstp = ({alertBuilder: {type}}: AppState): StateProps => {
+const mstp = ({alertBuilder: {type}}: AppState) => {
   return {checkType: type}
 }
 

--- a/ui/src/checks/components/CheckConditionsCard.tsx
+++ b/ui/src/checks/components/CheckConditionsCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {

--- a/ui/src/checks/components/CheckEOHeader.tsx
+++ b/ui/src/checks/components/CheckEOHeader.tsx
@@ -29,16 +29,12 @@ import {DEFAULT_CHECK_NAME, CHECK_NAME_MAX_LENGTH} from 'src/alerting/constants'
 
 // Types
 import {RemoteDataState, AppState} from 'src/types'
-import {
-  createCheckFromTimeMachine,
-  updateCheckFromTimeMachine,
-} from 'src/checks/actions/thunks'
 
 interface OwnProps {
   name: string
   onSetName: (name: string) => void
   onCancel: () => void
-  onSave: typeof createCheckFromTimeMachine | typeof updateCheckFromTimeMachine
+  onSave: () => Promise<void>
 }
 
 type ReduxProps = ConnectedProps<typeof connector>

--- a/ui/src/checks/components/CheckEOHeader.tsx
+++ b/ui/src/checks/components/CheckEOHeader.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useState, FC, MouseEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
@@ -28,14 +28,7 @@ import {setActiveTab} from 'src/timeMachine/actions'
 import {DEFAULT_CHECK_NAME, CHECK_NAME_MAX_LENGTH} from 'src/alerting/constants'
 
 // Types
-import {
-  CheckType,
-  TimeMachineTab,
-  RemoteDataState,
-  AppState,
-  DashboardDraftQuery,
-  Threshold,
-} from 'src/types'
+import {RemoteDataState, AppState} from 'src/types'
 import {
   createCheckFromTimeMachine,
   updateCheckFromTimeMachine,
@@ -48,18 +41,8 @@ interface OwnProps {
   onSave: typeof createCheckFromTimeMachine | typeof updateCheckFromTimeMachine
 }
 
-interface StateProps {
-  activeTab: TimeMachineTab
-  draftQueries: DashboardDraftQuery[]
-  checkType: CheckType
-  thresholds: Threshold[]
-}
-
-interface DispatchProps {
-  setActiveTab: typeof setActiveTab
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const saveButtonClass = 'veo-header--save-cell-button'
 
@@ -150,7 +133,7 @@ const CheckEOHeader: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {activeTab, draftQueries} = getActiveTimeMachine(state)
   const {
     alertBuilder: {type, thresholds},
@@ -159,8 +142,10 @@ const mstp = (state: AppState): StateProps => {
   return {activeTab, draftQueries, checkType: type, thresholds}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setActiveTab: setActiveTab,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(CheckEOHeader)
+const connector = connect(mstp, mdtp)
+
+export default connector(CheckEOHeader)

--- a/ui/src/checks/components/CheckHistory.tsx
+++ b/ui/src/checks/components/CheckHistory.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useMemo, FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Page} from '@influxdata/clockface'

--- a/ui/src/checks/components/CheckHistory.tsx
+++ b/ui/src/checks/components/CheckHistory.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useMemo, FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {Page} from '@influxdata/clockface'

--- a/ui/src/checks/components/CheckHistoryVisualization.tsx
+++ b/ui/src/checks/components/CheckHistoryVisualization.tsx
@@ -11,12 +11,11 @@ import ViewLoadingSpinner from 'src/shared/components/ViewLoadingSpinner'
 
 // Types
 import {ResourceIDs} from 'src/checks/reducers'
-import {Check, TimeZone, CheckViewProperties, TimeRange} from 'src/types'
+import {Check, TimeZone, CheckViewProperties} from 'src/types'
 
 // Utils
 import {createView} from 'src/views/helpers'
 import {checkResultsLength} from 'src/shared/utils/vis'
-import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
 
 export const ResourceIDsContext = createContext<ResourceIDs>(null)
 
@@ -33,14 +32,11 @@ const CheckHistoryVisualization: FC<Props> = ({check, timeZone}) => {
   const [submitToken] = useState(0)
   const [manualRefresh] = useState(0)
 
-  const vars = [...getTimeRangeVars({lower: 'now() - 5m'} as TimeRange)]
-
   return (
     <TimeSeries
       submitToken={submitToken}
       queries={[check.query]}
       key={manualRefresh}
-      variables={vars}
       check={check}
     >
       {({giraffeResult, loading, errorMessage, isInitialFetch, statuses}) => {

--- a/ui/src/checks/components/CheckMatchingRulesCard.tsx
+++ b/ui/src/checks/components/CheckMatchingRulesCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useState, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {uniq} from 'lodash'
 import {fromFlux} from '@influxdata/giraffe'
 
@@ -158,7 +158,7 @@ const CheckMatchingRulesCard: FC<StateProps> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     alertBuilder: {tags},
   } = state
@@ -171,4 +171,4 @@ const mstp = (state: AppState): StateProps => {
   return {tags, orgID, queryResults: files}
 }
 
-export default connect<StateProps>(mstp, null)(CheckMatchingRulesCard)
+export default connector(CheckMatchingRulesCard)

--- a/ui/src/checks/components/CheckMatchingRulesCard.tsx
+++ b/ui/src/checks/components/CheckMatchingRulesCard.tsx
@@ -25,7 +25,6 @@ import {getNotificationRules as apiGetNotificationRules} from 'src/client'
 import {
   NotificationRule,
   AppState,
-  CheckTagSet,
   GenRule,
   NotificationRuleDraft,
 } from 'src/types'
@@ -33,17 +32,10 @@ import {EmptyState, ComponentSize, RemoteDataState} from '@influxdata/clockface'
 import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
-interface StateProps {
-  tags: CheckTagSet[]
-  orgID: string
-  queryResults: string[] | null
-}
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
-const CheckMatchingRulesCard: FC<StateProps> = ({
-  orgID,
-  tags,
-  queryResults,
-}) => {
+const CheckMatchingRulesCard: FC<Props> = ({orgID, tags, queryResults}) => {
   const getMatchingRules = async (): Promise<NotificationRule[]> => {
     const checkTags = tags
       .filter(t => t.key && t.value)
@@ -170,5 +162,7 @@ const mstp = (state: AppState) => {
 
   return {tags, orgID, queryResults: files}
 }
+
+const connector = connect(mstp)
 
 export default connector(CheckMatchingRulesCard)

--- a/ui/src/checks/components/CheckMessageCard.tsx
+++ b/ui/src/checks/components/CheckMessageCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -25,7 +25,7 @@ interface StateProps {
   statusMessageTemplate: string
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const CheckMessageCard: FC<Props> = ({
   statusMessageTemplate,
@@ -91,17 +91,12 @@ const CheckMessageCard: FC<Props> = ({
   )
 }
 
-const mstp = ({
-  alertBuilder: {statusMessageTemplate},
-}: AppState): StateProps => ({
+const mstp = ({alertBuilder: {statusMessageTemplate}}: AppState) => ({
   statusMessageTemplate,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetStatusMessageTemplate: setStatusMessageTemplate,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(CheckMessageCard)
+export default connector(CheckMessageCard)

--- a/ui/src/checks/components/CheckMessageCard.tsx
+++ b/ui/src/checks/components/CheckMessageCard.tsx
@@ -17,14 +17,7 @@ import {setStatusMessageTemplate} from 'src/alerting/actions/alertBuilder'
 // Types
 import {AppState} from 'src/types'
 
-interface DispatchProps {
-  onSetStatusMessageTemplate: typeof setStatusMessageTemplate
-}
-
-interface StateProps {
-  statusMessageTemplate: string
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const CheckMessageCard: FC<Props> = ({
@@ -98,5 +91,7 @@ const mstp = ({alertBuilder: {statusMessageTemplate}}: AppState) => ({
 const mdtp = {
   onSetStatusMessageTemplate: setStatusMessageTemplate,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(CheckMessageCard)

--- a/ui/src/checks/components/CheckMetaCard.tsx
+++ b/ui/src/checks/components/CheckMetaCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, ComponentSize, ComponentColor, Grid} from '@influxdata/clockface'
@@ -37,7 +37,7 @@ interface StateProps {
   every: string
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const EMPTY_TAG_SET = {
   key: '',
@@ -105,7 +105,7 @@ const CheckMetaCard: FC<Props> = ({
   )
 }
 
-const mstp = ({alertBuilder: {tags, offset, every}}: AppState): StateProps => {
+const mstp = ({alertBuilder: {tags, offset, every}}: AppState) => {
   return {
     tags: tags || [],
     offset,
@@ -113,11 +113,11 @@ const mstp = ({alertBuilder: {tags, offset, every}}: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSelectCheckEvery: selectCheckEvery,
   onSetOffset: setOffset,
   onRemoveTagSet: removeTagSet,
   onEditTagSetByIndex: editTagSetByIndex,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(CheckMetaCard)
+export default connector(CheckMetaCard)

--- a/ui/src/checks/components/CheckMetaCard.tsx
+++ b/ui/src/checks/components/CheckMetaCard.tsx
@@ -22,21 +22,9 @@ import {CHECK_OFFSET_OPTIONS} from 'src/alerting/constants'
 import {DURATIONS} from 'src/timeMachine/constants/queryBuilder'
 
 // Types
-import {AppState, CheckTagSet} from 'src/types'
+import {AppState} from 'src/types'
 
-interface DispatchProps {
-  onSelectCheckEvery: typeof selectCheckEvery
-  onSetOffset: typeof setOffset
-  onRemoveTagSet: typeof removeTagSet
-  onEditTagSetByIndex: typeof editTagSetByIndex
-}
-
-interface StateProps {
-  tags: CheckTagSet[]
-  offset: string
-  every: string
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const EMPTY_TAG_SET = {
@@ -119,5 +107,7 @@ const mdtp = {
   onRemoveTagSet: removeTagSet,
   onEditTagSetByIndex: editTagSetByIndex,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(CheckMetaCard)

--- a/ui/src/checks/components/ChecksColumn.tsx
+++ b/ui/src/checks/components/ChecksColumn.tsx
@@ -23,13 +23,8 @@ import {
   ResourceType,
 } from 'src/types'
 
-interface StateProps {
-  checks: Check[]
-  rules: NotificationRuleDraft[]
-  endpoints: NotificationEndpoint[]
-}
-
-type Props = StateProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 const ChecksColumn: FunctionComponent<Props> = ({
   checks,
@@ -115,5 +110,7 @@ const mstp = (state: AppState) => {
     endpoints: sortEndpointsByName(endpoints),
   }
 }
+
+const connector = connect(mstp)
 
 export default connector(withRouter(ChecksColumn))

--- a/ui/src/checks/components/ChecksColumn.tsx
+++ b/ui/src/checks/components/ChecksColumn.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
@@ -116,4 +116,4 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps>(mstp, null)(withRouter(ChecksColumn))
+export default connector(withRouter(ChecksColumn))

--- a/ui/src/checks/components/EditCheckEO.tsx
+++ b/ui/src/checks/components/EditCheckEO.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -40,7 +40,7 @@ interface StateProps {
 }
 
 type Props = RouteComponentProps<{orgID: string; checkID: string}> &
-  DispatchProps &
+  ReduxProps &
   StateProps
 
 const EditCheckEditorOverlay: FunctionComponent<Props> = ({
@@ -107,7 +107,7 @@ const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     timeMachines: {activeTimeMachineID},
     alertBuilder: {status, name, id},
@@ -124,7 +124,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onGetCheckForTimeMachine: getCheckForTimeMachine,
   onSaveCheckFromTimeMachine: updateCheckFromTimeMachine,
   onExecuteQueries: executeQueries,
@@ -132,7 +132,4 @@ const mdtp: DispatchProps = {
   onUpdateAlertBuilderName: updateName,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(EditCheckEditorOverlay))
+export default connector(withRouter(EditCheckEditorOverlay))

--- a/ui/src/checks/components/EditCheckEO.tsx
+++ b/ui/src/checks/components/EditCheckEO.tsx
@@ -21,27 +21,10 @@ import {executeQueries} from 'src/timeMachine/actions/queries'
 import {resetAlertBuilder, updateName} from 'src/alerting/actions/alertBuilder'
 
 // Types
-import {AppState, RemoteDataState, TimeMachineID, QueryView} from 'src/types'
+import {AppState, RemoteDataState} from 'src/types'
 
-interface DispatchProps {
-  onSaveCheckFromTimeMachine: typeof updateCheckFromTimeMachine
-  onGetCheckForTimeMachine: typeof getCheckForTimeMachine
-  onExecuteQueries: typeof executeQueries
-  onResetAlertBuilder: typeof resetAlertBuilder
-  onUpdateAlertBuilderName: typeof updateName
-}
-
-interface StateProps {
-  view: QueryView | null
-  status: RemoteDataState
-  activeTimeMachineID: TimeMachineID
-  loadedCheckID: string
-  checkName: string
-}
-
-type Props = RouteComponentProps<{orgID: string; checkID: string}> &
-  ReduxProps &
-  StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string; checkID: string}> & ReduxProps
 
 const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   onUpdateAlertBuilderName,
@@ -131,5 +114,7 @@ const mdtp = {
   onResetAlertBuilder: resetAlertBuilder,
   onUpdateAlertBuilderName: updateName,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(EditCheckEditorOverlay))

--- a/ui/src/checks/components/NewDeadmanCheckEO.tsx
+++ b/ui/src/checks/components/NewDeadmanCheckEO.tsx
@@ -23,19 +23,7 @@ import {createView} from 'src/views/helpers'
 // Types
 import {AppState, RemoteDataState, CheckViewProperties} from 'src/types'
 
-interface DispatchProps {
-  onSetActiveTimeMachine: typeof setActiveTimeMachine
-  onSaveCheckFromTimeMachine: typeof createCheckFromTimeMachine
-  onResetAlertBuilder: typeof resetAlertBuilder
-  onUpdateAlertBuilderName: typeof updateName
-  onInitializeAlertBuilder: typeof initializeAlertBuilder
-}
-
-interface StateProps {
-  checkName: string
-  status: RemoteDataState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
@@ -98,5 +86,7 @@ const mdtp = {
   onUpdateAlertBuilderName: updateName,
   onInitializeAlertBuilder: initializeAlertBuilder,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(NewCheckOverlay))

--- a/ui/src/checks/components/NewDeadmanCheckEO.tsx
+++ b/ui/src/checks/components/NewDeadmanCheckEO.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -36,7 +36,7 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = DispatchProps & StateProps & RouteComponentProps<{orgID: string}>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
   match: {
@@ -87,11 +87,11 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = ({alertBuilder: {name, status}}: AppState): StateProps => {
+const mstp = ({alertBuilder: {name, status}}: AppState) => {
   return {checkName: name, status}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetActiveTimeMachine: setActiveTimeMachine,
   onSaveCheckFromTimeMachine: createCheckFromTimeMachine,
   onResetAlertBuilder: resetAlertBuilder,
@@ -99,7 +99,4 @@ const mdtp: DispatchProps = {
   onInitializeAlertBuilder: initializeAlertBuilder,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(NewCheckOverlay))
+export default connector(withRouter(NewCheckOverlay))

--- a/ui/src/checks/components/NewThresholdCheckEO.tsx
+++ b/ui/src/checks/components/NewThresholdCheckEO.tsx
@@ -23,19 +23,7 @@ import {createView} from 'src/views/helpers'
 // Types
 import {AppState, RemoteDataState, CheckViewProperties} from 'src/types'
 
-interface DispatchProps {
-  onSetActiveTimeMachine: typeof setActiveTimeMachine
-  onSaveCheckFromTimeMachine: typeof createCheckFromTimeMachine
-  onResetAlertBuilder: typeof resetAlertBuilder
-  onUpdateAlertBuilderName: typeof updateName
-  onInitializeAlertBuilder: typeof initializeAlertBuilder
-}
-
-interface StateProps {
-  checkName: string
-  status: RemoteDataState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
@@ -98,5 +86,7 @@ const mdtp = {
   onUpdateAlertBuilderName: updateName,
   onInitializeAlertBuilder: initializeAlertBuilder,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(NewCheckOverlay))

--- a/ui/src/checks/components/NewThresholdCheckEO.tsx
+++ b/ui/src/checks/components/NewThresholdCheckEO.tsx
@@ -81,7 +81,7 @@ const mstp = ({alertBuilder: {name, status}}: AppState) => {
 
 const mdtp = {
   onSetActiveTimeMachine: setActiveTimeMachine,
-  onSaveCheckFromTimeMachine: createCheckFromTimeMachine,
+  onSaveCheckFromTimeMachine: createCheckFromTimeMachine as any,
   onResetAlertBuilder: resetAlertBuilder,
   onUpdateAlertBuilderName: updateName,
   onInitializeAlertBuilder: initializeAlertBuilder,

--- a/ui/src/checks/components/NewThresholdCheckEO.tsx
+++ b/ui/src/checks/components/NewThresholdCheckEO.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -36,7 +36,7 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = DispatchProps & StateProps & RouteComponentProps<{orgID: string}>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
   status,
@@ -87,11 +87,11 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = ({alertBuilder: {name, status}}: AppState): StateProps => {
+const mstp = ({alertBuilder: {name, status}}: AppState) => {
   return {checkName: name, status}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetActiveTimeMachine: setActiveTimeMachine,
   onSaveCheckFromTimeMachine: createCheckFromTimeMachine,
   onResetAlertBuilder: resetAlertBuilder,
@@ -99,7 +99,4 @@ const mdtp: DispatchProps = {
   onInitializeAlertBuilder: initializeAlertBuilder,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(NewCheckOverlay))
+export default connector(withRouter(NewCheckOverlay))

--- a/ui/src/clientLibraries/components/ClientArduinoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientArduinoOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -88,7 +88,7 @@ const ClientArduinoOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientArduinoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientArduinoOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -103,7 +103,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -76,7 +76,7 @@ const ClientGoOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -81,4 +81,4 @@ const mstp = (state: AppState) => {
 }
 
 export {ClientJSOverlay}
-export default connect<StateProps, {}, Props>(mstp, null)(ClientJSOverlay)
+export default connect<StateProps, {}, Props>(mstp)(ClientJSOverlay)

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -72,7 +72,7 @@ const ClientJSOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {id} = getOrg(state)
 
   return {

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -94,7 +94,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -73,7 +73,7 @@ const ClientKotlinOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientKotlinOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -14,6 +14,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 interface OwnProps {
   title: string
+  children: React.ReactNode
 }
 
 interface StateProps {

--- a/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -44,7 +44,7 @@ const ClientLibraryOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   org: getOrg(state),
 })
 

--- a/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -88,7 +88,7 @@ const ClientPHPOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {id} = getOrg(state)
 
   return {

--- a/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPHPOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -88,7 +88,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {id} = getOrg(state)
 
   return {

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -91,7 +91,7 @@ const ClientRubyOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {id} = getOrg(state)
 
   return {

--- a/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientRubyOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -76,7 +76,7 @@ const ClientScalaOverlay: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
   }

--- a/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientScalaOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'

--- a/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
+++ b/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components

--- a/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
+++ b/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -69,7 +69,7 @@ class ClientLibrariesPage extends PureComponent<StateProps> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   org: getOrg(state),
 })
 

--- a/ui/src/cloud/components/GetAssetLimits.tsx
+++ b/ui/src/cloud/components/GetAssetLimits.tsx
@@ -6,11 +6,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {getAssetLimits as getAssetLimitsAction} from 'src/cloud/actions/limits'
 
 // Components
-import {
-  TechnoSpinner,
-  SpinnerContainer,
-  RemoteDataState,
-} from '@influxdata/clockface'
+import {TechnoSpinner, SpinnerContainer} from '@influxdata/clockface'
 
 // Types
 import {AppState} from 'src/types'
@@ -18,15 +14,12 @@ import {AppState} from 'src/types'
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
-interface StateProps {
-  status: RemoteDataState
+interface OwnProps {
+  children: React.ReactNode
 }
 
-interface DispatchProps {
-  getAssetLimits: typeof getAssetLimitsAction
-}
-
-type Props = ReduxProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 class GetAssetLimits extends PureComponent<Props> {
   public componentDidMount() {
@@ -55,5 +48,7 @@ const mstp = ({
 }: AppState) => ({status})
 
 const mdtp = {getAssetLimits: getAssetLimitsAction}
+
+const connector = connect(mstp, mdtp)
 
 export default connector(GetAssetLimits)

--- a/ui/src/cloud/components/GetAssetLimits.tsx
+++ b/ui/src/cloud/components/GetAssetLimits.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {getAssetLimits as getAssetLimitsAction} from 'src/cloud/actions/limits'
@@ -26,7 +26,7 @@ interface DispatchProps {
   getAssetLimits: typeof getAssetLimitsAction
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 class GetAssetLimits extends PureComponent<Props> {
   public componentDidMount() {
@@ -52,11 +52,8 @@ const mstp = ({
   cloud: {
     limits: {status},
   },
-}: AppState): StateProps => ({status})
+}: AppState) => ({status})
 
-const mdtp: DispatchProps = {getAssetLimits: getAssetLimitsAction}
+const mdtp = {getAssetLimits: getAssetLimitsAction}
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(GetAssetLimits)
+export default connector(GetAssetLimits)

--- a/ui/src/cloud/components/LimitChecker.tsx
+++ b/ui/src/cloud/components/LimitChecker.tsx
@@ -6,11 +6,14 @@ import {CLOUD} from 'src/shared/constants'
 // Actions
 import {getReadWriteCardinalityLimits as getReadWriteCardinalityLimitsAction} from 'src/cloud/actions/limits'
 
-interface DispatchProps {
-  getReadWriteCardinalityLimits: typeof getReadWriteCardinalityLimitsAction
+interface OwnProps {
+  children: React.ReactNode
 }
 
-class LimitChecker extends PureComponent<DispatchProps, {}> {
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
+
+class LimitChecker extends PureComponent<Props> {
   public componentDidMount() {
     if (CLOUD) {
       this.props.getReadWriteCardinalityLimits()
@@ -26,4 +29,6 @@ const mdtp = {
   getReadWriteCardinalityLimits: getReadWriteCardinalityLimitsAction,
 }
 
-export default connect<{}, DispatchProps, {}>(null, mdtp)(LimitChecker)
+const connector = connect(null, mdtp)
+
+export default connector(LimitChecker)

--- a/ui/src/cloud/components/LimitChecker.tsx
+++ b/ui/src/cloud/components/LimitChecker.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {CLOUD} from 'src/shared/constants'
 
 // Actions
@@ -22,7 +22,7 @@ class LimitChecker extends PureComponent<DispatchProps, {}> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getReadWriteCardinalityLimits: getReadWriteCardinalityLimitsAction,
 }
 

--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -6,7 +6,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {CLOUD} from 'src/shared/constants'
 
 // Types
-import {AppState, Organization, OrgSetting} from 'src/types'
+import {AppState} from 'src/types'
 
 // Actions
 import {getOrgSettings as getOrgSettingsAction} from 'src/cloud/actions/orgsettings'
@@ -18,14 +18,8 @@ import {updateReportingContext} from 'src/cloud/utils/reporting'
 interface PassedInProps {
   children: React.ReactElement<any>
 }
-interface StateProps {
-  org: Organization
-  settings: OrgSetting[]
-}
-interface DispatchProps {
-  getOrgSettings: typeof getOrgSettingsAction
-}
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & PassedInProps
 
 const OrgSettings: FunctionComponent<Props> = ({
@@ -64,5 +58,7 @@ const mstp = (state: AppState) => ({
 const mdtp = {
   getOrgSettings: getOrgSettingsAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(OrgSettings)

--- a/ui/src/cloud/components/OrgSettings.tsx
+++ b/ui/src/cloud/components/OrgSettings.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import {FunctionComponent, useEffect, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -26,7 +26,7 @@ interface DispatchProps {
   getOrgSettings: typeof getOrgSettingsAction
 }
 
-type Props = StateProps & DispatchProps & PassedInProps
+type Props = ReduxProps & PassedInProps
 
 const OrgSettings: FunctionComponent<Props> = ({
   org,
@@ -56,16 +56,13 @@ const OrgSettings: FunctionComponent<Props> = ({
   return children
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   org: getOrg(state),
   settings: getOrgSettings(state),
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getOrgSettings: getOrgSettingsAction,
 }
 
-export default connect<StateProps, DispatchProps, PassedInProps>(
-  mstp,
-  mdtp
-)(OrgSettings)
+export default connector(OrgSettings)

--- a/ui/src/cloud/components/RateLimitAlert.tsx
+++ b/ui/src/cloud/components/RateLimitAlert.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {
@@ -112,4 +112,4 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps, {}>(mstp, null)(RateLimitAlert)
+export default connect<StateProps>(mstp)(RateLimitAlert)

--- a/ui/src/cloud/components/RateLimitAlert.tsx
+++ b/ui/src/cloud/components/RateLimitAlert.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -98,7 +98,7 @@ class RateLimitAlert extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     cloud: {limits},
   } = state

--- a/ui/src/dashboards/components/Dashboard.tsx
+++ b/ui/src/dashboards/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import Cells from 'src/shared/components/cells/Cells'
@@ -52,7 +52,7 @@ class DashboardComponent extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     cells: getCells(state, state.currentDashboard.id),
     status: state.resources.cells.status,

--- a/ui/src/dashboards/components/Dashboard.tsx
+++ b/ui/src/dashboards/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import Cells from 'src/shared/components/cells/Cells'
@@ -59,4 +59,4 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps, {}, OwnProps>(mstp, null)(DashboardComponent)
+export default connect<StateProps, {}, OwnProps>(mstp)(DashboardComponent)

--- a/ui/src/dashboards/components/DashboardContainer.tsx
+++ b/ui/src/dashboards/components/DashboardContainer.tsx
@@ -19,19 +19,11 @@ import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 
 // Types
-import {AppState, ResourceType, AutoRefresh, AutoRefreshStatus} from 'src/types'
+import {AppState, ResourceType, AutoRefreshStatus} from 'src/types'
 
 const {Active} = AutoRefreshStatus
 
-interface StateProps {
-  autoRefresh: AutoRefresh
-  dashboard: string
-}
-
-interface DispatchProps {
-  onSetCurrentPage: typeof setCurrentPage
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const DashboardContainer: FC<Props> = ({
@@ -83,5 +75,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onSetCurrentPage: setCurrentPage,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DashboardContainer)

--- a/ui/src/dashboards/components/DashboardContainer.tsx
+++ b/ui/src/dashboards/components/DashboardContainer.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import GetResource from 'src/resources/components/GetResource'
@@ -32,7 +32,7 @@ interface DispatchProps {
   onSetCurrentPage: typeof setCurrentPage
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 const DashboardContainer: FC<Props> = ({
   autoRefresh,
@@ -71,7 +71,7 @@ const DashboardContainer: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const dashboard = state.currentDashboard.id
   const autoRefresh = state.autoRefresh[dashboard] || AUTOREFRESH_DEFAULT
   return {
@@ -80,11 +80,8 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetCurrentPage: setCurrentPage,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(DashboardContainer)
+export default connector(DashboardContainer)

--- a/ui/src/dashboards/components/DashboardExportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardExportOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -35,7 +35,7 @@ interface StateProps {
 
 type Props = OwnProps &
   StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string}>
 
 class DashboardExportOverlay extends PureComponent<Props> {
@@ -78,17 +78,14 @@ class DashboardExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   dashboardTemplate: state.resources.templates.exportTemplate.item,
   status: state.resources.templates.exportTemplate.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(DashboardExportOverlay))
+export default connector(withRouter(DashboardExportOverlay))

--- a/ui/src/dashboards/components/DashboardExportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardExportOverlay.tsx
@@ -10,38 +10,23 @@ import {convertToTemplate as convertToTemplateAction} from 'src/dashboards/actio
 import {clearExportTemplate as clearExportTemplateAction} from 'src/templates/actions/thunks'
 
 // Types
-import {DocumentCreate} from '@influxdata/influx'
 import {AppState} from 'src/types'
-import {RemoteDataState} from 'src/types'
 
 import {
   dashboardCopySuccess,
   dashboardCopyFailed,
 } from 'src/shared/copy/notifications'
 
-interface OwnProps {
-  match: {dashboardID: string}
-}
-
-interface DispatchProps {
-  convertToTemplate: typeof convertToTemplateAction
-  clearExportTemplate: typeof clearExportTemplateAction
-}
-
-interface StateProps {
-  dashboardTemplate: DocumentCreate
-  status: RemoteDataState
-}
-
-type Props = OwnProps &
-  StateProps &
-  ReduxProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps &
+  RouteComponentProps<{orgID: string; dashboardID: string}>
 
 class DashboardExportOverlay extends PureComponent<Props> {
   public componentDidMount() {
     const {
-      match: {dashboardID},
+      match: {
+        params: {dashboardID},
+      },
       convertToTemplate,
     } = this.props
 
@@ -87,5 +72,7 @@ const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(DashboardExportOverlay))

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -45,7 +45,6 @@ import {
   AutoRefresh,
   AutoRefreshStatus,
   Dashboard,
-  Organization,
   ResourceType,
   TimeRange,
 } from 'src/types'
@@ -55,26 +54,8 @@ interface OwnProps {
   onManualRefresh: () => void
 }
 
-interface StateProps {
-  org: Organization
-  dashboard: Dashboard
-  showVariablesControls: boolean
-  timeRange: TimeRange
-}
-
-interface DispatchProps {
-  toggleShowVariablesControls: typeof toggleShowVariablesControlsAction
-  updateDashboard: typeof updateDashboardAction
-  onSetAutoRefreshStatus: typeof setAutoRefreshStatusAction
-  updateQueryParams: typeof updateQueryParamsAction
-  setDashboardTimeRange: typeof setDashboardTimeRangeAction
-  setAutoRefreshInterval: typeof setAutoRefreshIntervalAction
-}
-
-type Props = OwnProps &
-  StateProps &
-  ReduxProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const DashboardHeader: FC<Props> = ({
   dashboard,
@@ -224,5 +205,7 @@ const mdtp = {
   setDashboardTimeRange: setDashboardTimeRangeAction,
   setAutoRefreshInterval: setAutoRefreshIntervalAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(DashboardHeader))

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -73,7 +73,7 @@ interface DispatchProps {
 
 type Props = OwnProps &
   StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string}>
 
 const DashboardHeader: FC<Props> = ({
@@ -197,7 +197,7 @@ const DashboardHeader: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {showVariablesControls} = state.userSettings
   const dashboard = getByID<Dashboard>(
     state,
@@ -216,7 +216,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   toggleShowVariablesControls: toggleShowVariablesControlsAction,
   updateDashboard: updateDashboardAction,
   onSetAutoRefreshStatus: setAutoRefreshStatusAction,
@@ -225,7 +225,4 @@ const mdtp: DispatchProps = {
   setAutoRefreshInterval: setAutoRefreshIntervalAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(DashboardHeader))
+export default connector(withRouter(DashboardHeader))

--- a/ui/src/dashboards/components/DashboardImportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardImportOverlay.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {isEmpty} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -27,13 +27,8 @@ interface State {
   status: ComponentStatus
 }
 
-interface DispatchProps {
-  createDashboardFromTemplate: typeof createDashboardFromTemplateAction
-  notify: typeof notifyAction
-  populateDashboards: typeof getDashboards
-}
-
-type Props = RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 class DashboardImportOverlay extends PureComponent<Props> {
   public state: State = {
@@ -84,13 +79,12 @@ class DashboardImportOverlay extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   populateDashboards: getDashboards,
   createDashboardFromTemplate: createDashboardFromTemplateAction,
 }
 
-export default connect<{}, DispatchProps>(
-  null,
-  mdtp
-)(withRouter(DashboardImportOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(DashboardImportOverlay))

--- a/ui/src/dashboards/components/DashboardLightModeToggle.tsx
+++ b/ui/src/dashboards/components/DashboardLightModeToggle.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SelectGroup, ButtonShape, Icon, IconFont} from '@influxdata/clockface'
@@ -21,7 +21,7 @@ interface DispatchProps {
 
 interface OwnProps {}
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 const DashboardLightModeToggle: FC<Props> = ({theme, onSetTheme}) => {
   return (
@@ -51,7 +51,7 @@ const DashboardLightModeToggle: FC<Props> = ({theme, onSetTheme}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     app: {
       persisted: {theme},
@@ -61,11 +61,8 @@ const mstp = (state: AppState): StateProps => {
   return {theme}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetTheme: setTheme,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(DashboardLightModeToggle)
+export default connector(DashboardLightModeToggle)

--- a/ui/src/dashboards/components/DashboardLightModeToggle.tsx
+++ b/ui/src/dashboards/components/DashboardLightModeToggle.tsx
@@ -9,19 +9,10 @@ import {SelectGroup, ButtonShape, Icon, IconFont} from '@influxdata/clockface'
 import {setTheme} from 'src/shared/actions/app'
 
 // Types
-import {AppState, Theme} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  theme: Theme
-}
-
-interface DispatchProps {
-  onSetTheme: typeof setTheme
-}
-
-interface OwnProps {}
-
-type Props = OwnProps & ReduxProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const DashboardLightModeToggle: FC<Props> = ({theme, onSetTheme}) => {
   return (
@@ -64,5 +55,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onSetTheme: setTheme,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DashboardLightModeToggle)

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -28,19 +28,12 @@ import {getByID} from 'src/resources/selectors'
 import {AppState, AutoRefresh, ResourceType, Dashboard} from 'src/types'
 import {ManualRefreshProps} from 'src/shared/components/ManualRefresh'
 
-interface DispatchProps {
-  resetCachedQueryResults: typeof resetCachedQueryResults
-}
-
-interface StateProps {
-  dashboard: Dashboard
-}
-
 interface OwnProps {
   autoRefresh: AutoRefresh
 }
 
-type Props = OwnProps & StateProps & ManualRefreshProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ManualRefreshProps & ReduxProps
 
 import {
   ORGS,
@@ -96,7 +89,7 @@ class DashboardPage extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const dashboard = getByID<Dashboard>(
     state,
     ResourceType.Dashboards,
@@ -112,7 +105,6 @@ const mdtp = {
   resetCachedQueryResults: resetCachedQueryResults,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(ManualRefresh<OwnProps>(DashboardPage))
+const connector = connect(mstp, mdtp)
+
+export default connector(ManualRefresh<OwnProps>(DashboardPage))

--- a/ui/src/dashboards/components/EditVEO.tsx
+++ b/ui/src/dashboards/components/EditVEO.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -31,7 +31,7 @@ interface StateProps {
   view: QueryView | null
 }
 
-type Props = DispatchProps &
+type Props = ReduxProps &
   StateProps &
   RouteComponentProps<{orgID: string; cellID: string; dashboardID: string}>
 
@@ -94,20 +94,17 @@ const EditViewVEO: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {activeTimeMachineID} = state.timeMachines
   const {view} = getActiveTimeMachine(state)
 
   return {view, activeTimeMachineID}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getViewAndResultsForVEO: getViewAndResultsForVEO,
   onSetName: setName,
   onSaveView: saveVEOView,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(EditViewVEO))
+export default connector(withRouter(EditViewVEO))

--- a/ui/src/dashboards/components/EditVEO.tsx
+++ b/ui/src/dashboards/components/EditVEO.tsx
@@ -18,21 +18,10 @@ import {getViewAndResultsForVEO} from 'src/views/actions/thunks'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
-import {AppState, RemoteDataState, QueryView, TimeMachineID} from 'src/types'
+import {AppState, RemoteDataState} from 'src/types'
 
-interface DispatchProps {
-  getViewAndResultsForVEO: typeof getViewAndResultsForVEO
-  onSetName: typeof setName
-  onSaveView: typeof saveVEOView
-}
-
-interface StateProps {
-  activeTimeMachineID: TimeMachineID
-  view: QueryView | null
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps &
-  StateProps &
   RouteComponentProps<{orgID: string; cellID: string; dashboardID: string}>
 
 const EditViewVEO: FunctionComponent<Props> = ({
@@ -106,5 +95,7 @@ const mdtp = {
   onSetName: setName,
   onSaveView: saveVEOView,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(EditViewVEO))

--- a/ui/src/dashboards/components/GetTimeRange.tsx
+++ b/ui/src/dashboards/components/GetTimeRange.tsx
@@ -8,17 +8,9 @@ import {getTimeRange} from 'src/dashboards/selectors'
 import * as actions from 'src/dashboards/actions/ranges'
 
 // Types
-import {TimeRange, AppState} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  timeRange: TimeRange
-}
-
-interface DispatchProps {
-  setDashboardTimeRange: typeof actions.setDashboardTimeRange
-  updateQueryParams: typeof actions.updateQueryParams
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = RouteComponentProps<{dashboardID: string}> & ReduxProps
 
 const GetTimeRange: FC<Props> = ({
@@ -57,5 +49,7 @@ const mdtp = {
   updateQueryParams: actions.updateQueryParams,
   setDashboardTimeRange: actions.setDashboardTimeRange,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default withRouter(connector(GetTimeRange))

--- a/ui/src/dashboards/components/GetTimeRange.tsx
+++ b/ui/src/dashboards/components/GetTimeRange.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {getTimeRange} from 'src/dashboards/selectors'
 
@@ -19,9 +19,7 @@ interface DispatchProps {
   updateQueryParams: typeof actions.updateQueryParams
 }
 
-type Props = RouteComponentProps<{dashboardID: string}> &
-  StateProps &
-  DispatchProps
+type Props = RouteComponentProps<{dashboardID: string}> & ReduxProps
 
 const GetTimeRange: FC<Props> = ({
   location,
@@ -55,11 +53,9 @@ const mstp = (state: AppState) => {
   return {timeRange}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   updateQueryParams: actions.updateQueryParams,
   setDashboardTimeRange: actions.setDashboardTimeRange,
 }
 
-export default withRouter(
-  connect<StateProps, DispatchProps>(mstp, mdtp)(GetTimeRange)
-)
+export default withRouter(connector(GetTimeRange))

--- a/ui/src/dashboards/components/NewVEO.tsx
+++ b/ui/src/dashboards/components/NewVEO.tsx
@@ -18,21 +18,10 @@ import {saveVEOView} from 'src/dashboards/actions/thunks'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
-import {AppState, RemoteDataState, View, TimeMachineID} from 'src/types'
+import {AppState, RemoteDataState} from 'src/types'
 
-interface DispatchProps {
-  onSetName: typeof setName
-  onSaveView: typeof saveVEOView
-  onLoadNewVEO: typeof loadNewVEO
-}
-
-interface StateProps {
-  activeTimeMachineID: TimeMachineID
-  view: View
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps &
-  StateProps &
   RouteComponentProps<{orgID: string; dashboardID: string}>
 
 const NewViewVEO: FunctionComponent<Props> = ({
@@ -102,5 +91,7 @@ const mdtp = {
   onSaveView: saveVEOView,
   onLoadNewVEO: loadNewVEO,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(NewViewVEO))

--- a/ui/src/dashboards/components/NewVEO.tsx
+++ b/ui/src/dashboards/components/NewVEO.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -31,7 +31,7 @@ interface StateProps {
   view: View
 }
 
-type Props = DispatchProps &
+type Props = ReduxProps &
   StateProps &
   RouteComponentProps<{orgID: string; dashboardID: string}>
 
@@ -90,20 +90,17 @@ const NewViewVEO: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {activeTimeMachineID} = state.timeMachines
   const {view} = getActiveTimeMachine(state)
 
   return {view, activeTimeMachineID}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetName: setName,
   onSaveView: saveVEOView,
   onLoadNewVEO: loadNewVEO,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(NewViewVEO))
+export default connector(withRouter(NewViewVEO))

--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -24,21 +24,8 @@ import {
 // Types
 import {AppState, NoteEditorMode} from 'src/types'
 
-interface StateProps {
-  note: string
-  showNoteWhenEmpty: boolean
-  hasQuery: boolean
-}
-
-interface DispatchProps {
-  onSetIsPreviewing: typeof setIsPreviewing
-  onToggleShowNoteWhenEmpty: typeof toggleShowNoteWhenEmpty
-  onSetNote: typeof setNote
-}
-
-interface OwnProps {}
-
-type Props = ReduxProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 interface State {
   scrollTop: number
@@ -129,5 +116,7 @@ const mdtp = {
   onToggleShowNoteWhenEmpty: toggleShowNoteWhenEmpty,
   onSetNote: setNote,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(NoteEditor)

--- a/ui/src/dashboards/components/NoteEditor.tsx
+++ b/ui/src/dashboards/components/NoteEditor.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -38,7 +38,7 @@ interface DispatchProps {
 
 interface OwnProps {}
 
-type Props = StateProps & DispatchProps & OwnProps
+type Props = ReduxProps & OwnProps
 
 interface State {
   scrollTop: number
@@ -130,7 +130,4 @@ const mdtp = {
   onSetNote: setNote,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(NoteEditor)
+export default connector(NoteEditor)

--- a/ui/src/dashboards/components/NoteEditorOverlay.tsx
+++ b/ui/src/dashboards/components/NoteEditorOverlay.tsx
@@ -34,21 +34,7 @@ interface OwnProps {
   onClose: () => void
 }
 
-interface StateProps {
-  mode: NoteEditorMode
-  viewsStatus: RemoteDataState
-  cellID?: string
-  dashboardID: string
-}
-
-interface DispatchProps {
-  onCreateNoteCell: typeof createNoteCell
-  onUpdateViewNote: typeof updateViewNote
-  resetNote: typeof resetNoteState
-  onNotify: typeof notify
-  loadNote: typeof loadNote
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
 interface State {
@@ -208,5 +194,7 @@ const mdtp = {
   resetNote: resetNoteState,
   loadNote,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(NoteEditorOverlay)

--- a/ui/src/dashboards/components/NoteEditorOverlay.tsx
+++ b/ui/src/dashboards/components/NoteEditorOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -49,7 +49,7 @@ interface DispatchProps {
   loadNote: typeof loadNote
 }
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 interface State {
   savingStatus: RemoteDataState
@@ -190,7 +190,7 @@ class NoteEditorOverlay extends PureComponent<Props, State> {
   }
 }
 
-const mstp = ({noteEditor, resources, overlays}: AppState): StateProps => {
+const mstp = ({noteEditor, resources, overlays}: AppState) => {
   const {params} = overlays
   const {mode} = noteEditor
   const {status} = resources.views
@@ -209,7 +209,4 @@ const mdtp = {
   loadNote,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(NoteEditorOverlay)
+export default connector(NoteEditorOverlay)

--- a/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.scss
+++ b/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.scss
@@ -31,7 +31,7 @@
   padding-bottom: 57.3170731707317%;
 }
 
-.dashbpard-empty--graphic-content {
+.dashboard-empty--graphic-content {
   position: absolute;
   top: 0;
   left: 0;
@@ -44,7 +44,7 @@
 }
 
 .clockface--app-wrapper.dashboard-light-mode {
-  .dashbpard-empty--graphic-content {
+  .dashboard-empty--graphic-content {
     background-image: url('../../assets/images/dashboard-empty--light.svg');
   }
   .dashboard-empty .cf-empty-state--text {

--- a/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
+++ b/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -30,7 +30,7 @@ class DashboardEmpty extends Component<Props> {
       <div className="dashboard-empty">
         <EmptyState size={ComponentSize.Large}>
           <div className="dashboard-empty--graphic">
-            <div className="dashbpard-empty--graphic-content" />
+            <div className="dashboard-empty--graphic-content" />
           </div>
           <EmptyState.Text>
             This Dashboard doesn't have any <b>Cells</b>, why not add one?
@@ -61,7 +61,4 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps, {}, {}>(
-  mstp,
-  null
-)(withRouter(DashboardEmpty))
+export default connect<StateProps>(mstp)(withRouter(DashboardEmpty))

--- a/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
+++ b/ui/src/dashboards/components/dashboard_empty/DashboardEmpty.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -54,7 +54,7 @@ class DashboardEmpty extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state).id,
     dashboard: state.currentDashboard.id,

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -45,7 +45,7 @@ interface DispatchProps {
   onResetViews: typeof resetViews
 }
 
-type Props = OwnProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 class DashboardCard extends PureComponent<Props> {
   public render() {
@@ -189,7 +189,7 @@ class DashboardCard extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddDashboardLabel: addDashboardLabel,
   onRemoveDashboardLabel: removeDashboardLabel,
   onResetViews: resetViews,
@@ -198,7 +198,4 @@ const mdtp: DispatchProps = {
   onUpdateDashboard: updateDashboard,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(withRouter(DashboardCard))
+export default connector(withRouter(DashboardCard))

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -36,15 +36,7 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface DispatchProps {
-  onDeleteDashboard: typeof deleteDashboard
-  onCloneDashboard: typeof cloneDashboard
-  onUpdateDashboard: typeof updateDashboard
-  onAddDashboardLabel: typeof addDashboardLabel
-  onRemoveDashboardLabel: typeof removeDashboardLabel
-  onResetViews: typeof resetViews
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 class DashboardCard extends PureComponent<Props> {
@@ -197,5 +189,7 @@ const mdtp = {
   onDeleteDashboard: deleteDashboard,
   onUpdateDashboard: updateDashboard,
 }
+
+const connector = connect(null, mdtp)
 
 export default connector(withRouter(DashboardCard))

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Decorators
@@ -44,7 +44,7 @@ interface StateProps {
   sortOptions: DashboardSortParams
 }
 
-type Props = DispatchProps & StateProps & RouteComponentProps<{orgID: string}>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   searchTerm: string
@@ -174,7 +174,7 @@ class DashboardIndex extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     cloud: {limits},
   } = state
@@ -186,9 +186,9 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createDashboard: createDashboardAction,
   setDashboardSort,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(DashboardIndex)
+export default connector(DashboardIndex)

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -28,22 +28,13 @@ import {createDashboard as createDashboardAction} from 'src/dashboards/actions/t
 import {setDashboardSort} from 'src/dashboards/actions/creators'
 
 // Types
-import {AppState, ResourceType, DashboardSortParams} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
 import {ComponentStatus, Sort} from '@influxdata/clockface'
 import {SortTypes} from 'src/shared/utils/sort'
 import {DashboardSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
-interface DispatchProps {
-  createDashboard: typeof createDashboardAction
-  setDashboardSort: typeof setDashboardSort
-}
-
-interface StateProps {
-  limitStatus: LimitStatus
-  sortOptions: DashboardSortParams
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
@@ -190,5 +181,7 @@ const mdtp = {
   createDashboard: createDashboardAction,
   setDashboardSort,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DashboardIndex)

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import Table from 'src/dashboards/components/dashboard_index/Table'
@@ -39,7 +39,7 @@ interface StateProps {
   limitStatus: RemoteDataState
 }
 
-type Props = DispatchProps & StateProps & OwnProps
+type Props = ReduxProps & OwnProps
 
 const FilterDashboards = FilterList<Dashboard>()
 
@@ -87,7 +87,7 @@ class DashboardsIndexContents extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     cloud: {
       limits: {status},
@@ -100,12 +100,9 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   retainRangesDashTimeV1: retainRangesDashTimeV1Action,
   checkDashboardLimits: checkDashboardLimitsAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(DashboardsIndexContents)
+export default connector(DashboardsIndexContents)

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -14,7 +14,7 @@ import {checkDashboardLimits as checkDashboardLimitsAction} from 'src/cloud/acti
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Dashboard, AppState, RemoteDataState, ResourceType} from 'src/types'
+import {Dashboard, AppState, ResourceType} from 'src/types'
 import {Sort} from '@influxdata/clockface'
 import {getAll} from 'src/resources/selectors'
 import {SortTypes} from 'src/shared/utils/sort'
@@ -29,16 +29,7 @@ interface OwnProps {
   sortKey: DashboardSortKey
 }
 
-interface DispatchProps {
-  retainRangesDashTimeV1: typeof retainRangesDashTimeV1Action
-  checkDashboardLimits: typeof checkDashboardLimitsAction
-}
-
-interface StateProps {
-  dashboards: Dashboard[]
-  limitStatus: RemoteDataState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 const FilterDashboards = FilterList<Dashboard>()
@@ -104,5 +95,7 @@ const mdtp = {
   retainRangesDashTimeV1: retainRangesDashTimeV1Action,
   checkDashboardLimits: checkDashboardLimitsAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(DashboardsIndexContents)

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -2,11 +2,10 @@
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import _ from 'lodash'
 
 // Components
 import DashboardCards from 'src/dashboards/components/dashboard_index/DashboardCards'
-import DashobardsTableEmpty from 'src/dashboards/components/dashboard_index/DashboardsTableEmpty'
+import DashboardsTableEmpty from 'src/dashboards/components/dashboard_index/DashboardsTableEmpty'
 
 // Utilities
 import {getLabels} from 'src/labels/actions/thunks'
@@ -30,20 +29,8 @@ interface OwnProps {
   sortType: SortTypes
 }
 
-interface StateProps {
-  status: RemoteDataState
-}
-
-interface DispatchProps {
-  getDashboards: typeof getDashboards
-  onCreateDashboard: typeof createDashboard
-  getLabels: typeof getLabels
-}
-
-type Props = OwnProps &
-  StateProps &
-  ReduxProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 class DashboardsTable extends PureComponent<Props> {
   public componentDidMount() {
@@ -65,7 +52,7 @@ class DashboardsTable extends PureComponent<Props> {
 
     if (status === RemoteDataState.Done && !dashboards.length) {
       return (
-        <DashobardsTableEmpty
+        <DashboardsTableEmpty
           searchTerm={searchTerm}
           onCreateDashboard={onCreateDashboard}
           summonImportFromTemplateOverlay={this.summonImportFromTemplateOverlay}
@@ -116,8 +103,10 @@ const mstp = (state: AppState) => {
 
 const mdtp = {
   getDashboards: getDashboards,
-  onCreateDashboard: createDashboard,
+  onCreateDashboard: createDashboard as any,
   getLabels: getLabels,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(DashboardsTable))

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import _ from 'lodash'
 
@@ -42,7 +42,7 @@ interface DispatchProps {
 
 type Props = OwnProps &
   StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string}>
 
 class DashboardsTable extends PureComponent<Props> {
@@ -106,7 +106,7 @@ class DashboardsTable extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const status = state.resources.dashboards.status
 
   return {
@@ -114,13 +114,10 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getDashboards: getDashboards,
   onCreateDashboard: createDashboard,
   getLabels: getLabels,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(DashboardsTable))
+export default connector(withRouter(DashboardsTable))

--- a/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -23,7 +23,7 @@ import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
 import {moveVariable} from 'src/variables/actions/thunks'
 
 // Types
-import {AppState, Variable} from 'src/types'
+import {AppState} from 'src/types'
 import {ComponentSize} from '@influxdata/clockface'
 
 // Decorators
@@ -32,28 +32,18 @@ import {RemoteDataState} from 'src/types'
 import DraggableDropdown from 'src/dashboards/components/variablesControlBar/DraggableDropdown'
 import withDragDropContext from 'src/shared/decorators/withDragDropContext'
 
-interface StateProps {
-  variables: Variable[]
-  variablesStatus: RemoteDataState
-  inPresentationMode: boolean
-  show: boolean
-}
-
-interface DispatchProps {
-  moveVariable: typeof moveVariable
-}
-
 interface State {
   initialLoading: RemoteDataState
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 @ErrorHandling
 class VariablesControlBar extends PureComponent<Props, State> {
   public state: State = {initialLoading: RemoteDataState.Loading}
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props: Props, state: State) {
     if (
       props.variablesStatus === RemoteDataState.Done &&
       state.initialLoading !== RemoteDataState.Done
@@ -173,5 +163,7 @@ const mstp = (state: AppState) => {
     show,
   }
 }
+
+const connector = connect(mstp, mdtp)
 
 export default withDragDropContext(connector(VariablesControlBar))

--- a/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {isEmpty} from 'lodash'
 import classnames from 'classnames'
 
@@ -47,7 +47,7 @@ interface State {
   initialLoading: RemoteDataState
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 @ErrorHandling
 class VariablesControlBar extends PureComponent<Props, State> {
@@ -149,7 +149,7 @@ const mdtp = {
   moveVariable,
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const dashboardID = state.currentDashboard.id
   const variables = getVariables(state)
   const variablesStatus = getDashboardVariablesStatus(state)
@@ -174,6 +174,4 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default withDragDropContext(
-  connect<StateProps, DispatchProps>(mstp, mdtp)(VariablesControlBar)
-)
+export default withDragDropContext(connector(VariablesControlBar))

--- a/ui/src/dataExplorer/components/DataExplorer.tsx
+++ b/ui/src/dataExplorer/components/DataExplorer.tsx
@@ -16,12 +16,8 @@ import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import {readQueryParams} from 'src/shared/utils/queryParams'
 
-interface DispatchProps {
-  onSetActiveTimeMachine: typeof setActiveTimeMachine
-  onSetBuilderBucketIfExists: typeof setBuilderBucketIfExists
-}
-
-type Props = DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const DataExplorer: FC<Props> = ({
   onSetActiveTimeMachine,
@@ -51,4 +47,6 @@ const mdtp = {
   onSetBuilderBucketIfExists: setBuilderBucketIfExists,
 }
 
-export default connect<{}, DispatchProps, {}>(null, mdtp)(DataExplorer)
+const connector = connect(null, mdtp)
+
+export default connector(DataExplorer)

--- a/ui/src/dataExplorer/components/DataExplorer.tsx
+++ b/ui/src/dataExplorer/components/DataExplorer.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TimeMachine from 'src/timeMachine/components/TimeMachine'
@@ -46,7 +46,7 @@ const DataExplorer: FC<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetActiveTimeMachine: setActiveTimeMachine,
   onSetBuilderBucketIfExists: setBuilderBucketIfExists,
 }

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {get} from 'lodash'
 
@@ -14,7 +14,7 @@ import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {convertTimeRangeToCustom} from 'src/shared/utils/duration'
 
 // Types
-import {AppState, TimeRange, ResourceType} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 
 // Actions
 import {
@@ -23,18 +23,8 @@ import {
   setBucketAndKeys,
 } from 'src/shared/actions/predicates'
 
-interface StateProps {
-  bucketNameFromDE: string
-  timeRangeFromDE: TimeRange
-}
-
-interface DispatchProps {
-  resetPredicateState: typeof resetPredicateState
-  setTimeRange: typeof setTimeRange
-  setBucketAndKeys: typeof setBucketAndKeys
-}
-
-type Props = StateProps & RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 const DeleteDataOverlay: FunctionComponent<Props> = ({
   history,
@@ -78,7 +68,7 @@ const DeleteDataOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const activeQuery = getActiveQuery(state)
   const bucketNameFromDE = get(activeQuery, 'builderConfig.buckets.0')
 
@@ -90,13 +80,12 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   resetPredicateState,
   setTimeRange,
   setBucketAndKeys,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(DeleteDataOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(DeleteDataOverlay))

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -45,23 +45,11 @@ interface State {
   newDashboardName: string
 }
 
-interface StateProps {
-  dashboards: Dashboard[]
-  view: View
-  orgID: string
-}
-
-interface DispatchProps {
-  onGetDashboards: typeof getDashboards
-  onCreateCellWithView: typeof createCellWithView
-  onCreateDashboardWithView: typeof createDashboardWithView
-  notify: typeof notify
-}
-
 interface OwnProps {
   dismiss: () => void
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 @ErrorHandling
@@ -248,5 +236,7 @@ const mdtp = {
   onCreateDashboardWithView: createDashboardWithView,
   notify,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(SaveAsCellForm)

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get, isEmpty} from 'lodash'
 
 // Selectors
@@ -62,7 +62,7 @@ interface OwnProps {
   dismiss: () => void
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type Props = ReduxProps & OwnProps
 
 @ErrorHandling
 class SaveAsCellForm extends PureComponent<Props, State> {
@@ -230,7 +230,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const view = getSaveableView(state)
   const org = getOrg(state)
   const dashboards = getAll<Dashboard>(state, ResourceType.Dashboards)
@@ -242,11 +242,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onGetDashboards: getDashboards,
   onCreateCellWithView: createCellWithView,
   onCreateDashboardWithView: createDashboardWithView,
   notify,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(SaveAsCellForm)
+export default connector(SaveAsCellForm)

--- a/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -25,34 +25,14 @@ import {getOrg} from 'src/organizations/selectors'
 import {getActiveQuery} from 'src/timeMachine/selectors'
 
 // Types
-import {
-  AppState,
-  VariableAssignment,
-  TaskSchedule,
-  TaskOptions,
-  TaskOptionKeys,
-  DashboardDraftQuery,
-} from 'src/types'
+import {AppState, TaskSchedule, TaskOptionKeys} from 'src/types'
 
 interface OwnProps {
   dismiss: () => void
 }
 
-interface DispatchProps {
-  saveNewScript: typeof saveNewScript
-  setTaskOption: typeof setTaskOption
-  clearTask: typeof clearTask
-  setNewScript: typeof setNewScript
-}
-
-interface StateProps {
-  taskOptions: TaskOptions
-  activeQuery: DashboardDraftQuery
-  newScript: string
-  userDefinedVars: VariableAssignment[]
-}
-
-type Props = StateProps & OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class SaveAsTaskForm extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -145,7 +125,7 @@ class SaveAsTaskForm extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {newScript, taskOptions} = state.resources.tasks
   const activeQuery = getActiveQuery(state)
   const org = getOrg(state)
@@ -161,14 +141,13 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   saveNewScript,
   setTaskOption,
   clearTask,
   setNewScript,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(SaveAsTaskForm))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(SaveAsTaskForm))

--- a/ui/src/dataExplorer/components/SaveAsVariable.tsx
+++ b/ui/src/dataExplorer/components/SaveAsVariable.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import VariableFormContext from 'src/variables/components/VariableFormContext'

--- a/ui/src/dataExplorer/components/SaveAsVariable.tsx
+++ b/ui/src/dataExplorer/components/SaveAsVariable.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import VariableFormContext from 'src/variables/components/VariableFormContext'
@@ -36,7 +36,7 @@ class SaveAsVariable extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const activeQuery = getActiveQuery(state)
 
   return {

--- a/ui/src/dataLoaders/components/TelegrafEditor.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditor.tsx
@@ -95,7 +95,7 @@ class TelegrafEditor extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const pluginHashMap = state.telegrafEditorPlugins
     .filter(
       (a: TelegrafEditorPlugin) => a.type !== 'bundle' || !!a.include.length
@@ -110,4 +110,4 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default connect<StateProps, {}>(mstp, null)(TelegrafEditor)
+export default connect<StateProps>(mstp)(TelegrafEditor)

--- a/ui/src/dataLoaders/components/TelegrafEditorFooter.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorFooter.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {downloadTextFile} from 'src/shared/utils/download'
 import {ComponentColor, Button} from '@influxdata/clockface'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -10,13 +10,8 @@ interface OwnProps {
   onDismiss: () => void
 }
 
-interface StateProps {
-  script: string
-}
-
-interface DispatchProps {}
-
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 export class TelegrafEditorFooter extends PureComponent<Props> {
   public render() {
@@ -49,7 +44,7 @@ export class TelegrafEditorFooter extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const script = state.telegrafEditor.text
 
   return {
@@ -57,9 +52,6 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {}
+const connector = connect(mstp)
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(TelegrafEditorFooter)
+export default connector(TelegrafEditorFooter)

--- a/ui/src/dataLoaders/components/TelegrafEditorMonaco.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorMonaco.tsx
@@ -8,15 +8,7 @@ import {TelegrafEditorPluginType} from 'src/dataLoaders/reducers/telegrafEditor'
 
 const PLUGIN_REGEX = /\[\[\s*(inputs|outputs|processors|aggregators)\.(.+)\s*\]\]/
 
-interface DispatchProps {
-  onSetText: typeof setText
-  onSetActivePlugins: typeof setActivePlugins
-}
-
-interface StateProps {
-  script: string
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 interface InterumMatchFormat {
@@ -149,6 +141,6 @@ const mdtp = {
   onSetText: setText,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp, null, {
-  withRef: true,
-})(TelegrafEditorMonaco)
+const connector = connect(mstp, mdtp, null, {withRef: true})
+
+export default connector(TelegrafEditorMonaco)

--- a/ui/src/dataLoaders/components/TelegrafEditorMonaco.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorMonaco.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {AppState} from 'src/types'
 import Editor from 'src/shared/components/TomlMonacoEditor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
@@ -17,7 +17,7 @@ interface StateProps {
   script: string
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 interface InterumMatchFormat {
   name: string
@@ -122,7 +122,7 @@ class TelegrafEditorMonaco extends PureComponent<Props> {
 
 export {TelegrafEditorMonaco}
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const map = state.telegrafEditorPlugins.reduce((prev, curr) => {
     prev[curr.name] = curr
     return prev
@@ -144,7 +144,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetActivePlugins: setActivePlugins,
   onSetText: setText,
 }

--- a/ui/src/dataLoaders/components/TelegrafEditorPluginLookup.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorPluginLookup.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import classnames from 'classnames'
 
 // Components

--- a/ui/src/dataLoaders/components/TelegrafEditorPluginLookup.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorPluginLookup.tsx
@@ -10,25 +10,14 @@ import {SquareButton, IconFont, ComponentSize} from '@influxdata/clockface'
 import {setLookup} from 'src/dataLoaders/actions/telegrafEditor'
 
 // Types
-import {
-  TelegrafEditorActivePluginState,
-  TelegrafEditorActivePlugin,
-} from 'src/dataLoaders/reducers/telegrafEditor'
-
-interface PluginStateProps {
-  plugins: TelegrafEditorActivePluginState
-  show: boolean
-}
+import {TelegrafEditorActivePlugin} from 'src/dataLoaders/reducers/telegrafEditor'
 
 interface OwnProps {
   onJump: (which: TelegrafEditorActivePlugin) => void
 }
 
-interface PluginDispatchProps {
-  onChangeLookup: typeof setLookup
-}
-
-type Props = OwnProps & PluginStateProps & PluginDispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const TelegrafEditorSideBar: FC<Props> = ({
   plugins,
@@ -60,18 +49,17 @@ const TelegrafEditorSideBar: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): PluginStateProps => {
+const mstp = (state: AppState) => {
   const plugins = state.telegrafEditorActivePlugins || []
   const show = state.telegrafEditor.showLookup
 
   return {plugins, show}
 }
 
-const mdtp: PluginDispatchProps = {
+const mdtp = {
   onChangeLookup: setLookup,
 }
 
-export default connect<PluginStateProps, PluginDispatchProps>(
-  mstp,
-  mdtp
-)(TelegrafEditorSideBar)
+const connector = connect(mstp, mdtp)
+
+export default connector(TelegrafEditorSideBar)

--- a/ui/src/dataLoaders/components/TelegrafEditorSidebar.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorSidebar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, SyntheticEvent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import classnames from 'classnames'
 
 // Components
@@ -56,7 +56,7 @@ interface OwnProps {
   onAdd: (which: TelegrafEditorPlugin) => void
 }
 
-type TelegrafEditorSidebarProps = StateProps & DispatchProps & OwnProps
+type TelegrafEditorSidebarProps = ReduxProps & OwnProps
 
 class TelegrafEditorSideBar extends PureComponent<TelegrafEditorSidebarProps> {
   private renderPlugins() {
@@ -115,7 +115,7 @@ class TelegrafEditorSideBar extends PureComponent<TelegrafEditorSidebarProps> {
   }
 }
 
-const mstp_3 = (state: AppState): StateProps => {
+const mstp_3 = (state: AppState) => {
   const filter = state.telegrafEditor.filter
   const show = state.telegrafEditor.showList
 
@@ -125,7 +125,7 @@ const mstp_3 = (state: AppState): StateProps => {
   }
 }
 
-const mdtp_3: DispatchProps = {
+const mdtp_3 = {
   onSetList: setList,
   onSetFilter: setFilter,
 }

--- a/ui/src/dataLoaders/components/TelegrafEditorSidebar.tsx
+++ b/ui/src/dataLoaders/components/TelegrafEditorSidebar.tsx
@@ -39,23 +39,14 @@ const mstp_2 = (state: AppState): PluginStateProps => {
   }
 }
 
-const AllPluginList = connect<PluginStateProps, {}>(mstp_2, null)(PluginList)
-
-interface StateProps {
-  filter: string
-  show: boolean
-}
-
-interface DispatchProps {
-  onSetFilter: typeof setFilter
-  onSetList: typeof setList
-}
+const AllPluginList = connect<PluginStateProps>(mstp_2)(PluginList)
 
 interface OwnProps {
   onJump: (which: TelegrafEditorActivePlugin) => void
   onAdd: (which: TelegrafEditorPlugin) => void
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type TelegrafEditorSidebarProps = ReduxProps & OwnProps
 
 class TelegrafEditorSideBar extends PureComponent<TelegrafEditorSidebarProps> {
@@ -130,7 +121,6 @@ const mdtp_3 = {
   onSetFilter: setFilter,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp_3,
-  mdtp_3
-)(TelegrafEditorSideBar)
+const connector = connect(mstp_3, mdtp_3)
+
+export default connector(TelegrafEditorSideBar)

--- a/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -45,9 +45,7 @@ import {
 import {reset} from 'src/dataLoaders/actions/telegrafEditor'
 
 // Types
-import {Links} from 'src/types/links'
-import {Substep, TelegrafPlugin} from 'src/types/dataLoaders'
-import {AppState, Bucket, Organization, ResourceType} from 'src/types'
+import {AppState, Bucket, ResourceType} from 'src/types'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
@@ -64,36 +62,11 @@ export interface CollectorsStepProps {
   onExit: () => void
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-  onSetBucketInfo: typeof setBucketInfo
-  onIncrementCurrentStepIndex: typeof incrementCurrentStepIndex
-  onDecrementCurrentStepIndex: typeof decrementCurrentStepIndex
-  onSetCurrentStepIndex: typeof setCurrentStepIndex
-  onClearDataLoaders: typeof clearDataLoaders
-  onClearSteps: typeof clearSteps
-  onClearTelegrafEditor: typeof reset
-  onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
-  onSetPluginConfiguration: typeof setPluginConfiguration
-}
-
-interface StateProps {
-  links: Links
-  buckets: Bucket[]
-  telegrafPlugins: TelegrafPlugin[]
-  currentStepIndex: number
-  substep: Substep
-  username: string
-  bucket: string
-  text: string
-  org: Organization
-}
-
-type Props = ReduxProps
-type AllProps = Props & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
-class CollectorsWizard extends PureComponent<AllProps> {
+class CollectorsWizard extends PureComponent<Props> {
   public componentDidMount() {
     const {bucket, buckets} = this.props
     if (!bucket && buckets && buckets.length) {
@@ -208,5 +181,7 @@ const mdtp = {
   onSetActiveTelegrafPlugin: setActiveTelegrafPlugin,
   onSetPluginConfiguration: setPluginConfiguration,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(CollectorsWizard))

--- a/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import Loadable from 'react-loadable'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -89,7 +89,7 @@ interface StateProps {
   org: Organization
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 type AllProps = Props & RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
@@ -164,7 +164,7 @@ class CollectorsWizard extends PureComponent<AllProps> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     links,
     dataLoading: {
@@ -196,7 +196,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   onSetBucketInfo: setBucketInfo,
   onIncrementCurrentStepIndex: incrementCurrentStepIndex,
@@ -209,7 +209,4 @@ const mdtp: DispatchProps = {
   onSetPluginConfiguration: setPluginConfiguration,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(CollectorsWizard))
+export default connector(withRouter(CollectorsWizard))

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -26,14 +26,8 @@ interface OwnProps {
   telegrafPlugin: TelegrafPlugin
 }
 
-interface DispatchProps {
-  onUpdateTelegrafPluginConfig: typeof updateTelegrafPluginConfig
-  onAddConfigValue: typeof addConfigValue
-  onRemoveConfigValue: typeof removeConfigValue
-  onSetConfigArrayValue: typeof setConfigArrayValue
-}
-
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 export class ConfigFieldHandler extends PureComponent<Props> {
   public render() {
@@ -108,14 +102,13 @@ export class ConfigFieldHandler extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateTelegrafPluginConfig: updateTelegrafPluginConfig,
   onAddConfigValue: addConfigValue,
   onRemoveConfigValue: removeConfigValue,
   onSetConfigArrayValue: setConfigArrayValue,
 }
 
-export default connect<null, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(ConfigFieldHandler)
+const connector = connect(null, mdtp)
+
+export default connector(ConfigFieldHandler)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -32,7 +32,7 @@ interface StateProps {
   telegrafPlugins: TelegrafPlugin[]
 }
 
-type Props = OwnProps & StateProps & DispatchProps
+type Props = OwnProps & ReduxProps
 
 export class PluginConfigForm extends PureComponent<Props> {
   public render() {
@@ -101,16 +101,13 @@ const mstp = ({
   dataLoading: {
     dataLoaders: {telegrafPlugins},
   },
-}: AppState): StateProps => ({
+}: AppState) => ({
   telegrafPlugins,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetActiveTelegrafPlugin: setActiveTelegrafPlugin,
   onSetPluginConfiguration: setPluginConfiguration,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(PluginConfigForm)
+export default connector(PluginConfigForm)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -23,15 +23,7 @@ interface OwnProps {
   configFields: ConfigFields
 }
 
-interface DispatchProps {
-  onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
-  onSetPluginConfiguration: typeof setPluginConfiguration
-}
-
-interface StateProps {
-  telegrafPlugins: TelegrafPlugin[]
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
 export class PluginConfigForm extends PureComponent<Props> {
@@ -109,5 +101,7 @@ const mdtp = {
   onSetActiveTelegrafPlugin: setActiveTelegrafPlugin,
   onSetPluginConfiguration: setPluginConfiguration,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(PluginConfigForm)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -25,6 +25,7 @@ const setup = (override = {}) => {
     onClickNext: jest.fn(),
     onClickPrevious: jest.fn(),
     onClickSkip: jest.fn(),
+    dispatch: jest.fn,
     ...override,
   }
 

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
 
 // Components
 import PluginConfigForm from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm'
@@ -15,11 +14,8 @@ import {TelegrafPlugin, ConfigFields} from 'src/types/dataLoaders'
 import {AppState} from 'src/types'
 import TelegrafPluginInstructions from 'src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions'
 
-interface StateProps {
-  telegrafPlugins: TelegrafPlugin[]
-}
-
-type Props = StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 export class PluginConfigSwitcher extends PureComponent<Props> {
   public render() {
@@ -58,5 +54,7 @@ const mstp = ({
 }: AppState) => ({
   telegrafPlugins,
 })
+
+const connector = connect(mstp)
 
 export default connector(PluginConfigSwitcher)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -55,8 +55,8 @@ const mstp = ({
   dataLoading: {
     dataLoaders: {telegrafPlugins},
   },
-}: AppState): StateProps => ({
+}: AppState) => ({
   telegrafPlugins,
 })
 
-export default connect<StateProps>(mstp, null)(PluginConfigSwitcher)
+export default connector(PluginConfigSwitcher)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
@@ -32,7 +32,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Types
-import {AppState, TelegrafPlugin, ConfigurationState} from 'src/types'
+import {AppState, ConfigurationState} from 'src/types'
 import {InputType, ComponentSize} from '@influxdata/clockface'
 import {influxdbTemplateList} from 'src/templates/constants/defaultTemplates'
 
@@ -40,25 +40,7 @@ import {influxdbTemplateList} from 'src/templates/constants/defaultTemplates'
 import {getOrg} from 'src/organizations/selectors'
 import {getDataLoaders} from 'src/dataLoaders/selectors'
 
-interface DispatchProps {
-  onSetTelegrafConfigName: typeof setTelegrafConfigName
-  onSetTelegrafConfigDescription: typeof setTelegrafConfigDescription
-  onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
-  onSetPluginConfiguration: typeof setPluginConfiguration
-  onIncrementStep: typeof incrementCurrentStepIndex
-  onDecrementStep: typeof decrementCurrentStepIndex
-  notify: typeof notifyAction
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
-}
-
-interface StateProps {
-  telegrafConfigName: string
-  telegrafConfigDescription: string
-  telegrafPlugins: TelegrafPlugin[]
-  telegrafConfigID: string
-  orgID: string
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 export class TelegrafPluginInstructions extends PureComponent<Props> {
@@ -234,5 +216,7 @@ const mdtp = {
   onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
   notify: notifyAction,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(TelegrafPluginInstructions)

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {includes, get} from 'lodash'
 
 // Components
@@ -59,7 +59,7 @@ interface StateProps {
   orgID: string
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 export class TelegrafPluginInstructions extends PureComponent<Props> {
   public render() {
@@ -205,7 +205,7 @@ export class TelegrafPluginInstructions extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     telegrafConfigName,
     telegrafConfigDescription,
@@ -224,7 +224,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetTelegrafConfigName: setTelegrafConfigName,
   onSetTelegrafConfigDescription: setTelegrafConfigDescription,
   onIncrementStep: incrementCurrentStepIndex,
@@ -235,7 +235,4 @@ const mdtp: DispatchProps = {
   notify: notifyAction,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(TelegrafPluginInstructions)
+export default connector(TelegrafPluginInstructions)

--- a/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, DapperScrollbars} from '@influxdata/clockface'
@@ -19,26 +19,15 @@ import {setBucketInfo} from 'src/dataLoaders/actions/steps'
 import {Bucket} from 'src/types'
 import {ComponentStatus} from '@influxdata/clockface'
 import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
-import {TelegrafPlugin, BundleName} from 'src/types/dataLoaders'
+import {BundleName} from 'src/types/dataLoaders'
 import {AppState} from 'src/types'
 
 export interface OwnProps extends CollectorsStepProps {
   buckets: Bucket[]
 }
 
-export interface StateProps {
-  bucket: string
-  telegrafPlugins: TelegrafPlugin[]
-  pluginBundles: BundleName[]
-}
-
-export interface DispatchProps {
-  onAddPluginBundle: typeof addPluginBundleWithPlugins
-  onRemovePluginBundle: typeof removePluginBundleWithPlugins
-  onSetBucketInfo: typeof setBucketInfo
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 export class SelectCollectorsStep extends PureComponent<Props> {
@@ -134,19 +123,18 @@ const mstp = ({
     dataLoaders: {telegrafPlugins, pluginBundles},
     steps: {bucket},
   },
-}: AppState): StateProps => ({
+}: AppState) => ({
   telegrafPlugins,
   bucket,
   pluginBundles,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddPluginBundle: addPluginBundleWithPlugins,
   onRemovePluginBundle: removePluginBundleWithPlugins,
   onSetBucketInfo: setBucketInfo,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(SelectCollectorsStep)
+const connector = connect(mstp, mdtp)
+
+export default connector(SelectCollectorsStep)

--- a/ui/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {Form, DapperScrollbars} from '@influxdata/clockface'

--- a/ui/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, DapperScrollbars} from '@influxdata/clockface'
@@ -73,7 +73,7 @@ const mstp = ({
     steps: {bucket, org},
   },
   me: {name},
-}: AppState): StateProps => ({
+}: AppState) => ({
   username: name,
   telegrafConfigID,
   bucket,

--- a/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -40,24 +40,8 @@ interface OwnProps {
   startingStep?: number
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-  onSetBucketInfo: typeof setBucketInfo
-  onIncrementCurrentStepIndex: typeof incrementCurrentStepIndex
-  onDecrementCurrentStepIndex: typeof decrementCurrentStepIndex
-  onSetCurrentStepIndex: typeof setCurrentStepIndex
-  onClearDataLoaders: typeof clearDataLoaders
-  onClearSteps: typeof clearSteps
-}
-
-interface StateProps {
-  currentStepIndex: number
-  username: string
-  bucket: string
-  buckets: Bucket[]
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 class LineProtocolWizard extends PureComponent<
@@ -132,7 +116,7 @@ class LineProtocolWizard extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     dataLoading: {
       steps: {currentStep, bucket},
@@ -150,7 +134,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   onSetBucketInfo: setBucketInfo,
   onIncrementCurrentStepIndex: incrementCurrentStepIndex,
@@ -160,7 +144,6 @@ const mdtp: DispatchProps = {
   onClearSteps: clearSteps,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(LineProtocolWizard))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(LineProtocolWizard))

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, Overlay} from '@influxdata/clockface'
@@ -20,7 +20,6 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {LineProtocolTab} from 'src/types/dataLoaders'
 import {AppState} from 'src/types/index'
-import {WritePrecision} from '@influxdata/influx'
 import {RemoteDataState} from 'src/types'
 import {LineProtocolStepProps} from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 
@@ -29,19 +28,8 @@ import {getOrg} from 'src/organizations/selectors'
 
 type OwnProps = LineProtocolStepProps
 
-interface StateProps {
-  lineProtocolBody: string
-  precision: WritePrecision
-  bucket: string
-  org: string
-}
-
-interface DispatchProps {
-  setLPStatus: typeof setLPStatusAction
-  writeLineProtocolAction: typeof writeLineProtocolAction
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 export class LineProtocol extends PureComponent<Props> {
@@ -84,7 +72,7 @@ export class LineProtocol extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {dataLoading} = state
   const {
     dataLoaders: {lineProtocolBody, precision},
@@ -95,12 +83,11 @@ const mstp = (state: AppState): StateProps => {
   return {lineProtocolBody, precision, bucket, org}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setLPStatus: setLPStatusAction,
   writeLineProtocolAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(LineProtocol)
+const connector = connect(mstp, mdtp)
+
+export default connector(LineProtocol)

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
 
 // Components
 import PrecisionDropdown from 'src/dataLoaders/components/lineProtocolWizard/configure/PrecisionDropdown'
@@ -10,7 +9,6 @@ import TabBody from 'src/dataLoaders/components/lineProtocolWizard/configure/Tab
 
 // Types
 import {AppState, LineProtocolTab} from 'src/types'
-import {WritePrecision} from '@influxdata/influx'
 
 // Actions
 import {
@@ -25,19 +23,8 @@ interface OwnProps {
   org: string
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
-
-interface DispatchProps {
-  setLineProtocolBody: typeof setLineProtocolBody
-  setActiveLPTab: typeof setActiveLPTab
-  setPrecision: typeof setPrecision
-}
-
-interface StateProps {
-  lineProtocolBody: string
-  activeLPTab: LineProtocolTab
-  precision: WritePrecision
-}
 
 interface State {
   urlInput: string
@@ -114,5 +101,7 @@ const mdtp = {
   setActiveLPTab,
   setPrecision,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(LineProtocolTabs)

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -25,7 +25,7 @@ interface OwnProps {
   org: string
 }
 
-type Props = OwnProps & DispatchProps & StateProps
+type Props = OwnProps & ReduxProps
 
 interface DispatchProps {
   setLineProtocolBody: typeof setLineProtocolBody
@@ -109,13 +109,10 @@ const mstp = ({
   return {lineProtocolBody, activeLPTab, precision}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setLineProtocolBody,
   setActiveLPTab,
   setPrecision,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(LineProtocolTabs)
+export default connector(LineProtocolTabs)

--- a/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import classnames from 'classnames'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SparkleSpinner} from '@influxdata/clockface'
@@ -70,7 +70,7 @@ const mstp = ({
   dataLoading: {
     dataLoaders: {lpStatus, lpError},
   },
-}: AppState): StateProps => ({
+}: AppState) => ({
   status: lpStatus,
   errorMessage: lpError,
 })

--- a/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import classnames from 'classnames'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {SparkleSpinner} from '@influxdata/clockface'

--- a/ui/src/eventViewer/components/EventTable.tsx
+++ b/ui/src/eventViewer/components/EventTable.tsx
@@ -26,14 +26,11 @@ import {RemoteDataState} from 'src/types'
 // Constants
 import {checkStatusLoading} from 'src/shared/copy/notifications'
 
-type DispatchProps = {
-  notify: typeof notifyAction
-}
-
 type OwnProps = {
   fields: Fields
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = EventViewerChildProps & ReduxProps & OwnProps
 
 const EventTable: FC<Props> = ({state, dispatch, loadRows, fields, notify}) => {
@@ -135,5 +132,7 @@ const EventTable: FC<Props> = ({state, dispatch, loadRows, fields, notify}) => {
 const mdtp = {
   notify: notifyAction,
 }
+
+const connector = connect(null, mdtp)
 
 export default connector(EventTable)

--- a/ui/src/eventViewer/components/EventTable.tsx
+++ b/ui/src/eventViewer/components/EventTable.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useLayoutEffect, FC, useEffect, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer, InfiniteLoader, List} from 'react-virtualized'
 
 // Components
@@ -34,7 +34,7 @@ type OwnProps = {
   fields: Fields
 }
 
-type Props = EventViewerChildProps & DispatchProps & OwnProps
+type Props = EventViewerChildProps & ReduxProps & OwnProps
 
 const EventTable: FC<Props> = ({state, dispatch, loadRows, fields, notify}) => {
   const rowCount = getRowCount(state)
@@ -132,8 +132,8 @@ const EventTable: FC<Props> = ({state, dispatch, loadRows, fields, notify}) => {
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(EventTable)
+export default connector(EventTable)

--- a/ui/src/labels/components/LabelsTab.tsx
+++ b/ui/src/labels/components/LabelsTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Button, EmptyState} from '@influxdata/clockface'
@@ -52,7 +52,7 @@ interface DispatchProps {
   deleteLabel: typeof deleteLabel
 }
 
-type Props = DispatchProps & StateProps
+type Props = ReduxProps
 
 const FilterLabels = FilterList<Label>()
 @ErrorHandling
@@ -205,15 +205,15 @@ class Labels extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const labels = getAll<Label>(state, ResourceType.Labels)
   return {labels}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createLabel: createLabel,
   updateLabel: updateLabel,
   deleteLabel: deleteLabel,
 }
 
-export default connect(mstp, mdtp)(Labels)
+export default connector(Labels)

--- a/ui/src/labels/components/LabelsTab.tsx
+++ b/ui/src/labels/components/LabelsTab.tsx
@@ -34,10 +34,6 @@ import {LabelSortKey} from 'src/shared/components/resource_sort_dropdown/generat
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface StateProps {
-  labels: Label[]
-}
-
 interface State {
   searchTerm: string
   isOverlayVisible: boolean
@@ -46,12 +42,7 @@ interface State {
   sortType: SortTypes
 }
 
-interface DispatchProps {
-  createLabel: typeof createLabel
-  updateLabel: typeof updateLabel
-  deleteLabel: typeof deleteLabel
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const FilterLabels = FilterList<Label>()
@@ -215,5 +206,7 @@ const mdtp = {
   updateLabel: updateLabel,
   deleteLabel: deleteLabel,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(Labels)

--- a/ui/src/labels/containers/LabelsIndex.tsx
+++ b/ui/src/labels/containers/LabelsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/ui/src/labels/containers/LabelsIndex.tsx
+++ b/ui/src/labels/containers/LabelsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -44,4 +44,4 @@ class LabelsIndex extends PureComponent<StateProps> {
 
 const mstp = (state: AppState) => ({org: getOrg(state)})
 
-export default connect<StateProps, {}, {}>(mstp, null)(LabelsIndex)
+export default connect<StateProps>(mstp)(LabelsIndex)

--- a/ui/src/me/components/DashboardsList.tsx
+++ b/ui/src/me/components/DashboardsList.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useState, ChangeEvent} from 'react'
 import {Link} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {sortBy} from 'lodash'
 
 // Components
@@ -95,7 +95,7 @@ const DashboardList: FC<Props> = ({dashboards, org}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   // map names and sort via a selector
   const dashboards = getSortedDashboardNames(
     getAll<Dashboard>(state, ResourceType.Dashboards)

--- a/ui/src/me/components/DashboardsList.tsx
+++ b/ui/src/me/components/DashboardsList.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useState, ChangeEvent} from 'react'
 import {Link} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {sortBy} from 'lodash'
 
 // Components
@@ -107,4 +107,4 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps, {}, {}>(mstp, null)(DashboardList)
+export default connect(mstp)(DashboardList)

--- a/ui/src/me/components/GettingStarted.tsx
+++ b/ui/src/me/components/GettingStarted.tsx
@@ -22,11 +22,8 @@ import {AppState} from 'src/types'
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 
-interface StateProps {
-  orgID: string
-}
-
-type Props = RouteComponentProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps & ReduxProps
 
 const GettingStarted: FunctionComponent<Props> = ({orgID, history}) => {
   const [loadDataAnimating, setLoadDataAnimation] = useState<boolean>(false)
@@ -133,5 +130,7 @@ const mstp = (state: AppState) => {
     orgID: id,
   }
 }
+
+const connector = connect(mstp)
 
 export default withRouter(connector(GettingStarted))

--- a/ui/src/me/components/GettingStarted.tsx
+++ b/ui/src/me/components/GettingStarted.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useState} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -127,11 +127,11 @@ const GettingStarted: FunctionComponent<Props> = ({orgID, history}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {id} = getOrg(state)
   return {
     orgID: id,
   }
 }
 
-export default withRouter(connect<StateProps>(mstp, null)(GettingStarted))
+export default withRouter(connector(GettingStarted))

--- a/ui/src/me/components/account/Settings.tsx
+++ b/ui/src/me/components/account/Settings.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, Input, Button, Panel, Grid} from '@influxdata/clockface'

--- a/ui/src/me/components/account/Settings.tsx
+++ b/ui/src/me/components/account/Settings.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Components
 import {Form, Input, Button, Panel, Grid} from '@influxdata/clockface'
@@ -67,4 +67,4 @@ const mstp = ({me}: AppState) => ({
   me,
 })
 
-export default connect<StateProps>(mstp)(Settings)
+export default connect(mstp)(Settings)

--- a/ui/src/me/containers/MePage.tsx
+++ b/ui/src/me/containers/MePage.tsx
@@ -27,12 +27,11 @@ import {AppState} from 'src/types'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface StateProps {
-  me: AppState['me']
-}
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 @ErrorHandling
-export class MePage extends PureComponent<StateProps> {
+export class MePage extends PureComponent<Props> {
   public render() {
     const {me} = this.props
 
@@ -77,5 +76,7 @@ const mstp = (state: AppState) => {
 
   return {me}
 }
+
+const connector = connect(mstp)
 
 export default connector(MePage)

--- a/ui/src/me/containers/MePage.tsx
+++ b/ui/src/me/containers/MePage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -72,10 +72,10 @@ export class MePage extends PureComponent<StateProps> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {me} = state
 
   return {me}
 }
 
-export default connect<StateProps>(mstp, null)(MePage)
+export default connector(MePage)

--- a/ui/src/members/components/Members.tsx
+++ b/ui/src/members/components/Members.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 // Libraries
 import {isEmpty} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -31,7 +31,7 @@ interface DispatchProps {
   onRemoveMember: typeof deleteMember
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 interface State {
   searchTerm: string
@@ -127,16 +127,13 @@ class Members extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const members = getAll<Member>(state, ResourceType.Members)
   return {members}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onRemoveMember: deleteMember,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(Members))
+export default connector(withRouter(Members))

--- a/ui/src/members/components/Members.tsx
+++ b/ui/src/members/components/Members.tsx
@@ -23,14 +23,7 @@ import {SortTypes} from 'src/shared/utils/sort'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
-interface StateProps {
-  members: Member[]
-}
-
-interface DispatchProps {
-  onRemoveMember: typeof deleteMember
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 interface State {
@@ -135,5 +128,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onRemoveMember: deleteMember,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(Members))

--- a/ui/src/members/containers/MembersIndex.tsx
+++ b/ui/src/members/containers/MembersIndex.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -60,4 +60,4 @@ const mstp = (state: AppState, props: Props) => {
   }
 }
 
-export default connect<StateProps>(mstp, null)(withRouter(MembersIndex))
+export default connector(withRouter(MembersIndex))

--- a/ui/src/members/containers/MembersIndex.tsx
+++ b/ui/src/members/containers/MembersIndex.tsx
@@ -17,11 +17,9 @@ import {getByID} from 'src/resources/selectors'
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
 
-interface StateProps {
-  org: Organization
-}
-
-type Props = RouteComponentProps<{orgID: string}> & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string}>
+type Props = RouterProps & ReduxProps
 
 @ErrorHandling
 class MembersIndex extends Component<Props> {
@@ -48,7 +46,7 @@ class MembersIndex extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState, props: Props) => {
+const mstp = (state: AppState, props: RouterProps) => {
   const org = getByID<Organization>(
     state,
     ResourceType.Orgs,
@@ -59,5 +57,7 @@ const mstp = (state: AppState, props: Props) => {
     org,
   }
 }
+
+const connector = connect(mstp)
 
 export default connector(withRouter(MembersIndex))

--- a/ui/src/notebooks/components/header/Submit.tsx
+++ b/ui/src/notebooks/components/header/Submit.tsx
@@ -118,6 +118,7 @@ export const Submit: FC = () => {
       submitButtonDisabled={!hasQueries}
       queryStatus={isLoading}
       onSubmit={submit}
+      onNotify={noop}
     />
   )
 }

--- a/ui/src/notebooks/components/header/Submit.tsx
+++ b/ui/src/notebooks/components/header/Submit.tsx
@@ -6,6 +6,7 @@ import QueryProvider, {QueryContext} from 'src/notebooks/context/query'
 import {NotebookContext, PipeMeta} from 'src/notebooks/context/notebook'
 import {TimeContext} from 'src/notebooks/context/time'
 import {IconFont} from '@influxdata/clockface'
+import {notify} from 'src/shared/actions/notifications'
 
 // Utils
 import {event} from 'src/notebooks/shared/event'
@@ -15,6 +16,8 @@ import {RemoteDataState} from 'src/types'
 
 const PREVIOUS_REGEXP = /__PREVIOUS_RESULT__/g
 const COMMENT_REMOVER = /(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm
+
+const fakeNotify = notify
 
 export const Submit: FC = () => {
   const {query} = useContext(QueryContext)
@@ -118,7 +121,7 @@ export const Submit: FC = () => {
       submitButtonDisabled={!hasQueries}
       queryStatus={isLoading}
       onSubmit={submit}
-      onNotify={noop}
+      onNotify={fakeNotify}
     />
   )
 }

--- a/ui/src/notebooks/components/header/TimeZoneDropdown.tsx
+++ b/ui/src/notebooks/components/header/TimeZoneDropdown.tsx
@@ -20,7 +20,7 @@ const TimeZoneDropdown: FC = React.memo(() => {
   return (
     <StatelessTimeZoneDropdown
       timeZone={timeZone}
-      onSetTimeZone={setTimeZone}
+      onSetTimeZone={setTimeZone as any}
     />
   )
 })

--- a/ui/src/notebooks/components/minimap/MiniMap.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMap.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 
 // Contexts
 import {NotebookContext, PipeMeta} from 'src/notebooks/context/notebook'

--- a/ui/src/notebooks/components/minimap/MiniMap.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMap.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Contexts
 import {NotebookContext, PipeMeta} from 'src/notebooks/context/notebook'
@@ -60,7 +60,7 @@ const MiniMap: FC<StateProps> = ({notebookMiniMapState}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     app: {
       persisted: {notebookMiniMapState},

--- a/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
@@ -12,16 +12,9 @@ import {setNotebookMiniMapState} from 'src/shared/actions/app'
 import {event} from 'src/notebooks/shared/event'
 
 // Types
-import {AppState, NotebookMiniMapState} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  notebookMiniMapState: NotebookMiniMapState
-}
-
-interface DispatchProps {
-  handleSetNotebookMiniMapState: typeof setNotebookMiniMapState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const MiniMapToggle: FC<Props> = ({
@@ -74,5 +67,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   handleSetNotebookMiniMapState: setNotebookMiniMapState,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(MiniMapToggle)

--- a/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
+++ b/ui/src/notebooks/components/minimap/MiniMapToggle.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Icon, IconFont} from '@influxdata/clockface'
@@ -22,7 +22,7 @@ interface DispatchProps {
   handleSetNotebookMiniMapState: typeof setNotebookMiniMapState
 }
 
-type Props = StateProps & DispatchProps
+type Props = ReduxProps
 
 const MiniMapToggle: FC<Props> = ({
   notebookMiniMapState,
@@ -59,7 +59,7 @@ const MiniMapToggle: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     app: {
       persisted: {notebookMiniMapState},
@@ -71,8 +71,8 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   handleSetNotebookMiniMapState: setNotebookMiniMapState,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(MiniMapToggle)
+export default connector(MiniMapToggle)

--- a/ui/src/notebooks/context/app.tsx
+++ b/ui/src/notebooks/context/app.tsx
@@ -6,15 +6,7 @@ import {timeZone as timeZoneFromState} from 'src/shared/selectors/app'
 
 import {AppState, TimeZone, Organization} from 'src/types'
 
-export interface StateProps {
-  timeZone: TimeZone
-  org: Organization
-}
-
-export interface DispatchProps {
-  onSetTimeZone: typeof setTimeZone
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 export type Props = ReduxProps
 
 type Modifier = typeof setTimeZone
@@ -62,5 +54,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onSetTimeZone: setTimeZone,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(AppSettingProvider)

--- a/ui/src/notebooks/context/app.tsx
+++ b/ui/src/notebooks/context/app.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {getOrg} from 'src/organizations/selectors'
 import {setTimeZone} from 'src/shared/actions/app'
 import {timeZone as timeZoneFromState} from 'src/shared/selectors/app'
@@ -15,7 +15,7 @@ export interface DispatchProps {
   onSetTimeZone: typeof setTimeZone
 }
 
-export type Props = StateProps & DispatchProps
+export type Props = ReduxProps
 
 type Modifier = typeof setTimeZone
 export interface AppSettingContextType {
@@ -50,7 +50,7 @@ export const AppSettingProvider: FC<Props> = React.memo(
   }
 )
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const org = getOrg(state)
 
   return {
@@ -59,11 +59,8 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetTimeZone: setTimeZone,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(AppSettingProvider)
+export default connector(AppSettingProvider)

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {getBuckets} from 'src/buckets/actions/thunks'
@@ -20,7 +20,7 @@ export interface DispatchProps {
   getBuckets: typeof getBuckets
 }
 
-export type Props = StateProps & DispatchProps
+export type Props = ReduxProps
 
 export interface BucketContextType {
   loading: RemoteDataState
@@ -71,7 +71,7 @@ export const BucketProvider: FC<Props> = React.memo(
   }
 )
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const buckets = getSortedBuckets(state)
   const loading = getStatus(state, ResourceType.Buckets)
 
@@ -81,8 +81,8 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getBuckets: getBuckets,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(BucketProvider)
+export default connector(BucketProvider)

--- a/ui/src/notebooks/context/buckets.tsx
+++ b/ui/src/notebooks/context/buckets.tsx
@@ -11,15 +11,7 @@ import {getStatus} from 'src/resources/selectors'
 // Types
 import {AppState, Bucket, ResourceType, RemoteDataState} from 'src/types'
 
-export interface StateProps {
-  loading: RemoteDataState
-  buckets: Bucket[]
-}
-
-export interface DispatchProps {
-  getBuckets: typeof getBuckets
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 export type Props = ReduxProps
 
 export interface BucketContextType {
@@ -84,5 +76,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   getBuckets: getBuckets,
 }
+
+const connector = connect(mstp, mdtp)
 
 export default connector(BucketProvider)

--- a/ui/src/notebooks/context/query.tsx
+++ b/ui/src/notebooks/context/query.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useContext, useMemo} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import {AppState, Variable, Organization} from 'src/types'
 import {runQuery} from 'src/shared/apis/query'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'

--- a/ui/src/notebooks/context/query.tsx
+++ b/ui/src/notebooks/context/query.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useContext, useMemo} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {AppState, Variable, Organization} from 'src/types'
 import {runQuery} from 'src/shared/apis/query'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'
@@ -73,7 +73,7 @@ interface StateProps {
   org: Organization
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const variables = getVariables(state)
   const org = getOrg(state)
 

--- a/ui/src/notebooks/pipes/TestFlux/view.tsx
+++ b/ui/src/notebooks/pipes/TestFlux/view.tsx
@@ -69,7 +69,7 @@ const TestFlux: FC<PipeProp> = ({Context, data, onUpdate}) => {
     <>
       <ViewTypeDropdown
         viewType={data.properties.type}
-        onUpdateType={updateType}
+        onUpdateType={updateType as any}
       />
       <SquareButton
         icon={IconFont.Import}

--- a/ui/src/notebooks/pipes/Visualization/DashboardList.tsx
+++ b/ui/src/notebooks/pipes/Visualization/DashboardList.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useEffect, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {getDashboards} from 'src/dashboards/actions/thunks'
 import {
   createCellWithView,
@@ -39,25 +39,14 @@ import {event} from 'src/notebooks/shared/event'
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
-interface StateProps {
-  dashboards: Dashboard[]
-  orgID: string
-}
-
-interface DispatchProps {
-  loadDashboards: typeof getDashboards
-  createViewAndDashboard: typeof createDashboardWithView
-  createView: typeof createCellWithView
-  notify: typeof notifyAction
-}
-
 interface OwnProps {
   query: string
   properties: ViewProperties
   onClose: () => void
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 const ExportConfirmationNotification = (
   dashboardName: string
@@ -212,7 +201,7 @@ const DashboardList: FC<Props> = ({
 
 export {DashboardList}
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const dashboards = getAll<Dashboard>(state, ResourceType.Dashboards)
   const orgID = getOrg(state).id
 
@@ -222,14 +211,13 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   loadDashboards: getDashboards,
   createView: createCellWithView,
   createViewAndDashboard: createDashboardWithView,
   notify: notifyAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(DashboardList)
+const connector = connect(mstp, mdtp)
+
+export default connector(DashboardList)

--- a/ui/src/notebooks/pipes/Visualization/view.tsx
+++ b/ui/src/notebooks/pipes/Visualization/view.tsx
@@ -103,7 +103,7 @@ const Visualization: FC<PipeProp> = ({
 
   const updateType = (type: ViewType) => {
     event('Notebook Visualization Type Changed', {
-      type: type as string,
+      type,
     })
 
     updateVisualizationType(type, results.parsed, onUpdate)
@@ -113,7 +113,7 @@ const Visualization: FC<PipeProp> = ({
     <>
       <ViewTypeDropdown
         viewType={data.properties.type}
-        onUpdateType={updateType}
+        onUpdateType={updateType as any}
       />
       <ExportVisualizationButton disabled={!results.source}>
         {onHidePopover => (

--- a/ui/src/notifications/endpoints/components/EditEndpointOverlay.tsx
+++ b/ui/src/notifications/endpoints/components/EditEndpointOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Constants
@@ -21,18 +21,9 @@ import {NotificationEndpoint, AppState, ResourceType} from 'src/types'
 // Utils
 import {getByID} from 'src/resources/selectors'
 
-interface DispatchProps {
-  onUpdateEndpoint: typeof updateEndpoint
-  onNotify: typeof notify
-}
-
-interface StateProps {
-  endpoint: NotificationEndpoint
-}
-
-type Props = RouteComponentProps<{orgID: string; endpointID: string}> &
-  DispatchProps &
-  StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string; endpointID: string}>
+type Props = RouterProps & ReduxProps
 
 const EditEndpointOverlay: FC<Props> = ({
   match,
@@ -82,7 +73,7 @@ const mdtp = {
   onNotify: notify,
 }
 
-const mstp = (state: AppState, {match}: Props): StateProps => {
+const mstp = (state: AppState, {match}: RouterProps) => {
   const endpoint = getByID<NotificationEndpoint>(
     state,
     ResourceType.NotificationEndpoints,
@@ -92,6 +83,6 @@ const mstp = (state: AppState, {match}: Props): StateProps => {
   return {endpoint}
 }
 
-export default withRouter(
-  connect<StateProps, DispatchProps, Props>(mstp, mdtp)(EditEndpointOverlay)
-)
+const connector = connect(mstp, mdtp)
+
+export default withRouter(connector(EditEndpointOverlay))

--- a/ui/src/notifications/endpoints/components/EndpointCard.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {
@@ -36,19 +36,12 @@ import {NotificationEndpoint, Label, AlertHistoryType} from 'src/types'
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 
-interface DispatchProps {
-  onDeleteEndpoint: typeof deleteEndpoint
-  onAddEndpointLabel: typeof addEndpointLabel
-  onRemoveEndpointLabel: typeof deleteEndpointLabel
-  onUpdateEndpointProperties: typeof updateEndpointProperties
-  onCloneEndpoint: typeof cloneEndpoint
-}
-
 interface OwnProps {
   endpoint: NotificationEndpoint
 }
 
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & RouteComponentProps<{orgID: string}> & ReduxProps
 
 const EndpointCard: FC<Props> = ({
   history,
@@ -161,7 +154,7 @@ const EndpointCard: FC<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onDeleteEndpoint: deleteEndpoint,
   onAddEndpointLabel: addEndpointLabel,
   onRemoveEndpointLabel: deleteEndpointLabel,
@@ -169,7 +162,6 @@ const mdtp: DispatchProps = {
   onCloneEndpoint: cloneEndpoint,
 }
 
-export default connect<{}, DispatchProps, {}>(
-  null,
-  mdtp
-)(withRouter(EndpointCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(EndpointCard))

--- a/ui/src/notifications/endpoints/components/EndpointTypeDropdown.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointTypeDropdown.tsx
@@ -80,7 +80,7 @@ const EndpointTypeDropdown: FC<Props> = ({
   )
 }
 
-const mstp = ({cloud: {limits}}: AppState): StateProps => {
+const mstp = ({cloud: {limits}}: AppState) => {
   return {
     blockedEndpoints: extractBlockedEndpoints(limits),
   }

--- a/ui/src/notifications/endpoints/components/NewEndpointOverlay.tsx
+++ b/ui/src/notifications/endpoints/components/NewEndpointOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useMemo} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Actions
@@ -15,11 +15,8 @@ import EndpointOverlayContents from 'src/notifications/endpoints/components/Endp
 import {NEW_ENDPOINT_DRAFT} from 'src/alerting/constants'
 import {NotificationEndpoint} from 'src/types'
 
-interface DispatchProps {
-  onCreateEndpoint: typeof createEndpoint
-}
-
-type Props = RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 const NewRuleOverlay: FC<Props> = ({match, history, onCreateEndpoint}) => {
   const {orgID} = match.params
@@ -58,7 +55,6 @@ const mdtp = {
   onCreateEndpoint: createEndpoint,
 }
 
-export default connect<null, DispatchProps>(
-  null,
-  mdtp
-)(withRouter(NewRuleOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(NewRuleOverlay))

--- a/ui/src/notifications/rules/components/EditRuleOverlay.tsx
+++ b/ui/src/notifications/rules/components/EditRuleOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Constants
 import {getNotificationRuleFailed} from 'src/shared/copy/notifications'
@@ -21,18 +21,9 @@ import {getByID} from 'src/resources/selectors'
 // Types
 import {NotificationRuleDraft, AppState, ResourceType} from 'src/types'
 
-interface StateProps {
-  stateRule: NotificationRuleDraft
-}
-
-interface DispatchProps {
-  onNotify: typeof notify
-  onUpdateRule: typeof updateRule
-}
-
-type Props = RouteComponentProps<{orgID: string; ruleID: string}> &
-  StateProps &
-  DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string; ruleID: string}>
+type Props = RouterProps & ReduxProps
 
 const EditRuleOverlay: FC<Props> = ({
   match,
@@ -78,7 +69,7 @@ const EditRuleOverlay: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState, {match}: Props): StateProps => {
+const mstp = (state: AppState, {match}: RouterProps) => {
   const {ruleID} = match.params
 
   const stateRule = getByID<NotificationRuleDraft>(
@@ -97,7 +88,6 @@ const mdtp = {
   onUpdateRule: updateRule,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(EditRuleOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(EditRuleOverlay))

--- a/ui/src/notifications/rules/components/NewRuleOverlay.tsx
+++ b/ui/src/notifications/rules/components/NewRuleOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {useMemo, FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {createRule} from 'src/notifications/rules/actions/thunks'
@@ -17,11 +17,8 @@ import {initRuleDraft} from 'src/notifications/rules/utils'
 // Types
 import {NotificationRuleDraft} from 'src/types'
 
-interface DispatchProps {
-  onCreateRule: (rule: Partial<NotificationRuleDraft>) => Promise<void>
-}
-
-type Props = RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 const NewRuleOverlay: FC<Props> = ({
   match: {
@@ -64,10 +61,9 @@ const NewRuleOverlay: FC<Props> = ({
 }
 
 const mdtp = {
-  onCreateRule: createRule as any,
+  onCreateRule: createRule,
 }
 
-export default connect<{}, DispatchProps>(
-  null,
-  mdtp
-)(withRouter(NewRuleOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(NewRuleOverlay))

--- a/ui/src/notifications/rules/components/RuleCard.tsx
+++ b/ui/src/notifications/rules/components/RuleCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -39,19 +39,12 @@ import {NotificationRuleDraft, Label, AlertHistoryType} from 'src/types'
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 
-interface DispatchProps {
-  onUpdateRuleProperties: typeof updateRuleProperties
-  deleteNotificationRule: typeof deleteRule
-  onAddRuleLabel: typeof addRuleLabel
-  onRemoveRuleLabel: typeof deleteRuleLabel
-  onCloneRule: typeof cloneRule
-}
-
 interface OwnProps {
   rule: NotificationRuleDraft
 }
 
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & RouteComponentProps<{orgID: string}> & ReduxProps
 
 const RuleCard: FC<Props> = ({
   rule,
@@ -188,7 +181,7 @@ const RuleCard: FC<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateRuleProperties: updateRuleProperties,
   deleteNotificationRule: deleteRule,
   onAddRuleLabel: addRuleLabel,
@@ -196,4 +189,6 @@ const mdtp: DispatchProps = {
   onCloneRule: cloneRule,
 }
 
-export default connect<{}, DispatchProps>(null, mdtp)(withRouter(RuleCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(RuleCard))

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -45,11 +45,9 @@ class CompletionAdvancedButton extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     orgID: state.onboarding.orgID,
   }
 }
-export default connect<StateProps, {}>(mstp)(
-  withRouter(CompletionAdvancedButton)
-)
+export default connect<StateProps>(mstp)(withRouter(CompletionAdvancedButton))

--- a/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -11,13 +11,12 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {ISetupParams} from '@influxdata/influx'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
-import {setupAdmin} from 'src/onboarding/actions'
 
 interface Props {
   onboardingStepProps: OnboardingStepProps
   setupParams: ISetupParams
   currentStepIndex: number
-  onSetupAdmin: typeof setupAdmin
+  onSetupAdmin: any
   orgID: string
   bucketID: string
 }

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -1,8 +1,8 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
-import _, {get} from 'lodash'
+import {connect, ConnectedProps} from 'react-redux'
+import {get} from 'lodash'
 
 // Components
 import {Form, Input, Button, Grid} from '@influxdata/clockface'
@@ -40,7 +40,8 @@ interface State {
   password: string
 }
 
-type Props = OwnProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & RouteComponentProps & ReduxProps
 
 @ErrorHandling
 class SigninForm extends PureComponent<Props, State> {
@@ -158,4 +159,6 @@ const mdtp = {
   notify: notifyAction,
 }
 
-export default connect(mstp, mdtp)(withRouter(SigninForm))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(SigninForm))

--- a/ui/src/onboarding/containers/LoginPageContents.tsx
+++ b/ui/src/onboarding/containers/LoginPageContents.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {
   AlignItems,
   ComponentSize,
@@ -37,10 +37,6 @@ interface ErrorObject {
   passwordError?: string
 }
 
-interface DispatchProps {
-  onNotify: typeof notify
-}
-
 interface State {
   buttonStatus: ComponentStatus
   email: string
@@ -49,7 +45,10 @@ interface State {
   passwordError: string
 }
 
-class LoginPageContents extends PureComponent<DispatchProps> {
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
+
+class LoginPageContents extends PureComponent<Props> {
   private auth0: typeof WebAuth
 
   state: State = {
@@ -259,8 +258,10 @@ class LoginPageContents extends PureComponent<DispatchProps> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onNotify: notify,
 }
 
-export default connect<{}, DispatchProps>(null, mdtp)(LoginPageContents)
+const connector = connect(null, mdtp)
+
+export default connector(LoginPageContents)

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -51,22 +51,8 @@ interface OwnProps {
   onSetCurrentStepIndex: (stepNumber: number) => void
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-  onSetSetupParams: typeof setSetupParams
-  onSetStepStatus: typeof setStepStatus
-  onSetupAdmin: typeof setupAdmin
-}
-
-interface StateProps {
-  links: Links
-  stepStatuses: StepStatus[]
-  setupParams: ISetupParams
-  orgID: string
-  bucketID: string
-}
-
-type Props = OwnProps & StateProps & DispatchProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps
 
 @ErrorHandling
 class OnboardingWizard extends PureComponent<Props> {
@@ -175,7 +161,7 @@ class OnboardingWizard extends PureComponent<Props> {
 const mstp = ({
   links,
   onboarding: {stepStatuses, setupParams, orgID, bucketID},
-}: AppState): StateProps => ({
+}: AppState) => ({
   links,
   stepStatuses,
   setupParams,
@@ -183,14 +169,13 @@ const mstp = ({
   bucketID,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   onSetSetupParams: setSetupParams,
   onSetStepStatus: setStepStatus,
   onSetupAdmin: setupAdmin,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(OnboardingWizard))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(OnboardingWizard))

--- a/ui/src/onboarding/containers/SigninPage.tsx
+++ b/ui/src/onboarding/containers/SigninPage.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // APIs
 import {client} from 'src/utils/api'
@@ -32,11 +32,8 @@ interface State {
   status: RemoteDataState
 }
 
-interface DispatchProps {
-  dismissAllNotifications: typeof dismissAllNotifications
-}
-
-type Props = RouteComponentProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps & ReduxProps
 @ErrorHandling
 class SigninPage extends PureComponent<Props, State> {
   constructor(props) {
@@ -92,7 +89,10 @@ class SigninPage extends PureComponent<Props, State> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   dismissAllNotifications,
 }
-export default connect(null, mdtp)(withRouter(SigninPage))
+
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(SigninPage))

--- a/ui/src/organizations/components/CreateOrgOverlay.tsx
+++ b/ui/src/organizations/components/CreateOrgOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 
 import {sample, startCase} from 'lodash'
@@ -21,11 +21,8 @@ import {createOrgWithBucket} from 'src/organizations/actions/thunks'
 
 interface OwnProps {}
 
-interface DispatchProps {
-  createOrgWithBucket: typeof createOrgWithBucket
-}
-
-type Props = OwnProps & DispatchProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps
 
 interface State {
   org: Organization
@@ -193,7 +190,6 @@ const mdtp = {
   createOrgWithBucket,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(withRouter(CreateOrgOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(CreateOrgOverlay))

--- a/ui/src/organizations/components/OrgProfileTab.tsx
+++ b/ui/src/organizations/components/OrgProfileTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 
 // Components
@@ -30,15 +30,10 @@ import {
 
 // Types
 import {ButtonType} from 'src/clockface'
-import {AppState, Organization} from 'src/types'
-import {MeState} from 'src/shared/reducers/me'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  me: MeState
-  org: Organization
-}
-
-type Props = StateProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
 class OrgProfileTab extends PureComponent<Props> {
@@ -133,4 +128,6 @@ const mstp = (state: AppState) => {
   }
 }
 
-export default connect<StateProps>(mstp, null)(withRouter(OrgProfileTab))
+const connector = connect(mstp)
+
+export default connector(withRouter(OrgProfileTab))

--- a/ui/src/organizations/components/RenameOrgForm.tsx
+++ b/ui/src/organizations/components/RenameOrgForm.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 
 // Components
@@ -28,16 +28,8 @@ import {AppState, Organization, ResourceType} from 'src/types'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
-interface StateProps {
-  startOrg: Organization
-  orgNames: string[]
-}
-
-interface DispatchProps {
-  onRenameOrg: typeof renameOrg
-}
-
-type Props = StateProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   org: Organization
@@ -168,7 +160,6 @@ const mdtp = {
   onRenameOrg: renameOrg,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(RenameOrgForm))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(RenameOrgForm))

--- a/ui/src/organizations/containers/NoOrgsPage.tsx
+++ b/ui/src/organizations/containers/NoOrgsPage.tsx
@@ -2,16 +2,13 @@
 import React, {FC} from 'react'
 import {FunnelPage, Button, ComponentColor} from '@influxdata/clockface'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Types
 import {AppState} from 'src/types'
 
-interface DispatchProps {
-  me: AppState['me']
-}
-
-type Props = DispatchProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps
 
 const NoOrgsPage: FC<Props> = ({history, me}) => {
   const handleClick = () => {
@@ -46,4 +43,6 @@ const mstp = ({me}: AppState) => {
   return {me}
 }
 
-export default connect(mstp)(withRouter(NoOrgsPage))
+const connector = connect(mstp)
+
+export default connector(withRouter(NoOrgsPage))

--- a/ui/src/organizations/containers/OrgProfilePage.tsx
+++ b/ui/src/organizations/containers/OrgProfilePage.tsx
@@ -52,4 +52,4 @@ class OrgProfilePage extends Component<StateProps> {
 
 const mstp = (state: AppState) => ({org: getOrg(state)})
 
-export default connect<StateProps, {}, {}>(mstp, null)(OrgProfilePage)
+export default connect<StateProps>(mstp)(OrgProfilePage)

--- a/ui/src/overlays/components/OverlayController.tsx
+++ b/ui/src/overlays/components/OverlayController.tsx
@@ -1,10 +1,9 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Types
 import {AppState} from 'src/types'
-import {OverlayID} from 'src/overlays/reducers/overlays'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -19,16 +18,8 @@ import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 // Actions
 import {dismissOverlay} from 'src/overlays/actions/overlays'
 
-interface StateProps {
-  overlayID: OverlayID
-  onClose: () => void
-}
-
-interface DispatchProps {
-  clearOverlayControllerState: typeof dismissOverlay
-}
-
-type OverlayControllerProps = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type OverlayControllerProps = ReduxProps
 
 const OverlayController: FunctionComponent<OverlayControllerProps> = props => {
   let activeOverlay = <></>
@@ -73,7 +64,7 @@ const OverlayController: FunctionComponent<OverlayControllerProps> = props => {
   return <Overlay visible={visibility}>{activeOverlay}</Overlay>
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const id = state.overlays.id
   const onClose = state.overlays.onClose
 
@@ -87,7 +78,5 @@ const mdtp = {
   clearOverlayControllerState: dismissOverlay,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(OverlayController)
+const connector = connect(mstp, mdtp)
+export default connector(OverlayController)

--- a/ui/src/overlays/components/RouteOverlay.tsx
+++ b/ui/src/overlays/components/RouteOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, Component, ComponentClass, useEffect} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {OverlayID} from 'src/overlays/reducers/overlays'
 
 // Actions
@@ -20,12 +20,8 @@ interface OwnProps {
   onClose: OverlayDismissalWithRoute
 }
 
-interface DispatchProps {
-  onShowOverlay: typeof showOverlay
-  onDismissOverlay: typeof dismissOverlay
-}
-
-type OverlayHandlerProps = OwnProps & DispatchProps & RouteComponentProps
+type ReduxProps = ConnectedProps<typeof connector>
+type OverlayHandlerProps = OwnProps & ReduxProps & RouteComponentProps
 
 const OverlayHandler: FC<OverlayHandlerProps> = props => {
   const {
@@ -50,15 +46,14 @@ const OverlayHandler: FC<OverlayHandlerProps> = props => {
   return null
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onShowOverlay: showOverlay,
   onDismissOverlay: dismissOverlay,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(withRouter(OverlayHandler))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(OverlayHandler))
 
 interface RouteOverlayProps {
   overlayID: string

--- a/ui/src/overlays/components/RouteOverlay.tsx
+++ b/ui/src/overlays/components/RouteOverlay.tsx
@@ -52,15 +52,16 @@ const mdtp = {
 }
 
 const connector = connect(null, mdtp)
+const connectedComponent = connector(withRouter(OverlayHandler))
 
-export default connector(withRouter(OverlayHandler))
+export default connectedComponent
 
 interface RouteOverlayProps {
-  overlayID: string
+  overlayID: OverlayID
 }
 
 export function RouteOverlay<P>(
-  WrappedComponent: ComponentClass<P & RouteOverlayProps>,
+  WrappedComponent: typeof connectedComponent,
   overlayID: string,
   onClose?: OverlayDismissalWithRoute
 ): ComponentClass<P> {

--- a/ui/src/overlays/components/index.tsx
+++ b/ui/src/overlays/components/index.tsx
@@ -3,42 +3,43 @@ import OverlayHandler, {
 } from 'src/overlays/components/RouteOverlay'
 
 export const AddNoteOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'add-note',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/dashboards/${params.dashboardID}`)
   }
 )
 export const EditNoteOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'edit-note',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/dashboards/${params.dashboardID}`)
   }
 )
 export const AllAccessTokenOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'add-master-token',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/tokens`)
   }
 )
 export const BucketsTokenOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'add-token',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/tokens`)
   }
 )
 export const TelegrafConfigOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'telegraf-config',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
   }
 )
+
 export const TelegrafOutputOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'telegraf-output',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)

--- a/ui/src/overlays/components/index.tsx
+++ b/ui/src/overlays/components/index.tsx
@@ -3,35 +3,35 @@ import OverlayHandler, {
 } from 'src/overlays/components/RouteOverlay'
 
 export const AddNoteOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'add-note',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/dashboards/${params.dashboardID}`)
   }
 )
 export const EditNoteOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'edit-note',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/dashboards/${params.dashboardID}`)
   }
 )
 export const AllAccessTokenOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'add-master-token',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/tokens`)
   }
 )
 export const BucketsTokenOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'add-token',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/tokens`)
   }
 )
 export const TelegrafConfigOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'telegraf-config',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
@@ -39,7 +39,7 @@ export const TelegrafConfigOverlay = RouteOverlay(
 )
 
 export const TelegrafOutputOverlay = RouteOverlay(
-  OverlayHandler as any,
+  OverlayHandler,
   'telegraf-output',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)

--- a/ui/src/pageLayout/components/OrgSwitcherOverlay.tsx
+++ b/ui/src/pageLayout/components/OrgSwitcherOverlay.tsx
@@ -55,7 +55,7 @@ const OrgSwitcherOverlay: FC<Props> = ({orgs, onClose, currentOrg}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const orgs = getAll<Organization>(state, ResourceType.Orgs)
   const currentOrg = getOrg(state)
 

--- a/ui/src/pageLayout/components/UserWidget.tsx
+++ b/ui/src/pageLayout/components/UserWidget.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {Link} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {TreeNav} from '@influxdata/clockface'
@@ -20,24 +20,14 @@ import {
 } from 'src/shared/constants'
 
 // Types
-import {AppState, Organization} from 'src/types'
-import {MeState} from 'src/shared/reducers/me'
+import {AppState} from 'src/types'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getNavItemActivation} from '../utils'
 
-interface StateProps {
-  org: Organization
-  me: MeState
-}
-
-interface DispatchProps {
-  handleShowOverlay: typeof showOverlay
-  handleDismissOverlay: typeof dismissOverlay
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const UserWidget: FC<Props> = ({
   org,
@@ -152,4 +142,5 @@ const mdtp = {
   handleDismissOverlay: dismissOverlay,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(UserWidget)
+const connector = connect(mstp, mdtp)
+export default connector(UserWidget)

--- a/ui/src/pageLayout/containers/TreeNav.tsx
+++ b/ui/src/pageLayout/containers/TreeNav.tsx
@@ -6,7 +6,7 @@ import {
   RouteComponentProps,
   Link,
 } from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -26,7 +26,7 @@ import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
 import {getNavItemActivation} from 'src/pageLayout/utils'
 
 // Types
-import {AppState, NavBarState} from 'src/types'
+import {AppState} from 'src/types'
 
 // Actions
 import {setNavBarState} from 'src/shared/actions/app'
@@ -34,16 +34,8 @@ import {setNavBarState} from 'src/shared/actions/app'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface StateProps {
-  isHidden: boolean
-  navBarState: NavBarState
-}
-
-interface DispatchProps {
-  handleSetNavBarState: typeof setNavBarState
-}
-
-type Props = StateProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
 class TreeSidebar extends PureComponent<Props> {
@@ -208,18 +200,17 @@ class TreeSidebar extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   handleSetNavBarState: setNavBarState,
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const isHidden = get(state, 'app.ephemeral.inPresentationMode', false)
   const navBarState = get(state, 'app.persisted.navBarState', 'collapsed')
 
   return {isHidden, navBarState}
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(TreeSidebar))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TreeSidebar))

--- a/ui/src/resources/components/GetResource.tsx
+++ b/ui/src/resources/components/GetResource.tsx
@@ -1,12 +1,12 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {getDashboard} from 'src/dashboards/actions/thunks'
 
 // Types
-import {AppState, RemoteDataState, ResourceType} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -15,14 +15,6 @@ import {TechnoSpinner, SpinnerContainer} from '@influxdata/clockface'
 // Selectors
 import {getResourceStatus} from 'src/resources/selectors/getResourceStatus'
 
-interface StateProps {
-  remoteDataState: RemoteDataState
-}
-
-interface DispatchProps {
-  getDashboard: typeof getDashboard
-}
-
 export interface Resource {
   type: ResourceType
   id: string
@@ -30,12 +22,14 @@ export interface Resource {
 
 interface OwnProps {
   resources: Resource[]
+  children: React.ReactNode
 }
 
-export type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+export type Props = ReduxProps & OwnProps
 
 @ErrorHandling
-class GetResource extends PureComponent<Props, StateProps> {
+class GetResource extends PureComponent<Props> {
   public componentDidMount() {
     const {resources} = this.props
     const promises = []
@@ -76,7 +70,7 @@ class GetResource extends PureComponent<Props, StateProps> {
   }
 }
 
-const mstp = (state: AppState, props: Props): StateProps => {
+const mstp = (state: AppState, props: OwnProps) => {
   const remoteDataState = getResourceStatus(state, props.resources)
 
   return {
@@ -88,4 +82,6 @@ const mdtp = {
   getDashboard: getDashboard,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(GetResource)
+const connector = connect(mstp, mdtp)
+
+export default connector(GetResource)

--- a/ui/src/resources/components/GetResources.tsx
+++ b/ui/src/resources/components/GetResources.tsx
@@ -1,6 +1,6 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import React, {PureComponent, ReactNode} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {getAuthorizations} from 'src/authorizations/actions/thunks'
@@ -22,7 +22,7 @@ import {getVariables} from 'src/variables/actions/thunks'
 import {reportSimpleQueryPerformanceDuration} from 'src/cloud/utils/reporting'
 
 // Types
-import {AppState, RemoteDataState, ResourceType} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -31,35 +31,16 @@ import {TechnoSpinner, SpinnerContainer} from '@influxdata/clockface'
 // Selectors
 import {getResourcesStatus} from 'src/resources/selectors/getResourcesStatus'
 
-interface StateProps {
-  remoteDataState: RemoteDataState
-}
-
-interface DispatchProps {
-  getLabels: typeof getLabels
-  getBuckets: typeof getBuckets
-  getTelegrafs: typeof getTelegrafs
-  getPlugins: typeof getPlugins
-  getVariables: typeof getVariables
-  getScrapers: typeof getScrapers
-  getAuthorizations: typeof getAuthorizations
-  getDashboards: typeof getDashboards
-  getTasks: typeof getTasks
-  getTemplates: typeof getTemplates
-  getMembers: typeof getMembers
-  getChecks: typeof getChecks
-  getNotificationRules: typeof getNotificationRules
-  getEndpoints: typeof getEndpoints
-}
-
-interface PassedProps {
+interface OwnProps {
   resources: Array<ResourceType>
+  children: ReactNode
 }
 
-export type Props = StateProps & DispatchProps & PassedProps
+type ReduxProps = ConnectedProps<typeof connector>
+export type Props = ReduxProps & OwnProps
 
 @ErrorHandling
-class GetResources extends PureComponent<Props, StateProps> {
+class GetResources extends PureComponent<Props> {
   public componentDidMount() {
     const {resources} = this.props
     const promises = []
@@ -156,7 +137,7 @@ class GetResources extends PureComponent<Props, StateProps> {
   }
 }
 
-const mstp = (state: AppState, {resources}: Props): StateProps => {
+const mstp = (state: AppState, {resources}: OwnProps) => {
   const remoteDataState = getResourcesStatus(state, resources)
 
   return {
@@ -181,4 +162,6 @@ const mdtp = {
   getEndpoints: getEndpoints,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(GetResources)
+const connector = connect(mstp, mdtp)
+
+export default connector(GetResources)

--- a/ui/src/scrapers/components/CreateScraperOverlay.tsx
+++ b/ui/src/scrapers/components/CreateScraperOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 import {get} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -22,17 +22,9 @@ interface OwnProps {
   visible: boolean
 }
 
-interface StateProps {
-  buckets: Bucket[]
-}
-
-interface DispatchProps {
-  onCreateScraper: typeof createScraper
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps &
-  StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string; bucketID: string}>
 
 interface State {
@@ -127,15 +119,14 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   buckets: getAll<Bucket>(state, ResourceType.Buckets),
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateScraper: createScraper,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(CreateScraperOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(CreateScraperOverlay))

--- a/ui/src/scrapers/components/Scrapers.tsx
+++ b/ui/src/scrapers/components/Scrapers.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {isEmpty} from 'lodash'
 
 // Components
@@ -27,25 +27,15 @@ import {
   ComponentColor,
   ComponentStatus,
 } from '@influxdata/clockface'
-import {AppState, Bucket, Scraper, Organization, ResourceType} from 'src/types'
+import {AppState, Bucket, Scraper, ResourceType} from 'src/types'
 import {ScraperSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
 
-interface StateProps {
-  scrapers: Scraper[]
-  buckets: Bucket[]
-  org: Organization
-}
-
-interface DispatchProps {
-  onUpdateScraper: typeof updateScraper
-  onDeleteScraper: typeof deleteScraper
-}
-
-type Props = StateProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   searchTerm: string
@@ -208,18 +198,17 @@ class Scrapers extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   scrapers: getAll<Scraper>(state, ResourceType.Scrapers),
   buckets: getAll<Bucket>(state, ResourceType.Buckets),
   org: getOrg(state),
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onDeleteScraper: deleteScraper,
   onUpdateScraper: updateScraper,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(Scrapers))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(Scrapers))

--- a/ui/src/scrapers/containers/ScrapersIndex.tsx
+++ b/ui/src/scrapers/containers/ScrapersIndex.tsx
@@ -60,4 +60,4 @@ class ScrapersIndex extends Component<StateProps> {
 
 const mstp = (state: AppState) => ({org: getOrg(state)})
 
-export default connect<StateProps>(mstp, null)(ScrapersIndex)
+export default connect(mstp)(ScrapersIndex)

--- a/ui/src/shared/components/CheckPlot.tsx
+++ b/ui/src/shared/components/CheckPlot.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Config, Table} from '@influxdata/giraffe'
 import {flatMap} from 'lodash'
 
@@ -31,10 +31,6 @@ import {updateThresholds} from 'src/alerting/actions/alertBuilder'
 const X_COLUMN = '_time'
 const Y_COLUMN = '_value'
 
-interface DispatchProps {
-  onUpdateThresholds: typeof updateThresholds
-}
-
 interface OwnProps {
   table: Table
   checkType: CheckType
@@ -46,7 +42,8 @@ interface OwnProps {
   statuses: StatusRow[][]
 }
 
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const CheckPlot: FunctionComponent<Props> = ({
   table,
@@ -157,8 +154,10 @@ const CheckPlot: FunctionComponent<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateThresholds: updateThresholds,
 }
 
-export default connect<{}, DispatchProps, {}>(null, mdtp)(CheckPlot)
+const connector = connect(null, mdtp)
+
+export default connector(CheckPlot)

--- a/ui/src/shared/components/CopyButton.tsx
+++ b/ui/src/shared/components/CopyButton.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Button, ComponentColor, ComponentSize} from '@influxdata/clockface'
@@ -24,11 +24,8 @@ interface OwnProps {
   onCopyText?: (text: string, status: boolean) => Notification
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-}
-
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class CopyButton extends PureComponent<Props> {
   public static defaultProps = {
@@ -80,8 +77,10 @@ class CopyButton extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(CopyButton)
+const connector = connect(null, mdtp)
+
+export default connector(CopyButton)

--- a/ui/src/shared/components/DashboardRoute.tsx
+++ b/ui/src/shared/components/DashboardRoute.tsx
@@ -1,24 +1,14 @@
 import React, {PureComponent} from 'react'
 import qs from 'qs'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {setDashboard} from 'src/shared/actions/currentDashboard'
 import {getVariables} from 'src/variables/selectors'
 import {selectValue} from 'src/variables/actions/thunks'
-import {AppState, Variable} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  variables: Variable[]
-  dashboard: string
-}
-
-interface DispatchProps {
-  updateDashboard: typeof setDashboard
-  selectValue: typeof selectValue
-}
-
-type Props = StateProps &
-  DispatchProps &
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps &
   RouteComponentProps<{orgID: string; dashboardID: string}>
 
 class DashboardRoute extends PureComponent<Props> {
@@ -108,7 +98,7 @@ class DashboardRoute extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const variables = getVariables(state)
 
   return {
@@ -117,12 +107,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   updateDashboard: setDashboard,
   selectValue: selectValue,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(DashboardRoute))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(DashboardRoute))

--- a/ui/src/shared/components/DashboardRoute.tsx
+++ b/ui/src/shared/components/DashboardRoute.tsx
@@ -8,7 +8,12 @@ import {selectValue} from 'src/variables/actions/thunks'
 import {AppState} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
+interface OwnProps {
+  children: React.ReactNode
+}
+
 type Props = ReduxProps &
+  OwnProps &
   RouteComponentProps<{orgID: string; dashboardID: string}>
 
 class DashboardRoute extends PureComponent<Props> {

--- a/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
@@ -34,7 +34,7 @@ const BucketsDropdown: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   // map names and sort via a selector
   const buckets = getSortedBuckets(state)
 

--- a/ui/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
+++ b/ui/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect, useState} from 'react'
 import moment from 'moment'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {
   Columns,
   ComponentSize,
@@ -25,7 +25,7 @@ import PreviewDataTable from 'src/shared/components/DeleteDataForm/PreviewDataTa
 import TimeRangeDropdown from 'src/shared/components/DeleteDataForm/TimeRangeDropdown'
 
 // Types
-import {Filter, RemoteDataState, CustomTimeRange, AppState} from 'src/types'
+import {Filter, AppState} from 'src/types'
 
 // Selectors
 import {setCanDelete} from 'src/shared/selectors/canDelete'
@@ -47,31 +47,8 @@ interface OwnProps {
   handleDismiss: () => void
 }
 
-interface StateProps {
-  canDelete: boolean
-  deletionStatus: RemoteDataState
-  files: string[]
-  filters: Filter[]
-  isSerious: boolean
-  keys: string[]
-  timeRange: CustomTimeRange
-  values: (string | number)[]
-  bucketName: string
-  orgID: string
-}
-
-interface DispatchProps {
-  deleteFilter: typeof deleteFilter
-  deleteWithPredicate: typeof deleteWithPredicate
-  executePreviewQuery: typeof executePreviewQuery
-  resetFilters: typeof resetFilters
-  setFilter: typeof setFilter
-  setIsSerious: typeof setIsSerious
-  setBucketAndKeys: typeof setBucketAndKeys
-  setTimeRange: typeof setTimeRange
-}
-
-export type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+export type Props = ReduxProps & OwnProps
 
 const DeleteDataForm: FC<Props> = ({
   canDelete,
@@ -261,7 +238,7 @@ const DeleteDataForm: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {predicates} = state
   const {
     bucketName,
@@ -288,7 +265,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   deleteFilter,
   deleteWithPredicate,
   resetFilters,
@@ -299,4 +276,6 @@ const mdtp: DispatchProps = {
   setTimeRange,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(DeleteDataForm)
+const connector = connect(mstp, mdtp)
+
+export default connector(DeleteDataForm)

--- a/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -7,7 +7,7 @@ import {
   IconFont,
   SelectDropdown,
 } from '@influxdata/clockface'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import SearchableDropdown from 'src/shared/components/SearchableDropdown'
@@ -18,7 +18,7 @@ import {Filter} from 'src/types'
 // Actions
 import {setValuesByKey} from 'src/shared/actions/predicates'
 
-interface Props {
+interface OwnProps {
   bucket: string
   filter: Filter
   keys: string[]
@@ -28,11 +28,10 @@ interface Props {
   values: (string | number)[]
 }
 
-interface DispatchProps {
-  setValuesByKey: typeof setValuesByKey
-}
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
-const FilterRow: FC<Props & DispatchProps> = ({
+const FilterRow: FC<Props> = ({
   bucket,
   filter: {key, equality, value},
   keys,
@@ -123,4 +122,6 @@ const FilterRow: FC<Props & DispatchProps> = ({
 
 const mdtp = {setValuesByKey}
 
-export default connect<{}, DispatchProps>(null, mdtp)(FilterRow)
+const connector = connect(null, mdtp)
+
+export default connector(FilterRow)

--- a/ui/src/shared/components/DeleteDataOverlay.tsx
+++ b/ui/src/shared/components/DeleteDataOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
@@ -17,18 +17,8 @@ import {
 import {Bucket, AppState, RemoteDataState, ResourceType} from 'src/types'
 import {getAll} from 'src/resources/selectors'
 
-interface StateProps {
-  buckets: Bucket[]
-}
-
-interface DispatchProps {
-  resetPredicateState: typeof resetPredicateState
-  setBucketAndKeys: typeof setBucketAndKeys
-}
-
-type Props = RouteComponentProps<{orgID: string; bucketID: string}> &
-  DispatchProps &
-  StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string; bucketID: string}> & ReduxProps
 
 const DeleteDataOverlay: FunctionComponent<Props> = ({
   buckets,
@@ -69,18 +59,17 @@ const DeleteDataOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     buckets: getAll<Bucket>(state, ResourceType.Buckets),
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   resetPredicateState,
   setBucketAndKeys,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(DeleteDataOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(DeleteDataOverlay))

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -33,11 +33,8 @@ interface OwnProps {
   isVisible: boolean
 }
 
-interface DispatchProps {
-  onCreateTemplateFromResource: typeof createTemplateFromResource
-}
-
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class ExportOverlay extends PureComponent<Props> {
   public static defaultProps = {
@@ -156,8 +153,10 @@ class ExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateTemplateFromResource: createTemplateFromResource,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(ExportOverlay)
+const connector = connect(null, mdtp)
+
+export default connector(ExportOverlay)

--- a/ui/src/shared/components/FluxMonacoEditor.tsx
+++ b/ui/src/shared/components/FluxMonacoEditor.tsx
@@ -27,7 +27,6 @@ export interface EditorProps {
   script: string
   onChangeScript: OnChangeScript
   onSubmitScript?: () => void
-  skipFocus?: boolean
   autogrow?: boolean
 }
 
@@ -40,7 +39,6 @@ const FluxEditorMonaco: FC<Props> = ({
   onChangeScript,
   onSubmitScript,
   setEditorInstance,
-  skipFocus,
   autogrow,
 }) => {
   const lspServer = useRef<LSPServer>(null)
@@ -83,14 +81,12 @@ const FluxEditorMonaco: FC<Props> = ({
       updateDiagnostics(diagnostics)
 
       if (isFlagEnabled('cursorAtEOF')) {
-        if (!skipFocus) {
-          const lines = (script || '').split('\n')
-          editor.setPosition({
-            lineNumber: lines.length,
-            column: lines[lines.length - 1].length + 1,
-          })
-          editor.focus()
-        }
+        const lines = (script || '').split('\n')
+        editor.setPosition({
+          lineNumber: lines.length,
+          column: lines[lines.length - 1].length + 1,
+        })
+        editor.focus()
       } else {
         editor.focus()
       }

--- a/ui/src/shared/components/MarkdownMonacoEditor.tsx
+++ b/ui/src/shared/components/MarkdownMonacoEditor.tsx
@@ -20,7 +20,6 @@ import {EditorProps} from 'src/shared/components/FluxMonacoEditor'
 const MarkdownMonacoEditor: FC<EditorProps> = ({
   script,
   onChangeScript,
-  skipFocus,
   autogrow,
 }) => {
   const editorDidMount = (editor: EditorType) => {
@@ -29,14 +28,12 @@ const MarkdownMonacoEditor: FC<EditorProps> = ({
     }
 
     if (isFlagEnabled('cursorAtEOF')) {
-      if (!skipFocus) {
-        const lines = (script || '').split('\n')
-        editor.setPosition({
-          lineNumber: lines.length,
-          column: lines[lines.length - 1].length + 1,
-        })
-        editor.focus()
-      }
+      const lines = (script || '').split('\n')
+      editor.setPosition({
+        lineNumber: lines.length,
+        column: lines[lines.length - 1].length + 1,
+      })
+      editor.focus()
     } else {
       editor.focus()
     }

--- a/ui/src/shared/components/PresentationModeToggle.tsx
+++ b/ui/src/shared/components/PresentationModeToggle.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SquareButton, IconFont} from '@influxdata/clockface'
@@ -8,13 +8,10 @@ import {SquareButton, IconFont} from '@influxdata/clockface'
 // Actions
 import {delayEnablePresentationMode} from 'src/shared/actions/app'
 
-interface DispatchProps {
-  handleClickPresentationButton: typeof delayEnablePresentationMode
-}
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
-const PresentationModeToggle: FC<DispatchProps> = ({
-  handleClickPresentationButton,
-}) => (
+const PresentationModeToggle: FC<Props> = ({handleClickPresentationButton}) => (
   <SquareButton
     icon={IconFont.ExpandA}
     testID="presentation-mode-toggle"
@@ -22,11 +19,10 @@ const PresentationModeToggle: FC<DispatchProps> = ({
   />
 )
 
-const mdtp: DispatchProps = {
+const mdtp = {
   handleClickPresentationButton: delayEnablePresentationMode,
 }
 
-export default connect<{}, DispatchProps, {}>(
-  null,
-  mdtp
-)(PresentationModeToggle)
+const connector = connect(null, mdtp)
+
+export default connector(PresentationModeToggle)

--- a/ui/src/shared/components/RefreshingView.tsx
+++ b/ui/src/shared/components/RefreshingView.tsx
@@ -140,7 +140,7 @@ class RefreshingView extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, ownProps: OwnProps): StateProps => {
+const mstp = (state: AppState, ownProps: OwnProps) => {
   const timeRange = getTimeRange(state)
   const ranges = getActiveTimeRange(timeRange, ownProps.properties.queries)
   const {timeZone, theme} = state.app.persisted

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -1,7 +1,7 @@
 // Library
 import React, {Component, RefObject, CSSProperties} from 'react'
 import {isEqual} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {
   default as fromFlux,
@@ -54,7 +54,6 @@ import {
   Bucket,
   ResourceType,
   DashboardQuery,
-  Variable,
   VariableAssignment,
   AppState,
   CancelBox,
@@ -71,12 +70,6 @@ interface QueriesState {
   statuses: StatusRow[][]
 }
 
-interface StateProps {
-  queryLink: string
-  buckets: Bucket[]
-  variables: Variable[]
-}
-
 interface OwnProps {
   className?: string
   style?: CSSProperties
@@ -88,15 +81,8 @@ interface OwnProps {
   check?: Partial<Check>
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-  onSetQueryResultsByQueryID: typeof setQueryResultsByQueryID
-}
-
-type Props = StateProps &
-  OwnProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   loading: RemoteDataState
@@ -339,7 +325,7 @@ class TimeSeries extends Component<Props, State> {
   }
 }
 
-const mstp = (state: AppState, props: OwnProps): StateProps => {
+const mstp = (state: AppState, props: OwnProps) => {
   const timeRange = getTimeRange(state)
 
   // NOTE: cannot use getAllVariables here because the TimeSeries
@@ -365,12 +351,11 @@ const mstp = (state: AppState, props: OwnProps): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   onSetQueryResultsByQueryID: setQueryResultsByQueryID,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(TimeSeries))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TimeSeries))

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -54,7 +54,6 @@ import {
   Bucket,
   ResourceType,
   DashboardQuery,
-  VariableAssignment,
   AppState,
   CancelBox,
 } from 'src/types'
@@ -73,7 +72,6 @@ interface QueriesState {
 interface OwnProps {
   className?: string
   style?: CSSProperties
-  variables?: VariableAssignment[]
   queries: DashboardQuery[]
   submitToken: number
   implicitSubmit?: boolean

--- a/ui/src/shared/components/TimeZoneDropdown.tsx
+++ b/ui/src/shared/components/TimeZoneDropdown.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {SelectDropdown, IconFont} from '@influxdata/clockface'
 
 // Actions & Selectors
@@ -11,17 +11,10 @@ import {getTimeZone} from 'src/dashboards/selectors'
 import {TIME_ZONES} from 'src/shared/constants/timeZones'
 
 // Types
-import {AppState, TimeZone} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  timeZone: TimeZone
-}
-
-interface DispatchProps {
-  onSetTimeZone: typeof setTimeZone | ((timeZone: TimeZone) => void)
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const TimeZoneDropdown: FunctionComponent<Props> = ({
   timeZone: selectedTimeZone,
@@ -40,10 +33,12 @@ const TimeZoneDropdown: FunctionComponent<Props> = ({
 
 export {TimeZoneDropdown}
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {timeZone: getTimeZone(state)}
 }
 
 const mdtp = {onSetTimeZone: setTimeZone}
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(TimeZoneDropdown)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeZoneDropdown)

--- a/ui/src/shared/components/TokenCodeSnippet.tsx
+++ b/ui/src/shared/components/TokenCodeSnippet.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {
   Button,
   ComponentColor,
@@ -19,7 +19,7 @@ import CopyButton from 'src/shared/components/CopyButton'
 // Actions
 import {generateTelegrafToken} from 'src/dataLoaders/actions/dataLoaders'
 
-export interface Props {
+export interface OwnProps {
   configID: string
   label: string
   onCopyText?: (text: string, status: boolean) => Notification
@@ -28,11 +28,10 @@ export interface Props {
   token: string
 }
 
-interface DispatchProps {
-  onGenerateTelegrafToken: typeof generateTelegrafToken
-}
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
-const TokenCodeSnippet: FC<Props & DispatchProps> = ({
+const TokenCodeSnippet: FC<Props> = ({
   configID,
   onCopyText,
   label = 'Code Snippet',
@@ -83,8 +82,9 @@ const TokenCodeSnippet: FC<Props & DispatchProps> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onGenerateTelegrafToken: generateTelegrafToken,
 }
 
-export default connect<{}, DispatchProps>(null, mdtp)(TokenCodeSnippet)
+const connector = connect(null, mdtp)
+export default connector(TokenCodeSnippet)

--- a/ui/src/shared/components/cells/Cell.tsx
+++ b/ui/src/shared/components/cells/Cell.tsx
@@ -111,7 +111,7 @@ class CellComponent extends Component<Props, State> {
   }
 }
 
-const mstp = (state: AppState, ownProps: OwnProps): StateProps => {
+const mstp = (state: AppState, ownProps: OwnProps) => {
   const view = getByID<View>(state, ResourceType.Views, ownProps.cell.id)
 
   return {view}

--- a/ui/src/shared/components/cells/CellContext.tsx
+++ b/ui/src/shared/components/cells/CellContext.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useRef, RefObject, useState} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 import classnames from 'classnames'
 
@@ -26,18 +26,14 @@ import {deleteCell, createCellWithView} from 'src/cells/actions/thunks'
 // Types
 import {Cell, View} from 'src/types'
 
-interface DispatchProps {
-  onDeleteCell: typeof deleteCell
-  onCloneCell: typeof createCellWithView
-}
-
 interface OwnProps {
   cell: Cell
   view: View
   onCSVDownload: () => void
 }
 
-type Props = OwnProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const CellContext: FC<Props> = ({
   view,
@@ -172,9 +168,11 @@ const CellContext: FC<Props> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onDeleteCell: deleteCell,
   onCloneCell: createCellWithView,
 }
 
-export default withRouter(connect<{}, DispatchProps>(null, mdtp)(CellContext))
+const connector = connect(null, mdtp)
+
+export default withRouter(connector(CellContext))

--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import ReactGridLayout, {WidthProvider, Layout} from 'react-grid-layout'
 import {get} from 'lodash'
 
@@ -20,26 +20,16 @@ import {getCells} from 'src/cells/selectors'
 import {LAYOUT_MARGIN, DASHBOARD_LAYOUT_ROW_HEIGHT} from 'src/shared/constants'
 
 // Types
-import {AppState, Cell, RemoteDataState, View} from 'src/types'
+import {AppState, Cell, RemoteDataState} from 'src/types'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
-type ViewsByID = {[viewID: string]: View}
-
-interface StateProps {
-  views: ViewsByID
-  cells: Cell[]
-  dashboard: string
-}
-
-interface DispatchProps {
-  updateCells: typeof updateCells
-}
 
 interface OwnProps {
   manualRefresh: number
 }
 
-type Props = StateProps & OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 @ErrorHandling
 class Cells extends Component<Props> {
@@ -135,7 +125,7 @@ class Cells extends Component<Props> {
     updateCells(dashboard, cells)
   }
 }
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const dashboard = state.currentDashboard.id
 
   return {
@@ -144,8 +134,10 @@ const mstp = (state: AppState): StateProps => {
     views: state.resources.views.byID,
   }
 }
-const mdtp: DispatchProps = {
+const mdtp = {
   updateCells: updateCells,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(mstp, mdtp)(Cells)
+const connector = connect(mstp, mdtp)
+
+export default connector(Cells)

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component, ChangeEvent, createRef} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -36,19 +36,14 @@ export const ADD_NEW_LABEL_LABEL: Label = {
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface DispatchProps {
-  onCreateLabel: typeof createLabel
-}
-
-interface StateProps {}
-
 interface OwnProps {
   selectedLabels: Label[]
   labels: Label[]
   onAddLabel: (label: Label) => void
 }
 
-type Props = DispatchProps & StateProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 interface State {
   searchTerm: string
@@ -289,15 +284,10 @@ class InlineLabelsEditor extends Component<Props, State> {
   }
 }
 
-const mstp = (): StateProps => {
-  return {}
-}
-
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateLabel: createLabel,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(InlineLabelsEditor)
+const connector = connect(null, mdtp)
+
+export default connector(InlineLabelsEditor)

--- a/ui/src/shared/components/notifications/Notifications.tsx
+++ b/ui/src/shared/components/notifications/Notifications.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {Link} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 //Actions
@@ -9,20 +9,10 @@ import {dismissNotification as dismissNotificationAction} from 'src/shared/actio
 import {Notification, ComponentSize, Gradients} from '@influxdata/clockface'
 
 //Types
-import {
-  Notification as NotificationType,
-  NotificationStyle,
-} from 'src/types/notifications'
+import {AppState, NotificationStyle} from 'src/types'
 
-interface StateProps {
-  notifications: NotificationType[]
-}
-
-interface DispatchProps {
-  dismissNotification: typeof dismissNotificationAction
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const matchGradientToColor = (style: NotificationStyle): Gradients => {
   const converter = {
@@ -85,12 +75,14 @@ class Notifications extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps = ({notifications}): StateProps => ({
+const mstp = ({notifications}: AppState) => ({
   notifications,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   dismissNotification: dismissNotificationAction,
 }
 
-export default connect(mapStateToProps, mdtp)(Notifications)
+const connector = connect(mstp, mdtp)
+
+export default connector(Notifications)

--- a/ui/src/shared/components/tables/TableGraphs.tsx
+++ b/ui/src/shared/components/tables/TableGraphs.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -25,11 +25,8 @@ interface PassedProps {
   theme: Theme
 }
 
-interface DispatchProps {
-  setFieldOptions: typeof setFieldOptionsAction
-}
-
-type Props = PassedProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = PassedProps & ReduxProps
 
 interface State {
   selectedTableName: string
@@ -111,11 +108,10 @@ class TableGraphs extends PureComponent<Props, State> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setFieldOptions: setFieldOptionsAction,
 }
 
-export default connect<null, DispatchProps, PassedProps>(
-  null,
-  mdtp
-)(TableGraphs)
+const connector = connect(null, mdtp)
+
+export default connector(TableGraphs)

--- a/ui/src/shared/containers/GetFlags.tsx
+++ b/ui/src/shared/containers/GetFlags.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useEffect, FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 import GetOrganizations from 'src/shared/containers/GetOrganizations'
 
@@ -9,7 +9,6 @@ import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
 // Types
 import {RemoteDataState, AppState} from 'src/types'
-import {FlagMap} from 'src/shared/reducers/flags'
 
 // Actions
 import {getFlags as getFlagsAction} from 'src/shared/actions/flags'
@@ -18,16 +17,8 @@ import {getFlags as getFlagsAction} from 'src/shared/actions/flags'
 import {activeFlags} from 'src/shared/selectors/flags'
 import {updateReportingContext} from 'src/cloud/utils/reporting'
 
-interface DispatchProps {
-  getFlags: typeof getFlagsAction
-}
-
-interface StateProps {
-  status: RemoteDataState
-  flags: FlagMap
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const GetFlags: FC<Props> = ({status, getFlags, flags}) => {
   useEffect(() => {
@@ -59,9 +50,11 @@ const mdtp = {
   getFlags: getFlagsAction,
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   flags: activeFlags(state),
   status: state.flags.status || RemoteDataState.NotStarted,
 })
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(GetFlags)
+const connector = connect(mstp, mdtp)
+
+export default connector(GetFlags)

--- a/ui/src/shared/containers/GetLinks.tsx
+++ b/ui/src/shared/containers/GetLinks.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -14,19 +14,16 @@ import {getLinks} from 'src/shared/actions/links'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface PassedInProps {
+interface OwnProps {
   children: React.ReactElement<any>
-}
-
-interface ConnectDispatchProps {
-  getLinks: typeof getLinks
 }
 
 interface State {
   loading: RemoteDataState
 }
 
-type Props = ConnectDispatchProps & PassedInProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 @ErrorHandling
 class GetLinks extends PureComponent<Props, State> {
@@ -58,7 +55,6 @@ const mdtp = {
   getLinks,
 }
 
-export default connect<{}, ConnectDispatchProps, PassedInProps>(
-  null,
-  mdtp
-)(GetLinks)
+const connector = connect(null, mdtp)
+
+export default connector(GetLinks)

--- a/ui/src/shared/containers/GetMe.tsx
+++ b/ui/src/shared/containers/GetMe.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {Switch, Route} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -16,15 +16,12 @@ import {getMe} from 'src/shared/actions/me'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface ConnectDispatchProps {
-  getMe: typeof getMe
-}
-
 interface State {
   loading: RemoteDataState
 }
 
-type Props = ConnectDispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 @ErrorHandling
 class GetMe extends PureComponent<Props, State> {
@@ -58,4 +55,6 @@ const mdtp = {
   getMe,
 }
 
-export default connect<{}, ConnectDispatchProps>(null, mdtp)(GetMe)
+const connector = connect(null, mdtp)
+
+export default connector(GetMe)

--- a/ui/src/shared/containers/GetOrganizations.tsx
+++ b/ui/src/shared/containers/GetOrganizations.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useEffect, FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
@@ -15,15 +15,8 @@ import {RemoteDataState, AppState} from 'src/types'
 import {getOrganizations as getOrganizationsAction} from 'src/organizations/actions/thunks'
 import RouteToOrg from './RouteToOrg'
 
-interface DispatchProps {
-  getOrganizations: typeof getOrganizationsAction
-}
-
-interface StateProps {
-  status: RemoteDataState
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const GetOrganizations: FunctionComponent<Props> = ({
   status,
@@ -50,8 +43,10 @@ const mdtp = {
   getOrganizations: getOrganizationsAction,
 }
 
-const mstp = ({resources}: AppState): StateProps => ({
+const mstp = ({resources}: AppState) => ({
   status: resources.orgs.status,
 })
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(GetOrganizations)
+const connector = connect(mstp, mdtp)
+
+export default connector(GetOrganizations)

--- a/ui/src/shared/containers/RouteToOrg.tsx
+++ b/ui/src/shared/containers/RouteToOrg.tsx
@@ -41,7 +41,7 @@ class RouteToOrg extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const org = getOrg(state)
   const orgs = getAll<Organization>(state, ResourceType.Orgs)
 

--- a/ui/src/shared/containers/SetOrg.tsx
+++ b/ui/src/shared/containers/SetOrg.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useEffect, useState, FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
@@ -52,22 +52,12 @@ import {
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
-interface PassedInProps {
+interface OwnProps {
   children: React.ReactElement<any>
 }
 
-interface DispatchProps {
-  setOrg: typeof setOrgAction
-}
-
-interface StateProps {
-  orgs: Organization[]
-}
-
-type Props = StateProps &
-  DispatchProps &
-  PassedInProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const SetOrg: FC<Props> = ({
   match: {
@@ -193,13 +183,12 @@ const mdtp = {
   setOrg: setOrgAction,
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const orgs = getAll<Organization>(state, ResourceType.Orgs)
 
   return {orgs}
 }
 
-export default connect<StateProps, DispatchProps, PassedInProps>(
-  mstp,
-  mdtp
-)(SetOrg)
+const connector = connect(mstp, mdtp)
+
+export default connector(SetOrg)

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -38,12 +38,8 @@ interface PassedProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface DispatchProps {
-  onAddTaskLabel: typeof addTaskLabel
-  onDeleteTaskLabel: typeof deleteTaskLabel
-}
-
-type Props = PassedProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = PassedProps & ReduxProps
 
 export class TaskCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -239,12 +235,11 @@ export class TaskCard extends PureComponent<
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddTaskLabel: addTaskLabel,
   onDeleteTaskLabel: deleteTaskLabel,
 }
 
-export default connect<{}, DispatchProps, PassedProps>(
-  null,
-  mdtp
-)(withRouter(TaskCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(TaskCard))

--- a/ui/src/tasks/components/TaskExportOverlay.tsx
+++ b/ui/src/tasks/components/TaskExportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ExportOverlay from 'src/shared/components/ExportOverlay'
@@ -11,22 +11,9 @@ import {clearExportTemplate as clearExportTemplateAction} from 'src/templates/ac
 
 // Types
 import {AppState} from 'src/types'
-import {DocumentCreate} from '@influxdata/influx'
-import {RemoteDataState} from 'src/types'
 
-interface DispatchProps {
-  convertToTemplate: typeof convertToTemplateAction
-  clearExportTemplate: typeof clearExportTemplateAction
-}
-
-interface StateProps {
-  taskTemplate: DocumentCreate
-  status: RemoteDataState
-}
-
-type Props = StateProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string; id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string; id: string}>
 
 class TaskExportOverlay extends PureComponent<Props> {
   public componentDidMount() {
@@ -61,17 +48,16 @@ class TaskExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   taskTemplate: state.resources.templates.exportTemplate.item,
   status: state.resources.templates.exportTemplate.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(TaskExportOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TaskExportOverlay))

--- a/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
+++ b/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {sortBy} from 'lodash'
 
 // Components
@@ -25,7 +25,6 @@ import {
   Template,
   TemplateType,
   AppState,
-  RemoteDataState,
   TaskTemplate,
   ResourceType,
 } from 'src/types'
@@ -33,21 +32,13 @@ import {
 // Selectors
 import {getAll} from 'src/resources/selectors/getAll'
 
-interface StateProps {
-  templates: TemplateSummary[]
-  templateStatus: RemoteDataState
-}
-
-interface DispatchProps {
-  createTaskFromTemplate: typeof createTaskFromTemplateAction
-}
-
 interface State {
   selectedTemplateSummary: TemplateSummary
   selectedTemplate: Template
 }
 
-type Props = DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TaskImportFromTemplateOverlay extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>,
@@ -141,7 +132,7 @@ class TaskImportFromTemplateOverlay extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     resources: {
       templates: {status},
@@ -162,11 +153,10 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createTaskFromTemplate: createTaskFromTemplateAction,
 }
 
-export default connect<StateProps>(
-  mstp,
-  mdtp
-)(withRouter(TaskImportFromTemplateOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TaskImportFromTemplateOverlay))

--- a/ui/src/tasks/components/TaskImportOverlay.tsx
+++ b/ui/src/tasks/components/TaskImportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -22,12 +22,8 @@ interface State {
   status: ComponentStatus
 }
 
-interface DispatchProps {
-  createTaskFromTemplate: typeof createTaskFromTemplateAction
-  notify: typeof notifyAction
-}
-
-type Props = DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 class TaskImportOverlay extends PureComponent<Props> {
   public state: State = {
@@ -73,12 +69,11 @@ class TaskImportOverlay extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createTaskFromTemplate: createTaskFromTemplateAction,
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, Props>(
-  null,
-  mdtp
-)(withRouter(TaskImportOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(TaskImportOverlay))

--- a/ui/src/tasks/components/TaskRunsPage.tsx
+++ b/ui/src/tasks/components/TaskRunsPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -9,7 +9,7 @@ import TaskRunsList from 'src/tasks/components/TaskRunsList'
 import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 
 // Types
-import {AppState, RemoteDataState, Task, Run} from 'src/types'
+import {AppState, Run} from 'src/types'
 import {
   SpinnerContainer,
   TechnoSpinner,
@@ -26,20 +26,8 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 // Types
 import {SortTypes} from 'src/shared/utils/sort'
 
-interface DispatchProps {
-  getRuns: typeof getRuns
-  onRunTask: typeof runTask
-}
-
-interface StateProps {
-  runs: Run[]
-  runStatus: RemoteDataState
-  currentTask: Task
-}
-
-type Props = DispatchProps &
-  StateProps &
-  RouteComponentProps<{id: string; orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{id: string; orgID: string}>
 
 interface State {
   sortKey: SortKey
@@ -146,7 +134,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {runs, runStatus, currentTask} = state.resources.tasks
 
   return {
@@ -156,12 +144,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getRuns: getRuns,
   onRunTask: runTask,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(TaskRunsPage))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TaskRunsPage))

--- a/ui/src/tasks/components/TaskRunsRow.tsx
+++ b/ui/src/tasks/components/TaskRunsRow.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import moment from 'moment'
 
 // Components
@@ -12,7 +12,7 @@ import {getLogs} from 'src/tasks/actions/thunks'
 
 // Types
 import {ComponentSize, ComponentColor, Button} from '@influxdata/clockface'
-import {AppState, LogEvent, Run} from 'src/types'
+import {AppState, Run} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 interface OwnProps {
@@ -20,15 +20,8 @@ interface OwnProps {
   run: Run
 }
 
-interface DispatchProps {
-  getLogs: typeof getLogs
-}
-
-interface StateProps {
-  logs: LogEvent[]
-}
-
-type Props = OwnProps & DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 interface State {
   isImportOverlayVisible: boolean
@@ -101,15 +94,13 @@ class TaskRunsRow extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {logs} = state.resources.tasks
 
   return {logs}
 }
 
-const mdtp: DispatchProps = {getLogs: getLogs}
+const mdtp = {getLogs: getLogs}
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(TaskRunsRow)
+const connector = connect(mstp, mdtp)
+export default connector(TaskRunsRow)

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -11,8 +11,6 @@ import EmptyTasksList from 'src/tasks/components/EmptyTasksList'
 import {Task} from 'src/types'
 import {SortTypes} from 'src/shared/utils/sort'
 import {Sort} from '@influxdata/clockface'
-import {addTaskLabel, runTask} from 'src/tasks/actions/thunks'
-import {checkTaskLimits as checkTaskLimitsAction} from 'src/cloud/actions/limits'
 import {TaskSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 // Selectors
@@ -27,15 +25,15 @@ interface Props {
   onClone: (task: Task) => void
   onFilterChange: (searchTerm: string) => void
   totalCount: number
-  onAddTaskLabel: typeof addTaskLabel
-  onRunTask: typeof runTask
+  onAddTaskLabel: any
+  onRunTask: any
   onUpdate: (name: string, taskID: string) => void
   filterComponent?: JSX.Element
   onImportTask: () => void
   sortKey: TaskSortKey
   sortDirection: Sort
   sortType: SortTypes
-  checkTaskLimits: typeof checkTaskLimitsAction
+  checkTaskLimits: any
   onImportFromTemplate: () => void
 }
 

--- a/ui/src/tasks/components/TasksOptionsBucketDropdown.tsx
+++ b/ui/src/tasks/components/TasksOptionsBucketDropdown.tsx
@@ -125,7 +125,7 @@ class TaskOptionsBucketDropdown extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const buckets = getAll<Bucket>(state, ResourceType.Buckets).filter(
     (bucket: Bucket): boolean => bucket.type !== 'system'
   )

--- a/ui/src/tasks/components/TemplateBrowserEmpty.tsx
+++ b/ui/src/tasks/components/TemplateBrowserEmpty.tsx
@@ -50,7 +50,7 @@ class TemplateBrowserEmpty extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   org: getOrg(state),
 })
 

--- a/ui/src/tasks/containers/TaskEditPage.tsx
+++ b/ui/src/tasks/containers/TaskEditPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -27,31 +27,10 @@ import {
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
-import {
-  AppState,
-  Task,
-  TaskOptions,
-  TaskOptionKeys,
-  TaskSchedule,
-} from 'src/types'
+import {AppState, TaskOptionKeys, TaskSchedule} from 'src/types'
 
-interface StateProps {
-  taskOptions: TaskOptions
-  currentTask: Task
-  currentScript: string
-}
-
-interface DispatchProps {
-  setTaskOption: typeof setTaskOption
-  setCurrentScript: typeof setCurrentScript
-  updateScript: typeof updateScript
-  cancel: typeof cancel
-  selectTaskByID: typeof selectTaskByID
-  clearTask: typeof clearTask
-  setAllTaskOptionsByID: typeof setAllTaskOptionsByID
-}
-
-type Props = StateProps & DispatchProps & RouteComponentProps<{id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{id: string}>
 
 class TaskEditPage extends PureComponent<Props> {
   constructor(props) {
@@ -139,7 +118,7 @@ class TaskEditPage extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {taskOptions, currentScript, currentTask} = state.resources.tasks
 
   return {
@@ -149,7 +128,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setTaskOption,
   setCurrentScript,
   updateScript,
@@ -159,4 +138,5 @@ const mdtp: DispatchProps = {
   clearTask,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(TaskEditPage)
+const connector = connect(mstp, mdtp)
+export default connector(TaskEditPage)

--- a/ui/src/tasks/containers/TaskPage.tsx
+++ b/ui/src/tasks/containers/TaskPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TaskForm from 'src/tasks/components/TaskForm'
@@ -25,22 +25,10 @@ import {
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
-import {AppState, TaskOptions, TaskOptionKeys, TaskSchedule} from 'src/types'
+import {AppState, TaskOptionKeys, TaskSchedule} from 'src/types'
 
-interface StateProps {
-  taskOptions: TaskOptions
-  newScript: string
-}
-
-interface DispatchProps {
-  setNewScript: typeof setNewScript
-  saveNewScript: typeof saveNewScript
-  setTaskOption: typeof setTaskOption
-  clearTask: typeof clearTask
-  cancel: typeof cancel
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TaskPage extends PureComponent<Props> {
   constructor(props) {
@@ -131,7 +119,7 @@ class TaskPage extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {tasks} = state.resources
   const {taskOptions, newScript} = tasks
 
@@ -141,7 +129,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   setNewScript,
   saveNewScript,
   setTaskOption,
@@ -149,4 +137,6 @@ const mdtp: DispatchProps = {
   cancel,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(TaskPage)
+const connector = connect(mstp, mdtp)
+
+export default connector(TaskPage)

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -34,13 +34,10 @@ import {
   setShowInactive as setShowInactiveAction,
 } from 'src/tasks/actions/creators'
 
-import {
-  checkTaskLimits as checkTasksLimitsAction,
-  LimitStatus,
-} from 'src/cloud/actions/limits'
+import {checkTaskLimits as checkTasksLimitsAction} from 'src/cloud/actions/limits'
 
 // Types
-import {AppState, Task, RemoteDataState, ResourceType} from 'src/types'
+import {AppState, Task, ResourceType} from 'src/types'
 import {RouteComponentProps} from 'react-router-dom'
 import {Sort} from '@influxdata/clockface'
 import {SortTypes} from 'src/shared/utils/sort'
@@ -50,29 +47,8 @@ import {TaskSortKey} from 'src/shared/components/resource_sort_dropdown/generate
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
-interface ConnectedDispatchProps {
-  updateTaskStatus: typeof updateTaskStatus
-  updateTaskName: typeof updateTaskName
-  deleteTask: typeof deleteTask
-  cloneTask: typeof cloneTask
-  setSearchTerm: typeof setSearchTermAction
-  setShowInactive: typeof setShowInactiveAction
-  onAddTaskLabel: typeof addTaskLabel
-  onRunTask: typeof runTask
-  checkTaskLimits: typeof checkTasksLimitsAction
-}
-
-interface ConnectedStateProps {
-  tasks: Task[]
-  searchTerm: string
-  showInactive: boolean
-  status: RemoteDataState
-  limitStatus: LimitStatus
-}
-
-type Props = ConnectedDispatchProps &
-  ConnectedStateProps &
-  RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   isImporting: boolean
@@ -286,7 +262,7 @@ class TasksPage extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): ConnectedStateProps => {
+const mstp = (state: AppState) => {
   const {
     resources,
     cloud: {limits},
@@ -302,7 +278,7 @@ const mstp = (state: AppState): ConnectedStateProps => {
   }
 }
 
-const mdtp: ConnectedDispatchProps = {
+const mdtp = {
   updateTaskStatus,
   updateTaskName,
   deleteTask,
@@ -314,7 +290,6 @@ const mdtp: ConnectedDispatchProps = {
   checkTaskLimits: checkTasksLimitsAction,
 }
 
-export default connect<ConnectedStateProps, ConnectedDispatchProps>(
-  mstp,
-  mdtp
-)(TasksPage)
+const connector = connect(mstp, mdtp)
+
+export default connector(TasksPage)

--- a/ui/src/telegrafs/components/CollectorCard.tsx
+++ b/ui/src/telegrafs/components/CollectorCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps, Link} from 'react-router-dom'
 
 // Components
@@ -22,7 +22,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
 
 // Types
-import {AppState, Organization, Label, Telegraf} from 'src/types'
+import {AppState, Label, Telegraf} from 'src/types'
 
 interface OwnProps {
   collector: Telegraf
@@ -31,16 +31,8 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface StateProps {
-  org: Organization
-}
-
-interface DispatchProps {
-  onAddLabels: typeof addTelegrafLabelsAsync
-  onRemoveLabels: typeof removeTelegrafLabelsAsync
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class CollectorRow extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -156,18 +148,17 @@ class CollectorRow extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const org = getOrg(state)
 
   return {org}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddLabels: addTelegrafLabelsAsync,
   onRemoveLabels: removeTelegrafLabelsAsync,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(CollectorRow))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(CollectorRow))

--- a/ui/src/telegrafs/components/CollectorList.tsx
+++ b/ui/src/telegrafs/components/CollectorList.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import memoizeOne from 'memoize-one'
 
 // Components
@@ -25,16 +25,8 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface StateProps {
-  collectors: Telegraf[]
-}
-
-interface DispatchProps {
-  onUpdateTelegraf: typeof updateTelegraf
-  onDeleteTelegraf: typeof deleteTelegraf
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class CollectorList extends PureComponent<Props> {
   private memGetSortedResources = memoizeOne<typeof getSortedResources>(
@@ -87,16 +79,14 @@ class CollectorList extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   collectors: getAll<Telegraf>(state, ResourceType.Telegrafs),
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateTelegraf: updateTelegraf,
   onDeleteTelegraf: deleteTelegraf,
 }
-
-connect<StateProps, DispatchProps, OwnProps>(mstp, mdtp)(CollectorList)
 
 type FilteredOwnProps = OwnProps & {
   searchTerm: string
@@ -141,9 +131,8 @@ class FilteredCollectorList extends PureComponent<FilteredProps> {
   }
 }
 
-const FilteredList = connect<StateProps, DispatchProps, FilteredOwnProps>(
-  mstp,
-  mdtp
-)(FilteredCollectorList)
+const connector = connect(mstp, mdtp)
+
+const FilteredList = connector(FilteredCollectorList)
 
 export {FilteredCollectorList, FilteredList}

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import _ from 'lodash'
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -44,21 +44,8 @@ import {TelegrafSortKey} from 'src/shared/components/resource_sort_dropdown/gene
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
 
-interface StateProps {
-  hasTelegrafs: boolean
-  orgName: string
-  buckets: Bucket[]
-}
-
-interface DispatchProps {
-  onSetTelegrafConfigID: typeof setTelegrafConfigID
-  onSetTelegrafConfigName: typeof setTelegrafConfigName
-  onClearDataLoaders: typeof clearDataLoaders
-  onUpdateTelegraf: typeof updateTelegraf
-  onDeleteTelegraf: typeof deleteTelegraf
-}
-
-type Props = DispatchProps & StateProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 interface State {
   dataLoaderOverlay: OverlayState
@@ -266,7 +253,7 @@ class Collectors extends PureComponent<Props, State> {
     this.setState({searchTerm})
   }
 }
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {telegrafs} = state.resources
   const orgName = getOrg(state).name
   const buckets = getAll<Bucket>(state, ResourceType.Buckets)
@@ -279,7 +266,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetTelegrafConfigID: setTelegrafConfigID,
   onSetTelegrafConfigName: setTelegrafConfigName,
   onClearDataLoaders: clearDataLoaders,
@@ -287,7 +274,6 @@ const mdtp: DispatchProps = {
   onDeleteTelegraf: deleteTelegraf,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(Collectors))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(Collectors))

--- a/ui/src/telegrafs/components/TelegrafConfig.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfig.tsx
@@ -1,12 +1,11 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import Editor from 'src/shared/components/TomlMonacoEditor'
-import {RemoteDataState} from '@influxdata/clockface'
 
 // Actions
 import {getTelegrafConfigToml} from 'src/telegrafs/actions/thunks'
@@ -14,16 +13,8 @@ import {getTelegrafConfigToml} from 'src/telegrafs/actions/thunks'
 // Types
 import {AppState} from 'src/types'
 
-interface DispatchProps {
-  getTelegrafConfigToml: typeof getTelegrafConfigToml
-}
-
-interface StateProps {
-  telegrafConfig: string
-  status: RemoteDataState
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 @ErrorHandling
 export class TelegrafConfig extends PureComponent<
@@ -49,16 +40,15 @@ export class TelegrafConfig extends PureComponent<
   }
 }
 
-const mstp = ({resources}: AppState): StateProps => ({
+const mstp = ({resources}: AppState) => ({
   telegrafConfig: resources.telegrafs.currentConfig.item,
   status: resources.telegrafs.currentConfig.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   getTelegrafConfigToml: getTelegrafConfigToml,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(TelegrafConfig))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TelegrafConfig))

--- a/ui/src/telegrafs/components/TelegrafConfigOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafConfigOverlay.tsx
@@ -93,7 +93,7 @@ class TelegrafConfigOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {overlays, resources} = state
   const {status, currentConfig} = resources.telegrafs
   const {id} = overlays.params
@@ -106,4 +106,4 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default connect<StateProps, {}, {}>(mstp, null)(TelegrafConfigOverlay)
+export default connect<StateProps>(mstp)(TelegrafConfigOverlay)

--- a/ui/src/telegrafs/components/TelegrafInstructionsOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafInstructionsOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
@@ -17,19 +17,8 @@ import {Telegraf, AppState, ResourceType} from 'src/types'
 import {getAll, getToken} from 'src/resources/selectors'
 import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
 
-interface StateProps {
-  username: string
-  token: string
-  collectors: Telegraf[]
-}
-
-interface DispatchProps {
-  onClearDataLoaders: typeof clearDataLoaders
-}
-
-type Props = StateProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string; id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string; id: string}>
 
 @ErrorHandling
 export class TelegrafInstructionsOverlay extends PureComponent<Props> {
@@ -81,7 +70,7 @@ export class TelegrafInstructionsOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     me: {name},
   } = state
@@ -96,11 +85,10 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onClearDataLoaders: clearDataLoaders,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter(TelegrafInstructionsOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TelegrafInstructionsOverlay))

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -168,7 +168,7 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {name, id} = getOrg(state)
   const server = window.location.origin
   const buckets = getAll<Bucket>(state, ResourceType.Buckets)
@@ -182,4 +182,4 @@ const mstp = (state: AppState): StateProps => {
 }
 
 export {TelegrafOutputOverlay}
-export default connect<StateProps, {}, {}>(mstp, null)(TelegrafOutputOverlay)
+export default connect<StateProps>(mstp)(TelegrafOutputOverlay)

--- a/ui/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/ui/src/telegrafs/containers/TelegrafsPage.tsx
@@ -24,14 +24,14 @@ import OverlayHandler, {
 } from 'src/overlays/components/RouteOverlay'
 
 const TelegrafConfigOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'telegraf-config',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
   }
 )
 const TelegrafOutputOverlay = RouteOverlay(
-  OverlayHandler,
+  OverlayHandler as any,
   'telegraf-output',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)

--- a/ui/src/templates/components/CommunityTemplateContents.tsx
+++ b/ui/src/templates/components/CommunityTemplateContents.tsx
@@ -1,9 +1,9 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Types
-import {AppState, CommunityTemplate} from 'src/types'
+import {AppState} from 'src/types'
 
 // Components
 import {
@@ -20,15 +20,8 @@ import CommunityTemplateListGroup from 'src/templates/components/CommunityTempla
 import {toggleTemplateResourceInstall} from 'src/templates/actions/creators'
 import {getResourceInstallCount} from 'src/templates/selectors'
 
-interface StateProps {
-  summary: CommunityTemplate
-}
-
-interface DispatchProps {
-  toggleTemplateResourceInstall: typeof toggleTemplateResourceInstall
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
   render() {
@@ -223,7 +216,7 @@ class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {summary: state.resources.templates.communityTemplateToInstall.summary}
 }
 
@@ -231,7 +224,8 @@ const mdtp = {
   toggleTemplateResourceInstall,
 }
 
-export const CommunityTemplateContents = connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(CommunityTemplateContentsUnconnected)
+const connector = connect(mstp, mdtp)
+
+export const CommunityTemplateContents = connector(
+  CommunityTemplateContentsUnconnected
+)

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {CommunityTemplateInstallerOverlay} from 'src/templates/components/CommunityTemplateInstallerOverlay'
@@ -11,8 +11,6 @@ import {createTemplate as createTemplateAction} from 'src/templates/actions/thun
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 import {getTotalResourceCount} from 'src/templates/selectors'
-
-import {FlagMap} from 'src/shared/reducers/flags'
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
@@ -30,22 +28,9 @@ interface State {
   status: ComponentStatus
 }
 
-interface DispatchProps {
-  createTemplate: typeof createTemplateAction
-  notify: typeof notifyAction
-  setCommunityTemplateToInstall: typeof setCommunityTemplateToInstall
-}
-
-interface StateProps {
-  flags: FlagMap
-  org: Organization
-  templateName: string
-  resourceCount: number
-}
-
-type Props = DispatchProps &
-  RouteComponentProps<{orgID: string; templateName: string}> &
-  StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string; templateName: string}>
+type Props = ReduxProps & RouterProps
 
 class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   public state: State = {
@@ -104,7 +89,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState, props: Props): StateProps => {
+const mstp = (state: AppState, props: RouterProps) => {
   const org = getByID<Organization>(
     state,
     ResourceType.Orgs,
@@ -121,17 +106,14 @@ const mstp = (state: AppState, props: Props): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createTemplate: createTemplateAction,
   notify: notifyAction,
   setCommunityTemplateToInstall,
 }
 
-export const CommunityTemplateImportOverlay = connect<
-  StateProps,
-  DispatchProps,
-  Props
->(
-  mstp,
-  mdtp
-)(withRouter(UnconnectedTemplateImportOverlay))
+const connector = connect(mstp, mdtp)
+
+export const CommunityTemplateImportOverlay = connector(
+  withRouter(UnconnectedTemplateImportOverlay)
+)

--- a/ui/src/templates/components/StaticTemplateCard.tsx
+++ b/ui/src/templates/components/StaticTemplateCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
 import {get, capitalize} from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {
   Button,
@@ -22,7 +22,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
-import {AppState, Organization, TemplateSummary} from 'src/types'
+import {AppState, TemplateSummary} from 'src/types'
 
 // Constants
 interface OwnProps {
@@ -31,15 +31,8 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface DispatchProps {
-  onCreateFromTemplate: typeof createResourceFromStaticTemplate
-}
-
-interface StateProps {
-  org: Organization
-}
-
-type Props = DispatchProps & OwnProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 class StaticTemplateCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -106,17 +99,16 @@ class StaticTemplateCard extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state),
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onCreateFromTemplate: createResourceFromStaticTemplate,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(StaticTemplateCard))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(StaticTemplateCard))

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get, capitalize} from 'lodash'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {
@@ -31,7 +31,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
-import {AppState, Organization, Label, TemplateSummary} from 'src/types'
+import {AppState, Label, TemplateSummary} from 'src/types'
 
 // Constants
 import {DEFAULT_TEMPLATE_NAME} from 'src/templates/constants'
@@ -41,20 +41,8 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface DispatchProps {
-  onDelete: typeof deleteTemplate
-  onClone: typeof cloneTemplate
-  onUpdate: typeof updateTemplate
-  onCreateFromTemplate: typeof createResourceFromTemplate
-  onAddTemplateLabels: typeof addTemplateLabelsAsync
-  onRemoveTemplateLabels: typeof removeTemplateLabelsAsync
-}
-
-interface StateProps {
-  org: Organization
-}
-
-type Props = DispatchProps & OwnProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 class TemplateCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -198,13 +186,13 @@ class TemplateCard extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state),
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onDelete: deleteTemplate,
   onClone: cloneTemplate,
   onUpdate: updateTemplate,
@@ -213,7 +201,6 @@ const mdtp: DispatchProps = {
   onRemoveTemplateLabels: removeTemplateLabelsAsync,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(TemplateCard))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TemplateCard))

--- a/ui/src/templates/components/TemplateExportOverlay.tsx
+++ b/ui/src/templates/components/TemplateExportOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -12,27 +12,15 @@ import {
 } from 'src/templates/actions/thunks'
 
 // Types
-import {DocumentCreate} from '@influxdata/influx'
 import {AppState} from 'src/types'
-import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
   match: {id: string}
 }
 
-interface DispatchProps {
-  convertToTemplate: typeof convertToTemplateAction
-  clearExportTemplate: typeof clearExportTemplateAction
-}
-
-interface StateProps {
-  exportTemplate: DocumentCreate
-  status: RemoteDataState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps &
-  StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string; id: string}>
 
 class TemplateExportOverlay extends PureComponent<Props> {
@@ -67,17 +55,16 @@ class TemplateExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   exportTemplate: state.resources.templates.exportTemplate.item,
   status: state.resources.templates.exportTemplate.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(TemplateExportOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TemplateExportOverlay))

--- a/ui/src/templates/components/TemplateImportOverlay.tsx
+++ b/ui/src/templates/components/TemplateImportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -24,16 +24,9 @@ interface State {
   status: ComponentStatus
 }
 
-interface DispatchProps {
-  createTemplate: typeof createTemplateAction
-  notify: typeof notifyAction
-}
-
-interface StateProps {
-  org: Organization
-}
-
-type Props = DispatchProps & StateProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string}>
+type Props = ReduxProps & RouterProps
 
 class TemplateImportOverlay extends PureComponent<Props> {
   public state: State = {
@@ -78,7 +71,7 @@ class TemplateImportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState, props: Props): StateProps => {
+const mstp = (state: AppState, props: RouterProps) => {
   const org = getByID<Organization>(
     state,
     ResourceType.Orgs,
@@ -88,12 +81,11 @@ const mstp = (state: AppState, props: Props): StateProps => {
   return {org}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
   createTemplate: createTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps, Props>(
-  mstp,
-  mdtp
-)(withRouter(TemplateImportOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TemplateImportOverlay))

--- a/ui/src/templates/components/TemplateViewOverlay.tsx
+++ b/ui/src/templates/components/TemplateViewOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import _ from 'lodash'
 
@@ -14,27 +14,15 @@ import {
 } from 'src/templates/actions/thunks'
 
 // Types
-import {DocumentCreate} from '@influxdata/influx'
 import {AppState} from 'src/types'
-import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
   match: {id: string}
 }
 
-interface DispatchProps {
-  convertToTemplate: typeof convertToTemplateAction
-  clearExportTemplate: typeof clearExportTemplateAction
-}
-
-interface StateProps {
-  exportTemplate: DocumentCreate
-  status: RemoteDataState
-}
-
+type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps &
-  StateProps &
-  DispatchProps &
+  ReduxProps &
   RouteComponentProps<{orgID: string; id: string}>
 
 @ErrorHandling
@@ -78,17 +66,16 @@ class TemplateExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   exportTemplate: state.resources.templates.exportTemplate.item,
   status: state.resources.templates.exportTemplate.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(TemplateExportOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TemplateExportOverlay))

--- a/ui/src/templates/components/TemplatesPage.tsx
+++ b/ui/src/templates/components/TemplatesPage.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import FilterList from 'src/shared/components/FilterList'
@@ -42,11 +42,8 @@ interface OwnProps {
   onImport: () => void
 }
 
-interface StateProps {
-  templates: TemplateSummary[]
-}
-
-type Props = OwnProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 interface State {
   searchTerm: string
@@ -213,8 +210,10 @@ class TemplatesPage extends PureComponent<Props, State> {
     this.setState({searchTerm})
   }
 }
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   templates: getAll(state, ResourceType.Templates),
 })
 
-export default connect<StateProps>(mstp, null)(TemplatesPage)
+const connector = connect(mstp)
+
+export default connector(TemplatesPage)

--- a/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {sortBy} from 'lodash'
 
 // Components
@@ -29,22 +29,12 @@ import {
   TemplateType,
   DashboardTemplateIncluded,
   AppState,
-  RemoteDataState,
   DashboardTemplate,
   ResourceType,
 } from 'src/types'
 
 // Selectors
 import {getAll} from 'src/resources/selectors/getAll'
-
-interface StateProps {
-  templates: TemplateSummary[]
-  templateStatus: RemoteDataState
-}
-
-interface DispatchProps {
-  createDashboardFromTemplate: typeof createDashboardFromTemplateAction
-}
 
 interface State {
   selectedTemplateSummary: TemplateSummary
@@ -53,7 +43,8 @@ interface State {
   cells: string[]
 }
 
-type Props = DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class DashboardImportFromTemplateOverlay extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>,
@@ -189,7 +180,7 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {
     resources: {
       templates: {status},
@@ -210,11 +201,10 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createDashboardFromTemplate: createDashboardFromTemplateAction,
 }
 
-export default connect<StateProps>(
-  mstp,
-  mdtp
-)(withRouter(DashboardImportFromTemplateOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(DashboardImportFromTemplateOverlay))

--- a/ui/src/templates/components/createFromTemplateOverlay/TemplateBrowserEmpty.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/TemplateBrowserEmpty.tsx
@@ -50,7 +50,7 @@ class TemplateBrowserEmpty extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   org: getOrg(state),
 })
 

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -1,9 +1,16 @@
 import React, {Component} from 'react'
-import {withRouter, RouteComponentProps, matchPath} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {
+  withRouter,
+  matchPath,
+  RouteComponentProps,
+  Switch,
+  Route,
+} from 'react-router-dom'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import {CommunityTemplateImportOverlay} from 'src/templates/components/CommunityTemplateImportOverlay'
 import {
   Bullet,
   Button,
@@ -32,18 +39,15 @@ import {
 } from 'src/templates/utils'
 
 // Types
-import {AppState, Organization} from 'src/types'
+import {AppState} from 'src/types'
 
 const communityTemplatesUrl =
   'https://github.com/influxdata/community-templates#templates'
-
-interface StateProps {
-  org: Organization
-}
+const templatesPath = '/orgs/:orgID/settings/templates'
 
 type Params = {params: {templateName: string}}
-
-type Props = StateProps & RouteComponentProps<{templateName: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{templateName: string}>
 
 @ErrorHandling
 class UnconnectedTemplatesIndex extends Component<Props> {
@@ -67,7 +71,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
   }
 
   public render() {
-    const {org, children} = this.props
+    const {org} = this.props
     return (
       <>
         <Page titleTag={pageTitleSuffixer(['Templates', 'Settings'])}>
@@ -124,7 +128,12 @@ class UnconnectedTemplatesIndex extends Component<Props> {
             </div>
           </SettingsTabbedPage>
         </Page>
-        {children}
+        <Switch>
+          <Route
+            path={`${templatesPath}/import/:templateName`}
+            component={CommunityTemplateImportOverlay}
+          />
+        </Switch>
       </>
     )
   }
@@ -150,12 +159,14 @@ class UnconnectedTemplatesIndex extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state),
   }
 }
 
-export const CommunityTemplatesIndex = connect<StateProps>(mstp)(
+const connector = connect(mstp)
+
+export const CommunityTemplatesIndex = connector(
   withRouter(UnconnectedTemplatesIndex)
 )

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import {RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -23,15 +23,10 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
-import {FlagMap} from 'src/shared/reducers/flags'
+import {AppState, ResourceType} from 'src/types'
 
-interface StateProps {
-  flags: FlagMap
-  org: Organization
-}
-
-type Props = RouteComponentProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps & ReduxProps
 
 const templatesPath = '/orgs/:orgID/settings/templates'
 export const communityTemplatesImportPath = `${templatesPath}/import/:templateName`
@@ -41,16 +36,7 @@ class TemplatesIndex extends Component<Props> {
   public render() {
     const {org, flags} = this.props
     if (flags.communityTemplates) {
-      return (
-        <CommunityTemplatesIndex>
-          <Switch>
-            <Route
-              path={communityTemplatesImportPath}
-              component={CommunityTemplateImportOverlay}
-            />
-          </Switch>
-        </CommunityTemplatesIndex>
-      )
+      return <CommunityTemplatesIndex />
     }
 
     return (
@@ -95,11 +81,13 @@ class TemplatesIndex extends Component<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {
     org: getOrg(state),
     flags: state.flags.original,
   }
 }
 
-export default connect<StateProps, {}, {}>(mstp, null)(TemplatesIndex)
+const connector = connect(mstp)
+
+export default connector(TemplatesIndex)

--- a/ui/src/timeMachine/components/CustomizeCheckQueryButton.tsx
+++ b/ui/src/timeMachine/components/CustomizeCheckQueryButton.tsx
@@ -28,7 +28,7 @@ const CustomizeCheckQueryButton: FC<DispatchProps> = ({
   )
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onLoadCustomCheckQueryState: loadCustomCheckQueryState,
 }
 

--- a/ui/src/timeMachine/components/FunctionSelector.tsx
+++ b/ui/src/timeMachine/components/FunctionSelector.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -38,23 +38,12 @@ import {
 } from 'src/timeMachine/constants/queryBuilder'
 
 // Types
-import {AppState, BuilderConfig} from 'src/types'
+import {AppState} from 'src/types'
 
 const FUNCTION_NAMES = FUNCTIONS.map(f => f.name)
 
-interface StateProps {
-  autoWindowPeriod: number | null
-  aggregateWindow: BuilderConfig['aggregateWindow']
-  selectedFunctions: BuilderConfig['functions']
-  isInCheckOverlay: boolean
-}
-
-interface DispatchProps {
-  onSelectFunction: typeof selectBuilderFunction
-  onSelectAggregateWindow: typeof selectAggregateWindow
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 interface State {
   searchTerm: string
@@ -179,7 +168,7 @@ class FunctionSelector extends PureComponent<Props, State> {
     input == 'none' || input == this.autoLabel
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {builderConfig} = getActiveQuery(state)
   const {functions: selectedFunctions, aggregateWindow} = builderConfig
 
@@ -196,4 +185,6 @@ const mdtp = {
   onSelectAggregateWindow: selectAggregateWindow,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(FunctionSelector)
+const connector = connect(mstp, mdtp)
+
+export default connector(FunctionSelector)

--- a/ui/src/timeMachine/components/Queries.tsx
+++ b/ui/src/timeMachine/components/Queries.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TimeMachineFluxEditor from 'src/timeMachine/components/TimeMachineFluxEditor'
@@ -33,27 +33,10 @@ import {
 import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
-import {
-  AppState,
-  DashboardQuery,
-  TimeRange,
-  AutoRefresh,
-  AutoRefreshStatus,
-} from 'src/types'
+import {AppState, TimeRange, AutoRefreshStatus} from 'src/types'
 
-interface StateProps {
-  activeQuery: DashboardQuery
-  timeRange: TimeRange
-  autoRefresh: AutoRefresh
-  isInCheckOverlay: boolean
-}
-
-interface DispatchProps {
-  onSetTimeRange: typeof setTimeRange
-  onSetAutoRefresh: typeof setAutoRefresh
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TimeMachineQueries extends PureComponent<Props> {
   public render() {
@@ -142,7 +125,6 @@ const mdtp = {
   onSetAutoRefresh: setAutoRefresh,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineQueries)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineQueries)

--- a/ui/src/timeMachine/components/QueriesSwitcher.tsx
+++ b/ui/src/timeMachine/components/QueriesSwitcher.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -24,18 +24,10 @@ import {
 } from 'src/timeMachine/utils/queryBuilder'
 
 // Types
-import {AppState, DashboardQuery} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  activeQuery: DashboardQuery
-}
-
-interface DispatchProps {
-  onEditWithBuilder: typeof editActiveQueryWithBuilder
-  onEditAsFlux: typeof editActiveQueryAsFlux
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TimeMachineQueriesSwitcher extends PureComponent<Props> {
   public render() {
@@ -97,7 +89,6 @@ const mdtp = {
   onEditAsFlux: editActiveQueryAsFlux,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineQueriesSwitcher)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineQueriesSwitcher)

--- a/ui/src/timeMachine/components/QueryBuilder.tsx
+++ b/ui/src/timeMachine/components/QueryBuilder.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {range} from 'lodash'
 
 // Components
@@ -19,21 +19,11 @@ import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {reportSimpleQueryPerformanceEvent} from 'src/cloud/utils/reporting'
 
 // Types
-import {CheckType, AppState} from 'src/types'
+import {AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
-interface StateProps {
-  tagFiltersLength: number
-  moreTags: boolean
-  checkType: CheckType
-}
-
-interface DispatchProps {
-  onLoadBuckets: typeof loadBuckets
-  onAddTagSelector: () => void
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 interface State {}
 
@@ -92,7 +82,7 @@ class TimeMachineQueryBuilder extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const tagFiltersLength = getActiveQuery(state).builderConfig.tags.length
   const {
     queryBuilder: {tags},
@@ -116,7 +106,6 @@ const mdtp = {
   onAddTagSelector: addTagSelector,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineQueryBuilder)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineQueryBuilder)

--- a/ui/src/timeMachine/components/QueryTab.tsx
+++ b/ui/src/timeMachine/components/QueryTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, MouseEvent, RefObject, createRef} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import classnames from 'classnames'
 
 // Components
@@ -23,24 +23,13 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {AppState} from 'src/types'
 import {DashboardDraftQuery} from 'src/types/dashboards'
 
-interface StateProps {
-  activeQueryIndex: number
-  queryCount: number
-}
-
-interface DispatchProps {
-  onSetActiveQueryIndex: typeof setActiveQueryIndex
-  onRemoveQuery: typeof removeQuery
-  onUpdateActiveQueryName: typeof updateActiveQueryName
-  onToggleQuery: typeof toggleQuery
-}
-
 interface OwnProps {
   queryIndex: number
   query: DashboardDraftQuery
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 interface State {
   isEditingName: boolean
@@ -199,7 +188,5 @@ const mdtp = {
   onToggleQuery: toggleQuery,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(TimeMachineQueryTab)
+const connector = connect(mstp, mdtp)
+export default connector(TimeMachineQueryTab)

--- a/ui/src/timeMachine/components/QueryTabs.tsx
+++ b/ui/src/timeMachine/components/QueryTabs.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TimeMachineQueryTab from 'src/timeMachine/components/QueryTab'
@@ -21,18 +21,10 @@ import {
 } from 'src/timeMachine/selectors'
 
 // Types
-import {AppState, DashboardDraftQuery} from 'src/types'
+import {AppState} from 'src/types'
 
-interface StateProps {
-  draftQueries: DashboardDraftQuery[]
-  isInCheckOverlay: boolean
-}
-
-interface DispatchProps {
-  onAddQuery: () => any
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const QueryTabs: FC<Props> = ({draftQueries, isInCheckOverlay, onAddQuery}) => {
   return (
@@ -57,7 +49,7 @@ const QueryTabs: FC<Props> = ({draftQueries, isInCheckOverlay, onAddQuery}) => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {draftQueries} = getActiveTimeMachine(state)
   const isInCheckOverlay = getIsInCheckOverlay(state)
 
@@ -68,4 +60,6 @@ const mdtp = {
   onAddQuery: addQuery,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(QueryTabs)
+const connector = connect(mstp, mdtp)
+
+export default connector(QueryTabs)

--- a/ui/src/timeMachine/components/RawDataToggle.tsx
+++ b/ui/src/timeMachine/components/RawDataToggle.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {SlideToggle, InputLabel, ComponentSize} from '@influxdata/clockface'
@@ -14,15 +14,8 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState} from 'src/types'
 
-interface StateProps {
-  isViewingRawData: boolean
-}
-
-interface DispatchProps {
-  onSetIsViewingRawData: typeof setIsViewingRawData
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TimeMachineQueries extends PureComponent<Props> {
   public render() {
@@ -58,7 +51,6 @@ const mdtp = {
   onSetIsViewingRawData: setIsViewingRawData,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineQueries)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineQueries)

--- a/ui/src/timeMachine/components/RefreshDropdown.tsx
+++ b/ui/src/timeMachine/components/RefreshDropdown.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {isEqual} from 'lodash'
 
 // Components
@@ -11,20 +11,12 @@ import {AutoRefresher} from 'src/utils/AutoRefresher'
 
 // Actions
 import {executeQueries} from 'src/timeMachine/actions/queries'
-import {AutoRefreshStatus, AutoRefresh, AppState} from 'src/types'
+import {AutoRefreshStatus, AppState} from 'src/types'
 import {setAutoRefresh} from 'src/timeMachine/actions'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
-interface DispatchProps {
-  onExecuteQueries: typeof executeQueries
-  onSetAutoRefresh: typeof setAutoRefresh
-}
-
-interface StateProps {
-  autoRefresh: AutoRefresh
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class TimeMachineRefreshDropdown extends PureComponent<Props> {
   private autoRefresher = new AutoRefresher()
@@ -92,18 +84,17 @@ class TimeMachineRefreshDropdown extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {autoRefresh} = getActiveTimeMachine(state)
 
   return {autoRefresh}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onExecuteQueries: executeQueries,
   onSetAutoRefresh: setAutoRefresh,
 }
 
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineRefreshDropdown)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineRefreshDropdown)

--- a/ui/src/timeMachine/components/SelectorListCreateBucket.tsx
+++ b/ui/src/timeMachine/components/SelectorListCreateBucket.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useReducer,
 } from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -33,7 +33,7 @@ import {
 import {createBucket} from 'src/buckets/actions/thunks'
 
 // Types
-import {Organization, AppState} from 'src/types'
+import {AppState} from 'src/types'
 import {
   createBucketReducer,
   RuleType,
@@ -44,20 +44,9 @@ import {
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 
-interface StateProps {
-  org: Organization
-  isRetentionLimitEnforced: boolean
-  limitStatus: LimitStatus
-}
-
-interface DispatchProps {
-  createBucket: typeof createBucket
-  checkBucketLimits: typeof checkBucketLimitsAction
-}
-
 interface OwnProps {}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const SelectorListCreateBucket: FC<Props> = ({
   org,
@@ -167,7 +156,7 @@ const SelectorListCreateBucket: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const org = getOrg(state)
   const isRetentionLimitEnforced = !!extractBucketMaxRetentionSeconds(
     state.cloud.limits
@@ -181,12 +170,11 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createBucket,
   checkBucketLimits: checkBucketLimitsAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(SelectorListCreateBucket)
+const connector = connect(mstp, mdtp)
+
+export default connector(SelectorListCreateBucket)

--- a/ui/src/timeMachine/components/SubmitCheckQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitCheckQueryButton.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -20,16 +20,8 @@ import {getActiveTimeMachine, getActiveQuery} from 'src/timeMachine/selectors'
 import {RemoteDataState} from 'src/types'
 import {AppState} from 'src/types'
 
-interface StateProps {
-  submitButtonDisabled: boolean
-  queryStatus: RemoteDataState
-}
-
-interface DispatchProps {
-  onExecuteCheckQuery: typeof executeCheckQuery
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 interface State {
   didClick: boolean
@@ -93,4 +85,6 @@ const mdtp = {
   onExecuteCheckQuery: executeCheckQuery,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(SubmitQueryButton)
+const connector = connect(mstp, mdtp)
+
+export default connector(SubmitQueryButton)

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -23,23 +23,14 @@ import {queryCancelRequest} from 'src/shared/copy/notifications'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-interface StateProps {
-  submitButtonDisabled: boolean
-  queryStatus: RemoteDataState
-}
-
-interface DispatchProps {
-  onSubmit: typeof saveAndExecuteQueries | (() => void)
-  onNotify?: typeof notify
-}
-
 interface OwnProps {
   text?: string
   icon?: IconFont
   testID?: string
 }
 
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class SubmitQueryButton extends PureComponent<Props> {
   public static defaultProps = {
@@ -128,4 +119,6 @@ const mdtp = {
   onNotify: notify,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(SubmitQueryButton)
+const connector = connect(mstp, mdtp)
+
+export default connector(SubmitQueryButton)

--- a/ui/src/timeMachine/components/TagSelector.tsx
+++ b/ui/src/timeMachine/components/TagSelector.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -51,36 +51,12 @@ const SEARCH_DEBOUNCE_MS = 500
 // We don't show these columns in results but they're able to be grouped on for most queries
 const ADDITIONAL_GROUP_BY_COLUMNS = ['_start', '_stop', '_time']
 
-interface StateProps {
-  aggregateFunctionType: BuilderAggregateFunctionType
-  emptyText: string
-  keys: string[]
-  keysStatus: RemoteDataState
-  selectedKey: string
-  values: string[]
-  valuesStatus: RemoteDataState
-  selectedValues: string[]
-  valuesSearchTerm: string
-  keysSearchTerm: string
-  isInCheckOverlay: boolean
-}
-
-interface DispatchProps {
-  onRemoveTagSelector: typeof removeTagSelector
-  onSearchKeys: typeof searchTagKeys
-  onSearchValues: typeof searchTagValues
-  onSelectTag: typeof selectTagKey
-  onSelectValue: typeof selectTagValue
-  onSetBuilderAggregateFunctionType: typeof setBuilderAggregateFunctionType
-  onSetKeysSearchTerm: typeof setKeysSearchTerm
-  onSetValuesSearchTerm: typeof setValuesSearchTerm
-}
-
 interface OwnProps {
   index: number
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 @ErrorHandling
 class TagSelector extends PureComponent<Props> {
@@ -297,7 +273,7 @@ class TagSelector extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState, ownProps: OwnProps): StateProps => {
+const mstp = (state: AppState, ownProps: OwnProps) => {
   const activeQueryBuilder = getActiveTimeMachine(state).queryBuilder
 
   const {
@@ -354,7 +330,6 @@ const mdtp = {
   onSetValuesSearchTerm: setValuesSearchTerm,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(TagSelector)
+const connector = connect(mstp, mdtp)
+
+export default connector(TagSelector)

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import FluxEditor from 'src/shared/components/FluxMonacoEditor'
@@ -21,25 +21,14 @@ import {
 import {AppState, FluxToolbarFunction, EditorType} from 'src/types'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 
-interface StateProps {
-  activeQueryText: string
-  activeTab: string
-  skipFocus?: boolean
-}
-
-interface DispatchProps {
-  onSetActiveQueryText: typeof setActiveQueryText | ((text: string) => void)
-  onSubmitQueries: typeof saveAndExecuteQueries | (() => void)
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const TimeMachineFluxEditor: FC<Props> = ({
   activeQueryText,
   onSubmitQueries,
   onSetActiveQueryText,
   activeTab,
-  skipFocus,
 }) => {
   const [editorInstance, setEditorInstance] = useState<EditorType>(null)
 
@@ -146,7 +135,6 @@ const TimeMachineFluxEditor: FC<Props> = ({
           onChangeScript={onSetActiveQueryText}
           onSubmitScript={onSubmitQueries}
           setEditorInstance={setEditorInstance}
-          skipFocus={skipFocus}
         />
       </div>
       <div className="flux-editor--right-panel">
@@ -174,7 +162,6 @@ const mdtp = {
   onSubmitQueries: saveAndExecuteQueries,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(TimeMachineFluxEditor)
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineFluxEditor)

--- a/ui/src/timeMachine/components/Vis.tsx
+++ b/ui/src/timeMachine/components/Vis.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {SFC} from 'react'
-import {connect} from 'react-redux'
-import {FromFluxResult} from '@influxdata/giraffe'
+import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 import classnames from 'classnames'
 
@@ -25,40 +24,13 @@ import {
 import {getTimeRange, getTimeZone} from 'src/dashboards/selectors'
 
 // Types
-import {
-  RemoteDataState,
-  AppState,
-  QueryViewProperties,
-  TimeZone,
-  TimeRange,
-  StatusRow,
-  CheckType,
-  Threshold,
-} from 'src/types'
+import {RemoteDataState, AppState} from 'src/types'
 
 // Selectors
 import {getActiveTimeRange} from 'src/timeMachine/selectors/index'
 
-interface StateProps {
-  timeRange: TimeRange | null
-  loading: RemoteDataState
-  errorMessage: string
-  files: string[]
-  viewProperties: QueryViewProperties
-  isInitialFetch: boolean
-  isViewingRawData: boolean
-  giraffeResult: FromFluxResult
-  xColumn: string
-  yColumn: string
-  checkType: CheckType
-  checkThresholds: Threshold[]
-  fillColumns: string[]
-  symbolColumns: string[]
-  timeZone: TimeZone
-  statuses: StatusRow[][]
-}
-
-type Props = StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const TimeMachineVis: SFC<Props> = ({
   loading,
@@ -141,7 +113,7 @@ const TimeMachineVis: SFC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const activeTimeMachine = getActiveTimeMachine(state)
   const {
     isViewingRawData,
@@ -187,4 +159,6 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default connect<StateProps>(mstp)(TimeMachineVis)
+const connector = connect(mstp)
+
+export default connector(TimeMachineVis)

--- a/ui/src/timeMachine/components/VisOptionsButton.tsx
+++ b/ui/src/timeMachine/components/VisOptionsButton.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
@@ -18,11 +18,8 @@ interface StateProps {
   isViewingVisOptions: boolean
 }
 
-interface DispatchProps {
-  onToggleVisOptions: typeof toggleVisOptions
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = StateProps & ReduxProps
 
 export const VisOptionsButton: FC<Props> = ({
   isViewingVisOptions,
@@ -43,14 +40,16 @@ export const VisOptionsButton: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {isViewingVisOptions} = getActiveTimeMachine(state)
 
   return {isViewingVisOptions}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onToggleVisOptions: toggleVisOptions,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(VisOptionsButton)
+const connector = connect(mstp, mdtp)
+
+export default connector(VisOptionsButton)

--- a/ui/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/ui/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TransformToolbarFunctions from 'src/timeMachine/components/fluxFunctionsToolbar/TransformToolbarFunctions'
@@ -25,15 +25,8 @@ interface OwnProps {
   onInsertFluxFunction: (func: FluxToolbarFunction) => void
 }
 
-interface StateProps {
-  activeQueryText: string
-}
-
-interface DispatchProps {
-  onSetActiveQueryText: (script: string) => void
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 interface State {
   searchTerm: string
@@ -93,7 +86,6 @@ const mdtp = {
   onSetActiveQueryText: setActiveQueryText,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(ErrorHandling(FluxFunctionsToolbar))
+const connector = connect(mstp, mdtp)
+
+export default connector(ErrorHandling(FluxFunctionsToolbar))

--- a/ui/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
+++ b/ui/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
@@ -20,17 +20,8 @@ import {getAll, getStatus} from 'src/resources/selectors'
 import {AppState, Bucket, ResourceType} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
-interface StateProps {
-  selectedBucket: string
-  bucketNames: string[]
-  bucketsStatus: RemoteDataState
-}
-
-interface DispatchProps {
-  onSelectBucket: (bucket: string, resetSelections: boolean) => void
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 const fb = term => bucket =>
   bucket.toLocaleLowerCase().includes(term.toLocaleLowerCase())
@@ -121,7 +112,6 @@ const mdtp = {
   onSelectBucket: selectBucket,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(BucketSelector)
+const connector = connect(mstp, mdtp)
+
+export default connector(BucketSelector)

--- a/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useState, useEffect, FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import FluxToolbarSearch from 'src/timeMachine/components/FluxToolbarSearch'
@@ -18,21 +18,14 @@ import {hydrateVariables} from 'src/variables/actions/thunks'
 import {getAllVariables, sortVariablesByName} from 'src/variables/selectors'
 
 // Types
-import {AppState, Variable} from 'src/types'
+import {AppState} from 'src/types'
 
 interface OwnProps {
   onClickVariable: (variableName: string) => void
 }
 
-interface StateProps {
-  variables: Variable[]
-}
-
-interface DispatchProps {
-  hydrateVariables: typeof hydrateVariables
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const VariableToolbar: FunctionComponent<Props> = ({
   variables,
@@ -73,7 +66,7 @@ const VariableToolbar: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const variables = getAllVariables(state)
 
   return {variables: sortVariablesByName(variables)}
@@ -83,4 +76,6 @@ const mdtp = {
   hydrateVariables: hydrateVariables,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(VariableToolbar)
+const connector = connect(mstp, mdtp)
+
+export default connector(VariableToolbar)

--- a/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableTooltipContents.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {executeQueries} from 'src/timeMachine/actions/queries'
@@ -9,15 +9,13 @@ import {executeQueries} from 'src/timeMachine/actions/queries'
 import {Form} from '@influxdata/clockface'
 import VariableDropdown from 'src/variables/components/VariableDropdown'
 
-interface DispatchProps {
-  execute: typeof executeQueries
-}
-
 interface OwnProps {
   variableID: string
 }
 
-type Props = DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+
+type Props = ReduxProps & OwnProps
 
 const VariableTooltipContents: FunctionComponent<Props> = ({
   variableID,
@@ -46,7 +44,6 @@ const mdtp = {
   execute: executeQueries,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(VariableTooltipContents)
+const connector = connect(null, mdtp)
+
+export default connector(VariableTooltipContents)

--- a/ui/src/timeMachine/components/view_options/GaugeOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/GaugeOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Grid} from '@influxdata/clockface'
@@ -33,16 +33,8 @@ interface OwnProps {
   tickSuffix: string
 }
 
-interface DispatchProps {
-  onUpdatePrefix: (prefix: string) => void
-  onUpdateTickPrefix: (tickPrefix: string) => void
-  onUpdateSuffix: (suffix: string) => void
-  onUpdateTickSuffix: (tickSuffix: string) => void
-  onUpdateDecimalPlaces: (decimalPlaces: DecimalPlaces) => void
-  onUpdateColors: (colors: Color[]) => void
-}
-
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class GaugeOptions extends PureComponent<Props> {
   public render() {
@@ -105,7 +97,7 @@ class GaugeOptions extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdatePrefix: setPrefix,
   onUpdateTickPrefix: setTickPrefix,
   onUpdateSuffix: setSuffix,
@@ -114,4 +106,6 @@ const mdtp: DispatchProps = {
   onUpdateColors: setColors,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(null, mdtp)(GaugeOptions)
+const connector = connect(null, mdtp)
+
+export default connector(GaugeOptions)

--- a/ui/src/timeMachine/components/view_options/HeatmapOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/HeatmapOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, ChangeEvent, useState} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {VIRIDIS, MAGMA, INFERNO, PLASMA} from '@influxdata/giraffe'
 import {
   Form,
@@ -53,27 +53,6 @@ const HEATMAP_COLOR_SCHEMES = [
   {name: 'Plasma', colors: PLASMA},
 ]
 
-interface StateProps {
-  xColumn: string
-  yColumn: string
-  numericColumns: string[]
-  timeFormat: string
-}
-
-interface DispatchProps {
-  onSetXColumn: typeof setXColumn
-  onSetYColumn: typeof setYColumn
-  onSetBinSize: typeof setBinSize
-  onSetColors: typeof setColorHexes
-  onSetXDomain: typeof setXDomain
-  onSetYDomain: typeof setYDomain
-  onSetXAxisLabel: typeof setXAxisLabel
-  onSetYAxisLabel: typeof setYAxisLabel
-  onSetPrefix: typeof setAxisPrefix
-  onSetSuffix: typeof setAxisSuffix
-  onSetTimeFormat: typeof setTimeFormat
-}
-
 interface OwnProps {
   xDomain: number[]
   yDomain: number[]
@@ -87,7 +66,8 @@ interface OwnProps {
   binSize: number
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 const HeatmapOptions: FunctionComponent<Props> = props => {
   const [binInputStatus, setBinInputStatus] = useState(ComponentStatus.Default)
@@ -234,7 +214,6 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(HeatmapOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(HeatmapOptions)

--- a/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {SFC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -41,23 +41,6 @@ import {Color} from 'src/types/colors'
 import {AppState} from 'src/types'
 import ColumnSelector from 'src/shared/components/ColumnSelector'
 
-interface StateProps {
-  xColumn: string
-  fillColumns: string[]
-  numericColumns: string[]
-  availableGroupColumns: string[]
-}
-
-interface DispatchProps {
-  onSetXColumn: typeof setXColumn
-  onSetFillColumns: typeof setFillColumns
-  onSetBinCount: typeof setBinCount
-  onSetPosition: typeof setHistogramPosition
-  onSetColors: typeof setColors
-  onSetXDomain: typeof setXDomain
-  onSetXAxisLabel: typeof setXAxisLabel
-}
-
 interface OwnProps {
   position: HistogramPosition
   binCount: number
@@ -66,7 +49,8 @@ interface OwnProps {
   xAxisLabel: string
 }
 
-type Props = OwnProps & DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const HistogramOptions: SFC<Props> = props => {
   const {
@@ -194,7 +178,6 @@ const mdtp = {
   onSetXAxisLabel: setXAxisLabel,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(HistogramOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(HistogramOptions)

--- a/ui/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/LineOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {capitalize} from 'lodash'
 
 // Components
@@ -63,30 +63,8 @@ interface OwnProps {
   position: LinePosition
 }
 
-interface StateProps {
-  xColumn: string
-  yColumn: string
-  numericColumns: string[]
-  timeFormat: string
-}
-
-interface DispatchProps {
-  onUpdateYAxisLabel: typeof setYAxisLabel
-  onUpdateAxisPrefix: typeof setAxisPrefix
-  onUpdateAxisSuffix: typeof setAxisSuffix
-  onUpdateYAxisBounds: typeof setYAxisBounds
-  onUpdateYAxisBase: typeof setYAxisBase
-  onUpdateColors: typeof setColors
-  onSetShadeBelow: typeof setShadeBelow
-  onSetXColumn: typeof setXColumn
-  onSetYColumn: typeof setYColumn
-  onSetGeom: typeof setGeom
-  onSetPosition: typeof setLinePosition
-  onSetTimeFormat: typeof setTimeFormat
-  onSetHoverDimension: typeof SetHoverDimension
-}
-
-type Props = OwnProps & DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class LineOptions extends PureComponent<Props> {
   public render() {
@@ -285,7 +263,7 @@ const mstp = (state: AppState) => {
   return {xColumn, yColumn, numericColumns, timeFormat}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateYAxisLabel: setYAxisLabel,
   onUpdateAxisPrefix: setAxisPrefix,
   onUpdateAxisSuffix: setAxisSuffix,
@@ -301,7 +279,6 @@ const mdtp: DispatchProps = {
   onSetHoverDimension: SetHoverDimension,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(LineOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(LineOptions)

--- a/ui/src/timeMachine/components/view_options/ScatterOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/ScatterOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {SFC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Form, Input, Grid, MultiSelectDropdown} from '@influxdata/clockface'
@@ -43,30 +43,6 @@ import HexColorSchemeDropdown from 'src/shared/components/HexColorSchemeDropdown
 import AutoDomainInput from 'src/shared/components/AutoDomainInput'
 import ColumnSelector from 'src/shared/components/ColumnSelector'
 
-interface StateProps {
-  fillColumns: string[]
-  symbolColumns: string[]
-  availableGroupColumns: string[]
-  xColumn: string
-  yColumn: string
-  numericColumns: string[]
-  timeFormat: string
-}
-
-interface DispatchProps {
-  onSetFillColumns: typeof setFillColumns
-  onSetSymbolColumns: typeof setSymbolColumns
-  onSetColors: typeof setColorHexes
-  onSetYAxisLabel: typeof setYAxisLabel
-  onSetXAxisLabel: typeof setXAxisLabel
-  onUpdateAxisSuffix: typeof setAxisSuffix
-  onUpdateAxisPrefix: typeof setAxisPrefix
-  onSetYDomain: typeof setYDomain
-  onSetXColumn: typeof setXColumn
-  onSetYColumn: typeof setYColumn
-  onSetTimeFormat: typeof setTimeFormat
-}
-
 interface OwnProps {
   xColumn: string
   yColumn: string
@@ -84,7 +60,8 @@ interface OwnProps {
   showNoteWhenEmpty: boolean
 }
 
-type Props = OwnProps & DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 const ScatterOptions: SFC<Props> = props => {
   const {
@@ -221,7 +198,7 @@ const ScatterOptions: SFC<Props> = props => {
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const availableGroupColumns = getGroupableColumns(state)
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
@@ -258,7 +235,5 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(ScatterOptions)
+const connector = connect(mstp, mdtp)
+export default connector(ScatterOptions)

--- a/ui/src/timeMachine/components/view_options/SingleStatOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/SingleStatOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {SFC} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Grid} from '@influxdata/clockface'
@@ -40,16 +40,8 @@ interface StateProps {
   decimalPlaces: DecimalPlaces
 }
 
-interface DispatchProps {
-  onSetPrefix: typeof setPrefix
-  onSetTickPrefix: typeof setTickPrefix
-  onSetSuffix: typeof setSuffix
-  onSetTickSuffix: typeof setTickSuffix
-  onSetDecimalPlaces: typeof setDecimalPlaces
-  onSetColors: typeof setColors
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = StateProps & ReduxProps
 
 const SingleStatOptions: SFC<Props> = props => {
   const {
@@ -119,7 +111,7 @@ const mstp = (state: AppState) => {
   return {colors, prefix, suffix, decimalPlaces, tickPrefix, tickSuffix}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetPrefix: setPrefix,
   onSetTickPrefix: setTickPrefix,
   onSetSuffix: setSuffix,
@@ -128,4 +120,6 @@ const mdtp: DispatchProps = {
   onSetColors: setColors,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(SingleStatOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(SingleStatOptions)

--- a/ui/src/timeMachine/components/view_options/TableOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/TableOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import DecimalPlacesOption from 'src/timeMachine/components/view_options/DecimalPlaces'
@@ -50,19 +50,11 @@ interface StateProps {
   tableOptions: ViewTableOptions
 }
 
-interface DispatchProps {
-  onSetColors: typeof setColors
-  onSetTimeFormat: typeof setTimeFormat
-  onSetFieldOptions: typeof setFieldOptions
-  onUpdateFieldOption: typeof updateFieldOption
-  onSetTableOptions: typeof setTableOptions
-  onSetDecimalPlaces: typeof setDecimalPlaces
-}
-
-type Props = DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = StateProps & ReduxProps
 
 @ErrorHandling
-export class TableOptions extends Component<Props, {}> {
+export class TableOptions extends Component<Props> {
   public render() {
     const {
       timeFormat,
@@ -187,7 +179,7 @@ const mstp = (state: AppState) => {
   return {colors, decimalPlaces, fieldOptions, tableOptions, timeFormat}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onSetDecimalPlaces: setDecimalPlaces,
   onSetColors: setColors,
   onSetFieldOptions: setFieldOptions,
@@ -196,4 +188,6 @@ const mdtp: DispatchProps = {
   onSetTimeFormat: setTimeFormat,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(TableOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(TableOptions)

--- a/ui/src/timeMachine/components/view_options/ThresholdColoring.tsx
+++ b/ui/src/timeMachine/components/view_options/ThresholdColoring.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -29,12 +29,8 @@ interface StateProps {
   colors: Color[]
 }
 
-interface DispatchProps {
-  onSetBackground: typeof setBackgroundThresholdColoring
-  onSetText: typeof setTextThresholdColoring
-}
-
-type Props = StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = StateProps & ReduxProps
 
 class ThresholdColoring extends PureComponent<Props> {
   public render() {
@@ -97,4 +93,6 @@ const mdtp = {
   onSetText: setTextThresholdColoring,
 }
 
-export default connect<StateProps, DispatchProps>(mstp, mdtp)(ThresholdColoring)
+const connector = connect(mstp, mdtp)
+
+export default connector(ThresholdColoring)

--- a/ui/src/timeMachine/components/view_options/ViewOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/ViewOptions.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {setType} from 'src/timeMachine/actions'
@@ -13,17 +13,10 @@ import {Grid, DapperScrollbars} from '@influxdata/clockface'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
-import {View, NewView, AppState} from 'src/types'
+import {AppState} from 'src/types'
 
-interface DispatchProps {
-  onUpdateType: typeof setType
-}
-
-interface StateProps {
-  view: View | NewView
-}
-
-type Props = DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class ViewOptions extends PureComponent<Props> {
   public render() {
@@ -46,14 +39,16 @@ class ViewOptions extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {view} = getActiveTimeMachine(state)
 
   return {view}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateType: setType,
 }
 
-export default connect<StateProps, DispatchProps, {}>(mstp, mdtp)(ViewOptions)
+const connector = connect(mstp, mdtp)
+
+export default connector(ViewOptions)

--- a/ui/src/timeMachine/components/view_options/ViewTypeDropdown.tsx
+++ b/ui/src/timeMachine/components/view_options/ViewTypeDropdown.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Actions
 import {setType} from 'src/timeMachine/actions'
@@ -18,15 +18,8 @@ import {VIS_GRAPHICS} from 'src/timeMachine/constants/visGraphics'
 import {AppState, ViewType} from 'src/types'
 import {ComponentStatus} from 'src/clockface'
 
-interface DispatchProps {
-  onUpdateType: typeof setType | ((type: ViewType) => void)
-}
-
-interface StateProps {
-  viewType: ViewType
-}
-
-type Props = DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
 
 class ViewTypeDropdown extends PureComponent<Props> {
   public render() {
@@ -109,16 +102,16 @@ class ViewTypeDropdown extends PureComponent<Props> {
 
 export {ViewTypeDropdown}
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const {view} = getActiveTimeMachine(state)
 
   return {viewType: view.properties.type}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateType: setType,
 }
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(ViewTypeDropdown)
+
+const connector = connect(mstp, mdtp)
+
+export default connector(ViewTypeDropdown)

--- a/ui/src/variables/components/MapVariableBuilder.tsx
+++ b/ui/src/variables/components/MapVariableBuilder.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 import _ from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Component
 import {
@@ -32,11 +32,8 @@ interface OwnProps {
   selected?: string[]
 }
 
-interface DispatchProps {
-  notify: typeof notifyAction
-}
-
-type Props = DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps
 
 interface State {
   templateValuesString: string
@@ -154,11 +151,10 @@ class MapVariableBuilder extends PureComponent<Props, State> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(MapVariableBuilder)
+const connector = connect(null, mdtp)
+
+export default connector(MapVariableBuilder)

--- a/ui/src/variables/components/RenameVariableForm.tsx
+++ b/ui/src/variables/components/RenameVariableForm.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 import _ from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -31,19 +31,9 @@ interface State {
   isNameValid: boolean
 }
 
-interface StateProps {
-  variables: Variable[]
-  startVariable: Variable
-}
-
-interface DispatchProps {
-  onUpdateVariable: typeof updateVariable
-}
-
-type Props = StateProps &
-  OwnProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string; id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type RouterProps = RouteComponentProps<{orgID: string; id: string}>
+type Props = OwnProps & RouterProps & ReduxProps
 
 class RenameVariableOverlayForm extends PureComponent<Props, State> {
   public state: State = {
@@ -138,20 +128,17 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, {match}: Props): StateProps => {
+const mstp = (state: AppState, {match}: RouterProps) => {
   const variables = getVariables(state)
   const startVariable = variables.find(v => v.id === match.params.id)
 
   return {variables, startVariable}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateVariable: updateVariable,
 }
 
-export default withRouter(
-  connect<StateProps, DispatchProps, OwnProps>(
-    mstp,
-    mdtp
-  )(RenameVariableOverlayForm)
-)
+const connector = connect(mstp, mdtp)
+
+export default withRouter(connector(RenameVariableOverlayForm))

--- a/ui/src/variables/components/UpdateVariableOverlay.tsx
+++ b/ui/src/variables/components/UpdateVariableOverlay.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, FormEvent} from 'react'
-import _ from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -39,18 +38,9 @@ interface State {
   hasValidArgs: boolean
 }
 
-interface StateProps {
-  variables: Variable[]
-  startVariable: Variable
-}
-
-interface DispatchProps {
-  onUpdateVariable: typeof updateVariable
-}
-
-type Props = StateProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string; id: string}>
+type RouterProps = RouteComponentProps<{orgID: string; id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouterProps & ReduxProps
 
 class UpdateVariableOverlay extends PureComponent<Props, State> {
   public state: State = {
@@ -258,17 +248,17 @@ class UpdateVariableOverlay extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, {match}: Props): StateProps => {
+const mstp = (state: AppState, {match}: RouterProps) => {
   const variables = getVariables(state)
   const startVariable = variables.find(v => v.id === match.params.id)
 
   return {variables, startVariable}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onUpdateVariable: updateVariable,
 }
 
-export default withRouter(
-  connect<StateProps, DispatchProps>(mstp, mdtp)(UpdateVariableOverlay)
-)
+const connector = connect(mstp, mdtp)
+
+export default withRouter(connector(UpdateVariableOverlay))

--- a/ui/src/variables/components/VariableCard.tsx
+++ b/ui/src/variables/components/VariableCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -24,12 +24,8 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-interface DispatchProps {
-  onAddVariableLabel: typeof addVariableLabelAsync
-  onRemoveVariableLabel: typeof removeVariableLabelAsync
-}
-
-type Props = OwnProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class VariableCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
@@ -112,12 +108,11 @@ class VariableCard extends PureComponent<
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onAddVariableLabel: addVariableLabelAsync,
   onRemoveVariableLabel: removeVariableLabelAsync,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(withRouter(VariableCard))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(VariableCard))

--- a/ui/src/variables/components/VariableDropdown.tsx
+++ b/ui/src/variables/components/VariableDropdown.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -18,23 +18,14 @@ import {getVariable, normalizeValues} from 'src/variables/selectors'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-interface StateProps {
-  values: string[]
-  selectedValue: string
-  status: RemoteDataState
-}
-
-interface DispatchProps {
-  onSelectValue: typeof selectValue
-}
-
 interface OwnProps {
   variableID: string
   testID?: string
   onSelect?: () => void
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
 
 class VariableDropdown extends PureComponent<Props> {
   render() {
@@ -127,7 +118,7 @@ class VariableDropdown extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState, props: OwnProps): StateProps => {
+const mstp = (state: AppState, props: OwnProps) => {
   const {variableID} = props
   const variable = getVariable(state, variableID)
   const selected =
@@ -144,7 +135,6 @@ const mdtp = {
   onSelectValue: selectValue,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(VariableDropdown)
+const connector = connect(mstp, mdtp)
+
+export default connector(VariableDropdown)

--- a/ui/src/variables/components/VariableExportOverlay.tsx
+++ b/ui/src/variables/components/VariableExportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ExportOverlay from 'src/shared/components/ExportOverlay'
@@ -11,27 +11,9 @@ import {clearExportTemplate as clearExportTemplateAction} from 'src/templates/ac
 
 // Types
 import {AppState} from 'src/types'
-import {DocumentCreate} from '@influxdata/influx'
-import {RemoteDataState} from 'src/types'
 
-interface OwnProps {
-  match: {id: string}
-}
-
-interface DispatchProps {
-  convertToTemplate: typeof convertToTemplateAction
-  clearExportTemplate: typeof clearExportTemplateAction
-}
-
-interface StateProps {
-  variableTemplate: DocumentCreate
-  status: RemoteDataState
-}
-
-type Props = OwnProps &
-  StateProps &
-  DispatchProps &
-  RouteComponentProps<{orgID: string; id: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string; id: string}> & ReduxProps
 
 class VariableExportOverlay extends PureComponent<Props> {
   public componentDidMount() {
@@ -66,17 +48,16 @@ class VariableExportOverlay extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => ({
+const mstp = (state: AppState) => ({
   variableTemplate: state.resources.templates.exportTemplate.item,
   status: state.resources.templates.exportTemplate.status,
 })
 
-const mdtp: DispatchProps = {
+const mdtp = {
   convertToTemplate: convertToTemplateAction,
   clearExportTemplate: clearExportTemplateAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
-  mdtp
-)(withRouter(VariableExportOverlay))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(VariableExportOverlay))

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -197,7 +197,7 @@ export default class VariableForm extends PureComponent<Props, State> {
       selected,
       name,
       arguments: this.activeVariable,
-    })
+    } as any)
 
     onHideOverlay()
   }

--- a/ui/src/variables/components/VariableFormContext.tsx
+++ b/ui/src/variables/components/VariableFormContext.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Utils
 import {
@@ -27,14 +27,7 @@ import {createVariable} from 'src/variables/actions/thunks'
 import VariableForm from 'src/variables/components/VariableForm'
 
 // Types
-import {
-  AppState,
-  VariableArgumentType,
-  QueryArguments,
-  CSVArguments,
-  MapArguments,
-  Variable,
-} from 'src/types'
+import {AppState} from 'src/types'
 
 interface ComponentProps {
   onHideOverlay?: () => void
@@ -42,28 +35,8 @@ interface ComponentProps {
   submitButtonText?: string
 }
 
-interface DispatchProps {
-  onCreateVariable: (
-    variable: Pick<Variable, 'name' | 'arguments' | 'selected'>
-  ) => void
-  onNameUpdate: typeof updateName
-  onTypeUpdate: typeof updateType
-  onQueryUpdate: typeof updateQuery
-  onMapUpdate: typeof updateMap
-  onConstantUpdate: typeof updateConstant
-  onEditorClose: typeof clearEditor
-}
-
-interface StateProps {
-  variables: Variable[]
-  name: string
-  variableType: VariableArgumentType
-  query: QueryArguments
-  map: MapArguments
-  constant: CSVArguments
-}
-
-type Props = ComponentProps & DispatchProps & StateProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ComponentProps & ReduxProps
 
 class VariableFormContext extends PureComponent<Props> {
   render() {
@@ -83,7 +56,7 @@ class VariableFormContext extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const variables = getVariables(state),
     name = extractVariableEditorName(state),
     variableType = extractVariableEditorType(state),
@@ -101,7 +74,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onNameUpdate: updateName,
   onTypeUpdate: updateType,
   onQueryUpdate: updateQuery,
@@ -111,9 +84,8 @@ const mdtp: DispatchProps = {
   onCreateVariable: createVariable,
 }
 
+const connector = connect(mstp, mdtp)
+
 export {Props}
 export {VariableFormContext}
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(VariableFormContext)
+export default connector(VariableFormContext)

--- a/ui/src/variables/components/VariableImportOverlay.tsx
+++ b/ui/src/variables/components/VariableImportOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -25,13 +25,8 @@ interface State {
   status: ComponentStatus
 }
 
-interface DispatchProps {
-  createVariableFromTemplate: typeof createVariableFromTemplateAction
-  getVariables: typeof getVariablesAction
-  notify: typeof notifyAction
-}
-
-type Props = DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 class VariableImportOverlay extends PureComponent<Props> {
   public state: State = {
@@ -79,13 +74,12 @@ class VariableImportOverlay extends PureComponent<Props> {
   }
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   createVariableFromTemplate: createVariableFromTemplateAction,
   getVariables: getVariablesAction,
   notify: notifyAction,
 }
 
-export default connect<{}, DispatchProps, Props>(
-  null,
-  mdtp
-)(withRouter(VariableImportOverlay))
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(VariableImportOverlay))

--- a/ui/src/variables/components/VariablesTab.tsx
+++ b/ui/src/variables/components/VariablesTab.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Utils
@@ -25,15 +24,8 @@ import {ComponentSize} from '@influxdata/clockface'
 import {SortTypes} from 'src/shared/utils/sort'
 import {VariableSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
-interface StateProps {
-  variables: Variable[]
-}
-
-interface DispatchProps {
-  onDeleteVariable: typeof deleteVariable
-}
-
-type Props = StateProps & DispatchProps & RouteComponentProps<{orgID: string}>
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
 
 interface State {
   searchTerm: string
@@ -171,17 +163,16 @@ class VariablesTab extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   const variables = getVariables(state)
 
   return {variables}
 }
 
-const mdtp: DispatchProps = {
+const mdtp = {
   onDeleteVariable: deleteVariable,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
-  mdtp
-)(withRouter(VariablesTab))
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(VariablesTab))

--- a/ui/src/variables/containers/VariablesIndex.tsx
+++ b/ui/src/variables/containers/VariablesIndex.tsx
@@ -69,8 +69,8 @@ class VariablesIndex extends Component<StateProps> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState) => {
   return {org: state.resources.orgs.org}
 }
 
-export default connect<StateProps, {}, {}>(mstp, null)(VariablesIndex)
+export default connect<StateProps>(mstp)(VariablesIndex)

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1095,6 +1095,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.6.tgz#ed8fc802c45b8e8f54419c2d054e55c9ea344356"
   integrity sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1214,12 +1222,14 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-redux@^6.0.9":
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.9.tgz#96aa7f5b0716bcc3bfb36ceaa1223118d509f79a"
-  integrity sha512-LatgnnZ7bG63SmzEqGMjAIP1bN36iaXpb4G7UW3SqpHyo+OQ97MnMXm9BoNi720r61+PvseyIUJN4el4GVhAAg==
+"@types/react-redux@^7.1.9":
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.9.tgz#280c13565c9f13ceb727ec21e767abe0e9b4aec3"
+  integrity sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==
   dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
 "@types/react-router-dom@^5.1.5":


### PR DESCRIPTION
### Why
In order for use to use all the fancy new hooks we get with the upgrades made in #18854, we also need to upgrade `react-redux` types.  There are some pretty great advantages with the new typings.  Specifically, the `connect` function is MUCH smarter and can infer types from `mstp` and `mdtp`.  For more info on the new patterns on typing connected components see:

https://react-redux.js.org/using-react-redux/static-typing

### Notes
The react redux docs recommend using hooks for "connecting" components to the store from here on out.