### PR TITLE
refactor: remove outdated URM deletion from kv dashboard service

### DIFF
--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -884,16 +884,6 @@ func (s *Service) deleteDashboard(ctx context.Context, tx Tx, id influxdb.ID) er
 		}
 	}
 
-	err = s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
-		ResourceID:   id,
-		ResourceType: influxdb.DashboardsResourceType,
-	})
-	if err != nil {
-		return &influxdb.Error{
-			Err: err,
-		}
-	}
-
 	if err := s.appendDashboardEventToLog(ctx, tx, d.ID, dashboardRemovedEvent); err != nil {
 		return &influxdb.Error{
 			Err: err,


### PR DESCRIPTION
This PR removes a block of code deleting URMs in the kv dashboard service since URM creation has already been removed from dashboards, so this code is obsolete.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
