### PR TITLE
feat(autoAggregate): BE work for autoAggregate

### DIFF
--- a/cmd/influxd/launcher/pkger_test.go
+++ b/cmd/influxd/launcher/pkger_test.go
@@ -2568,7 +2568,8 @@ spec:
 							Name string `json:"name"`
 						}{},
 						AggregateWindow: struct {
-							Period string `json:"period"`
+							Period     string `json:"period"`
+							FillValues bool   `json:"fillValues"`
 						}{},
 					},
 					Text:     "from(v.bucket) |> count()",

--- a/dashboard.go
+++ b/dashboard.go
@@ -889,7 +889,8 @@ type BuilderConfig struct {
 		Name string `json:"name"`
 	} `json:"functions"`
 	AggregateWindow struct {
-		Period string `json:"period"`
+		Period     string `json:"period"`
+		FillValues bool   `json:"fillValues"`
 	} `json:"aggregateWindow"`
 }
 

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -693,7 +693,7 @@ func TestService_handlePostCheck(t *testing.T) {
   "query": {
   	"builderConfig": {
     "aggregateWindow": {
-			"fillValues": false,
+      "fillValues": false,
       "period": ""
     },
     "buckets": [],
@@ -1136,7 +1136,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		  "query": {
             "builderConfig": {
               "aggregateWindow": {
-								"fillValues": false,
+                "fillValues": false,
                 "period": ""
               },
               "buckets": [],

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -148,6 +148,7 @@ func TestService_handleGetChecks(t *testing.T) {
 			"query": {
 				"builderConfig": {
 					"aggregateWindow": {
+						"fillValues": false,
 						"period": ""
 					},
 					"buckets": [],
@@ -191,6 +192,7 @@ func TestService_handleGetChecks(t *testing.T) {
 			"query": {
 				"builderConfig": {
 					"aggregateWindow": {
+						"fillValues": false,
 						"period": ""
 					},
 					"buckets": [],
@@ -510,7 +512,8 @@ func TestService_handleGetCheck(t *testing.T) {
 		  "query": {
             "builderConfig": {
               "aggregateWindow": {
-                "period": ""
+								"fillValues": false,
+								"period": ""
               },
               "buckets": [],
               "functions": [],
@@ -690,6 +693,7 @@ func TestService_handlePostCheck(t *testing.T) {
   "query": {
   	"builderConfig": {
     "aggregateWindow": {
+			"fillValues": false,
       "period": ""
     },
     "buckets": [],
@@ -945,6 +949,7 @@ func TestService_handlePatchCheck(t *testing.T) {
 		  "query": {
 				"builderConfig": {
 					"aggregateWindow": {
+						"fillValues": false,
 						"period": ""
 					},
 					"buckets": [],
@@ -1131,6 +1136,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		  "query": {
             "builderConfig": {
               "aggregateWindow": {
+								"fillValues": false,
                 "period": ""
               },
               "buckets": [],

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8875,6 +8875,8 @@ components:
           properties:
             period:
               type: string
+            fillValues:
+              type: boolean
     BuilderTagsType:
       type: object
       properties:

--- a/notification/check/threshold.go
+++ b/notification/check/threshold.go
@@ -156,7 +156,16 @@ func addCreateEmptyFalseToAggregateWindow(pkg *ast.Package) {
 			if id, ok := call.Callee.(*ast.Identifier); ok && id.Name == "aggregateWindow" {
 				for _, args := range call.Arguments {
 					if obj, ok := args.(*ast.ObjectExpression); ok {
-						obj.Properties = append(obj.Properties, flux.Property("createEmpty", flux.Bool(false)))
+						foundCreateEmpty := false
+						for _, props := range obj.Properties {
+							if props.Key.Key() == "createEmpty" {
+								foundCreateEmpty = true
+								break
+							}
+						}
+						if !foundCreateEmpty {
+							obj.Properties = append(obj.Properties, flux.Property("createEmpty", flux.Bool(false)))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This PR has the backend changes for the autoaggregation work to be incorporated in to the UI:
- Add the new `fillValues` property to the autoAggregate property of the builderConfig in dashboards and in the swagger definition
- Change check flux generation logic to check if a createEmpty exists on a call to aggregateWindow, before adding it
- Fix tests
