### PR TITLE
chore(auth): remove unnecessary URM service from Bucket authorizer

### DIFF
--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -2,6 +2,7 @@ package authorizer
 
 import (
 	"context"
+
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/tracing"
 )
@@ -12,14 +13,12 @@ var _ influxdb.BucketService = (*BucketService)(nil)
 // against it appropriately.
 type BucketService struct {
 	s influxdb.BucketService
-	u influxdb.UserResourceMappingService
 }
 
 // NewBucketService constructs an instance of an authorizing bucket serivce.
-func NewBucketService(s influxdb.BucketService, u influxdb.UserResourceMappingService) *BucketService {
+func NewBucketService(s influxdb.BucketService) *BucketService {
 	return &BucketService{
 		s: s,
-		u: u,
 	}
 }
 

--- a/authorizer/bucket_test.go
+++ b/authorizer/bucket_test.go
@@ -104,7 +104,7 @@ func TestBucketService_FindBucketByID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, []influxdb.Permission{tt.args.permission}))
@@ -189,7 +189,7 @@ func TestBucketService_FindBucket(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, []influxdb.Permission{tt.args.permission}))
@@ -314,7 +314,7 @@ func TestBucketService_FindBuckets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, []influxdb.Permission{tt.args.permission}))
@@ -429,7 +429,7 @@ func TestBucketService_UpdateBucket(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, tt.args.permissions))
@@ -534,7 +534,7 @@ func TestBucketService_DeleteBucket(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, tt.args.permissions))
@@ -616,7 +616,7 @@ func TestBucketService_CreateBucket(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewBucketService(tt.fields.BucketService, nil)
+			s := authorizer.NewBucketService(tt.fields.BucketService)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, mock.NewMockAuthorizer(false, []influxdb.Permission{tt.args.permission}))

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -737,7 +737,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	deps, err := influxdb.NewDependencies(
 		storageflux.NewReader(readservice.NewStore(m.engine)),
 		m.engine,
-		authorizer.NewBucketService(ts.BucketService, ts.UserResourceMappingService),
+		authorizer.NewBucketService(ts.BucketService),
 		authorizer.NewOrgService(ts.OrganizationService),
 		authorizer.NewSecretService(secretSvc),
 		nil,
@@ -828,7 +828,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		}
 	}
 
-	dbrpSvc := dbrp.NewService(ctx, authorizer.NewBucketService(ts.BucketService, ts.UserResourceMappingService), m.kvStore)
+	dbrpSvc := dbrp.NewService(ctx, authorizer.NewBucketService(ts.BucketService), m.kvStore)
 	dbrpSvc = dbrp.NewAuthorizedService(dbrpSvc)
 
 	var checkSvc platform.CheckService
@@ -1029,7 +1029,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		pkgSVC = pkger.NewService(
 			pkger.WithLogger(pkgerLogger),
 			pkger.WithStore(pkger.NewStoreKV(m.kvStore)),
-			pkger.WithBucketSVC(authorizer.NewBucketService(b.BucketService, b.UserResourceMappingService)),
+			pkger.WithBucketSVC(authorizer.NewBucketService(b.BucketService)),
 			pkger.WithCheckSVC(authorizer.NewCheckService(b.CheckService, authedUrmSVC, authedOrgSVC)),
 			pkger.WithDashboardSVC(authorizer.NewDashboardService(b.DashboardService)),
 			pkger.WithLabelSVC(authorizer.NewLabelServiceWithOrg(b.LabelService, b.OrgLookupService)),

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -125,7 +125,6 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 		Router: NewBaseChiRouter(kithttp.NewAPI(kithttp.WithLog(b.Logger))),
 	}
 
-	noAuthUserResourceMappingService := b.UserResourceMappingService
 	b.UserResourceMappingService = authorizer.NewURMService(b.OrgLookupService, b.UserResourceMappingService)
 
 	h.Mount("/api/v2", serveLinksHandler(b.HTTPErrorHandler))
@@ -169,7 +168,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	sourceBackend := NewSourceBackend(b.Logger.With(zap.String("handler", "source")), b)
 	sourceBackend.SourceService = authorizer.NewSourceService(b.SourceService)
-	sourceBackend.BucketService = authorizer.NewBucketService(b.BucketService, noAuthUserResourceMappingService)
+	sourceBackend.BucketService = authorizer.NewBucketService(b.BucketService)
 	h.Mount(prefixSources, NewSourceHandler(b.Logger, sourceBackend))
 
 	h.Mount("/api/v2/swagger.json", newSwaggerLoader(b.Logger.With(zap.String("service", "swagger-loader")), b.HTTPErrorHandler))


### PR DESCRIPTION
This simply removes a dangling field from the bucket authorizer service implementation.
The field was a URM service, which is no longer consumed by the authorizer type.
