### PR TITLE
fix: remove fancy types from notebooks

### DIFF
--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -169,5 +169,5 @@ export const useLoadTimeReporting = (measurement: string) => {
     event(measurement, {
       time: loadStartTime,
     })
-  }, [event, loadStartTime])
+  }, [measurement, loadStartTime])
 }

--- a/ui/src/notebooks/components/NotebookPipe.tsx
+++ b/ui/src/notebooks/components/NotebookPipe.tsx
@@ -1,12 +1,12 @@
 import React, {FC, createElement, useMemo} from 'react'
 
-import {PipeContextProps, PipeData, DataID} from 'src/notebooks'
+import {PipeContextProps} from 'src/notebooks'
 import Pipe from 'src/notebooks/components/Pipe'
 import NotebookPanel from 'src/notebooks/components/panel/NotebookPanel'
 import {PipeProvider} from 'src/notebooks/context/pipe'
 
 export interface NotebookPipeProps {
-  id: DataID<PipeData>
+  id: string
 }
 
 const NotebookPipe: FC<NotebookPipeProps> = ({id}) => {

--- a/ui/src/notebooks/components/panel/InsertCellButton.tsx
+++ b/ui/src/notebooks/components/panel/InsertCellButton.tsx
@@ -16,13 +16,12 @@ import {
 } from '@influxdata/clockface'
 import AddButtons from 'src/notebooks/components/AddButtons'
 import {NotebookContext} from 'src/notebooks/context/notebook.current'
-import {DataID, PipeData} from 'src/notebooks'
 
 // Styles
 import 'src/notebooks/components/panel/InsertCellButton.scss'
 
 interface Props {
-  id: DataID<PipeData>
+  id: string
 }
 
 const InsertCellButton: FC<Props> = ({id}) => {

--- a/ui/src/notebooks/components/panel/NotebookPanel.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanel.tsx
@@ -25,18 +25,18 @@ import MovePanelButton from 'src/notebooks/components/panel/MovePanelButton'
 import NotebookPanelTitle from 'src/notebooks/components/panel/NotebookPanelTitle'
 
 // Types
-import {PipeContextProps, DataID, PipeData} from 'src/notebooks'
+import {PipeContextProps} from 'src/notebooks'
 
 // Contexts
 import {NotebookContext} from 'src/notebooks/context/notebook.current'
 import {RefContext} from 'src/notebooks/context/refs'
 
 export interface Props extends PipeContextProps {
-  id: DataID<PipeData>
+  id: string
 }
 
 export interface HeaderProps {
-  id: DataID<PipeData>
+  id: string
   controls?: ReactNode
 }
 

--- a/ui/src/notebooks/components/panel/NotebookPanelTitle.tsx
+++ b/ui/src/notebooks/components/panel/NotebookPanelTitle.tsx
@@ -1,10 +1,9 @@
 // Libraries
 import React, {FC, ChangeEvent, useContext} from 'react'
-import {DataID, PipeData} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook.current'
 
 interface Props {
-  id: DataID<PipeData>
+  id: string
 }
 
 const NotebookPanelTitle: FC<Props> = ({id}) => {

--- a/ui/src/notebooks/components/panel/PanelVisibilityToggle.tsx
+++ b/ui/src/notebooks/components/panel/PanelVisibilityToggle.tsx
@@ -8,10 +8,8 @@ import {NotebookContext} from 'src/notebooks/context/notebook.current'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-import {DataID, PipeData} from 'src/notebooks'
-
 export interface Props {
-  id: DataID<PipeData>
+  id: string
 }
 
 const PanelVisibilityToggle: FC<Props> = ({id}) => {

--- a/ui/src/notebooks/context/notebook.current.tsx
+++ b/ui/src/notebooks/context/notebook.current.tsx
@@ -1,6 +1,6 @@
 import React, {FC, useContext, useEffect, useCallback, useMemo} from 'react'
 import createPersistedState from 'use-persisted-state'
-import {Notebook, DataID, PipeData} from 'src/notebooks'
+import {Notebook, PipeData} from 'src/notebooks'
 import {
   NotebookListContext,
   NotebookListProvider,
@@ -11,9 +11,9 @@ import {RemoteDataState} from 'src/types'
 const useNotebookCurrentState = createPersistedState('current-notebook')
 
 export interface NotebookContextType {
-  id: DataID<Notebook> | null
+  id: string | null
   notebook: Notebook | null
-  change: (id: DataID<Notebook>) => void
+  change: (id: string) => void
   add: (data: Partial<PipeData>, index?: number) => string
   update: (notebook: Partial<Notebook>) => void
   remove: () => void
@@ -56,7 +56,7 @@ export const NotebookProvider: FC = ({children}) => {
   const {notebooks, add, update, remove} = useContext(NotebookListContext)
 
   const change = useCallback(
-    (id: DataID<Notebook>) => {
+    (id: string) => {
       if (!notebooks || !notebooks.hasOwnProperty(id)) {
         throw new Error('Notebook does note exist')
       }

--- a/ui/src/notebooks/context/notebook.list.tsx
+++ b/ui/src/notebooks/context/notebook.list.tsx
@@ -5,7 +5,6 @@ import {
   NotebookList,
   Notebook,
   NotebookState,
-  DataID,
   Resource,
   PipeData,
   PipeMeta,
@@ -16,8 +15,8 @@ const useNotebookListState = createPersistedState('notebooks')
 
 export interface NotebookListContextType extends NotebookList {
   add: (notebook?: Notebook) => string
-  update: (id: DataID<Notebook>, notebook: Notebook) => void
-  remove: (id: DataID<Notebook>) => void
+  update: (id: string, notebook: Notebook) => void
+  remove: (id: string) => void
 }
 
 export const EMPTY_NOTEBOOK: NotebookState = {
@@ -35,8 +34,8 @@ export const EMPTY_NOTEBOOK: NotebookState = {
 export const DEFAULT_CONTEXT: NotebookListContextType = {
   notebooks: {},
   add: (_notebook?: Notebook) => {},
-  update: (_id: DataID<Notebook>, _notebook: Notebook) => {},
-  remove: (_id: DataID<Notebook>) => {},
+  update: (_id: string, _notebook: Notebook) => {},
+  remove: (_id: string) => {},
 } as NotebookListContextType
 
 export const NotebookListContext = React.createContext<NotebookListContextType>(
@@ -72,7 +71,7 @@ export const NotebookListProvider: FC = ({children}) => {
     return id
   }
 
-  const update = (id: DataID<Notebook>, notebook: Notebook) => {
+  const update = (id: string, notebook: Notebook) => {
     if (!notebooks.hasOwnProperty(id)) {
       throw new Error('Notebook not found')
     }
@@ -87,7 +86,7 @@ export const NotebookListProvider: FC = ({children}) => {
     })
   }
 
-  const remove = (id: DataID<Notebook>) => {
+  const remove = (id: string) => {
     const _notebooks = {
       ...notebooks,
     }

--- a/ui/src/notebooks/context/pipe.tsx
+++ b/ui/src/notebooks/context/pipe.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useContext} from 'react'
-import {DataID, PipeData, FluxResult} from 'src/notebooks'
+import {PipeData, FluxResult} from 'src/notebooks'
 import {NotebookContext} from 'src/notebooks/context/notebook.current'
 import {ResultsContext} from 'src/notebooks/context/results'
 import {RemoteDataState} from 'src/types'
@@ -27,7 +27,7 @@ export const DEFAULT_CONTEXT: PipeContextType = {
 export const PipeContext = React.createContext<PipeContextType>(DEFAULT_CONTEXT)
 
 interface PipeContextProps {
-  id: DataID<PipeData>
+  id: string
 }
 
 export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {

--- a/ui/src/notebooks/context/refs.tsx
+++ b/ui/src/notebooks/context/refs.tsx
@@ -1,5 +1,4 @@
 import React, {FC, useState, RefObject} from 'react'
-import {DataID, PipeData} from 'src/notebooks'
 
 export interface Ref {
   panel: RefObject<HTMLDivElement>
@@ -7,12 +6,12 @@ export interface Ref {
 }
 
 export interface RefMap {
-  [key: DataID<PipeData>]: Ref
+  [key: string]: Ref
 }
 
 export interface RefContextType {
-  get: (id: DataID<PipeData>) => Ref
-  update: (id: DataID<PipeData>, data: Partial<Ref>) => void
+  get: (id: string) => Ref
+  update: (id: string, data: Partial<Ref>) => void
 }
 
 export const DEFAULT_CONTEXT: RefContextType = {
@@ -25,7 +24,7 @@ export const RefContext = React.createContext<RefContextType>(DEFAULT_CONTEXT)
 export const RefProvider: FC = ({children}) => {
   const [refs, setRefs] = useState({})
 
-  const get = (id: DataID<PipeData>) => {
+  const get = (id: string) => {
     return (
       refs[id] || {
         panel: null,
@@ -33,7 +32,7 @@ export const RefProvider: FC = ({children}) => {
       }
     )
   }
-  const update = (id: DataID<PipeData>, data: Partial<Ref>) => {
+  const update = (id: string, data: Partial<Ref>) => {
     refs[id] = {
       ...get(id),
       ...data,

--- a/ui/src/notebooks/context/resource.hook.tsx
+++ b/ui/src/notebooks/context/resource.hook.tsx
@@ -3,7 +3,6 @@ import {
   ResourceManipulator,
   ResourceUpdater,
   ResourceGenerator,
-  DataID,
 } from 'src/notebooks'
 
 function useResource<T>(
@@ -12,14 +11,14 @@ function useResource<T>(
   generator?: ResourceGenerator<T>
 ): ResourceManipulator<T> {
   return {
-    get: (id: DataID<T>): T => {
+    get: (id: string): T => {
       if (!resource.byID.hasOwnProperty(id)) {
         throw new Error(`Could not find resource [${id}]`)
       }
 
       return resource.byID[id]
     },
-    add: (id: DataID<T>, data?: T) => {
+    add: (id: string, data?: T) => {
       if (data) {
         resource.byID[id] = data
         resource.allIDs.push(id)
@@ -42,7 +41,7 @@ function useResource<T>(
       resource.allIDs.push(id)
       onChange(resource)
     },
-    update: (id: DataID<T>, data: Partial<T>) => {
+    update: (id: string, data: Partial<T>) => {
       if (!resource.byID.hasOwnProperty(id)) {
         throw new Error(`Could not update resource [${id}]`)
       }
@@ -57,7 +56,7 @@ function useResource<T>(
 
       onChange(resource)
     },
-    remove: (id: DataID<T>) => {
+    remove: (id: string) => {
       if (!resource.byID.hasOwnProperty(id)) {
         return
       }
@@ -75,10 +74,10 @@ function useResource<T>(
       return resource.allIDs.map(id => resource.byID[id])
     },
 
-    indexOf: (id: DataID<T>): number => {
+    indexOf: (id: string): number => {
       return resource.allIDs.indexOf(id)
     },
-    move: (id: DataID<T>, index: number) => {
+    move: (id: string, index: number) => {
       const _index =
         ((index % resource.allIDs.length) + resource.allIDs.length) %
         resource.allIDs.length

--- a/ui/src/notebooks/context/results.tsx
+++ b/ui/src/notebooks/context/results.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useContext, useEffect, useState} from 'react'
-import {FluxResult, Resource, ResourceManipulator, DataID} from 'src/notebooks'
+import {FluxResult, Resource, ResourceManipulator} from 'src/notebooks'
 import useResource from 'src/notebooks/context/resource.hook'
 import {NotebookContext} from 'src/notebooks/context/notebook.current'
 
@@ -40,7 +40,7 @@ export const ResultsProvider: FC = ({children}) => {
 
   const value = {
     ...manipulator,
-    add: (id: DataID<FluxResult>, result?: FluxResult) => {
+    add: (id: string, result?: FluxResult) => {
       try {
         if (result) {
           manipulator.add(id, result)

--- a/ui/src/notebooks/context/time.test.tsx
+++ b/ui/src/notebooks/context/time.test.tsx
@@ -95,11 +95,11 @@ describe('Notebook Time Context', () => {
   describe('error suite', () => {
     beforeEach(() => {
       jest.spyOn(console, 'error')
-      (console.error as any).mockImplementation(() => {})
+      ;(console.error as any).mockImplementation(() => {}) // eslint-disable-line no-extra-semi
     })
 
     afterEach(() => {
-      (console.error as any).mockRestore()
+      ;(console.error as any).mockRestore() // eslint-disable-line no-extra-semi
     })
 
     it('yells if you try to overwrite something', () => {

--- a/ui/src/notebooks/context/time.test.tsx
+++ b/ui/src/notebooks/context/time.test.tsx
@@ -92,39 +92,49 @@ describe('Notebook Time Context', () => {
     })
   })
 
-  it('yells if you try to overwrite something', () => {
-    const contextCallback = jest.fn()
+  describe('error suite', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error')
+      ;(console.error as any).mockImplementation(() => {})
+    })
 
-    render(
-      <TimeProvider>
-        <TimeContext.Consumer>{contextCallback}</TimeContext.Consumer>
-      </TimeProvider>
-    )
+    afterEach(() => {
+      ;(console.error as any).mockRestore()
+    })
+    it('yells if you try to overwrite something', () => {
+      const contextCallback = jest.fn()
 
-    const context = contextCallback.mock.calls[0][0]
-    expect(context.timeContext).toEqual({})
+      render(
+        <TimeProvider>
+          <TimeContext.Consumer>{contextCallback}</TimeContext.Consumer>
+        </TimeProvider>
+      )
 
-    context.addTimeContext('sweet')
-    expect(() => {
+      const context = contextCallback.mock.calls[0][0]
+      expect(context.timeContext).toEqual({})
+
       context.addTimeContext('sweet')
-    }).toThrow('TimeContext[sweet] already exists: use updateContext instead')
-  })
+      expect(() => {
+        context.addTimeContext('sweet')
+      }).toThrow('TimeContext[sweet] already exists: use updateContext instead')
+    })
 
-  it('yells if you try to delete nothing', () => {
-    const contextCallback = jest.fn()
+    it('yells if you try to delete nothing', () => {
+      const contextCallback = jest.fn()
 
-    render(
-      <TimeProvider>
-        <TimeContext.Consumer>{contextCallback}</TimeContext.Consumer>
-      </TimeProvider>
-    )
+      render(
+        <TimeProvider>
+          <TimeContext.Consumer>{contextCallback}</TimeContext.Consumer>
+        </TimeProvider>
+      )
 
-    const context = contextCallback.mock.calls[0][0]
-    expect(context.timeContext).toEqual({})
+      const context = contextCallback.mock.calls[0][0]
+      expect(context.timeContext).toEqual({})
 
-    expect(() => {
-      context.removeTimeContext('sweet')
-    }).toThrow("TimeContext[sweet] doesn't exist")
+      expect(() => {
+        context.removeTimeContext('sweet')
+      }).toThrow("TimeContext[sweet] doesn't exist")
+    })
   })
 
   it('totally chill with deleting', () => {

--- a/ui/src/notebooks/context/time.test.tsx
+++ b/ui/src/notebooks/context/time.test.tsx
@@ -95,12 +95,13 @@ describe('Notebook Time Context', () => {
   describe('error suite', () => {
     beforeEach(() => {
       jest.spyOn(console, 'error')
-      ;(console.error as any).mockImplementation(() => {})
+      (console.error as any).mockImplementation(() => {})
     })
 
     afterEach(() => {
-      ;(console.error as any).mockRestore()
+      (console.error as any).mockRestore()
     })
+
     it('yells if you try to overwrite something', () => {
       const contextCallback = jest.fn()
 

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -14,7 +14,6 @@ export interface PipeMeta {
   visible: boolean
   loading: RemoteDataState
   error?: string
-  focus: boolean
 }
 
 export interface PipeProp {
@@ -30,31 +29,29 @@ export interface FluxResult {
   error?: string // any error that might have happend while fetching
 }
 
-export type DataID<_T> = string
-
 interface DataLookup<T> {
-  [key: DataID<T>]: T
+  [key: string]: T
 }
 
 export interface Resource<T> {
   byID: DataLookup<T>
-  allIDs: DataID<T>[]
+  allIDs: string[]
 }
 
 export type ResourceGenerator<T> = () => T | T
 export type ResourceUpdater<T> = (resource: Resource<T>) => void
 
 export interface ResourceManipulator<T> {
-  get: (id: DataID<T>) => T
-  add: (id: DataID<T>, data?: T) => void
-  update: (id: DataID<T>, data: Partial<T>) => void
-  remove: (id: DataID<T>) => void
-  indexOf: (id: DataID<T>) => number
-  move: (id: DataID<T>, index: number) => void
+  get: (id: string) => T
+  add: (id: string, data?: T) => void
+  update: (id: string, data: Partial<T>) => void
+  remove: (id: string) => void
+  indexOf: (id: string) => number
+  move: (id: string, index: number) => void
 
   serialize: () => Resource<T>
 
-  allIDs: DataID<T>[]
+  allIDs: string[]
   all: T[]
 }
 
@@ -73,13 +70,13 @@ export interface Notebook {
 
 export interface NotebookListState {
   notebooks: {
-    [key: DataID<Notebook>]: Resource<NotebookState>
+    [key: string]: Resource<NotebookState>
   }
 }
 
 export interface NotebookList {
   notebooks: {
-    [key: DataID<Notebook>]: ResourceManipulator<Notebook>
+    [key: string]: Notebook
   }
 }
 


### PR DESCRIPTION
there's errors that keep showing up on our ci pipelines that are frustrating

this cleans them