### PR TITLE
chore(Flux): fix typo in aggregate.range description

### DIFF
--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -176,7 +176,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'experimental/aggregate',
-    desc: 'Calculates the range of change per windows of time.',
+    desc: 'Calculates the rate of change per windows of time.',
     example: 'aggregate.rate(every: 1m, unit: 1s)',
     category: 'Transformations',
     link:


### PR DESCRIPTION
Fixed a typo in aggregate.range description.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
