### PR TITLE
fix(tenant): add support for offset to list urms

### DIFF
--- a/session/service.go
+++ b/session/service.go
@@ -147,7 +147,6 @@ func (s *Service) RenewSession(ctx context.Context, session *influxdb.Session, n
 }
 
 func (s *Service) getPermissionSet(ctx context.Context, uid influxdb.ID) ([]influxdb.Permission, error) {
-
 	mappings, _, err := s.urmService.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{UserID: uid}, influxdb.FindOptions{Limit: 100})
 	if err != nil {
 		return nil, err

--- a/tenant/storage_urm.go
+++ b/tenant/storage_urm.go
@@ -91,7 +91,7 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 			}
 
 			// respect pagination in URMs
-			if len(opt) > 0 && len(ms) >= opt[0].Limit {
+			if len(opt) > 0 && opt[0].Limit > 0 && len(ms) >= opt[0].Limit {
 				return errPageLimit
 			}
 
@@ -134,7 +134,7 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 			ms = append(ms, m)
 		}
 
-		if len(opt) > 0 && len(ms) >= opt[0].Limit {
+		if len(opt) > 0 && opt[0].Limit > 0 && len(ms) >= opt[0].Limit {
 			break
 		}
 	}

--- a/tenant/storage_urm.go
+++ b/tenant/storage_urm.go
@@ -71,17 +71,22 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 	}
 
 	if filter.UserID.Valid() {
-		errPageLimit := errors.New("page limit reached")
+		var (
+			errPageLimit = errors.New("page limit reached")
+			// urm by user index lookup
+			userID, _ = filter.UserID.Encode()
+			seen      int
+		)
 
-		// urm by user index lookup
-		userID, _ := filter.UserID.Encode()
 		if err := s.urmByUserIndex.Walk(ctx, tx, userID, func(k, v []byte) error {
 			m := &influxdb.UserResourceMapping{}
 			if err := json.Unmarshal(v, m); err != nil {
 				return CorruptURMError(err)
 			}
 
-			if filterFn(m) {
+			// respect offset parameter
+			reachedOffset := (len(opt) == 0 || seen >= opt[0].Offset)
+			if filterFn(m) && reachedOffset {
 				ms = append(ms, m)
 			}
 
@@ -89,6 +94,8 @@ func (s *Store) ListURMs(ctx context.Context, tx kv.Tx, filter influxdb.UserReso
 			if len(opt) > 0 && len(ms) >= opt[0].Limit {
 				return errPageLimit
 			}
+
+			seen++
 
 			return nil
 		}); err != nil && err != errPageLimit {


### PR DESCRIPTION
Support `offset` parameter in ListURM.

Currently, this parameter is not supported and sessions depends on it for pagination.

The recent change to support `limit` has (when occasion permits) now made pages return the size of the page limit. Which breaks the session code when listing URMs. As that code keeps attempting pages until the limit is not met, using an `offset`. However, the `offset` was never added to this action.
