### PR TITLE
feat(storage/reads): add min/max aggregate array cursors

### DIFF
--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -45,13 +45,15 @@ func (caps mockReaderCaps) ReadWindowAggregate(ctx context.Context, spec query.R
 }
 
 type mockGroupCapability struct {
-	count, sum, first, last bool
+	count, sum, first, last, min, max bool
 }
 
 func (c mockGroupCapability) HaveCount() bool { return c.count }
 func (c mockGroupCapability) HaveSum() bool   { return c.sum }
 func (c mockGroupCapability) HaveFirst() bool { return c.first }
 func (c mockGroupCapability) HaveLast() bool  { return c.last }
+func (c mockGroupCapability) HaveMin() bool   { return c.min }
+func (c mockGroupCapability) HaveMax() bool   { return c.max }
 
 // Mock Window Aggregate Capability
 type mockWAC struct {

--- a/query/storage.go
+++ b/query/storage.go
@@ -29,6 +29,8 @@ type GroupCapability interface {
 	HaveSum() bool
 	HaveFirst() bool
 	HaveLast() bool
+	HaveMin() bool
+	HaveMax() bool
 }
 
 type GroupAggregator interface {

--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -136,6 +136,40 @@ func newWindowSumArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
 	}
 }
 
+func newWindowMinArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
+	switch cur := cur.(type) {
+
+	case cursors.FloatArrayCursor:
+		return newFloatWindowMinArrayCursor(cur, every)
+
+	case cursors.IntegerArrayCursor:
+		return newIntegerWindowMinArrayCursor(cur, every)
+
+	case cursors.UnsignedArrayCursor:
+		return newUnsignedWindowMinArrayCursor(cur, every)
+
+	default:
+		panic(fmt.Sprintf("unsupported for aggregate min: %T", cur))
+	}
+}
+
+func newWindowMaxArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
+	switch cur := cur.(type) {
+
+	case cursors.FloatArrayCursor:
+		return newFloatWindowMaxArrayCursor(cur, every)
+
+	case cursors.IntegerArrayCursor:
+		return newIntegerWindowMaxArrayCursor(cur, every)
+
+	case cursors.UnsignedArrayCursor:
+		return newUnsignedWindowMaxArrayCursor(cur, every)
+
+	default:
+		panic(fmt.Sprintf("unsupported for aggregate max: %T", cur))
+	}
+}
+
 // ********************
 // Float Array Cursor
 
@@ -661,6 +695,248 @@ WINDOWS:
 			// do not generate a point for empty windows
 			if windowHasPoints {
 				c.res.Timestamps[pos] = windowEnd
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
+type floatWindowMinArrayCursor struct {
+	cursors.FloatArrayCursor
+	every int64
+	res   *cursors.FloatArray
+	tmp   *cursors.FloatArray
+}
+
+func newFloatWindowMinArrayCursor(cur cursors.FloatArrayCursor, every int64) *floatWindowMinArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &floatWindowMinArrayCursor{
+		FloatArrayCursor: cur,
+		every:            every,
+		res:              cursors.NewFloatArrayLen(resLen),
+		tmp:              &cursors.FloatArray{},
+	}
+}
+
+func (c *floatWindowMinArrayCursor) Stats() cursors.CursorStats {
+	return c.FloatArrayCursor.Stats()
+}
+
+func (c *floatWindowMinArrayCursor) Next() *cursors.FloatArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.FloatArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.FloatArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.FloatArray{}
+	}
+
+	rowIdx := 0
+	var acc float64 = math.MaxFloat64
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = math.MaxFloat64
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] < acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.FloatArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
+type floatWindowMaxArrayCursor struct {
+	cursors.FloatArrayCursor
+	every int64
+	res   *cursors.FloatArray
+	tmp   *cursors.FloatArray
+}
+
+func newFloatWindowMaxArrayCursor(cur cursors.FloatArrayCursor, every int64) *floatWindowMaxArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &floatWindowMaxArrayCursor{
+		FloatArrayCursor: cur,
+		every:            every,
+		res:              cursors.NewFloatArrayLen(resLen),
+		tmp:              &cursors.FloatArray{},
+	}
+}
+
+func (c *floatWindowMaxArrayCursor) Stats() cursors.CursorStats {
+	return c.FloatArrayCursor.Stats()
+}
+
+func (c *floatWindowMaxArrayCursor) Next() *cursors.FloatArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.FloatArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.FloatArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.FloatArray{}
+	}
+
+	rowIdx := 0
+	var acc float64 = -math.MaxFloat64
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = -math.MaxFloat64
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] > acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.FloatArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
 				c.res.Values[pos] = acc
 				pos++
 			}
@@ -1225,6 +1501,248 @@ WINDOWS:
 	return c.res
 }
 
+type integerWindowMinArrayCursor struct {
+	cursors.IntegerArrayCursor
+	every int64
+	res   *cursors.IntegerArray
+	tmp   *cursors.IntegerArray
+}
+
+func newIntegerWindowMinArrayCursor(cur cursors.IntegerArrayCursor, every int64) *integerWindowMinArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &integerWindowMinArrayCursor{
+		IntegerArrayCursor: cur,
+		every:              every,
+		res:                cursors.NewIntegerArrayLen(resLen),
+		tmp:                &cursors.IntegerArray{},
+	}
+}
+
+func (c *integerWindowMinArrayCursor) Stats() cursors.CursorStats {
+	return c.IntegerArrayCursor.Stats()
+}
+
+func (c *integerWindowMinArrayCursor) Next() *cursors.IntegerArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.IntegerArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.IntegerArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.IntegerArray{}
+	}
+
+	rowIdx := 0
+	var acc int64 = math.MaxInt64
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = math.MaxInt64
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] < acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.IntegerArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
+type integerWindowMaxArrayCursor struct {
+	cursors.IntegerArrayCursor
+	every int64
+	res   *cursors.IntegerArray
+	tmp   *cursors.IntegerArray
+}
+
+func newIntegerWindowMaxArrayCursor(cur cursors.IntegerArrayCursor, every int64) *integerWindowMaxArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &integerWindowMaxArrayCursor{
+		IntegerArrayCursor: cur,
+		every:              every,
+		res:                cursors.NewIntegerArrayLen(resLen),
+		tmp:                &cursors.IntegerArray{},
+	}
+}
+
+func (c *integerWindowMaxArrayCursor) Stats() cursors.CursorStats {
+	return c.IntegerArrayCursor.Stats()
+}
+
+func (c *integerWindowMaxArrayCursor) Next() *cursors.IntegerArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.IntegerArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.IntegerArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.IntegerArray{}
+	}
+
+	rowIdx := 0
+	var acc int64 = math.MinInt64
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = math.MinInt64
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] > acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.IntegerArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
 type integerEmptyArrayCursor struct {
 	res cursors.IntegerArray
 }
