### PR TITLE
chore: connected community template stacks to redux

### DIFF
--- a/ui/src/templates/actions/creators.ts
+++ b/ui/src/templates/actions/creators.ts
@@ -7,6 +7,8 @@ import {
 import {DocumentCreate} from '@influxdata/influx'
 import {NormalizedSchema} from 'normalizr'
 
+import {InstalledStack} from 'src/types'
+
 export const ADD_TEMPLATE_SUMMARY = 'ADD_TEMPLATE_SUMMARY'
 export const GET_TEMPLATE_SUMMARIES_FOR_ORG = 'GET_TEMPLATE_SUMMARIES_FOR_ORG'
 export const POPULATE_TEMPLATE_SUMMARIES = 'POPULATE_TEMPLATE_SUMMARIES'
@@ -19,6 +21,8 @@ export const SET_TEMPLATES_STATUS = 'SET_TEMPLATES_STATUS'
 export const TOGGLE_TEMPLATE_RESOURCE_INSTALL =
   'TOGGLE_TEMPLATE_RESOURCE_INSTALL'
 
+export const SET_STACKS = 'SET_STACKS'
+
 export type Action =
   | ReturnType<typeof addTemplateSummary>
   | ReturnType<typeof populateTemplateSummaries>
@@ -28,6 +32,7 @@ export type Action =
   | ReturnType<typeof setTemplateSummary>
   | ReturnType<typeof setCommunityTemplateToInstall>
   | ReturnType<typeof toggleTemplateResourceInstall>
+  | ReturnType<typeof setStacks>
 
 type TemplateSummarySchema<R extends string | string[]> = NormalizedSchema<
   TemplateSummaryEntities,
@@ -100,4 +105,10 @@ export const toggleTemplateResourceInstall = (
     resourceType,
     templateMetaName,
     shouldInstall,
+  } as const)
+
+export const setStacks = (stacks: InstalledStack[]) =>
+  ({
+    type: SET_STACKS,
+    stacks,
   } as const)

--- a/ui/src/templates/actions/thunks.ts
+++ b/ui/src/templates/actions/thunks.ts
@@ -3,6 +3,7 @@ import {normalize} from 'normalizr'
 
 // APIs
 import {client} from 'src/utils/api'
+import {fetchStacks} from 'src/templates/api'
 import {createDashboardFromTemplate} from 'src/dashboards/actions/thunks'
 import {createVariableFromTemplate} from 'src/variables/actions/thunks'
 import {createTaskFromTemplate} from 'src/tasks/actions/thunks'
@@ -14,10 +15,11 @@ import {templateSchema, arrayOfTemplates} from 'src/schemas/templates'
 import {notify, Action as NotifyAction} from 'src/shared/actions/notifications'
 import {
   addTemplateSummary,
+  setStacks,
   populateTemplateSummaries,
+  removeTemplateSummary,
   setExportTemplate,
   setTemplatesStatus,
-  removeTemplateSummary,
   setTemplateSummary,
   Action as TemplateAction,
 } from 'src/templates/actions/creators'
@@ -274,5 +276,16 @@ export const removeTemplateLabelsAsync = (
   } catch (error) {
     console.error(error)
     dispatch(notify(copy.removeTemplateLabelFailed()))
+  }
+}
+
+export const fetchAndSetStacks = (orgID: string) => async (
+  dispatch: Dispatch<Action>
+): Promise<void> => {
+  try {
+    const stacks = await fetchStacks(orgID)
+    dispatch(setStacks(stacks))
+  } catch (error) {
+    console.error(error)
   }
 }

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -34,8 +34,9 @@ import {
   postDashboardsLabel as apiPostDashboardsLabel,
   postDashboardsCell as apiPostDashboardsCell,
   patchDashboardsCellsView as apiPatchDashboardsCellsView,
-  Error as PkgError,
   postTemplatesApply,
+  getStacks,
+  Error as PkgError,
   TemplateSummary,
 } from 'src/client'
 import {addDashboardDefaults} from 'src/schemas/dashboards'
