### PR TITLE
feat: added backend for mosaic graph type

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -3,7 +3,6 @@ package influxdb
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"sort"
 	"time"
@@ -375,6 +374,7 @@ const (
 	ViewPropertyTypeSingleStatPlusLine = "line-plus-single-stat"
 	ViewPropertyTypeTable              = "table"
 	ViewPropertyTypeXY                 = "xy"
+	ViewPropertyTypeMosaic             = "mosaic"
 )
 
 // ViewProperties is used to mark other structures as conforming to a View.
@@ -484,6 +484,12 @@ func UnmarshalViewPropertiesJSON(b []byte) (ViewProperties, error) {
 				return nil, err
 			}
 			vis = sv
+		case ViewPropertyTypeMosaic:
+			var mv MosaicViewProperties
+			if err := json.Unmarshal(v.B, &mv); err != nil {
+				return nil, err
+			}
+			vis = mv
 		}
 	case "empty":
 		var ev EmptyViewProperties
@@ -573,6 +579,15 @@ func MarshalViewPropertiesJSON(v ViewProperties) ([]byte, error) {
 			Shape: "chronograf-v2",
 
 			ScatterViewProperties: vis,
+		}
+	case MosaicViewProperties:
+		s = struct {
+			Shape string `json:"shape"`
+			MosaicViewProperties
+		}{
+			Shape: "chronograf-v2",
+
+			MosaicViewProperties: vis,
 		}
 	case MarkdownViewProperties:
 		s = struct {
@@ -790,6 +805,26 @@ type ScatterViewProperties struct {
 	TimeFormat        string           `json:"timeFormat"`
 }
 
+// MosaicViewProperties represents options for mosaic view in Chronograf
+type MosaicViewProperties struct {
+	Type              string           `json:"type"`
+	Queries           []DashboardQuery `json:"queries"`
+	ViewColors        []string         `json:"colors"`
+	FillColumns       []string         `json:"fillColumns"`
+	XColumn           string           `json:"xColumn"`
+	YColumn           []string         `json:"yColumn"`
+	XDomain           []float64        `json:"xDomain,omitempty"`
+	YDomain           []float64        `json:"yDomain,omitempty"`
+	XAxisLabel        string           `json:"xAxisLabel"`
+	YAxisLabel        string           `json:"yAxisLabel"`
+	XPrefix           string           `json:"xPrefix"`
+	XSuffix           string           `json:"xSuffix"`
+	YPrefix           string           `json:"yPrefix"`
+	YSuffix           string           `json:"ySuffix"`
+	Note              string           `json:"note"`
+	ShowNoteWhenEmpty bool             `json:"showNoteWhenEmpty"`
+	TimeFormat        string           `json:"timeFormat"`
+}
 // GaugeViewProperties represents options for gauge view in Chronograf
 type GaugeViewProperties struct {
 	Type              string           `json:"type"`
@@ -848,6 +883,7 @@ func (SingleStatViewProperties) viewProperties()     {}
 func (HistogramViewProperties) viewProperties()      {}
 func (HeatmapViewProperties) viewProperties()        {}
 func (ScatterViewProperties) viewProperties()        {}
+func (MosaicViewProperties) viewProperties()         {}
 func (GaugeViewProperties) viewProperties()          {}
 func (TableViewProperties) viewProperties()          {}
 func (MarkdownViewProperties) viewProperties()       {}
@@ -860,6 +896,7 @@ func (v SingleStatViewProperties) GetType() string     { return v.Type }
 func (v HistogramViewProperties) GetType() string      { return v.Type }
 func (v HeatmapViewProperties) GetType() string        { return v.Type }
 func (v ScatterViewProperties) GetType() string        { return v.Type }
+func (v MosaicViewProperties) GetType() string         { return v.Type }
 func (v GaugeViewProperties) GetType() string          { return v.Type }
 func (v TableViewProperties) GetType() string          { return v.Type }
 func (v MarkdownViewProperties) GetType() string       { return v.Type }

--- a/dashboard.go
+++ b/dashboard.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"sort"
 	"time"

--- a/dashboard.go
+++ b/dashboard.go
@@ -813,7 +813,7 @@ type MosaicViewProperties struct {
 	ViewColors        []string         `json:"colors"`
 	FillColumns       []string         `json:"fillColumns"`
 	XColumn           string           `json:"xColumn"`
-	YColumn           []string         `json:"yColumn"`
+	YSeriesColumns    []string         `json:"ySeriesColumns"`
 	XDomain           []float64        `json:"xDomain,omitempty"`
 	YDomain           []float64        `json:"yDomain,omitempty"`
 	XAxisLabel        string           `json:"xAxisLabel"`

--- a/dashboard.go
+++ b/dashboard.go
@@ -826,6 +826,7 @@ type MosaicViewProperties struct {
 	ShowNoteWhenEmpty bool             `json:"showNoteWhenEmpty"`
 	TimeFormat        string           `json:"timeFormat"`
 }
+
 // GaugeViewProperties represents options for gauge view in Chronograf
 type GaugeViewProperties struct {
 	Type              string           `json:"type"`

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9009,6 +9009,81 @@ components:
           type: string
         decimalPlaces:
           $ref: "#/components/schemas/DecimalPlaces"
+    MosaicViewProperties:
+      type: object
+      required:
+        - type
+        - queries
+        - colors
+        - shape
+        - note
+        - showNoteWhenEmpty
+        - xColumn
+        - yColumn
+        - fillColumns
+        - xDomain
+        - yDomain
+        - xAxisLabel
+        - yAxisLabel
+        - xPrefix
+        - yPrefix
+        - xSuffix
+        - ySuffix
+      properties:
+        timeFormat:
+          type: string
+        type:
+          type: string
+          enum: [mosaic]
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardQuery"
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+            type: string
+        shape:
+          type: string
+          enum: ["chronograf-v2"]
+        note:
+          type: string
+        showNoteWhenEmpty:
+          description: If true, will display note when empty
+          type: boolean
+        xColumn:
+          type: string
+        yColumn:
+          type: array
+          items:
+            type: string
+        fillColumns:
+          type: array
+          items:
+            type: string
+        xDomain:
+          type: array
+          items:
+            type: number
+          maxItems: 2
+        yDomain:
+          type: array
+          items:
+            type: number
+          maxItems: 2
+        xAxisLabel:
+          type: string
+        yAxisLabel:
+          type: string
+        xPrefix:
+          type: string
+        xSuffix:
+          type: string
+        yPrefix:
+          type: string
+        ySuffix:
+          type: string
     ScatterViewProperties:
       type: object
       required:
@@ -9591,6 +9666,7 @@ components:
         - $ref: "#/components/schemas/CheckViewProperties"
         - $ref: "#/components/schemas/ScatterViewProperties"
         - $ref: "#/components/schemas/HeatmapViewProperties"
+        - $ref: "#/components/schemas/MosaicViewProperties"
     View:
       required:
         - name

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9019,7 +9019,7 @@ components:
         - note
         - showNoteWhenEmpty
         - xColumn
-        - yColumn
+        - ySeriesColumns
         - fillColumns
         - xDomain
         - yDomain
@@ -9054,7 +9054,7 @@ components:
           type: boolean
         xColumn:
           type: string
-        yColumn:
+        ySeriesColumns:
           type: array
           items:
             type: string

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -641,6 +641,18 @@ func convertCellView(cell influxdb.Cell) chart {
 		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
 		ch.TickPrefix = p.TickPrefix
 		ch.TickSuffix = p.TickSuffix
+	case influxdb.MosaicViewProperties:
+		ch.Kind = chartKindMosaic
+		ch.Queries = convertQueries(p.Queries)
+		ch.Colors = stringsToColors(p.ViewColors)
+		ch.XCol = p.XColumn
+		ch.YSeriesColumns = p.YSeriesColumns
+		ch.Axes = []axis{
+			{Label: p.XAxisLabel, Prefix: p.XPrefix, Suffix: p.XSuffix, Name: "x", Domain: p.XDomain},
+			{Label: p.YAxisLabel, Prefix: p.YPrefix, Suffix: p.YSuffix, Name: "y", Domain: p.YDomain},
+		}
+		ch.Note = p.Note
+		ch.NoteOnEmpty = p.ShowNoteWhenEmpty
 	case influxdb.ScatterViewProperties:
 		ch.Kind = chartKindScatter
 		ch.Queries = convertQueries(p.Queries)
@@ -704,6 +716,9 @@ func convertChartToResource(ch chart) Resource {
 	}
 	if len(ch.Axes) > 0 {
 		r[fieldChartAxes] = ch.Axes
+	}
+	if len(ch.YSeriesColumns) > 0 {
+		r[fieldChartYSeriesColumns] = ch.YSeriesColumns
 	}
 	if ch.EnforceDecimals {
 		r[fieldChartDecimalPlaces] = ch.DecimalPlaces

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1415,6 +1415,7 @@ func parseChart(r Resource) (chart, []validationErr) {
 		XPos:           r.intShort(fieldChartXPos),
 		YPos:           r.intShort(fieldChartYPos),
 		FillColumns:    r.slcStr(fieldChartFillColumns),
+		YSeriesColumns: r.slcStr(fieldChartYSeriesColumns),
 	}
 
 	if presLeg, ok := r[fieldChartLegend].(legend); ok {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -422,6 +422,7 @@ const (
 	chartKindHeatMap            chartKind = "heatmap"
 	chartKindHistogram          chartKind = "histogram"
 	chartKindMarkdown           chartKind = "markdown"
+	chartKindMosaic             chartKind = "mosaic"
 	chartKindScatter            chartKind = "scatter"
 	chartKindSingleStat         chartKind = "single_stat"
 	chartKindSingleStatPlusLine chartKind = "single_stat_plus_line"
@@ -432,8 +433,9 @@ const (
 func (c chartKind) ok() bool {
 	switch c {
 	case chartKindGauge, chartKindHeatMap, chartKindHistogram,
-		chartKindMarkdown, chartKindScatter, chartKindSingleStat,
-		chartKindSingleStatPlusLine, chartKindTable, chartKindXY:
+		chartKindMarkdown, chartKindMosaic, chartKindScatter,
+		chartKindSingleStat, chartKindSingleStatPlusLine, chartKindTable,
+		chartKindXY:
 		return true
 	default:
 		return false
@@ -526,6 +528,7 @@ const (
 	fieldChartTickPrefix     = "tickPrefix"
 	fieldChartTickSuffix     = "tickSuffix"
 	fieldChartTimeFormat     = "timeFormat"
+	fieldChartYSeriesColumns = "ySeriesColumns"
 	fieldChartWidth          = "width"
 	fieldChartXCol           = "xCol"
 	fieldChartXPos           = "xPos"
@@ -551,6 +554,7 @@ type chart struct {
 	Queries         queries
 	Axes            axes
 	Geom            string
+	YSeriesColumns  []string
 	XCol, YCol      string
 	XPos, YPos      int
 	Height, Width   int
@@ -619,6 +623,25 @@ func (c chart) properties() influxdb.ViewProperties {
 		return influxdb.MarkdownViewProperties{
 			Type: influxdb.ViewPropertyTypeMarkdown,
 			Note: c.Note,
+		}
+	case chartKindMosaic:
+		return influxdb.MosaicViewProperties{
+			Type:              influxdb.ViewPropertyTypeMosaic,
+			Queries:           c.Queries.influxDashQueries(),
+			ViewColors:        c.Colors.strings(),
+			XColumn:           c.XCol,
+			YSeriesColumns:    c.YSeriesColumns,
+			XDomain:           c.Axes.get("x").Domain,
+			YDomain:           c.Axes.get("y").Domain,
+			XPrefix:           c.Axes.get("x").Prefix,
+			YPrefix:           c.Axes.get("y").Prefix,
+			XSuffix:           c.Axes.get("x").Suffix,
+			YSuffix:           c.Axes.get("y").Suffix,
+			XAxisLabel:        c.Axes.get("x").Label,
+			YAxisLabel:        c.Axes.get("y").Label,
+			Note:              c.Note,
+			ShowNoteWhenEmpty: c.NoteOnEmpty,
+			TimeFormat:        c.TimeFormat,
 		}
 	case chartKindScatter:
 		return influxdb.ScatterViewProperties{

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -2111,6 +2111,31 @@ func TestService(t *testing.T) {
 							},
 						},
 						{
+							name: "mosaic",
+							expectedView: influxdb.View{
+								ViewContents: influxdb.ViewContents{
+									Name: "view name",
+								},
+								Properties: influxdb.MosaicViewProperties{
+									Type:              influxdb.ViewPropertyTypeMosaic,
+									Note:              "a note",
+									Queries:           []influxdb.DashboardQuery{newQuery()},
+									ShowNoteWhenEmpty: true,
+									ViewColors:        []string{"#8F8AF4", "#8F8AF4", "#8F8AF4"},
+									XColumn:           "x",
+									YSeriesColumns:    []string{"y"},
+									XDomain:           []float64{0, 10},
+									YDomain:           []float64{0, 100},
+									XAxisLabel:        "x_label",
+									XPrefix:           "x_prefix",
+									XSuffix:           "x_suffix",
+									YAxisLabel:        "y_label",
+									YPrefix:           "y_prefix",
+									YSuffix:           "y_suffix",
+								},
+							},
+						},
+						{
 							name: "without new name single stat",
 							expectedView: influxdb.View{
 								ViewContents: influxdb.ViewContents{

--- a/pkger/testdata/dashboard_mosaic.yml
+++ b/pkger/testdata/dashboard_mosaic.yml
@@ -1,0 +1,42 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Dashboard
+metadata:
+  name:  dash-0
+spec:
+  description: a dashboard w/ single mosaic chart
+  charts:
+    - kind:   Mosaic
+      name:   mosaic chart
+      note: mosaic note
+      noteOnEmpty: true
+      prefix: sumtin
+      suffix: days
+      xPos:  1
+      yPos:  2
+      xCol: _time
+      yCol: _value
+      width:  6
+      height: 3
+      ySeriesColumns: ["_value", "foo"]
+      queries:
+        - query: >
+            from(bucket: v.bucket)  |> range(start: v.timeRangeStart)  |> filter(fn: (r) => r._measurement == "mem")  |> filter(fn: (r) => r._field == "used_percent")  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)  |> yield(name: "mean")
+      colors:
+        - hex: "#8F8AF4"
+        - hex: "#F4CF31"
+        - hex: "#FFFFFF"
+      axes:
+        - name : "x"
+          label: x_label
+          prefix: x_prefix
+          suffix: x_suffix
+          domain:
+            - 0
+            - 10
+        - name: "y"
+          label: y_label
+          prefix: y_prefix
+          suffix: y_suffix
+          domain:
+            - 0
+            - 100


### PR DESCRIPTION
Closes: #19121 
Closes: #19211

Added mosaic type in the backend files, so that the mosaic graph can be saved. 

Co-authored-by: Rose Parker <reparker837@gmail.com>

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
