### PR TITLE
docs(swagger): repair description

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2449,7 +2449,7 @@ paths:
               - "UpdatedAt"
         - in: query
           name: id
-          description: List of dashboard IDs to return. If both `id and `owner` are specified, only `id` is used.
+          description: List of dashboard IDs to return. If both `id` and `owner` are specified, only `id` is used.
           schema:
             type: array
             items:


### PR DESCRIPTION
The generated typescript code (for influxdb-client-js) does not pass a tsdoc linter check and complains with `The code span is missing its closing backtick`. A fix is provided herein.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
