### PR TITLE
fix: descending array cursor should include end time

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -760,6 +760,25 @@ func TestQueryPushDowns(t *testing.T) {
 		want  string
 	}{
 		{
+			name: "range last single point start time",
+			data: []string{
+				"m,tag=a f=1i 1",
+			},
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00.000000001Z, stop: 1970-01-01T01:00:00Z)
+	|> last()
+`,
+			op: "readWindow(last)",
+			want: `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,tag
+,,0,1970-01-01T00:00:00.000000001Z,1970-01-01T01:00:00Z,1970-01-01T00:00:00.000000001Z,1,f,m,a
+`,
+		},
+		{
 			name: "window last",
 			data: []string{
 				"m0,k=k0 f=0i 0",

--- a/tsdb/tsm1/array_cursor.gen.go
+++ b/tsdb/tsm1/array_cursor.gen.go
@@ -293,9 +293,11 @@ func (c *floatArrayDescendingCursor) Next() *cursors.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -603,9 +605,11 @@ func (c *integerArrayDescendingCursor) Next() *cursors.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -913,9 +917,11 @@ func (c *unsignedArrayDescendingCursor) Next() *cursors.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -1225,9 +1231,11 @@ func (c *stringArrayDescendingCursor) Next() *cursors.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -1537,9 +1545,11 @@ func (c *booleanArrayDescendingCursor) Next() *cursors.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/tsm1/array_cursor.gen.go.tmpl
+++ b/tsdb/tsm1/array_cursor.gen.go.tmpl
@@ -300,9 +300,11 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// If the earliest timestamp is strictly earlier than
+	// the end time, remove it from the result and repeat.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++


### PR DESCRIPTION
Previously a descending array cursor excluded points whose timestamps were equal to the end time, i.e the beginning of the range. This bug only recently showed up because until now we haven't been using descending array cursors at all. However we recently enabled pushing down `last()` to storage which does in fact use them.