### PR TITLE
fix(dashboard-variable-hydration): hydrate variables after the views have been set

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -78,8 +78,16 @@
   expose: true
 
 - name: Query Cache for Dashboards UI
-  description: Enables a Dashboard Cache on the uI
+  description: Enables a Dashboard Cache on the UI
   key: queryCacheForDashboards
+  default: false
+  contact: Ariel Salem / Monitoring Team
+  lifetime: temporary
+  expose: true
+
+- name: Contextualizing Variable Hydration for Get Dashboard UI
+  description: Contextualized Variable Hydration for the Dashboard UI
+  key: dashboardVariableContext
   default: false
   contact: Ariel Salem / Monitoring Team
   lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -137,9 +137,23 @@ var queryCacheForDashboards = MakeBoolFlag(
 	true,
 )
 
-// QueryCacheForDashboardsUi - Enables a Dashboard Cache on the uI
+// QueryCacheForDashboardsUi - Enables a Dashboard Cache on the UI
 func QueryCacheForDashboardsUi() BoolFlag {
 	return queryCacheForDashboards
+}
+
+var dashboardVariableContext = MakeBoolFlag(
+	"Contextualizing Variable Hydration for Get Dashboard UI",
+	"dashboardVariableContext",
+	"Ariel Salem / Monitoring Team",
+	false,
+	Temporary,
+	true,
+)
+
+// ContextualizingVariableHydrationForGetDashboardUi - Contextualized Variable Hydration for the Dashboard UI
+func ContextualizingVariableHydrationForGetDashboardUi() BoolFlag {
+	return dashboardVariableContext
 }
 
 var memoryOptimizedFill = MakeBoolFlag(
@@ -251,6 +265,7 @@ var all = []Flag{
 	newLabels,
 	hydratevars,
 	queryCacheForDashboards,
+	dashboardVariableContext,
 	memoryOptimizedFill,
 	memoryOptimizedSchemaMutation,
 	simpleTaskOptionsExtraction,
@@ -271,6 +286,7 @@ var byKey = map[string]Flag{
 	"newLabels":                     newLabels,
 	"hydratevars":                   hydratevars,
 	"queryCacheForDashboards":       queryCacheForDashboards,
+	"dashboardVariableContext":      dashboardVariableContext,
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,
 	"simpleTaskOptionsExtraction":   simpleTaskOptionsExtraction,

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -360,9 +360,6 @@ export const getDashboard = (
       throw new Error(resp.data.message)
     }
 
-    const skipCache = true
-    dispatch(hydrateVariables(skipCache, controller))
-
     const normDash = normalize<Dashboard, DashboardEntities, string>(
       resp.data,
       dashboardSchema
@@ -388,6 +385,11 @@ export const getDashboard = (
         creators.setDashboard(dashboardID, RemoteDataState.Done, normDash)
       )
       dispatch(updateTimeRangeFromQueryParams(dashboardID))
+      // Hydrating the variables after the views have been set creates context
+      // for the variable hydration process and limits the number of variables
+      // we are querying to only the ones that exist within the view
+      const skipCache = true
+      dispatch(hydrateVariables(skipCache, controller))
     }, 0)
   } catch (error) {
     if (error.name === 'AbortError') {


### PR DESCRIPTION
### Problem

Variable hydration utilizes the view in order to contextualize which variables to hydrate. If the view hasn't been set or returns with no values, then we hydrate all the variables. In `getDashboard` we are currently hydrating the variables before the view has been set. Since there is no available view for the hydrateVars function to limit itself by, we end up hydrating all the variables, then setting the view, then hydrating a limited number of variables based on the view that was set

### Solution

in `getDashboard`, hydrate the variables after the view has been set in order to provide context to the hydrateVars function