### PR TITLE
chore(query): use dbrp v2 service in flux influx.v1 dependencies

### DIFF
--- a/cmd/chronograf-migrator/dashboard.go
+++ b/cmd/chronograf-migrator/dashboard.go
@@ -376,22 +376,29 @@ func convertQueries(qs []chronograf.DashboardQuery) []influxdb.DashboardQuery {
 	return ds
 }
 
-type dbrpMapper struct {
+type dbrpMapper struct{}
+
+// FindBy returns the dbrp mapping for the specified ID.
+func (d dbrpMapper) FindByID(ctx context.Context, orgID influxdb.ID, id influxdb.ID) (*influxdb.DBRPMappingV2, error) {
+	return nil, errors.New("mapping not found")
 }
 
-func (m dbrpMapper) FindBy(ctx context.Context, cluster string, db string, rp string) (*influxdb.DBRPMapping, error) {
-	return nil, errors.New("mapping not found")
-}
-func (m dbrpMapper) Find(ctx context.Context, filter influxdb.DBRPMappingFilter) (*influxdb.DBRPMapping, error) {
-	return nil, errors.New("mapping not found")
-}
-func (m dbrpMapper) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.DBRPMapping, int, error) {
+// FindMany returns a list of dbrp mappings that match filter and the total count of matching dbrp mappings.
+func (d dbrpMapper) FindMany(ctx context.Context, dbrp influxdb.DBRPMappingFilterV2, opts ...influxdb.FindOptions) ([]*influxdb.DBRPMappingV2, int, error) {
 	return nil, 0, errors.New("mapping not found")
-
 }
-func (m dbrpMapper) Create(ctx context.Context, dbrpMap *influxdb.DBRPMapping) error {
+
+// Create creates a new dbrp mapping, if a different mapping exists an error is returned.
+func (d dbrpMapper) Create(ctx context.Context, dbrp *influxdb.DBRPMappingV2) error {
 	return errors.New("dbrpMapper does not support creating new mappings")
 }
-func (m dbrpMapper) Delete(ctx context.Context, cluster string, db string, rp string) error {
-	return errors.New("dbrpMapper does not support deleteing mappings")
+
+// Update a new dbrp mapping
+func (d dbrpMapper) Update(ctx context.Context, dbrp *influxdb.DBRPMappingV2) error {
+	return errors.New("dbrpMapper does not support updating mappings")
+}
+
+// Delete removes a dbrp mapping.
+func (d dbrpMapper) Delete(ctx context.Context, orgID influxdb.ID, id influxdb.ID) error {
+	return errors.New("dbrpMapper does not support deleting mappings")
 }

--- a/cmd/influx/transpile.go
+++ b/cmd/influx/transpile.go
@@ -62,19 +62,27 @@ func transpileF(cmd *cobra.Command, args []string) error {
 
 type dbrpMapper struct{}
 
-func (m dbrpMapper) FindBy(ctx context.Context, cluster string, db string, rp string) (*influxdb.DBRPMapping, error) {
+// FindBy returns the dbrp mapping for the specified ID.
+func (d dbrpMapper) FindByID(ctx context.Context, orgID influxdb.ID, id influxdb.ID) (*influxdb.DBRPMappingV2, error) {
 	return nil, errors.New("mapping not found")
 }
-func (m dbrpMapper) Find(ctx context.Context, filter influxdb.DBRPMappingFilter) (*influxdb.DBRPMapping, error) {
-	return nil, errors.New("mapping not found")
-}
-func (m dbrpMapper) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.DBRPMapping, int, error) {
-	return nil, 0, errors.New("mapping not found")
 
+// FindMany returns a list of dbrp mappings that match filter and the total count of matching dbrp mappings.
+func (d dbrpMapper) FindMany(ctx context.Context, dbrp influxdb.DBRPMappingFilterV2, opts ...influxdb.FindOptions) ([]*influxdb.DBRPMappingV2, int, error) {
+	return nil, 0, errors.New("mapping not found")
 }
-func (m dbrpMapper) Create(ctx context.Context, dbrpMap *influxdb.DBRPMapping) error {
+
+// Create creates a new dbrp mapping, if a different mapping exists an error is returned.
+func (d dbrpMapper) Create(ctx context.Context, dbrp *influxdb.DBRPMappingV2) error {
 	return errors.New("dbrpMapper does not support creating new mappings")
 }
-func (m dbrpMapper) Delete(ctx context.Context, cluster string, db string, rp string) error {
-	return errors.New("dbrpMapper does not support deleteing mappings")
+
+// Update a new dbrp mapping
+func (d dbrpMapper) Update(ctx context.Context, dbrp *influxdb.DBRPMappingV2) error {
+	return errors.New("dbrpMapper does not support updating mappings")
+}
+
+// Delete removes a dbrp mapping.
+func (d dbrpMapper) Delete(ctx context.Context, orgID influxdb.ID, id influxdb.ID) error {
+	return errors.New("dbrpMapper does not support deleting mappings")
 }

--- a/query/influxql/compiler.go
+++ b/query/influxql/compiler.go
@@ -14,7 +14,7 @@ import (
 const CompilerType = "influxql"
 
 // AddCompilerMappings adds the influxql specific compiler mappings.
-func AddCompilerMappings(mappings flux.CompilerMappings, dbrpMappingSvc platform.DBRPMappingService) error {
+func AddCompilerMappings(mappings flux.CompilerMappings, dbrpMappingSvc platform.DBRPMappingServiceV2) error {
 	return mappings.Add(CompilerType, func() flux.Compiler {
 		return NewCompiler(dbrpMappingSvc)
 	})
@@ -31,12 +31,12 @@ type Compiler struct {
 
 	logicalPlannerOptions []plan.LogicalOption
 
-	dbrpMappingSvc platform.DBRPMappingService
+	dbrpMappingSvc platform.DBRPMappingServiceV2
 }
 
 var _ flux.Compiler = &Compiler{}
 
-func NewCompiler(dbrpMappingSvc platform.DBRPMappingService) *Compiler {
+func NewCompiler(dbrpMappingSvc platform.DBRPMappingServiceV2) *Compiler {
 	return &Compiler{
 		dbrpMappingSvc: dbrpMappingSvc,
 	}

--- a/query/influxql/end_to_end_test.go
+++ b/query/influxql/end_to_end_test.go
@@ -27,25 +27,21 @@ import (
 
 const generatedInfluxQLDataDir = "testdata"
 
-var dbrpMappingSvcE2E = mock.NewDBRPMappingService()
+var dbrpMappingSvcE2E = &mock.DBRPMappingServiceV2{}
 
 func init() {
-	mapping := platform.DBRPMapping{
-		Cluster:         "cluster",
+	mapping := platform.DBRPMappingV2{
 		Database:        "db0",
 		RetentionPolicy: "autogen",
 		Default:         true,
 		OrganizationID:  platformtesting.MustIDBase16("cadecadecadecade"),
 		BucketID:        platformtesting.MustIDBase16("da7aba5e5eedca5e"),
 	}
-	dbrpMappingSvcE2E.FindByFn = func(ctx context.Context, cluster string, db string, rp string) (*platform.DBRPMapping, error) {
+	dbrpMappingSvcE2E.FindByIDFn = func(ctx context.Context, orgID, id platform.ID) (*platform.DBRPMappingV2, error) {
 		return &mapping, nil
 	}
-	dbrpMappingSvcE2E.FindFn = func(ctx context.Context, filter platform.DBRPMappingFilter) (*platform.DBRPMapping, error) {
-		return &mapping, nil
-	}
-	dbrpMappingSvcE2E.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilter, opt ...platform.FindOptions) ([]*platform.DBRPMapping, int, error) {
-		return []*platform.DBRPMapping{&mapping}, 1, nil
+	dbrpMappingSvcE2E.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilterV2, opt ...platform.FindOptions) ([]*platform.DBRPMappingV2, int, error) {
+		return []*platform.DBRPMappingV2{&mapping}, 1, nil
 	}
 }
 

--- a/query/influxql/spectests/testing.go
+++ b/query/influxql/spectests/testing.go
@@ -16,46 +16,35 @@ import (
 	platformtesting "github.com/influxdata/influxdb/v2/testing"
 )
 
-var dbrpMappingSvc = mock.NewDBRPMappingService()
+var dbrpMappingSvc = &mock.DBRPMappingServiceV2{}
 var organizationID platform.ID
 var bucketID platform.ID
 var altBucketID platform.ID
 
 func init() {
-	mapping := platform.DBRPMapping{
-		Cluster:         "cluster",
+	mapping := platform.DBRPMappingV2{
 		Database:        "db0",
 		RetentionPolicy: "autogen",
 		Default:         true,
 		OrganizationID:  organizationID,
 		BucketID:        bucketID,
 	}
-	altMapping := platform.DBRPMapping{
-		Cluster:         "cluster",
+	altMapping := platform.DBRPMappingV2{
 		Database:        "db0",
 		RetentionPolicy: "autogen",
 		Default:         true,
 		OrganizationID:  organizationID,
 		BucketID:        altBucketID,
 	}
-	dbrpMappingSvc.FindByFn = func(ctx context.Context, cluster string, db string, rp string) (*platform.DBRPMapping, error) {
-		if rp == "alternate" {
-			return &altMapping, nil
-		}
+	dbrpMappingSvc.FindByIDFn = func(ctx context.Context, orgID, id platform.ID) (*platform.DBRPMappingV2, error) {
 		return &mapping, nil
 	}
-	dbrpMappingSvc.FindFn = func(ctx context.Context, filter platform.DBRPMappingFilter) (*platform.DBRPMapping, error) {
-		if filter.RetentionPolicy != nil && *filter.RetentionPolicy == "alternate" {
-			return &altMapping, nil
-		}
-		return &mapping, nil
-	}
-	dbrpMappingSvc.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilter, opt ...platform.FindOptions) ([]*platform.DBRPMapping, int, error) {
+	dbrpMappingSvc.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilterV2, opt ...platform.FindOptions) ([]*platform.DBRPMappingV2, int, error) {
 		m := &mapping
 		if filter.RetentionPolicy != nil && *filter.RetentionPolicy == "alternate" {
 			m = &altMapping
 		}
-		return []*platform.DBRPMapping{m}, 1, nil
+		return []*platform.DBRPMappingV2{m}, 1, nil
 	}
 }
 

--- a/query/influxql/transpiler_test.go
+++ b/query/influxql/transpiler_test.go
@@ -13,25 +13,21 @@ import (
 	"github.com/pkg/errors"
 )
 
-var dbrpMappingSvc = mock.NewDBRPMappingService()
+var dbrpMappingSvc = &mock.DBRPMappingServiceV2{}
 
 func init() {
-	mapping := platform.DBRPMapping{
-		Cluster:         "cluster",
+	mapping := platform.DBRPMappingV2{
 		Database:        "db0",
 		RetentionPolicy: "autogen",
 		Default:         true,
 		OrganizationID:  platformtesting.MustIDBase16("aaaaaaaaaaaaaaaa"),
 		BucketID:        platformtesting.MustIDBase16("bbbbbbbbbbbbbbbb"),
 	}
-	dbrpMappingSvc.FindByFn = func(ctx context.Context, cluster string, db string, rp string) (*platform.DBRPMapping, error) {
+	dbrpMappingSvc.FindByIDFn = func(ctx context.Context, orgID, id platform.ID) (*platform.DBRPMappingV2, error) {
 		return &mapping, nil
 	}
-	dbrpMappingSvc.FindFn = func(ctx context.Context, filter platform.DBRPMappingFilter) (*platform.DBRPMapping, error) {
-		return &mapping, nil
-	}
-	dbrpMappingSvc.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilter, opt ...platform.FindOptions) ([]*platform.DBRPMapping, int, error) {
-		return []*platform.DBRPMapping{&mapping}, 1, nil
+	dbrpMappingSvc.FindManyFn = func(ctx context.Context, filter platform.DBRPMappingFilterV2, opt ...platform.FindOptions) ([]*platform.DBRPMappingV2, int, error) {
+		return []*platform.DBRPMappingV2{&mapping}, 1, nil
 	}
 }
 

--- a/query/stdlib/influxdata/influxdb/v1/databases.go
+++ b/query/stdlib/influxdata/influxdb/v1/databases.go
@@ -40,7 +40,7 @@ func (s *LocalDatabasesProcedureSpec) Copy() plan.ProcedureSpec {
 type DatabasesDecoder struct {
 	orgID     platform.ID
 	deps      *DatabasesDependencies
-	databases []*platform.DBRPMapping
+	databases []*platform.DBRPMappingV2
 	alloc     *memory.Allocator
 }
 
@@ -49,7 +49,7 @@ func (bd *DatabasesDecoder) Connect(ctx context.Context) error {
 }
 
 func (bd *DatabasesDecoder) Fetch(ctx context.Context) (bool, error) {
-	b, _, err := bd.deps.DBRP.FindMany(ctx, platform.DBRPMappingFilter{})
+	b, _, err := bd.deps.DBRP.FindMany(ctx, platform.DBRPMappingFilterV2{})
 	if err != nil {
 		return false, err
 	}
@@ -59,7 +59,7 @@ func (bd *DatabasesDecoder) Fetch(ctx context.Context) (bool, error) {
 
 func (bd *DatabasesDecoder) Decode(ctx context.Context) (flux.Table, error) {
 	type databaseInfo struct {
-		*platform.DBRPMapping
+		*platform.DBRPMappingV2
 		RetentionPeriod time.Duration
 	}
 
@@ -74,7 +74,7 @@ func (bd *DatabasesDecoder) Decode(ctx context.Context) (flux.Table, error) {
 			return nil, err
 		}
 		databases = append(databases, databaseInfo{
-			DBRPMapping:     db,
+			DBRPMappingV2:   db,
 			RetentionPeriod: bucket.RetentionPeriod,
 		})
 	}
@@ -169,7 +169,7 @@ type key int
 const dependenciesKey key = iota
 
 type DatabasesDependencies struct {
-	DBRP         platform.DBRPMappingService
+	DBRP         platform.DBRPMappingServiceV2
 	BucketLookup platform.BucketService
 }
 


### PR DESCRIPTION
Updating the DBRP Mapping Service to the v2 version within the flux `v1` packages dependencies.
The interface is almost identical. Save a few changes to Find and the obvious V2 suffix.

Moving to v2 will allow me to use the new DBRP mapping service client. Meaning the DBRP metadata can be retrieved from a remote service instead of directly from the kv store.

Update as this now adds it to more places:

- Query Dependencies
- Transpiler