### PR TITLE
fix(tsdb): Fix mincore wait() out of bounds calls

### DIFF
--- a/tsdb/tsi1/measurement_block.go
+++ b/tsdb/tsi1/measurement_block.go
@@ -91,7 +91,7 @@ func (blk *MeasurementBlock) Elem(name []byte, limiter *mincore.Limiter) (e Meas
 		if offset > 0 {
 			// Parse into element.
 			var e MeasurementBlockElem
-			_ = wait(limiter, blk.hashData[offset:offset+1])
+			_ = wait(limiter, blk.data[offset:offset+1])
 			e.UnmarshalBinary(blk.data[offset:])
 
 			// Return if name match.

--- a/tsdb/tsi1/tag_block.go
+++ b/tsdb/tsi1/tag_block.go
@@ -248,8 +248,8 @@ func (itr *tagBlockValueIterator) Next() TagValueElem {
 
 	// Unmarshal next element & move data forward.
 	itr.e.unmarshal(itr.data)
-	itr.data = itr.data[itr.e.size:]
 	_ = wait(itr.limiter, itr.data[:itr.e.size])
+	itr.data = itr.data[itr.e.size:]
 
 	assert(len(itr.e.Value()) > 0, "invalid zero-length tag value")
 	return &itr.e


### PR DESCRIPTION
This commit fixes a panic caused by `mincore()` checks.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
