### PR TITLE
feat(tenant): Allow tenant to be composable and still maintain access across services

### DIFF
--- a/tenant/service.go
+++ b/tenant/service.go
@@ -1,6 +1,8 @@
 package tenant
 
 import (
+	"context"
+
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/metric"
 	"github.com/influxdata/influxdb/v2/label"
@@ -9,14 +11,39 @@ import (
 	"go.uber.org/zap"
 )
 
-type Service struct {
-	store *Store
+type contextKey string
+
+const (
+	ctxInternal contextKey = "influx/tenant/internal"
+)
+
+func internalCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxInternal, true)
 }
 
-func NewService(st *Store) influxdb.TenantService {
-	return &Service{
-		store: st,
-	}
+func isInternal(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxInternal).(bool)
+	return ok
+}
+
+type Service struct {
+	influxdb.UserService
+	influxdb.PasswordsService
+	influxdb.UserResourceMappingService
+	influxdb.OrganizationService
+	influxdb.BucketService
+}
+
+func NewService(st *Store) *Service {
+	svc := &Service{}
+	userSvc := NewUserSvc(st, svc)
+	svc.UserService = userSvc
+	svc.PasswordsService = userSvc
+	svc.UserResourceMappingService = NewUserResourceMappingSvc(st, svc)
+	svc.OrganizationService = NewOrganizationSvc(st, svc)
+	svc.BucketService = NewBucketSvc(st, svc)
+
+	return svc
 }
 
 type TenantSystem struct {

--- a/tenant/service_bucket.go
+++ b/tenant/service_bucket.go
@@ -7,8 +7,20 @@ import (
 	"github.com/influxdata/influxdb/v2/kv"
 )
 
+type BucketSvc struct {
+	store *Store
+	svc   *Service
+}
+
+func NewBucketSvc(st *Store, svc *Service) *BucketSvc {
+	return &BucketSvc{
+		store: st,
+		svc:   svc,
+	}
+}
+
 // FindBucketByID returns a single bucket by ID.
-func (s *Service) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+func (s *BucketSvc) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
 	var bucket *influxdb.Bucket
 	err := s.store.View(ctx, func(tx kv.Tx) error {
 		b, err := s.store.GetBucket(ctx, tx, id)
@@ -24,10 +36,9 @@ func (s *Service) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb
 	}
 
 	return bucket, nil
-
 }
 
-func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, name string) (*influxdb.Bucket, error) {
+func (s *BucketSvc) FindBucketByName(ctx context.Context, orgID influxdb.ID, name string) (*influxdb.Bucket, error) {
 	var bucket *influxdb.Bucket
 	err := s.store.View(ctx, func(tx kv.Tx) error {
 		b, err := s.store.GetBucketByName(ctx, tx, orgID, name)
@@ -47,7 +58,7 @@ func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, name 
 }
 
 // FindBucket returns the first bucket that matches filter.
-func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+func (s *BucketSvc) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
 	if filter.ID != nil {
 		return s.FindBucketByID(ctx, *filter.ID)
 	}
@@ -73,7 +84,7 @@ func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) 
 
 // FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
 // Additional options provide pagination & sorting.
-func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+func (s *BucketSvc) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
 	if filter.ID != nil {
 		b, err := s.FindBucketByID(ctx, *filter.ID)
 		if err != nil {
@@ -81,17 +92,16 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 		}
 		return []*influxdb.Bucket{b}, 1, nil
 	}
+	if filter.OrganizationID == nil && filter.Org != nil {
+		org, err := s.svc.FindOrganization(ctx, influxdb.OrganizationFilter{Name: filter.Org})
+		if err != nil {
+			return nil, 0, err
+		}
+		filter.OrganizationID = &org.ID
+	}
 
 	var buckets []*influxdb.Bucket
 	err := s.store.View(ctx, func(tx kv.Tx) error {
-		if filter.OrganizationID == nil && filter.Org != nil {
-			org, err := s.store.GetOrgByName(ctx, tx, *filter.Org)
-			if err != nil {
-				return err
-			}
-			filter.OrganizationID = &org.ID
-		}
-
 		if filter.Name != nil && filter.OrganizationID != nil {
 			b, err := s.store.GetBucketByName(ctx, tx, *filter.OrganizationID, *filter.Name)
 			if err != nil {
@@ -162,25 +172,25 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 }
 
 // CreateBucket creates a new bucket and sets b.ID with the new identifier.
-func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
+func (s *BucketSvc) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
 	if !b.OrgID.Valid() {
 		// we need a valid org id
 		return ErrOrgNotFound
 	}
 
-	return s.store.Update(ctx, func(tx kv.Tx) error {
-		// make sure the org exists
-		if _, err := s.store.GetOrg(ctx, tx, b.OrgID); err != nil {
-			return err
-		}
+	// make sure the org exists
+	if _, err := s.svc.FindOrganizationByID(ctx, b.OrgID); err != nil {
+		return err
+	}
 
+	return s.store.Update(ctx, func(tx kv.Tx) error {
 		return s.store.CreateBucket(ctx, tx, b)
 	})
 }
 
 // UpdateBucket updates a single bucket with changeset.
 // Returns the new bucket state after update.
-func (s *Service) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
+func (s *BucketSvc) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
 	var bucket *influxdb.Bucket
 	err := s.store.Update(ctx, func(tx kv.Tx) error {
 		b, err := s.store.UpdateBucket(ctx, tx, id, upd)
@@ -199,13 +209,13 @@ func (s *Service) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb
 }
 
 // DeleteBucket removes a bucket by ID.
-func (s *Service) DeleteBucket(ctx context.Context, id influxdb.ID) error {
-	return s.store.Update(ctx, func(tx kv.Tx) error {
+func (s *BucketSvc) DeleteBucket(ctx context.Context, id influxdb.ID) error {
+	err := s.store.Update(ctx, func(tx kv.Tx) error {
 		bucket, err := s.store.GetBucket(ctx, tx, id)
 		if err != nil {
 			return err
 		}
-		if bucket.Type == influxdb.BucketTypeSystem {
+		if bucket.Type == influxdb.BucketTypeSystem && !isInternal(ctx) {
 			// TODO: I think we should allow bucket deletes but maybe im wrong.
 			return errDeleteSystemBucket
 		}
@@ -213,6 +223,27 @@ func (s *Service) DeleteBucket(ctx context.Context, id influxdb.ID) error {
 		if err := s.store.DeleteBucket(ctx, tx, id); err != nil {
 			return err
 		}
-		return s.removeResourceRelations(ctx, tx, id)
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return s.removeResourceRelations(ctx, id)
+}
+
+// removeResourceRelations allows us to clean up any resource relationship that would have normally been left over after a delete action of a resource.
+func (s *BucketSvc) removeResourceRelations(ctx context.Context, resourceID influxdb.ID) error {
+	urms, _, err := s.svc.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
+		ResourceID: resourceID,
+	})
+	if err != nil {
+		return err
+	}
+	for _, urm := range urms {
+		err := s.svc.DeleteUserResourceMapping(ctx, urm.ResourceID, urm.UserID)
+		if err != nil && err != ErrURMNotFound {
+			return err
+		}
+	}
+	return nil
 }

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -8,8 +8,20 @@ import (
 	"github.com/influxdata/influxdb/v2/kv"
 )
 
+type OrgSvc struct {
+	store *Store
+	svc   *Service
+}
+
+func NewOrganizationSvc(st *Store, svc *Service) *OrgSvc {
+	return &OrgSvc{
+		store: st,
+		svc:   svc,
+	}
+}
+
 // Returns a single organization by ID.
-func (s *Service) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+func (s *OrgSvc) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
 	var org *influxdb.Organization
 	err := s.store.View(ctx, func(tx kv.Tx) error {
 		o, err := s.store.GetOrg(ctx, tx, id)
@@ -28,7 +40,7 @@ func (s *Service) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*in
 }
 
 // Returns the first organization that matches filter.
-func (s *Service) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+func (s *OrgSvc) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
 	if filter.ID != nil {
 		return s.FindOrganizationByID(ctx, *filter.ID)
 	}
@@ -56,7 +68,7 @@ func (s *Service) FindOrganization(ctx context.Context, filter influxdb.Organiza
 
 // Returns a list of organizations that match filter and the total count of matching organizations.
 // Additional options provide pagination & sorting.
-func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+func (s *OrgSvc) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
 	// if im given a id or a name I know I can only return 1
 	if filter.ID != nil || filter.Name != nil {
 		org, err := s.FindOrganization(ctx, filter)
@@ -70,7 +82,7 @@ func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.Organiz
 
 	if filter.UserID != nil {
 		// find urms for orgs with this user
-		urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
+		urms, _, err := s.svc.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
 			UserID:       *filter.UserID,
 			ResourceType: influxdb.OrgsResourceType,
 		}, opt...)
@@ -106,60 +118,59 @@ func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.Organiz
 }
 
 // Creates a new organization and sets b.ID with the new identifier.
-func (s *Service) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
+func (s *OrgSvc) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
 	err := s.store.Update(ctx, func(tx kv.Tx) error {
-		err := s.store.CreateOrg(ctx, tx, o)
+		return s.store.CreateOrg(ctx, tx, o)
+	})
+	if err != nil {
+		return err
+	}
+
+	tb := &influxdb.Bucket{
+		OrgID:           o.ID,
+		Type:            influxdb.BucketTypeSystem,
+		Name:            influxdb.TasksSystemBucketName,
+		RetentionPeriod: influxdb.TasksSystemBucketRetention,
+		Description:     "System bucket for task logs",
+	}
+
+	if err := s.svc.CreateBucket(ctx, tb); err != nil {
+		return err
+	}
+
+	mb := &influxdb.Bucket{
+		OrgID:           o.ID,
+		Type:            influxdb.BucketTypeSystem,
+		Name:            influxdb.MonitoringSystemBucketName,
+		RetentionPeriod: influxdb.MonitoringSystemBucketRetention,
+		Description:     "System bucket for monitoring logs",
+	}
+
+	if err := s.svc.CreateBucket(ctx, mb); err != nil {
+		return err
+	}
+
+	// create associated URM
+	userID, err := icontext.GetUserID(ctx)
+	if err == nil {
+		// if I am given a userid i can associate the user as the org owner
+		err = s.svc.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
+			UserID:       userID,
+			UserType:     influxdb.Owner,
+			MappingType:  influxdb.UserMappingType,
+			ResourceType: influxdb.OrgsResourceType,
+			ResourceID:   o.ID,
+		})
 		if err != nil {
 			return err
 		}
-
-		tb := &influxdb.Bucket{
-			OrgID:           o.ID,
-			Type:            influxdb.BucketTypeSystem,
-			Name:            influxdb.TasksSystemBucketName,
-			RetentionPeriod: influxdb.TasksSystemBucketRetention,
-			Description:     "System bucket for task logs",
-		}
-
-		if err := s.store.CreateBucket(ctx, tx, tb); err != nil {
-			return err
-		}
-
-		mb := &influxdb.Bucket{
-			OrgID:           o.ID,
-			Type:            influxdb.BucketTypeSystem,
-			Name:            influxdb.MonitoringSystemBucketName,
-			RetentionPeriod: influxdb.MonitoringSystemBucketRetention,
-			Description:     "System bucket for monitoring logs",
-		}
-
-		if err := s.store.CreateBucket(ctx, tx, mb); err != nil {
-			return err
-		}
-
-		// create assiciated URM
-		userID, err := icontext.GetUserID(ctx)
-		if err == nil {
-			// if I am given a userid i can associate the user as the org owner
-			err = s.store.CreateURM(ctx, tx, &influxdb.UserResourceMapping{
-				UserID:       userID,
-				UserType:     influxdb.Owner,
-				MappingType:  influxdb.UserMappingType,
-				ResourceType: influxdb.OrgsResourceType,
-				ResourceID:   o.ID,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	return err
+	}
+	return nil
 }
 
 // Updates a single organization with changeset.
 // Returns the new organization state after update.
-func (s *Service) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+func (s *OrgSvc) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
 	var org *influxdb.Organization
 	err := s.store.Update(ctx, func(tx kv.Tx) error {
 		o, err := s.store.UpdateOrg(ctx, tx, id, upd)
@@ -176,32 +187,46 @@ func (s *Service) UpdateOrganization(ctx context.Context, id influxdb.ID, upd in
 }
 
 // DeleteOrganization removes a organization by ID and its dependent resources.
-func (s *Service) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
-	err := s.store.Update(ctx, func(tx kv.Tx) error {
-		// clean up the buckets for this organization
-		filter := BucketFilter{
-			OrganizationID: &id,
-		}
-		bs, err := s.store.ListBuckets(ctx, tx, filter)
-		if err != nil {
-			return err
-		}
-		for _, b := range bs {
-			if err := s.store.DeleteBucket(ctx, tx, b.ID); err != nil {
-				if err != ErrBucketNotFound {
-					return err
-				}
-			}
-			if err := s.removeResourceRelations(ctx, tx, b.ID); err != nil {
+func (s *OrgSvc) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
+	// clean up the buckets for this organization
+	filter := influxdb.BucketFilter{
+		OrganizationID: &id,
+	}
+	bs, _, err := s.svc.FindBuckets(ctx, filter)
+	if err != nil {
+		return err
+	}
+	for _, b := range bs {
+		if err := s.svc.DeleteBucket(internalCtx(ctx), b.ID); err != nil {
+			if err != ErrBucketNotFound {
 				return err
 			}
 		}
+	}
 
-		if err := s.removeResourceRelations(ctx, tx, id); err != nil {
-			return err
-		}
-
+	err = s.store.Update(ctx, func(tx kv.Tx) error {
 		return s.store.DeleteOrg(ctx, tx, id)
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	return s.removeResourceRelations(ctx, id)
+}
+
+// removeResourceRelations allows us to clean up any resource relationship that would have normally been left over after a delete action of a resource.
+func (s *OrgSvc) removeResourceRelations(ctx context.Context, resourceID influxdb.ID) error {
+	urms, _, err := s.svc.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
+		ResourceID: resourceID,
+	})
+	if err != nil {
+		return err
+	}
+	for _, urm := range urms {
+		err := s.svc.DeleteUserResourceMapping(ctx, urm.ResourceID, urm.UserID)
+		if err != nil && err != ErrURMNotFound {
+			return err
+		}
+	}
+	return nil
 }

--- a/tenant/service_urm.go
+++ b/tenant/service_urm.go
@@ -7,8 +7,20 @@ import (
 	"github.com/influxdata/influxdb/v2/kv"
 )
 
+type URMSvc struct {
+	store *Store
+	svc   *Service
+}
+
+func NewUserResourceMappingSvc(st *Store, svc *Service) *URMSvc {
+	return &URMSvc{
+		store: st,
+		svc:   svc,
+	}
+}
+
 // FindUserResourceMappings returns a list of UserResourceMappings that match filter and the total count of matching mappings.
-func (s *Service) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
+func (s *URMSvc) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
 	var urms []*influxdb.UserResourceMapping
 	err := s.store.View(ctx, func(tx kv.Tx) error {
 		u, err := s.store.ListURMs(ctx, tx, filter, opt...)
@@ -25,7 +37,7 @@ func (s *Service) FindUserResourceMappings(ctx context.Context, filter influxdb.
 }
 
 // CreateUserResourceMapping creates a user resource mapping.
-func (s *Service) CreateUserResourceMapping(ctx context.Context, m *influxdb.UserResourceMapping) error {
+func (s *URMSvc) CreateUserResourceMapping(ctx context.Context, m *influxdb.UserResourceMapping) error {
 	err := s.store.Update(ctx, func(tx kv.Tx) error {
 		return s.store.CreateURM(ctx, tx, m)
 	})
@@ -33,7 +45,7 @@ func (s *Service) CreateUserResourceMapping(ctx context.Context, m *influxdb.Use
 }
 
 // DeleteUserResourceMapping deletes a user resource mapping.
-func (s *Service) DeleteUserResourceMapping(ctx context.Context, resourceID, userID influxdb.ID) error {
+func (s *URMSvc) DeleteUserResourceMapping(ctx context.Context, resourceID, userID influxdb.ID) error {
 	err := s.store.Update(ctx, func(tx kv.Tx) error {
 		_, err := s.store.GetURM(ctx, tx, resourceID, userID)
 		if err != nil {
@@ -42,37 +54,4 @@ func (s *Service) DeleteUserResourceMapping(ctx context.Context, resourceID, use
 		return s.store.DeleteURM(ctx, tx, resourceID, userID)
 	})
 	return err
-}
-
-// removeResourceRelations allows us to clean up any resource relationship that would have normally been left over after a delete action of a resource.
-func (s *Service) removeResourceRelations(ctx context.Context, tx kv.Tx, resourceID influxdb.ID) error {
-	urms, err := s.store.ListURMs(ctx, tx, influxdb.UserResourceMappingFilter{
-		ResourceID: resourceID,
-	})
-	if err != nil {
-		return err
-	}
-	for _, urm := range urms {
-		err := s.store.DeleteURM(ctx, tx, urm.ResourceID, urm.UserID)
-		if err != nil && err != ErrURMNotFound {
-			return err
-		}
-	}
-	return nil
-}
-
-func permissionFromMapping(mappings []*influxdb.UserResourceMapping) ([]influxdb.Permission, error) {
-	ps := make([]influxdb.Permission, 0, len(mappings))
-	for _, m := range mappings {
-		p, err := m.ToPermissions()
-		if err != nil {
-			return nil, &influxdb.Error{
-				Err: err,
-			}
-		}
-
-		ps = append(ps, p...)
-	}
-
-	return ps, nil
 }


### PR DESCRIPTION
Tenant services often need to make function calls to other services inside the tenant system. This can cause a problem when a external system needs to inject middleware into the call stack for the secondary system call. For instance when a bucket is created we may need to alert the storage system of the change. To accomplish this we need a way for the org svc to call a middleware influxdb.BucketService that is a tenant type service wrapped with a middleware piece. This is accomplished by allowing the individual services access to the tenant system that was generated. If a middleware is wrapping one of the systems the embedded system can still make internal calls

Closes #19155

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
