### PR TITLE
fix(testing): accidental shadowing in parallel tests

### DIFF
--- a/testing/auth.go
+++ b/testing/auth.go
@@ -97,6 +97,7 @@ func AuthorizationService(
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -115,6 +115,7 @@ func BucketService(
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -207,6 +207,7 @@ func CheckService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -93,6 +93,7 @@ func DashboardService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/dbrp_mapping_v2.go
+++ b/testing/dbrp_mapping_v2.go
@@ -80,6 +80,7 @@ func DBRPMappingServiceV2(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/keyvalue_log.go
+++ b/testing/keyvalue_log.go
@@ -56,6 +56,7 @@ func KeyValueLog(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -76,6 +76,7 @@ func KVStore(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -82,6 +82,7 @@ func LabelService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/notification_endpoint.go
+++ b/testing/notification_endpoint.go
@@ -75,6 +75,7 @@ func NotificationEndpointService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -72,6 +72,7 @@ func NotificationRuleStore(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -85,6 +85,7 @@ func OrganizationService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/passwords.go
+++ b/testing/passwords.go
@@ -39,6 +39,7 @@ func PasswordsService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -106,6 +106,7 @@ func ScraperService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/secret.go
+++ b/testing/secret.go
@@ -72,6 +72,7 @@ func SecretService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/session.go
+++ b/testing/session.go
@@ -77,6 +77,7 @@ func SessionService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -71,6 +71,7 @@ func TelegrafConfigStore(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -74,6 +74,7 @@ func UserResourceMappingService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/user_service.go
+++ b/testing/user_service.go
@@ -85,6 +85,7 @@ func UserService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})

--- a/testing/variable.go
+++ b/testing/variable.go
@@ -78,6 +78,7 @@ func VariableService(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})


### PR DESCRIPTION
I mistakenly shadowed a bunch of tests using `t.Parallel()` in some of our test harnesses.
This stops the shadowing happening. Which was leading to some tests not being run and some tests being duplicated.
