### PR TITLE
feat(pkger): parameterize task queries

### DIFF
--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1109,9 +1109,11 @@ func (p *Template) graphTasks() *parseErr {
 			description: o.Spec.stringShort(fieldDescription),
 			every:       o.Spec.durationShort(fieldEvery),
 			offset:      o.Spec.durationShort(fieldOffset),
-			query:       strings.TrimSpace(o.Spec.stringShort(fieldQuery)),
 			status:      normStr(o.Spec.stringShort(fieldStatus)),
 		}
+
+		prefix := fmt.Sprintf("tasks[%s].spec", t.MetaName())
+		t.query, _ = p.parseQuery(prefix, o.Spec.stringShort(fieldQuery), o.Spec.slcResource(fieldParams))
 
 		failures := p.parseNestedLabels(o.Spec, func(l *label) error {
 			t.labels = append(t.labels, l)
@@ -1121,7 +1123,7 @@ func (p *Template) graphTasks() *parseErr {
 		sort.Sort(t.labels)
 
 		p.mTasks[t.MetaName()] = t
-		p.setRefs(t.name, t.displayName)
+		p.setRefs(t.refs()...)
 		return append(failures, t.valid()...)
 	})
 }

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -1369,7 +1369,7 @@ func (t *stateTask) diffTask() DiffTask {
 			Description: t.parserTask.description,
 			Every:       durToStr(t.parserTask.every),
 			Offset:      durToStr(t.parserTask.offset),
-			Query:       t.parserTask.query,
+			Query:       t.parserTask.query.DashboardQuery(),
 			Status:      t.parserTask.Status(),
 		},
 	}

--- a/pkger/testdata/tasks_params.yml
+++ b/pkger/testdata/tasks_params.yml
@@ -1,0 +1,37 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Task
+metadata:
+  name: task-uuid
+spec:
+  every: 10m
+  query: |
+    option params = {
+      bucket:   "foo",
+      start:    -1d,
+      stop:     now(),
+      name:     "max",
+      floatVal: 1.0,
+      minVal:   10
+    }
+
+    from(bucket: params.bucket)
+      |> range(start: params.start, end: params.stop)
+      |> filter(fn: (r) => r._measurement == "processes")
+      |> filter(fn: (r) => r.floater == params.floatVal)
+      |> filter(fn: (r) => r._value > params.minVal)
+      |> aggregateWindow(every: v.windowPeriod, fn: max)
+      |> yield(name: params.name)
+  params:
+    - key: bucket
+      default: "bar"
+      type: string
+    - key: start
+      type: duration
+    - key: stop
+      type: time
+    - key: floatVal
+      default: 37.2
+      type: float
+    - key: minVal
+      type: int
+    - key: name # infer type


### PR DESCRIPTION
This is a follow up to the work to the PR #19191. This PR adds paremeterization to task queries.

references: #18237 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass