### PR TITLE
feat(mincore): Add page fault limiter

### DIFF
--- a/pkg/mincore/limiter.go
+++ b/pkg/mincore/limiter.go
@@ -1,0 +1,175 @@
+package mincore
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/time/rate"
+)
+
+// Limiter defaults.
+const (
+	DefaultUpdateInterval = 10 * time.Second
+)
+
+// Limiter represents a token bucket rate limiter based on
+type Limiter struct {
+	mu         sync.Mutex
+	underlying *rate.Limiter
+	data       []byte    // mmap reference
+	incore     []byte    // in-core vector
+	updatedAt  time.Time // last incore update
+
+	// Frequency of updates of the in-core vector.
+	// Updates are performed lazily so this is the maximum frequency.
+	UpdateInterval time.Duration
+
+	// OS mincore() function.
+	Mincore func(data []byte) ([]byte, error)
+}
+
+// NewLimiter returns a new instance of Limiter associated with an mmap.
+// The underlying limiter can be shared to limit faults across the entire process.
+func NewLimiter(underlying *rate.Limiter, data []byte) *Limiter {
+	return &Limiter{
+		underlying: underlying,
+		data:       data,
+
+		UpdateInterval: DefaultUpdateInterval,
+		Mincore:        Mincore,
+	}
+}
+
+// WaitPointer checks if ptr would cause a page fault and, if so, rate limits its access.
+// Once a page access is limited, it's updated to be considered memory resident.
+func (l *Limiter) WaitPointer(ctx context.Context, ptr unsafe.Pointer) error {
+	// Check if the page is in-memory under lock.
+	// However, we want to exclude the wait from the limiter lock.
+	if wait, err := func() (bool, error) {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+
+		// Update incore mapping if data is too stale.
+		if err := l.checkUpdate(); err != nil {
+			return false, err
+		}
+
+		return l.wait(uintptr(ptr)), nil
+	}(); err != nil {
+		return err
+	} else if !wait {
+		return nil
+	}
+
+	return l.underlying.Wait(ctx)
+}
+
+// WaitRange checks all pages in b for page faults and, if so, rate limits their access.
+// Once a page access is limited, it's updated to be considered memory resident.
+func (l *Limiter) WaitRange(ctx context.Context, b []byte) error {
+	// Empty byte slices will never access memory so skip them.
+	if len(b) == 0 {
+		return nil
+	}
+
+	// Check every page for being in-memory under lock.
+	// However, we want to exclude the wait from the limiter lock.
+	var n int
+	if err := func() error {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+
+		// Update incore mapping if data is too stale.
+		if err := l.checkUpdate(); err != nil {
+			return err
+		}
+
+		// Iterate over every page within the range.
+		pageSize := uintptr(os.Getpagesize())
+		start := (uintptr(unsafe.Pointer(&b[0])) / pageSize) * pageSize
+		end := (uintptr(unsafe.Pointer(&b[len(b)-1])) / pageSize) * pageSize
+
+		for i := start; i <= end; i += pageSize {
+			if l.wait(i) {
+				n++
+			}
+		}
+
+		return nil
+	}(); err != nil {
+		return err
+	} else if n == 0 {
+		return nil
+	}
+
+	for i := 0; i < n; i++ {
+		if err := l.underlying.Wait(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Limiter) wait(ptr uintptr) bool {
+	// Check if page access requires page fault. If not, exit immediately.
+	// If so, mark the page as memory resident afterward.
+	if l.isInCore(ptr) {
+		return false
+	}
+
+	// Otherwise mark page as resident in memory and rate limit.
+	if i := l.index(ptr); i < len(l.incore) {
+		l.incore[l.index(ptr)] |= 1
+	}
+	return true
+}
+
+// IsInCore returns true if the address is resident in memory or if the
+// address is outside the range of the data the limiter is tracking.
+func (l *Limiter) IsInCore(ptr uintptr) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.isInCore(ptr)
+}
+
+func (l *Limiter) isInCore(ptr uintptr) bool {
+	if i := l.index(ptr); i < len(l.incore) {
+		return (l.incore[i] & 1) == 1
+	}
+	return true
+}
+
+// Update updates the vector of in-core pages. Automatically updated when calling Wait().
+func (l *Limiter) Update() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.update()
+}
+
+func (l *Limiter) update() error {
+	vec, err := l.Mincore(l.data)
+	if err != nil {
+		return err
+	}
+
+	l.incore = vec
+	l.updatedAt = time.Now()
+
+	return nil
+}
+
+// checkUpdate performs an update if one hasn't been done before or the interval has passed.
+func (l *Limiter) checkUpdate() error {
+	if l.incore != nil && time.Since(l.updatedAt) < l.UpdateInterval {
+		return nil
+	}
+	return l.update()
+}
+
+// index returns the position in the in-core vector that represents ptr.
+func (l *Limiter) index(ptr uintptr) int {
+	return int(int64(ptr-uintptr(unsafe.Pointer(&l.data[0]))) / int64(os.Getpagesize()))
+}

