### PR TITLE
feat(pkger): add Stack resource type to global list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [18910](https://github.com/influxdata/influxdb/pull/18910): Add uninstall functionality for stacks
 1. [18912](https://github.com/influxdata/influxdb/pull/18912): Drop deprecated influx pkg command tree
 1. [18997](https://github.com/influxdata/influxdb/pull/18997): Add telegraf management commands to influx CLI
+1. [19000](https://github.com/influxdata/influxdb/pull/19000): Transition Stack permissions to be accessible by any non root user
 
 ### Bug Fixes
 

--- a/authorizer/agent.go
+++ b/authorizer/agent.go
@@ -36,7 +36,7 @@ func (a *AuthAgent) IsWritable(ctx context.Context, orgID influxdb.ID, resType i
 	if resTypeErr != nil && orgErr != nil {
 		return &influxdb.Error{
 			Code: influxdb.EUnauthorized,
-			Msg:  "not authorized to create " + string(resType),
+			Msg:  "not authorized to write " + string(resType),
 		}
 	}
 

--- a/authz.go
+++ b/authz.go
@@ -129,8 +129,9 @@ const (
 	NotificationEndpointResourceType = ResourceType("notificationEndpoints") // 15
 	// ChecksResourceType gives permission to one or more Checks.
 	ChecksResourceType = ResourceType("checks") // 16
-	// DBRPType gives permission to one or more DBRPs.
-	DBRPResourceType = ResourceType("dbrp") // 17
+	// DBRPResourceType gives permission to one or more DBRPs.
+	DBRPResourceType               = ResourceType("dbrp") // 17
+	ResourceTypeStack ResourceType = "stack"
 )
 
 // AllResourceTypes is the list of all known resource types.
@@ -153,6 +154,7 @@ var AllResourceTypes = []ResourceType{
 	NotificationEndpointResourceType, // 15
 	ChecksResourceType,               // 16
 	DBRPResourceType,                 // 17
+	ResourceTypeStack,                //18
 	// NOTE: when modifying this list, please update the swagger for components.schemas.Permission resource enum.
 }
 
@@ -171,6 +173,7 @@ var OrgResourceTypes = []ResourceType{
 	NotificationEndpointResourceType, // 15
 	ChecksResourceType,               // 16
 	DBRPResourceType,                 // 17
+	ResourceTypeStack,                // 18
 }
 
 // Valid checks if the resource type is a member of the ResourceType enum.
@@ -199,6 +202,7 @@ func (t ResourceType) Valid() (err error) {
 	case NotificationEndpointResourceType: // 15
 	case ChecksResourceType: // 16
 	case DBRPResourceType: // 17
+	case ResourceTypeStack: // 18
 	default:
 		err = ErrInvalidResourceType
 	}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7351,6 +7351,7 @@ components:
             - notificationEndpoints
             - checks
             - dbrp
+            - stack
         id:
           type: string
           nullable: true

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -120,8 +120,6 @@ func (e StackEventType) String() string {
 	}
 }
 
-const ResourceTypeStack influxdb.ResourceType = "stack"
-
 // SVC is the packages service interface.
 type SVC interface {
 	InitStack(ctx context.Context, userID influxdb.ID, stack StackCreate) (Stack, error)

--- a/pkger/service_auth.go
+++ b/pkger/service_auth.go
@@ -29,7 +29,7 @@ func MWAuth(authAgent AuthAgent) SVCMiddleware {
 }
 
 func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack StackCreate) (Stack, error) {
-	err := s.authAgent.IsWritable(ctx, newStack.OrgID, ResourceTypeStack)
+	err := s.authAgent.IsWritable(ctx, newStack.OrgID, influxdb.ResourceTypeStack)
 	if err != nil {
 		return Stack{}, err
 	}
@@ -37,7 +37,7 @@ func (s *authMW) InitStack(ctx context.Context, userID influxdb.ID, newStack Sta
 }
 
 func (s *authMW) UninstallStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) (Stack, error) {
-	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, ResourceTypeStack)
+	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, influxdb.ResourceTypeStack)
 	if err != nil {
 		return Stack{}, err
 	}
@@ -45,7 +45,7 @@ func (s *authMW) UninstallStack(ctx context.Context, identifiers struct{ OrgID, 
 }
 
 func (s *authMW) DeleteStack(ctx context.Context, identifiers struct{ OrgID, UserID, StackID influxdb.ID }) error {
-	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, ResourceTypeStack)
+	err := s.authAgent.IsWritable(ctx, identifiers.OrgID, influxdb.ResourceTypeStack)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (s *authMW) UpdateStack(ctx context.Context, upd StackUpdate) (Stack, error
 		return Stack{}, err
 	}
 
-	err = s.authAgent.IsWritable(ctx, stack.OrgID, ResourceTypeStack)
+	err = s.authAgent.IsWritable(ctx, stack.OrgID, influxdb.ResourceTypeStack)
 	if err != nil {
 		return Stack{}, err
 	}

--- a/tenant/service_user_test.go
+++ b/tenant/service_user_test.go
@@ -155,6 +155,7 @@ func TestFindPermissionsFromUser(t *testing.T) {
 		influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{OrgID: &orgID, Type: influxdb.NotificationEndpointResourceType}},
 		influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{OrgID: &orgID, Type: influxdb.ChecksResourceType}},
 		influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{OrgID: &orgID, Type: influxdb.DBRPResourceType}},
+		influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{OrgID: &orgID, Type: influxdb.ResourceTypeStack}},
 		influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.UsersResourceType, ID: &u.ID}},
 		influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.UsersResourceType, ID: &u.ID}},
 	}

--- a/ui/src/authorizations/utils/permissions.test.ts
+++ b/ui/src/authorizations/utils/permissions.test.ts
@@ -181,6 +181,20 @@ const hvhs: Permission[] = [
     action: 'read',
     resource: {
       orgID: 'bulldogs',
+      type: 'stack',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'bulldogs',
+      type: 'stack',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      orgID: 'bulldogs',
       type: 'tasks',
     },
   },

--- a/ui/src/authorizations/utils/permissions.ts
+++ b/ui/src/authorizations/utils/permissions.ts
@@ -20,6 +20,7 @@ const allPermissionTypes: PermissionTypes[] = [
   'secrets',
   'scrapers',
   'sources',
+  'stack',
   'tasks',
   'telegrafs',
   'users',
@@ -47,6 +48,7 @@ const ensureT = (orgID: string, userID: string) => (
     case 'secrets':
     case 'scrapers':
     case 'sources':
+    case 'stack':
     case 'tasks':
     case 'telegrafs':
     case 'variables':


### PR DESCRIPTION
now that Stacks have landed, the resource type can now be included for
any all access tokens, not just the token from setup


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)