### PR TITLE
fix(tenant): use rand org bucket id generator over snowflake in tenant service

### DIFF
--- a/tenant/service_bucket_test.go
+++ b/tenant/service_bucket_test.go
@@ -32,7 +32,10 @@ func initBucketService(s kv.SchemaStore, f influxdbtesting.BucketFields, t *test
 	svc := tenant.NewService(storage)
 
 	for _, o := range f.Organizations {
-		if err := svc.CreateOrganization(context.Background(), o); err != nil {
+		// use storage create org in order to avoid creating system buckets
+		if err := s.Update(context.Background(), func(tx kv.Tx) error {
+			return storage.CreateOrg(tx.Context(), tx, o)
+		}); err != nil {
 			t.Fatalf("failed to populate organizations: %s", err)
 		}
 	}

--- a/tenant/storage_bucket.go
+++ b/tenant/storage_bucket.go
@@ -278,7 +278,7 @@ func (s *Store) listBucketsByOrg(ctx context.Context, tx kv.Tx, orgID influxdb.I
 
 func (s *Store) CreateBucket(ctx context.Context, tx kv.Tx, bucket *influxdb.Bucket) error {
 	if !bucket.ID.Valid() {
-		id, err := s.generateSafeID(ctx, tx, bucketBucket)
+		id, err := s.generateSafeOrgBucketID(ctx, tx, bucketBucket)
 		if err != nil {
 			return err
 		}

--- a/tenant/storage_org.go
+++ b/tenant/storage_org.go
@@ -156,7 +156,7 @@ func (s *Store) ListOrgs(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOpti
 
 func (s *Store) CreateOrg(ctx context.Context, tx kv.Tx, o *influxdb.Organization) error {
 	if !o.ID.Valid() {
-		id, err := s.generateSafeID(ctx, tx, organizationBucket)
+		id, err := s.generateSafeOrgBucketID(ctx, tx, organizationBucket)
 		if err != nil {
 			return err
 		}

--- a/tenant/storage_user.go
+++ b/tenant/storage_user.go
@@ -147,11 +147,7 @@ func (s *Store) ListUsers(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOpt
 
 func (s *Store) CreateUser(ctx context.Context, tx kv.Tx, u *influxdb.User) error {
 	if !u.ID.Valid() {
-		id, err := s.generateSafeID(ctx, tx, userBucket)
-		if err != nil {
-			return err
-		}
-		u.ID = id
+		u.ID = s.IDGen.ID()
 	}
 
 	encodedID, err := u.ID.Encode()


### PR DESCRIPTION
Closes #19017

This move tenant back to using the `rand` packages id generator when generating IDs for orgs and buckets.

Prior to this change, it was possible for harmful IDs to be generated for buckets and organizations. Which could leave buckets or even entire orgs unable to read their data (empty responses).
