### PR TITLE
perf: calculate and emit event for cell mount => cell visualized

### DIFF
--- a/ui/src/cloud/utils/reporting.ts
+++ b/ui/src/cloud/utils/reporting.ts
@@ -141,8 +141,15 @@ export const event = (
     /* eslint-disable no-console */
     console.log(`Event:  [ ${measurement} ]`)
     if (Object.keys(meta).length) {
+      console.log('tags')
       console.log(
         Object.entries(meta)
+          .map(([k, v]) => `        ${k}: ${v}`)
+          .join('\n')
+      )
+      console.log('fields')
+      console.log(
+        Object.entries(values)
           .map(([k, v]) => `        ${k}: ${v}`)
           .join('\n')
       )

--- a/ui/src/perf/actions/index.ts
+++ b/ui/src/perf/actions/index.ts
@@ -1,9 +1,11 @@
 export const SET_RENDER_ID = 'SET_RENDER_ID'
 export const SET_SCROLL = 'SET_SCROLL'
+export const SET_CELL_MOUNT = 'SET_CELL_MOUNT'
 
 export type Action =
   | ReturnType<typeof setRenderID>
   | ReturnType<typeof setScroll>
+  | ReturnType<typeof setCellMount>
 
 export type ComponentKey = 'dashboard'
 export type ScrollState = 'not scrolled' | 'scrolled'
@@ -20,4 +22,11 @@ export const setScroll = (component: ComponentKey, scroll: ScrollState) =>
     type: SET_SCROLL,
     component,
     scroll,
+  } as const)
+
+export const setCellMount = (cellID: string, mountStartMs: number) =>
+  ({
+    type: SET_CELL_MOUNT,
+    cellID,
+    mountStartMs,
   } as const)

--- a/ui/src/perf/components/CellEvent.tsx
+++ b/ui/src/perf/components/CellEvent.tsx
@@ -7,7 +7,6 @@ import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState} from 'src/types'
-import {render} from '@testing-library/react'
 
 interface Props {
   id: string

--- a/ui/src/perf/components/CellEvent.tsx
+++ b/ui/src/perf/components/CellEvent.tsx
@@ -54,6 +54,11 @@ const CellEvent: FC<Props> = ({id, type}) => {
       return
     }
 
+    const hasIDs = dashboardID && id && renderID
+    if (!hasIDs) {
+      return
+    }
+
     const visRenderedMs = new Date().getTime()
     const timeToAppearMs = visRenderedMs - cellMountStartMs
 

--- a/ui/src/perf/reducers/index.ts
+++ b/ui/src/perf/reducers/index.ts
@@ -2,12 +2,24 @@
 import {produce} from 'immer'
 
 // Actions
-import {SET_RENDER_ID, SET_SCROLL, Action} from 'src/perf/actions'
+import {
+  SET_RENDER_ID,
+  SET_SCROLL,
+  Action,
+  SET_CELL_MOUNT,
+} from 'src/perf/actions'
 
 export interface PerfState {
   dashboard: {
     scroll: 'not scrolled' | 'scrolled'
     renderID: string
+  }
+  cells: {
+    byID: {
+      [id: string]: {
+        mountStartMs: number
+      }
+    }
   }
 }
 
@@ -15,6 +27,9 @@ const initialState = (): PerfState => ({
   dashboard: {
     scroll: 'not scrolled',
     renderID: '',
+  },
+  cells: {
+    byID: {},
   },
 })
 
@@ -34,6 +49,21 @@ const perfReducer = (
       case SET_SCROLL: {
         const {component, scroll} = action
         draftState[component].scroll = scroll
+
+        return
+      }
+
+      case SET_CELL_MOUNT: {
+        const {cellID, mountStartMs} = action
+        const exists = draftState.cells.byID[cellID]
+
+        if (!exists) {
+          draftState.cells.byID[cellID] = {mountStartMs}
+
+          return
+        }
+
+        draftState.cells.byID[cellID].mountStartMs = mountStartMs
 
         return
       }

--- a/ui/src/shared/components/cells/Cell.tsx
+++ b/ui/src/shared/components/cells/Cell.tsx
@@ -11,6 +11,9 @@ import RefreshingView from 'src/shared/components/RefreshingView'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
+// Action
+import {setCellMount as setCellMountAction} from 'src/perf/actions'
+
 // Utils
 import {getByID} from 'src/resources/selectors'
 
@@ -30,10 +33,20 @@ interface State {
   inView: boolean
 }
 
-type Props = StateProps & OwnProps
+interface DispatchProps {
+  setCellMount: typeof setCellMountAction
+}
+
+type Props = StateProps & OwnProps & DispatchProps
 
 @ErrorHandling
 class CellComponent extends Component<Props, State> {
+  componentDidMount() {
+    const {cell, setCellMount} = this.props
+
+    setCellMount(cell.id, new Date().getTime())
+  }
+
   public render() {
     const {cell, view} = this.props
 
@@ -118,4 +131,11 @@ const mstp = (state: AppState, ownProps: OwnProps) => {
   return {view}
 }
 
-export default connect<StateProps, {}, OwnProps>(mstp)(CellComponent)
+const mdtp = {
+  setCellMount: setCellMountAction,
+}
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(CellComponent)


### PR DESCRIPTION
Closes #19163 

### The Problem
Just because a dashboard mounts does not necessarily mean a cell visualization renders.  Users can navigate away, refresh the page, close the browser etc.

### The Solution
Do a some work on the frontend and record the delta between cell mounting and a visualization render.  Emit said event on vis render.

![Screen Shot 2020-08-03 at 12 01 33 PM](https://user-images.githubusercontent.com/7582765/89217479-1d762180-d581-11ea-8e48-3d17b6946a39.png)
  
