### PR TITLE
fix(tasks): import from template overlay

### DIFF
--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -54,9 +54,25 @@ from(bucket: "${name}"{rightarrow}
 
     cy.getByTestID('task-save-btn').click()
 
+    cy.getByTestID('notification-success--dismiss').click()
+
     cy.getByTestID('task-card')
       .should('have.length', 1)
       .and('contain', taskName)
+
+    // TODO: extend to create from template overlay
+    cy.getByTestID('add-resource-dropdown--button').click()
+    cy.getByTestID('add-resource-dropdown--template').click()
+    cy.getByTestID('task-import-template--overlay').within(() => {
+      cy.get('.cf-overlay--dismiss').click()
+    })
+
+    // TODO: extend to create a template from JSON
+    cy.getByTestID('add-resource-dropdown--button').click()
+    cy.getByTestID('add-resource-dropdown--import').click()
+    cy.getByTestID('task-import--overlay').within(() => {
+      cy.get('.cf-overlay--dismiss').click()
+    })
   })
   // this test is broken due to a failure on the post route
   it.skip('can create a task using http.post', () => {

--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -55,7 +55,7 @@ class ImportOverlay extends PureComponent<Props, State> {
     const {selectedImportOption} = this.state
 
     return (
-      <Overlay visible={isVisible}>
+      <Overlay visible={isVisible} testID="task-import--overlay">
         <Overlay.Container maxWidth={800}>
           <Form onSubmit={this.submit}>
             <Overlay.Header

--- a/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
+++ b/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
@@ -63,7 +63,7 @@ class TaskImportFromTemplateOverlay extends PureComponent<
 
   render() {
     return (
-      <Overlay visible={true}>
+      <Overlay visible={true} testID="task-import-template--overlay">
         <GetResources resources={[ResourceType.Templates]}>
           <Overlay.Container maxWidth={900}>
             <Overlay.Header
@@ -128,8 +128,8 @@ class TaskImportFromTemplateOverlay extends PureComponent<
   }
 
   private onDismiss = () => {
-    const {history} = this.props
-    history.goBack()
+    const {history, match} = this.props
+    history.push(`/orgs/${match.params.orgID}/tasks`)
   }
 
   private onSubmit = () => {

--- a/ui/src/tasks/components/TemplateBrowserEmpty.tsx
+++ b/ui/src/tasks/components/TemplateBrowserEmpty.tsx
@@ -46,7 +46,7 @@ class TemplateBrowserEmpty extends PureComponent<Props> {
   private handleButtonClick = (): void => {
     const {history, org} = this.props
 
-    history.push(`/orgs/${org.id}/tasks/import`)
+    history.push(`/orgs/${org.id}/settings/templates/import`)
   }
 }
 

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -181,12 +181,12 @@ class TasksPage extends PureComponent<Props, State> {
             component={TaskExportOverlay}
           />
           <Route
-            path="/orgs/:orgID/tasks/import"
-            component={TaskImportOverlay}
+            path="/orgs/:orgID/tasks/import-template"
+            component={TaskImportFromTemplateOverlay}
           />
           <Route
-            path="/orgs/:orgID/tasks/import/template"
-            component={TaskImportFromTemplateOverlay}
+            path="/orgs/:orgID/tasks/import"
+            component={TaskImportOverlay}
           />
         </Switch>
       </>
@@ -232,7 +232,7 @@ class TasksPage extends PureComponent<Props, State> {
       },
     } = this.props
 
-    history.push(`/orgs/${orgID}/tasks/import/template`)
+    history.push(`/orgs/${orgID}/tasks/import-template`)
   }
 
   private summonImportOverlay = (): void => {


### PR DESCRIPTION
Closes influxdata/idpe/issues/7838

### The Problem
`tasks/import` also matches `tasks/import/template`

### The Solution
Changed the route for importing tasks from a template to end in `import-template`.  Also, added non-existent tests that would have easily caught this.  