### PR TITLE
feat(httpd): configurable http read timeout

### DIFF
--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	MaxEnqueuedWriteLimit   int               `toml:"max-enqueued-write-limit"`
 	EnqueuedWriteTimeout    time.Duration     `toml:"enqueued-write-timeout"`
 	TLS                     *tls.Config       `toml:"-"`
+	ReadTimeout             time.Duration     `toml:"read-timeout"`
 }
 
 // NewConfig returns a new Config with default settings.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -87,7 +87,8 @@ func NewService(c Config) *Service {
 		bindSocket:     c.BindSocket,
 		Handler:        handler,
 		httpServer: http.Server{
-			Handler: handler,
+			Handler:     handler,
+			ReadTimeout: c.ReadTimeout,
 		},
 		Logger: zap.NewNop(),
 	}


### PR DESCRIPTION
HTTP read timeout is useful to avoid half-open connections due to
bad network.

Closes #15410