@@ -1761,6 +2279,248 @@ WINDOWS:
 			// do not generate a point for empty windows
 			if windowHasPoints {
 				c.res.Timestamps[pos] = windowEnd
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
+type unsignedWindowMinArrayCursor struct {
+	cursors.UnsignedArrayCursor
+	every int64
+	res   *cursors.UnsignedArray
+	tmp   *cursors.UnsignedArray
+}
+
+func newUnsignedWindowMinArrayCursor(cur cursors.UnsignedArrayCursor, every int64) *unsignedWindowMinArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &unsignedWindowMinArrayCursor{
+		UnsignedArrayCursor: cur,
+		every:               every,
+		res:                 cursors.NewUnsignedArrayLen(resLen),
+		tmp:                 &cursors.UnsignedArray{},
+	}
+}
+
+func (c *unsignedWindowMinArrayCursor) Stats() cursors.CursorStats {
+	return c.UnsignedArrayCursor.Stats()
+}
+
+func (c *unsignedWindowMinArrayCursor) Next() *cursors.UnsignedArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.UnsignedArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.UnsignedArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.UnsignedArray{}
+	}
+
+	rowIdx := 0
+	var acc uint64 = math.MaxUint64
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = math.MaxUint64
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] < acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.UnsignedArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
+				c.res.Values[pos] = acc
+				pos++
+			}
+			break WINDOWS
+		}
+		rowIdx = 0
+	}
+
+	c.res.Timestamps = c.res.Timestamps[:pos]
+	c.res.Values = c.res.Values[:pos]
+
+	return c.res
+}
+
+type unsignedWindowMaxArrayCursor struct {
+	cursors.UnsignedArrayCursor
+	every int64
+	res   *cursors.UnsignedArray
+	tmp   *cursors.UnsignedArray
+}
+
+func newUnsignedWindowMaxArrayCursor(cur cursors.UnsignedArrayCursor, every int64) *unsignedWindowMaxArrayCursor {
+	resLen := MaxPointsPerBlock
+	if every == 0 {
+		resLen = 1
+	}
+	return &unsignedWindowMaxArrayCursor{
+		UnsignedArrayCursor: cur,
+		every:               every,
+		res:                 cursors.NewUnsignedArrayLen(resLen),
+		tmp:                 &cursors.UnsignedArray{},
+	}
+}
+
+func (c *unsignedWindowMaxArrayCursor) Stats() cursors.CursorStats {
+	return c.UnsignedArrayCursor.Stats()
+}
+
+func (c *unsignedWindowMaxArrayCursor) Next() *cursors.UnsignedArray {
+	pos := 0
+	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
+	c.res.Values = c.res.Values[:cap(c.res.Values)]
+
+	var a *cursors.UnsignedArray
+	if c.tmp.Len() > 0 {
+		a = c.tmp
+	} else {
+		a = c.UnsignedArrayCursor.Next()
+	}
+
+	if a.Len() == 0 {
+		return &cursors.UnsignedArray{}
+	}
+
+	rowIdx := 0
+	var acc uint64 = 0
+	var tsAcc int64
+
+	var windowEnd int64
+	if c.every != 0 {
+		firstTimestamp := a.Timestamps[rowIdx]
+		windowStart := firstTimestamp - firstTimestamp%c.every
+		windowEnd = windowStart + c.every
+	} else {
+		windowEnd = math.MaxInt64
+	}
+
+	windowHasPoints := false
+
+	// enumerate windows
+WINDOWS:
+	for {
+		for ; rowIdx < a.Len(); rowIdx++ {
+			ts := a.Timestamps[rowIdx]
+			if c.every != 0 && ts >= windowEnd {
+				// new window detected, close the current window
+				// do not generate a point for empty windows
+				if windowHasPoints {
+					c.res.Timestamps[pos] = tsAcc
+					c.res.Values[pos] = acc
+					pos++
+					if pos >= MaxPointsPerBlock {
+						// the output array is full,
+						// save the remaining points in the input array in tmp.
+						// they will be processed in the next call to Next()
+						c.tmp.Timestamps = a.Timestamps[rowIdx:]
+						c.tmp.Values = a.Values[rowIdx:]
+						break WINDOWS
+					}
+				}
+
+				// start the new window
+				acc = 0
+
+				firstTimestamp := a.Timestamps[rowIdx]
+				windowStart := firstTimestamp - firstTimestamp%c.every
+				windowEnd = windowStart + c.every
+				windowHasPoints = false
+
+				continue WINDOWS
+			} else {
+				if !windowHasPoints || a.Values[rowIdx] > acc {
+					acc = a.Values[rowIdx]
+					tsAcc = a.Timestamps[rowIdx]
+				}
+				windowHasPoints = true
+			}
+		}
+
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
+
+		// get the next chunk
+		a = c.UnsignedArrayCursor.Next()
+		if a.Len() == 0 {
+			// write the final point
+			// do not generate a point for empty windows
+			if windowHasPoints {
+				c.res.Timestamps[pos] = tsAcc
 				c.res.Values[pos] = acc
 				pos++
 			}

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -80,6 +80,38 @@ func newWindowSumArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
 		panic(fmt.Sprintf("unsupported for aggregate sum: %T", cur))
 	}
 }
+
+func newWindowMinArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
+	switch cur := cur.(type) {
+{{range .}}
+{{$Type := .Name}}
+{{range .Aggs}}
+{{if eq .Name "Min"}}
+	case cursors.{{$Type}}ArrayCursor:
+		return new{{$Type}}WindowMinArrayCursor(cur, every)
+{{end}}
+{{end}}{{/* for each supported agg fn */}}
+{{end}}{{/* for each field type */}}
+	default:
+		panic(fmt.Sprintf("unsupported for aggregate min: %T", cur))
+	}
+}
+
+func newWindowMaxArrayCursor(cur cursors.Cursor, every int64) cursors.Cursor {
+	switch cur := cur.(type) {
+{{range .}}
+{{$Type := .Name}}
+{{range .Aggs}}
+{{if eq .Name "Max"}}
+	case cursors.{{$Type}}ArrayCursor:
+		return new{{$Type}}WindowMaxArrayCursor(cur, every)
+{{end}}
+{{end}}{{/* for each supported agg fn */}}
+{{end}}{{/* for each field type */}}
+	default:
+		panic(fmt.Sprintf("unsupported for aggregate max: %T", cur))
+	}
+}
 {{range .}}
 {{$arrayType := print "*cursors." .Name "Array"}}
 {{$type := print .name "ArrayFilterCursor"}}
