### PR TITLE
feat(tm): adding new meta queries behind feature flag

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -143,3 +143,11 @@
   contact: Monitoring Team
   lifetime: temporary
   expose: true
+
+- name: New v1 Meta Queries in Time Machine
+  description: Switching the data explorer queries to use v1 meta queries
+  key: new-v1-meta-queries
+  default: false
+  contact: Monitoring Team
+  lifetime: temporary
+  expose: true

--- a/ui/src/timeMachine/apis/QueryBuilderFetcher.ts
+++ b/ui/src/timeMachine/apis/QueryBuilderFetcher.ts
@@ -1,12 +1,17 @@
 // APIs
 import {
   findBuckets,
+  findBucketsNew,
   findKeys,
+  findKeysNew,
   findValues,
+  findValuesNew,
   FindBucketsOptions,
   FindKeysOptions,
   FindValuesOptions,
 } from 'src/timeMachine/apis/queryBuilder'
+
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {CancelBox} from 'src/types'
@@ -30,8 +35,12 @@ class QueryBuilderFetcher {
     if (cachedResult) {
       return Promise.resolve(cachedResult)
     }
-
-    const pendingResult = findBuckets(options)
+    let pendingResult
+    if (isFlagEnabled('new-v1-meta-queries')) {
+      pendingResult = findBucketsNew(options)
+    } else {
+      pendingResult = findBuckets(options)
+    }
 
     pendingResult.promise
       .then(result => {
@@ -61,7 +70,12 @@ class QueryBuilderFetcher {
       return Promise.resolve(cachedResult)
     }
 
-    const pendingResult = findKeys(options)
+    let pendingResult
+    if (isFlagEnabled('new-v1-meta-queries')) {
+      pendingResult = findKeysNew(options)
+    } else {
+      pendingResult = findKeys(options)
+    }
 
     this.findKeysQueries[index] = pendingResult
 
@@ -93,7 +107,12 @@ class QueryBuilderFetcher {
       return Promise.resolve(cachedResult)
     }
 
-    const pendingResult = findValues(options)
+    let pendingResult
+    if (isFlagEnabled('new-v1-meta-queries')) {
+      pendingResult = findValuesNew(options)
+    } else {
+      pendingResult = findValues(options)
+    }
 
     this.findValuesQueries[index] = pendingResult
 


### PR DESCRIPTION
I added the new v1 meta queries being the feature flag `influx.set('new-v1-meta-queries', true)`

lots of clean up to do in the code i'm sure.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
