### PR TITLE
feat(pkger): add resource links to a stack's resources from public HTTP API list/read calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [19066](https://github.com/influxdata/influxdb/pull/19066): Drop deprecated /packages route tree
 
+### Features
+
+1. [19075](https://github.com/influxdata/influxdb/pull/19075): Aadd resource links to a stack's resources from public HTTP API list/read calls
+
 ### Bug Fixes
 
 1. [19043](https://github.com/influxdata/influxdb/pull/19043): Enforce all influx CLI flag args are valid

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8504,6 +8504,11 @@ components:
                             $ref: "#/components/schemas/TemplateKind"
                           metaName:
                             type: string
+                    links:
+                      type: object
+                      properties:
+                        self:
+                          type: string
               urls:
                 type: array
                 items:

--- a/pkger/http_remote_service.go
+++ b/pkger/http_remote_service.go
@@ -330,14 +330,7 @@ func convertRespStackResources(resources []RespStackResource) ([]StackResource, 
 			Kind:       r.Kind,
 		}
 		for _, a := range r.Associations {
-			sra := StackResourceAssociation{
-				Kind:     a.Kind,
-				MetaName: a.MetaName,
-			}
-			if sra.MetaName == "" && a.PkgName != nil {
-				sra.MetaName = *a.PkgName
-			}
-			sr.Associations = append(sr.Associations, sra)
+			sr.Associations = append(sr.Associations, StackResourceAssociation(a))
 		}
 
 		resID, err := influxdb.IDFromString(r.ID)
@@ -346,9 +339,6 @@ func convertRespStackResources(resources []RespStackResource) ([]StackResource, 
 		}
 		sr.ID = *resID
 
-		if sr.MetaName == "" && r.PkgName != nil {
-			sr.MetaName = *r.PkgName
-		}
 		out = append(out, sr)
 	}
 	return out, nil


### PR DESCRIPTION
closes: #19049

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)