### PR TITLE
fix(influx): add -b flag to influx delete subcommand

### DIFF
--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -53,6 +53,7 @@ func (b *cmdDeleteBuilder) cmd() *cobra.Command {
 		{
 			DestP:      &b.flags.Bucket,
 			Flag:       "bucket",
+			Short:      'b',
 			Desc:       "The name of destination bucket",
 			EnvVar:     "BUCKET_NAME",
 			Persistent: true,


### PR DESCRIPTION
Now `influx delete -b my-bucket` works, like `influx write -b my-bucket`.