### PR TITLE
fix: urm list actions when filtering by userID needs to respect page limits

### DIFF
--- a/tenant/storage_urm.go
+++ b/tenant/storage_urm.go
@@ -3,6 +3,7 @@ package tenant
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kv"
@@ -70,6 +71,8 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 	}
 
 	if filter.UserID.Valid() {
+		errPageLimit := errors.New("page limit reached")
+
 		// urm by user index lookup
 		userID, _ := filter.UserID.Encode()
 		if err := s.urmByUserIndex.Walk(ctx, tx, userID, func(k, v []byte) error {
@@ -82,8 +85,13 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 				ms = append(ms, m)
 			}
 
+			// respect pagination in URMs
+			if len(opt) > 0 && len(ms) >= opt[0].Limit {
+				return errPageLimit
+			}
+
 			return nil
-		}); err != nil {
+		}); err != nil && err != errPageLimit {
 			return nil, err
 		}
 

--- a/tenant/storage_urm_test.go
+++ b/tenant/storage_urm_test.go
@@ -185,6 +185,63 @@ func TestURM(t *testing.T) {
 			},
 		},
 		{
+			name: "list by user with limit",
+			setup: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+				uid := influxdb.ID(1)
+				err := store.CreateUser(context.Background(), tx, &influxdb.User{
+					ID:   uid,
+					Name: "user",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for i := 1; i <= 25; i++ {
+					// User must exist to create urm.
+					err = store.CreateURM(context.Background(), tx, &influxdb.UserResourceMapping{
+						UserID:       uid,
+						UserType:     influxdb.Owner,
+						MappingType:  influxdb.UserMappingType,
+						ResourceType: influxdb.OrgsResourceType,
+						ResourceID:   influxdb.ID(i + 1),
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			results: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+				urms, err := store.ListURMs(context.Background(), tx, influxdb.UserResourceMappingFilter{UserID: influxdb.ID(1)}, influxdb.FindOptions{Limit: 10})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if len(urms) != 10 {
+					t.Fatalf("when setting the limit to 10 we got: %d", len(urms))
+				}
+				var expected []*influxdb.UserResourceMapping
+				for i := 1; i <= 10; i++ {
+					expected = append(expected, &influxdb.UserResourceMapping{
+						UserID:       influxdb.ID(1),
+						UserType:     influxdb.Owner,
+						MappingType:  influxdb.UserMappingType,
+						ResourceType: influxdb.OrgsResourceType,
+						ResourceID:   influxdb.ID(i + 1),
+					})
+				}
+				sort.Slice(expected, func(i, j int) bool {
+					irid, _ := expected[i].ResourceID.Encode()
+					iuid, _ := expected[i].UserID.Encode()
+					jrid, _ := expected[j].ResourceID.Encode()
+					juid, _ := expected[j].UserID.Encode()
+					return string(irid)+string(iuid) < string(jrid)+string(juid)
+				})
+
+				if !reflect.DeepEqual(urms, expected) {
+					t.Fatalf("expected identical urms: \n%s", cmp.Diff(urms, expected))
+				}
+			},
+		},
+		{
 			name:  "delete",
 			setup: simpleSetup,
 			update: func(t *testing.T, store *tenant.Store, tx kv.Tx) {


### PR DESCRIPTION


We will now respect limits when passed in for user resource mapping lookups for allrequest types.
