### PR TITLE
feat(tsdb): Add CreatedAt field for tsm1.FileStat

### DIFF
--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -230,6 +230,7 @@ type FileStat struct {
 	Path             string
 	HasTombstone     bool
 	Size             uint32
+	CreatedAt        int64
 	LastModified     int64
 	MinTime, MaxTime int64
 	MinKey, MaxKey   []byte

--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -457,7 +457,8 @@ func (t *TSMReader) Stats() FileStat {
 	return FileStat{
 		Path:         t.Path(),
 		Size:         t.Size(),
-		LastModified: t.LastModified(),
+		CreatedAt:    t.lastModified,   // tsm file only
+		LastModified: t.LastModified(), // tsm file & tombstones
 		MinTime:      minTime,
 		MaxTime:      maxTime,
 		MinKey:       minKey,

--- a/tsdb/tsm1/tombstone.go
+++ b/tsdb/tsm1/tombstone.go
@@ -276,6 +276,7 @@ func (t *Tombstoner) TombstoneFiles() []FileStat {
 	t.mu.Lock()
 	t.fileStats = append(t.fileStats[:0], FileStat{
 		Path:         t.tombstonePath(),
+		CreatedAt:    stat.ModTime().UnixNano(),
 		LastModified: stat.ModTime().UnixNano(),
 		Size:         uint32(stat.Size()),
 	})


### PR DESCRIPTION
This pull request adds a "created at" field to `tsm1.FileStat` which uses the `ModTime()` of the TSM file but excludes any updates for tombstone files.