### PR TITLE
fix: add quotation marks to bucket name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [19043](https://github.com/influxdata/influxdb/pull/19043): Enforce all influx CLI flag args are valid
 1. [19188](https://github.com/influxdata/influxdb/pull/19188): Dashboard cells correctly map results when multiple queries exist
 1. [19146](https://github.com/influxdata/influxdb/pull/19146): Dashboard cells and overlay use UTC as query time when toggling to UTC timezone
+1. [19222](https://github.com/influxdata/influxdb/pull/19222): Bucket names may not include quotation marks
 
 ## v2.0.0-beta.15 [2020-07-23]
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -361,10 +361,7 @@ func (b *postBucketRequest) OK() error {
 
 	// names starting with an underscore are reserved for system buckets
 	if err := validBucketName(b.toInfluxDB()); err != nil {
-		return &influxdb.Error{
-			Code: influxdb.EUnprocessableEntity,
-			Msg:  err.Error(),
-		}
+		return err
 	}
 
 	return nil

--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -454,7 +454,7 @@ func TestService_handlePostBucket(t *testing.T) {
 				},
 			},
 			wants: wants{
-				statusCode: http.StatusUnprocessableEntity,
+				statusCode: http.StatusBadRequest,
 			},
 		},
 		{

--- a/tenant/http_server_bucket.go
+++ b/tenant/http_server_bucket.go
@@ -313,10 +313,7 @@ func (b *postBucketRequest) OK() error {
 
 	// names starting with an underscore are reserved for system buckets
 	if err := validBucketName(b.toInfluxDB()); err != nil {
-		return &influxdb.Error{
-			Code: influxdb.EUnprocessableEntity,
-			Msg:  err.Error(),
-		}
+		return err
 	}
 
 	return nil
@@ -496,6 +493,14 @@ func validBucketName(bucket *influxdb.Bucket) error {
 			Code: influxdb.EInvalid,
 			Op:   "http/bucket",
 			Msg:  fmt.Sprintf("bucket name %s is invalid. Buckets may not start with underscore", bucket.Name),
+		}
+	}
+	// quotation marks will cause queries to fail
+	if strings.Contains(bucket.Name, "\"") {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Op:   "http/bucket",
+			Msg:  fmt.Sprintf("bucket name %s is invalid. Bucket names may not include quotation marks", bucket.Name),
 		}
 	}
 	return nil

--- a/tenant/http_server_bucket_test.go
+++ b/tenant/http_server_bucket_test.go
@@ -60,5 +60,5 @@ func initBucketHttpService(f itesting.BucketFields, t *testing.T) (influxdb.Buck
 }
 
 func TestBucketService(t *testing.T) {
-	itesting.BucketService(initBucketHttpService, t, itesting.WithoutHooks())
+	itesting.BucketService(initBucketHttpService, t, itesting.WithoutHooks(), itesting.WithHTTPValidation())
 }


### PR DESCRIPTION
Closes #19179

This PR adds a check for quotation marks in the Bucket name when creating a Bucket. I checked other special symbols and only quotation marks seem to cause a problem for queries.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
