### PR TITLE
feat: add tab index to alerts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 1. [19146](https://github.com/influxdata/influxdb/pull/19146): Dashboard cells and overlay use UTC as query time when toggling to UTC timezone
 1. [19222](https://github.com/influxdata/influxdb/pull/19222): Bucket names may not include quotation marks
 
+### UI Improvements
+1. [19231](https://github.com/influxdata/influxdb/pull/19231): Alerts page filter inputs now have tab indices for keyboard navigation
+
 ## v2.0.0-beta.15 [2020-07-23]
 
 ### Breaking

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -202,5 +202,19 @@ describe('Checks', () => {
         .trigger('mousemove', {which: 1, pageX: 700, pageY: 100})
         .trigger('mouseup', {force: true})
     })
+
+    it('accepts keyboard tabs as navigation', () => {
+      // have to make the viewport huge to get it not to switch to tablet size
+      cy.viewport(1800, 980)
+
+      cy.get('body').tab()
+      cy.getByTestID('filter--input checks').should('have.focus')
+
+      cy.focused().tab()
+      cy.getByTestID('filter--input endpoints').should('have.focus')
+
+      cy.focused().tab()
+      cy.getByTestID('filter--input rules').should('have.focus')
+    })
   })
 })

--- a/ui/cypress/support/index.js
+++ b/ui/cypress/support/index.js
@@ -17,6 +17,7 @@
 import './commands'
 
 import 'cypress-pipe'
+import 'cypress-plugin-tab'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/ui/package.json
+++ b/ui/package.json
@@ -89,6 +89,7 @@
     "cypress": "4.7.0",
     "cypress-file-upload": "^4.0.7",
     "cypress-pipe": "^1.5.0",
+    "cypress-plugin-tab": "^1.0.5",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "enzyme-to-json": "^3.3.4",
@@ -192,8 +193,8 @@
     "reselect": "^4.0.0",
     "rome": "^2.1.22",
     "seamless-immutable": "^7.1.3",
-    "uuid": "^3.2.1",
     "use-persisted-state": "^0.3.0",
+    "uuid": "^3.2.1",
     "webpack-bundle-analyzer": "^3.6.0"
   }
 }

