### PR TITLE
feat(tsdb): SHOW TAG KEYS (no time) query using only TSI data.

### DIFF
--- a/storage/engine_measurement_notime_schema.go
+++ b/storage/engine_measurement_notime_schema.go
@@ -25,6 +25,24 @@ func (e *Engine) MeasurementNamesNoTime(ctx context.Context, orgID, bucketID inf
 	return e.engine.MeasurementNamesNoTime(ctx, orgID, bucketID, predicate)
 }
 
+// MeasurementTagKeysNoTime returns an iterator which enumerates the tag keys
+// for the given bucket, measurement and tag key and filtered using the optional
+// the predicate.
+//
+// MeasurementTagKeysNoTime will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementTagKeysNoTime has finished processing, a non-nil
+// error will be returned along with statistics for the already scanned data.
+func (e *Engine) MeasurementTagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID, measurement, tagKey string, predicate influxql.Expr) (cursors.StringIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	return e.engine.MeasurementTagKeysNoTime(ctx, orgID, bucketID, measurement, predicate)
+}
+
 // MeasurementTagValuesNoTime returns an iterator which enumerates the tag values for the given
 // bucket, measurement and tag key and filtered using the optional the predicate.
 //

--- a/tsdb/tsm1/engine_measurement_notime_schema.go
+++ b/tsdb/tsm1/engine_measurement_notime_schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/cursors"
+	"github.com/influxdata/influxdb/v2/tsdb/seriesfile"
 	"github.com/influxdata/influxql"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -239,4 +240,83 @@ func (e *Engine) fieldsNoTime(ctx context.Context, orgID, bucketID influxdb.ID, 
 	}
 
 	return cursors.NewMeasurementFieldsSliceIterator([]cursors.MeasurementFields{{Fields: vals}}), nil
+}
+
+// MeasurementTagKeysNoTime returns an iterator which enumerates the tag keys
+// for the given bucket, measurement and tag key and filtered using the optional
+// the predicate.
+//
+// MeasurementTagKeysNoTime will always return a StringIterator if there is no error.
+//
+// If the context is canceled before MeasurementTagKeysNoTime has finished
+// processing, a non-nil error will be returned along with statistics for the
+// already scanned data.
+func (e *Engine) MeasurementTagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID, measurement string, predicate influxql.Expr) (cursors.StringIterator, error) {
+	predicate = AddMeasurementToExpr(measurement, predicate)
+	return e.tagKeysNoTime(ctx, orgID, bucketID, predicate)
+}
+
+func (e *Engine) tagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID, predicate influxql.Expr) (cursors.StringIterator, error) {
+	if err := ValidateTagPredicate(predicate); err != nil {
+		return nil, err
+	}
+
+	orgBucket := tsdb.EncodeName(orgID, bucketID)
+
+	vals := make([]string, 0, 128)
+
+	span := opentracing.SpanFromContext(ctx)
+	if span != nil {
+		defer func() {
+			span.LogFields(
+				log.Int("values_count", len(vals)),
+			)
+		}()
+	}
+
+	keyset := map[string]struct{}{}
+
+	if err := func() error {
+		sitr, err := e.index.MeasurementSeriesByExprIterator(orgBucket[:], predicate)
+		if err != nil {
+			return err
+		}
+		defer sitr.Close()
+
+		var tagsReuse models.Tags
+
+		for {
+			elem, err := sitr.Next()
+			if err != nil {
+				return err
+			} else if elem.SeriesID.IsZero() {
+				return nil
+			}
+
+			sf := e.index.SeriesFile()
+			if sf == nil {
+				return nil
+			}
+
+			skey := sf.SeriesKey(elem.SeriesID)
+			if len(skey) == 0 {
+				continue
+			}
+
+			_, tags := seriesfile.ParseSeriesKeyInto(skey, tagsReuse[:0])
+			for _, t := range tags {
+				keyset[string(t.Key)] = struct{}{}
+			}
+		}
+		return nil
+	}(); err != nil {
+		return cursors.NewStringSliceIterator(nil), err
+	}
+
+	for k := range keyset {
+		vals = append(vals, k)
+	}
+	sort.Strings(vals)
+
+	return cursors.NewStringSliceIterator(vals), nil
 }

