### PR TITLE
feat(pkger): extend stacks API with uninstall ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [18888](https://github.com/influxdata/influxdb/pull/18888): Add event source to influx stack operations
+1. [18910](https://github.com/influxdata/influxdb/pull/18910): Add uninstall functionality for stacks
 
 ### Bug Fixes
 

--- a/cmd/influx/template.go
+++ b/cmd/influx/template.go
@@ -1780,7 +1780,7 @@ func writeStackRows(tabW *internal.TabWriter, stacks ...pkger.Stack) {
 		tabW.Write(map[string]interface{}{
 			"ID":            stack.ID,
 			"OrgID":         stack.OrgID,
-			"Active":        latest.EventType != pkger.StackEventDelete,
+			"Active":        latest.EventType != pkger.StackEventUninstalled,
 			"Name":          latest.Name,
 			"Description":   latest.Description,
 			"Num Resources": len(latest.Resources),

--- a/cmd/influx/template_test.go
+++ b/cmd/influx/template_test.go
@@ -795,6 +795,10 @@ func (f *fakePkgSVC) ListStacks(ctx context.Context, orgID influxdb.ID, filter p
 	panic("not implemented")
 }
 
+func (f *fakePkgSVC) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (pkger.Stack, error) {
+	panic("not implemeted")
+}
+
 func (f *fakePkgSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	panic("not implemented")
 }

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4725,7 +4725,7 @@ paths:
       operationId: UpdateStack
       tags:
         - InfluxDB Templates
-      summary: Update a an InfluxDB Stack
+      summary: Update an InfluxDB Stack
       parameters:
         - in: path
           name: stack_id
@@ -4795,6 +4795,32 @@ paths:
       responses:
         "204":
           description: Stack and all its associated resources are deleted
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /stacks/{stack_id}/uninstall:
+    post:
+      operationId: UninstallStack
+      tags:
+        - InfluxDB Templates
+      summary: Uninstall an InfluxDB Stack
+      parameters:
+        - in: path
+          name: stack_id
+          required: true
+          schema:
+            type: string
+          description: The stack id
+      responses:
+        "200":
+          description: Influx stack uninstalled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stack"
         default:
           description: Unexpected error
           content:

--- a/pkger/http_server_packages_deprecated_test.go
+++ b/pkger/http_server_packages_deprecated_test.go
@@ -1350,6 +1350,10 @@ func (f *fakeSVC) InitStack(ctx context.Context, userID influxdb.ID, stack pkger
 	return f.initStackFn(ctx, userID, stack)
 }
 
+func (f *fakeSVC) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (pkger.Stack, error) {
+	panic("not implemented")
+}
+
 func (f *fakeSVC) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	panic("not implemented yet")
 }

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -36,6 +36,14 @@ func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Sta
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *authMW) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (Stack, error) {
+	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, ResourceTypeStack)
+	if err != nil {
+		return Stack{}, err
+	}
+	return s.next.UninstallStack(ctx, identifiers)
+}
+
 func (s *authMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, ResourceTypeStack)
 	if err != nil {

--- a/pkger/service_logging.go
+++ b/pkger/service_logging.go
@@ -43,6 +43,24 @@ func (s *loggingMW) InitStack(ctx context.Context, userID influxdb.ID, newStack 
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *loggingMW) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (_ Stack, err error) {
+	defer func(start time.Time) {
+		if err == nil {
+			return
+		}
+
+		s.logger.Error(
+			"failed to uninstall stack",
+			zap.Error(err),
+			zap.Stringer("orgID", identifiers.OrgID),
+			zap.Stringer("userID", identifiers.OrgID),
+			zap.Stringer("stackID", identifiers.StackID),
+			zap.Duration("took", time.Since(start)),
+		)
+	}(time.Now())
+	return s.next.UninstallStack(ctx, identifiers)
+}
+
 func (s *loggingMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (err error) {
 	defer func(start time.Time) {
 		if err == nil {

--- a/pkger/service_metrics.go
+++ b/pkger/service_metrics.go
@@ -38,6 +38,12 @@ func (s *mwMetrics) InitStack(ctx context.Context, userID influxdb.ID, newStack 
 	return stack, rec(err)
 }
 
+func (s *mwMetrics) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (Stack, error) {
+	rec := s.rec.Record("uninstall_stack")
+	stack, err := s.next.UninstallStack(ctx, identifiers)
+	return stack, rec(err)
+}
+
 func (s *mwMetrics) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	rec := s.rec.Record("delete_stack")
 	return rec(s.next.DeleteStack(ctx, identifiers))

--- a/pkger/service_tracing.go
+++ b/pkger/service_tracing.go
@@ -27,6 +27,12 @@ func (s *traceMW) InitStack(ctx context.Context, userID influxdb.ID, newStack St
 	return s.next.InitStack(ctx, userID, newStack)
 }
 
+func (s *traceMW) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (Stack, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+	return s.next.UninstallStack(ctx, identifiers)
+}
+
 func (s *traceMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()


### PR DESCRIPTION
this new ability removes the resources associated with the stack
and adds the uninstall event.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)