### PR TITLE
feat(community-templates-flagged): name installed templates

### DIFF
--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -980,7 +980,7 @@ export const communityTemplateInstallFailed = (
 export const communityTemplateDeleteSucceeded = (
   templateName: string
 ): Notification => ({
-  ...defaultSuccessNotification,
+  ...defaultDeletionNotification,
   message: `We've successfully deleted: ${templateName}`,
 })
 
@@ -1001,4 +1001,9 @@ export const communityTemplateFetchStackFailed = (
 export const communityTemplateUnsupportedFormatError = (): Notification => ({
   ...defaultErrorNotification,
   message: `Please provide a link to a template file`,
+})
+
+export const communityTemplateRenameFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `We've successfully installed your template but weren't able to name it properly. It may appear as a blank template.`,
 })

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -36,6 +36,7 @@ import {
   patchDashboardsCellsView as apiPatchDashboardsCellsView,
   deleteStack as apiDeleteStack,
   getStacks,
+  patchStack,
   postTemplatesApply,
   Error as PkgError,
   TemplateApply,
@@ -530,6 +531,23 @@ export const fetchStacks = async (orgID: string) => {
 export const deleteStack = async (stackId, orgID) => {
   const resp = await apiDeleteStack({stack_id: stackId, query: {orgID}})
 
+  if (resp.status >= 300) {
+    throw new Error((resp.data as PkgError).message)
+  }
+
+  return resp
+}
+
+export const updateStackName = async (stackID, name) => {
+  const resp = await patchStack({
+    stack_id: stackID,
+    data: {
+      name,
+      description: null,
+      templateURLs: null,
+      additionalResources: null,
+    },
+  })
   if (resp.status >= 300) {
     throw new Error((resp.data as PkgError).message)
   }

--- a/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -72,7 +72,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
       if (source.includes('github')) {
         return (
           <a key={source} href={source}>
-            Github
+            {source}
           </a>
         )
       }


### PR DESCRIPTION
Closes #19095
Closes #19096

![Screen Shot 2020-07-28 at 5 08 11 PM](https://user-images.githubusercontent.com/146112/88741779-6186a380-d0f5-11ea-9d12-1af34610a80f.png)


Names the newly installed template based on the directory and template name. This depends on our github [templates directory](https://github.com/influxdata/community-templates) structure. This'll have to be changed for files.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
