### PR TITLE
fix: decoupling remounting from onboarding state

### DIFF
--- a/ui/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -147,7 +147,7 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
   private setStepIndex = (index: number) => {
     const {history} = this.props
 
-    history.push(`/onboarding/${index}`)
+    history.replace(`/onboarding/${index}`)
   }
 }
 


### PR DESCRIPTION
Closes #18931

remounting caused the onboarding "is there currently user" api request to refire and invalidate product flow. can also be fixed with memoized FCs, but i think the back button isn't the biggest deal in this flow