--- a/ui/src/alerting/components/AlertingIndex.tsx
+++ b/ui/src/alerting/components/AlertingIndex.tsx
@@ -62,6 +62,7 @@ const AlertingIndex: FunctionComponent = () => {
                   name="alerting-active-tab"
                   active={activeColumn === 'checks'}
                   testID="alerting-tab--checks"
+                  tabIndex={1}
                 >
                   Checks
                 </SelectGroup.Option>
@@ -72,6 +73,7 @@ const AlertingIndex: FunctionComponent = () => {
                   name="alerting-active-tab"
                   active={activeColumn === 'endpoints'}
                   testID="alerting-tab--endpoints"
+                  tabIndex={2}
                 >
                   Notification Endpoints
                 </SelectGroup.Option>
@@ -82,19 +84,20 @@ const AlertingIndex: FunctionComponent = () => {
                   name="alerting-active-tab"
                   active={activeColumn === 'rules'}
                   testID="alerting-tab--rules"
+                  tabIndex={3}
                 >
                   Notification Rules
                 </SelectGroup.Option>
               </SelectGroup>
               <div className="alerting-index--columns">
                 <GetResources resources={[ResourceType.Checks]}>
-                  <ChecksColumn />
+                  <ChecksColumn tabIndex={1} />
                 </GetResources>
                 <GetResources resources={[ResourceType.NotificationEndpoints]}>
-                  <EndpointsColumn />
+                  <EndpointsColumn tabIndex={2} />
                 </GetResources>
                 <GetResources resources={[ResourceType.NotificationRules]}>
-                  <RulesColumn />
+                  <RulesColumn tabIndex={3} />
                 </GetResources>
               </div>
             </GetAssetLimits>

--- a/ui/src/alerting/components/AlertsColumn.tsx
+++ b/ui/src/alerting/components/AlertsColumn.tsx
@@ -38,6 +38,7 @@ interface OwnProps {
   createButton: JSX.Element
   questionMarkTooltipContents: JSX.Element | string
   children: (searchTerm: string) => ReactChild
+  tabIndex: number
 }
 
 interface StateProps {
@@ -51,6 +52,7 @@ const AlertsColumnHeader: FC<OwnProps & StateProps> = ({
   limitStatus,
   createButton,
   questionMarkTooltipContents,
+  tabIndex,
 }) => {
   const [searchTerm, onChangeSearchTerm] = useState('')
 
@@ -96,6 +98,7 @@ const AlertsColumnHeader: FC<OwnProps & StateProps> = ({
           value={searchTerm}
           onChange={e => onChangeSearchTerm(e.target.value)}
           testID={`filter--input ${type}`}
+          tabIndex={tabIndex}
         />
       </div>
       <div className="alerting-index--column-body">

--- a/ui/src/checks/components/ChecksColumn.tsx
+++ b/ui/src/checks/components/ChecksColumn.tsx
@@ -26,8 +26,12 @@ import {
 // Utils
 import {extractChecksLimits} from 'src/cloud/utils/limits'
 
+interface OwnProps {
+  tabIndex: number
+}
+
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const ChecksColumn: FunctionComponent<Props> = ({
   checks,
@@ -38,6 +42,7 @@ const ChecksColumn: FunctionComponent<Props> = ({
   rules,
   endpoints,
   limitStatus,
+  tabIndex,
 }) => {
   const handleCreateThreshold = () => {
     history.push(`/orgs/${orgID}/alerting/checks/new-threshold`)
@@ -82,6 +87,7 @@ const ChecksColumn: FunctionComponent<Props> = ({
       title="Checks"
       createButton={createButton}
       questionMarkTooltipContents={tooltipContents}
+      tabIndex={tabIndex}
     >
       {searchTerm => (
         <CheckCards

--- a/ui/src/notifications/endpoints/components/EndpointsColumn.tsx
+++ b/ui/src/notifications/endpoints/components/EndpointsColumn.tsx
@@ -15,10 +15,13 @@ import {getAll} from 'src/resources/selectors'
 interface StateProps {
   endpoints: NotificationEndpoint[]
 }
-type OwnProps = {}
+interface OwnProps {
+  tabIndex: number
+}
+
 type Props = OwnProps & RouteComponentProps<{orgID: string}> & StateProps
 
-const EndpointsColumn: FC<Props> = ({history, match, endpoints}) => {
+const EndpointsColumn: FC<Props> = ({history, match, endpoints, tabIndex}) => {
   const handleOpenOverlay = () => {
     const newRuleRoute = `/orgs/${match.params.orgID}/alerting/endpoints/new`
     history.push(newRuleRoute)
@@ -58,6 +61,7 @@ const EndpointsColumn: FC<Props> = ({history, match, endpoints}) => {
       title="Notification Endpoints"
       createButton={createButton}
       questionMarkTooltipContents={tooltipContents}
+      tabIndex={tabIndex}
     >
       {searchTerm => (
         <EndpointCards endpoints={endpoints} searchTerm={searchTerm} />

--- a/ui/src/notifications/rules/components/RulesColumn.tsx
+++ b/ui/src/notifications/rules/components/RulesColumn.tsx
@@ -24,18 +24,23 @@ import AlertsColumn from 'src/alerting/components/AlertsColumn'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
+interface OwnProps {
+  tabIndex: number
+}
+
 interface StateProps {
   rules: NotificationRuleDraft[]
   endpoints: NotificationEndpoint[]
 }
 
-type Props = StateProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & StateProps & RouteComponentProps<{orgID: string}>
 
 const NotificationRulesColumn: FunctionComponent<Props> = ({
   rules,
   history,
   match,
   endpoints,
+  tabIndex,
 }) => {
   const handleOpenOverlay = () => {
     const newRuleRoute = `/orgs/${match.params.orgID}/alerting/rules/new`
@@ -88,6 +93,7 @@ const NotificationRulesColumn: FunctionComponent<Props> = ({
       title="Notification Rules"
       createButton={createButton}
       questionMarkTooltipContents={tooltipContents}
+      tabIndex={tabIndex}
     >
       {searchTerm => (
         <NotificationRuleCards rules={rules} searchTerm={searchTerm} />

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1725,6 +1725,14 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+ally.js@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ally.js/-/ally.js-1.4.1.tgz#9fb7e6ba58efac4ee9131cb29aa9ee3b540bcf1e"
+  integrity sha1-n7fmuljvrE7pExyymqnuO1QLzx4=
+  dependencies:
+    css.escape "^1.5.0"
+    platform "1.3.3"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -3473,6 +3481,11 @@ css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css.escape@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 cssesc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
@@ -3603,6 +3616,13 @@ cypress-pipe@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/cypress-pipe/-/cypress-pipe-1.5.0.tgz#bf8603a8eb6969b3ebad49080957192b03be85a0"
   integrity sha512-yetAgWrnMoeNP7ZYW/tmMUxY13rAI2j2JPNRtEPoxjqdA7ZvOKak+3iDByTmle5ouBMj59nluTorn5C8RtxP8g==
+
+cypress-plugin-tab@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"
+  integrity sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==
+  dependencies:
+    ally.js "^1.4.1"
 
 cypress@4.7.0:
   version "4.7.0"
@@ -8683,6 +8703,11 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I got annoyed trying to use my keyboard to filter things on the alerts page, so I rage fixed it. You can use `tab` to navigate into the filter text boxes now.

![tabaf](https://user-images.githubusercontent.com/146112/89474463-8d7bd780-d73a-11ea-9084-58983b8107b2.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
