### PR TITLE
fix: removing default sort on tables

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import {fastMap, fastReduce, fastFilter} from 'src/utils/fast'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {CELL_HORIZONTAL_PADDING} from 'src/shared/constants/tableGraph'
 import {DEFAULT_TIME_FIELD, FORMAT_OPTIONS} from 'src/dashboards/constants'
@@ -215,6 +216,11 @@ export const sortTableData = (
 
   if (headerSet.has(sort.field)) {
     sortIndex = _.indexOf(data[0], sort.field)
+  } else if (isFlagEnabled('disableDefaultTableSort') && !sort.field) {
+    return {
+      sortedData: [...data],
+      sortedTimeVals: data.map(col => col[0]),
+    }
   }
 
   const dataValues = _.drop(data, 1)

--- a/ui/src/shared/selectors/flags.ts
+++ b/ui/src/shared/selectors/flags.ts
@@ -15,6 +15,7 @@ export const OSS_FLAGS = {
   streamEvents: false,
   'notebook-panel--spotify': false,
   'notebook-panel--test-flux': false,
+  disableDefaultTableSort: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -31,6 +32,7 @@ export const CLOUD_FLAGS = {
   streamEvents: false,
   'notebook-panel--spotify': false,
   'notebook-panel--test-flux': false,
+  disableDefaultTableSort: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {


### PR DESCRIPTION
![Peek 2020-07-28 13-05](https://user-images.githubusercontent.com/1434802/88716340-c9c48d80-d0d3-11ea-805d-a6dfb223bca8.gif)

this addresses influxdata/ear#1644

the current default behavior is to implement a sort on the first column returned from the backend. this over-writes any sort that was explicitly defined in the query and not in the interface. i made it return data just like it came back from the server unless the user specifies a sort in the view options.

weary about the product level consequences, so i'm wrapping it in a flag to let russ click around before removing the flag