### PR TITLE
feat(httpc): add error return argument to auth func

### DIFF
--- a/pkg/httpc/client.go
+++ b/pkg/httpc/client.go
@@ -36,7 +36,7 @@ type Client struct {
 
 	writerFns []WriteCloserFn
 
-	authFn   func(*http.Request)
+	authFn   func(*http.Request) error
 	respFn   func(*http.Response) error
 	statusFn func(*http.Response) error
 }
@@ -44,7 +44,7 @@ type Client struct {
 // New creates a new httpc client.
 func New(opts ...ClientOptFn) (*Client, error) {
 	opt := clientOpt{
-		authFn: func(*http.Request) {},
+		authFn: func(*http.Request) error { return nil },
 	}
 	for _, o := range opts {
 		if err := o(&opt); err != nil {

--- a/pkg/httpc/options.go
+++ b/pkg/httpc/options.go
@@ -17,7 +17,7 @@ type clientOpt struct {
 	insecureSkipVerify bool
 	doer               doer
 	headers            http.Header
-	authFn             func(*http.Request)
+	authFn             func(*http.Request) error
 	respFn             func(*http.Response) error
 	statusFn           func(*http.Response) error
 	writerFns          []WriteCloserFn
@@ -33,7 +33,7 @@ func WithAddr(addr string) ClientOptFn {
 
 // WithAuth provides a means to set a custom auth that doesn't match
 // the provided auth types here.
-func WithAuth(fn func(r *http.Request)) ClientOptFn {
+func WithAuth(fn func(r *http.Request) error) ClientOptFn {
 	return func(opt *clientOpt) error {
 		opt.authFn = fn
 		return nil
@@ -42,19 +42,22 @@ func WithAuth(fn func(r *http.Request)) ClientOptFn {
 
 // WithAuthToken provides token auth for requests.
 func WithAuthToken(token string) ClientOptFn {
-	return WithAuth(func(r *http.Request) {
+	return WithAuth(func(r *http.Request) error {
 		r.Header.Set("Authorization", "Token "+token)
+		return nil
 	})
 }
 
 // WithSessionCookie provides cookie auth for requests to mimic the browser.
 // Typically, session is influxdb.Session.Key.
 func WithSessionCookie(session string) ClientOptFn {
-	return WithAuth(func(r *http.Request) {
+	return WithAuth(func(r *http.Request) error {
 		r.AddCookie(&http.Cookie{
 			Name:  "session",
 			Value: session,
 		})
+
+		return nil
 	})
 }
 

--- a/pkg/httpc/req.go
+++ b/pkg/httpc/req.go
@@ -25,7 +25,7 @@ type Req struct {
 	client doer
 
 	req    *http.Request
-	authFn func(*http.Request)
+	authFn func(*http.Request) error
 
 	decodeFn func(*http.Response) error
 	respFn   func(*http.Response) error
@@ -40,7 +40,7 @@ func (r *Req) Accept(contentType string) *Req {
 }
 
 // Auth sets the authorization for a request.
-func (r *Req) Auth(authFn func(r *http.Request)) *Req {
+func (r *Req) Auth(authFn func(r *http.Request) error) *Req {
 	if r.err != nil {
 		return r
 	}
@@ -139,7 +139,11 @@ func (r *Req) Do(ctx context.Context) error {
 	if r.err != nil {
 		return r.err
 	}
-	r.authFn(r.req)
+
+	if err := r.authFn(r.req); err != nil {
+		return err
+	}
+
 	// TODO(@jsteenb2): wrap do with retry/backoff policy.
 	return r.do(ctx)
 }


### PR DESCRIPTION
This adds an error return argument to the auth func in httpc package. Just so an auth func provided can get into the control flow if something goes wrong deriving authorization. This is useful for example when deriving a jwt.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
