### PR TITLE
feat(onboard): allow optional password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [19075](https://github.com/influxdata/influxdb/pull/19075): Add resource links to a stack's resources from public HTTP API list/read calls
 1. [19103](https://github.com/influxdata/influxdb/pull/19103): Enhance resource creation experience when limits are reached
 1. [19223](https://github.com/influxdata/influxdb/pull/19223): Add dashboards command to influx CLI
+1. [19225](https://github.com/influxdata/influxdb/pull/19225): Allow user onboarding to optionally set passwords
 
 ### Bug Fixes
 

--- a/http/onboarding_test.go
+++ b/http/onboarding_test.go
@@ -29,7 +29,7 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	svc.OrgBucketIDs = f.IDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	if f.TimeGenerator == nil {
-		svc.TimeGenerator = platform.RealTimeGenerator{}
+		f.TimeGenerator = platform.RealTimeGenerator{}
 	}
 	svc.TimeGenerator = f.TimeGenerator
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10706,7 +10706,6 @@ components:
           type: integer
       required:
         - username
-        - password
         - org
         - bucket
     OnboardingResponse:

--- a/kv/onboarding.go
+++ b/kv/onboarding.go
@@ -129,8 +129,10 @@ func (s *Service) OnboardInitialUser(ctx context.Context, req *influxdb.Onboardi
 			return err
 		}
 
-		if err := s.setPassword(ctx, tx, u.ID, req.Password); err != nil {
-			return err
+		if req.Password != "" {
+			if err := s.setPassword(ctx, tx, u.ID, req.Password); err != nil {
+				return err
+			}
 		}
 
 		if err := s.createOrganization(ctx, tx, o); err != nil {

--- a/onboarding.go
+++ b/onboarding.go
@@ -34,13 +34,6 @@ type OnboardingRequest struct {
 }
 
 func (r *OnboardingRequest) Valid() error {
-	if r.Password == "" {
-		return &Error{
-			Code: EEmptyValue,
-			Msg:  "password is empty",
-		}
-	}
-
 	if r.User == "" {
 		return &Error{
 			Code: EEmptyValue,

--- a/tenant/service_onboarding.go
+++ b/tenant/service_onboarding.go
@@ -57,7 +57,7 @@ func (s *OnboardService) OnboardUser(ctx context.Context, req *influxdb.Onboardi
 
 // onboardUser allows us to onboard new users.
 func (s *OnboardService) onboardUser(ctx context.Context, req *influxdb.OnboardingRequest, permFn func(orgID influxdb.ID) []influxdb.Permission) (*influxdb.OnboardingResults, error) {
-	if req == nil || req.User == "" || req.Password == "" || req.Org == "" || req.Bucket == "" {
+	if req == nil || req.User == "" || req.Org == "" || req.Bucket == "" {
 		return nil, ErrOnboardInvalid
 	}
 

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -67,26 +67,6 @@ func OnboardInitialUser(
 			},
 		},
 		{
-			name: "missing password",
-			fields: OnboardingFields{
-				IDGenerator: &loopIDGenerator{
-					s: []string{oneID, twoID, threeID, fourID},
-				},
-				TokenGenerator: mock.NewTokenGenerator(oneToken, nil),
-				IsOnboarding:   true,
-			},
-			args: args{
-				request: &platform.OnboardingRequest{
-					User:   "admin",
-					Org:    "org1",
-					Bucket: "bucket1",
-				},
-			},
-			wants: wants{
-				errCode: platform.EEmptyValue,
-			},
-		},
-		{
 			name: "missing username",
 			fields: OnboardingFields{
 				IDGenerator: &loopIDGenerator{
@@ -141,6 +121,63 @@ func OnboardInitialUser(
 			},
 			wants: wants{
 				errCode: platform.EEmptyValue,
+			},
+		},
+		{
+			name: "missing password should still work",
+			fields: OnboardingFields{
+				IDGenerator: &loopIDGenerator{
+					s: []string{oneID, twoID, threeID, fourID},
+				},
+				TokenGenerator: mock.NewTokenGenerator(oneToken, nil),
+				IsOnboarding:   true,
+			},
+			args: args{
+				request: &platform.OnboardingRequest{
+					User:   "admin",
+					Org:    "org1",
+					Bucket: "bucket1",
+				},
+			},
+			wants: wants{
+				results: &platform.OnboardingResults{
+					User: &platform.User{
+						ID:     MustIDBase16(oneID),
+						Name:   "admin",
+						Status: platform.Active,
+					},
+					Org: &platform.Organization{
+						ID:   MustIDBase16(twoID),
+						Name: "org1",
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					Bucket: &platform.Bucket{
+						ID:              MustIDBase16(threeID),
+						Name:            "bucket1",
+						OrgID:           MustIDBase16(twoID),
+						RetentionPeriod: 0,
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+					Auth: &platform.Authorization{
+						ID:          MustIDBase16(fourID),
+						Token:       oneToken,
+						Status:      platform.Active,
+						UserID:      MustIDBase16(oneID),
+						Description: "admin's Token",
+						OrgID:       MustIDBase16(twoID),
+						Permissions: platform.OperPermissions(),
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
We can now allow passwords as an optional argument. This facilitates api only users.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
