### PR TITLE
fix(dedup-window-vars): added condition and tests for ensuring windowVars don't get passed an extern more than once

### DIFF
--- a/ui/src/shared/apis/query.test.ts
+++ b/ui/src/shared/apis/query.test.ts
@@ -207,6 +207,45 @@ describe('query', () => {
         }
       })
     })
+    it('deduplicates variables and returns the cached results when an unexpired match with the same variable is found', done => {
+      mocked(runQuery).mockImplementation(() => ({
+        promise,
+        cancel: jest.fn(),
+      }))
+      const queryText = `|> v.bucket
+      |> v.bucket`
+      const result = getCachedResultsOrRunQuery(orgID, queryText, mockState)
+      expect(runQuery).toHaveBeenCalledTimes(1)
+      result.promise.then(() => {
+        try {
+          getCachedResultsOrRunQuery(orgID, queryText, mockState)
+          expect(runQuery).toHaveBeenCalledTimes(1)
+          done()
+        } catch (error) {
+          done(error)
+        }
+      })
+    })
+    it.only('deduplicates windowPeriod variables and returns the cached results when an unexpired match with the same variable is found', done => {
+      mocked(runQuery).mockImplementation(() => ({
+        promise,
+        cancel: jest.fn(),
+      }))
+      const queryText = `v.bucket
+      |> v.windowPeriod
+      |> v.windowPeriod`
+      const result = getCachedResultsOrRunQuery(orgID, queryText, mockState)
+      expect(runQuery).toHaveBeenCalledTimes(1)
+      result.promise.then(() => {
+        try {
+          getCachedResultsOrRunQuery(orgID, queryText, mockState)
+          expect(runQuery).toHaveBeenCalledTimes(1)
+          done()
+        } catch (error) {
+          done(error)
+        }
+      })
+    })
     it('resets the matching query if the variables do not match and reruns the query', done => {
       mocked(runQuery).mockImplementation(() => ({
         promise,

--- a/ui/src/shared/apis/query.test.ts
+++ b/ui/src/shared/apis/query.test.ts
@@ -226,7 +226,7 @@ describe('query', () => {
         }
       })
     })
-    it.only('deduplicates windowPeriod variables and returns the cached results when an unexpired match with the same variable is found', done => {
+    it('deduplicates windowPeriod variables and returns the cached results when an unexpired match with the same variable is found', done => {
       mocked(runQuery).mockImplementation(() => ({
         promise,
         cancel: jest.fn(),

--- a/ui/src/shared/apis/queryCache.ts
+++ b/ui/src/shared/apis/queryCache.ts
@@ -11,8 +11,11 @@ import {getWindowVars} from 'src/variables/utils/getWindowVars'
 // Types
 import {RunQueryResult} from 'src/shared/apis/query'
 import {CancelBox} from 'src/types/promises'
-import {AppState, GetState, Variable} from 'src/types'
+import {AppState, GetState, Variable, VariableAssignment} from 'src/types'
 import {RunQueryPromiseMutex} from './singleQuery'
+
+// Constants
+import {WINDOW_PERIOD} from 'src/variables/constants'
 
 export const TIME_INVALIDATION = 1000 * 60 * 10 // 10 minutes
 
@@ -143,6 +146,9 @@ export const resetQueryCacheByQuery = (query: string): void => {
   queryCache.resetCacheByID(queryID)
 }
 
+const hasWindowVars = (variables: VariableAssignment[]): boolean =>
+  variables.some(vari => vari.id.name === WINDOW_PERIOD)
+
 export const getCachedResultsOrRunQuery = (
   orgID: string,
   query: string,
@@ -173,7 +179,11 @@ export const getCachedResultsOrRunQuery = (
     .map(v => asAssignment(v))
     .filter(v => !!v)
 
-  const windowVars = getWindowVars(query, variableAssignments)
+  let windowVars = []
+
+  if (hasWindowVars(variableAssignments) === false) {
+    windowVars = getWindowVars(query, variableAssignments)
+  }
 
   // otherwise query & set results
   const extern = buildVarsOption([...variableAssignments, ...windowVars])


### PR DESCRIPTION
### Problem

The previous implementation of the Query cache appended the windowPeriod variable regardless of whether it was added as a variableAssignment. These duplicated extern values were causing an issue when trying to run the query

### Solution

Added a helper function to check whether the variableAssignment has a reference to the windowPeriod before appending it to the list of variables. Added tests to ensure that windowPeriod (and variableAssignments) are deduplicated before passing them in to runQuery 
