### PR TITLE
feat(query/stdlib): enable read group min max

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -2237,6 +2237,80 @@ from(bucket: v.bucket)
 ,,1,kk1,35
 `,
 		},
+		{
+			name: "min group",
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			op: "readGroup(min)",
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
+	|> group(columns: ["kk"])
+	|> min()
+	|> keep(columns: ["kk", "_value"])
+`,
+			want: `
+#datatype,string,long,string,long
+#group,false,false,true,false
+#default,_result,,,
+,result,table,kk,_value
+,,0,kk0,0
+,,1,kk1,1
+`,
+		},
+		{
+			name: "max group",
+			data: []string{
+				"m0,k=k0,kk=kk0 f=0i 0",
+				"m0,k=k0,kk=kk1 f=1i 1000000000",
+				"m0,k=k0,kk=kk0 f=2i 2000000000",
+				"m0,k=k0,kk=kk1 f=3i 3000000000",
+				"m0,k=k0,kk=kk0 f=4i 4000000000",
+				"m0,k=k0,kk=kk1 f=5i 5000000000",
+				"m0,k=k0,kk=kk0 f=6i 6000000000",
+				"m0,k=k0,kk=kk1 f=5i 7000000000",
+				"m0,k=k0,kk=kk0 f=0i 8000000000",
+				"m0,k=k0,kk=kk1 f=6i 9000000000",
+				"m0,k=k0,kk=kk0 f=6i 10000000000",
+				"m0,k=k0,kk=kk1 f=7i 11000000000",
+				"m0,k=k0,kk=kk0 f=5i 12000000000",
+				"m0,k=k0,kk=kk1 f=8i 13000000000",
+				"m0,k=k0,kk=kk0 f=9i 14000000000",
+				"m0,k=k0,kk=kk1 f=5i 15000000000",
+			},
+			op: "readGroup(max)",
+			query: `
+from(bucket: v.bucket)
+	|> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
+	|> group(columns: ["kk"])
+	|> max()
+	|> keep(columns: ["kk", "_value"])
+`,
+			want: `
+#datatype,string,long,string,long
+#group,false,false,true,false
+#default,_result,,,
+,result,table,kk,_value
+,,0,kk0,9
+,,1,kk1,8
+`,
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -2247,6 +2321,7 @@ from(bucket: v.bucket)
 				feature.PushDownWindowAggregateMean():  true,
 				feature.PushDownWindowAggregateMin():   true,
 				feature.PushDownWindowAggregateMax():   true,
+				feature.PushDownGroupAggregateMinMax(): true,
 			}))
 
 			l.SetupOrFail(t)

--- a/flags.yml
+++ b/flags.yml
@@ -151,3 +151,9 @@
   contact: Monitoring Team
   lifetime: temporary
   expose: true
+
+- name: Push Down Group Aggregate Min Max
+  description: Enable the min and max variants of the PushDownGroupAggregate planner rule
+  key: pushDownGroupAggregateMinMax
+  default: false
+  contact: Query Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -282,6 +282,20 @@ func Notebooks() BoolFlag {
 	return notebooks
 }
 
