### PR TITLE
fix: dashboard exports overlay

### DIFF
--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -36,7 +36,8 @@ describe('Dashboards', () => {
     })
   })
 
-  it('can create a dashboard from empty state', () => {
+  it('can CRUD dashboards from empty state, header, and a Template', () => {
+    // Create from empty state
     cy.getByTestID('empty-dashboards-list').within(() => {
       cy.getByTestID('add-resource-dropdown--button').click()
     })
@@ -49,14 +50,33 @@ describe('Dashboards', () => {
             cy.visit(`${orgs}/${id}/dashboards-list`)
           })
         })
-
-        cy.getByTestID('dashboard-card').should('have.length', 1)
       })
-  })
 
-  it('can create a dashboard from the header', () => {
+    const newName = 'new 🅱️ashboard'
+
+    cy.getByTestID('dashboard-card').within(() => {
+      cy.getByTestID('dashboard-card--name')
+        .first()
+        .trigger('mouseover')
+
+      cy.getByTestID('dashboard-card--name-button')
+        .first()
+        .click()
+
+      cy.get('.cf-input-field')
+        .type(newName)
+        .type('{enter}')
+    })
+
+    cy.getByTestID('dashboard-card').should('contain', newName)
+
+    // Open Export overlay
+    cy.getByTestID('context-menu-item-export').click({force: true})
+    cy.getByTestID('export-overlay--text-area').should('exist')
+    cy.get('.cf-overlay--dismiss').click()
+
+    // Create from header
     cy.getByTestID('add-resource-dropdown--button').click()
-
     cy.getByTestID('add-resource-dropdown--new').click()
 
     cy.fixture('routes').then(({orgs}) => {
@@ -65,11 +85,7 @@ describe('Dashboards', () => {
       })
     })
 
-    cy.getByTestID('dashboard-card').should('have.length', 1)
-  })
-
-  it('can create a dashboard from a Template', () => {
-    cy.getByTestID('dashboard-card').should('have.length', 0)
+    // Create from Template
     cy.get('@org').then(({id}: Organization) => {
       cy.createDashboardTemplate(id)
     })
@@ -81,7 +97,35 @@ describe('Dashboards', () => {
     cy.getByTestID('template--Bashboard-Template').click()
     cy.getByTestID('template-panel').should('exist')
     cy.getByTestID('create-dashboard-button').click()
-    cy.getByTestID('dashboard-card').should('have.length', 1)
+
+    cy.getByTestID('dashboard-card').should('have.length', 3)
+
+    // Delete dashboards
+    cy.getByTestID('dashboard-card')
+      .first()
+      .trigger('mouseover')
+      .within(() => {
+        cy.getByTestID('context-delete-menu').click()
+        cy.getByTestID('context-delete-dashboard').click()
+      })
+
+    cy.getByTestID('dashboard-card')
+      .first()
+      .trigger('mouseover')
+      .within(() => {
+        cy.getByTestID('context-delete-menu').click()
+        cy.getByTestID('context-delete-dashboard').click()
+      })
+
+    cy.getByTestID('dashboard-card')
+      .first()
+      .trigger('mouseover')
+      .within(() => {
+        cy.getByTestID('context-delete-menu').click()
+        cy.getByTestID('context-delete-dashboard').click()
+      })
+
+    cy.getByTestID('empty-dashboards-list').should('exist')
   })
 
   it('keeps user input in text area when attempting to import invalid JSON', () => {
@@ -128,20 +172,6 @@ describe('Dashboards', () => {
       })
     })
 
-    it('can delete a dashboard', () => {
-      cy.getByTestID('dashboard-card').should('have.length', 2)
-
-      cy.getByTestID('dashboard-card')
-        .first()
-        .trigger('mouseover')
-        .within(() => {
-          cy.getByTestID('context-delete-menu').click()
-          cy.getByTestID('context-delete-dashboard').click()
-        })
-
-      cy.getByTestID('dashboard-card').should('have.length', 1)
-    })
-
     it('can clone a dashboard', () => {
       cy.getByTestID('dashboard-card').should('have.length', 2)
 
@@ -157,26 +187,6 @@ describe('Dashboards', () => {
       })
 
       cy.getByTestID('dashboard-card').should('have.length', 3)
-    })
-
-    it('can edit a dashboards name', () => {
-      const newName = 'new 🅱️ashboard'
-
-      cy.getByTestID('dashboard-card').within(() => {
-        cy.getByTestID('dashboard-card--name')
-          .first()
-          .trigger('mouseover')
-
-        cy.getByTestID('dashboard-card--name-button')
-          .first()
-          .click()
-
-        cy.get('.cf-input-field')
-          .type(newName)
-          .type('{enter}')
-      })
-
-      cy.getByTestID('dashboard-card').should('contain', newName)
     })
 
     it('retains dashboard sort order after navigating away', () => {

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -99,7 +99,11 @@ class DashboardCard extends PureComponent<Props> {
     return (
       <Context>
         <Context.Menu icon={IconFont.CogThick}>
-          <Context.Item label="Export" action={this.handleExport} />
+          <Context.Item
+            label="Export"
+            action={this.handleExport}
+            testID="context-menu-item-export"
+          />
         </Context.Menu>
         <Context.Menu
           icon={IconFont.Duplicate}
@@ -177,7 +181,7 @@ class DashboardCard extends PureComponent<Props> {
       id,
     } = this.props
 
-    history.push(`/orgs/${orgID}/dashboards/${id}/export`)
+    history.push(`/orgs/${orgID}/dashboards-list/${id}/export`)
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -18,6 +18,7 @@ import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/R
 import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
+import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -111,6 +112,10 @@ class DashboardIndex extends PureComponent<Props, State> {
           </Page.Contents>
         </Page>
         <Switch>
+          <Route
+            path="/orgs/:orgID/dashboards-list/:dashboardID/export"
+            component={DashboardExportOverlay}
+          />
           <Route
             path="/orgs/:orgID/dashboards-list/import/template"
             component={CreateFromTemplateOverlay}

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -84,7 +84,10 @@ class ExportOverlay extends PureComponent<Props> {
       completeSingle: false,
     }
     return (
-      <div className="export-overlay--text-area">
+      <div
+        className="export-overlay--text-area"
+        data-testid="export-overlay--text-area"
+      >
         <ReactCodeMirror
           autoFocus={false}
           autoCursor={true}


### PR DESCRIPTION
### The Problem
The dashboard export overlay was both linked to improperly and not rendered

### The Solution
Render and link to the dashboard export overlay

### Bonus
Refactored many tiny unit-style e2e tests into one larger e2e test as per Cypress best practices.  This includes an added test to ensure the export overlay is rendered properly from the dashboard index.

@jacobmarble