--- a/pkg/mincore/limiter_test.go
+++ b/pkg/mincore/limiter_test.go
@@ -1,0 +1,131 @@
+package mincore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/influxdata/influxdb/v2/pkg/mincore"
+	"golang.org/x/time/rate"
+)
+
+func TestLimiter(t *testing.T) {
+	pageSize := os.Getpagesize()
+
+	// Ensure limiter waits long enough between faults
+	t.Run("WaitPointer", func(t *testing.T) {
+		t.Parallel()
+
+		data := make([]byte, pageSize*2)
+		l := mincore.NewLimiter(rate.NewLimiter(1, 1), data) // 1 fault per sec
+		l.Mincore = func(data []byte) ([]byte, error) { return make([]byte, 2), nil }
+
+		start := time.Now()
+		if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[0])); err != nil {
+			t.Fatal(err)
+		} else if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[pageSize])); err != nil {
+			t.Fatal(err)
+		}
+
+		if d := time.Since(start); d < time.Second {
+			t.Fatalf("not enough time elapsed: %s", d)
+		}
+	})
+
+	// Ensure limiter waits long enough between faults for a byte slice.
+	t.Run("WaitRange", func(t *testing.T) {
+		t.Parallel()
+
+		data := make([]byte, 2*pageSize)
+		l := mincore.NewLimiter(rate.NewLimiter(1, 1), data) // 1 fault per sec
+		l.Mincore = func(data []byte) ([]byte, error) { return make([]byte, 2), nil }
+
+		start := time.Now()
+		if err := l.WaitRange(context.Background(), data); err != nil {
+			t.Fatal(err)
+		}
+
+		if d := time.Since(start); d < time.Second {
+			t.Fatalf("not enough time elapsed: %s", d)
+		}
+	})
+
+	// Ensure pages are marked as in-core after calling Wait() on them.
+	t.Run("MoveToInMemoryAfterUse", func(t *testing.T) {
+		t.Parallel()
+
+		data := make([]byte, pageSize*10)
+		l := mincore.NewLimiter(rate.NewLimiter(1, 1), data)
+		l.Mincore = func(data []byte) ([]byte, error) {
+			return make([]byte, 10), nil
+		}
+		if err := l.Update(); err != nil {
+			t.Fatal(err)
+		} else if l.IsInCore(uintptr(unsafe.Pointer(&data[0]))) {
+			t.Fatal("expected page to not be in-memory")
+		}
+
+		if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[0])); err != nil {
+			t.Fatal(err)
+		} else if !l.IsInCore(uintptr(unsafe.Pointer(&data[0]))) {
+			t.Fatal("expected page to be in-memory")
+		}
+	})
+
+	// Ensure fresh in-core data is pulled after the update interval.
+	t.Run("UpdateAfterInterval", func(t *testing.T) {
+		t.Parallel()
+
+		data := make([]byte, pageSize*10)
+		l := mincore.NewLimiter(rate.NewLimiter(1, 1), data)
+		l.UpdateInterval = 100 * time.Millisecond
+
+		var n int
+		l.Mincore = func(data []byte) ([]byte, error) {
+			n++
+			return make([]byte, 10), nil
+		}
+
+		// Wait for two pages to pull them in-memory.
+		if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[0])); err != nil {
+			t.Fatal(err)
+		} else if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[pageSize])); err != nil {
+			t.Fatal(err)
+		} else if !l.IsInCore(uintptr(unsafe.Pointer(&data[0]))) {
+			t.Fatal("expected page to be in-memory")
+		} else if !l.IsInCore(uintptr(unsafe.Pointer(&data[pageSize]))) {
+			t.Fatal("expected page to be in-memory")
+		}
+
+		// Wait for interval to pass.
+		time.Sleep(l.UpdateInterval)
+
+		// Fetch one of the previous pages and ensure the other one has been flushed from the update.
+		if err := l.WaitPointer(context.Background(), unsafe.Pointer(&data[0])); err != nil {
+			t.Fatal(err)
+		} else if !l.IsInCore(uintptr(unsafe.Pointer(&data[0]))) {
+			t.Fatal("expected page to be in-memory")
+		} else if l.IsInCore(uintptr(unsafe.Pointer(&data[pageSize]))) {
+			t.Fatal("expected page to not be in-memory")
+		}
+
+		if got, want := n, 2; got != want {
+			t.Fatalf("refreshed %d times, expected %d times", got, want)
+		}
+	})
+
+	// Ensure referencing data outside the limiter's data shows as in-memory.
+	t.Run("OutOfBounds", func(t *testing.T) {
+		l := mincore.NewLimiter(rate.NewLimiter(1, 1), make([]byte, pageSize))
+		l.Mincore = func(data []byte) ([]byte, error) {
+			return make([]byte, 1), nil
+		}
+
+		data := make([]byte, pageSize)
+		if !l.IsInCore(uintptr(unsafe.Pointer(&data[0]))) {
+			t.Fatal("expected out-of-bounds page to be resident")
+		}
+	})
+}

