### PR TITLE
fix(tsdb): revert disable series id set cache size by default

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -68,8 +68,7 @@ const (
 	DefaultMaxIndexLogFileSize = 1 * 1024 * 1024 // 1MB
 
 	// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache in the TSI index.
-	// It is disabled by default.
-	DefaultSeriesIDSetCacheSize = 0
+	DefaultSeriesIDSetCacheSize = 100
 
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.


### PR DESCRIPTION
This reverts commit 9c41e12ee4fac47434f32af93a07a29129951512 from https://github.com/influxdata/influxdb/pull/18158, which changed `DefaultSeriesIDSetCacheSize` to zero. The change caused some users to experience significantly higher memory usage. A future PR will address the original problem with a different solution.