@@ -46,6 +47,7 @@ import {
   DashboardTemplate,
   Dashboard,
   TemplateType,
+  InstalledStack,
   Cell,
   CellIncluded,
   LabelIncluded,
@@ -491,4 +493,14 @@ export const installTemplate = async (orgID: string, templateUrl: string) => {
   }
 
   return applyTemplates(params)
+}
+
+export const fetchStacks = async (orgID: string) => {
+  const resp = await getStacks({query: {orgID}})
+
+  if (resp.status >= 300) {
+    throw new Error((resp.data as PkgError).message)
+  }
+
+  return (resp.data as {stacks: InstalledStack[]}).stacks
 }

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -7,8 +7,8 @@ import {CommunityTemplateInstallerOverlay} from 'src/templates/components/Commun
 
 // Actions
 import {setCommunityTemplateToInstall} from 'src/templates/actions/creators'
-import {createTemplate as createTemplateAction} from 'src/templates/actions/thunks'
-import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {createTemplate, fetchAndSetStacks} from 'src/templates/actions/thunks'
+import {notify} from 'src/shared/actions/notifications'
 
 import {getTotalResourceCount} from 'src/templates/selectors'
 
@@ -98,6 +98,8 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       const summary = await installTemplate(org.id, yamlLocation)
       this.props.notify(communityTemplateInstallSucceeded(templateName))
 
+      this.props.fetchAndSetStacks(org.id)
+
       this.onDismiss()
 
       return summary
@@ -125,9 +127,10 @@ const mstp = (state: AppState, props: RouterProps) => {
 }
 
 const mdtp = {
-  createTemplate: createTemplateAction,
-  notify: notifyAction,
+  createTemplate,
+  notify,
   setCommunityTemplateToInstall,
+  fetchAndSetStacks,
 }
 
 const connector = connect(mstp, mdtp)

--- a/ui/src/templates/reducers/index.test.ts
+++ b/ui/src/templates/reducers/index.test.ts
@@ -53,6 +53,7 @@ const initialState = () => ({
   },
   allIDs: [templateSummary.id, '2'],
   exportTemplate,
+  stacks: [],
 })
 
 describe('templates reducer', () => {
@@ -98,6 +99,7 @@ describe('templates reducer', () => {
       allIDs,
       exportTemplate,
       communityTemplateToInstall,
+      stacks: [],
     }
     const actual = reducer(state, removeTemplateSummary(state.allIDs[1]))
 

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -9,6 +9,7 @@ import {
   SET_TEMPLATE_SUMMARY,
   SET_TEMPLATES_STATUS,
   TOGGLE_TEMPLATE_RESOURCE_INSTALL,
+  SET_STACKS,
 } from 'src/templates/actions/creators'
 import {
   CommunityTemplate,
@@ -42,6 +43,7 @@ export const defaultState = (): TemplatesState => ({
     status: RemoteDataState.NotStarted,
     item: null,
   },
+  stacks: [],
 })
 
 export const templatesReducer = (
@@ -201,6 +203,14 @@ export const templatesReducer = (
         })
 
         draftState.communityTemplateToInstall = templateToInstall
+        return
+      }
+
+      case SET_STACKS: {
+        const {stacks} = action
+
+        draftState.stacks = stacks
+        return
       }
     }
   })

--- a/ui/src/types/templates.ts
+++ b/ui/src/types/templates.ts
@@ -17,6 +17,15 @@ import {
   Label,
 } from 'src/types'
 
+import {Stack} from 'src/client'
+
+export interface InstalledStack extends Stack {
+  eventType: string
+  name: string
+  resources: any[]
+  sources: string[]
+}
+
 export interface TemplateSummary extends Omit<GenTemplateSummary, 'labels'> {
   labels: string[]
   status: RemoteDataState
@@ -27,6 +36,7 @@ export type CommunityTemplate = any
 export interface TemplatesState extends NormalizedState<TemplateSummary> {
   exportTemplate: {status: RemoteDataState; item: DocumentCreate}
   communityTemplateToInstall: CommunityTemplate
+  stacks: InstalledStack[]
 }
 
 interface KeyValuePairs {


### PR DESCRIPTION
Closes #18552

Cleans up the template install process:
* adds stacks (which represent installed templates) to templates store in redux

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
