### PR TITLE
fix: community templates ui polish

### DIFF
--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -18,7 +18,7 @@ import {ComponentStatus} from '@influxdata/clockface'
 
 // Utils
 import {getByID} from 'src/resources/selectors'
-import {getGithubUrlFromTemplateName} from 'src/templates/utils'
+import {getGithubUrlFromTemplateUrlDetails} from 'src/templates/utils'
 
 import {installTemplate, reviewTemplate} from 'src/templates/api'
 
@@ -75,7 +75,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     templateName,
     templateExtension
   ) => {
-    const yamlLocation = getGithubUrlFromTemplateName(
+    const yamlLocation = getGithubUrlFromTemplateUrlDetails(
       directory,
       templateName,
       templateExtension
@@ -103,7 +103,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   private handleInstallTemplate = async () => {
     const {directory, org, templateExtension, templateName} = this.props
 
-    const yamlLocation = getGithubUrlFromTemplateName(
+    const yamlLocation = getGithubUrlFromTemplateUrlDetails(
       directory,
       templateName,
       templateExtension

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -18,10 +18,7 @@ import {ComponentStatus} from '@influxdata/clockface'
 
 // Utils
 import {getByID} from 'src/resources/selectors'
-import {
-  getGithubUrlFromTemplateName,
-  getRawUrlFromGithub,
-} from 'src/templates/utils'
+import {getGithubUrlFromTemplateName} from 'src/templates/utils'
 
 import {installTemplate, reviewTemplate} from 'src/templates/api'
 
@@ -32,7 +29,12 @@ interface State {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string; templateName: string}>
+type RouterProps = RouteComponentProps<{
+  directory: string
+  orgID: string
+  templateName: string
+  templateExtension: string
+}>
 type Props = ReduxProps & RouterProps
 
 class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
@@ -41,9 +43,13 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   }
 
   public componentDidMount() {
-    const {org, templateName} = this.props
-
-    this.reviewTemplateResources(org.id, templateName)
+    const {directory, org, templateExtension, templateName} = this.props
+    this.reviewTemplateResources(
+      org.id,
+      directory,
+      templateName,
+      templateExtension
+    )
   }
 
   public render() {
@@ -63,10 +69,17 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     )
   }
 
-  private reviewTemplateResources = async (orgID, templateName) => {
-    const yamlLocation = `${getRawUrlFromGithub(
-      getGithubUrlFromTemplateName(templateName)
-    )}/${templateName}.yml`
+  private reviewTemplateResources = async (
+    orgID,
+    directory,
+    templateName,
+    templateExtension
+  ) => {
+    const yamlLocation = getGithubUrlFromTemplateName(
+      directory,
+      templateName,
+      templateExtension
+    )
 
     try {
       const summary = await reviewTemplate(orgID, yamlLocation)
@@ -88,11 +101,13 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     this.setState(() => ({status}))
 
   private handleInstallTemplate = async () => {
-    const {org, templateName} = this.props
+    const {directory, org, templateExtension, templateName} = this.props
 
-    const yamlLocation = `${getRawUrlFromGithub(
-      getGithubUrlFromTemplateName(templateName)
-    )}/${templateName}.yml`
+    const yamlLocation = getGithubUrlFromTemplateName(
+      directory,
+      templateName,
+      templateExtension
+    )
 
     try {
       const summary = await installTemplate(
@@ -122,7 +137,9 @@ const mstp = (state: AppState, props: RouterProps) => {
 
   return {
     org,
+    directory: props.match.params.directory,
     templateName: props.match.params.templateName,
+    templateExtension: props.match.params.templateExtension,
     flags: state.flags.original,
     resourceCount: getTotalResourceCount(
       state.resources.templates.communityTemplateToInstall.summary

--- a/ui/src/templates/components/CommunityTemplateName.tsx
+++ b/ui/src/templates/components/CommunityTemplateName.tsx
@@ -30,7 +30,7 @@ const CommunityTemplateName: FC<Props> = ({
 }) => {
   let installButton
 
-  if (onClickInstall) {
+  if (onClickInstall && resourceCount > 0) {
     installButton = (
       <Button
         text="Install Template"

--- a/ui/src/templates/components/CommunityTemplatesActivityLog.tsx
+++ b/ui/src/templates/components/CommunityTemplatesActivityLog.tsx
@@ -24,6 +24,9 @@ import {TemplateKind} from 'src/client'
 // API
 import {deleteStack} from 'src/templates/api'
 
+// Utils
+import {getTemplateUrlDetailsFromGithubSource} from 'src/templates/utils'
+
 interface OwnProps {
   orgID: string
 }
@@ -106,9 +109,14 @@ class CommunityTemplatesActivityLogUnconnected extends PureComponent<Props> {
           </Table.Header>
           <Table.Body>
             {this.props.stacks.map(stack => {
+              const [source] = stack.sources
+              const {
+                directory,
+                templateName,
+              } = getTemplateUrlDetailsFromGithubSource(source)
               return (
                 <Table.Row key={`stack-${stack.id}`}>
-                  <Table.Cell>{stack.name}</Table.Cell>
+                  <Table.Cell>{`${directory}/${templateName}`}</Table.Cell>
                   <Table.Cell>
                     {this.renderStackResources(stack.resources)}
                   </Table.Cell>

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -36,8 +36,8 @@ import {getOrg} from 'src/organizations/selectors'
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {
-  getGithubUrlFromTemplateName,
-  getTemplateNameFromGithubSource,
+  getGithubUrlFromTemplateUrlDetails,
+  getTemplateUrlDetailsFromGithubSource,
 } from 'src/templates/utils'
 
 // Types
@@ -73,7 +73,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       match?.params?.templateExtension
     ) {
       this.setState({
-        templateUrl: getGithubUrlFromTemplateName(
+        templateUrl: getGithubUrlFromTemplateUrlDetails(
           match.params.directory,
           match.params.templateName,
           match.params.templateExtension
@@ -161,7 +161,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       directory,
       templateExtension,
       templateName,
-    } = getTemplateNameFromGithubSource(this.state.templateUrl)
+    } = getTemplateUrlDetailsFromGithubSource(this.state.templateUrl)
 
     this.props.history.push(
       `/orgs/${this.props.org.id}/settings/templates/import/${directory}/${templateName}/${templateExtension}`

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -37,7 +37,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {
   getGithubUrlFromTemplateName,
-  getTemplateNameFromGithubUrl,
+  getTemplateNameFromGithubSource,
 } from 'src/templates/utils'
 
 // Types
@@ -47,7 +47,9 @@ const communityTemplatesUrl =
   'https://github.com/influxdata/community-templates#templates'
 const templatesPath = '/orgs/:orgID/settings/templates'
 
-type Params = {params: {templateName: string}}
+type Params = {
+  params: {directory: string; templateName: string; templateExtension: string}
+}
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{templateName: string}>
 
@@ -65,9 +67,17 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       path: communityTemplatesImportPath,
     }) as Params
 
-    if (match?.params?.templateName) {
+    if (
+      match?.params?.directory &&
+      match?.params?.templateName &&
+      match?.params?.templateExtension
+    ) {
       this.setState({
-        templateUrl: getGithubUrlFromTemplateName(match.params.templateName),
+        templateUrl: getGithubUrlFromTemplateName(
+          match.params.directory,
+          match.params.templateName,
+          match.params.templateExtension
+        ),
       })
     }
   }
@@ -133,7 +143,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
         </Page>
         <Switch>
           <Route
-            path={`${templatesPath}/import/:templateName`}
+            path={`${templatesPath}/import/:directory/:templateName/:templateExtension`}
             component={CommunityTemplateImportOverlay}
           />
         </Switch>
@@ -147,14 +157,15 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       return false
     }
 
-    const name = getTemplateNameFromGithubUrl(this.state.templateUrl)
-    this.showInstallerOverlay(name)
-  }
+    const {
+      directory,
+      templateExtension,
+      templateName,
+    } = getTemplateNameFromGithubSource(this.state.templateUrl)
 
-  private showInstallerOverlay = templateName => {
-    const {history, org} = this.props
-
-    history.push(`/orgs/${org.id}/settings/templates/import/${templateName}`)
+    this.props.history.push(
+      `/orgs/${this.props.org.id}/settings/templates/import/${directory}/${templateName}/${templateExtension}`
+    )
   }
 
   private handleTemplateChange = event => {

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -29,7 +29,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = RouteComponentProps & ReduxProps
 
 const templatesPath = '/orgs/:orgID/settings/templates'
-export const communityTemplatesImportPath = `${templatesPath}/import/:templateName`
+export const communityTemplatesImportPath = `${templatesPath}/import/:directory/:templateName/:templateExtension`
 
 @ErrorHandling
 class TemplatesIndex extends Component<Props> {

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -77,22 +77,28 @@ export const getIncludedLabels = (included: {type: TemplateType}[]) =>
 // See https://github.com/influxdata/community-templates/
 // an example of a url that works with this function:
 // https://github.com/influxdata/community-templates/tree/master/csgo
-export const getTemplateNameFromGithubUrl = (url: string): string => {
+export const getTemplateNameFromGithubSource = (
+  url: string
+): {directory: string; templateExtension: string; templateName: string} => {
   if (!url.includes('https://github.com/influxdata/community-templates/')) {
     throw new Error(
       "We're only going to fetch from influxdb's github repo right now"
     )
   }
-  const [, name] = url.split('/tree/master/')
-  return name
+  const [, templatePath] = url.split('/blob/master/')
+  const [directory, name] = templatePath.split('/')
+  const [templateName, templateExtension] = name.split('.')
+  return {
+    directory,
+    templateExtension,
+    templateName,
+  }
 }
 
-export const getGithubUrlFromTemplateName = (templateName: string): string => {
-  return `https://github.com/influxdata/community-templates/tree/master/${templateName}`
-}
-
-export const getRawUrlFromGithub = repoUrl => {
-  return repoUrl
-    .replace('github.com', 'raw.githubusercontent.com')
-    .replace('tree/', '')
+export const getGithubUrlFromTemplateName = (
+  directory: string,
+  templateName: string,
+  templateExtension: string
+): string => {
+  return `https://github.com/influxdata/community-templates/blob/master/${directory}/${templateName}.${templateExtension}`
 }

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -75,9 +75,7 @@ export const getIncludedLabels = (included: {type: TemplateType}[]) =>
   included.filter((i): i is LabelIncluded => i.type === TemplateType.Label)
 
 // See https://github.com/influxdata/community-templates/
-// an example of a url that works with this function:
-// https://github.com/influxdata/community-templates/tree/master/csgo
-export const getTemplateNameFromGithubSource = (
+export const getTemplateUrlDetailsFromGithubSource = (
   url: string
 ): {directory: string; templateExtension: string; templateName: string} => {
   if (!url.includes('https://github.com/influxdata/community-templates/')) {
@@ -95,7 +93,7 @@ export const getTemplateNameFromGithubSource = (
   }
 }
 
-export const getGithubUrlFromTemplateName = (
+export const getGithubUrlFromTemplateUrlDetails = (
   directory: string,
   templateName: string,
   templateExtension: string


### PR DESCRIPTION
Closes #19050
Closes #19052

First round of spit and polish.

- Upload form used to take the url of the repository / directory. Now it takes specific template resources (e.g. yml, json)
- Now shows template name in the activity log.

![Screen Shot 2020-07-24 at 5 10 03 PM](https://user-images.githubusercontent.com/146112/88444160-9979a800-cdd0-11ea-8774-1bc07b7c58a3.png)
![Screen Shot 2020-07-24 at 5 09 47 PM](https://user-images.githubusercontent.com/146112/88444162-9c749880-cdd0-11ea-90d7-277cfde12ca4.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass