### PR TITLE
feat(pkger): make stacks event sourced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0-beta.15 [unreleased]
+
+### Features
+
+1. [18888](https://github.com/influxdata/influxdb/pull/18888): Add event source to influx stack operations 
+
 ## v2.0.0-beta.14 [2020-07-08]
 
 ### Features

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8437,48 +8437,55 @@ components:
           type: string
         orgID:
           type: string
-        name:
-          type: string
-        description:
-          type: string
-        sources:
-          type: array
-          items:
-            type: string
-        resources:
-          type: array
-          items:
-            type: object
-            properties:
-              apiVersion:
-                type: string
-              resourceID:
-                type: string
-              kind:
-                $ref: "#/components/schemas/TemplateKind"
-              templateMetaName:
-                type: string
-              associations:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    kind:
-                      $ref: "#/components/schemas/TemplateKind"
-                    metaName:
-                      type: string
-        urls:
-          type: array
-          items:
-            type: string
         createdAt:
           type: string
           format: date-time
           readOnly: true
-        updatedAt:
-          type: string
-          format: date-time
-          readOnly: true
+        events:
+          type: array
+          items:
+            type: object
+            properties:
+              eventType:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+              sources:
+                type: array
+                items:
+                  type: string
+              resources:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                    resourceID:
+                      type: string
+                    kind:
+                      $ref: "#/components/schemas/TemplateKind"
+                    templateMetaName:
+                      type: string
+                    associations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          kind:
+                            $ref: "#/components/schemas/TemplateKind"
+                          metaName:
+                            type: string
+              urls:
+                type: array
+                items:
+                  type: string
+              updatedAt:
+                type: string
+                format: date-time
+                readOnly: true
     Runs:
       type: object
       properties:

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -394,16 +394,16 @@ func (ex *resourceExporter) getEndpointRule(ctx context.Context, id influxdb.ID)
 }
 
 func (ex *resourceExporter) uniqName() string {
-	return uniqMetaName(ex.nameGen, ex.mPkgNames)
+	return uniqMetaName(ex.nameGen, idGenerator, ex.mPkgNames)
 }
 