+var pushDownGroupAggregateMinMax = MakeBoolFlag(
+	"Push Down Group Aggregate Min Max",
+	"pushDownGroupAggregateMinMax",
+	"Query Team",
+	false,
+	Temporary,
+	false,
+)
+
+// PushDownGroupAggregateMinMax - Enable the min and max variants of the PushDownGroupAggregate planner rule
+func PushDownGroupAggregateMinMax() BoolFlag {
+	return pushDownGroupAggregateMinMax
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -303,6 +317,7 @@ var all = []Flag{
 	useUserPermission,
 	mergeFiltersRule,
 	notebooks,
+	pushDownGroupAggregateMinMax,
 }
 
 var byKey = map[string]Flag{
@@ -326,4 +341,5 @@ var byKey = map[string]Flag{
 	"useUserPermission":             useUserPermission,
 	"mergeFiltersRule":              mergeFiltersRule,
 	"notebooks":                     notebooks,
+	"pushDownGroupAggregateMinMax":  pushDownGroupAggregateMinMax,
 }

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/errors"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/query"
@@ -273,6 +274,12 @@ func (gi *groupIterator) Do(f func(flux.Table) error) error {
 	req.Range.Start = int64(gi.spec.Bounds.Start)
 	req.Range.End = int64(gi.spec.Bounds.Stop)
 
+	if len(gi.spec.GroupKeys) > 0 && gi.spec.GroupMode == query.GroupModeNone {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  "cannot have group mode none with group key values",
+		}
+	}
 	req.Group = convertGroupMode(gi.spec.GroupMode)
 	req.GroupKeys = gi.spec.GroupKeys
 

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -1,6 +1,7 @@
 package storageflux 
 
 import (
+	"fmt"
 	"math"
 	"sync"
 
@@ -742,49 +743,29 @@ func (t *{{.name}}GroupTable) advance() bool {
 		return true
 	}
 
-	// handle the group with aggregate case
-	var value {{.Type}}
-	// For group count, sum, min, and max, the timestamp here is always math.MaxInt64.
-	// their final result does not contain _time, so this timestamp value can be anything
-	// and it won't matter.
-	// For group first, we need to assign the initial value to math.MaxInt64 so
-	// we can find the row with the smallest timestamp.
-	// Do not worry about data with math.MaxInt64 as its real timestamp.
-	// In OSS we require a |> range() call in the query and a math.MaxInt64 timestamp
-	// cannot make it through.
-	var timestamp int64 = math.MaxInt64
-	if t.gc.Aggregate().Type == datatypes.AggregateTypeLast {
-		timestamp = math.MinInt64
+	aggregate, err := determine{{.Name}}AggregateMethod(t.gc.Aggregate().Type)
+	if err != nil {
+		t.err = err
+		return false
 	}
+
+	ts, v := aggregate(arr.Timestamps, arr.Values)
+	timestamps, values := []int64{ts}, []{{.Type}}{v}
 	for {
-		// note that for the group aggregate case, len here should always be 1
-		for i := 0; i < len; i++ {
-			switch t.gc.Aggregate().Type {
-			case datatypes.AggregateTypeCount:
-				{{if eq .Name "Integer"}}fallthrough{{else}}panic("unsupported for aggregate count: {{.Name}}"){{end}}
-			case datatypes.AggregateTypeSum:
-				{{if or (eq .Name "String") (eq .Name "Boolean")}}panic("unsupported for aggregate sum: {{.Name}}"){{else}}value += arr.Values[i]{{end}}
-			case datatypes.AggregateTypeFirst:
-				if arr.Timestamps[i] < timestamp {
-					timestamp = arr.Timestamps[i]
-					value = arr.Values[i]
-				}
-			case datatypes.AggregateTypeLast:
-				if arr.Timestamps[i] > timestamp {
-					timestamp = arr.Timestamps[i]
-					value = arr.Values[i]
-				}
-			}
-		}
 		arr = t.cur.Next()
-		len = arr.Len()
-		if len > 0 {
+		if arr.Len() > 0 {
+			ts, v := aggregate(arr.Timestamps, arr.Values)
+			timestamps = append(timestamps, ts)
+			values = append(values, v)
 			continue
 		}
+
 		if !t.advanceCursor() {
 			break
 		}
 	}
+	timestamp, value := aggregate(timestamps, values)
+
 	colReader := t.allocateBuffer(1)
 	if IsSelector(t.gc.Aggregate()) {
 		colReader.cols[timeColIdx] = arrow.NewInt([]int64{timestamp}, t.alloc)
@@ -795,6 +776,141 @@ func (t *{{.name}}GroupTable) advance() bool {
 	t.appendTags(colReader)
 	t.appendBounds(colReader)
 	return true
+}
+
+type {{.name}}AggregateMethod func([]int64, []{{.Type}}) (int64, {{.Type}})
+
+// determine{{.Name}}AggregateMethod returns the method for aggregating
+// returned points within the same group. The incoming points are the
+// ones returned for each series and the method returned here will
+// aggregate the aggregates.
+func determine{{.Name}}AggregateMethod(agg datatypes.Aggregate_AggregateType) ({{.name}}AggregateMethod, error){
+ 	switch agg {
+	case datatypes.AggregateTypeFirst:
+		return aggregateFirstGroups{{.Name}}, nil
+	case datatypes.AggregateTypeLast:
+		return aggregateLastGroups{{.Name}}, nil
+	case datatypes.AggregateTypeCount:
+		{{if eq .Name "Integer"}}
+		return aggregateCountGroups{{.Name}}, nil
+		{{else}}
+		return nil, &influxdb.Error {
+			Code: influxdb.EInvalid,
+			Msg: "unsupported for aggregate count: {{.Name}}",
+		}
+		{{end}}
+	case datatypes.AggregateTypeSum:
+		{{if and (ne .Name "Boolean") (ne .Name "String")}}
+		return aggregateSumGroups{{.Name}}, nil
+		{{else}}
+		return nil, &influxdb.Error {
+			Code: influxdb.EInvalid,
+			Msg: "unsupported for aggregate sum: {{.Name}}",
+		}
+		{{end}}
+	case datatypes.AggregateTypeMin:
+		{{if and (ne .Name "Boolean") (ne .Name "String")}}
+		return aggregateMinGroups{{.Name}}, nil
+		{{else}}
+		return nil, &influxdb.Error {
+			Code: influxdb.EInvalid,
+			Msg: "unsupported for aggregate min: {{.Name}}",
+		}
+		{{end}}
+	case datatypes.AggregateTypeMax:
+		{{if and (ne .Name "Boolean") (ne .Name "String")}}
+		return aggregateMaxGroups{{.Name}}, nil
+		{{else}}
+		return nil, &influxdb.Error {
+			Code: influxdb.EInvalid,
+			Msg: "unsupported for aggregate max: {{.Name}}",
+		}
+		{{end}}
+	default:
+		return nil, &influxdb.Error {
+			Code: influxdb.EInvalid,
+			Msg: fmt.Sprintf("unknown/unimplemented aggregate type: %v", agg),
+		}
+	}
+}
+
+{{if and (ne .Name "Boolean") (ne .Name "String")}}
+func aggregateMinGroups{{.Name}}(timestamps []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	value := values[0]
+	timestamp := timestamps[0]
+
+	for i := 1; i < len(values); i++ {
+		if value > values[i] {
+			value = values[i]
+			timestamp = timestamps[i]
+		}
+	}
+
+	return timestamp, value
+}
+{{end}}
+
+{{if and (ne .Name "Boolean") (ne .Name "String")}}
+func aggregateMaxGroups{{.Name}}(timestamps []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	value := values[0]
+	timestamp := timestamps[0]
+
+	for i := 1; i < len(values); i++ {
+		if value < values[i] {
+			value = values[i]
+			timestamp = timestamps[i]
+		}
+	}
+
+	return timestamp, value
+}
+{{end}}
+
+// For group count and sum, the timestamp here is always math.MaxInt64.
+// their final result does not contain _time, so this timestamp value can be anything
+// and it won't matter.
+{{if eq .Name "Integer"}}
+func aggregateCountGroups{{.Name}}(timestamps []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	return aggregateSumGroups{{.Name}}(timestamps, values)
+}
+{{end}}
+
+{{if and (ne .Name "Boolean") (ne .Name "String")}}
+func aggregateSumGroups{{.Name}}(_ []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	var sum {{.Type}}
+	for _, v := range values {
+		sum += v
+	}
+	return math.MaxInt64, sum
+}
+{{end}}
+
+func aggregateFirstGroups{{.Name}}(timestamps []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	value := values[0]
+	timestamp := timestamps[0]
+
+	for i := 1; i < len(values); i++ {
+		if timestamp > timestamps[i] {
+			value = values[i]
+			timestamp = timestamps[i]
+		}
+	}
+
+	return timestamp, value
+}
+
+func aggregateLastGroups{{.Name}}(timestamps []int64, values []{{.Type}}) (int64, {{.Type}}) {
+	value := values[0]
+	timestamp := timestamps[0]
+
+	for i := 1; i < len(values); i++ {
+		if timestamp < timestamps[i] {
+			value = values[i]
+			timestamp = timestamps[i]
+		}
+	}
+
+	return timestamp, value
 }
 
 func (t *{{.name}}GroupTable) advanceCursor() bool {

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -71,7 +71,7 @@ func (t *table) isCancelled() bool {
 }
 
 func (t *table) init(advance func() bool) {
-	t.empty = !advance()
+	t.empty = !advance() && t.err == nil
 }
 
 func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
@@ -81,6 +81,12 @@ func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 		return errors.New("table already used")
 	}
 	defer t.closeDone()
+
+	// If an error occurred during initialization, that is
+	// returned here.
+	if t.err != nil {
+		return t.err
+	}
 
 	if !t.Empty() {
 		t.err = f(t.colBufs)


### PR DESCRIPTION
This PR will enable readGroup min/max in OSS behind a feature flag. 

To do: 
- [x] Create feature flags specific to min/max for ReadGroup
- [x] Update storage capabilities in OSS and/or idpe to include min/max for ReadGroup
- [x] Update planner rule PushDownGroupRule and add tests
- [x] Add tests to storage/flux/table_test.go (tests added, and passing, but there are issues with GroupTable as seen below)
- [x] Add flux end-to-end tests (influxdata/flux#3051)
- [x] Add launcher test to OSS
- [x] Add pipeline test to idpe