@@ -400,7 +432,7 @@ NEXT:
 type {{$name}}Window{{$aggName}}ArrayCursor struct {
 	cursors.{{$Name}}ArrayCursor
 	every int64
-	res   *cursors.{{.AccTypeName}}Array
+	res   *cursors.{{.OutputTypeName}}Array
 	tmp   {{$arrayType}}
 }
 
@@ -412,7 +444,7 @@ func new{{$Name}}Window{{$aggName}}ArrayCursor(cur cursors.{{$Name}}ArrayCursor,
 	return &{{$name}}Window{{$aggName}}ArrayCursor{
 		{{$Name}}ArrayCursor: cur,
 		every: every,
-		res: cursors.New{{.AccTypeName}}ArrayLen(resLen),
+		res: cursors.New{{.OutputTypeName}}ArrayLen(resLen),
 		tmp: &cursors.{{$Name}}Array{},
 	}
 }
@@ -421,7 +453,7 @@ func (c *{{$name}}Window{{$aggName}}ArrayCursor) Stats() cursors.CursorStats {
 	return c.{{$Name}}ArrayCursor.Stats()
 }
 
-func (c *{{$name}}Window{{$aggName}}ArrayCursor) Next() *cursors.{{.AccTypeName}}Array {
+func (c *{{$name}}Window{{$aggName}}ArrayCursor) Next() *cursors.{{.OutputTypeName}}Array {
 	pos := 0
 	c.res.Timestamps = c.res.Timestamps[:cap(c.res.Timestamps)]
 	c.res.Values = c.res.Values[:cap(c.res.Values)]
@@ -434,11 +466,11 @@ func (c *{{$name}}Window{{$aggName}}ArrayCursor) Next() *cursors.{{.AccTypeName}
 	}
 
 	if a.Len() == 0 {
-		return &cursors.{{.AccTypeName}}Array{}
+		return &cursors.{{.OutputTypeName}}Array{}
 	}
 
 	rowIdx := 0
-	var acc {{.AccType}} = {{.AccInit}}
+	{{.AccDecls}}
 
 	var windowEnd int64
 	if c.every != 0 {
@@ -460,8 +492,7 @@ WINDOWS:
 				// new window detected, close the current window
 				// do not generate a point for empty windows
 				if windowHasPoints {
-					c.res.Timestamps[pos] = windowEnd
-					c.res.Values[pos] = acc
+					{{.AccEmit}}
 					pos++
 					if pos >= MaxPointsPerBlock {
 						// the output array is full,
@@ -474,7 +505,7 @@ WINDOWS:
 				}
 
 				// start the new window
-				acc = {{.AccInit}}
+				{{.AccReset}}
 
 				firstTimestamp := a.Timestamps[rowIdx]
 				windowStart := firstTimestamp - firstTimestamp%c.every
@@ -499,8 +530,7 @@ WINDOWS:
 			// write the final point
 			// do not generate a point for empty windows
 			if windowHasPoints {
-				c.res.Timestamps[pos] = windowEnd
-				c.res.Values[pos] = acc
+				{{.AccEmit}}
 				pos++
 			}
 			break WINDOWS

--- a/storage/reads/array_cursor.gen.go.tmpldata
+++ b/storage/reads/array_cursor.gen.go.tmpldata
@@ -5,19 +5,37 @@
 		"Type":"float64",
 		"Aggs": [
 			{
-		 		"Name":"Count",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc++"
-		 	},
+				"Name":"Count",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc++",
+				"AccEmit": "c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
 			{
-		 		"Name":"Sum",
-				"AccType":"float64",
-				"AccTypeName":"Float",
-		 		"AccInit":"0",
-				"Accumulate":"acc += a.Values[rowIdx]"
-		 	}
+				"Name":"Sum",
+				"OutputTypeName":"Float",
+				"AccDecls":"var acc float64 = 0",
+				"Accumulate":"acc += a.Values[rowIdx]",
+				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
+			{
+				"Name":"Min",
+				"OutputTypeName":"Float",
+				"AccDecls":"var acc float64 = math.MaxFloat64; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] < acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = math.MaxFloat64"
+			},
+			{
+				"Name":"Max",
+				"OutputTypeName":"Float",
+				"AccDecls":"var acc float64 = -math.MaxFloat64; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] > acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = -math.MaxFloat64"
+			}
 		]
 	},
 	{
@@ -26,19 +44,37 @@
 		"Type":"int64",
 		"Aggs": [
 			{
-		 		"Name":"Count",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc++"
-		 	},
+				"Name":"Count",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc++",
+				"AccEmit": "c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
 			{
-		 		"Name":"Sum",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc += a.Values[rowIdx]"
-		 	}
+				"Name":"Sum",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc += a.Values[rowIdx]",
+				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
+			{
+				"Name":"Min",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = math.MaxInt64; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] < acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = math.MaxInt64"
+			},
+			{
+				"Name":"Max",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = math.MinInt64; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] > acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = math.MinInt64"
+			}
 		]
 	},
 	{
@@ -47,19 +83,37 @@
 		"Type":"uint64",
 		"Aggs": [
 			{
-		 		"Name":"Count",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc++"
-		 	},
+				"Name":"Count",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc++",
+				"AccEmit": "c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
 			{
-		 		"Name":"Sum",
-				"AccType":"uint64",
-				"AccTypeName":"Unsigned",
-		 		"AccInit":"0",
-				"Accumulate":"acc += a.Values[rowIdx]"
-		 	}
+				"Name":"Sum",
+				"OutputTypeName":"Unsigned",
+				"AccDecls":"var acc uint64 = 0",
+				"Accumulate":"acc += a.Values[rowIdx]",
+				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			},
+			{
+				"Name":"Min",
+				"OutputTypeName":"Unsigned",
+				"AccDecls":"var acc uint64 = math.MaxUint64; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] < acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = math.MaxUint64"
+			},
+			{
+				"Name":"Max",
+				"OutputTypeName":"Unsigned",
+				"AccDecls":"var acc uint64 = 0; var tsAcc int64",
+				"Accumulate":"if !windowHasPoints || a.Values[rowIdx] > acc { acc = a.Values[rowIdx]; tsAcc = a.Timestamps[rowIdx] }",
+				"AccEmit":"c.res.Timestamps[pos] = tsAcc; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			}
 		]
 	},
 	{
@@ -68,12 +122,13 @@
 		"Type":"string",
 		"Aggs": [
 			{
-		 		"Name":"Count",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc++"
-		 	}
+				"Name":"Count",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc++",
+				"AccEmit": "c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			}
 		]
 	},
 	{
@@ -82,12 +137,13 @@
 		"Type":"bool",
 		"Aggs": [
 			{
-		 		"Name":"Count",
-				"AccType":"int64",
-				"AccTypeName":"Integer",
-		 		"AccInit":"0",
-				"Accumulate":"acc++"
-		 	}
+				"Name":"Count",
+				"OutputTypeName":"Integer",
+				"AccDecls":"var acc int64 = 0",
+				"Accumulate":"acc++",
+				"AccEmit": "c.res.Timestamps[pos] = windowEnd; c.res.Values[pos] = acc",
+				"AccReset":"acc = 0"
+			}
 		]
 	}
 ]