--- a/tsdb/tsm1/engine_measurement_notime_schema.go
+++ b/tsdb/tsm1/engine_measurement_notime_schema.go
@@ -318,7 +318,6 @@ func (e *Engine) tagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID,
 			keys = parseSeriesKeys(skey, keys)
 			km.MergeKeys(keys)
 		}
-		return nil
 	}(); err != nil {
 		return cursors.NewStringSliceIterator(nil), err
 	}

--- a/tsdb/tsm1/engine_measurement_notime_schema.go
+++ b/tsdb/tsm1/engine_measurement_notime_schema.go
@@ -326,7 +326,6 @@ func (e *Engine) tagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID,
 	for _, v := range km.Get() {
 		vals = append(vals, string(v))
 	}
-	sort.Strings(vals)
 
 	return cursors.NewStringSliceIterator(vals), nil
 }

--- a/tsdb/tsm1/engine_measurement_notime_schema.go
+++ b/tsdb/tsm1/engine_measurement_notime_schema.go
@@ -285,7 +285,16 @@ func (e *Engine) tagKeysNoTime(ctx context.Context, orgID, bucketID influxdb.ID,
 
 		var tagsReuse models.Tags
 
-		for {
+		for i := 0; ; i++ {
+			// to keep cache scans fast, check context every 'cancelCheckInterval' iterations
+			if i%cancelCheckInterval == 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
+			}
+
 			elem, err := sitr.Next()
 			if err != nil {
 				return err

--- a/tsdb/tsm1/keymerger.go
+++ b/tsdb/tsm1/keymerger.go
@@ -1,0 +1,109 @@
+package tsm1
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/influxdata/influxdb/v2/models"
+)
+
+// keyMerger is responsible for determining a merged set of tag keys
+type keyMerger struct {
+	i    int
+	tmp  [][]byte
+	keys [2][][]byte
+}
+
+func (km *keyMerger) Clear() {
+	km.i = 0
+	km.keys[0] = km.keys[0][:0]
+	if km.tmp != nil {
+		tmp := km.tmp[:cap(km.tmp)]
+		for i := range tmp {
+			tmp[i] = nil
+		}
+	}
+}
+
+func (km *keyMerger) Get() [][]byte { return km.keys[km.i&1] }
+
+func (km *keyMerger) String() string {
+	var s []string
+	for _, k := range km.Get() {
+		s = append(s, string(k))
+	}
+	return strings.Join(s, ",")
+}
+
+func (km *keyMerger) MergeTagKeys(tags models.Tags) {
+	if cap(km.tmp) < len(tags) {
+		km.tmp = make([][]byte, len(tags))
+	} else {
+		km.tmp = km.tmp[:len(tags)]
+	}
+
+	for i := range tags {
+		km.tmp[i] = tags[i].Key
+	}
+
+	km.MergeKeys(km.tmp)
+}
+
+func (km *keyMerger) MergeKeys(in [][]byte) {
+	keys := km.keys[km.i&1]
+	i, j := 0, 0
+	for i < len(keys) && j < len(in) && bytes.Equal(keys[i], in[j]) {
+		i++
+		j++
+	}
+
+	if j == len(in) {
+		// no new tags
+		return
+	}
+
+	km.i = (km.i + 1) & 1
+	l := len(keys) + len(in)
+	if cap(km.keys[km.i]) < l {
+		km.keys[km.i] = make([][]byte, l)
+	} else {
+		km.keys[km.i] = km.keys[km.i][:l]
+	}
+
+	keya := km.keys[km.i]
+
+	// back up the pointers
+	if i > 0 {
+		i--
+		j--
+	}
+
+	k := i
+	copy(keya[:k], keys[:k])
+
+	for i < len(keys) && j < len(in) {
+		cmp := bytes.Compare(keys[i], in[j])
+		if cmp < 0 {
+			keya[k] = keys[i]
+			i++
+		} else if cmp > 0 {
+			keya[k] = in[j]
+			j++
+		} else {
+			keya[k] = keys[i]
+			i++
+			j++
+		}
+		k++
+	}
+
+	if i < len(keys) {
+		k += copy(keya[k:], keys[i:])
+	}
+
+	if j < len(in) {
+		k += copy(keya[k:], in[j:])
+	}
+
+	km.keys[km.i] = keya[:k]
+}

--- a/tsdb/tsm1/keymerger_test.go
+++ b/tsdb/tsm1/keymerger_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/influxdb/v2/models"
 )
 
-func TestkeyMerger_MergeTagKeys(t *testing.T) {
+func TestKeyMerger_MergeTagKeys(t *testing.T) {
 	tests := []struct {
 		name string
 		tags []models.Tags
@@ -73,7 +73,7 @@ func TestkeyMerger_MergeTagKeys(t *testing.T) {
 
 var commaB = []byte(",")
 
-func TestkeyMerger_MergeKeys(t *testing.T) {
+func TestKeyMerger_MergeKeys(t *testing.T) {
 
 	tests := []struct {
 		name string
@@ -135,7 +135,7 @@ func TestkeyMerger_MergeKeys(t *testing.T) {
 	}
 }
 
-func BenchmarkkeyMerger_MergeKeys(b *testing.B) {
+func BenchmarkKeyMerger_MergeKeys(b *testing.B) {
 	keys := [][][]byte{
 		bytes.Split([]byte("tag00,tag01,tag02"), commaB),
 		bytes.Split([]byte("tag00,tag01,tag02"), commaB),
@@ -169,7 +169,7 @@ func BenchmarkkeyMerger_MergeKeys(b *testing.B) {
 	}
 }
 
-func BenchmarkkeyMerger_MergeTagKeys(b *testing.B) {
+func BenchmarkKeyMerger_MergeTagKeys(b *testing.B) {
 	tags := []models.Tags{
 		models.ParseTags([]byte("foo,tag00=v0,tag01=v0,tag02=v0")),
 		models.ParseTags([]byte("foo,tag00=v0,tag01=v0,tag02=v0")),

--- a/tsdb/tsm1/keymerger_test.go
+++ b/tsdb/tsm1/keymerger_test.go
@@ -1,0 +1,204 @@
+package tsm1
+
+import (
+	"bytes"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb/v2/models"
+)
+
+func TestkeyMerger_MergeTagKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []models.Tags
+		exp  string
+	}{
+		{
+			name: "mixed",
+			tags: []models.Tags{
+				models.ParseTags([]byte("foo,tag0=v0,tag1=v0,tag2=v0")),
+				models.ParseTags([]byte("foo,tag0=v0,tag1=v0,tag2=v1")),
+				models.ParseTags([]byte("foo,tag0=v0")),
+				models.ParseTags([]byte("foo,tag0=v0,tag3=v0")),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "mixed 2",
+			tags: []models.Tags{
+				models.ParseTags([]byte("foo,tag0=v0")),
+				models.ParseTags([]byte("foo,tag0=v0,tag3=v0")),
+				models.ParseTags([]byte("foo,tag0=v0,tag1=v0,tag2=v0")),
+				models.ParseTags([]byte("foo,tag0=v0,tag1=v0,tag2=v1")),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "all different",
+			tags: []models.Tags{
+				models.ParseTags([]byte("foo,tag0=v0")),
+				models.ParseTags([]byte("foo,tag1=v0")),
+				models.ParseTags([]byte("foo,tag2=v1")),
+				models.ParseTags([]byte("foo,tag3=v0")),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "new tags,verify clear",
+			tags: []models.Tags{
+				models.ParseTags([]byte("foo,tag9=v0")),
+				models.ParseTags([]byte("foo,tag8=v0")),
+			},
+			exp: "tag8,tag9",
+		},
+	}
+
+	var km keyMerger
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			km.Clear()
+			for _, tags := range tt.tags {
+				km.MergeTagKeys(tags)
+			}
+
+			if got := km.String(); !cmp.Equal(got, tt.exp) {
+				t.Errorf("unexpected keys -got/+exp\n%s", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
+var commaB = []byte(",")
+
+func TestkeyMerger_MergeKeys(t *testing.T) {
+
+	tests := []struct {
+		name string
+		keys [][][]byte
+		exp  string
+	}{
+		{
+			name: "mixed",
+			keys: [][][]byte{
+				bytes.Split([]byte("tag0,tag1,tag2"), commaB),
+				bytes.Split([]byte("tag0,tag1,tag2"), commaB),
+				bytes.Split([]byte("tag0"), commaB),
+				bytes.Split([]byte("tag0,tag3"), commaB),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "mixed 2",
+			keys: [][][]byte{
+				bytes.Split([]byte("tag0"), commaB),
+				bytes.Split([]byte("tag0,tag3"), commaB),
+				bytes.Split([]byte("tag0,tag1,tag2"), commaB),
+				bytes.Split([]byte("tag0,tag1,tag2"), commaB),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "all different",
+			keys: [][][]byte{
+				bytes.Split([]byte("tag0"), commaB),
+				bytes.Split([]byte("tag3"), commaB),
+				bytes.Split([]byte("tag1"), commaB),
+				bytes.Split([]byte("tag2"), commaB),
+			},
+			exp: "tag0,tag1,tag2,tag3",
+		},
+		{
+			name: "new tags,verify clear",
+			keys: [][][]byte{
+				bytes.Split([]byte("tag9"), commaB),
+				bytes.Split([]byte("tag8"), commaB),
+			},
+			exp: "tag8,tag9",
+		},
+	}
+
+	var km keyMerger
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			km.Clear()
+			for _, keys := range tt.keys {
+				km.MergeKeys(keys)
+			}
+
+			if got := km.String(); !cmp.Equal(got, tt.exp) {
+				t.Errorf("unexpected keys -got/+exp\n%s", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
+func BenchmarkkeyMerger_MergeKeys(b *testing.B) {
+	keys := [][][]byte{
+		bytes.Split([]byte("tag00,tag01,tag02"), commaB),
+		bytes.Split([]byte("tag00,tag01,tag02"), commaB),
+		bytes.Split([]byte("tag00,tag01,tag05,tag06,tag10,tag11,tag12,tag13,tag14,tag15"), commaB),
+		bytes.Split([]byte("tag00"), commaB),
+		bytes.Split([]byte("tag00,tag03"), commaB),
+		bytes.Split([]byte("tag01,tag03,tag13,tag14,tag15"), commaB),
+		bytes.Split([]byte("tag04,tag05"), commaB),
+	}
+
+	rand.Seed(20040409)
+
+	tests := []int{
+		10,
+		1000,
+		1000000,
+	}
+
+	for _, n := range tests {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ResetTimer()
+
+			var km keyMerger
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < n; j++ {
+					km.MergeKeys(keys[rand.Int()%len(keys)])
+				}
+				km.Clear()
+			}
+		})
+	}
+}
+
+func BenchmarkkeyMerger_MergeTagKeys(b *testing.B) {
+	tags := []models.Tags{
+		models.ParseTags([]byte("foo,tag00=v0,tag01=v0,tag02=v0")),
+		models.ParseTags([]byte("foo,tag00=v0,tag01=v0,tag02=v0")),
+		models.ParseTags([]byte("foo,tag00=v0,tag01=v0,tag05=v0,tag06=v0,tag10=v0,tag11=v0,tag12=v0,tag13=v0,tag14=v0,tag15=v0")),
+		models.ParseTags([]byte("foo,tag00=v0")),
+		models.ParseTags([]byte("foo,tag00=v0,tag03=v0")),
+		models.ParseTags([]byte("foo,tag01=v0,tag03=v0,tag13=v0,tag14=v0,tag15=v0")),
+		models.ParseTags([]byte("foo,tag04=v0,tag05=v0")),
+	}
+
+	rand.Seed(20040409)
+
+	tests := []int{
+		10,
+		1000,
+		1000000,
+	}
+
+	for _, n := range tests {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ResetTimer()
+
+			var km keyMerger
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < n; j++ {
+					km.MergeTagKeys(tags[rand.Int()%len(tags)])
+				}
+				km.Clear()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Continuation of the work @stuartcarnie performed in https://github.com/influxdata/influxdb/pull/18894.

Fixes influxdata/idpe#7843
