### PR TITLE
fix(EventTable): fixed a max call stack exceeded error

### DIFF
--- a/ui/src/eventViewer/components/EventTable.tsx
+++ b/ui/src/eventViewer/components/EventTable.tsx
@@ -48,16 +48,17 @@ const EventTable: FC<Props> = ({state, dispatch, loadRows, fields}) => {
   const reduxDispatch = useDispatch()
 
   useEffect(() => {
-    setTimeout(() => {
+    const timeoutID = setTimeout(() => {
       setIsLongRunningQuery(true)
     }, 5000)
-  })
+    return () => clearTimeout(timeoutID)
+  }, [setIsLongRunningQuery])
 
   useEffect(() => {
     if (isLongRunningQuery && !isRowLoadedBoolean) {
       reduxDispatch(notify(checkStatusLoading))
     }
-  }, [reduxDispatch, isLongRunningQuery, isRowLoadedBoolean, isRowLoaded])
+  }, [isLongRunningQuery, isRowLoadedBoolean, reduxDispatch])
 
   const rowRenderer = ({key, index, style}) => {
     const isLastRow = index === state.rows.length


### PR DESCRIPTION
### Problem

The Notification Rule history page was erroring out after dispatching a notification. The reason for this is that one of the `useEffect` parameters being passed in was causing a series of rerenders that were crashing the app.

### Solution

Remove the offending useEffect parameter (since it wasn't being used in the useEffect), and added a clearTimeout function