### PR TITLE
refactor: remove options from storage bucket finder

### DIFF
--- a/mock/bucket_finder.go
+++ b/mock/bucket_finder.go
@@ -1,0 +1,40 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb/v2"
+)
+
+// BucketFinder is a mock implementation of storage.BucketFinder
+type BucketFinder struct {
+	// Methods for a retention.BucketFinder
+	OpenFn           func() error
+	CloseFn          func() error
+	FindBucketsFn    func(context.Context, influxdb.BucketFilter) ([]*influxdb.Bucket, int, error)
+	FindBucketsCalls SafeCount
+}
+
+// NewBucketFinder returns a mock BucketFinder where its methods will return
+// zero values.
+func NewBucketFinder() *BucketFinder {
+	return &BucketFinder{
+		OpenFn:  func() error { return nil },
+		CloseFn: func() error { return nil },
+		FindBucketsFn: func(context.Context, influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
+			return nil, 0, nil
+		},
+	}
+}
+
+// Open opens the BucketFinder.
+func (s *BucketFinder) Open() error { return s.OpenFn() }
+
+// Close closes the BucketFinder.
+func (s *BucketFinder) Close() error { return s.CloseFn() }
+
+// FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
+func (s *BucketFinder) FindBuckets(ctx context.Context, filter influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
+	defer s.FindBucketsCalls.IncrFn()()
+	return s.FindBucketsFn(ctx, filter)
+}

--- a/storage/bucket_finder.go
+++ b/storage/bucket_finder.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb/v2"
+)
+
+var _ BucketFinder = (*AllBucketsFinder)(nil)
+
+// AllBucketsFinder is responsible for iterating over the paginated reponses from FindBuckets to return every bucket
+type AllBucketsFinder struct {
+	bucketSvc influxdb.BucketService
+}
+
+func NewAllBucketsFinder(bucketSvc influxdb.BucketService) *AllBucketsFinder {
+	return &AllBucketsFinder{
+		bucketSvc: bucketSvc,
+	}
+}
+
+func (p *AllBucketsFinder) FindBuckets(ctx context.Context, filter influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
+	buckets := []*influxdb.Bucket{}
+	o := influxdb.FindOptions{Limit: influxdb.MaxPageSize}
+
+	res, n, err := p.bucketSvc.FindBuckets(ctx, filter, o)
+	if err != nil {
+		return buckets, 0, err
+	}
+	buckets = append(buckets, res...)
+
+	// used to filter out duplicate system buckets
+	foundTask := false
+	foundMonitoring := false
+
+	if n == o.Limit {
+		for {
+			o.Offset = o.Offset + o.Limit
+			res, n, err := p.bucketSvc.FindBuckets(ctx, filter, o)
+			if err != nil {
+				return []*influxdb.Bucket{}, 0, err
+			}
+			for i := 0; i < len(res); i++ {
+				if res[i].Name == "_tasks" && !foundTask {
+					buckets = append(buckets, res[i])
+					foundTask = true
+				} else if res[i].Name == "_monitoring" && !foundMonitoring {
+					buckets = append(buckets, res[i])
+					foundMonitoring = true
+				} else {
+					buckets = append(buckets, res[i])
+				}
+			}
+
+			if n < o.Limit {
+				break
+			}
+		}
+	}
+
+	return buckets, len(buckets), nil
+}

--- a/storage/bucket_finder_test.go
+++ b/storage/bucket_finder_test.go
@@ -1,0 +1,44 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/inmem"
+	"github.com/influxdata/influxdb/v2/kv/migration/all"
+	"github.com/influxdata/influxdb/v2/storage"
+	"github.com/influxdata/influxdb/v2/tenant"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFindBuckets(t *testing.T) {
+	s := inmem.NewKVStore()
+	ctx := context.Background()
+	if err := all.Up(ctx, zaptest.NewLogger(t), s); err != nil {
+		t.Fatal(err)
+	}
+
+	st := tenant.NewStore(s)
+	tenant := tenant.NewService(st)
+	id := influxdb.ID(1)
+	err := tenant.CreateOrganization(ctx, &influxdb.Organization{Name: "default", ID: id})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := 25
+	for i := 0; i < expected; i++ {
+		tenant.CreateBucket(ctx, &influxdb.Bucket{Name: fmt.Sprintf("bucket%d", i), OrgID: id})
+	}
+
+	finder := storage.NewAllBucketsFinder(tenant)
+	_, n, err := finder.FindBuckets(ctx, influxdb.BucketFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != expected+2 { // add two for the system buckets
+		t.Fatalf("expected %d buckets, got: %d", expected, n)
+	}
+}

--- a/storage/points_writer_test.go
+++ b/storage/points_writer_test.go
@@ -73,8 +73,8 @@ func TestLoggingPointsWriter(t *testing.T) {
 			}
 		}
 
