### PR TITLE
fix(query): produce error, not panic, for influxdb.to()

### DIFF
--- a/query/stdlib/influxdata/influxdb/dependencies.go
+++ b/query/stdlib/influxdata/influxdb/dependencies.go
@@ -26,6 +26,9 @@ func (d StorageDependencies) Inject(ctx context.Context) context.Context {
 }
 
 func GetStorageDependencies(ctx context.Context) StorageDependencies {
+	if ctx.Value(dependenciesKey) == nil {
+		return StorageDependencies{}
+	}
 	return ctx.Value(dependenciesKey).(StorageDependencies)
 }
 

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -241,8 +241,15 @@ func createToTransformation(id execute.DatasetID, mode execute.AccumulationMode,
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
-	deps := GetStorageDependencies(a.Context()).ToDeps
-	t, err := NewToTransformation(a.Context(), d, cache, s, deps)
+	deps := GetStorageDependencies(a.Context())
+	if deps == (StorageDependencies{}) {
+		return nil, nil, &flux.Error{
+			Code: codes.Unimplemented,
+			Msg:  "cannot return storage dependencies; storage dependencies are unimplemented",
+		}
+	}
+	toDeps := deps.ToDeps
+	t, err := NewToTransformation(a.Context(), d, cache, s, toDeps)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Closes #18106

This PR just produces an error for `influxdb.to()` instead of a panic when storage dependencies are absent. There will be another issue to fill in the storage dependencies and resolve this error. 