### PR TITLE
chore(tenant): make tenant and kv both conform with harness

### DIFF
--- a/authorization/service_test.go
+++ b/authorization/service_test.go
@@ -32,11 +32,16 @@ func initBoltAuthService(f influxdbtesting.AuthorizationFields, t *testing.T) (i
 
 func initAuthService(s kv.Store, f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, func()) {
 	st := tenant.NewStore(s)
+	if f.OrgIDGenerator != nil {
+		st.OrgIDGen = f.OrgIDGenerator
+	}
+
 	ts := tenant.NewService(st)
 	storage, err := authorization.NewStore(s)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	svc := authorization.NewService(storage, ts)
 
 	for _, u := range f.Users {
@@ -60,7 +65,7 @@ func initAuthService(s kv.Store, f influxdbtesting.AuthorizationFields, t *testi
 	return svc, func() {
 		for _, m := range f.Authorizations {
 			if err := svc.DeleteAuthorization(context.Background(), m.ID); err != nil {
-				t.Logf("failed to remove user resource mapping: %v", err)
+				t.Logf("failed to remove authorization token: %v", err)
 			}
 		}
 	}

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -870,6 +870,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 
 	store := NewTestInmemStore(t)
 	svc := kv.NewService(zaptest.NewLogger(t), store)
+	svc.OrgIDs = f.OrgIDGenerator
 	svc.IDGenerator = f.IDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	svc.TimeGenerator = f.TimeGenerator
@@ -883,6 +884,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 	}
 
 	for _, o := range f.Orgs {
+		o.ID = svc.OrgIDs.ID()
 		if err := svc.PutOrganization(ctx, o); err != nil {
 			t.Fatalf("failed to populate orgs")
 		}

--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -1205,18 +1205,27 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (influxdb.B
 	store := NewTestInmemStore(t)
 	svc := kv.NewService(logger, store)
 	svc.IDGenerator = f.IDGenerator
-	svc.OrgBucketIDs = f.OrgBucketIDs
+	svc.OrgIDs = f.OrgIDs
+	svc.BucketIDs = f.BucketIDs
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {
 		svc.TimeGenerator = influxdb.RealTimeGenerator{}
 	}
 
 	for _, o := range f.Organizations {
+		// PutOrgs no longer creates an ID
+		// that is what CreateOrganization does
+		// so we have to generate one
+		o.ID = svc.OrgIDs.ID()
 		if err := svc.PutOrganization(ctx, o); err != nil {
 			t.Fatalf("failed to populate organizations")
 		}
 	}
 	for _, b := range f.Buckets {
+		// PutBuckets no longer creates an ID
+		// that is what CreateBucket does
+		// so we have to generate one
+		b.ID = svc.BucketIDs.ID()
 		if err := svc.PutBucket(ctx, b); err != nil {
 			t.Fatalf("failed to populate buckets")
 		}

--- a/http/onboarding_test.go
+++ b/http/onboarding_test.go
@@ -26,7 +26,8 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	store := NewTestInmemStore(t)
 	svc := kv.NewService(zaptest.NewLogger(t), store)
 	svc.IDGenerator = f.IDGenerator
-	svc.OrgBucketIDs = f.IDGenerator
+	svc.OrgIDs = f.IDGenerator
+	svc.BucketIDs = f.IDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	if f.TimeGenerator == nil {
 		f.TimeGenerator = platform.RealTimeGenerator{}

--- a/http/org_service_test.go
+++ b/http/org_service_test.go
@@ -42,13 +42,18 @@ func initOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T)
 	store := NewTestInmemStore(t)
 	svc := kv.NewService(logger, store)
 	svc.IDGenerator = f.IDGenerator
-	svc.OrgBucketIDs = f.OrgBucketIDs
+	svc.OrgIDs = f.OrgBucketIDs
+	svc.BucketIDs = f.OrgBucketIDs
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {
 		svc.TimeGenerator = influxdb.RealTimeGenerator{}
 	}
 
 	for _, o := range f.Organizations {
+		// PutOrgs no longer creates an ID
+		// that is what CreateOrganization does
+		// so we have to generate one
+		o.ID = svc.OrgIDs.ID()
 		if err := svc.PutOrganization(ctx, o); err != nil {
 			t.Fatalf("failed to populate organizations")
 		}

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -329,8 +329,9 @@ func (b *Bucket) ForwardCursor(seek []byte, opts ...kv.CursorOption) (kv.Forward
 		if config.Direction == kv.CursorDescending {
 			iterate = b.descend
 			if len(seek) == 0 {
-				seek = b.btree.Max().(*item).key
-
+				if item, ok := b.btree.Max().(*item); ok {
+					seek = item.key
+				}
 			}
 		}
 

--- a/kv/auth_test.go
+++ b/kv/auth_test.go
@@ -31,6 +31,7 @@ func initAuthorizationService(s kv.SchemaStore, f influxdbtesting.AuthorizationF
 	ctx := context.Background()
 	svc := kv.NewService(zaptest.NewLogger(t), s)
 	svc.IDGenerator = f.IDGenerator
+	svc.OrgIDs = f.OrgIDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	svc.TimeGenerator = f.TimeGenerator
 
@@ -41,6 +42,7 @@ func initAuthorizationService(s kv.SchemaStore, f influxdbtesting.AuthorizationF
 	}
 
 	for _, o := range f.Orgs {
+		o.ID = svc.OrgIDs.ID()
 		if err := svc.PutOrganization(ctx, o); err != nil {
 			t.Fatalf("failed to populate orgs")
 		}

--- a/kv/lookup_service_test.go
+++ b/kv/lookup_service_test.go
@@ -244,8 +244,8 @@ func testLookupName(newStore StoreFn, t *testing.T) {
 			defer done()
 
 			svc.IDGenerator = mock.NewMockIDGenerator()
-			svc.OrgBucketIDs = mock.NewMockIDGenerator()
-			svc.WithSpecialOrgBucketIDs(svc.IDGenerator)
+			svc.OrgIDs = svc.IDGenerator
+			svc.BucketIDs = svc.IDGenerator
 			ctx := context.Background()
 			if tt.args.init != nil {
 				if err := tt.args.init(ctx, svc); err != nil {

--- a/kv/onboarding_test.go
+++ b/kv/onboarding_test.go
@@ -31,7 +31,8 @@ func initOnboardingService(s kv.SchemaStore, f influxdbtesting.OnboardingFields,
 	ctx := context.Background()
 	svc := kv.NewService(zaptest.NewLogger(t), s)
 	svc.IDGenerator = f.IDGenerator
-	svc.OrgBucketIDs = f.IDGenerator
+	svc.OrgIDs = f.IDGenerator
+	svc.BucketIDs = f.IDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {

--- a/kv/org.go
+++ b/kv/org.go
@@ -18,9 +18,6 @@ import (
 const (
 	// MaxIDGenerationN is the maximum number of times an ID generation is done before failing.
 	MaxIDGenerationN = 100
-	// ReservedIDs are the number of IDs reserved from 1 - ReservedIDs we use
-	// for our system org/buckets
-	ReservedIDs = 1000
 )
 
 var (
@@ -335,7 +332,7 @@ func (s *Service) createOrganization(ctx context.Context, tx Tx, o *influxdb.Org
 }
 
 func (s *Service) generateOrgID(ctx context.Context, tx Tx) (influxdb.ID, error) {
-	return s.generateSafeID(ctx, tx, organizationBucket)
+	return s.generateSafeID(ctx, tx, organizationBucket, s.OrgIDs)
 }
 
 // PutOrganization will put a organization without setting an ID.

--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -30,16 +30,18 @@ func initBoltOrganizationService(f influxdbtesting.OrganizationFields, t *testin
 func initOrganizationService(s kv.SchemaStore, f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
 	ctx := context.Background()
 	svc := kv.NewService(zaptest.NewLogger(t), s)
-	svc.OrgBucketIDs = f.OrgBucketIDs
+	svc.OrgIDs = f.OrgBucketIDs
+	svc.BucketIDs = f.OrgBucketIDs
 	svc.IDGenerator = f.IDGenerator
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {
 		svc.TimeGenerator = influxdb.RealTimeGenerator{}
 	}
 
-	for _, u := range f.Organizations {
-		if err := svc.PutOrganization(ctx, u); err != nil {
-			t.Fatalf("failed to populate organizations")
+	for _, o := range f.Organizations {
+		o.ID = svc.OrgIDs.ID()
+		if err := svc.PutOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to populate organizations: %s", err)
 		}
 	}
 

--- a/kv/service.go
+++ b/kv/service.go
@@ -37,7 +37,8 @@ type Service struct {
 	// special ID generator that never returns bytes with backslash,
 	// comma, or space. Used to support very specific encoding of org &
 	// bucket into the old measurement in storage.
-	OrgBucketIDs influxdb.IDGenerator
+	OrgIDs    influxdb.IDGenerator
+	BucketIDs influxdb.IDGenerator
 
 	TokenGenerator influxdb.TokenGenerator
 	// TODO(desa:ariel): this should not be embedded
@@ -59,7 +60,8 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		log:         log,
 		IDGenerator: snowflake.NewIDGenerator(),
 		// Seed the random number generator with the current time
-		OrgBucketIDs:   rand.NewOrgBucketID(time.Now().UnixNano()),
+		OrgIDs:         rand.NewOrgBucketID(time.Now().UnixNano()),
+		BucketIDs:      rand.NewOrgBucketID(time.Now().UnixNano()),
 		TokenGenerator: rand.NewTokenGenerator(64),
 		Hash:           &Bcrypt{},
 		kv:             kv,
@@ -107,14 +109,6 @@ func (s *Service) WithResourceLogger(audit resource.Logger) {
 // Should only be used in tests for mocking.
 func (s *Service) WithStore(store Store) {
 	s.kv = store
-}
-
-// WithSpecialOrgBucketIDs sets the generator for the org
-// and bucket ids.
-//
-// Should only be used in tests for mocking.
-func (s *Service) WithSpecialOrgBucketIDs(gen influxdb.IDGenerator) {
-	s.OrgBucketIDs = gen
 }
 
 // WithMaxPermissionFunc sets the useAuthorizationsForMaxPermissions function

--- a/kv/unique.go
+++ b/kv/unique.go
@@ -79,14 +79,10 @@ func (s *Service) uniqueID(ctx context.Context, tx Tx, bucket []byte, id influxd
 
 // generateSafeID attempts to create ids for buckets
 // and orgs that are without backslash, commas, and spaces, BUT ALSO do not already exist.
-func (s *Service) generateSafeID(ctx context.Context, tx Tx, bucket []byte) (influxdb.ID, error) {
+func (s *Service) generateSafeID(ctx context.Context, tx Tx, bucket []byte, gen influxdb.IDGenerator) (influxdb.ID, error) {
 	for i := 0; i < MaxIDGenerationN; i++ {
-		id := s.OrgBucketIDs.ID()
-		// we have reserved a certain number of IDs
-		// for orgs and buckets.
-		if id < ReservedIDs {
-			continue
-		}
+		id := gen.ID()
+
 		err := s.uniqueID(ctx, tx, bucket, id)
 		if err == nil {
 			return id, nil

--- a/kv/urm_test.go
+++ b/kv/urm_test.go
@@ -67,6 +67,7 @@ func initUserResourceMappingService(s kv.SchemaStore, f influxdbtesting.UserReso
 	}
 
 	for _, b := range f.Buckets {
+		b.ID = svc.BucketIDs.ID()
 		if err := svc.PutBucket(ctx, b); err != nil {
 			t.Fatalf("failed to create bucket %q", err)
 		}

--- a/tenant/error.go
+++ b/tenant/error.go
@@ -14,9 +14,9 @@ var (
 		Msg:  "name is empty",
 	}
 
-	// NotUniqueIDError is used when attempting to create an org or bucket that already
+	// ErrIDNotUnique is used when attempting to create an org or bucket that already
 	// exists.
-	NotUniqueIDError = &influxdb.Error{
+	ErrIDNotUnique = &influxdb.Error{
 		Code: influxdb.EConflict,
 		Msg:  "ID already exists",
 	}

--- a/tenant/http_server_bucket_test.go
+++ b/tenant/http_server_bucket_test.go
@@ -23,24 +23,40 @@ func initBucketHttpService(f itesting.BucketFields, t *testing.T) (influxdb.Buck
 	}
 
 	store := tenant.NewStore(s)
-	svc := tenant.NewService(store)
+	if f.IDGenerator != nil {
+		store.IDGen = f.IDGenerator
+	}
+
+	if f.OrgIDs != nil {
+		store.OrgIDGen = f.OrgIDs
+	}
+
+	if f.BucketIDs != nil {
+		store.BucketIDGen = f.BucketIDs
+	}
 
 	ctx := context.Background()
-	for _, o := range f.Organizations {
-		// use storage create org in order to avoid creating system buckets
-		if err := s.Update(ctx, func(tx kv.Tx) error {
-			return store.CreateOrg(tx.Context(), tx, o)
-		}); err != nil {
-			t.Fatalf("failed to populate organizations: %s", err)
+
+	// go direct to storage for test data
+	if err := s.Update(ctx, func(tx kv.Tx) error {
+		for _, o := range f.Organizations {
+			if err := store.CreateOrg(tx.Context(), tx, o); err != nil {
+				return err
+			}
 		}
-	}
-	for _, b := range f.Buckets {
-		if err := svc.CreateBucket(ctx, b); err != nil {
-			t.Fatalf("failed to populate buckets")
+
+		for _, b := range f.Buckets {
+			if err := store.CreateBucket(tx.Context(), tx, b); err != nil {
+				return err
+			}
 		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to seed data: %s", err)
 	}
 
-	handler := tenant.NewHTTPBucketHandler(zaptest.NewLogger(t), svc, nil, nil, nil)
+	handler := tenant.NewHTTPBucketHandler(zaptest.NewLogger(t), tenant.NewService(store), nil, nil, nil)
 	r := chi.NewRouter()
 	r.Mount(handler.Prefix(), handler)
 	server := httptest.NewServer(r)
@@ -59,6 +75,6 @@ func initBucketHttpService(f itesting.BucketFields, t *testing.T) (influxdb.Buck
 	}
 }
 
-func TestBucketService(t *testing.T) {
-	itesting.BucketService(initBucketHttpService, t, itesting.WithoutHooks(), itesting.WithHTTPValidation())
+func TestHTTPBucketService(t *testing.T) {
+	itesting.BucketService(initBucketHttpService, t)
 }

--- a/tenant/middleware_bucket_logging_test.go
+++ b/tenant/middleware_bucket_logging_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestBucketLoggingService(t *testing.T) {
-	influxdbtesting.BucketService(initBoltBucketLoggingService, t, influxdbtesting.WithoutHooks())
+	influxdbtesting.BucketService(initInmemBucketLoggingService, t)
 }
 
-func initBoltBucketLoggingService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
-	svc, s, closer := initBoltBucketService(f, t)
+func initInmemBucketLoggingService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
+	svc, s, closer := initInmemBucketService(f, t)
 	return tenant.NewBucketLogger(zaptest.NewLogger(t), svc), s, closer
 }

--- a/tenant/service_test.go
+++ b/tenant/service_test.go
@@ -65,7 +65,17 @@ func initBoltTenantService(t *testing.T, f influxdbtesting.TenantFields) (influx
 		t.Fatalf("failed to create new kv store: %v", err)
 	}
 
-	svc := tenant.NewService(tenant.NewStore(s))
+	store := tenant.NewStore(s)
+
+	if f.OrgIDGenerator != nil {
+		store.OrgIDGen = f.OrgIDGenerator
+	}
+
+	if f.BucketIDGenerator != nil {
+		store.BucketIDGen = f.BucketIDGenerator
+	}
+
+	svc := tenant.NewService(store)
 
 	for _, u := range f.Users {
 		if err := svc.CreateUser(context.Background(), u); err != nil {

--- a/tenant/storage_test.go
+++ b/tenant/storage_test.go
@@ -1,0 +1,11 @@
+package tenant
+
+import "time"
+
+// WithNow is a test only option used to override the now time
+// generating function
+func WithNow(fn func() time.Time) StoreOption {
+	return func(s *Store) {
+		s.now = fn
+	}
+}

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -50,6 +50,7 @@ func WithoutFindByToken() AuthTestOpts {
 // AuthorizationFields will include the IDGenerator, and authorizations
 type AuthorizationFields struct {
 	IDGenerator    influxdb.IDGenerator
+	OrgIDGenerator influxdb.IDGenerator
 	TokenGenerator influxdb.TokenGenerator
 	TimeGenerator  influxdb.TimeGenerator
 	Authorizations []*influxdb.Authorization
@@ -126,7 +127,8 @@ func CreateAuthorization(
 		{
 			name: "basic create authorization",
 			fields: AuthorizationFields{
-				IDGenerator: mock.NewIDGenerator(authTwoID, t),
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
+				IDGenerator:    mock.NewIDGenerator(authTwoID, t),
 				TimeGenerator: &mock.TimeGenerator{
 					FakeValue: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				},
@@ -144,25 +146,24 @@ func CreateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 				},
 			},
 			args: args{
 				authorization: &influxdb.Authorization{
-					OrgID:       MustIDBase16(orgOneID),
+					OrgID:       idOne,
 					UserID:      MustIDBase16(userOneID),
-					Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+					Permissions: createUsersPermission(idOne),
 					Description: "new auth",
 				},
 			},
@@ -171,19 +172,19 @@ func CreateAuthorization(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand",
 						Status:      influxdb.Active,
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 						Description: "new auth",
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
@@ -196,7 +197,8 @@ func CreateAuthorization(
 		{
 			name: "providing a non existing user is invalid",
 			fields: AuthorizationFields{
-				IDGenerator: mock.NewIDGenerator(authTwoID, t),
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
+				IDGenerator:    mock.NewIDGenerator(authTwoID, t),
 				TimeGenerator: &mock.TimeGenerator{
 					FakeValue: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				},
@@ -214,25 +216,24 @@ func CreateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 				},
 			},
 			args: args{
 				authorization: &influxdb.Authorization{
-					OrgID:       MustIDBase16(orgOneID),
+					OrgID:       idOne,
 					UserID:      MustIDBase16(userTwoID),
-					Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+					Permissions: createUsersPermission(idOne),
 					Description: "auth with non-existent user",
 				},
 			},
@@ -241,10 +242,10 @@ func CreateAuthorization(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 				},
@@ -254,7 +255,8 @@ func CreateAuthorization(
 		{
 			name: "providing a non existing org is invalid",
 			fields: AuthorizationFields{
-				IDGenerator: mock.NewIDGenerator(authTwoID, t),
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
+				IDGenerator:    mock.NewIDGenerator(authTwoID, t),
 				TimeGenerator: &mock.TimeGenerator{
 					FakeValue: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				},
@@ -272,25 +274,24 @@ func CreateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 				},
 			},
 			args: args{
 				authorization: &influxdb.Authorization{
-					OrgID:       MustIDBase16(orgTwoID),
+					OrgID:       idTwo,
 					UserID:      MustIDBase16(userOneID),
-					Permissions: createUsersPermission(MustIDBase16(orgTwoID)),
+					Permissions: createUsersPermission(idTwo),
 					Description: "auth with non-existent org",
 				},
 			},
@@ -299,10 +300,10 @@ func CreateAuthorization(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "supersecret",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 						Description: "already existing auth",
 					},
 				},
@@ -354,6 +355,7 @@ func FindAuthorizationByID(
 		{
 			name: "basic find authorization by id",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -368,22 +370,22 @@ func FindAuthorizationByID(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 				Orgs: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 			},
@@ -392,18 +394,18 @@ func FindAuthorizationByID(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
 						Status:      "active",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
 						Status:      "active",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -455,6 +457,7 @@ func UpdateAuthorization(
 		{
 			name: "regular update",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				TimeGenerator: &mock.TimeGenerator{
 					FakeValue: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				},
@@ -471,11 +474,9 @@ func UpdateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
@@ -484,29 +485,29 @@ func UpdateAuthorization(
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand1",
 						Status:      influxdb.Inactive,
-						OrgID:       MustIDBase16(orgTwoID),
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						OrgID:       idTwo,
+						Permissions: allUsersPermission(idTwo),
 					},
 					{
 						ID:          MustIDBase16(authZeroID),
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand0",
-						OrgID:       MustIDBase16(orgOneID),
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						OrgID:       idOne,
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 				},
 			},
@@ -521,9 +522,9 @@ func UpdateAuthorization(
 				authorization: &influxdb.Authorization{
 					ID:          MustIDBase16(authTwoID),
 					UserID:      MustIDBase16(userTwoID),
-					OrgID:       MustIDBase16(orgOneID),
+					OrgID:       idOne,
 					Token:       "rand2",
-					Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+					Permissions: createUsersPermission(idOne),
 					Status:      influxdb.Inactive,
 					Description: "desc1",
 					CRUDLog: influxdb.CRUDLog{
@@ -535,6 +536,7 @@ func UpdateAuthorization(
 		{
 			name: "update with id not found",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -548,11 +550,9 @@ func UpdateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
@@ -561,22 +561,22 @@ func UpdateAuthorization(
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand1",
 						Status:      influxdb.Inactive,
-						OrgID:       MustIDBase16(orgTwoID),
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						OrgID:       idTwo,
+						Permissions: allUsersPermission(idTwo),
 					},
 					{
 						ID:          MustIDBase16(authZeroID),
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand0",
-						OrgID:       MustIDBase16(orgOneID),
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						OrgID:       idOne,
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -597,6 +597,7 @@ func UpdateAuthorization(
 		{
 			name: "update with unknown status",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				TimeGenerator: &mock.TimeGenerator{
 					FakeValue: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				},
@@ -613,11 +614,9 @@ func UpdateAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
@@ -626,29 +625,29 @@ func UpdateAuthorization(
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand1",
 						Status:      influxdb.Inactive,
-						OrgID:       MustIDBase16(orgTwoID),
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						OrgID:       idTwo,
+						Permissions: allUsersPermission(idTwo),
 					},
 					{
 						ID:          MustIDBase16(authZeroID),
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand0",
-						OrgID:       MustIDBase16(orgOneID),
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						OrgID:       idOne,
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 				},
 			},
@@ -714,6 +713,7 @@ func FindAuthorizationByToken(
 		{
 			name: "basic find authorization by token",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -727,11 +727,9 @@ func FindAuthorizationByToken(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
@@ -740,29 +738,29 @@ func FindAuthorizationByToken(
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand1",
 						Status:      influxdb.Inactive,
-						OrgID:       MustIDBase16(orgTwoID),
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						OrgID:       idTwo,
+						Permissions: allUsersPermission(idTwo),
 					},
 					{
 						ID:          MustIDBase16(authZeroID),
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand0",
-						OrgID:       MustIDBase16(orgOneID),
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						OrgID:       idOne,
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 				},
 			},
@@ -773,16 +771,17 @@ func FindAuthorizationByToken(
 				authorization: &influxdb.Authorization{
 					ID:          MustIDBase16(authOneID),
 					UserID:      MustIDBase16(userOneID),
-					OrgID:       MustIDBase16(orgTwoID),
+					OrgID:       idTwo,
 					Status:      influxdb.Inactive,
 					Token:       "rand1",
-					Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+					Permissions: allUsersPermission(idTwo),
 				},
 			},
 		},
 		{
 			name: "find authorization by token",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -796,37 +795,36 @@ func FindAuthorizationByToken(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authZeroID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand4",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 				},
 			},
@@ -837,10 +835,10 @@ func FindAuthorizationByToken(
 				authorization: &influxdb.Authorization{
 					ID:          MustIDBase16(authTwoID),
 					UserID:      MustIDBase16(userTwoID),
-					OrgID:       MustIDBase16(orgOneID),
+					OrgID:       idOne,
 					Token:       "rand2",
 					Status:      influxdb.Active,
-					Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+					Permissions: createUsersPermission(idOne),
 				},
 			},
 		},
@@ -887,6 +885,7 @@ func FindAuthorizations(
 		{
 			name: "find all authorizations",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -900,23 +899,22 @@ func FindAuthorizations(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -926,18 +924,18 @@ func FindAuthorizations(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
 						Status:      influxdb.Active,
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
 						Status:      influxdb.Active,
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -945,6 +943,7 @@ func FindAuthorizations(
 		{
 			name: "find authorization by user id",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -958,31 +957,30 @@ func FindAuthorizations(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
 						Status:      influxdb.Active,
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand3",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 				},
 			},
@@ -994,18 +992,18 @@ func FindAuthorizations(
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand3",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 				},
 			},
@@ -1013,6 +1011,7 @@ func FindAuthorizations(
 		{
 			name: "find authorization by org id",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -1022,60 +1021,58 @@ func FindAuthorizations(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand1",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand2",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgTwoID),
+						OrgID:       idTwo,
 						Status:      influxdb.Active,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						Permissions: allUsersPermission(idTwo),
 					},
 				},
 			},
 			args: args{
-				OrgID: MustIDBase16(orgOneID),
+				OrgID: idOne,
 			},
 			wants: wants{
 				authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand1",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand2",
-						Permissions: deleteUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: deleteUsersPermission(idOne),
 					},
 				},
 			},
@@ -1083,6 +1080,7 @@ func FindAuthorizations(
 		{
 			name: "find authorization by org id and user id",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -1096,61 +1094,60 @@ func FindAuthorizations(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
 						Name: "o2",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgTwoID),
+						OrgID:       idTwo,
 						Status:      influxdb.Active,
 						Token:       "rand2",
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						Permissions: allUsersPermission(idTwo),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand3",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authThreeID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgTwoID),
+						OrgID:       idTwo,
 						Status:      influxdb.Active,
 						Token:       "rand4",
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						Permissions: allUsersPermission(idTwo),
 					},
 				},
 			},
 			args: args{
 				UserID: MustIDBase16(userOneID),
-				OrgID:  MustIDBase16(orgTwoID),
+				OrgID:  idTwo,
 			},
 			wants: wants{
 				authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgTwoID),
+						OrgID:       idTwo,
 						Status:      influxdb.Active,
 						Token:       "rand2",
-						Permissions: allUsersPermission(MustIDBase16(orgTwoID)),
+						Permissions: allUsersPermission(idTwo),
 					},
 				},
 			},
@@ -1208,6 +1205,7 @@ func DeleteAuthorization(
 		{
 			name: "delete authorizations using exist id",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -1221,23 +1219,22 @@ func DeleteAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -1249,10 +1246,10 @@ func DeleteAuthorization(
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Status:      influxdb.Active,
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -1260,6 +1257,7 @@ func DeleteAuthorization(
 		{
 			name: "delete authorizations using id that does not exist",
 			fields: AuthorizationFields{
+				OrgIDGenerator: mock.NewIncrementingIDGenerator(1),
 				Users: []*influxdb.User{
 					{
 						Name: "cooluser",
@@ -1273,23 +1271,22 @@ func DeleteAuthorization(
 				Orgs: []*influxdb.Organization{
 					{
 						Name: "o1",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Authorizations: []*influxdb.Authorization{
 					{
 						ID:          MustIDBase16(authOneID),
 						UserID:      MustIDBase16(userOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand1",
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						UserID:      MustIDBase16(userTwoID),
 						Token:       "rand2",
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},
@@ -1308,16 +1305,16 @@ func DeleteAuthorization(
 						UserID:      MustIDBase16(userOneID),
 						Token:       "rand1",
 						Status:      influxdb.Active,
-						OrgID:       MustIDBase16(orgOneID),
-						Permissions: allUsersPermission(MustIDBase16(orgOneID)),
+						OrgID:       idOne,
+						Permissions: allUsersPermission(idOne),
 					},
 					{
 						ID:          MustIDBase16(authTwoID),
 						UserID:      MustIDBase16(userTwoID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Token:       "rand2",
 						Status:      influxdb.Active,
-						Permissions: createUsersPermission(MustIDBase16(orgOneID)),
+						Permissions: createUsersPermission(idOne),
 					},
 				},
 			},

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	bucketOneID   = "020f755c3c082000"
-	bucketTwoID   = "020f755c3c082001"
-	bucketThreeID = "9565493717473001"
+	idOne = influxdb.ID(iota + 1)
+	idTwo
+	idThree
+	idFour
+	idFive
 )
 
 var bucketCmpOptions = cmp.Options{
@@ -46,32 +48,11 @@ var bucketCmpOptions = cmp.Options{
 	}),
 }
 
-type BucketSvcOpts struct {
-	NoHooks        bool
-	HTTPValidation bool
-}
-
-type BucketOptsFn func(opts *BucketSvcOpts)
-
-// WithoutHooks allows the test suite to be run without being able to hook into the underlying implementation of theservice
-// in most cases that is to remove specific id generation controls.
-func WithoutHooks() BucketOptsFn {
-	return func(opts *BucketSvcOpts) {
-		opts.NoHooks = true
-	}
-}
-
-// WithHTTPValidation skips tests involving name validation that only occurs at the HTTP layer
-func WithHTTPValidation() BucketOptsFn {
-	return func(opts *BucketSvcOpts) {
-		opts.HTTPValidation = true
-	}
-}
-
 // BucketFields will include the IDGenerator, and buckets
 type BucketFields struct {
 	IDGenerator   influxdb.IDGenerator
-	OrgBucketIDs  influxdb.IDGenerator
+	OrgIDs        influxdb.IDGenerator
+	BucketIDs     influxdb.IDGenerator
 	TimeGenerator influxdb.TimeGenerator
 	Buckets       []*influxdb.Bucket
 	Organizations []*influxdb.Organization
@@ -85,8 +66,7 @@ type bucketServiceF func(
 // BucketService tests all the service functions.
 func BucketService(
 	init func(BucketFields, *testing.T) (influxdb.BucketService, string, func()),
-	t *testing.T,
-	opts ...BucketOptsFn) {
+	t *testing.T) {
 	tests := []struct {
 		name string
 		fn   bucketServiceF
@@ -94,14 +74,6 @@ func BucketService(
 		{
 			name: "CreateBucket",
 			fn:   CreateBucket,
-		},
-		{
-			name: "IDUnique",
-			fn:   IDUnique,
-		},
-		{
-			name: "HTTPValidation",
-			fn:   HTTPValidation,
 		},
 		{
 			name: "FindBucketByID",
@@ -124,23 +96,10 @@ func BucketService(
 			fn:   DeleteBucket,
 		},
 	}
-	opt := BucketSvcOpts{
-		NoHooks:        false,
-		HTTPValidation: false,
-	}
-	for _, o := range opts {
-		o(&opt)
-	}
 
 	for _, tt := range tests {
-		if tt.name == "IDUnique" && opt.NoHooks {
-			continue
-		}
-		if tt.name == "HTTPValidation" && !opt.HTTPValidation {
-			continue
-		}
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
 			t.Parallel()
 			tt.fn(init, t)
 		})
@@ -165,26 +124,26 @@ func CreateBucket(
 		fields BucketFields
 		args   args
 		wants  wants
-		skip   string
 	}{
 		{
 			name: "create buckets with empty set",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketOneID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketOneID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idOne),
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Buckets:       []*influxdb.Bucket{},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 			},
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:        "name1",
-					OrgID:       MustIDBase16(orgOneID),
+					OrgID:       idOne,
 					Description: "desc1",
 				},
 			},
@@ -192,8 +151,8 @@ func CreateBucket(
 				buckets: []*influxdb.Bucket{
 					{
 						Name:        "name1",
-						ID:          MustIDBase16(bucketOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						ID:          idOne,
+						OrgID:       idOne,
 						Description: "desc1",
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -206,44 +165,45 @@ func CreateBucket(
 		{
 			name: "basic create bucket",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketTwoID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketTwoID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idTwo),
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
-				Buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Buckets: []*influxdb.Bucket{
+					{
+						// ID(1)
+						Name:  "bucket1",
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:  "bucket2",
-					OrgID: MustIDBase16(orgTwoID),
+					OrgID: idTwo,
 				},
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
+						ID:    idOne,
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
+						ID:    idTwo,
 						Name:  "bucket2",
-						OrgID: MustIDBase16(orgTwoID),
+						OrgID: idTwo,
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
 							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -255,39 +215,40 @@ func CreateBucket(
 		{
 			name: "names should be unique within an organization",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketTwoID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketTwoID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idTwo),
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
-				Buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+					},
+				},
+				Buckets: []*influxdb.Bucket{
+					{
+						// ID(1)
+						Name:  "bucket1",
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:  "bucket1",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 				},
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
+						ID:    idOne,
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 				err: &influxdb.Error{
@@ -300,44 +261,47 @@ func CreateBucket(
 		{
 			name: "names should not be unique across organizations",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketTwoID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketTwoID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idTwo),
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
+						// ID(1)
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:  "bucket1",
-					OrgID: MustIDBase16(orgTwoID),
+					OrgID: idTwo,
 				},
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
+						ID:    idOne,
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
+						// CRUDLog is missing because seed data is created through
+						// storage layer and not service layer (where CRUDLog is populated)
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
+						ID:    idTwo,
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgTwoID),
+						OrgID: idTwo,
 						CRUDLog: influxdb.CRUDLog{
 							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
 							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -345,13 +309,13 @@ func CreateBucket(
 					},
 				},
 			},
-			skip: "flaky test: https://github.com/influxdata/influxdb/issues/19109",
 		},
 		{
 			name: "create bucket with orgID not exist",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketOneID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketOneID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idOne),
+				OrgIDs:        mock.NewStaticIDGenerator(idOne),
+				BucketIDs:     mock.NewStaticIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Buckets:       []*influxdb.Bucket{},
 				Organizations: []*influxdb.Organization{},
@@ -359,7 +323,7 @@ func CreateBucket(
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:  "name1",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 				},
 			},
 			wants: wants{
@@ -371,218 +335,32 @@ func CreateBucket(
 				},
 			},
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip != "" {
-				t.Skip(tt.skip)
-			}
-
-			s, opPrefix, done := init(tt.fields, t)
-			defer done()
-			ctx := context.Background()
-			err := s.CreateBucket(ctx, tt.args.bucket)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
-
-			// Delete only newly created buckets - ie., with a not nil ID
-			// if tt.args.bucket.ID.Valid() {
-			defer s.DeleteBucket(ctx, tt.args.bucket.ID)
-			// }
-
-			buckets, _, err := s.FindBuckets(ctx, influxdb.BucketFilter{})
-			if err != nil {
-				t.Fatalf("failed to retrieve buckets: %v", err)
-			}
-
-			// remove system buckets
-			filteredBuckets := []*influxdb.Bucket{}
-			for _, b := range buckets {
-				if b.Type != influxdb.BucketTypeSystem {
-					filteredBuckets = append(filteredBuckets, b)
-				}
-			}
-
-			if diff := cmp.Diff(filteredBuckets, tt.wants.buckets, bucketCmpOptions...); diff != "" {
-				t.Errorf("buckets are different -got/+want\ndiff %s", diff)
-			}
-		})
-	}
-}
-
-func HTTPValidation(
-	init func(BucketFields, *testing.T) (influxdb.BucketService, string, func()),
-	t *testing.T,
-) {
-	type args struct {
-		bucket *influxdb.Bucket
-	}
-	type wants struct {
-		err     error
-		buckets []*influxdb.Bucket
-	}
-	tests := []struct {
-		name   string
-		fields BucketFields
-		args   args
-		wants  wants
-	}{
 		{
 			name: "create bucket with illegal quotation mark",
 			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketOneID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketOneID, t),
+				IDGenerator:   mock.NewStaticIDGenerator(idOne),
+				BucketIDs:     mock.NewStaticIDGenerator(idOne),
+				OrgIDs:        mock.NewStaticIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Buckets:       []*influxdb.Bucket{},
-				Organizations: []*influxdb.Organization{},
+				Organizations: []*influxdb.Organization{
+					{
+						Name: "org",
+					},
+				},
 			},
 			args: args{
 				bucket: &influxdb.Bucket{
 					Name:  "namewith\"quote",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 				},
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{},
 				err: &influxdb.Error{
 					Code: influxdb.EInvalid,
-					Msg:  "bucket name namewith\"quote is invalid. Bucket names may not include quotation marks",
 					Op:   influxdb.OpCreateBucket,
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
-			defer done()
-			ctx := context.Background()
-			err := s.CreateBucket(ctx, tt.args.bucket)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
-
-			// Delete only newly created buckets - ie., with a not nil ID
-			// if tt.args.bucket.ID.Valid() {
-			defer s.DeleteBucket(ctx, tt.args.bucket.ID)
-			// }
-
-			buckets, _, err := s.FindBuckets(ctx, influxdb.BucketFilter{})
-			if err != nil {
-				t.Fatalf("failed to retrieve buckets: %v", err)
-			}
-
-			// remove system buckets
-			filteredBuckets := []*influxdb.Bucket{}
-			for _, b := range buckets {
-				if b.Type != influxdb.BucketTypeSystem {
-					filteredBuckets = append(filteredBuckets, b)
-				}
-			}
-
-			if diff := cmp.Diff(filteredBuckets, tt.wants.buckets, bucketCmpOptions...); diff != "" {
-				t.Errorf("buckets are different -got/+want\ndiff %s", diff)
-			}
-		})
-	}
-}
-
-// CreateBucket testing
-func IDUnique(
-	init func(BucketFields, *testing.T) (influxdb.BucketService, string, func()),
-	t *testing.T,
-) {
-	type args struct {
-		bucket *influxdb.Bucket
-	}
-	type wants struct {
-		err     error
-		buckets []*influxdb.Bucket
-	}
-
-	tests := []struct {
-		name   string
-		fields BucketFields
-		args   args
-		wants  wants
-	}{
-		{
-			name: "ids should be unique",
-			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator(bucketOneID, t),
-				OrgBucketIDs:  mock.NewIDGenerator(bucketOneID, t),
-				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
-				Buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
-				Organizations: []*influxdb.Organization{
-					{
-						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
-					},
-				},
-			},
-			args: args{
-				bucket: &influxdb.Bucket{
-					ID:    MustIDBase16(bucketOneID),
-					Name:  "bucket2",
-					OrgID: MustIDBase16(orgOneID),
-				},
-			},
-			wants: wants{
-				buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
-				err: &influxdb.Error{
-					Code: influxdb.EInternal,
-					Msg:  "unable to generate valid id",
-				},
-			},
-		},
-		{
-			name: "reserved ids should not be created",
-			fields: BucketFields{
-				IDGenerator:   mock.NewIDGenerator("000000000000000a", t),
-				OrgBucketIDs:  mock.NewIDGenerator("000000000000000a", t),
-				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
-				Buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
-				Organizations: []*influxdb.Organization{
-					{
-						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
-					},
-				},
-			},
-			args: args{
-				bucket: &influxdb.Bucket{
-					Name:  "bucket2",
-					OrgID: MustIDBase16(orgOneID),
-				},
-			},
-			wants: wants{
-				buckets: []*influxdb.Bucket{
-					{
-						ID:    MustIDBase16(bucketOneID),
-						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
-					},
-				},
-				err: &influxdb.Error{
-					Code: influxdb.EInternal,
-					Msg:  "unable to generate valid id",
+					Msg:  "bucket name namewith\"quote is invalid. Bucket names may not include quotation marks",
 				},
 			},
 		},
@@ -643,60 +421,65 @@ func FindBucketByID(
 		{
 			name: "basic find bucket by id",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
+				Organizations: []*influxdb.Organization{
+					{
+						// ID(1)
+						Name: "theorg",
+						ID:   idOne,
+					},
+				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
-					},
-				},
-				Organizations: []*influxdb.Organization{
-					{
-						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 			},
 			args: args{
-				id: MustIDBase16(bucketTwoID),
+				id: idOne,
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:    MustIDBase16(bucketTwoID),
-					OrgID: MustIDBase16(orgOneID),
-					Name:  "bucket2",
+					ID:    idOne,
+					OrgID: idOne,
+					Name:  "bucket1",
 				},
 			},
 		},
 		{
 			name: "find bucket by id not exist",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
+				Organizations: []*influxdb.Organization{
+					{
+						// ID(1)
+						Name: "theorg",
+					},
+				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
-					},
-				},
-				Organizations: []*influxdb.Organization{
-					{
-						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 			},
 			args: args{
-				id: MustIDBase16(threeID),
+				id: idThree,
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -750,25 +533,25 @@ func FindBuckets(
 		{
 			name: "find all buckets",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgTwoID),
+						OrgID: idTwo,
 						Name:  "xyz",
 					},
 				},
@@ -777,13 +560,13 @@ func FindBuckets(
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgTwoID),
+						ID:    idTwo,
+						OrgID: idTwo,
 						Name:  "xyz",
 					},
 				},
@@ -792,26 +575,28 @@ func FindBuckets(
 		{
 			name: "find all buckets by offset and limit",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "def",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(3)
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
@@ -825,8 +610,8 @@ func FindBuckets(
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idTwo,
+						OrgID: idOne,
 						Name:  "def",
 					},
 				},
@@ -835,26 +620,28 @@ func FindBuckets(
 		{
 			name: "find all buckets by descending",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "def",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(3)
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
@@ -868,13 +655,13 @@ func FindBuckets(
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idTwo,
+						OrgID: idOne,
 						Name:  "def",
 					},
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 						Name:  "abc",
 					},
 				},
@@ -883,30 +670,32 @@ func FindBuckets(
 		{
 			name: "find buckets by organization name",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgTwoID),
+						// ID(2)
+						OrgID: idTwo,
 						Name:  "xyz",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(3)
+						OrgID: idOne,
 						Name:  "123",
 					},
 				},
@@ -917,13 +706,13 @@ func FindBuckets(
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idThree,
+						OrgID: idOne,
 						Name:  "123",
 					},
 				},
@@ -932,47 +721,49 @@ func FindBuckets(
 		{
 			name: "find buckets by organization id",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgTwoID),
+						// ID(2)
+						OrgID: idTwo,
 						Name:  "xyz",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(3)
+						OrgID: idOne,
 						Name:  "123",
 					},
 				},
 			},
 			args: args{
-				organizationID: MustIDBase16(orgOneID),
+				organizationID: idOne,
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idThree,
+						OrgID: idOne,
 						Name:  "123",
 					},
 				},
@@ -981,21 +772,23 @@ func FindBuckets(
 		{
 			name: "find bucket by name",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
@@ -1006,8 +799,8 @@ func FindBuckets(
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idTwo,
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
@@ -1016,10 +809,12 @@ func FindBuckets(
 		{
 			name: "missing bucket returns no buckets",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{},
@@ -1075,7 +870,7 @@ func DeleteBucket(
 	t *testing.T,
 ) {
 	type args struct {
-		ID string
+		ID influxdb.ID
 	}
 	type wants struct {
 		err     error
@@ -1091,34 +886,36 @@ func DeleteBucket(
 		{
 			name: "delete buckets using exist id",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
+						// ID(1)
 						Name:  "A",
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
+						// ID(2)
 						Name:  "B",
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
-				ID: bucketOneID,
+				ID: idOne,
 			},
 			wants: wants{
 				buckets: []*influxdb.Bucket{
 					{
 						Name:  "B",
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idTwo,
+						OrgID: idOne,
 					},
 				},
 			},
@@ -1126,27 +923,29 @@ func DeleteBucket(
 		{
 			name: "delete buckets using id that does not exist",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
+						// ID(1)
 						Name:  "A",
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
+						// ID(2)
 						Name:  "B",
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
-				ID: "1234567890654321",
+				ID: MustIDBase16("1234567890654321"),
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -1157,13 +956,13 @@ func DeleteBucket(
 				buckets: []*influxdb.Bucket{
 					{
 						Name:  "A",
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 					},
 					{
 						Name:  "B",
-						ID:    MustIDBase16(bucketThreeID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idTwo,
+						OrgID: idOne,
 					},
 				},
 			},
@@ -1171,23 +970,25 @@ func DeleteBucket(
 		{
 			name: "delete system buckets",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
+						// ID(1)
 						Name:  "A",
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Type:  influxdb.BucketTypeSystem,
 					},
 				},
 			},
 			args: args{
-				ID: bucketOneID,
+				ID: idOne,
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -1198,8 +999,8 @@ func DeleteBucket(
 				buckets: []*influxdb.Bucket{
 					{
 						Name:  "A",
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						ID:    idOne,
+						OrgID: idOne,
 						Type:  influxdb.BucketTypeSystem,
 					},
 				},
@@ -1212,7 +1013,7 @@ func DeleteBucket(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			err := s.DeleteBucket(ctx, MustIDBase16(tt.args.ID))
+			err := s.DeleteBucket(ctx, tt.args.ID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			filter := influxdb.BucketFilter{}
@@ -1261,33 +1062,35 @@ func FindBucket(
 		{
 			name: "find bucket by name",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
 			},
 			args: args{
 				name:           "abc",
-				organizationID: MustIDBase16(orgOneID),
+				organizationID: idOne,
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:    MustIDBase16(bucketOneID),
-					OrgID: MustIDBase16(orgOneID),
+					ID:    idOne,
+					OrgID: idOne,
 					Name:  "abc",
 				},
 			},
@@ -1295,51 +1098,55 @@ func FindBucket(
 		{
 			name: "find bucket by id",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "abc",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "xyz",
 					},
 				},
 			},
 			args: args{
-				id:             MustIDBase16(bucketOneID),
-				organizationID: MustIDBase16(orgOneID),
+				id:             idTwo,
+				organizationID: idOne,
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:    MustIDBase16(bucketOneID),
-					OrgID: MustIDBase16(orgOneID),
-					Name:  "abc",
+					ID:    idTwo,
+					OrgID: idOne,
+					Name:  "xyz",
 				},
 			},
 		},
 		{
 			name: "missing bucket returns error",
 			fields: BucketFields{
+				OrgIDs:    mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{},
 			},
 			args: args{
 				name:           "xyz",
-				organizationID: MustIDBase16(orgOneID),
+				organizationID: idOne,
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -1402,34 +1209,36 @@ func UpdateBucket(
 		{
 			name: "update name",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(bucketOneID),
+				id:   idTwo,
 				name: "changed",
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:    MustIDBase16(bucketOneID),
-					OrgID: MustIDBase16(orgOneID),
+					ID:    idTwo,
+					OrgID: idOne,
 					Name:  "changed",
 					CRUDLog: influxdb.CRUDLog{
 						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -1440,28 +1249,30 @@ func UpdateBucket(
 		{
 			name: "update name unique",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(bucketOneID),
+				id:   idOne,
 				name: "bucket2",
 			},
 			wants: wants{
@@ -1474,24 +1285,26 @@ func UpdateBucket(
 		{
 			name: "update system bucket name",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Type:  influxdb.BucketTypeSystem,
 						Name:  "bucket1",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(bucketOneID),
+				id:   idOne,
 				name: "bucket2",
 			},
 			wants: wants{
@@ -1504,34 +1317,36 @@ func UpdateBucket(
 		{
 			name: "update retention",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:        MustIDBase16(bucketOneID),
+				id:        idOne,
 				retention: 100,
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:              MustIDBase16(bucketOneID),
-					OrgID:           MustIDBase16(orgOneID),
+					ID:              idOne,
+					OrgID:           idOne,
 					Name:            "bucket1",
 					RetentionPeriod: 100 * time.Minute,
 					CRUDLog: influxdb.CRUDLog{
@@ -1543,34 +1358,36 @@ func UpdateBucket(
 		{
 			name: "update description",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:          MustIDBase16(bucketOneID),
+				id:          idOne,
 				description: stringPtr("desc1"),
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:          MustIDBase16(bucketOneID),
-					OrgID:       MustIDBase16(orgOneID),
+					ID:          idOne,
+					OrgID:       idOne,
 					Name:        "bucket1",
 					Description: "desc1",
 					CRUDLog: influxdb.CRUDLog{
@@ -1582,35 +1399,37 @@ func UpdateBucket(
 		{
 			name: "update retention and name",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:        MustIDBase16(bucketTwoID),
+				id:        idOne,
 				retention: 101,
 				name:      "changed",
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:              MustIDBase16(bucketTwoID),
-					OrgID:           MustIDBase16(orgOneID),
+					ID:              idOne,
+					OrgID:           idOne,
 					Name:            "changed",
 					RetentionPeriod: 101 * time.Minute,
 					CRUDLog: influxdb.CRUDLog{
@@ -1622,40 +1441,74 @@ func UpdateBucket(
 		{
 			name: "update retention and same name",
 			fields: BucketFields{
+				OrgIDs:        mock.NewIncrementingIDGenerator(idOne),
+				BucketIDs:     mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
 					},
 				},
 				Buckets: []*influxdb.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(1)
+						OrgID: idOne,
 						Name:  "bucket1",
 					},
 					{
-						ID:    MustIDBase16(bucketTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						// ID(2)
+						OrgID: idOne,
 						Name:  "bucket2",
 					},
 				},
 			},
 			args: args{
-				id:        MustIDBase16(bucketTwoID),
+				id:        idTwo,
 				retention: 101,
 				name:      "bucket2",
 			},
 			wants: wants{
 				bucket: &influxdb.Bucket{
-					ID:              MustIDBase16(bucketTwoID),
-					OrgID:           MustIDBase16(orgOneID),
+					ID:              idTwo,
+					OrgID:           idOne,
 					Name:            "bucket2",
 					RetentionPeriod: 101 * time.Minute,
 					CRUDLog: influxdb.CRUDLog{
 						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
 					},
+				},
+			},
+		},
+		{
+			name: "update bucket with illegal quotation mark",
+			fields: BucketFields{
+				OrgIDs:        mock.NewStaticIDGenerator(idOne),
+				BucketIDs:     mock.NewStaticIDGenerator(idOne),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
+				Organizations: []*influxdb.Organization{
+					{
+						// ID(1)
+						Name: "org",
+					},
+				},
+				Buckets: []*influxdb.Bucket{
+					{
+						// ID(1)
+						Name:  "valid name",
+						OrgID: idOne,
+					},
+				},
+			},
+			args: args{
+				id:   idOne,
+				name: "namewith\"quote",
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.EInvalid,
+					Op:   influxdb.OpCreateBucket,
+					Msg:  "bucket name namewith\"quote is invalid. Bucket names may not include quotation marks",
 				},
 			},
 		},

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -39,7 +39,7 @@ var deadman1 = &check.Deadman{
 	Base: check.Base{
 		Name:        "name1",
 		ID:          MustIDBase16(checkOneID),
-		OrgID:       MustIDBase16(orgOneID),
+		OrgID:       idOne,
 		OwnerID:     MustIDBase16(sixID),
 		Description: "desc1",
 		TaskID:      1,
@@ -84,7 +84,7 @@ var threshold1 = &check.Threshold{
 	Base: check.Base{
 		Name:                  "name2",
 		ID:                    MustIDBase16(checkTwoID),
-		OrgID:                 MustIDBase16(orgTwoID),
+		OrgID:                 idTwo,
 		OwnerID:               MustIDBase16(sixID),
 		TaskID:                1,
 		Description:           "desc2",
@@ -244,24 +244,24 @@ func CreateCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(fiveID),
 						UserType:     influxdb.Owner,
 					},
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
 					},
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(twoID),
 						UserType:     influxdb.Member,
@@ -273,7 +273,7 @@ func CreateCheck(
 				check: &check.Deadman{
 					Base: check.Base{
 						Name:        "name1",
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Description: "desc1",
 						Query: influxdb.DashboardQuery{
 							Text: script,
@@ -330,7 +330,7 @@ func CreateCheck(
 						Base: check.Base{
 							Name:    "name1",
 							ID:      MustIDBase16(checkOneID),
-							OrgID:   MustIDBase16(orgOneID),
+							OrgID:   idOne,
 							OwnerID: MustIDBase16(twoID),
 							Query: influxdb.DashboardQuery{
 								Text: script,
@@ -382,13 +382,13 @@ func CreateCheck(
 				},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceID:   idTwo,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
 					},
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
@@ -407,11 +407,11 @@ func CreateCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 			},
@@ -420,7 +420,7 @@ func CreateCheck(
 				check: &check.Threshold{
 					Base: check.Base{
 						Name:                  "name2",
-						OrgID:                 MustIDBase16(orgTwoID),
+						OrgID:                 idTwo,
 						OwnerID:               MustIDBase16(twoID),
 						Description:           "desc2",
 						StatusMessageTemplate: "msg2",
@@ -482,13 +482,13 @@ func CreateCheck(
 			fields: CheckFields{
 				UserResourceMappings: []*influxdb.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceID:   idTwo,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
 					},
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
@@ -512,11 +512,11 @@ func CreateCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 			},
@@ -525,7 +525,7 @@ func CreateCheck(
 				check: &check.Threshold{
 					Base: check.Base{
 						Name:        "name1",
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Description: "desc1",
 						Every:       mustDuration("1m"),
 						Query: influxdb.DashboardQuery{
@@ -582,13 +582,13 @@ func CreateCheck(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(orgTwoID),
+						ResourceID:   idTwo,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(twoID),
 						UserType:     influxdb.Owner,
 					},
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: influxdb.OrgsResourceType,
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Owner,
@@ -603,11 +603,11 @@ func CreateCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -619,7 +619,7 @@ func CreateCheck(
 				check: &check.Threshold{
 					Base: check.Base{
 						Name:        "name1",
-						OrgID:       MustIDBase16(orgTwoID),
+						OrgID:       idTwo,
 						Description: "desc2",
 						Every:       mustDuration("1m"),
 						Query: influxdb.DashboardQuery{
@@ -667,7 +667,7 @@ func CreateCheck(
 						Base: check.Base{
 							ID:    MustIDBase16(checkTwoID),
 							Name:  "name1",
-							OrgID: MustIDBase16(orgTwoID),
+							OrgID: idTwo,
 							Every: mustDuration("1m"),
 							Query: influxdb.DashboardQuery{
 								Text: script,
@@ -718,7 +718,7 @@ func CreateCheck(
 				check: &check.Threshold{
 					Base: check.Base{
 						Name:  "name1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Every: mustDuration("1m"),
 						Query: influxdb.DashboardQuery{
 							Text: script,
@@ -819,7 +819,7 @@ func FindCheckByID(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 			},
@@ -840,7 +840,7 @@ func FindCheckByID(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 			},
@@ -917,11 +917,11 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -959,7 +959,7 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -999,7 +999,7 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1040,11 +1040,11 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1082,11 +1082,11 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "otherorg",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1096,7 +1096,7 @@ func FindChecks(
 			},
 			args: args{
 				userID: MustIDBase16(sixID),
-				OrgID:  MustIDBase16(orgTwoID),
+				OrgID:  idTwo,
 			},
 			wants: wants{
 				checks: []influxdb.Check{
@@ -1110,7 +1110,7 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
@@ -1148,7 +1148,7 @@ func FindChecks(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{},
@@ -1223,7 +1223,7 @@ func DeleteCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
@@ -1244,7 +1244,7 @@ func DeleteCheck(
 					{
 						Flux: `option task = { every: 10s, name: "foo" }
 data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
+						OrganizationID: idOne,
 						OwnerID:        MustIDBase16(sixID),
 					},
 				},
@@ -1270,7 +1270,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				UserResourceMappings: []*influxdb.UserResourceMapping{
@@ -1291,7 +1291,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 					{
 						Flux: `option task = { every: 10s, name: "foo" }
 		data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
+						OrganizationID: idOne,
 						OwnerID:        MustIDBase16(sixID),
 					},
 				},
@@ -1370,11 +1370,11 @@ func FindCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "theorg2",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1384,7 +1384,7 @@ func FindCheck(
 			},
 			args: args{
 				name:  "name1",
-				OrgID: MustIDBase16(orgOneID),
+				OrgID: idOne,
 			},
 			wants: wants{
 				check: deadman1,
@@ -1396,14 +1396,14 @@ func FindCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{},
 			},
 			args: args{
 				name:  "name2",
-				OrgID: MustIDBase16(orgOneID),
+				OrgID: idOne,
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -1419,14 +1419,14 @@ func FindCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{},
 			},
 			args: args{
 				name:  "xyz",
-				OrgID: MustIDBase16(orgOneID),
+				OrgID: idOne,
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -1489,14 +1489,14 @@ func UpdateCheck(
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Tasks: []influxdb.TaskCreate{
 					{
 						Flux: `option task = { every: 10s, name: "foo" }
 data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
+						OrganizationID: idOne,
 						OwnerID:        MustIDBase16(sixID),
 					},
 				},
@@ -1509,7 +1509,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				check: &check.Threshold{
 					Base: check.Base{
 						ID:      MustIDBase16(checkTwoID),
-						OrgID:   MustIDBase16(orgOneID),
+						OrgID:   idOne,
 						OwnerID: MustIDBase16(twoID),
 						Every:   mustDuration("1m"),
 						Query: influxdb.DashboardQuery{
@@ -1570,7 +1570,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				check: &check.Threshold{
 					Base: check.Base{
 						ID:      MustIDBase16(checkOneID),
-						OrgID:   MustIDBase16(orgOneID),
+						OrgID:   idOne,
 						Name:    "changed",
 						Every:   mustDuration("1m"),
 						OwnerID: MustIDBase16(sixID),
@@ -1635,7 +1635,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1643,7 +1643,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 					&check.Deadman{
 						Base: check.Base{
 							ID:    MustIDBase16(checkTwoID),
-							OrgID: MustIDBase16(orgOneID),
+							OrgID: idOne,
 							Every: mustDuration("1m"),
 							Query: influxdb.DashboardQuery{
 								Text: script,
@@ -1673,7 +1673,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				id: MustIDBase16(checkOneID),
 				check: &check.Deadman{
 					Base: check.Base{
-						OrgID:                 MustIDBase16(orgOneID),
+						OrgID:                 idOne,
 						OwnerID:               MustIDBase16(twoID),
 						Name:                  "check2",
 						Description:           "desc changed",
@@ -1754,14 +1754,14 @@ func PatchCheck(
 					{
 						Flux: `option task = { every: 10s, name: "foo" }
 data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
+						OrganizationID: idOne,
 						OwnerID:        MustIDBase16(sixID),
 					},
 				},
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1780,7 +1780,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				check: &check.Deadman{
 					Base: check.Base{
 						ID:          MustIDBase16(checkOneID),
-						OrgID:       MustIDBase16(orgOneID),
+						OrgID:       idOne,
 						Name:        "changed",
 						OwnerID:     MustIDBase16(sixID),
 						Every:       mustDuration("1m"),
@@ -1829,7 +1829,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1837,7 +1837,7 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 					&check.Deadman{
 						Base: check.Base{
 							ID:      MustIDBase16(checkTwoID),
-							OrgID:   MustIDBase16(orgOneID),
+							OrgID:   idOne,
 							Every:   mustDuration("1m"),
 							Name:    "check2",
 							OwnerID: MustIDBase16(sixID),

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -115,7 +115,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "label_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -126,7 +126,7 @@ func CreateLabel(
 				label: &influxdb.Label{
 					ID:    MustIDBase16(labelTwoID),
 					Name:  "label_1",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 					Properties: map[string]string{
 						"color": "fff000",
 					},
@@ -137,7 +137,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "label_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -158,7 +158,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -169,7 +169,7 @@ func CreateLabel(
 				label: &influxdb.Label{
 					ID:    MustIDBase16(labelOneID),
 					Name:  "     tag_1     ",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 					Properties: map[string]string{
 						"color": "fff000",
 					},
@@ -180,7 +180,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -201,7 +201,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -212,7 +212,7 @@ func CreateLabel(
 				label: &influxdb.Label{
 					ID:    MustIDBase16(labelOneID),
 					Name:  "TAG_1",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 					Properties: map[string]string{
 						"color": "fff000",
 					},
@@ -223,7 +223,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag_1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -246,7 +246,7 @@ func CreateLabel(
 				label: &influxdb.Label{
 					Name:  "Tag2",
 					ID:    MustIDBase16(labelOneID),
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 					Properties: map[string]string{
 						"color": "fff000",
 					},
@@ -257,7 +257,7 @@ func CreateLabel(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag2",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -313,12 +313,12 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
 						Name:  "Tag2",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -330,12 +330,12 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
 						Name:  "Tag2",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -347,24 +347,24 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
 						Name:  "Tag2",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
 						ID:    MustIDBase16(labelThreeID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgTwoID),
+						OrgID: idTwo,
 					},
 				},
 			},
 			args: args{
 				filter: influxdb.LabelFilter{
 					Name:  "Tag1",
-					OrgID: idPtr(MustIDBase16(orgOneID)),
+					OrgID: idPtr(idOne),
 				},
 			},
 			wants: wants{
@@ -372,7 +372,7 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -384,14 +384,14 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
 			args: args{
 				filter: influxdb.LabelFilter{
 					Name:  "TAG1",
-					OrgID: idPtr(MustIDBase16(orgOneID)),
+					OrgID: idPtr(idOne),
 				},
 			},
 			wants: wants{
@@ -399,7 +399,7 @@ func FindLabels(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -446,12 +446,12 @@ func FindLabelByID(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
 						Name:  "Tag2",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -462,7 +462,7 @@ func FindLabelByID(
 				label: &influxdb.Label{
 					ID:    MustIDBase16(labelOneID),
 					Name:  "Tag1",
-					OrgID: MustIDBase16(orgOneID),
+					OrgID: idOne,
 				},
 			},
 		},
@@ -524,7 +524,7 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 				},
@@ -539,7 +539,7 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "NotTag1",
 					},
 				},
@@ -551,12 +551,12 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_1",
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_2",
 					},
 				},
@@ -571,12 +571,12 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_1",
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_2",
 					},
 				},
@@ -593,12 +593,12 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_1",
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_2",
 					},
 				},
@@ -613,12 +613,12 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_1",
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "tag_2",
 					},
 				},
@@ -635,7 +635,7 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 				},
@@ -652,7 +652,7 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
@@ -667,7 +667,7 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
@@ -688,7 +688,7 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 						Properties: map[string]string{
 							"color":       "abc123",
@@ -704,7 +704,7 @@ func UpdateLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
@@ -725,7 +725,7 @@ func UpdateLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
@@ -801,12 +801,12 @@ func DeleteLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag2",
 					},
 				},
@@ -818,7 +818,7 @@ func DeleteLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelTwoID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag2",
 					},
 				},
@@ -830,7 +830,7 @@ func DeleteLabel(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 				},
@@ -842,7 +842,7 @@ func DeleteLabel(
 				labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 				},
@@ -899,7 +899,7 @@ func CreateLabelMapping(
 				Labels: []*influxdb.Label{
 					{
 						ID:    MustIDBase16(labelOneID),
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 						Name:  "Tag1",
 					},
 				},
@@ -907,10 +907,10 @@ func CreateLabelMapping(
 			args: args{
 				mapping: &influxdb.LabelMapping{
 					LabelID:    MustIDBase16(labelOneID),
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 				filter: &influxdb.LabelMappingFilter{
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 			},
 			wants: wants{
@@ -918,7 +918,7 @@ func CreateLabelMapping(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 			},
@@ -932,7 +932,7 @@ func CreateLabelMapping(
 			args: args{
 				mapping: &influxdb.LabelMapping{
 					LabelID:    MustIDBase16(labelOneID),
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 			},
 			wants: wants{
@@ -996,23 +996,23 @@ func DeleteLabelMapping(
 					{
 						ID:    MustIDBase16(labelOneID),
 						Name:  "Tag1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 				Mappings: []*influxdb.LabelMapping{
 					{
 						LabelID:    MustIDBase16(labelOneID),
-						ResourceID: MustIDBase16(bucketOneID),
+						ResourceID: idOne,
 					},
 				},
 			},
 			args: args{
 				mapping: &influxdb.LabelMapping{
 					LabelID:    MustIDBase16(labelOneID),
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 				filter: influxdb.LabelMappingFilter{
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 			},
 			wants: wants{

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -12,11 +12,6 @@ import (
 	"github.com/influxdata/influxdb/v2/mock"
 )
 
-const (
-	orgOneID = "020f755c3c083000"
-	orgTwoID = "020f755c3c083001"
-)
-
 var orgBucketsIDGenerator = mock.NewMockIDGenerator()
 
 var organizationCmpOptions = cmp.Options{
@@ -43,10 +38,10 @@ var organizationCmpOptions = cmp.Options{
 
 // OrganizationFields will include the IDGenerator, and organizations
 type OrganizationFields struct {
-	IDGenerator   *mock.MockIDGenerator
+	IDGenerator   influxdb.IDGenerator
+	OrgBucketIDs  influxdb.IDGenerator
 	Organizations []*influxdb.Organization
 	TimeGenerator influxdb.TimeGenerator
-	OrgBucketIDs  *mock.MockIDGenerator
 }
 
 // OrganizationService tests all the service functions.
@@ -122,7 +117,7 @@ func CreateOrganization(
 			args: args{
 				organization: &influxdb.Organization{
 					Name:        "name1",
-					ID:          MustIDBase16(orgOneID),
+					ID:          idOne,
 					Description: "desc1",
 				},
 			},
@@ -148,21 +143,21 @@ func CreateOrganization(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
 			},
 			args: args{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgTwoID),
+					ID:   idTwo,
 					Name: "organization2",
 				},
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 					{
@@ -184,20 +179,20 @@ func CreateOrganization(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
 			},
 			args: args{
 				organization: &influxdb.Organization{
-					ID: MustIDBase16(orgOneID),
+					ID: idTwo,
 				},
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
@@ -212,21 +207,21 @@ func CreateOrganization(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
 			},
 			args: args{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
+					ID:   idTwo,
 					Name: "  ",
 				},
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
@@ -241,21 +236,21 @@ func CreateOrganization(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
 			},
 			args: args{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
+					ID:   idTwo,
 					Name: "organization1",
 				},
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
@@ -274,7 +269,7 @@ func CreateOrganization(
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
@@ -287,7 +282,7 @@ func CreateOrganization(
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 					{
@@ -346,23 +341,24 @@ func FindOrganizationByID(
 		{
 			name: "basic find organization by id",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id: MustIDBase16(orgTwoID),
+				id: idTwo,
 			},
 			wants: wants{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgTwoID),
+					ID:   idTwo,
 					Name: "organization2",
 				},
 			},
@@ -370,19 +366,20 @@ func FindOrganizationByID(
 		{
 			name: "didn't find organization by id",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id: MustIDBase16(threeID),
+				id: idThree,
 			},
 			wants: wants{
 				organization: nil,
@@ -434,13 +431,14 @@ func FindOrganizations(
 		{
 			name: "find all organizations",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:          MustIDBase16(orgTwoID),
+						// ID(2)
 						Name:        "xyz",
 						Description: "desc xyz",
 					},
@@ -450,11 +448,11 @@ func FindOrganizations(
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "abc",
 					},
 					{
-						ID:          MustIDBase16(orgTwoID),
+						ID:          idTwo,
 						Name:        "xyz",
 						Description: "desc xyz",
 					},
@@ -464,24 +462,25 @@ func FindOrganizations(
 		{
 			name: "find organization by id",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "xyz",
 					},
 				},
 			},
 			args: args{
-				ID: MustIDBase16(orgTwoID),
+				ID: idTwo,
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 						Name: "xyz",
 					},
 				},
@@ -490,13 +489,14 @@ func FindOrganizations(
 		{
 			name: "find organization by name",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "xyz",
 					},
 				},
@@ -507,7 +507,7 @@ func FindOrganizations(
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 						Name: "xyz",
 					},
 				},
@@ -516,19 +516,20 @@ func FindOrganizations(
 		{
 			name: "find organization by id not exists",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "xyz",
 					},
 				},
 			},
 			args: args{
-				ID: MustIDBase16(threeID),
+				ID: idThree,
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{},
@@ -542,13 +543,14 @@ func FindOrganizations(
 		{
 			name: "find organization by name not exists",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "xyz",
 					},
 				},
@@ -597,7 +599,7 @@ func DeleteOrganization(
 	t *testing.T,
 ) {
 	type args struct {
-		ID string
+		ID influxdb.ID
 	}
 	type wants struct {
 		err           error
@@ -613,25 +615,26 @@ func DeleteOrganization(
 		{
 			name: "delete organizations using exist id",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "orgA",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "orgB",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 			},
 			args: args{
-				ID: orgOneID,
+				ID: idOne,
 			},
 			wants: wants{
 				organizations: []*influxdb.Organization{
 					{
 						Name: "orgB",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 			},
@@ -639,20 +642,21 @@ func DeleteOrganization(
 		{
 			name: "delete organizations using id that does not exist",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
+						// ID(1)
 						Name: "orgA",
-						ID:   MustIDBase16(orgOneID),
 					},
 					{
+						// ID(2)
 						Name: "orgB",
-						ID:   MustIDBase16(orgTwoID),
 					},
 				},
 			},
 			args: args{
-				ID: "1234567890654321",
+				ID: MustIDBase16("1234567890654321"),
 			},
 			wants: wants{
 				err: &influxdb.Error{
@@ -663,11 +667,11 @@ func DeleteOrganization(
 				organizations: []*influxdb.Organization{
 					{
 						Name: "orgA",
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 					},
 					{
 						Name: "orgB",
-						ID:   MustIDBase16(orgTwoID),
+						ID:   idTwo,
 					},
 				},
 			},
@@ -679,7 +683,7 @@ func DeleteOrganization(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			err := s.DeleteOrganization(ctx, MustIDBase16(tt.args.ID))
+			err := s.DeleteOrganization(ctx, tt.args.ID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			filter := influxdb.OrganizationFilter{}
@@ -717,13 +721,14 @@ func FindOrganization(
 		{
 			name: "find organization by name",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "abc",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "xyz",
 					},
 				},
@@ -733,7 +738,7 @@ func FindOrganization(
 			},
 			wants: wants{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
+					ID:   idOne,
 					Name: "abc",
 				},
 			},
@@ -766,9 +771,10 @@ func FindOrganization(
 		{
 			name: "find organization no filter is set returns an error about filters not provided",
 			fields: OrganizationFields{
+				OrgBucketIDs: mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "o1",
 					},
 				},
@@ -780,6 +786,7 @@ func FindOrganization(
 		{
 			name: "missing organization returns error",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				Organizations: []*influxdb.Organization{},
 			},
 			args: args{
@@ -842,14 +849,15 @@ func UpdateOrganization(
 		{
 			name: "update id not exists",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
@@ -869,25 +877,26 @@ func UpdateOrganization(
 		{
 			name: "update name",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(orgOneID),
+				id:   idOne,
 				name: strPtr("changed"),
 			},
 			wants: wants{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
+					ID:   idOne,
 					Name: "changed",
 					CRUDLog: influxdb.CRUDLog{
 						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -898,25 +907,26 @@ func UpdateOrganization(
 		{
 			name: "update name to same name",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(orgOneID),
+				id:   idOne,
 				name: strPtr("organization1"),
 			},
 			wants: wants{
 				organization: &influxdb.Organization{
-					ID:   MustIDBase16(orgOneID),
+					ID:   idOne,
 					Name: "organization1",
 					CRUDLog: influxdb.CRUDLog{
 						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
@@ -926,20 +936,21 @@ func UpdateOrganization(
 		}, {
 			name: "update name not unique",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(orgOneID),
+				id:   idOne,
 				name: strPtr("organization2"),
 			},
 			wants: wants{
@@ -953,20 +964,21 @@ func UpdateOrganization(
 		{
 			name: "update name is empty",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(orgOneID),
+				id:   idOne,
 				name: strPtr(""),
 			},
 			wants: wants{
@@ -976,20 +988,21 @@ func UpdateOrganization(
 		{
 			name: "update name only has space",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						// ID(1)
 						Name: "organization1",
 					},
 					{
-						ID:   MustIDBase16(orgTwoID),
+						// ID(2)
 						Name: "organization2",
 					},
 				},
 			},
 			args: args{
-				id:   MustIDBase16(orgOneID),
+				id:   idOne,
 				name: strPtr("            "),
 			},
 			wants: wants{
@@ -999,27 +1012,28 @@ func UpdateOrganization(
 		{
 			name: "update description",
 			fields: OrganizationFields{
+				OrgBucketIDs:  mock.NewIncrementingIDGenerator(idOne),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
-						ID:          MustIDBase16(orgOneID),
+						// ID(1)
 						Name:        "organization1",
 						Description: "organization1 description",
 					},
 					{
-						ID:          MustIDBase16(orgTwoID),
+						// ID(2)
 						Name:        "organization2",
 						Description: "organization2 description",
 					},
 				},
 			},
 			args: args{
-				id:          MustIDBase16(orgOneID),
+				id:          idOne,
 				description: strPtr("changed"),
 			},
 			wants: wants{
 				organization: &influxdb.Organization{
-					ID:          MustIDBase16(orgOneID),
+					ID:          idOne,
 					Name:        "organization1",
 					Description: "changed",
 					CRUDLog: influxdb.CRUDLog{

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -21,33 +21,33 @@ var (
 	target1 = influxdb.ScraperTarget{
 		Name:     "name1",
 		Type:     influxdb.PrometheusScraperType,
-		OrgID:    MustIDBase16(orgOneID),
-		BucketID: MustIDBase16(bucketOneID),
+		OrgID:    idOne,
+		BucketID: idOne,
 		URL:      "url1",
 		ID:       MustIDBase16(targetOneID),
 	}
 	target2 = influxdb.ScraperTarget{
 		Name:     "name2",
 		Type:     influxdb.PrometheusScraperType,
-		OrgID:    MustIDBase16(orgTwoID),
-		BucketID: MustIDBase16(bucketTwoID),
+		OrgID:    idTwo,
+		BucketID: idTwo,
 		URL:      "url2",
 		ID:       MustIDBase16(targetTwoID),
 	}
 	target3 = influxdb.ScraperTarget{
 		Name:     "name3",
 		Type:     influxdb.PrometheusScraperType,
-		OrgID:    MustIDBase16(orgOneID),
-		BucketID: MustIDBase16(bucketThreeID),
+		OrgID:    idOne,
+		BucketID: idThree,
 		URL:      "url3",
 		ID:       MustIDBase16(targetThreeID),
 	}
 	org1 = influxdb.Organization{
-		ID:   MustIDBase16(orgOneID),
+		ID:   idOne,
 		Name: "org1",
 	}
 	org2 = influxdb.Organization{
-		ID:   MustIDBase16(orgTwoID),
+		ID:   idTwo,
 		Name: "org2",
 	}
 )
@@ -147,8 +147,8 @@ func AddTarget(
 				target: &influxdb.ScraperTarget{
 					Name:     "name1",
 					Type:     influxdb.PrometheusScraperType,
-					OrgID:    MustIDBase16(orgOneID),
-					BucketID: MustIDBase16(bucketOneID),
+					OrgID:    idOne,
+					BucketID: idOne,
 					URL:      "url1",
 				},
 			},
@@ -165,8 +165,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -183,8 +183,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -195,7 +195,7 @@ func AddTarget(
 					ID:       MustIDBase16(targetTwoID),
 					Name:     "name2",
 					Type:     influxdb.PrometheusScraperType,
-					BucketID: MustIDBase16(bucketTwoID),
+					BucketID: idTwo,
 					URL:      "url2",
 				},
 			},
@@ -210,8 +210,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -228,8 +228,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -240,7 +240,7 @@ func AddTarget(
 					ID:    MustIDBase16(targetTwoID),
 					Name:  "name2",
 					Type:  influxdb.PrometheusScraperType,
-					OrgID: MustIDBase16(orgTwoID),
+					OrgID: idTwo,
 					URL:   "url2",
 				},
 			},
@@ -255,8 +255,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -271,8 +271,8 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
@@ -293,8 +293,8 @@ func AddTarget(
 					ID:       MustIDBase16(targetTwoID),
 					Name:     "name2",
 					Type:     influxdb.PrometheusScraperType,
-					OrgID:    MustIDBase16(orgTwoID),
-					BucketID: MustIDBase16(bucketTwoID),
+					OrgID:    idTwo,
+					BucketID: idTwo,
 					URL:      "url2",
 				},
 			},
@@ -317,16 +317,16 @@ func AddTarget(
 					{
 						Name:     "name1",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
 					},
 					{
 						Name:     "name2",
 						Type:     influxdb.PrometheusScraperType,
-						OrgID:    MustIDBase16(orgTwoID),
-						BucketID: MustIDBase16(bucketTwoID),
+						OrgID:    idTwo,
+						BucketID: idTwo,
 						URL:      "url2",
 						ID:       MustIDBase16(targetTwoID),
 					},
@@ -471,7 +471,7 @@ func ListTargets(
 			},
 			args: args{
 				filter: influxdb.ScraperTargetFilter{
-					OrgID: idPtr(MustIDBase16(orgOneID)),
+					OrgID: idPtr(idOne),
 				},
 			},
 			wants: wants{
@@ -495,7 +495,7 @@ func ListTargets(
 			},
 			args: args{
 				filter: influxdb.ScraperTargetFilter{
-					OrgID: idPtr(MustIDBase16(orgOneID)),
+					OrgID: idPtr(idOne),
 				},
 			},
 			wants: wants{
@@ -600,14 +600,14 @@ func GetTargetByID(
 					{
 						ID:       MustIDBase16(targetOneID),
 						Name:     "target1",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						Name:     "target2",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -618,8 +618,8 @@ func GetTargetByID(
 				target: &influxdb.ScraperTarget{
 					ID:       MustIDBase16(targetTwoID),
 					Name:     "target2",
-					OrgID:    MustIDBase16(orgOneID),
-					BucketID: MustIDBase16(bucketOneID),
+					OrgID:    idOne,
+					BucketID: idOne,
 				},
 			},
 		},
@@ -630,14 +630,14 @@ func GetTargetByID(
 					{
 						ID:       MustIDBase16(targetOneID),
 						Name:     "target1",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						Name:     "target2",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -709,13 +709,13 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 				Targets: []*influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -735,8 +735,8 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 				targets: []influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetTwoID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -762,13 +762,13 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 				Targets: []*influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -785,13 +785,13 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 				targets: []influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 				userResourceMappings: []*influxdb.UserResourceMapping{
@@ -869,14 +869,14 @@ func UpdateTarget(
 					{
 						ID:       MustIDBase16(targetOneID),
 						URL:      "url1",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						URL:      "url2",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -899,14 +899,14 @@ func UpdateTarget(
 					{
 						ID:       MustIDBase16(targetOneID),
 						URL:      "url1",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						URL:      "url2",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -930,14 +930,14 @@ func UpdateTarget(
 					{
 						ID:       MustIDBase16(targetOneID),
 						URL:      "url1",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						URL:      "url2",
-						OrgID:    MustIDBase16(orgOneID),
-						BucketID: MustIDBase16(bucketOneID),
+						OrgID:    idOne,
+						BucketID: idOne,
 					},
 				},
 			},
@@ -949,8 +949,8 @@ func UpdateTarget(
 				target: &influxdb.ScraperTarget{
 					ID:       MustIDBase16(targetOneID),
 					URL:      "changed",
-					OrgID:    MustIDBase16(orgOneID),
-					BucketID: MustIDBase16(bucketOneID),
+					OrgID:    idOne,
+					BucketID: idOne,
 				},
 			},
 		},

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -122,7 +122,7 @@ func CreateUserResourceMapping(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -132,7 +132,7 @@ func CreateUserResourceMapping(
 			}(),
 			args: args{
 				mapping: &platform.UserResourceMapping{
-					ResourceID:   MustIDBase16(bucketTwoID),
+					ResourceID:   idTwo,
 					UserID:       MustIDBase16(userTwoID),
 					UserType:     platform.Member,
 					ResourceType: platform.BucketsResourceType,
@@ -141,13 +141,13 @@ func CreateUserResourceMapping(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -161,7 +161,7 @@ func CreateUserResourceMapping(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -171,7 +171,7 @@ func CreateUserResourceMapping(
 			}(),
 			args: args{
 				mapping: &platform.UserResourceMapping{
-					ResourceID:   MustIDBase16(bucketOneID),
+					ResourceID:   idOne,
 					UserID:       MustIDBase16(userOneID),
 					UserType:     platform.Member,
 					ResourceType: platform.BucketsResourceType,
@@ -180,7 +180,7 @@ func CreateUserResourceMapping(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -245,7 +245,7 @@ func DeleteUserResourceMapping(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -254,7 +254,7 @@ func DeleteUserResourceMapping(
 				return f
 			}(),
 			args: args{
-				resourceID: MustIDBase16(bucketOneID),
+				resourceID: idOne,
 				userID:     MustIDBase16(userOneID),
 			},
 			wants: wants{
@@ -267,7 +267,7 @@ func DeleteUserResourceMapping(
 				UserResourceMappings: []*platform.UserResourceMapping{},
 			},
 			args: args{
-				resourceID: MustIDBase16(bucketOneID),
+				resourceID: idOne,
 				userID:     MustIDBase16(userOneID),
 			},
 			wants: wants{
@@ -280,7 +280,7 @@ func DeleteUserResourceMapping(
 			fields: UserResourceFields{
 				Organizations: []*platform.Organization{
 					{
-						ID:   MustIDBase16(orgOneID),
+						ID:   idOne,
 						Name: "organization1",
 					},
 				},
@@ -292,14 +292,14 @@ func DeleteUserResourceMapping(
 				},
 				Buckets: []*platform.Bucket{
 					{
-						ID:    MustIDBase16(bucketOneID),
+						ID:    idOne,
 						Name:  "bucket1",
-						OrgID: MustIDBase16(orgOneID),
+						OrgID: idOne,
 					},
 				},
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(orgOneID),
+						ResourceID:   idOne,
 						ResourceType: platform.OrgsResourceType,
 						MappingType:  platform.UserMappingType,
 						UserID:       MustIDBase16(userOneID),
@@ -308,7 +308,7 @@ func DeleteUserResourceMapping(
 				},
 			},
 			args: args{
-				resourceID: MustIDBase16(orgOneID),
+				resourceID: idOne,
 				userID:     MustIDBase16(userOneID),
 			},
 			wants: wants{
@@ -368,13 +368,13 @@ func FindUserResourceMappings(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -388,13 +388,13 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -408,13 +408,13 @@ func FindUserResourceMappings(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -430,7 +430,7 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -444,13 +444,13 @@ func FindUserResourceMappings(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -460,13 +460,13 @@ func FindUserResourceMappings(
 			}(),
 			args: args{
 				filter: platform.UserResourceMappingFilter{
-					ResourceID: MustIDBase16(bucketOneID),
+					ResourceID: idOne,
 				},
 			},
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -480,13 +480,13 @@ func FindUserResourceMappings(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketOneID),
+						ResourceID:   idOne,
 						UserID:       MustIDBase16(userOneID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Owner,
 						ResourceType: platform.BucketsResourceType,
@@ -502,7 +502,7 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Owner,
 						ResourceType: platform.BucketsResourceType,
@@ -516,7 +516,7 @@ func FindUserResourceMappings(
 				f := baseUserResourceFields()
 				f.UserResourceMappings = []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,
@@ -532,7 +532,7 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID:   MustIDBase16(bucketTwoID),
+						ResourceID:   idTwo,
 						UserID:       MustIDBase16(userTwoID),
 						UserType:     platform.Member,
 						ResourceType: platform.BucketsResourceType,


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19109

This is a big clean-up PR. Mostly targetted at tests. It is a precursor to some fixes I want to work on for pagination when listing buckets. As I want to write a solid and deterministic set of tests which exercise organizations with both legacy and new setups.

The minor changes to _internal behaviour_ are this:

1. Tenant stores no longer lets to specify your own ID. They _all_ get generated by the ID generator. (This was only used for tests).
2. There is no longer a set of `1000` reserved IDs. Now that system buckets don't live in this range, it appears arbitrary and complicates test data. You can't provide an ID via the API anyway, so this is purely an internal impact.

The `tenant` package stores were allowing for IDs to be provided through the front-door. Where the true exposed API would not let you do this. The http layer would not parse an ID. This was a case of test behaviour driving implementation.

The original `kv` implementations used the ID generator interface and I believe this was the right way to go about it.
Because, it means that we don't have any conditional changes just for non production use cases.
Meaning, we can test the entire implementation. (Providing an ID let you bypass uniqueness constraint validation).

The `testing` package contains harnesses for each of our services. We run them against service level implementation, middlewares and transport layer implementations. We expect the same behaviour from each layer.
However, this had started to bleed between layers. Which was evident in the fact that special override options were starting to be introduced into the `testing` package:

https://github.com/influxdata/influxdb/blob/50964d732c4221343bb03955b5de5d0d4421445d/testing/bucket_service.go#L49-L69

This change makes `tenant` and `kv` implement the same contract once again.

The bulk of this is ready. I am just ironing out some side effects in test depending on broken behaviour.
