### PR TITLE
chore(bolt): add option to skip fsync for test purposes

### DIFF
--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -24,7 +24,9 @@ func NewTestBoltStore(t *testing.T) (kv.SchemaStore, func(), error) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
 	path := f.Name()
-	s := bolt.NewKVStore(logger, path)
+
+	// skip fsync to improve test performance
+	s := bolt.NewKVStore(logger, path, bolt.WithNoSync)
 	if err := s.Open(context.Background()); err != nil {
 		return nil, nil, err
 	}

--- a/tenant/service_test.go
+++ b/tenant/service_test.go
@@ -25,7 +25,7 @@ func NewTestBoltStore(t *testing.T) (kv.SchemaStore, func(), error) {
 	f.Close()
 
 	path := f.Name()
-	s := bolt.NewKVStore(zaptest.NewLogger(t), path)
+	s := bolt.NewKVStore(zaptest.NewLogger(t), path, bolt.WithNoSync)
 	if err := s.Open(context.Background()); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Recently @jsternberg brought to our attention some significant slow down in the `kv` package tests:

```
ok  	github.com/influxdata/influxdb/v2/kv	232.568s
```
> OSX 16 hyperthreads

Upon inspection. It appeared that an increase in the number of buckets being created and initial update transactions performed on the multiple instances of bolt we create in parallel was causing a lot of time spent on fsync:

<img width="600" alt="Screenshot 2020-07-23 at 16 11 05" src="https://user-images.githubusercontent.com/1253326/88303607-22281380-ccff-11ea-8cc0-70ff3a6c7325.png">

Fortunately, bolt offers the ability to disable fsync if needed. So I have done for `kv` and `tenant` which both use the `testing` package with bolt.

```
ok  	github.com/influxdata/influxdb/v2/kv	12.623s
```

This has improved performance of tests in this package by a factor of >10.

<img width="450" alt="Screenshot 2020-07-23 at 14 55 42" src="https://user-images.githubusercontent.com/1253326/88303958-8945c800-ccff-11ea-856a-534ccfd8145e.png">

I am unsure if anyone has any reservations about doing this. I personally think it is worth it for test purposes and these gains.