### PR TITLE
fix(flashing-cells): prevent flashing cells by setting all the cell data when the dashboard is loaded

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -358,17 +358,25 @@ export const getDashboard = (
 
     const cellViews: CellsWithViewProperties = resp.data.cells || []
     const viewsData = viewsFromCells(cellViews, dashboardID)
+    setTimeout(() => {
+      const normCells = normalize<Dashboard, DashboardEntities, string[]>(
+        cellViews,
+        arrayOfCells
+      )
 
-    const normViews = normalize<View, ViewEntities, string[]>(
-      viewsData,
-      arrayOfViews
-    )
+      dispatch(setCells(dashboardID, RemoteDataState.Done, normCells))
+      const normViews = normalize<View, ViewEntities, string[]>(
+        viewsData,
+        arrayOfViews
+      )
 
-    dispatch(setViews(RemoteDataState.Done, normViews))
-
-    // Now that all the necessary state has been loaded, set the dashboard
-    dispatch(creators.setDashboard(dashboardID, RemoteDataState.Done, normDash))
-    dispatch(updateTimeRangeFromQueryParams(dashboardID))
+      dispatch(setViews(RemoteDataState.Done, normViews))
+      // Now that all the necessary state has been loaded, set the dashboard
+      dispatch(
+        creators.setDashboard(dashboardID, RemoteDataState.Done, normDash)
+      )
+      dispatch(updateTimeRangeFromQueryParams(dashboardID))
+    }, 0)
   } catch (error) {
     if (error.name === 'AbortError') {
       return


### PR DESCRIPTION
Related #18958

### Problem
Clicking on a dashboard immediately after it was set created a weird race where the cells and views were still loading from the initial getDashboards call and were setting over the cells and views that were being gotten from the getDashboard function.

### Solution
Set the cells when loading the dashboard and also wrap the process in a setTimeout so that it gets added to the callstack and should (hopefully) resolve once the initial getDashboards timeouts resolve

### Notes
Added an e2e test to ensure dashboard cloning doesn't break (#19207).

![crud-cells](https://user-images.githubusercontent.com/19984220/89350020-1542e280-d664-11ea-873b-e46b5da5a10b.gif)


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)