### PR TITLE
test: prefer NoError/Error over Nil/NotNil

### DIFF
--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -241,7 +241,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			reader, closer, err := test.flags.createLineReader(context.Background(), command, test.arguments)
 			require.NotNil(t, closer)
 			defer closer.Close()
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, reader)
 			if !test.lpData {
 				csvToLineReader, ok := reader.(*csv2lp.CsvToLineReader)
@@ -320,7 +320,7 @@ func Test_writeFlags_createLineReader_errors(t *testing.T) {
 			_, closer, err := test.flags.createLineReader(context.Background(), command, []string{})
 			require.NotNil(t, closer)
 			defer closer.Close()
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Contains(t, fmt.Sprintf("%s", err), test.message)
 		})
 	}
@@ -334,7 +334,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
 		command.SetArgs([]string{"dryrun", "--format", "csv"})
 		err := command.Execute()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, "stdin3 i=stdin1,j=stdin2,k=stdin4", strings.Trim(out.String(), "\n"))
 	})
 
@@ -344,7 +344,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
 		command.SetArgs([]string{"dryrun", "--format", "csvx"})
 		err := command.Execute()
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, fmt.Sprintf("%s", err), "unsupported") // unsupported format
 	})
 
@@ -354,7 +354,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
 		command.SetArgs([]string{"dryrun", "--format", "csv"})
 		err := command.Execute()
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, fmt.Sprintf("%s", err), "measurement") // no measurement column
 	})
 }
@@ -535,7 +535,7 @@ func Test_fluxWriteF(t *testing.T) {
 			w:  ioutil.Discard})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket-id", "4f14589c26df8286"})
 		err := command.Execute()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, "stdin3 i=stdin1,j=stdin2,k=stdin4", strings.Trim(string(lineData), "\n"))
 	})
 }

--- a/kit/io/limited_read_closer_test.go
+++ b/kit/io/limited_read_closer_test.go
@@ -27,7 +27,7 @@ func TestLimitedReadCloser_Happy(t *testing.T) {
 	out, err := ioutil.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("ho"), out)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 type closer struct {

--- a/pkg/csv2lp/csv_annotations_test.go
+++ b/pkg/csv2lp/csv_annotations_test.go
@@ -160,10 +160,10 @@ func Test_TimeZoneAnnotation(t *testing.T) {
 			table := &CsvTable{}
 			err := subject.setupTable(table, strings.Split(test.value, ","))
 			if test.err == "" {
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.NotNil(t, table.timeZone != nil)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.True(t, strings.Contains(fmt.Sprintf("%v", err), test.err))
 			}
 		})
@@ -207,7 +207,7 @@ func Test_ParseTimeZone(t *testing.T) {
 			require.NotNil(t, tz)
 			testDate := fmt.Sprintf("%d-%02d-%02d", now.Year(), now.Month(), now.Day())
 			result, err := time.ParseInLocation("2006-01-02", testDate, tz)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			_, offset := result.Zone()
 			require.Equal(t, test.offset, offset)
 		})

--- a/pkg/csv2lp/data_conversion_test.go
+++ b/pkg/csv2lp/data_conversion_test.go
@@ -270,14 +270,14 @@ func Test_CreateDecoder(t *testing.T) {
 		return string(s)
 	}
 	require.NotNil(t, decoder)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "\u2318", toUtf8([]byte{226, 140, 152}))
 	decoder, err = CreateDecoder("windows-1250")
 	require.NotNil(t, decoder)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "\u0160", toUtf8([]byte{0x8A}))
 	decoder, err = CreateDecoder("whateveritis")
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Nil(t, decoder)
 	// we can have valid IANA names that are not supported by golang/x/text
 	decoder, err = CreateDecoder("US-ASCII")
@@ -324,7 +324,7 @@ func Test_CreateBoolParseFn(t *testing.T) {
 				case "false":
 					require.Equal(t, false, result)
 				default:
-					require.NotNil(t, err)
+					require.Error(t, err)
 					require.True(t, strings.Contains(fmt.Sprintf("%v", err), pair.expect))
 				}
 			})

--- a/pkg/csv2lp/multi_closer_test.go
+++ b/pkg/csv2lp/multi_closer_test.go
@@ -55,7 +55,7 @@ func TestMultiCloser(t *testing.T) {
 			messages := strings.Count(buf.String(), prefix)
 			require.Equal(t, test.errors, messages)
 			if test.errors > 0 {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why is it important?

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.