-func uniqMetaName(nameGen NameGenerator, existingNames map[string]bool) string {
-	uuid := strings.ToLower(idGenerator.ID().String())
+func uniqMetaName(nameGen NameGenerator, idGen influxdb.IDGenerator, existingNames map[string]bool) string {
+	uuid := strings.ToLower(idGen.ID().String())
 	name := uuid
 	for i := 1; i < 250; i++ {
 		name = fmt.Sprintf("%s-%s", nameGen(), uuid[10:])
 		if !existingNames[name] {
-			return name
+			break
 		}
 	}
 	return name

--- a/pkger/http_server_packages_deprecated.go
+++ b/pkger/http_server_packages_deprecated.go
@@ -138,7 +138,7 @@ func (s *HTTPServerPackages) createStack(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	stack, err := s.svc.InitStack(r.Context(), auth.GetUserID(), Stack{
+	stack, err := s.svc.InitStack(r.Context(), auth.GetUserID(), StackCreate{
 		OrgID:        reqBody.orgID(),
 		Name:         reqBody.Name,
 		Description:  reqBody.Description,
@@ -429,36 +429,5 @@ func (s *HTTPServerPackages) encResp(w http.ResponseWriter, r *http.Request, enc
 			Code: influxdb.EInternal,
 			Err:  err,
 		})
-	}
-}
-
-func convertStackToRespStack(st Stack) RespStack {
-	resources := make([]RespStackResource, 0, len(st.Resources))
-	for _, r := range st.Resources {
-		asses := make([]RespStackResourceAssoc, 0, len(r.Associations))
-		for _, a := range r.Associations {
-			asses = append(asses, RespStackResourceAssoc{
-				Kind:     a.Kind,
-				MetaName: a.MetaName,
-			})
-		}
-		resources = append(resources, RespStackResource{
-			APIVersion:   r.APIVersion,
-			ID:           r.ID.String(),
-			Kind:         r.Kind,
-			MetaName:     r.MetaName,
-			Associations: asses,
-		})
-	}
-
-	return RespStack{
-		ID:          st.ID.String(),
-		OrgID:       st.OrgID.String(),
-		Name:        st.Name,
-		Description: st.Description,
-		Resources:   resources,
-		Sources:     append([]string{}, st.Sources...),
-		URLs:        append([]string{}, st.TemplateURLs...),
-		CRUDLog:     st.CRUDLog,
 	}
 }

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -25,21 +25,45 @@ import (
 // APIVersion marks the current APIVersion for influx packages.
 const APIVersion = "influxdata.com/v2alpha1"
 
+// Stack is an identifier for stateful application of a package(s). This stack
+// will map created resources from the template(s) to existing resources on the
+// platform. This stack is updated only after side effects of applying a template.
+// If the template is applied, and no changes are had, then the stack is not updated.
+type Stack struct {
+	ID        influxdb.ID
+	OrgID     influxdb.ID
+	CreatedAt time.Time `json:"createdAt"`
+	Events    []StackEvent
+}
+
+func (s Stack) LatestEvent() StackEvent {
+	if len(s.Events) == 0 {
+		return StackEvent{}
+	}
+	sort.Slice(s.Events, func(i, j int) bool {
+		return s.Events[i].UpdatedAt.Before(s.Events[j].UpdatedAt)
+	})
+	return s.Events[len(s.Events)-1]
+}
+
 type (
-	// Stack is an identifier for stateful application of a package(s). This stack
-	// will map created resources from the template(s) to existing resources on the
-	// platform. This stack is updated only after side effects of applying a template.
-	// If the template is applied, and no changes are had, then the stack is not updated.
-	Stack struct {
-		ID           influxdb.ID
+	StackEvent struct {
+		EventType    StackEventType
+		Name         string
+		Description  string
+		Sources      []string
+		TemplateURLs []string
+		Resources    []StackResource
+		UpdatedAt    time.Time `json:"updatedAt"`
+	}
+
+	StackCreate struct {
 		OrgID        influxdb.ID
 		Name         string
 		Description  string
 		Sources      []string
 		TemplateURLs []string
 		Resources    []StackResource
-
-		influxdb.CRUDLog
 	}
 
 	// StackResource is a record for an individual resource side effect genereated from
@@ -75,11 +99,32 @@ type (
 	}
 )
 
+type StackEventType uint
+
+const (
+	StackEventCreate StackEventType = iota
+	StackEventUpdate
+	StackEventDelete
+)
+
+func (e StackEventType) String() string {
+	switch e {
+	case StackEventCreate:
+		return "create"
+	case StackEventDelete:
+		return "delete"
+	case StackEventUpdate:
+		return "update"
+	default:
+		return "unknown"
+	}
+}
+
 const ResourceTypeStack influxdb.ResourceType = "stack"
 
 // SVC is the packages service interface.
 type SVC interface {
-	InitStack(ctx context.Context, userID influxdb.ID, stack Stack) (Stack, error)
+	InitStack(ctx context.Context, userID influxdb.ID, stack StackCreate) (Stack, error)
 	DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error
 	ListStacks(ctx context.Context, orgID influxdb.ID, filter ListFilter) ([]Stack, error)
 	ReadStack(ctx context.Context, id influxdb.ID) (Stack, error)
@@ -305,31 +350,40 @@ func NewService(opts ...ServiceSetterFn) *Service {
 // InitStack will create a new stack for the given user and its given org. The stack can be created
 // with urls that point to the location of packages that are included as part of the stack when
 // it is applied.
-func (s *Service) InitStack(ctx context.Context, userID influxdb.ID, stack Stack) (Stack, error) {
-	if err := validURLs(stack.TemplateURLs); err != nil {
+func (s *Service) InitStack(ctx context.Context, userID influxdb.ID, stCreate StackCreate) (Stack, error) {
+	if err := validURLs(stCreate.TemplateURLs); err != nil {
 		return Stack{}, err
 	}
 
-	if _, err := s.orgSVC.FindOrganizationByID(ctx, stack.OrgID); err != nil {
+	if _, err := s.orgSVC.FindOrganizationByID(ctx, stCreate.OrgID); err != nil {
 		if influxdb.ErrorCode(err) == influxdb.ENotFound {
-			msg := fmt.Sprintf("organization dependency does not exist for id[%q]", stack.OrgID.String())
+			msg := fmt.Sprintf("organization dependency does not exist for id[%q]", stCreate.OrgID.String())
 			return Stack{}, influxErr(influxdb.EConflict, msg)
 		}
 		return Stack{}, internalErr(err)
 	}
 
-	stack.ID = s.idGen.ID()
 	now := s.timeGen.Now()
-	stack.CRUDLog = influxdb.CRUDLog{
+	newStack := Stack{
+		ID:        s.idGen.ID(),
+		OrgID:     stCreate.OrgID,
 		CreatedAt: now,
-		UpdatedAt: now,
+		Events: []StackEvent{
+			{
+				EventType:    StackEventCreate,
+				Name:         stCreate.Name,
+				Description:  stCreate.Description,
+				Resources:    stCreate.Resources,
+				TemplateURLs: stCreate.TemplateURLs,
+				UpdatedAt:    now,
+			},
+		},
 	}
-
-	if err := s.store.CreateStack(ctx, stack); err != nil {
+	if err := s.store.CreateStack(ctx, newStack); err != nil {
 		return Stack{}, internalErr(err)
 	}
 
-	return stack, nil
+	return newStack, nil
 }
 
 // DeleteStack removes a stack and all the resources that have are associated with the stack.
@@ -362,7 +416,11 @@ func (s *Service) DeleteStack(ctx context.Context, identifiers struct{ OrgID, Us
 		return err
 	}
 
-	return s.store.DeleteStack(ctx, identifiers.StackID)
+	stack.Events = append(stack.Events, StackEvent{
+		EventType: StackEventDelete,
+		UpdatedAt: s.timeGen.Now(),
+	})
+	return s.store.UpdateStack(ctx, stack)
 }
 
 // ListFilter are filter options for filtering stacks from being returned.
@@ -397,16 +455,18 @@ func (s *Service) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, erro
 }
 
 func (s *Service) applyStackUpdate(existing Stack, upd StackUpdate) Stack {
+	ev := existing.LatestEvent()
+	ev.EventType = StackEventUpdate
+	ev.UpdatedAt = s.timeGen.Now()
 	if upd.Name != nil {
-		existing.Name = *upd.Name
+		ev.Name = *upd.Name
 	}
 	if upd.Description != nil {
-		existing.Description = *upd.Description
+		ev.Description = *upd.Description
 	}
 	if upd.TemplateURLs != nil {
-		existing.TemplateURLs = upd.TemplateURLs
+		ev.TemplateURLs = upd.TemplateURLs
 	}
-	existing.UpdatedAt = s.timeGen.Now()
 
 	type key struct {
 		k  Kind
@@ -414,11 +474,13 @@ func (s *Service) applyStackUpdate(existing Stack, upd StackUpdate) Stack {
 	}
 	mExistingResources := make(map[key]bool)
 	mExistingNames := make(map[string]bool)
-	for _, r := range existing.Resources {
+	for _, r := range ev.Resources {
 		k := key{k: r.Kind, id: r.ID}
 		mExistingResources[k] = true
 		mExistingNames[r.MetaName] = true
 	}
+
+	var out []StackResource
 	for _, r := range upd.AdditionalResources {
 		k := key{k: r.Kind, id: r.ID}
 		if mExistingResources[k] {
@@ -433,12 +495,15 @@ func (s *Service) applyStackUpdate(existing Stack, upd StackUpdate) Stack {
 
 		metaName := r.MetaName
 		if metaName == "" || mExistingNames[metaName] {
-			metaName = uniqMetaName(s.nameGen, mExistingNames)
+			metaName = uniqMetaName(s.nameGen, s.idGen, mExistingNames)
 		}
 		mExistingNames[metaName] = true
 		sr.MetaName = metaName
-		existing.Resources = append(existing.Resources, sr)
+
+		out = append(out, sr)
 	}
+	ev.Resources = out
+	existing.Events = append(existing.Events, ev)
 	return existing
 }
 
@@ -525,7 +590,7 @@ func (s *Service) Export(ctx context.Context, setters ...ExportOptFn) (*Template
 		}
 
 		var opts []ExportOptFn
-		for _, r := range stack.Resources {
+		for _, r := range stack.LatestEvent().Resources {
 			opts = append(opts, ExportWithExistingResources(ResourceToClone{
 				Kind:     r.Kind,
 				ID:       r.ID,
@@ -1409,7 +1474,7 @@ func (s *Service) Apply(ctx context.Context, orgID, userID influxdb.ID, opts ...
 	stackID := opt.StackID
 	// if stackID is not provided, a stack will be provided for the application.
 	if stackID == 0 {
-		newStack, err := s.InitStack(ctx, userID, Stack{OrgID: orgID})
+		newStack, err := s.InitStack(ctx, userID, StackCreate{OrgID: orgID})
 		if err != nil {
 			return ImpactSummary{}, err
 		}
@@ -2910,8 +2975,9 @@ func (s *Service) getStackRemoteTemplates(ctx context.Context, stackID influxdb.
 		return nil, err
 	}
 
+	lastEvent := stack.LatestEvent()
 	var remotes []*Template
-	for _, rawURL := range stack.TemplateURLs {
+	for _, rawURL := range lastEvent.TemplateURLs {
 		u, err := url.Parse(rawURL)
 		if err != nil {
 			return nil, &influxdb.Error{
@@ -3062,10 +3128,12 @@ func (s *Service) updateStackAfterSuccess(ctx context.Context, stackID influxdb.
 			Associations: stateLabelsToStackAssociations(v.labels()),
 		})
 	}
-	stack.Resources = stackResources
-
-	stack.Sources = sources
-	stack.UpdatedAt = time.Now()
+	ev := stack.LatestEvent()
+	ev.EventType = StackEventUpdate
+	ev.Resources = stackResources
+	ev.Sources = sources
+	ev.UpdatedAt = s.timeGen.Now()
+	stack.Events = append(stack.Events, ev)
 	return s.store.UpdateStack(ctx, stack)
 }
 
@@ -3083,10 +3151,11 @@ func (s *Service) updateStackAfterRollback(ctx context.Context, stackID influxdb
 		return key{k: k, metaName: metaName}
 	}
 
+	latestEvent := stack.LatestEvent()
 	existingResources := make(map[key]*StackResource)
-	for i := range stack.Resources {
-		res := stack.Resources[i]
-		existingResources[newKey(res.Kind, res.MetaName)] = &stack.Resources[i]
+	for i := range latestEvent.Resources {
+		res := latestEvent.Resources[i]
+		existingResources[newKey(res.Kind, res.MetaName)] = &latestEvent.Resources[i]
 	}
 
 	hasChanges := false
@@ -3182,7 +3251,10 @@ func (s *Service) updateStackAfterRollback(ctx context.Context, stackID influxdb
 		return nil
 	}
 
-	stack.UpdatedAt = time.Now()
+	latestEvent.EventType = StackEventUpdate
+	latestEvent.Sources = sources
+	latestEvent.UpdatedAt = s.timeGen.Now()
+	stack.Events = append(stack.Events, latestEvent)
 	return s.store.UpdateStack(ctx, stack)
 }
 

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -28,7 +28,7 @@ func MWAuth(authAgent AuthAgent) SVCMiddleware {
 	}
 }
 
-func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (Stack, error) {
+func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack StackCreate) (Stack, error) {
 	err := s.authAgent.IsWritable(ctx, newStack.OrgID, ResourceTypeStack)
 	if err != nil {
 		return Stack{}, err

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -25,7 +25,7 @@ func MWLogging(log *zap.Logger) SVCMiddleware {
 
 var _ SVC = (*loggingMW)(nil)
 
-func (s *loggingMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (stack Stack, err error) {
+func (s *loggingMW) InitStack(ctx context.Context, userID influxdb.ID, newStack StackCreate) (stack Stack, err error) {
 	defer func(start time.Time) {
 		if err == nil {
 			return

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -32,7 +32,7 @@ func MWMetrics(reg *prom.Registry) SVCMiddleware {
 	}
 }
 
-func (s *mwMetrics) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (Stack, error) {
+func (s *mwMetrics) InitStack(ctx context.Context, userID influxdb.ID, newStack StackCreate) (Stack, error) {
 	rec := s.rec.Record("init_stack")
 	stack, err := s.next.InitStack(ctx, userID, newStack)
 	return stack, rec(err)

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -430,7 +430,7 @@ func (s *stateCoordinator) addStackState(stack Stack) {
 		s.reconcileNotificationDependencies,
 	}
 	for _, reconcileFn := range reconcilers {
-		reconcileFn(stack.Resources)
+		reconcileFn(stack.LatestEvent().Resources)
 	}
 }
 

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -21,7 +21,7 @@ func MWTracing() SVCMiddleware {
 
 var _ SVC = (*traceMW)(nil)
 
-func (s *traceMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Stack) (Stack, error) {
+func (s *traceMW) InitStack(ctx context.Context, userID influxdb.ID, newStack StackCreate) (Stack, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	return s.next.InitStack(ctx, userID, newStack)

--- a/pkger/store_test.go
+++ b/pkger/store_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/inmem"
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/pkger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestStoreKV(t *testing.T) {
@@ -29,32 +30,35 @@ func TestStoreKV(t *testing.T) {
 			"http://abc.gov",
 		}
 		return pkger.Stack{
-			ID:          id,
-			OrgID:       orgID,
-			Name:        "threeve",
-			Description: "desc",
-			CRUDLog: influxdb.CRUDLog{
-				CreatedAt: now,
-				UpdatedAt: now.Add(time.Hour),
-			},
-			Sources:      urls,
-			TemplateURLs: urls,
-			Resources: []pkger.StackResource{
+			ID:        id,
+			OrgID:     orgID,
+			CreatedAt: now,
+			Events: []pkger.StackEvent{
 				{
-					APIVersion: pkger.APIVersion,
-					ID:         9000,
-					Kind:       pkger.KindBucket,
-					MetaName:   "buzz lightyear",
-					Associations: []pkger.StackResourceAssociation{{
-						Kind:     pkger.KindLabel,
-						MetaName: "foo_label",
-					}},
-				},
-				{
-					APIVersion: pkger.APIVersion,
-					ID:         333,
-					Kind:       pkger.KindBucket,
-					MetaName:   "beyond",
+					EventType:    pkger.StackEventCreate,
+					Name:         "threeve",
+					Description:  "desc",
+					UpdatedAt:    now.Add(time.Hour),
+					Sources:      urls,
+					TemplateURLs: urls,
+					Resources: []pkger.StackResource{
+						{
+							APIVersion: pkger.APIVersion,
+							ID:         9000,
+							Kind:       pkger.KindBucket,
+							MetaName:   "buzz lightyear",
+							Associations: []pkger.StackResourceAssociation{{
+								Kind:     pkger.KindLabel,
+								MetaName: "foo_label",
+							}},
+						},
+						{
+							APIVersion: pkger.APIVersion,
+							ID:         333,
+							Kind:       pkger.KindBucket,
+							MetaName:   "beyond",
+						},
+					},
 				},
 			},
 		}
@@ -103,22 +107,30 @@ func TestStoreKV(t *testing.T) {
 			pkger.Stack{
 				ID:    1,
 				OrgID: orgID1,
-				Name:  "first_name",
+				Events: []pkger.StackEvent{{
+					Name: "first_name",
+				}},
 			},
 			pkger.Stack{
 				ID:    2,
 				OrgID: orgID2,
-				Name:  "first_name",
+				Events: []pkger.StackEvent{{
+					Name: "first_name",
+				}},
 			},
 			pkger.Stack{
 				ID:    3,
 				OrgID: orgID1,
-				Name:  "second_name",
+				Events: []pkger.StackEvent{{
+					Name: "second_name",
+				}},
 			},
 			pkger.Stack{
 				ID:    4,
 				OrgID: orgID2,
-				Name:  "second_name",
+				Events: []pkger.StackEvent{{
+					Name: "second_name",
+				}},
 			},
 		)
 
@@ -135,12 +147,16 @@ func TestStoreKV(t *testing.T) {
 					{
 						ID:    1,
 						OrgID: orgID1,
-						Name:  "first_name",
+						Events: []pkger.StackEvent{{
+							Name: "first_name",
+						}},
 					},
 					{
 						ID:    3,
 						OrgID: orgID1,
-						Name:  "second_name",
+						Events: []pkger.StackEvent{{
+							Name: "second_name",
+						}},
 					},
 				},
 			},
@@ -154,12 +170,16 @@ func TestStoreKV(t *testing.T) {
 					{
 						ID:    1,
 						OrgID: orgID1,
-						Name:  "first_name",
+						Events: []pkger.StackEvent{{
+							Name: "first_name",
+						}},
 					},
 					{
 						ID:    3,
 						OrgID: orgID1,
-						Name:  "second_name",
+						Events: []pkger.StackEvent{{
+							Name: "second_name",
+						}},
 					},
 				},
 			},
@@ -172,7 +192,9 @@ func TestStoreKV(t *testing.T) {
 				expected: []pkger.Stack{{
 					ID:    1,
 					OrgID: orgID1,
-					Name:  "first_name",
+					Events: []pkger.StackEvent{{
+						Name: "first_name",
+					}},
 				}},
 			},
 			{
@@ -184,7 +206,9 @@ func TestStoreKV(t *testing.T) {
 				expected: []pkger.Stack{{
 					ID:    1,
 					OrgID: orgID1,
-					Name:  "first_name",
+					Events: []pkger.StackEvent{{
+						Name: "first_name",
+					}},
 				}},
 			},
 			{
@@ -196,7 +220,9 @@ func TestStoreKV(t *testing.T) {
 				expected: []pkger.Stack{{
 					ID:    1,
 					OrgID: orgID1,
-					Name:  "first_name",
+					Events: []pkger.StackEvent{{
+						Name: "first_name",
+					}},
 				}},
 			},
 			{
@@ -210,12 +236,16 @@ func TestStoreKV(t *testing.T) {
 					{
 						ID:    1,
 						OrgID: orgID1,
-						Name:  "first_name",
+						Events: []pkger.StackEvent{{
+							Name: "first_name",
+						}},
 					},
 					{
 						ID:    3,
 						OrgID: orgID1,
-						Name:  "second_name",
+						Events: []pkger.StackEvent{{
+							Name: "second_name",
+						}},
 					},
 				},
 			},
@@ -265,18 +295,22 @@ func TestStoreKV(t *testing.T) {
 		seedEntities(t, storeKV, expected)
 
 		t.Run("with valid ID updates stack successfully", func(t *testing.T) {
-			updateStack := expected
-			updateStack.Resources = append(updateStack.Resources, pkger.StackResource{
+			expected := stackStub(id, orgID)
+			event := expected.LatestEvent()
+			event.EventType = pkger.StackEventUpdate
+			event.UpdatedAt = event.UpdatedAt.Add(time.Hour)
+			event.Resources = append(event.Resources, pkger.StackResource{
 				APIVersion: pkger.APIVersion,
 				ID:         333,
 				Kind:       pkger.KindBucket,
 				MetaName:   "beyond",
 			})
+			expected.Events = append(expected.Events, event)
 
-			err := storeKV.UpdateStack(context.Background(), updateStack)
+			err := storeKV.UpdateStack(context.Background(), expected)
 			require.NoError(t, err)
 
-			readStackEqual(t, storeKV, updateStack)
+			readStackEqual(t, storeKV, expected)
 		})
 
 		t.Run("when no match found fails with not found error", func(t *testing.T) {


### PR DESCRIPTION
this PR is a bit of a monster. It upends all the stacks to be event sourced (sorta). The idea is this. We track each change to a stack, create/update/delete. When we retrieve the stack, it has all the details for that stack's operations.  

Things that are painful... working with a kv store here. Having a relational store here would have been super nice. We can order stacks listed coherently without having to force the app layer to get into the kv store weeds. Will take this as a follow up action item to see if I can make this a forcing function for using a relational store. Boy would that make this a thing of beauty.

closes: #18874

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)