### PR TITLE
test: rename the query in side menu

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -620,15 +620,26 @@ describe('DataExplorer', () => {
       cy.get('.query-tab').should('have.length', 1)
     })
 
-    it('can remove a second query using tab context menu', () => {
+    it.only('can rename and remove a second query using tab context menu', () => {
       cy.get('.query-tab').trigger('contextmenu')
       cy.getByTestID('right-click--remove-tab').should(
         'have.class',
         'cf-right-click--menu-item__disabled'
       )
 
+      //rename the first tab
+      cy.get('.query-tab')
+        .first()
+        .trigger('contextmenu')
+      cy.getByTestID('right-click--edit-tab').click()
+      cy.getByTestID('edit-query-name').type('NewName{enter}')
+      cy.get('.query-tab')
+      .first()
+      .contains('NewName')
+
       // Fire a click outside of the right click menu to dismiss it because
       // it is obscuring the + button
+
       cy.getByTestID('data-explorer--header').click()
 
       cy.get('.time-machine-queries--new').click()
@@ -697,6 +708,7 @@ describe('DataExplorer', () => {
         cy.getByTestID('raw-data--toggle').click()
         cy.getByTestID('raw-data-table').should('exist')
         cy.getByTestID('raw-data--toggle').click()
+        cy.getByTestID('giraffe-axes').should('exist')
       })
 
       it('can set min or max y-axis values', () => {

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -620,7 +620,7 @@ describe('DataExplorer', () => {
       cy.get('.query-tab').should('have.length', 1)
     })
 
-    it.only('can rename and remove a second query using tab context menu', () => {
+    it('can rename and remove a second query using tab context menu', () => {
       cy.get('.query-tab').trigger('contextmenu')
       cy.getByTestID('right-click--remove-tab').should(
         'have.class',

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -634,8 +634,8 @@ describe('DataExplorer', () => {
       cy.getByTestID('right-click--edit-tab').click()
       cy.getByTestID('edit-query-name').type('NewName{enter}')
       cy.get('.query-tab')
-      .first()
-      .contains('NewName')
+        .first()
+        .contains('NewName')
 
       // Fire a click outside of the right click menu to dismiss it because
       // it is obscuring the + button

--- a/ui/src/timeMachine/components/QueryTabName.tsx
+++ b/ui/src/timeMachine/components/QueryTabName.tsx
@@ -38,6 +38,7 @@ class TimeMachineQueryTabName extends PureComponent<Props, State> {
           onKeyUp={this.handleEnterKey}
           size={ComponentSize.ExtraSmall}
           autoFocus={true}
+          testID='edit-query-name'
         />
       )
     }

--- a/ui/src/timeMachine/components/QueryTabName.tsx
+++ b/ui/src/timeMachine/components/QueryTabName.tsx
@@ -38,7 +38,7 @@ class TimeMachineQueryTabName extends PureComponent<Props, State> {
           onKeyUp={this.handleEnterKey}
           size={ComponentSize.ExtraSmall}
           autoFocus={true}
-          testID='edit-query-name'
+          testID="edit-query-name"
         />
       )
     }


### PR DESCRIPTION
Rename the query and Confirm toggle goes back as well

Closes #idpe#7244 and #idpe#7247

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
