### PR TITLE
fix(ui): give user all access token permission to read user

### DIFF
--- a/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -23,6 +23,7 @@ import {createAuthorization} from 'src/authorizations/actions/thunks'
 // Utils
 import {allAccessPermissions} from 'src/authorizations/utils/permissions'
 import {getOrg} from 'src/organizations/selectors'
+import {getMe} from 'src/me/selectors'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -100,12 +101,12 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
   }
 
   private handleSave = () => {
-    const {orgID, onCreateAuthorization} = this.props
+    const {orgID, meID, onCreateAuthorization} = this.props
 
     const token: Authorization = {
       orgID,
       description: this.state.description,
-      permissions: allAccessPermissions(orgID),
+      permissions: allAccessPermissions(orgID, meID),
     }
 
     onCreateAuthorization(token)
@@ -127,6 +128,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
 const mstp = (state: AppState) => {
   return {
     orgID: getOrg(state).id,
+    meID: getMe(state).id,
   }
 }
 

--- a/ui/src/authorizations/utils/permissions.test.ts
+++ b/ui/src/authorizations/utils/permissions.test.ts
@@ -208,14 +208,14 @@ const hvhs: Permission[] = [
   {
     action: 'read',
     resource: {
-      orgID: 'bulldogs',
+      id: 'mario',
       type: 'users',
     },
   },
   {
     action: 'write',
     resource: {
-      orgID: 'bulldogs',
+      id: 'mario',
       type: 'users',
     },
   },
@@ -250,5 +250,5 @@ const hvhs: Permission[] = [
 ]
 
 test('all-access tokens/authorizations production test', () => {
-  expect(allAccessPermissions('bulldogs')).toMatchObject(hvhs)
+  expect(allAccessPermissions('bulldogs', 'mario')).toMatchObject(hvhs)
 })

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -31,7 +31,9 @@ const allPermissionTypes: PermissionTypes[] = [
 // if all allowable PermissionTypes generated in the client
 // generatedRoutes are not included in the switch statement BUT
 // they will need to be added to both the switch statement AND the allPermissionTypes array.
-const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
+const ensureT = (orgID: string, userID: string) => (
+  t: PermissionTypes
+): Permission[] => {
   switch (t) {
     case 'authorizations':
     case 'buckets':
@@ -47,7 +49,6 @@ const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
     case 'sources':
     case 'tasks':
     case 'telegrafs':
-    case 'users':
     case 'variables':
     case 'views':
       return [
@@ -69,13 +70,27 @@ const ensureT = (orgID: string) => (t: PermissionTypes): Permission[] => {
           resource: {type: t, id: orgID},
         },
       ]
+    case 'users':
+      return [
+        {
+          action: 'read' as 'read',
+          resource: {type: t, id: userID},
+        },
+        {
+          action: 'write' as 'write',
+          resource: {type: t, id: userID},
+        },
+      ]
     default:
       return assertNever(t)
   }
 }
 
-export const allAccessPermissions = (orgID: string): Permission[] => {
-  const withOrgID = ensureT(orgID)
+export const allAccessPermissions = (
+  orgID: string,
+  userID: string
+): Permission[] => {
+  const withOrgID = ensureT(orgID, userID)
   return allPermissionTypes.flatMap(withOrgID)
 }
 

--- a/ui/src/me/selectors/index.ts
+++ b/ui/src/me/selectors/index.ts
@@ -1,0 +1,20 @@
+// Libraries
+import {get} from 'lodash'
+
+// Types
+import {AppState} from 'src/types'
+import {MeState} from 'src/shared/reducers/me'
+
+// TODO(desa): is this reasonable or can I trust app state?
+const emptyMeState: MeState = {
+  id: '',
+  name: '',
+  links: {
+    self: '',
+    log: '',
+  },
+}
+
+export const getMe = (state: AppState): MeState => {
+  return get(state, 'me', emptyMeState)
+}

--- a/ui/src/me/selectors/index.ts
+++ b/ui/src/me/selectors/index.ts
@@ -1,20 +1,7 @@
-// Libraries
-import {get} from 'lodash'
-
 // Types
 import {AppState} from 'src/types'
 import {MeState} from 'src/shared/reducers/me'
 
-// TODO(desa): is this reasonable or can I trust app state?
-const emptyMeState: MeState = {
-  id: '',
-  name: '',
-  links: {
-    self: '',
-    log: '',
-  },
-}
-
 export const getMe = (state: AppState): MeState => {
-  return get(state, 'me', emptyMeState)
+  return state.me
 }


### PR DESCRIPTION
Users used to be given the permission `orgs/<orgID>/users`, but this
does not help when the user is trying to access the users api (as it is
not nested under orgs in the api). We have changed the
`orgs/<orgID>/users` to be `users/<userID>` so that the token has access
to the user that created it. This will allow users to access their
tokens via the api.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