-		var bs mock.BucketService
-		bs.FindBucketsFn = func(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+		var bf mock.BucketFinder
+		bf.FindBucketsFn = func(ctx context.Context, filter influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
 			if got, want := *filter.OrganizationID, influxdb.ID(1); got != want {
 				t.Fatalf("orgID=%d, want %d", got, want)
 			} else if got, want := *filter.Name, "logbkt"; got != want {
@@ -85,7 +85,7 @@ func TestLoggingPointsWriter(t *testing.T) {
 
 		lpw := &storage.LoggingPointsWriter{
 			Underlying:    &pw,
-			BucketFinder:  &bs,
+			BucketFinder:  &bf,
 			LogBucketName: "logbkt",
 		}
 
@@ -106,8 +106,8 @@ func TestLoggingPointsWriter(t *testing.T) {
 
 	// Ensure an error is returned if logging bucket cannot be found.
 	t.Run("BucketError", func(t *testing.T) {
-		var bs mock.BucketService
-		bs.FindBucketsFn = func(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+		var bf mock.BucketFinder
+		bf.FindBucketsFn = func(ctx context.Context, filter influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
 			return nil, 0, errors.New("bucket error")
 		}
 
@@ -117,7 +117,7 @@ func TestLoggingPointsWriter(t *testing.T) {
 					return errors.New("point error")
 				},
 			},
-			BucketFinder:  &bs,
+			BucketFinder:  &bf,
 			LogBucketName: "logbkt",
 		}
 

--- a/storage/retention.go
+++ b/storage/retention.go
@@ -30,8 +30,9 @@ type Snapshotter interface {
 }
 
 // A BucketFinder is responsible for providing access to buckets via a filter.
+// It does not provide support for find options, and instead returns all buckets without a limit.
 type BucketFinder interface {
-	FindBuckets(context.Context, influxdb.BucketFilter, ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error)
+	FindBuckets(context.Context, influxdb.BucketFilter) ([]*influxdb.Bucket, int, error)
 }
 
 // ErrServiceClosed is returned when the service is unavailable.

--- a/storage/retention_test.go
+++ b/storage/retention_test.go
@@ -334,19 +334,19 @@ func (s *TestSnapshotter) WriteSnapshot(ctx context.Context, status tsm1.CacheSt
 }
 
 type TestBucketFinder struct {
-	FindBucketsFn func(context.Context, influxdb.BucketFilter, ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error)
+	FindBucketsFn func(context.Context, influxdb.BucketFilter) ([]*influxdb.Bucket, int, error)
 }
 
 func NewTestBucketFinder() *TestBucketFinder {
 	return &TestBucketFinder{
-		FindBucketsFn: func(context.Context, influxdb.BucketFilter, ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+		FindBucketsFn: func(context.Context, influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
 			return nil, 0, nil
 		},
 	}
 }
 
-func (f *TestBucketFinder) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
-	return f.FindBucketsFn(ctx, filter, opts...)
+func (f *TestBucketFinder) FindBuckets(ctx context.Context, filter influxdb.BucketFilter) ([]*influxdb.Bucket, int, error) {
+	return f.FindBucketsFn(ctx, filter)
 }
 
 func MustTempDir() string {


### PR DESCRIPTION
Closes #19204

This PR updates the storage `BucketFinder` type to remove find options, as these are not actually used and the BucketFinder should return all Buckets without pagination. 

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass