### PR TITLE
chore(testing): add missing defer to clean up test temp files

### DIFF
--- a/tsdb/tsi1/legacy_test.go
+++ b/tsdb/tsi1/legacy_test.go
@@ -14,7 +14,7 @@ func TestLegacyOpen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 
 	sfile := seriesfile.NewSeriesFile(dir)
 	if err := sfile.Open(context.Background()); err != nil {


### PR DESCRIPTION
`TestLegacyOpen` wasn't cleaning up tmp files at termination because of a missing `defer`. 
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
