### PR TITLE
feat: Add Error Reporting to community templates

### DIFF
--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -19,6 +19,7 @@ import {ComponentStatus} from '@influxdata/clockface'
 // Utils
 import {getByID} from 'src/resources/selectors'
 import {getGithubUrlFromTemplateDetails} from 'src/templates/utils'
+import {reportError} from 'src/shared/utils/errors'
 
 import {
   installTemplate,
@@ -96,6 +97,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
+      reportError(err, {name: 'The community template install failed'})
     }
   }
 
@@ -126,14 +128,16 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
+      reportError(err, {name: 'Failed to install community template'})
     }
 
     try {
       await updateStackName(summary.stackID, templateName)
 
       this.props.notify(communityTemplateInstallSucceeded(templateName))
-    } catch {
+    } catch (err) {
       this.props.notify(communityTemplateRenameFailed())
+      reportError(err, {name: 'The community template rename failed'})
     } finally {
       this.props.fetchAndSetStacks(org.id)
       this.onDismiss()

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -97,7 +97,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
-      reportError(err, {name: 'The community template install failed'})
+      reportError(err, {name: 'The community template fetch for preview failed'})
     }
   }
 

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -97,7 +97,9 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
-      reportError(err, {name: 'The community template fetch for preview failed'})
+      reportError(err, {
+        name: 'The community template fetch for preview failed',
+      })
     }
   }
 

--- a/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -28,6 +28,9 @@ import {TemplateKind} from 'src/client'
 // API
 import {deleteStack} from 'src/templates/api'
 
+//Utils
+import {reportError} from 'src/shared/utils/errors'
+
 interface OwnProps {
   orgID: string
 }
@@ -53,6 +56,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
       this.props.fetchAndSetStacks(this.props.orgID)
     } catch (err) {
       this.props.notify(communityTemplateFetchStackFailed(err.message))
+      reportError(err, {name: 'The community template fetch stack failed'})
     }
   }
 
@@ -89,6 +93,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
         this.props.notify(communityTemplateDeleteSucceeded(stackID))
       } catch (err) {
         this.props.notify(communityTemplateDeleteFailed(err.message))
+        reportError(err, {name: 'The community template delete failed'})
       } finally {
         this.props.fetchAndSetStacks(this.props.orgID)
       }

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -170,7 +170,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateUnsupportedFormatError())
-      reportError(err, {name: 'The community template install failed'})
+      reportError(err, {name: 'The community template getTemplateDetails failed'})
     }
   }
 

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -40,6 +40,7 @@ import {
   getGithubUrlFromTemplateDetails,
   getTemplateDetails,
 } from 'src/templates/utils'
+import {reportError} from 'src/shared/utils/errors'
 
 import {communityTemplateUnsupportedFormatError} from 'src/shared/copy/notifications'
 // Types
@@ -169,6 +170,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateUnsupportedFormatError())
+      reportError(err, {name: 'The community template install failed'})
     }
   }
 

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -170,7 +170,9 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateUnsupportedFormatError())
-      reportError(err, {name: 'The community template getTemplateDetails failed'})
+      reportError(err, {
+        name: 'The community template getTemplateDetails failed',
+      })
     }
   }
 


### PR DESCRIPTION
Adding the error reporting to the community template pages. So when errors happen we have a paper trail of reporting, so we can patterns, bad apples, etc. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
