### PR TITLE
chore: remove Jacob from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@ http/swagger.yml @influxdata/monitoring-team
 /pkger/ @influxdata/tools-team
 
 # Storage code
-/storage/ @influxdata/storage-team @jacobmarble
-/tsdb/ @influxdata/storage-team @jacobmarble
+/storage/ @influxdata/storage-team
+/tsdb/ @influxdata/storage-team


### PR DESCRIPTION
CODEOWERS for the storage team was fixed by giving the team permission to write to the repository. Jacob can relax now.