### PR TITLE
feat(pkger): make envRef default values support more types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### Breaking
 
 1. [19066](https://github.com/influxdata/influxdb/pull/19066): Drop deprecated /packages route tree
+1. [19116](https://github.com/influxdata/influxdb/pull/19116): Support more types for template envRef default value and require explicit default values 
 
 ### Features
 
-1. [19075](https://github.com/influxdata/influxdb/pull/19075): Aadd resource links to a stack's resources from public HTTP API list/read calls
+1. [19075](https://github.com/influxdata/influxdb/pull/19075): Add resource links to a stack's resources from public HTTP API list/read calls
 
 ### Bug Fixes
 

--- a/cmd/influx/template.go
+++ b/cmd/influx/template.go
@@ -214,7 +214,7 @@ func (b *cmdTemplateBuilder) applyRunEFn(cmd *cobra.Command, args []string) erro
 
 	opts := []pkger.ApplyOptFn{
 		pkger.ApplyWithTemplate(template),
-		pkger.ApplyWithEnvRefs(providedEnvRefs),
+		pkger.ApplyWithEnvRefs(toMapInterface(providedEnvRefs)),
 		pkger.ApplyWithStackID(stackID),
 	}
 
@@ -2042,6 +2042,14 @@ func mapKeys(provided, kvPairs []string) map[string]string {
 		out[k] = v
 	}
 
+	return out
+}
+
+func toMapInterface(m map[string]string) map[string]interface{} {
+	out := make(map[string]interface{})
+	for k, v := range m {
+		out[k] = v
+	}
 	return out
 }
 

--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -2470,7 +2470,7 @@ spec:
 
 			impact, err := svc.DryRun(ctx, l.Org.ID, l.User.ID,
 				pkger.ApplyWithTemplate(pkg),
-				pkger.ApplyWithEnvRefs(map[string]string{
+				pkger.ApplyWithEnvRefs(map[string]interface{}{
 					"bkt-1-name-ref":   "new-bkt-name",
 					"label-1-name-ref": "new-label-name",
 				}),
@@ -3687,7 +3687,7 @@ spec:
 
 		impact, err = svc.Apply(ctx, l.Org.ID, l.User.ID,
 			pkger.ApplyWithTemplate(pkg),
-			pkger.ApplyWithEnvRefs(map[string]string{
+			pkger.ApplyWithEnvRefs(map[string]interface{}{
 				"bkt-1-name-ref":      "rucket_threeve",
 				"check-1-name-ref":    "check_threeve",
 				"dash-1-name-ref":     "dash_threeve",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7498,6 +7498,14 @@ components:
                   type: string
               contents:
                 $ref: "#/components/schemas/Template"
+        envRefs:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
         secrets:
           type: object
           additionalProperties:
@@ -7621,9 +7629,14 @@ components:
             type: string
             description: Value provided to fulfill reference
           defaultValue:
-            type: string
             description: Default value that will be provided for the reference when no value is provided
-        required: [resourceField, envRefKey, defaultValue]
+            nullable: true
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
+              - type: boolean
+        required: [resourceField, envRefKey]
     TemplateSummary:
       type: object
       properties:

--- a/pkger/http_server_template.go
+++ b/pkger/http_server_template.go
@@ -210,8 +210,8 @@ type ReqApply struct {
 	RawTemplates []ReqRawTemplate `json:"templates" yaml:"templates"`
 	RawTemplate  ReqRawTemplate   `json:"template" yaml:"template"`
 
-	EnvRefs map[string]string `json:"envRefs"`
-	Secrets map[string]string `json:"secrets"`
+	EnvRefs map[string]interface{} `json:"envRefs"`
+	Secrets map[string]string      `json:"secrets"`
 
 	RawActions []ReqRawAction `json:"actions"`
 }

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -648,10 +648,10 @@ type SummaryLabelMapping struct {
 // SummaryReference informs the consumer of required references for
 // this resource.
 type SummaryReference struct {
-	Field        string `json:"resourceField"`
-	EnvRefKey    string `json:"envRefKey"`
-	Value        string `json:"value"`
-	DefaultValue string `json:"defaultValue"`
+	Field        string      `json:"resourceField"`
+	EnvRefKey    string      `json:"envRefKey"`
+	Value        string      `json:"value"`
+	DefaultValue interface{} `json:"defaultValue"`
 }
 
 // SummaryTask provides a summary of a task.

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -354,7 +354,7 @@ type Template struct {
 	mVariables             map[string]*variable
 
 	mEnv     map[string]bool
-	mEnvVals map[string]string
+	mEnvVals map[string]interface{}
 	mSecrets map[string]bool
 
 	isParsed bool // indicates the pkg has been parsed and all resources graphed accordingly
@@ -458,13 +458,13 @@ func (p *Template) Summary() Summary {
 	return sum
 }
 
-func (p *Template) applyEnvRefs(envRefs map[string]string) error {
+func (p *Template) applyEnvRefs(envRefs map[string]interface{}) error {
 	if len(envRefs) == 0 {
 		return nil
 	}
 
 	if p.mEnvVals == nil {
-		p.mEnvVals = make(map[string]string)
+		p.mEnvVals = make(map[string]interface{})
 	}
 
 	for k, v := range envRefs {
@@ -1378,7 +1378,7 @@ func (p *Template) setRefs(refs ...*references) {
 			p.mSecrets[ref.Secret] = false
 		}
 		if ref.EnvRef != "" {
-			p.mEnv[ref.EnvRef] = p.mEnvVals[ref.EnvRef] != ""
+			p.mEnv[ref.EnvRef] = p.mEnvVals[ref.EnvRef] != nil
 		}
 	}
 }
@@ -1772,7 +1772,7 @@ func ifaceToReference(i interface{}) *references {
 			switch f {
 			case fieldReferencesEnv:
 				ref.EnvRef = keyRes.stringShort(fieldKey)
-				ref.defaultVal = keyRes.stringShort(fieldDefault)
+				ref.defaultVal = keyRes[fieldDefault]
 			case fieldReferencesSecret:
 				ref.Secret = keyRes.stringShort(fieldKey)
 			}

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -2050,10 +2050,11 @@ const (
 )
 
 type references struct {
+	EnvRef string
+	Secret string
+
 	val        interface{}
-	defaultVal string
-	EnvRef     string
-	Secret     string
+	defaultVal interface{}
 }
 
 func (r *references) hasValue() bool {
@@ -2072,24 +2073,17 @@ func (r *references) String() string {
 		return v
 	}
 	if r.EnvRef != "" {
-		return r.defaultEnvValue()
+		if s, _ := ifaceToStr(r.defaultVal); s != "" {
+			return s
+		}
+		return "env-" + r.EnvRef
 	}
 	return ""
-}
-
-func (r *references) defaultEnvValue() string {
-	if r.defaultVal != "" {
-		return r.defaultVal
-	}
-	return "env-" + r.EnvRef
 }
 
 func (r *references) StringVal() string {
-	if r.val != nil {
-		s, _ := r.val.(string)
-		return s
-	}
-	return ""
+	s, _ := ifaceToStr(r.val)
+	return s
 }
 
 func (r *references) SecretField() influxdb.SecretField {
@@ -2107,7 +2101,7 @@ func convertRefToRefSummary(field string, ref *references) SummaryReference {
 		Field:        field,
 		EnvRefKey:    ref.EnvRef,
 		Value:        ref.StringVal(),
-		DefaultValue: ref.defaultEnvValue(),
+		DefaultValue: ref.defaultVal,
 	}
 }
 

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -74,9 +74,8 @@ func TestParse(t *testing.T) {
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -215,14 +214,12 @@ spec:
 
 				expected := sumLabelGen("env-meta-name", "env-spec-name", "", "",
 					SummaryReference{
-						Field:        "metadata.name",
-						EnvRefKey:    "meta-name",
-						DefaultValue: "env-meta-name",
+						Field:     "metadata.name",
+						EnvRefKey: "meta-name",
 					},
 					SummaryReference{
-						Field:        "spec.name",
-						EnvRefKey:    "spec-name",
-						DefaultValue: "env-spec-name",
+						Field:     "spec.name",
+						EnvRefKey: "spec-name",
 					},
 				)
 				assert.Contains(t, actual, expected)
@@ -598,9 +595,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -2309,9 +2305,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expected, actual[0].EnvReferences)
@@ -2571,9 +2566,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -2896,14 +2890,12 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 					{
-						Field:        "spec.endpointName",
-						EnvRefKey:    "endpoint-meta-name",
-						DefaultValue: "env-endpoint-meta-name",
+						Field:     "spec.endpointName",
+						EnvRefKey: "endpoint-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -3238,9 +3230,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -3457,9 +3448,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -3588,9 +3578,8 @@ spec:
 						DefaultValue: "spectacles",
 					},
 					{
-						Field:        "spec.associations[0].name",
-						EnvRefKey:    "label-meta-name",
-						DefaultValue: "env-label-meta-name",
+						Field:     "spec.associations[0].name",
+						EnvRefKey: "label-meta-name",
 					},
 					{
 						Field:        "spec.selected[0]",
@@ -3598,9 +3587,8 @@ spec:
 						DefaultValue: "second val",
 					},
 					{
-						Field:        "spec.selected[1]",
-						EnvRefKey:    "the-2nd",
-						DefaultValue: "env-the-2nd",
+						Field:     "spec.selected[1]",
+						EnvRefKey: "the-2nd",
 					},
 				}
 				assert.Equal(t, expectedEnvRefs, actual[0].EnvReferences)
@@ -3879,7 +3867,7 @@ spec:
 
 			t.Log("applying env vars should populate env fields")
 			{
-				err := template.applyEnvRefs(map[string]string{
+				err := template.applyEnvRefs(map[string]interface{}{
 					"bkt-1-name-ref":   "bucket-1",
 					"label-1-name-ref": "label-1",
 				})

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -1375,7 +1375,7 @@ type (
 	// ApplyOpt is an option for applying a package.
 	ApplyOpt struct {
 		Templates       []*Template
-		EnvRefs         map[string]string
+		EnvRefs         map[string]interface{}
 		MissingSecrets  map[string]string
 		StackID         influxdb.ID
 		ResourcesToSkip map[ActionSkipResource]bool
@@ -1400,7 +1400,7 @@ type (
 )
 
 // ApplyWithEnvRefs provides env refs to saturate the missing reference fields in the template.
-func ApplyWithEnvRefs(envRefs map[string]string) ApplyOptFn {
+func ApplyWithEnvRefs(envRefs map[string]interface{}) ApplyOptFn {
 	return func(o *ApplyOpt) {
 		o.EnvRefs = envRefs
 	}


### PR DESCRIPTION
this change removes implicit default values from env refs returned via the API. All default values moving forward will have to be explicity provided via the template. The magical `env-ENVREFKEY` thing is finally going away. This work is in support of query parameterizations which will follow this.

references: #18237


- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
