### PR TITLE
fix(cmd/influx): query cli should not explicitly request gzipped content

### DIFF
--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -112,7 +112,6 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 	req, _ := http.NewRequest("POST", u.String(), bytes.NewReader(body))
 	req.Header.Set("Authorization", "Token "+flags.Token)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept-Encoding", "gzip")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
The `net/http` package default transport will request content gzipped
automatically if `DisableCompression` is set to false (which is the
default). If the transport does it automatically, it will decompress it
automatically which is what was the original intention of the code. But,
if it is requested explicitly, then go will not decompress the data
automatically.

Fixes #18674.