### PR TITLE
fix: don't overwrite build date set via ldflags

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -31,10 +31,14 @@ const maxTCPConnections = 10
 var (
 	version = "dev"
 	commit  = "none"
-	date    = time.Now().UTC().Format(time.RFC3339)
+	date    = ""
 )
 
 func main() {
+	if len(date) == 0 {
+		date = time.Now().UTC().Format(time.RFC3339)
+	}
+
 	influxCmd := influxCmd()
 	if err := influxCmd.Execute(); err != nil {
 		seeHelp(influxCmd, nil)

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -22,10 +22,14 @@ import (
 var (
 	version = "dev"
 	commit  = "none"
-	date    = fmt.Sprint(time.Now().UTC().Format(time.RFC3339))
+	date    = ""
 )
 
 func main() {
+	if len(date) == 0 {
+		date = time.Now().UTC().Format(time.RFC3339)
+	}
+
 	influxdb.SetBuildInfo(version, commit, date)
 
 	rootCmd := launcher.NewInfluxdCommand(context.Background(),


### PR DESCRIPTION
Closes #18628 

Calling a function on variable definition appears to be run after ldflags are processed, overwriting anything set in the ldflags. This respects any ldflag settings
