### PR TITLE
feat(influx): enable dynamic configs destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [18910](https://github.com/influxdata/influxdb/pull/18910): Add uninstall functionality for stacks
 1. [18912](https://github.com/influxdata/influxdb/pull/18912): Drop deprecated influx pkg command tree
 1. [18997](https://github.com/influxdata/influxdb/pull/18997): Add telegraf management commands to influx CLI
+1. [19030](https://github.com/influxdata/influxdb/pull/19030): Enable dynamic destination for the influx CLI configs file
 
 ### Bug Fixes
 

--- a/cmd/influx/config/config.go
+++ b/cmd/influx/config/config.go
@@ -33,8 +33,8 @@ var DefaultConfig = Config{
 // Configs is map of configs indexed by name.
 type Configs map[string]Config
 
-// ConfigsService is the service to list and write configs.
-type ConfigsService interface {
+// Service is the service to list and write configs.
+type Service interface {
 	CreateConfig(Config) (Config, error)
 	DeleteConfig(name string) (Config, error)
 	UpdateConfig(Config) (Config, error)
@@ -83,10 +83,10 @@ func newConfigsSVC(s store) localConfigsSVC {
 }
 
 // NewLocalConfigSVC create a new local config svc.
-func NewLocalConfigSVC(Path, Dir string) ConfigsService {
+func NewLocalConfigSVC(path, dir string) Service {
 	return newConfigsSVC(ioStore{
-		Path: Path,
-		Dir:  Dir,
+		Path: path,
+		Dir:  dir,
 	})
 }
 

--- a/cmd/influx/config/config_test.go
+++ b/cmd/influx/config/config_test.go
@@ -802,7 +802,7 @@ func TestConfigDelete(t *testing.T) {
 	}
 }
 
-func newBufferSVC() (ConfigsService, *bytesStore) {
+func newBufferSVC() (Service, *bytesStore) {
 	store := new(bytesStore)
 	return newConfigsSVC(store), store
 }


### PR DESCRIPTION
introduces the new flag --configs-path to the influx CLI. This new
flag has a corresponding env var INFLUX_CONFIGS_PATH. It is useful
to export this env var in a shell dotfile for consumption throughout the
box.

closes: #17979

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)