### PR TITLE
fix: restrict urm listing of a resource to members of org owning said resource

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -133,3 +133,9 @@
   key: pushDownGroupAggregateMinMax
   default: false
   contact: Query Team
+
+- name: Org Only Member list
+  description: Enforce only org members have access to view members of org related resorces
+  key: orgOnlyMemberList
+  default: false
+  contact: Compute Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -240,6 +240,20 @@ func PushDownGroupAggregateMinMax() BoolFlag {
 	return pushDownGroupAggregateMinMax
 }
 
+var orgOnlyMemberList = MakeBoolFlag(
+	"Org Only Member list",
+	"orgOnlyMemberList",
+	"Compute Team",
+	false,
+	Temporary,
+	false,
+)
+
+// OrgOnlyMemberList - Enforce only org members have access to view members of org related resorces
+func OrgOnlyMemberList() BoolFlag {
+	return orgOnlyMemberList
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -258,6 +272,7 @@ var all = []Flag{
 	mergeFiltersRule,
 	notebooks,
 	pushDownGroupAggregateMinMax,
+	orgOnlyMemberList,
 }
 
 var byKey = map[string]Flag{
@@ -278,4 +293,5 @@ var byKey = map[string]Flag{
 	"mergeFiltersRule":              mergeFiltersRule,
 	"notebooks":                     notebooks,
 	"pushDownGroupAggregateMinMax":  pushDownGroupAggregateMinMax,
+	"orgOnlyMemberList":             orgOnlyMemberList,
 }

--- a/tenant/middleware_urm_auth.go
+++ b/tenant/middleware_urm_auth.go
@@ -21,13 +21,21 @@ func NewAuthedURMService(orgSvc influxdb.OrganizationService, s influxdb.UserRes
 }
 
 func (s *AuthedURMService) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
+	orgID := kithttp.OrgIDFromContext(ctx) // resource's orgID
+
+	// Check if user making request has read access to organization prior to listing URMs.
+	if orgID != nil {
+		if _, _, err := authorizer.AuthorizeReadResource(ctx, influxdb.OrgsResourceType, *orgID); err != nil {
+			return nil, 0, err
+		}
+	}
+
 	urms, _, err := s.s.FindUserResourceMappings(ctx, filter, opt...)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	authedUrms := urms[:0]
-	orgID := kithttp.OrgIDFromContext(ctx)
 	for _, urm := range urms {
 		if orgID != nil {
 			if _, _, err := authorizer.AuthorizeRead(ctx, urm.ResourceType, urm.ResourceID, *orgID); err != nil {

--- a/tenant/middleware_urm_auth.go
+++ b/tenant/middleware_urm_auth.go
@@ -28,7 +28,7 @@ func (s *AuthedURMService) FindUserResourceMappings(ctx context.Context, filter 
 		// Check if user making request has read access to organization prior to listing URMs.
 		if orgID != nil {
 			if _, _, err := authorizer.AuthorizeReadResource(ctx, influxdb.OrgsResourceType, *orgID); err != nil {
-				return nil, 0, err
+				return nil, 0, ErrNotFound
 			}
 		}
 	}

--- a/tenant/middleware_urm_auth_test.go
+++ b/tenant/middleware_urm_auth_test.go
@@ -142,10 +142,7 @@ func TestURMService_FindUserResourceMappings(t *testing.T) {
 				},
 			},
 			wants: wants{
-				err: &influxdb.Error{
-					Msg:  "read:orgs/000000000000000a is unauthorized",
-					Code: influxdb.EUnauthorized,
-				},
+				err: ErrNotFound,
 			},
 		},
 	}

--- a/tenant/middleware_urm_auth_test.go
+++ b/tenant/middleware_urm_auth_test.go
@@ -62,6 +62,13 @@ func TestURMService_FindUserResourceMappings(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
 							Type: influxdb.BucketsResourceType,
 							// ID:    &idOne,
 							OrgID: influxdbtesting.IDPtr(10),
@@ -97,6 +104,46 @@ func TestURMService_FindUserResourceMappings(t *testing.T) {
 						ResourceID:   3,
 						ResourceType: influxdb.BucketsResourceType,
 					},
+				},
+			},
+		},
+		{
+			name: "authorized to see all users by org auth",
+			fields: fields{
+				UserResourceMappingService: &mock.UserResourceMappingService{
+					FindMappingsFn: func(ctx context.Context, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, int, error) {
+						return []*influxdb.UserResourceMapping{
+							{
+								ResourceID:   1,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   2,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   3,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type:  influxdb.BucketsResourceType,
+							OrgID: influxdbtesting.IDPtr(10),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/000000000000000a is unauthorized",
+					Code: influxdb.EUnauthorized,
 				},
 			},
 		},


### PR DESCRIPTION

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
