### PR TITLE
fix: allow custom set y-axis min to be 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ### Features
 
-1. [18888](https://github.com/influxdata/influxdb/pull/18888): Add event source to influx stack operations 
+1. [18888](https://github.com/influxdata/influxdb/pull/18888): Add event source to influx stack operations
+
+### Bug Fixes
+
+1. [18891](https://github.com/influxdata/influxdb/pull/18891): Allow 0 to be the custom set minimum value for Y Domain
 
 ## v2.0.0-beta.14 [2020-07-08]
 
 ### Features
 
 1. [18758](https://github.com/influxdata/influxdb/pull/18758): Extend influx stacks update cmd with ability to add resources without apply template
-1. [18793](https://github.com/influxdata/influxdb/pull/18793): Normalize InfluxDB templates under new /api/v2/templates and /api/v2/stacks public API 
-1. [18818](https://github.com/influxdata/influxdb/pull/18818): Extend template Summary and Diff nested types with kind identifiers 
+1. [18793](https://github.com/influxdata/influxdb/pull/18793): Normalize InfluxDB templates under new /api/v2/templates and /api/v2/stacks public API
+1. [18818](https://github.com/influxdata/influxdb/pull/18818): Extend template Summary and Diff nested types with kind identifiers
 1. [18857](https://github.com/influxdata/influxdb/pull/18857): Flux updated to v0.71.1
 1. [18805](https://github.com/influxdata/influxdb/pull/18805): Added static builds for Linux
 
@@ -19,7 +23,6 @@
 1. [18878](https://github.com/influxdata/influxdb/pull/18878): Don't overwrite build date set via ldflags
 1. [18842](https://github.com/influxdata/influxdb/pull/18842): Fixed an issue where define query was unusable after importing a Check
 1. [18845](https://github.com/influxdata/influxdb/pull/18845): Update documentation links
-
 
 ## v2.0.0-beta.13 [2020-06-25]
 

--- a/ui/src/shared/utils/useVisDomainSettings.test.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.test.ts
@@ -14,9 +14,11 @@ describe('getValidRange', () => {
   const unixStart: number = 1573094811000
   const endTime: string = '2019-11-28T14:46:51Z'
   const unixEnd: number = 1574952411000
+
   it('should return null when no parameters are input', () => {
     expect(getValidRange(undefined, undefined)).toEqual(null)
   })
+
   it('should return null when no data is passed', () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
@@ -25,6 +27,7 @@ describe('getValidRange', () => {
     }
     expect(getValidRange([], timeRange)).toEqual(null)
   })
+
   it("should return the startTime as startTime if it's before the first time in the data array", () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
@@ -37,6 +40,7 @@ describe('getValidRange', () => {
     const [beginning] = getValidRange(data, timeRange)
     expect(beginning).toEqual(data[0])
   })
+
   it("should return the endTime as endTime if it's before the last time in the data array", () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
@@ -50,6 +54,7 @@ describe('getValidRange', () => {
     const newRange = getValidRange(data, timeRange)
     expect(newRange[1]).toEqual(data[data.length - 1])
   })
+
   it('should return the start and end times based on the data array if no start / endTime are passed', () => {
     expect(getValidRange(data, null)).toEqual([data[0], data[data.length - 1]])
   })
@@ -59,10 +64,11 @@ describe('getRemainingRange', () => {
   const startTime: string = '2019-11-07T02:46:51Z'
   const unixStart: number = 1573094811000
   const endTime: string = '2019-11-28T14:46:51Z'
-  const unixEnd: number = 1574952411000
+
   it('should return null when no parameters are input', () => {
     expect(getRemainingRange(undefined, undefined, undefined)).toEqual(null)
   })
+
   it('should return null when no data is passed', () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
@@ -71,71 +77,85 @@ describe('getRemainingRange', () => {
     }
     expect(getRemainingRange([], timeRange, [null, null])).toEqual(null)
   })
+
   describe('should return a valid number from the stored domain as the min y-axis', () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
       lower: startTime,
       upper: endTime,
     }
+
     it('should handle a positive integer', () => {
       const setMin = unixStart - 10
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle a negative integer', () => {
       const setMin = -10
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle a positive float', () => {
       const setMin = Math.PI
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle a negative float', () => {
       const setMin = -35.67
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle zero', () => {
       const setMin = 0
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle positive zero', () => {
       const setMin = +0
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
+
     it('should handle negative zero', () => {
       const setMin = -0
       const [start] = getRemainingRange(data, timeRange, [setMin, null])
       expect(start).toEqual(setMin)
     })
   })
+
   describe('should return the min value of the data set if stored domain is not set to valid number', () => {
     let dummyData = [6, 1, 10, 20]
     let timeRange = null
+
     it('should handle NaN', () => {
       const setMin = NaN
       const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
       expect(start).toEqual(Math.min(...dummyData))
     })
+
     it('should handle Infinity', () => {
       const setMin = Infinity
       const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
       expect(start).toEqual(Math.min(...dummyData))
     })
+
     it('should handle positive Infinity', () => {
       const setMin = +Infinity
       const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
       expect(start).toEqual(Math.min(...dummyData))
     })
+
     it('should handle negative Infinity', () => {
       const setMin = -Infinity
       const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
       expect(start).toEqual(Math.min(...dummyData))
     })
+
     it('should include time range for determining min value', () => {
       timeRange = {
         type: 'custom',
@@ -150,6 +170,7 @@ describe('getRemainingRange', () => {
       expect(start).toEqual(startTimeValue)
     })
   })
+
   describe('should return a valid number from the stored domain as the max y-axis', () => {
     const timeRange = null
     it('should handle a positive integer', () => {
@@ -157,60 +178,72 @@ describe('getRemainingRange', () => {
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle a negative integer', () => {
       const setMax = -10
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle a positive float', () => {
       const setMax = Math.PI
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle a negative float', () => {
       const setMax = -35.67
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle zero', () => {
       const setMax = 0
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle positive zero', () => {
       const setMax = +0
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
+
     it('should handle negative zero', () => {
       const setMax = -0
       const range = getRemainingRange(data, timeRange, [null, setMax])
       expect(range[1]).toEqual(setMax)
     })
   })
+
   describe('should return the max value of the data set if stored domain is not set to valid number', () => {
     let dummyData = [6, 100, 10, 20]
     let timeRange = null
+
     it('should handle NaN', () => {
       const setMax = NaN
       const range = getRemainingRange(dummyData, timeRange, [null, setMax])
       expect(range[1]).toEqual(Math.max(...dummyData))
     })
+
     it('should handle Infinity', () => {
       const setMax = Infinity
       const range = getRemainingRange(dummyData, timeRange, [null, setMax])
       expect(range[1]).toEqual(Math.max(...dummyData))
     })
+
     it('should handle positive Infinity', () => {
       const setMax = +Infinity
       const range = getRemainingRange(dummyData, timeRange, [null, setMax])
       expect(range[1]).toEqual(Math.max(...dummyData))
     })
+
     it('should handle negative Infinity', () => {
       const setMax = -Infinity
       const range = getRemainingRange(dummyData, timeRange, [null, setMax])
       expect(range[1]).toEqual(Math.max(...dummyData))
     })
+
     it('should include time range for determining max value', () => {
       timeRange = {
         type: 'custom',

--- a/ui/src/shared/utils/useVisDomainSettings.test.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.test.ts
@@ -56,7 +56,6 @@ describe('getValidRange', () => {
 })
 
 describe('getRemainingRange', () => {
-  // const startTime: string = 'Nov 07 2019 02:46:51 GMT-0800'
   const startTime: string = '2019-11-07T02:46:51Z'
   const unixStart: number = 1573094811000
   const endTime: string = '2019-11-28T14:46:51Z'
@@ -72,24 +71,158 @@ describe('getRemainingRange', () => {
     }
     expect(getRemainingRange([], timeRange, [null, null])).toEqual(null)
   })
-  it("should return the min y-axis if it's set", () => {
+  describe('should return a valid number from the stored domain as the min y-axis', () => {
     const timeRange: CustomTimeRange = {
       type: 'custom',
       lower: startTime,
       upper: endTime,
     }
-    const setMin = unixStart - 10
-    const [start] = getRemainingRange(data, timeRange, [setMin, null])
-    expect(start).toEqual(setMin)
+    it('should handle a positive integer', () => {
+      const setMin = unixStart - 10
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle a negative integer', () => {
+      const setMin = -10
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle a positive float', () => {
+      const setMin = Math.PI
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle a negative float', () => {
+      const setMin = -35.67
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle zero', () => {
+      const setMin = 0
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle positive zero', () => {
+      const setMin = +0
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
+    it('should handle negative zero', () => {
+      const setMin = -0
+      const [start] = getRemainingRange(data, timeRange, [setMin, null])
+      expect(start).toEqual(setMin)
+    })
   })
-  it("should return the max y-axis if it's set", () => {
-    const timeRange: CustomTimeRange = {
-      type: 'custom',
-      lower: startTime,
-      upper: endTime,
-    }
-    const setMax = unixEnd + 10
-    const range = getRemainingRange(data, timeRange, [null, setMax])
-    expect(range[1]).toEqual(setMax)
+  describe('should return the min value of the data set if stored domain is not set to valid number', () => {
+    let dummyData = [6, 1, 10, 20]
+    let timeRange = null
+    it('should handle NaN', () => {
+      const setMin = NaN
+      const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
+      expect(start).toEqual(Math.min(...dummyData))
+    })
+    it('should handle Infinity', () => {
+      const setMin = Infinity
+      const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
+      expect(start).toEqual(Math.min(...dummyData))
+    })
+    it('should handle positive Infinity', () => {
+      const setMin = +Infinity
+      const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
+      expect(start).toEqual(Math.min(...dummyData))
+    })
+    it('should handle negative Infinity', () => {
+      const setMin = -Infinity
+      const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
+      expect(start).toEqual(Math.min(...dummyData))
+    })
+    it('should include time range for determining min value', () => {
+      timeRange = {
+        type: 'custom',
+        lower: startTime,
+        upper: endTime,
+      } as CustomTimeRange
+      const startTimeValue = Date.parse(startTime)
+      const endTimeValue = Date.parse(endTime)
+      dummyData = [startTimeValue + 10, endTimeValue - 10]
+      const setMin = NaN
+      const [start] = getRemainingRange(dummyData, timeRange, [setMin, null])
+      expect(start).toEqual(startTimeValue)
+    })
+  })
+  describe('should return a valid number from the stored domain as the max y-axis', () => {
+    const timeRange = null
+    it('should handle a positive integer', () => {
+      const setMax = unixStart - 10
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle a negative integer', () => {
+      const setMax = -10
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle a positive float', () => {
+      const setMax = Math.PI
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle a negative float', () => {
+      const setMax = -35.67
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle zero', () => {
+      const setMax = 0
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle positive zero', () => {
+      const setMax = +0
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+    it('should handle negative zero', () => {
+      const setMax = -0
+      const range = getRemainingRange(data, timeRange, [null, setMax])
+      expect(range[1]).toEqual(setMax)
+    })
+  })
+  describe('should return the max value of the data set if stored domain is not set to valid number', () => {
+    let dummyData = [6, 100, 10, 20]
+    let timeRange = null
+    it('should handle NaN', () => {
+      const setMax = NaN
+      const range = getRemainingRange(dummyData, timeRange, [null, setMax])
+      expect(range[1]).toEqual(Math.max(...dummyData))
+    })
+    it('should handle Infinity', () => {
+      const setMax = Infinity
+      const range = getRemainingRange(dummyData, timeRange, [null, setMax])
+      expect(range[1]).toEqual(Math.max(...dummyData))
+    })
+    it('should handle positive Infinity', () => {
+      const setMax = +Infinity
+      const range = getRemainingRange(dummyData, timeRange, [null, setMax])
+      expect(range[1]).toEqual(Math.max(...dummyData))
+    })
+    it('should handle negative Infinity', () => {
+      const setMax = -Infinity
+      const range = getRemainingRange(dummyData, timeRange, [null, setMax])
+      expect(range[1]).toEqual(Math.max(...dummyData))
+    })
+    it('should include time range for determining max value', () => {
+      timeRange = {
+        type: 'custom',
+        lower: startTime,
+        upper: endTime,
+      } as CustomTimeRange
+      const startTimeValue = Date.parse(startTime)
+      const endTimeValue = Date.parse(endTime)
+      dummyData = [startTimeValue + 10, endTimeValue - 10]
+      const setMax = NaN
+      const range = getRemainingRange(dummyData, timeRange, [null, setMax])
+      expect(range[1]).toEqual(endTimeValue)
+    })
   })
 })

--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -1,7 +1,7 @@
 // Libraries
 import {useMemo} from 'react'
 import {NumericColumnData} from '@influxdata/giraffe'
-import {isNull} from 'lodash'
+import {isNull, isNumber} from 'lodash'
 
 // Utils
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
@@ -55,6 +55,10 @@ export const useVisXDomainSettings = (
   return [domain, setDomain, resetDomain]
 }
 
+const isValidStoredDomainValue = (value): boolean => {
+  return isNumber(value) && !Number.isNaN(value) && Number.isFinite(value)
+}
+
 export const getRemainingRange = (
   data: NumericColumnData = [],
   timeRange: TimeRange | null,
@@ -64,10 +68,12 @@ export const getRemainingRange = (
   if (Array.isArray(range) && range.length >= 2) {
     const startTime = getStartTime(timeRange)
     const endTime = getEndTime(timeRange)
-    const start = storedDomain[0]
+    const start = isValidStoredDomainValue(storedDomain[0])
       ? storedDomain[0]
       : Math.min(startTime, range[0])
-    const end = storedDomain[1] ? storedDomain[1] : Math.max(endTime, range[1])
+    const end = isValidStoredDomainValue(storedDomain[1])
+      ? storedDomain[1]
+      : Math.max(endTime, range[1])
     return [start, end]
   }
   return range


### PR DESCRIPTION
Closes #18853 

0 is a falsy value and was considered an unallowable custom set minimum value. We will allow 0 and guard against NaN and Infinity instead.
