### PR TITLE
fix(urm): Sanitize urm response output

### DIFF
--- a/tenant/http_client_urm.go
+++ b/tenant/http_client_urm.go
@@ -41,7 +41,7 @@ func (s *UserResourceMappingClient) FindUserResourceMappings(ctx context.Context
 		urs[k] = &influxdb.UserResourceMapping{
 			ResourceID:   f.ResourceID,
 			ResourceType: f.ResourceType,
-			UserID:       item.User.ID,
+			UserID:       item.ID,
 			UserType:     item.Role,
 		}
 	}
@@ -90,7 +90,7 @@ func (s *SpecificURMSvc) FindUserResourceMappings(ctx context.Context, f influxd
 		urs[k] = &influxdb.UserResourceMapping{
 			ResourceID:   f.ResourceID,
 			ResourceType: f.ResourceType,
-			UserID:       item.User.ID,
+			UserID:       item.ID,
 			UserType:     item.Role,
 		}
 	}

--- a/tenant/http_handler_urm_test.go
+++ b/tenant/http_handler_urm_test.go
@@ -87,7 +87,6 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				"self": "/api/v2/users/0000000000000001"
 			},
 			"id": "0000000000000001",
-			"name": "user0000000000000001",
 			"status": "active"
 		},
 		{
@@ -96,7 +95,6 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				"self": "/api/v2/users/0000000000000002"
 			},
 			"id": "0000000000000002",
-			"name": "user0000000000000002",
 			"status": "active"
 		}
 	]
@@ -150,7 +148,6 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				"self": "/api/v2/users/0000000000000001"
 			},
 			"id": "0000000000000001",
-			"name": "user0000000000000001",
 			"status": "active"
 		},
 		{
@@ -159,7 +156,6 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				"self": "/api/v2/users/0000000000000002"
 			},
 			"id": "0000000000000002",
-			"name": "user0000000000000002",
 			"status": "active"
 		}
 	]
@@ -271,7 +267,6 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 		"self": "/api/v2/users/0000000000000001"
 	},
 	"id": "0000000000000001",
-	"name": "user0000000000000001",
 	"status": "active"
 }`,
 			},
@@ -309,7 +304,6 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 		"self": "/api/v2/users/0000000000000002"
 	},
 	"id": "0000000000000002",
-	"name": "user0000000000000002",
 	"status": "active"
 }`,
 			},


### PR DESCRIPTION
We would like to clean and sanitize the data being return from the urm
response to exclude user names as well as oauthID's
