### PR TITLE
fix(tsdb): Fix .gitignore path for tsi1 testdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ chronograf/server/swagger_gen.go
 http/swagger_gen.go
 
 # Ignore TSM testdata binary files
-tsdb/tsi/testdata
+tsdb/tsi1/testdata
 
 # The rest of the file is the .gitignore from the original influxdb repository,
 # copied here to prevent mistakenly checking in any binary files


### PR DESCRIPTION
This pull request corrects the `.gitignore` path for `tsdb/tsi1/testdata` added in https://github.com/influxdata/influxdb/pull/18972.
