### PR TITLE
fix(storage): Reduce the check frequency

### DIFF
--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -16,11 +16,11 @@ import (
 	"github.com/influxdata/influxql"
 )
 
-// cancelCheckInterval represents the period at which TagKeys and TagValues
-// will check for a canceled context. Specifically after every 64 series
-// scanned, the query context will be checked for cancellation, and if canceled,
-// the calls will immediately return.
-const cancelCheckInterval = 64
+// cancelCheckInterval represents the period at which various schema calls
+// will check for a canceled context. It is important this
+// is not too frequent, or it could cause expensive context switches in
+// tight loops.
+const cancelCheckInterval = 5000
 
 // TagValues returns an iterator which enumerates the values for the specific
 // tagKey in the given bucket matching the predicate within the


### PR DESCRIPTION
Checking a channel too regularly could cause context switching to other goroutines. In tight loops, it is prudent to check, but to do so less frequently so as to avoid thrashing.

I have observed traces with huge swings in latency calling the same function repeatedly, which suggests this might be a cause. The alternative is page faults, or other I/O contention.
