### PR TITLE
feat(paging): add support for after id parameter in find options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [19246](https://github.com/influxdata/influxdb/pull/19246): Redesign load data page to increase discovery and ease of use
 1. [19334](https://github.com/influxdata/influxdb/pull/19334): Add --active-config flag to influx to set config for single command
+1. [19219](https://github.com/influxdata/influxdb/pull/19219): List buckets via the API now supports after (ID) parameter as an alternative to offset.
 
 ### Bug Fixes
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3504,6 +3504,7 @@ paths:
         - $ref: "#/components/parameters/TraceSpan"
         - $ref: "#/components/parameters/Offset"
         - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/After"
         - in: query
           name: org
           description: The organization name.
@@ -6520,6 +6521,15 @@ components:
       required: false
       schema:
         type: string
+    After:
+      in: query
+      name: after
+      required: false
+      schema:
+        type: string
+      description: >
+        The last resource ID from which to seek from (but not including).
+        This is to be used instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.

--- a/tenant/storage_bucket.go
+++ b/tenant/storage_bucket.go
@@ -190,7 +190,17 @@ func (s *Store) ListBuckets(ctx context.Context, tx kv.Tx, filter BucketFilter, 
 	if o.Descending {
 		opts = append(opts, kv.WithCursorDirection(kv.CursorDescending))
 	}
-	cursor, err := b.ForwardCursor(nil, opts...)
+
+	var seek []byte
+	if o.After != nil {
+		after := (*o.After) + 1
+		seek, err = after.Encode()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cursor, err := b.ForwardCursor(seek, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -618,6 +618,55 @@ func FindBuckets(
 			},
 		},
 		{
+			name: "find all buckets by after and limit",
+			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "theorg",
+					},
+				},
+				Buckets: []*influxdb.Bucket{
+					{
+						// ID(1)
+						OrgID: idOne,
+						Name:  "abc",
+					},
+					{
+						// ID(2)
+						OrgID: idOne,
+						Name:  "def",
+					},
+					{
+						// ID(3)
+						OrgID: idOne,
+						Name:  "xyz",
+					},
+				},
+			},
+			args: args{
+				findOptions: influxdb.FindOptions{
+					After: idPtr(idOne),
+					Limit: 2,
+				},
+			},
+			wants: wants{
+				buckets: []*influxdb.Bucket{
+					{
+						ID:    idTwo,
+						OrgID: idOne,
+						Name:  "def",
+					},
+					{
+						ID:    idThree,
+						OrgID: idOne,
+						Name:  "xyz",
+					},
+				},
+			},
+		},
+		{
 			name: "find all buckets by descending",
 			fields: BucketFields{
 				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),


### PR DESCRIPTION
Closes #19218

This PR adds support for the `after` parameter in the `FindOptions` struct.

`after` is more sympathetic to the structure and interfaces of our K/V store implementations; as opposed to `offset`.
The K/V stores we use support `seek` operations to particular keys, but not numerical index offsets like we expose through our APIs.

To use this feature for pagination, you simply supply `after` with the last ID observed in a list of results.

This PR includes an implementation for `after` in both the `tenant` and `kv` bucket services.

Outstanding:

- ~Figure how widely used the paging links are leveraged and what needs to change to add support for auto-paging links using `after`.~
Im going to forgo forcing the use of after via the paging links for now as offset / limit suffice.

---

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
