### PR TITLE
chore(fs): refactor global file consts into internal/fs

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -340,7 +340,7 @@ func defaultConfigPath() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	return filepath.Join(dir, http.DefaultConfigsFile), dir, nil
+	return filepath.Join(dir, fs.DefaultConfigsFile), dir, nil
 }
 
 func getConfigFromDefaultPath() config.Config {
@@ -365,18 +365,18 @@ func migrateOldCredential() {
 		return // no need for migration
 	}
 
-	tokB, err := ioutil.ReadFile(filepath.Join(dir, http.DefaultTokenFile))
+	tokB, err := ioutil.ReadFile(filepath.Join(dir, fs.DefaultTokenFile))
 	if err != nil {
 		return // no need for migration
 	}
 
-	err = writeConfigToPath(strings.TrimSpace(string(tokB)), "", filepath.Join(dir, http.DefaultConfigsFile), dir)
+	err = writeConfigToPath(strings.TrimSpace(string(tokB)), "", filepath.Join(dir, fs.DefaultConfigsFile), dir)
 	if err != nil {
 		return
 	}
 
 	// ignore the remove err
-	_ = os.Remove(filepath.Join(dir, http.DefaultTokenFile))
+	_ = os.Remove(filepath.Join(dir, fs.DefaultTokenFile))
 }
 
 func writeConfigToPath(tok, org, path, dir string) error {

--- a/cmd/influxd/restore/command.go
+++ b/cmd/influxd/restore/command.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/influxdata/influxdb/v2/bolt"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
-	"github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/internal/fs"
 	"github.com/influxdata/influxdb/v2/kit/cli"
 	"github.com/influxdata/influxdb/v2/storage"
@@ -74,7 +73,7 @@ func init() {
 		{
 			DestP:   &flags.credPath,
 			Flag:    "credentials-path",
-			Default: filepath.Join(dir, http.DefaultTokenFile),
+			Default: filepath.Join(dir, fs.DefaultTokenFile),
 			Desc:    "path to target credentials file",
 		},
 		{
@@ -286,7 +285,7 @@ func restoreFile(backup string, target string, filetype string) error {
 }
 
 func restoreCred() error {
-	backupCred := filepath.Join(flags.backupPath, http.DefaultTokenFile)
+	backupCred := filepath.Join(flags.backupPath, fs.DefaultTokenFile)
 
 	_, err := os.Stat(backupCred)
 	if os.IsNotExist(err) {

--- a/http/backup_service.go
+++ b/http/backup_service.go
@@ -22,12 +22,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// DefaultTokenFile is deprecated, and will be only used for migration.
-const DefaultTokenFile = "credentials"
-
-// DefaultConfigsFile stores cli credentials and hosts.
-const DefaultConfigsFile = "configs"
-
 // BackupBackend is all services and associated parameters required to construct the BackupHandler.
 type BackupBackend struct {
 	Logger *zap.Logger
@@ -130,7 +124,7 @@ func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if credsExist {
-		files = append(files, DefaultConfigsFile)
+		files = append(files, fs.DefaultConfigsFile)
 	}
 
 	b := backup{
@@ -145,7 +139,7 @@ func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *BackupHandler) backupCredentials(internalBackupPath string) (bool, error) {
-	credBackupPath := filepath.Join(internalBackupPath, DefaultConfigsFile)
+	credBackupPath := filepath.Join(internalBackupPath, fs.DefaultConfigsFile)
 
 	credPath, err := defaultConfigsPath()
 	if err != nil {
@@ -268,7 +262,7 @@ func defaultConfigsPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, DefaultConfigsFile), nil
+	return filepath.Join(dir, fs.DefaultConfigsFile), nil
 }
 
 func (s *BackupService) InternalBackupPath(backupID int) string {

--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// DefaultTokenFile is deprecated, and will be only used for migration.
+const DefaultTokenFile = "credentials"
+
+// DefaultConfigsFile stores cli credentials and hosts.
+const DefaultConfigsFile = "configs"
+
 // InfluxDir retrieves the influxdbv2 directory.
 func InfluxDir() (string, error) {
 	var dir string


### PR DESCRIPTION
some refactoring to help address the hardcoding of the CLI base directory.

references: #17979


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass