### PR TITLE
fix: make Single Stat cells work in Safari again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 1. [18891](https://github.com/influxdata/influxdb/pull/18891): Allow 0 to be the custom set minimum value for Y Domain
+1. [18969](https://github.com/influxdata/influxdb/pull/18969): Single Stat cells should render properly in Safari again
 
 ## v2.0.0-beta.14 [2020-07-08]
 

--- a/ui/src/shared/components/SingleStat.scss
+++ b/ui/src/shared/components/SingleStat.scss
@@ -17,6 +17,7 @@
 }
 
 .single-stat--resizer {
+  display: flex;
   overflow: hidden;
   width: 100%;
   height: 100%;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1393,6 +1393,11 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
 
+"@use-it/event-listener@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.3.tgz#a9920b2819d211cf55e68e830997546eec6886d3"
+  integrity sha512-UCHkLOVU+xj3/1R8jXz8GzDTowkzfIDPESOBlVC2ndgwUSBEqiFdwCoUEs2lcGhJOOiEdmWxF+T23C5+60eEew==
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -11705,6 +11710,13 @@ url@0.11.0, url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-persisted-state@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.0.tgz#f8e3d2fd8eee67e0c86fd596c3ea3e8121c07402"
+  integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Closes #18964 
Closes #18966 

Explicitly set the `display` to `flex`.

## #18964

**Safari**
![Screen Shot 2020-07-15 at 4 46 59 PM](https://user-images.githubusercontent.com/146112/87610916-8de4fd80-c6bb-11ea-8e43-4b294cd988c7.png)

**Firefox**
![Screen Shot 2020-07-15 at 4 47 09 PM](https://user-images.githubusercontent.com/146112/87610930-94737500-c6bb-11ea-9bf4-1920e07ff404.png)

**Chrome**
![Screen Shot 2020-07-15 at 4 51 34 PM](https://user-images.githubusercontent.com/146112/87610939-9a695600-c6bb-11ea-9e2d-79da8bbae573.png)

## #18964
![Screen Shot 2020-07-15 at 4 52 02 PM](https://user-images.githubusercontent.com/146112/87610982-bc62d880-c6bb-11ea-9724-d7aaf85332d3.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
