### PR TITLE
perf: cancel dashboard page requests

### DIFF
--- a/ui/cypress/e2e/variables.test.ts
+++ b/ui/cypress/e2e/variables.test.ts
@@ -9,7 +9,7 @@ describe('Variables', () => {
     })
   })
 
-  it('can CRUD a CSV,upload, map, and query variable and search for variables based on names', () => {
+  it('can CRUD a CSV, upload, map, and query variable and search for variables based on names', () => {
     // Navigate away from and back to variables index using the nav bar
     cy.getByTestID('nav-item-dashboards').click()
     cy.getByTestID('nav-item-settings').click()

--- a/ui/src/client/index.ts
+++ b/ui/src/client/index.ts
@@ -5,7 +5,7 @@ import {
 } from './generatedRoutes'
 import {getAPIBasepath} from 'src/utils/basepath'
 
-setRequestHandler((url, query, init) => {
+setRequestHandler((url: string, query: string, init: RequestInit) => {
   return {
     url: `${getAPIBasepath()}${url}`,
     query,

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -326,15 +326,18 @@ export const deleteDashboard = (dashboardID: string, name: string) => async (
 
 export const getDashboard = (
   dashboardID: string,
-  signal?: AbortSignal
+  controller?: AbortController
 ) => async (dispatch, getState: GetState): Promise<void> => {
   try {
     dispatch(creators.setDashboard(dashboardID, RemoteDataState.Loading))
 
     // Fetch the dashboard, views, and all variables a user has access to
     const [resp] = await Promise.all([
-      api.getDashboard({dashboardID, query: {include: 'properties'}}, {signal}),
-      dispatch(getVariables(signal)),
+      api.getDashboard(
+        {dashboardID, query: {include: 'properties'}},
+        {signal: controller.signal}
+      ),
+      dispatch(getVariables(controller)),
     ])
 
     if (!resp) {
@@ -346,7 +349,7 @@ export const getDashboard = (
     }
 
     const skipCache = true
-    dispatch(hydrateVariables(skipCache))
+    dispatch(hydrateVariables(skipCache, controller))
 
     const normDash = normalize<Dashboard, DashboardEntities, string>(
       resp.data,

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -335,7 +335,7 @@ export const getDashboard = (
     const [resp] = await Promise.all([
       api.getDashboard(
         {dashboardID, query: {include: 'properties'}},
-        {signal: controller.signal}
+        {signal: controller?.signal}
       ),
       dispatch(getVariables(controller)),
     ])

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -73,12 +73,12 @@ const DashboardHeader: FC<Props> = ({
   history,
   org,
 }) => {
+  const demoDataset = DemoDataDashboardNames[dashboard.name]
   useEffect(() => {
-    const demoDataset = DemoDataDashboardNames[dashboard.name]
     if (demoDataset) {
       event('demoData_dashboardViewed', {demo_dataset: demoDataset})
     }
-  }, [dashboard.id])
+  }, [dashboard.id, demoDataset])
 
   const handleAddNote = () => {
     history.push(`/orgs/${org.id}/dashboards/${dashboard.id}/notes/new`)

--- a/ui/src/resources/components/GetResource.tsx
+++ b/ui/src/resources/components/GetResource.tsx
@@ -48,7 +48,7 @@ class GetResource extends PureComponent<Props> {
   private getResourceDetails({type, id}: Resource) {
     switch (type) {
       case ResourceType.Dashboards: {
-        return this.props.getDashboard(id, this.controller.signal)
+        return this.props.getDashboard(id, this.controller)
       }
 
       default: {

--- a/ui/src/resources/components/GetResource.tsx
+++ b/ui/src/resources/components/GetResource.tsx
@@ -30,6 +30,8 @@ export type Props = ReduxProps & OwnProps
 
 @ErrorHandling
 class GetResource extends PureComponent<Props> {
+  controller = new AbortController()
+
   public componentDidMount() {
     const {resources} = this.props
     const promises = []
@@ -39,10 +41,14 @@ class GetResource extends PureComponent<Props> {
     Promise.all(promises)
   }
 
+  public componentWillUnmount() {
+    this.controller.abort()
+  }
+
   private getResourceDetails({type, id}: Resource) {
     switch (type) {
       case ResourceType.Dashboards: {
-        return this.props.getDashboard(id)
+        return this.props.getDashboard(id, this.controller.signal)
       }
 
       default: {

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -58,7 +58,7 @@ export const runQuery = (
     method: 'POST',
     headers,
     body: JSON.stringify(body),
-    signal: controller.signal,
+    signal: controller?.signal,
   })
 
   const promise = request

--- a/ui/src/shared/apis/singleQuery.ts
+++ b/ui/src/shared/apis/singleQuery.ts
@@ -45,7 +45,7 @@ export function RunQueryPromiseMutex<T>() {
 
           runQuery(orgID, query, extern, abortController)
             .promise.then((...args) => {
-              ret.resolve.apply(ret, args)
+              ret.resolve.apply(ret, args) // eslint-disable-line prefer-spread
             })
             .catch((error: Error) => {
               ret.reject(error)
@@ -59,7 +59,7 @@ export function RunQueryPromiseMutex<T>() {
 
       while (cached.length) {
         curr = cached.pop()
-        curr.resolve.apply(curr, args)
+        curr.resolve.apply(curr, args) // eslint-disable-line prefer-spread
       }
 
       processing = false

--- a/ui/src/shared/apis/singleQuery.ts
+++ b/ui/src/shared/apis/singleQuery.ts
@@ -1,4 +1,4 @@
-import {File} from 'src/types'
+import {File, CancelBox} from 'src/types'
 import {runQuery} from 'src/shared/apis/query'
 
 /*\
@@ -15,12 +15,12 @@ import {runQuery} from 'src/shared/apis/query'
       }
 
 \*/
-export function RunQueryPromiseMutex() {
+export function RunQueryPromiseMutex<T>() {
   const cached = []
   let processing = false
 
   const ret = {
-    run: (orgID: string, query: string, extern?: File) => {
+    run: (orgID: string, query: string, extern?: File): CancelBox<T> => {
       return {
         promise: new Promise((resolve, reject) => {
           if (processing) {

--- a/ui/src/shared/apis/singleQuery.ts
+++ b/ui/src/shared/apis/singleQuery.ts
@@ -1,0 +1,91 @@
+import {File} from 'src/types'
+import {runQuery} from 'src/shared/apis/query'
+
+/*\
+
+    Declare this at the module level to create a CancelBox mutex
+    for runQuery. this will allow only one query to be run at a time, and
+    pass its results to any calls made to it while waiting for the api.
+    usage:
+      const mutex = RunQueryPromiseMutex()
+
+      function execute(query, state) {
+        // return runQuery(orgID, query, extern, abortController)
+        mutex.run(orgID, query, extern)
+      }
+
+\*/
+export function RunQueryPromiseMutex() {
+  const cached = []
+  let processing = false
+
+  const ret = {
+    run: (orgID: string, query: string, extern?: File) => {
+      return {
+        promise: new Promise((resolve, reject) => {
+          if (processing) {
+            cached.push({
+              resolve,
+              reject,
+              cancel: () => {},
+            })
+
+            return
+          }
+
+          processing = true
+          const abortController = new AbortController()
+          cached.push({
+            resolve,
+            reject,
+            cancel: () => {
+              abortController.abort()
+            },
+          })
+
+          runQuery(orgID, query, extern, abortController)
+            .promise.then((...args) => {
+              ret.resolve.apply(ret, args)
+            })
+            .catch((error: Error) => {
+              ret.reject(error)
+            })
+        }),
+        cancel: ret.cancel,
+      }
+    },
+    resolve: (...args) => {
+      let curr
+
+      while (cached.length) {
+        curr = cached.pop()
+        curr.resolve.apply(curr, args)
+      }
+
+      processing = false
+    },
+    reject: (error: Error) => {
+      let curr
+
+      while (cached.length) {
+        curr = cached.pop()
+        curr.reject(error)
+        curr.cancel()
+      }
+
+      processing = false
+    },
+    cancel: () => {
+      let curr
+
+      while (cached.length) {
+        curr = cached.pop()
+        curr.cancel()
+      }
+
+      processing = false
+    },
+  }
+
+  return ret
+}

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -103,6 +103,8 @@ const defaultState = (): State => ({
   statuses: [[]],
 })
 
+const controller = new AbortController()
+
 class TimeSeries extends Component<Props, State> {
   public static defaultProps = {
     implicitSubmit: true,
@@ -143,6 +145,7 @@ class TimeSeries extends Component<Props, State> {
 
   public componentWillUnmount() {
     this.observer && this.observer.disconnect()
+    this.pendingResults.forEach(({cancel}) => cancel())
   }
 
   public render() {

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -11,11 +11,7 @@ import {fromFlux as fromFluxGiraffe} from '@influxdata/giraffe'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // API
-import {
-  runQuery,
-  RunQueryResult,
-  RunQuerySuccessResult,
-} from 'src/shared/apis/query'
+import {RunQueryResult, RunQuerySuccessResult} from 'src/shared/apis/query'
 import {runStatusesQuery} from 'src/alerting/utils/statusEvents'
 
 // Utils
@@ -33,6 +29,7 @@ import {
   demoDataError,
 } from 'src/cloud/utils/demoDataErrors'
 import {hashCode} from 'src/queryCache/actions'
+import {RunQueryPromiseMutex} from 'src/shared/apis/singleQuery'
 
 // Constants
 import {
@@ -103,16 +100,15 @@ const defaultState = (): State => ({
   statuses: [[]],
 })
 
-const controller = new AbortController()
-
 class TimeSeries extends Component<Props, State> {
   public static defaultProps = {
     implicitSubmit: true,
     className: 'time-series-container',
     style: null,
   }
-
   public state: State = defaultState()
+
+  private mutex = RunQueryPromiseMutex<RunQueryResult>()
 
   private observer: IntersectionObserver
   private ref: RefObject<HTMLDivElement> = React.createRef()
@@ -222,7 +218,7 @@ class TimeSeries extends Component<Props, State> {
         const extern = buildVarsOption([...vars, ...windowVars])
 
         event('runQuery', {context: 'TimeSeries'})
-        return runQuery(orgID, text, extern)
+        return this.mutex.run(orgID, text, extern)
       })
 
       // Wait for new queries to complete

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -63,7 +63,7 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 type Action = VariableAction | EditorAction | NotifyAction
 
-export const getVariables = (signal?: AbortSignal) => async (
+export const getVariables = (controller?: AbortController) => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
@@ -77,7 +77,10 @@ export const getVariables = (signal?: AbortSignal) => async (
     }
 
     const org = getOrg(state)
-    const resp = await api.getVariables({query: {orgID: org.id}}, {signal})
+    const resp = await api.getVariables(
+      {query: {orgID: org.id}},
+      {signal: controller.signal}
+    )
     if (!resp) {
       return
     }
@@ -142,10 +145,10 @@ const getActiveView = (state: AppState) => {
   return []
 }
 
-export const hydrateVariables = (skipCache?: boolean) => async (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
+export const hydrateVariables = (
+  skipCache?: boolean,
+  controller?: AbortController
+) => async (dispatch: Dispatch<Action>, getState: GetState) => {
   const state = getState()
   const org = getOrg(state)
   const vars = getVariablesFromState(state)
@@ -156,6 +159,7 @@ export const hydrateVariables = (skipCache?: boolean) => async (
     orgID: org.id,
     url: state.links.query.self,
     skipCache,
+    controller,
   })
 
   hydration.on('status', (variable, status) => {

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -79,7 +79,7 @@ export const getVariables = (controller?: AbortController) => async (
     const org = getOrg(state)
     const resp = await api.getVariables(
       {query: {orgID: org.id}},
-      {signal: controller.signal}
+      {signal: controller?.signal}
     )
     if (!resp) {
       return

--- a/ui/src/variables/actions/thunks.ts
+++ b/ui/src/variables/actions/thunks.ts
@@ -63,7 +63,7 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 type Action = VariableAction | EditorAction | NotifyAction
 
-export const getVariables = () => async (
+export const getVariables = (signal?: AbortSignal) => async (
   dispatch: Dispatch<Action>,
   getState: GetState
 ) => {
@@ -77,7 +77,11 @@ export const getVariables = () => async (
     }
 
     const org = getOrg(state)
-    const resp = await api.getVariables({query: {orgID: org.id}})
+    const resp = await api.getVariables({query: {orgID: org.id}}, {signal})
+    if (!resp) {
+      return
+    }
+
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }

--- a/ui/src/variables/utils/ValueFetcher.ts
+++ b/ui/src/variables/utils/ValueFetcher.ts
@@ -72,7 +72,8 @@ export interface ValueFetcher {
     variables: VariableAssignment[],
     prevSelection: string,
     defaultSelection: string,
-    skipCache: boolean
+    skipCache: boolean,
+    controller?: AbortController
   ) => CancelBox<VariableValues>
 }
 
@@ -86,7 +87,8 @@ export class DefaultValueFetcher implements ValueFetcher {
     variables,
     prevSelection,
     defaultSelection,
-    skipCache
+    skipCache,
+    abortController
   ) {
     const key = cacheKey(url, orgID, query, variables)
     if (!skipCache) {
@@ -102,7 +104,7 @@ export class DefaultValueFetcher implements ValueFetcher {
     }
 
     const extern = buildVarsOption(variables)
-    const request = runQuery(orgID, query, extern)
+    const request = runQuery(orgID, query, extern, abortController)
     event('runQuery', {context: 'variables'})
 
     const promise = request.promise.then(result => {

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -370,7 +370,7 @@ const hydrateVarsHelper = async (
     null,
     '',
     options.skipCache,
-    options.controller,
+    options.controller
   )
 
   node.cancel = request.cancel

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -31,6 +31,7 @@ interface HydrateVarsOptions {
   selections?: ValueSelections
   fetcher?: ValueFetcher
   skipCache?: boolean
+  controller?: AbortController
 }
 
 export interface EventedCancelBox<T> extends CancelBox<T> {
@@ -368,7 +369,8 @@ const hydrateVarsHelper = async (
     assignments,
     null,
     '',
-    options.skipCache
+    options.skipCache,
+    options.controller,
   )
 
   node.cancel = request.cancel


### PR DESCRIPTION
Closes #18640

### The Problem
A bunch of slow and unresolved requests to `/query` would continue to fetch despite the user navigating away from the page.  Thus making the rest of their experience slow and 💩 

### The Solution
When the the Dashboard Page un-mounts cancel any requests to `/query` that are in flight.  

![Kapture 2020-07-22 at 16 39 05](https://user-images.githubusercontent.com/7582765/88239669-ed9e5400-cc39-11ea-8797-92871ce51e45.gif)
