### PR TITLE
fix(tsi): retaining fileset should not copy pointer

### DIFF
--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -30,6 +30,14 @@ func NewFileSet(levels []CompactionLevel, sfile *tsdb.SeriesFile, files []File) 
 	}, nil
 }
 
+func (fs *FileSet) Clone() *FileSet {
+	fs2 := &FileSet{
+		files: make([]File, len(fs.files)),
+	}
+	copy(fs2.files, fs.files)
+	return fs2
+}
+
 // bytes estimates the memory footprint of this FileSet, in bytes.
 func (fs *FileSet) bytes() int {
 	var b int

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -452,7 +452,7 @@ func (p *Partition) RetainFileSet() (*FileSet, error) {
 }
 
 func (p *Partition) retainFileSet() *FileSet {
-	fs := p.fileSet
+	fs := p.fileSet.Clone()
 	fs.Retain()
 	return fs
 }


### PR DESCRIPTION
Current implementation of `retainFileSet` is not safe because it returns `p.fileSet` directly. It is supposed to be protected by mutex:

```
func (p *Partition) retainFileSet() *FileSet {
	fs := p.fileSet
	fs.Retain()
	return fs
}
```

The bug may lead to deadlock if the fileset is modified while there is compaction.  
