### PR TITLE
fix: apply feedback from default sort order

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash'
 import {fastMap, fastReduce, fastFilter} from 'src/utils/fast'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {CELL_HORIZONTAL_PADDING} from 'src/shared/constants/tableGraph'
 import {DEFAULT_TIME_FIELD, FORMAT_OPTIONS} from 'src/dashboards/constants'
@@ -216,7 +215,7 @@ export const sortTableData = (
 
   if (headerSet.has(sort.field)) {
     sortIndex = _.indexOf(data[0], sort.field)
-  } else if (isFlagEnabled('disableDefaultTableSort') && !sort.field) {
+  } else if (!sort.field) {
     return {
       sortedData: [...data],
       sortedTimeVals: data.map(col => col[0]),

--- a/ui/src/shared/components/tables/TableGraph.tsx
+++ b/ui/src/shared/components/tables/TableGraph.tsx
@@ -73,8 +73,12 @@ class TableGraph extends PureComponent<Props, State> {
     this.setState(({sortOptions}) => {
       const newSortOptions = {...sortOptions}
       if (fieldName === sortOptions.field) {
-        newSortOptions.direction =
-          sortOptions.direction === ASCENDING ? DESCENDING : ASCENDING
+        if (sortOptions.direction === DESCENDING) {
+          newSortOptions.field = ''
+          newSortOptions.direction = DEFAULT_SORT_DIRECTION
+        } else {
+          newSortOptions.direction = DESCENDING
+        }
       } else {
         newSortOptions.field = fieldName
         newSortOptions.direction = DEFAULT_SORT_DIRECTION


### PR DESCRIPTION

![Peek 2020-07-30 14-27](https://user-images.githubusercontent.com/1434802/89064581-18b23300-d31f-11ea-80aa-d089c57d7806.gif)

this closes the loop on this issue #19118

essentially, not applying a default sort is super cool, but we also needed to be able to clear existing sorts