### PR TITLE
fix(community-templates): only install selected resources

### DIFF
--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -38,6 +38,7 @@ import {
   getStacks,
   postTemplatesApply,
   Error as PkgError,
+  TemplateApply,
   TemplateSummary,
 } from 'src/client'
 import {addDashboardDefaults} from 'src/schemas/dashboards'
@@ -484,13 +485,33 @@ export const reviewTemplate = async (orgID: string, templateUrl: string) => {
   return applyTemplates(params)
 }
 
-export const installTemplate = async (orgID: string, templateUrl: string) => {
+export const installTemplate = async (
+  orgID: string,
+  templateUrl: string,
+  resourcesToSkip
+) => {
+  const data: TemplateApply = {
+    dryRun: false,
+    orgID,
+    remotes: [{url: templateUrl}],
+  }
+
+  if (Object.keys(resourcesToSkip).length) {
+    const actions = []
+    for (const resourceTemplateName in resourcesToSkip) {
+      actions.push({
+        action: 'skipResource',
+        properties: {
+          kind: resourcesToSkip[resourceTemplateName],
+          resourceTemplateName,
+        },
+      })
+    }
+    data.actions = actions
+  }
+
   const params = {
-    data: {
-      dryRun: false,
-      orgID,
-      remotes: [{url: templateUrl}],
-    },
+    data,
   }
 
   return applyTemplates(params)

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -95,7 +95,11 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     )}/${templateName}.yml`
 
     try {
-      const summary = await installTemplate(org.id, yamlLocation)
+      const summary = await installTemplate(
+        org.id,
+        yamlLocation,
+        this.props.resourcesToSkip
+      )
       this.props.notify(communityTemplateInstallSucceeded(templateName))
 
       this.props.fetchAndSetStacks(org.id)
@@ -123,6 +127,8 @@ const mstp = (state: AppState, props: RouterProps) => {
     resourceCount: getTotalResourceCount(
       state.resources.templates.communityTemplateToInstall.summary
     ),
+    resourcesToSkip:
+      state.resources.templates.communityTemplateToInstall.resourcesToSkip,
   }
 }
 

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -31,6 +31,7 @@ const defaultCommunityTemplate = (): CommunityTemplate => {
     stackID: '',
     summary: {},
     diff: {},
+    resourcesToSkip: {},
   }
 }
 
@@ -199,6 +200,17 @@ export const templatesReducer = (
         templateToInstall.summary[resourceType].forEach(resource => {
           if (resource.templateMetaName === templateMetaName) {
             resource.shouldInstall = shouldInstall
+            if (!shouldInstall) {
+              templateToInstall.resourcesToSkip[resource.templateMetaName] =
+                resource.kind
+            } else if (
+              templateToInstall.resourcesToSkip[resource.templateMetaName]
+            ) {
+              // if we re-check a resource that we un-checked, remove it from the skipped resources hash
+              delete templateToInstall.resourcesToSkip[
+                resource.templateMetaName
+              ]
+            }
           }
         })
 


### PR DESCRIPTION
Previously, the UI would allow the user to toggle which resources got installed, but it was never hooked up to the install process. This hooks it up.

Created a hash/object in redux that is keyed on the `templateMetaName`, and stores the `templateKind` which are what is needed by pkger to selectively install resources.

![Screen Shot 2020-07-16 at 5 01 11 PM](https://user-images.githubusercontent.com/146112/87734281-09f84780-c787-11ea-88c0-583adfcb683f.png)

![Screen Shot 2020-07-16 at 5 01 17 PM](https://user-images.githubusercontent.com/146112/87734286-0e246500-c787-11ea-8240-6ebc08156c8f.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
