### PR TITLE
test: add unit test to default x and y column functions

### DIFF
--- a/ui/src/shared/utils/vis.test.ts
+++ b/ui/src/shared/utils/vis.test.ts
@@ -1,5 +1,10 @@
 // Funcs
-import {parseYBounds} from 'src/shared/utils/vis'
+import {
+  defaultXColumn,
+  defaultYColumn,
+  parseYBounds,
+} from 'src/shared/utils/vis'
+import {Table} from '@influxdata/giraffe'
 
 describe('parseYBounds', () => {
   it('should return null when bounds is null', () => {
@@ -17,5 +22,47 @@ describe('parseYBounds', () => {
   })
   it('should return [0.1, .6] when the bounds are ["0.1", "0.6"]', () => {
     expect(parseYBounds(['0.1', '0.6'])).toEqual([0.1, 0.6])
+  })
+})
+
+describe('getting default columns', () => {
+  const table = ({
+    getColumn() {
+      return [0, 0, 1000000]
+    },
+    getColumnName: jest.fn(),
+    getColumnType: columnKey => {
+      if (['_start', '_stop', '_time'].includes(columnKey)) {
+        return 'time'
+      }
+
+      if (columnKey === '_value') {
+        return 'number'
+      }
+
+      return 'boolean'
+    },
+    addColumn: jest.fn(),
+    columnKeys: [
+      'result',
+      'table',
+      '_start',
+      '_stop',
+      '_field',
+      '_measurement',
+      '_value',
+      'cpu',
+      'host',
+      '_time',
+    ],
+    length: 3,
+  } as unknown) as Table
+
+  it('returns _time for the default x column', () => {
+    expect(defaultXColumn(table)).toBe('_time')
+  })
+
+  it('does something for the default y column', () => {
+    expect(defaultYColumn(table)).toBe('_value')
   })
 })


### PR DESCRIPTION
Co-authored-by: Zoe Steinkamp <zoe.steinkamp@gmail.com>

Closes #19046 

Adds a unit test for the `defaultXColumn` and `defaultYColumn` functions.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
