### PR TITLE
fix(task): update task max page size error message to include an accurate limit

### DIFF
--- a/pkger/service.go
+++ b/pkger/service.go
@@ -3394,7 +3394,7 @@ func (s *Service) getAllTasks(ctx context.Context, orgID influxdb.ID) ([]*influx
 	for {
 		f := influxdb.TaskFilter{
 			OrganizationID: &orgID,
-			Limit:          100,
+			Limit:          influxdb.TaskMaxPageSize,
 		}
 		if afterID != nil {
 			f.After = afterID

--- a/task_errors.go
+++ b/task_errors.go
@@ -57,8 +57,13 @@ var (
 		Code: EInvalid,
 	}
 
+	// ErrPageSizeTooLarge indicates the page size is too large. This error is only
+	// used in the kv task service implementation. The name of this error may lead it
+	// to be used in a place that is not useful. The TaskMaxPageSize is the only one
+	// at 500, the rest at 100. This would likely benefit from a more specific name
+	// since those limits aren't shared globally.
 	ErrPageSizeTooLarge = &Error{
-		Msg:  fmt.Sprintf("cannot use page size larger then %d", MaxPageSize),
+		Msg:  fmt.Sprintf("cannot use page size larger then %d", TaskMaxPageSize),
 		Code: EInvalid,
 	}
 


### PR DESCRIPTION
previously it had returned and error of 100, but the limit was 500.

The other thing to note is that the error being changed here, is only used within the task kv service implementation.

This was caught during a discussion with the UI team. The 500 limit was updated in pkger so it could take advantage of a full page size on each find call it makes.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass