### PR TITLE
fix(swagger): correct key in TemplateApply component

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7665,7 +7665,7 @@ components:
               type: array
               items:
                 type: string
-            package:
+            contents:
               $ref: "#/components/schemas/Template"
         templates:
           type: array
@@ -7678,7 +7678,7 @@ components:
                 type: array
                 items:
                   type: string
-              package:
+              contents:
                 $ref: "#/components/schemas/Template"
         secrets:
           type: object


### PR DESCRIPTION
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)