### PR TITLE
feat(tsdb): Add optional mincore limiter to TSI & Series File

### DIFF
--- a/pkg/mincore/limiter.go
+++ b/pkg/mincore/limiter.go
@@ -34,6 +34,10 @@ type Limiter struct {
 // NewLimiter returns a new instance of Limiter associated with an mmap.
 // The underlying limiter can be shared to limit faults across the entire process.
 func NewLimiter(underlying *rate.Limiter, data []byte) *Limiter {
+	if underlying == nil {
+		return nil
+	}
+
 	return &Limiter{
 		underlying: underlying,
 		data:       data,

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -171,6 +171,8 @@ func WithWritePointsValidationEnabled(v bool) Option {
 func WithPageFaultLimiter(limiter *rate.Limiter) Option {
 	return func(e *Engine) {
 		e.engine.WithPageFaultLimiter(limiter)
+		e.index.WithPageFaultLimiter(limiter)
+		e.sfile.WithPageFaultLimiter(limiter)
 	}
 }
 

--- a/tsdb/tsi1/index_files.go
+++ b/tsdb/tsi1/index_files.go
@@ -284,7 +284,7 @@ func (p IndexFiles) writeTagsetTo(w io.Writer, name []byte, info *indexCompactIn
 		}
 
 		// Iterate over tag values.
-		vitr := ke.TagValueIterator()
+		vitr := ke.TagValueIterator(nil)
 		for ve := vitr.Next(); ve != nil; ve = vitr.Next() {
 			seriesIDs = seriesIDs[:0]
 

--- a/tsdb/tsi1/log_file.go
+++ b/tsdb/tsi1/log_file.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/pkg/bloom"
 	"github.com/influxdata/influxdb/v2/pkg/lifecycle"
+	"github.com/influxdata/influxdb/v2/pkg/mincore"
 	"github.com/influxdata/influxdb/v2/pkg/mmap"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/seriesfile"
@@ -453,7 +454,7 @@ func (f *LogFile) TagValueIterator(name, key []byte) TagValueIterator {
 		return nil
 	}
 
-	return tk.TagValueIterator()
+	return tk.TagValueIterator(nil)
 }
 
 // deleteTagKey adds a tombstone for a tag key to the log file without a lock.
@@ -1390,7 +1391,7 @@ func (tk *logTagKey) bytes() int {
 func (tk *logTagKey) Key() []byte   { return tk.name }
 func (tk *logTagKey) Deleted() bool { return tk.deleted }
 
-func (tk *logTagKey) TagValueIterator() TagValueIterator {
+func (tk *logTagKey) TagValueIterator(_ *mincore.Limiter) TagValueIterator {
 	a := make([]logTagValue, 0, len(tk.tagValues))
 	for _, v := range tk.tagValues {
 		a = append(a, v)

--- a/tsdb/tsi1/measurement_block_test.go
+++ b/tsdb/tsi1/measurement_block_test.go
@@ -117,7 +117,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 	}
 
 	// Verify data in block.
-	if e, ok := blk.Elem([]byte("foo")); !ok {
+	if e, ok := blk.Elem([]byte("foo"), nil); !ok {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 100 || e.TagBlockSize() != 10 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
@@ -125,7 +125,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 		t.Fatalf("unexpected series data: %#v", e.SeriesIDs())
 	}
 
-	if e, ok := blk.Elem([]byte("bar")); !ok {
+	if e, ok := blk.Elem([]byte("bar"), nil); !ok {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 200 || e.TagBlockSize() != 20 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
@@ -133,7 +133,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 		t.Fatalf("unexpected series data: %#v", e.SeriesIDs())
 	}
 
-	if e, ok := blk.Elem([]byte("baz")); !ok {
+	if e, ok := blk.Elem([]byte("baz"), nil); !ok {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 300 || e.TagBlockSize() != 30 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
@@ -142,7 +142,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 	}
 
 	// Verify non-existent measurement doesn't exist.
-	if _, ok := blk.Elem([]byte("BAD_MEASUREMENT")); ok {
+	if _, ok := blk.Elem([]byte("BAD_MEASUREMENT"), nil); ok {
 		t.Fatal("expected no element")
 	}
 }

--- a/tsdb/tsi1/tag_block_test.go
+++ b/tsdb/tsi1/tag_block_test.go
@@ -56,7 +56,7 @@ func TestTagBlockWriter(t *testing.T) {
 	}
 
 	// Verify data.
-	if e := blk.TagValueElem([]byte("region"), []byte("us-east")); e == nil {
+	if e := blk.TagValueElem([]byte("region"), []byte("us-east"), nil); e == nil {
 		t.Fatal("expected element")
 	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -64,28 +64,28 @@ func TestTagBlockWriter(t *testing.T) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 
-	if e := blk.TagValueElem([]byte("region"), []byte("us-west")); e == nil {
+	if e := blk.TagValueElem([]byte("region"), []byte("us-west"), nil); e == nil {
 		t.Fatal("expected element")
 	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if !reflect.DeepEqual(a, []uint64{3}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
-	if e := blk.TagValueElem([]byte("host"), []byte("server0")); e == nil {
+	if e := blk.TagValueElem([]byte("host"), []byte("server0"), nil); e == nil {
 		t.Fatal("expected element")
 	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if !reflect.DeepEqual(a, []uint64{1}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
-	if e := blk.TagValueElem([]byte("host"), []byte("server1")); e == nil {
+	if e := blk.TagValueElem([]byte("host"), []byte("server1"), nil); e == nil {
 		t.Fatal("expected element")
 	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if !reflect.DeepEqual(a, []uint64{2}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
-	if e := blk.TagValueElem([]byte("host"), []byte("server2")); e == nil {
+	if e := blk.TagValueElem([]byte("host"), []byte("server2"), nil); e == nil {
 		t.Fatal("expected element")
 	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -149,7 +149,7 @@ func benchmarkTagBlock_SeriesN(b *testing.B, tagN, valueN int, blk **tsi1.TagBlo
 
 	key, value := []byte("0"), []byte("0")
 	for i := 0; i < b.N; i++ {
-		if e := (*blk).TagValueElem(key, value); e == nil {
+		if e := (*blk).TagValueElem(key, value, nil); e == nil {
 			b.Fatal("expected element")
 		} else if n := e.(*tsi1.TagBlockValueElem).SeriesN(); n != 1 {
 			b.Fatalf("unexpected series count: %d", n)

--- a/tsdb/tsi1/tsi1_test.go
+++ b/tsdb/tsi1/tsi1_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/pkg/mincore"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/seriesfile"
 	"github.com/influxdata/influxdb/v2/tsdb/tsi1"
@@ -203,9 +204,9 @@ type TagKeyElem struct {
 	deleted bool
 }
 
-func (e *TagKeyElem) Key() []byte                             { return e.key }
-func (e *TagKeyElem) Deleted() bool                           { return e.deleted }
-func (e *TagKeyElem) TagValueIterator() tsi1.TagValueIterator { return nil }
+func (e *TagKeyElem) Key() []byte                                               { return e.key }
+func (e *TagKeyElem) Deleted() bool                                             { return e.deleted }
+func (e *TagKeyElem) TagValueIterator(_ *mincore.Limiter) tsi1.TagValueIterator { return nil }
 
 // TagKeyIterator represents an iterator over a slice of tag keys.
 type TagKeyIterator struct {


### PR DESCRIPTION
This pull request adds the `mincore.Limiter` into the TSI & Series File. The original PR (https://github.com/influxdata/influxdb/pull/18982) only injected the limiter into TSM.

