### PR TITLE
fix(reduce-dashboard-dispatches): reduce rerender cycles in dashboard list

### DIFF
--- a/ui/src/cells/actions/creators.ts
+++ b/ui/src/cells/actions/creators.ts
@@ -3,6 +3,8 @@ import {NormalizedSchema} from 'normalizr'
 import {RemoteDataState, CellEntities} from 'src/types'
 import {setLabelOnResource} from 'src/labels/actions/creators'
 
+import {setViewsAndCells} from 'src/views/actions/creators'
+
 export const SET_CELL = 'SET_CELL'
 export const SET_CELLS = 'SET_CELLS'
 export const REMOVE_CELL = 'REMOVE_CELL'
@@ -11,10 +13,14 @@ export type Action =
   | ReturnType<typeof setCell>
   | ReturnType<typeof removeCell>
   | ReturnType<typeof setCells>
+  | ReturnType<typeof setViewsAndCells>
   | ReturnType<typeof setLabelOnResource>
 
 // R is the type of the value of the "result" key in normalizr's normalization
-type CellSchema<R extends string | string[]> = NormalizedSchema<CellEntities, R>
+export type CellSchema<R extends string | string[]> = NormalizedSchema<
+  CellEntities,
+  R
+>
 
 export const setCell = (
   id: string,

--- a/ui/src/cells/reducers/index.ts
+++ b/ui/src/cells/reducers/index.ts
@@ -13,6 +13,7 @@ import {
   SET_DASHBOARD,
   Action as DashboardAction,
 } from 'src/dashboards/actions/creators'
+import {SET_VIEWS_AND_CELLS} from 'src/views/actions/creators'
 
 // Types
 import {Cell, ResourceState, RemoteDataState} from 'src/types'
@@ -50,6 +51,20 @@ export const cellsReducer = (
         if (get(schema, ['entities', 'cells'])) {
           draftState.byID = schema.entities['cells']
         }
+
+        return
+      }
+
+      case SET_VIEWS_AND_CELLS: {
+        const {status, cellsArray} = action
+
+        cellsArray.forEach(cellSchema => {
+          draftState.status = status
+
+          if (get(cellSchema, ['entities', 'cells'])) {
+            draftState.byID = cellSchema.entities['cells']
+          }
+        })
 
         return
       }

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -32,7 +32,11 @@ import {getVariables, hydrateVariables} from 'src/variables/actions/thunks'
 import {setExportTemplate} from 'src/templates/actions/creators'
 import {checkDashboardLimits} from 'src/cloud/actions/limits'
 import {setCells, Action as CellAction} from 'src/cells/actions/creators'
-import {setViews, Action as ViewAction} from 'src/views/actions/creators'
+import {
+  setViewsAndCells,
+  setViews,
+  Action as ViewAction,
+} from 'src/views/actions/creators'
 import {updateViewAndVariables} from 'src/views/actions/thunks'
 import {setLabelOnResource} from 'src/labels/actions/creators'
 import * as creators from 'src/dashboards/actions/creators'
@@ -238,15 +242,18 @@ export const getDashboards = () => async (
       return
     }
 
-    Object.values(dashboards.entities.dashboards)
-      .map(dashboard => {
-        return {
-          id: dashboard.id,
-          cells: dashboard.cells.map(cell => dashboards.entities.cells[cell]),
-        }
-      })
-      .forEach(entity => {
-        setTimeout(() => {
+    const normalizedCellsArray = []
+    const normalizedViewsArray = []
+
+    setTimeout(() => {
+      Object.values(dashboards.entities.dashboards)
+        .map(dashboard => {
+          return {
+            id: dashboard.id,
+            cells: dashboard.cells.map(cell => dashboards.entities.cells[cell]),
+          }
+        })
+        .forEach(entity => {
           const viewsData = viewsFromCells(entity.cells, entity.id)
 
           const normViews = normalize<View, ViewEntities, string[]>(
@@ -254,18 +261,23 @@ export const getDashboards = () => async (
             arrayOfViews
           )
 
-          dispatch(setViews(RemoteDataState.Done, normViews))
-        }, 0)
+          normalizedViewsArray.push(normViews)
 
-        setTimeout(() => {
           const normCells = normalize<Dashboard, DashboardEntities, string[]>(
             entity.cells,
             arrayOfCells
           )
 
-          dispatch(setCells(entity.id, RemoteDataState.Done, normCells))
-        }, 0)
-      })
+          normalizedCellsArray.push(normCells)
+        })
+      dispatch(
+        setViewsAndCells(
+          RemoteDataState.Done,
+          normalizedCellsArray,
+          normalizedViewsArray
+        )
+      )
+    }, 0)
   } catch (error) {
     dispatch(creators.setDashboards(RemoteDataState.Error))
     console.error(error)

--- a/ui/src/views/actions/creators.ts
+++ b/ui/src/views/actions/creators.ts
@@ -1,6 +1,7 @@
 // Types
 import {RemoteDataState, ViewEntities} from 'src/types'
 import {NormalizedSchema} from 'normalizr'
+import {CellSchema} from 'src/cells/actions/creators'
 
 // Actions
 import {setDashboard} from 'src/dashboards/actions/creators'
@@ -9,11 +10,13 @@ export type Action =
   | ReturnType<typeof resetViews>
   | ReturnType<typeof setView>
   | ReturnType<typeof setViews>
+  | ReturnType<typeof setViewsAndCells>
   | ReturnType<typeof setDashboard>
 
 export const RESET_VIEWS = 'RESET_VIEWS'
 export const SET_VIEW = 'SET_VIEW'
 export const SET_VIEWS = 'SET_VIEWS'
+export const SET_VIEWS_AND_CELLS = 'SET_VIEWS_AND_CELLS'
 
 type ViewSchema<R extends string | string[]> = NormalizedSchema<ViewEntities, R>
 
@@ -42,4 +45,16 @@ export const setView = (
     id,
     status,
     schema,
+  } as const)
+
+export const setViewsAndCells = (
+  status: RemoteDataState,
+  cellsArray: CellSchema<string[]>[],
+  viewsArray: ViewSchema<string[]>[]
+) =>
+  ({
+    type: SET_VIEWS_AND_CELLS,
+    cellsArray,
+    viewsArray,
+    status,
   } as const)

--- a/ui/src/views/reducers/index.ts
+++ b/ui/src/views/reducers/index.ts
@@ -3,9 +3,10 @@ import {produce} from 'immer'
 
 // Types
 import {
+  RESET_VIEWS,
   SET_VIEW,
   SET_VIEWS,
-  RESET_VIEWS,
+  SET_VIEWS_AND_CELLS,
   Action,
 } from 'src/views/actions/creators'
 import {SET_DASHBOARD} from 'src/dashboards/actions/creators'
@@ -34,6 +35,14 @@ const viewsReducer = (
 
       case SET_VIEWS: {
         setResource<View>(draftState, action, ResourceType.Views)
+
+        return
+      }
+      case SET_VIEWS_AND_CELLS: {
+        const {viewsArray} = action
+        viewsArray.forEach(view => {
+          setResource<View>(draftState, view, ResourceType.Views)
+        })
 
         return
       }


### PR DESCRIPTION
Related to IDPE 8040

### Problem

Loading dashboards was causing an exponential number of dispatches to trigger for each dashboard, that was then causing the render cycle of each dashboard card to be triggered, making the dashboard loading process slow. This ended up slowing down associated processes on the dashboard list until the operations finished rerendering. More specifically, this caused searching on the initial page load to be slow

### Solution

Rather than setting dashboard cells and views in a loop and call each one in a separate setTimeout, we are now wrapping the entire looping event in a setTimeout that is storing a reference to the normalized cell and view outside of the loop. Once the iterators resolve and we have a complete array of normalized cells and views, a new action is dispatched that triggers the views and cells to be iterated upon and set correctly within the reducer.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)