### PR TITLE
fix(disappearing-cells): wrapping set views and setting cells in a timeout to ensure they get populated

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -359,12 +359,20 @@ export const getDashboard = (
     const cellViews: CellsWithViewProperties = resp.data.cells || []
     const viewsData = viewsFromCells(cellViews, dashboardID)
 
-    const normViews = normalize<View, ViewEntities, string[]>(
-      viewsData,
-      arrayOfViews
-    )
+    setTimeout(() => {
+      const normCells = normalize<Dashboard, DashboardEntities, string[]>(
+        resp.data.cells,
+        arrayOfCells
+      )
+      dispatch(setCells(dashboardID, RemoteDataState.Done, normCells))
 
-    dispatch(setViews(RemoteDataState.Done, normViews))
+      const normViews = normalize<View, ViewEntities, string[]>(
+        viewsData,
+        arrayOfViews
+      )
+
+      dispatch(setViews(RemoteDataState.Done, normViews))
+    }, 0)
 
     // Now that all the necessary state has been loaded, set the dashboard
     dispatch(creators.setDashboard(dashboardID, RemoteDataState.Done, normDash))


### PR DESCRIPTION
Related #18598 

### Problem

Clicking on a dashboard immediately after it was set created a weird race where the cells and views were still loading from the initial getDashboards call and were setting over the cells and views that were being gotten from the getDashboard function.

### Solution

Store a reference to the timeOut that by reference of the dashboard ID and clear the timeout if the dashboard is being loaded since the cells and views for the dashboard are already being loaded when the dashboard mounts

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)