### PR TITLE
fix(cell-queries-error): created mutex hashmap to resolve queries independently of one another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking
 
 1. [19066](https://github.com/influxdata/influxdb/pull/19066): Drop deprecated /packages route tree
-1. [19116](https://github.com/influxdata/influxdb/pull/19116): Support more types for template envRef default value and require explicit default values 
+1. [19116](https://github.com/influxdata/influxdb/pull/19116): Support more types for template envRef default value and require explicit default values
 1. [19104](https://github.com/influxdata/influxdb/pull/19104): Remove orgs/labels nested routes from the API.
 
 ### Features
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 1. [19043](https://github.com/influxdata/influxdb/pull/19043): Enforce all influx CLI flag args are valid
+1. [19188](https://github.com/influxdata/influxdb/pull/19188): Dashboard cells correctly map results when multiple queries exist
 
 ## v2.0.0-beta.15 [2020-07-23]
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -204,11 +204,6 @@ export const executeQueries = (abortController?: AbortController) => async (
       .map(v => asAssignment(v))
       .filter(v => !!v)
 
-    // keeping getState() here ensures that the state we are working with
-    // is the most current one. By having this set to state, we were creating a race
-    // condition that was causing the following bug:
-    // https://github.com/influxdata/idpe/issues/6240
-
     const startTime = window.performance.now()
     const startDate = Date.now()
 


### PR DESCRIPTION
Closes #19058 

### Problem

Mutex instance was running one query and passing the results of that query to all queries being resolved in the cell context

### Solution

Create a hashmap of query's with a mutex as the corresponding value for each cell, and set the results to the hashmap per cell.


![two-queries](https://user-images.githubusercontent.com/19984220/89227621-e01a8f80-d592-11ea-8a8b-31773573b645.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)