### PR TITLE
feat(VariableControlBar): load nested query variables onto the dashboard variable control bar

### DIFF
--- a/ui/cypress/e2e/dashboardsView.test.ts
+++ b/ui/cypress/e2e/dashboardsView.test.ts
@@ -514,16 +514,16 @@ describe('Dashboard', () => {
           .getByTestID('flux-editor')
           .should('be.visible')
           .click()
-          .focused().type(`// v.build
-from(bucket: v.static)
+          .focused().type(`from(bucket: v.static)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
-|> filter(fn: (r) => r["container_name"] == v.dependent)`)
+|> filter(fn: (r) => r["container_name"] == v.build)`)
 
         cy.getByTestID('save-cell--button').click()
 
-        // the default bucket selection should have no results
+        // the default bucket selection should have no results and load all three variables
+        // even though only two variables are being used (because 1 is dependent upon another)
         cy.getByTestID('variable-dropdown')
           .should('have.length', 3)
           .eq(0)
@@ -547,24 +547,25 @@ from(bucket: v.static)
           .eq(1)
           .should('contain', 'beans')
 
-        // and also load the second result
+        // and also load the third result
         cy.getByTestID('variable-dropdown--button')
-          .eq(1)
+          .eq(2)
+          .should('contain', 'beans')
           .click()
         cy.get(`#cool`).click()
 
-        // and also load the third result
+        // and also load the second result
         cy.getByTestID('variable-dropdown')
-          .eq(2)
+          .eq(1)
           .should('contain', 'cool')
 
-        // updating the second variable should update the third
+        // updating the third variable should update the second
         cy.getByTestID('variable-dropdown--button')
-          .eq(1)
+          .eq(2)
           .click()
         cy.get(`#beans`).click()
         cy.getByTestID('variable-dropdown')
-          .eq(2)
+          .eq(1)
           .should('contain', 'beans')
       })
     })

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -334,7 +334,7 @@ export const getDashboard = (dashboardID: string) => async (
     // Fetch the dashboard, views, and all variables a user has access to
     const [resp] = await Promise.all([
       api.getDashboard({dashboardID, query: {include: 'properties'}}),
-      dispatch(getVariables()),
+      // dispatch(getVariables()),
     ])
 
     if (resp.status !== 200) {

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -334,7 +334,7 @@ export const getDashboard = (dashboardID: string) => async (
     // Fetch the dashboard, views, and all variables a user has access to
     const [resp] = await Promise.all([
       api.getDashboard({dashboardID, query: {include: 'properties'}}),
-      // dispatch(getVariables()),
+      dispatch(getVariables()),
     ])
 
     if (resp.status !== 200) {

--- a/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -17,11 +17,7 @@ import {
   getVariables,
   getDashboardVariablesStatus,
 } from 'src/variables/selectors'
-import {
-  filterUnusedVars,
-  getAllUsedVars,
-  createdUsedVarsCache,
-} from 'src/shared/utils/filterUnusedVars'
+import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
 
 // Actions
 import {moveVariable} from 'src/variables/actions/thunks'
@@ -155,16 +151,12 @@ const mstp = (state: AppState) => {
     },
   } = state
 
-  const usedVariables = filterUnusedVars(
+  const varsInUse = filterUnusedVars(
     variables,
     Object.values(state.resources.views.byID).filter(
       variable => variable.dashboardID === dashboardID
     )
   )
-
-  const usedVarsCache = createdUsedVarsCache(usedVariables)
-
-  const varsInUse = getAllUsedVars(variables, usedVariables, usedVarsCache)
 
   return {
     variables: varsInUse,

--- a/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -17,7 +17,11 @@ import {
   getVariables,
   getDashboardVariablesStatus,
 } from 'src/variables/selectors'
-import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
+import {
+  filterUnusedVars,
+  getAllUsedVars,
+  createdUsedVarsCache,
+} from 'src/shared/utils/filterUnusedVars'
 
 // Actions
 import {moveVariable} from 'src/variables/actions/thunks'
@@ -151,13 +155,19 @@ const mstp = (state: AppState) => {
     },
   } = state
 
+  const usedVariables = filterUnusedVars(
+    variables,
+    Object.values(state.resources.views.byID).filter(
+      variable => variable.dashboardID === dashboardID
+    )
+  )
+
+  const usedVarsCache = createdUsedVarsCache(usedVariables)
+
+  const varsInUse = getAllUsedVars(variables, usedVariables, usedVarsCache)
+
   return {
-    variables: filterUnusedVars(
-      variables,
-      Object.values(state.resources.views.byID).filter(
-        variable => variable.dashboardID === dashboardID
-      )
-    ),
+    variables: varsInUse,
     variablesStatus,
     inPresentationMode,
     show,

--- a/ui/src/shared/utils/filterUnusedVars.ts
+++ b/ui/src/shared/utils/filterUnusedVars.ts
@@ -30,11 +30,10 @@ export const filterUnusedVars = (variables: Variable[], views: View[]) => {
 }
 
 export const createdUsedVarsCache = (variables: Variable[]) => {
-  const cache = {}
-  variables.forEach((vari: Variable) => {
-    cache[vari.name] = true
-  })
-  return cache
+  return variables.reduce((cache, curr) => {
+    cache[curr.name] = true
+    return cache
+  }, {})
 }
 
 export const getAllUsedVars = (
@@ -43,18 +42,19 @@ export const getAllUsedVars = (
   cache: {[name: string]: boolean}
 ) => {
   const vars = usedVars.slice()
+  let varsInUse = []
   usedVars.forEach((vari: Variable) => {
     if (vari.arguments.type === 'query') {
       const queryText = get(vari, 'arguments.values.query', '')
-      const varsInUse = variables.filter(variable =>
-        isInQuery(queryText, variable)
-      )
-      varsInUse.forEach((v: Variable) => {
-        if (!cache[v.name]) {
-          vars.push(v)
-          cache[v.name] = true
-        }
-      })
+      const usedV = variables.filter(variable => isInQuery(queryText, variable))
+      varsInUse = varsInUse.concat(usedV)
+    }
+  })
+
+  varsInUse.forEach((v: Variable) => {
+    if (!cache[v.name]) {
+      vars.push(v)
+      cache[v.name] = true
     }
   })
 

--- a/ui/src/shared/utils/filterUnusedVars.ts
+++ b/ui/src/shared/utils/filterUnusedVars.ts
@@ -1,4 +1,5 @@
 // Utils
+import {get} from 'lodash'
 import {isInQuery} from 'src/variables/utils/hydrateVars'
 
 // Types
@@ -26,4 +27,40 @@ export const filterUnusedVars = (variables: Variable[], views: View[]) => {
   )
 
   return varsInUse
+}
+
+export const createdUsedVarsCache = (variables: Variable[]) => {
+  const cache = {}
+  variables.forEach((vari: Variable) => {
+    cache[vari.name] = true
+  })
+  return cache
+}
+
+export const getAllUsedVars = (
+  variables: Variable[],
+  usedVars: Variable[],
+  cache: {[name: string]: boolean}
+) => {
+  const vars = usedVars.slice()
+  usedVars.forEach((vari: Variable) => {
+    if (vari.arguments.type === 'query') {
+      const queryText = get(vari, 'arguments.values.query', '')
+      const varsInUse = variables.filter(variable =>
+        isInQuery(queryText, variable)
+      )
+      varsInUse.forEach((v: Variable) => {
+        if (!cache[v.name]) {
+          vars.push(v)
+          cache[v.name] = true
+        }
+      })
+    }
+  })
+
+  if (vars.length !== usedVars.length) {
+    return getAllUsedVars(variables, vars, cache)
+  }
+
+  return vars
 }

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -112,10 +112,6 @@ export const getVariables = () => async (
         variables.entities.variables[v.id].status = RemoteDataState.NotStarted
       })
 
-    // TODO: don't overwrite selected variables from context here
-    // we would need to modify the variables that are being passed in
-    // to respect variable values that are already set in the resource variable values
-
     await dispatch(setVariables(RemoteDataState.Done, variables))
   } catch (error) {
     console.error(error)

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -112,6 +112,10 @@ export const getVariables = () => async (
         variables.entities.variables[v.id].status = RemoteDataState.NotStarted
       })
 
+    // TODO: don't overwrite selected variables from context here
+    // we would need to modify the variables that are being passed in
+    // to respect variable values that are already set in the resource variable values
+
     await dispatch(setVariables(RemoteDataState.Done, variables))
   } catch (error) {
     console.error(error)
@@ -434,6 +438,8 @@ export const selectValue = (variableID: string, selected: string) => async (
   // Validate that we can make this selection
   const vals = normalizeValues(variable)
   if (!vals.includes(selected)) {
+    // TODO: there is an issue that's causing non-state set values to
+    // return with no results and not respect query params
     return
   }
 


### PR DESCRIPTION
This PR is part of a broader initiative to reduce the number of issues stemming from variable hydration. The change here is pretty straightforward. If a query variable depends on another variable that is not directly being called within a query, we should still consider that variable as "used" and it should therefore be displayed in the variable control bar.

![load-all-vars](https://user-images.githubusercontent.com/19984220/87096501-d8680500-c1f7-11ea-9c1b-6cadd8989c27.gif)