--- a/storage/reads/array_cursor.go
+++ b/storage/reads/array_cursor.go
@@ -38,6 +38,10 @@ func newWindowAggregateArrayCursor(ctx context.Context, agg *datatypes.Aggregate
 		return newWindowFirstArrayCursor(cursor, every)
 	case datatypes.AggregateTypeLast:
 		return newWindowLastArrayCursor(cursor, every)
+	case datatypes.AggregateTypeMin:
+		return newWindowMinArrayCursor(cursor, every)
+	case datatypes.AggregateTypeMax:
+		return newWindowMaxArrayCursor(cursor, every)
 	default:
 		// TODO(sgc): should be validated higher up
 		panic("invalid aggregate")

--- a/storage/reads/array_cursor_gen_test.go
+++ b/storage/reads/array_cursor_gen_test.go
@@ -66,6 +66,42 @@ func TestNewAggregateArrayCursor_Float(t *testing.T) {
 		}
 	})
 
+	t.Run("Min", func(t *testing.T) {
+		want := &floatWindowMinArrayCursor{
+			FloatArrayCursor: &MockFloatArrayCursor{},
+			res:              cursors.NewFloatArrayLen(1),
+			tmp:              &cursors.FloatArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockFloatArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(floatWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &floatWindowMaxArrayCursor{
+			FloatArrayCursor: &MockFloatArrayCursor{},
+			res:              cursors.NewFloatArrayLen(1),
+			tmp:              &cursors.FloatArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockFloatArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(floatWindowMaxArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
 }
 
 func TestNewWindowAggregateArrayCursor_Float(t *testing.T) {
@@ -104,6 +140,44 @@ func TestNewWindowAggregateArrayCursor_Float(t *testing.T) {
 		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockFloatArrayCursor{})
 
 		if diff := cmp.Diff(got, want, cmp.AllowUnexported(floatWindowSumArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Min", func(t *testing.T) {
+		want := &floatWindowMinArrayCursor{
+			FloatArrayCursor: &MockFloatArrayCursor{},
+			every:            int64(time.Hour),
+			res:              cursors.NewFloatArrayLen(MaxPointsPerBlock),
+			tmp:              &cursors.FloatArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockFloatArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(floatWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &floatWindowMaxArrayCursor{
+			FloatArrayCursor: &MockFloatArrayCursor{},
+			every:            int64(time.Hour),
+			res:              cursors.NewFloatArrayLen(MaxPointsPerBlock),
+			tmp:              &cursors.FloatArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockFloatArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(floatWindowMaxArrayCursor{})); diff != "" {
 			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 		}
 	})
@@ -160,6 +234,42 @@ func TestNewAggregateArrayCursor_Integer(t *testing.T) {
 		}
 	})
 
+	t.Run("Min", func(t *testing.T) {
+		want := &integerWindowMinArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			res:                cursors.NewIntegerArrayLen(1),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockIntegerArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &integerWindowMaxArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			res:                cursors.NewIntegerArrayLen(1),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockIntegerArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowMaxArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
 }
 
 func TestNewWindowAggregateArrayCursor_Integer(t *testing.T) {
@@ -198,6 +308,44 @@ func TestNewWindowAggregateArrayCursor_Integer(t *testing.T) {
 		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockIntegerArrayCursor{})
 
 		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowSumArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Min", func(t *testing.T) {
+		want := &integerWindowMinArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			every:              int64(time.Hour),
+			res:                cursors.NewIntegerArrayLen(MaxPointsPerBlock),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockIntegerArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &integerWindowMaxArrayCursor{
+			IntegerArrayCursor: &MockIntegerArrayCursor{},
+			every:              int64(time.Hour),
+			res:                cursors.NewIntegerArrayLen(MaxPointsPerBlock),
+			tmp:                &cursors.IntegerArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockIntegerArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(integerWindowMaxArrayCursor{})); diff != "" {
 			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 		}
 	})
@@ -254,6 +402,42 @@ func TestNewAggregateArrayCursor_Unsigned(t *testing.T) {
 		}
 	})
 
+	t.Run("Min", func(t *testing.T) {
+		want := &unsignedWindowMinArrayCursor{
+			UnsignedArrayCursor: &MockUnsignedArrayCursor{},
+			res:                 cursors.NewUnsignedArrayLen(1),
+			tmp:                 &cursors.UnsignedArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockUnsignedArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(unsignedWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &unsignedWindowMaxArrayCursor{
+			UnsignedArrayCursor: &MockUnsignedArrayCursor{},
+			res:                 cursors.NewUnsignedArrayLen(1),
+			tmp:                 &cursors.UnsignedArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newAggregateArrayCursor(context.Background(), agg, &MockUnsignedArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(unsignedWindowMaxArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
 }
 
 func TestNewWindowAggregateArrayCursor_Unsigned(t *testing.T) {
@@ -292,6 +476,44 @@ func TestNewWindowAggregateArrayCursor_Unsigned(t *testing.T) {
 		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockUnsignedArrayCursor{})
 
 		if diff := cmp.Diff(got, want, cmp.AllowUnexported(unsignedWindowSumArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Min", func(t *testing.T) {
+		want := &unsignedWindowMinArrayCursor{
+			UnsignedArrayCursor: &MockUnsignedArrayCursor{},
+			every:               int64(time.Hour),
+			res:                 cursors.NewUnsignedArrayLen(MaxPointsPerBlock),
+			tmp:                 &cursors.UnsignedArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMin,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockUnsignedArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(unsignedWindowMinArrayCursor{})); diff != "" {
+			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		want := &unsignedWindowMaxArrayCursor{
+			UnsignedArrayCursor: &MockUnsignedArrayCursor{},
+			every:               int64(time.Hour),
+			res:                 cursors.NewUnsignedArrayLen(MaxPointsPerBlock),
+			tmp:                 &cursors.UnsignedArray{},
+		}
+
+		agg := &datatypes.Aggregate{
+			Type: datatypes.AggregateTypeMax,
+		}
+
+		got := newWindowAggregateArrayCursor(context.Background(), agg, int64(time.Hour), &MockUnsignedArrayCursor{})
+
+		if diff := cmp.Diff(got, want, cmp.AllowUnexported(unsignedWindowMaxArrayCursor{})); diff != "" {
 			t.Fatalf("did not get expected cursor; -got/+want:\n%v", diff)
 		}
 	})

--- a/storage/reads/array_cursor_test.gen.go.tmpl
+++ b/storage/reads/array_cursor_test.gen.go.tmpl
@@ -32,7 +32,7 @@ func TestNewAggregateArrayCursor_{{$ColType}}(t *testing.T) {
 	t.Run("{{$Agg}}", func(t *testing.T) {
 		want := &{{$colType}}Window{{$Agg}}ArrayCursor{
 			{{$ColType}}ArrayCursor: &Mock{{$ColType}}ArrayCursor{},
-			res:                cursors.New{{.AccTypeName}}ArrayLen(1),
+			res:                cursors.New{{.OutputTypeName}}ArrayLen(1),
 			tmp:                &cursors.{{$ColType}}Array{},
 		}
 
@@ -56,7 +56,7 @@ func TestNewWindowAggregateArrayCursor_{{$ColType}}(t *testing.T) {
 		want := &{{$colType}}Window{{$Agg}}ArrayCursor{
 			{{$ColType}}ArrayCursor: &Mock{{$ColType}}ArrayCursor{},
 			every:              int64(time.Hour),
-			res:                cursors.New{{.AccTypeName}}ArrayLen(MaxPointsPerBlock),
+			res:                cursors.New{{.OutputTypeName}}ArrayLen(MaxPointsPerBlock),
 			tmp:                &cursors.{{$ColType}}Array{},
 		}
 

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -28,12 +28,16 @@ func NewStore(viewer reads.Viewer) reads.Store {
 			Sum:   true,
 			First: true,
 			Last:  true,
+			Min:   true,
+			Max:   true,
 		},
 		windowCap: WindowAggregateCapability{
 			Count: true,
 			Sum:   true,
 			First: true,
 			Last:  true,
+			Min:   true,
+			Max:   true,
 		},
 	}
 }
@@ -207,12 +211,16 @@ type GroupCapability struct {
 	Sum   bool
 	First bool
 	Last  bool
+	Min   bool
+	Max   bool
 }
 
 func (c GroupCapability) HaveCount() bool { return c.Count }
 func (c GroupCapability) HaveSum() bool   { return c.Sum }
 func (c GroupCapability) HaveFirst() bool { return c.First }
 func (c GroupCapability) HaveLast() bool  { return c.Last }
+func (c GroupCapability) HaveMin() bool   { return c.Min }
+func (c GroupCapability) HaveMax() bool   { return c.Max }
 
 type WindowAggregateCapability struct {
 	Min   bool


### PR DESCRIPTION
This PR adds new `min` and `max` aggregate cursors for the three numeric data types supported by storage.

I had to modify the aggregate cursor template a little bit to make this work right, since `min` and `max` are selectors and so must preserve the timestamps of their input rows (rather than just use the timestamp of the current window's upper bound).

Closes #18636 