--- a/pkg/mincore/mincore_unix.go
+++ b/pkg/mincore/mincore_unix.go
@@ -1,0 +1,24 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd
+
+package mincore
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mincore is a wrapper function for mincore(2).
+func Mincore(data []byte) ([]byte, error) {
+	vec := make([]byte, (int64(len(data))+int64(os.Getpagesize())-1)/int64(os.Getpagesize()))
+
+	if ret, _, err := unix.Syscall(
+		unix.SYS_MINCORE,
+		uintptr(unsafe.Pointer(&data[0])),
+		uintptr(len(data)),
+		uintptr(unsafe.Pointer(&vec[0]))); ret != 0 {
+		return nil, err
+	}
+	return vec, nil
+}

--- a/pkg/mincore/mincore_windows.go
+++ b/pkg/mincore/mincore_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package mincore
+
+// Mincore returns a zero-length vector.
+func Mincore(data []byte) ([]byte, error) {
+	return make([]byte, 0), nil
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 )
 
 // Static objects to prevent small allocs.
@@ -162,6 +163,14 @@ func WithCompactionSemaphore(s influxdb.Semaphore) Option {
 func WithWritePointsValidationEnabled(v bool) Option {
 	return func(e *Engine) {
 		e.writePointsValidationEnabled = v
+	}
+}
+
+// WithPageFaultLimiter allows the caller to set the limiter for restricting
+// the frequency of page faults.
+func WithPageFaultLimiter(limiter *rate.Limiter) Option {
+	return func(e *Engine) {
+		e.engine.WithPageFaultLimiter(limiter)
 	}
 }
 

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/influxql"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 )
 
 //go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@array_cursor.gen.go.tmpldata array_cursor.gen.go.tmpl array_cursor_iterator.gen.go.tmpl
@@ -271,6 +272,10 @@ func (e *Engine) WithCurrentGenerationFunc(fn func() int) {
 
 func (e *Engine) WithFileStoreObserver(obs FileStoreObserver) {
 	e.FileStore.WithObserver(obs)
+}
+
+func (e *Engine) WithPageFaultLimiter(limiter *rate.Limiter) {
+	e.FileStore.WithPageFaultLimiter(limiter)
 }
 
 func (e *Engine) WithCompactionPlanner(planner CompactionPlanner) {

--- a/tsdb/tsm1/reader.gen.go
+++ b/tsdb/tsm1/reader.gen.go
@@ -123,10 +123,13 @@ func (m *mmapAccessor) readFloatBlock(entry *IndexEntry, values *[]FloatValue) (
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeFloatBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	a, err := DecodeFloatBlock(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -142,10 +145,16 @@ func (m *mmapAccessor) readFloatArrayBlock(entry *IndexEntry, values *cursors.Fl
 		return ErrTSMClosed
 	}
 
-	err := DecodeFloatArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	err := DecodeFloatArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *mmapAccessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValue) ([]IntegerValue, error) {
@@ -157,10 +166,13 @@ func (m *mmapAccessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValu
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeIntegerBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	a, err := DecodeIntegerBlock(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -176,10 +188,16 @@ func (m *mmapAccessor) readIntegerArrayBlock(entry *IndexEntry, values *cursors.
 		return ErrTSMClosed
 	}
 
-	err := DecodeIntegerArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	err := DecodeIntegerArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *mmapAccessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedValue) ([]UnsignedValue, error) {
@@ -191,10 +209,13 @@ func (m *mmapAccessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedVa
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeUnsignedBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	a, err := DecodeUnsignedBlock(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -210,10 +231,16 @@ func (m *mmapAccessor) readUnsignedArrayBlock(entry *IndexEntry, values *cursors
 		return ErrTSMClosed
 	}
 
-	err := DecodeUnsignedArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	err := DecodeUnsignedArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *mmapAccessor) readStringBlock(entry *IndexEntry, values *[]StringValue) ([]StringValue, error) {
@@ -225,10 +252,13 @@ func (m *mmapAccessor) readStringBlock(entry *IndexEntry, values *[]StringValue)
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeStringBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	a, err := DecodeStringBlock(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -244,10 +274,16 @@ func (m *mmapAccessor) readStringArrayBlock(entry *IndexEntry, values *cursors.S
 		return ErrTSMClosed
 	}
 
-	err := DecodeStringArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	err := DecodeStringArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *mmapAccessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValue) ([]BooleanValue, error) {
@@ -259,10 +295,13 @@ func (m *mmapAccessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValu
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeBooleanBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	a, err := DecodeBooleanBlock(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -278,8 +317,14 @@ func (m *mmapAccessor) readBooleanArrayBlock(entry *IndexEntry, values *cursors.
 		return ErrTSMClosed
 	}
 
-	err := DecodeBooleanArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	err := DecodeBooleanArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }

--- a/tsdb/tsm1/reader.gen.go.tmpl
+++ b/tsdb/tsm1/reader.gen.go.tmpl
@@ -50,10 +50,13 @@ func (m *mmapAccessor) read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}
 		return nil, ErrTSMClosed
 	}
 
-	a, err := Decode{{.Name}}Block(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4:entry.Offset+int64(entry.Size)]
+	a, err := Decode{{.Name}}Block(b, values)
 	m.mu.RUnlock()
 
 	if err != nil {
+		return nil, err
+	} else if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -69,9 +72,15 @@ func (m *mmapAccessor) read{{.Name}}ArrayBlock(entry *IndexEntry, values *cursor
 		return ErrTSMClosed
 	}
 
-	err := Decode{{.Name}}ArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4:entry.Offset+int64(entry.Size)]
+	err := Decode{{.Name}}ArrayBlock(b, values)
 	m.mu.RUnlock()
 
-	return err
+	if err != nil {
+		return err
+	} else if err := m.wait(b); err != nil {
+		return err
+	}
+	return nil
 }
 {{end}}

--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/influxdata/influxdb/v2/pkg/mincore"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 )
 
 // ErrFileInUse is returned when attempting to remove or close a TSM file that is still being used.
@@ -40,6 +42,9 @@ type TSMReader struct {
 
 	// deleteMu limits concurrent deletes
 	deleteMu sync.Mutex
+
+	// limiter rate limits page faults by the underlying memory maps.
+	pageFaultLimiter *rate.Limiter
 }
 
 type tsmReaderOption func(*TSMReader)
@@ -48,6 +53,12 @@ type tsmReaderOption func(*TSMReader)
 var WithMadviseWillNeed = func(willNeed bool) tsmReaderOption {
 	return func(r *TSMReader) {
 		r.madviseWillNeed = willNeed
+	}
+}
+
+var WithTSMReaderPageFaultLimiter = func(limiter *rate.Limiter) tsmReaderOption {
+	return func(r *TSMReader) {
+		r.pageFaultLimiter = limiter
 	}
 }
 
@@ -72,17 +83,23 @@ func NewTSMReader(f *os.File, options ...tsmReaderOption) (*TSMReader, error) {
 	}
 	t.size = stat.Size()
 	t.lastModified = stat.ModTime().UnixNano()
-	t.accessor = &mmapAccessor{
+	accessor := &mmapAccessor{
 		logger:       t.logger,
 		f:            f,
 		mmapWillNeed: t.madviseWillNeed,
 	}
 
-	index, err := t.accessor.init()
+	index, err := accessor.init()
 	if err != nil {
 		return nil, err
 	}
 
+	// Set a limiter if passed in through options.
+	if t.pageFaultLimiter != nil {
+		accessor.pageFaultLimiter = mincore.NewLimiter(t.pageFaultLimiter, accessor.b)
+	}
+
+	t.accessor = accessor
 	t.index = index
 	t.tombstoner = NewTombstoner(t.Path(), index.MaybeContainsKey)
 

--- a/tsdb/tsm1/reader_mmap.go
+++ b/tsdb/tsm1/reader_mmap.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/influxdata/influxdb/v2/pkg/fs"
+	"github.com/influxdata/influxdb/v2/pkg/mincore"
 	"go.uber.org/zap"
 )
 
@@ -24,6 +26,8 @@ type mmapAccessor struct {
 	b     []byte
 	f     *os.File
 	_path string // If the underlying file is renamed then this gets updated
+
+	pageFaultLimiter *mincore.Limiter // limits page fault accesses
 
 	index *indirectIndex
 }
@@ -150,8 +154,14 @@ func (m *mmapAccessor) readBlock(entry *IndexEntry, values []Value) ([]Value, er
 	}
 	//TODO: Validate checksum
 	var err error
-	values, err = DecodeBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	b := m.b[entry.Offset+4 : entry.Offset+int64(entry.Size)]
+	values, err = DecodeBlock(b, values)
 	if err != nil {
+		return nil, err
+	}
+
+	// Rate limit page faults.
+	if err := m.wait(b); err != nil {
 		return nil, err
 	}
 
@@ -170,6 +180,13 @@ func (m *mmapAccessor) readBytes(entry *IndexEntry, b []byte) (uint32, []byte, e
 	// return the bytes after the 4 byte checksum
 	crc, block := binary.BigEndian.Uint32(m.b[entry.Offset:entry.Offset+4]), m.b[entry.Offset+4:entry.Offset+int64(entry.Size)]
 	m.mu.RUnlock()
+
+	// Rate limit page faults.
+	if err := m.wait(m.b[entry.Offset : entry.Offset+4]); err != nil {
+		return 0, nil, err
+	} else if err := m.wait(block); err != nil {
+		return 0, nil, err
+	}
 
 	return crc, block, nil
 }
@@ -209,6 +226,8 @@ func (m *mmapAccessor) readAll(key []byte) ([]Value, error) {
 		temp, err = DecodeBlock(m.b[block.Offset+4:block.Offset+int64(block.Size)], temp)
 		if err != nil {
 			return nil, err
+		} else if err := m.wait(m.b[block.Offset+4 : block.Offset+int64(block.Size)]); err != nil {
+			return nil, err
 		}
 
 		// Filter out any values that were deleted
@@ -243,4 +262,12 @@ func (m *mmapAccessor) close() error {
 
 	m.b = nil
 	return m.f.Close()
+}
+
+// wait rate limits page faults to the underlying data. Skipped if limiter is not set.
+func (m *mmapAccessor) wait(b []byte) error {
+	if m.pageFaultLimiter == nil {
+		return nil
+	}
+	return m.pageFaultLimiter.WaitRange(context.Background(), b)
 }


### PR DESCRIPTION
This commit adds `mincore.Limiter` which throttles page faults causedby mmap() data. It works by periodically calling `mincore()` to determine which pages are not resident in memory and using `rate.Limiter` to throttle accessing using a token bucket algorithm.