### PR TITLE
chore: use go generate to download large tsdb testdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ chronograf/dist/dist_gen.go
 chronograf/server/swagger_gen.go
 http/swagger_gen.go
 
-# Ignore TSM testdata binary files
+# Ignore TSM/TSI testdata binary files
 tsdb/tsi1/testdata
 tsdb/testdata
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,8 @@ chronograf/server/swagger_gen.go
 http/swagger_gen.go
 
 # Ignore TSM testdata binary files
-tsdb/tsi/testdata
+tsdb/tsi1/testdata
+tsdb/testdata
 
 # The rest of the file is the .gitignore from the original influxdb repository,
 # copied here to prevent mistakenly checking in any binary files

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,9 @@ generate: $(SUBDIRS)
 test-js: node_modules
 	make -C ui test
 
+# Download tsdb testdata before running unit tests
 test-go:
+	$(GO_GENERATE) ./tsdb/gen_test.go
 	$(GO_GENERATE) ./tsdb/tsi1/gen_test.go
 	$(GO_TEST) ./...
 

--- a/tsdb/gen_test.go
+++ b/tsdb/gen_test.go
@@ -1,0 +1,14 @@
+//go:generate sh -c "curl -L https://github.com/influxdata/testdata/raw/2020.07.20.1/tsdbtestdata.tar.gz | tar xz"
+package tsdb_test
+
+import (
+	"fmt"
+	"os"
+)
+
+func init() {
+	if _, err := os.Stat("./testdata"); err != nil {
+		fmt.Println("Run go generate to download testdata directory.")
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/influxdata/influxdb/pull/18972, expanding the pattern to the `tsdb/testdata` directory as well. These changes are a pre-requisite to copying OSS code into the Cloud 2 codebase, to avoid introducing large binary files to that project's tree.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
