### PR TITLE
fix: missing data when reading after writing

### DIFF
--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -413,14 +413,12 @@ func (c *Cache) Values(key []byte) Values {
 	// Create the buffer, and copy all hot values and snapshots. Individual
 	// entries are sorted at this point, so now the code has to check if the
 	// resultant buffer will be sorted from start to finish.
-	values := make(Values, sz)
-	n := 0
+	values := make(Values, 0, sz)
 	for _, e := range entries {
 		e.mu.RLock()
-		n += copy(values[n:], e.values)
+		values = append(values, e.values...)
 		e.mu.RUnlock()
 	}
-	values = values[:n]
 	values = values.Deduplicate()
 
 	return values

--- a/tsdb/tsm1/cache_race_test.go
+++ b/tsdb/tsm1/cache_race_test.go
@@ -3,8 +3,13 @@ package tsm1_test
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
+	"runtime"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/v2/tsdb/tsm1"
 )
@@ -201,6 +206,97 @@ func TestCacheRace2Compacters(t *testing.T) {
 	for err := range errC {
 		if err != nil {
 			t.Error(err)
+		}
+	}
+}
+
+func TestConcurrentReadAfterWrite(t *testing.T) {
+	t.Parallel()
+
+	var starttime int64 = 1594785691
+	series := [][]byte{[]byte("key1"), []byte("key2")}
+
+	concurrency := runtime.GOMAXPROCS(0) * 2
+	batch := 1024
+
+	errCh := make(chan error, concurrency)
+	closing := make(chan struct{})
+	var wg sync.WaitGroup
+
+	c := tsm1.NewCache(1024 * 1024 * 16)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		// read after read concurrently
+		go func() {
+			defer wg.Done()
+			for {
+
+				select {
+				case <-closing:
+					errCh <- nil
+					return
+				default:
+				}
+
+				ts := atomic.AddInt64(&starttime, int64(batch))
+				writes := make(tsm1.Values, 0, batch)
+				for j := 0; j < batch; j++ {
+					writes = append(writes,
+						tsm1.NewValue(ts+int64(j), ts+int64(j)))
+				}
+				for _, key := range series {
+					if err := c.Write(key, writes); err != nil {
+						errCh <- err
+						return
+					}
+				}
+				for _, key := range series {
+					// check the read result
+					reads := c.Values(key)
+
+					if len(reads) < len(writes) {
+						errCh <- fmt.Errorf("read count: %v less than write count: %v", len(reads), len(writes))
+						return
+					}
+
+					sort.Slice(reads, func(i, j int) bool {
+						return reads[i].UnixNano() < reads[j].UnixNano()
+					})
+
+					k := 0
+					for j := range writes {
+						write := writes[j].Value()
+
+						found := false
+						for k < len(reads) {
+							read := reads[k].Value()
+							if reflect.DeepEqual(read, write) {
+								found = true
+								break
+							}
+							k++
+						}
+
+						if !found {
+							errCh <- fmt.Errorf("write value: %v not found in reads", write)
+							return
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	// sleep for a little while and check
+	time.Sleep(time.Second * 20)
+	close(closing)
+	wg.Wait()
+
+	for i := 0; i < concurrency; i++ {
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+			return
 		}
 	}
 }

--- a/tsdb/tsm1/cache_race_test.go
+++ b/tsdb/tsm1/cache_race_test.go
@@ -223,7 +223,7 @@ func TestConcurrentReadAfterWrite(t *testing.T) {
 	closing := make(chan struct{})
 	var wg sync.WaitGroup
 
-	c := tsm1.NewCache(1024 * 1024 * 16)
+	c := tsm1.NewCache(1024 * 1024 * 128)
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		// read after read concurrently


### PR DESCRIPTION
Describe your proposed changes here.

This PR is to fixed the problem that the cache of the tsm engine may return less data than expected in reading when read&write conccurently.  This PR includes the fix and the unit test to cover this case. 

The `sz` aquired at 
https://github.com/influxdata/influxdb/blob/b74e1f649a0457e15d302328e9f29f2f41e881b5/tsdb/tsm1/cache.go#L395
may be outdated when copy data at
https://github.com/influxdata/influxdb/blob/b74e1f649a0457e15d302328e9f29f2f41e881b5/tsdb/tsm1/cache.go#L420

The actual value slice has already been modified by concurrent reading/writing, which leading the data missing in current reading.


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
