### PR TITLE
refactor: clean up community templates ui

### DIFF
--- a/ui/src/templates/actions/creators.ts
+++ b/ui/src/templates/actions/creators.ts
@@ -31,7 +31,7 @@ export type Action =
   | ReturnType<typeof setExportTemplate>
   | ReturnType<typeof setTemplatesStatus>
   | ReturnType<typeof setTemplateSummary>
-  | ReturnType<typeof setCommunityTemplateToInstall>
+  | ReturnType<typeof setStagedCommunityTemplate>
   | ReturnType<typeof toggleTemplateResourceInstall>
   | ReturnType<typeof setStacks>
   | ReturnType<typeof removeStack>
@@ -91,7 +91,7 @@ export const setTemplateSummary = (
     schema,
   } as const)
 
-export const setCommunityTemplateToInstall = (template: CommunityTemplate) =>
+export const setStagedCommunityTemplate = (template: CommunityTemplate) =>
   ({
     type: SET_COMMUNITY_TEMPLATE_TO_INSTALL,
     template,

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -3,7 +3,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components
-import {CommunityTemplateInstallerOverlay} from 'src/templates/components/CommunityTemplateInstallerOverlay'
+import {CommunityTemplateOverlay} from 'src/templates/components/CommunityTemplateOverlay'
 
 // Actions
 import {setCommunityTemplateToInstall} from 'src/templates/actions/creators'
@@ -63,7 +63,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
 
   public render() {
     return (
-      <CommunityTemplateInstallerOverlay
+      <CommunityTemplateOverlay
         onDismissOverlay={this.onDismiss}
         onInstall={this.handleInstallTemplate}
         resourceCount={this.props.resourceCount}

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -62,10 +62,6 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   }
 
   public render() {
-    if (!this.props.flags.communityTemplates) {
-      return null
-    }
-
     return (
       <CommunityTemplateInstallerOverlay
         onDismissOverlay={this.onDismiss}

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -6,7 +6,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {CommunityTemplateOverlay} from 'src/templates/components/CommunityTemplateOverlay'
 
 // Actions
-import {setCommunityTemplateToInstall} from 'src/templates/actions/creators'
+import {setStagedCommunityTemplate} from 'src/templates/actions/creators'
 import {createTemplate, fetchAndSetStacks} from 'src/templates/actions/thunks'
 import {notify} from 'src/shared/actions/notifications'
 
@@ -89,7 +89,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     try {
       const summary = await reviewTemplate(orgID, yamlLocation)
 
-      this.props.setCommunityTemplateToInstall(summary)
+      this.props.setStagedCommunityTemplate(summary)
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
@@ -157,17 +157,17 @@ const mstp = (state: AppState, props: RouterProps) => {
     templateExtension: props.match.params.templateExtension,
     flags: state.flags.original,
     resourceCount: getTotalResourceCount(
-      state.resources.templates.communityTemplateToInstall.summary
+      state.resources.templates.stagedCommunityTemplate.summary
     ),
     resourcesToSkip:
-      state.resources.templates.communityTemplateToInstall.resourcesToSkip,
+      state.resources.templates.stagedCommunityTemplate.resourcesToSkip,
   }
 }
 
 const mdtp = {
   createTemplate,
   notify,
-  setCommunityTemplateToInstall,
+  setStagedCommunityTemplate,
   fetchAndSetStacks,
 }
 

--- a/ui/src/templates/components/CommunityTemplateInstallInstructions.tsx
+++ b/ui/src/templates/components/CommunityTemplateInstallInstructions.tsx
@@ -15,7 +15,8 @@ import {
   AlignItems,
   InfluxColors,
 } from '@influxdata/clockface'
-import CommunityTemplateNameIcon from 'src/templates/components/CommunityTemplateNameIcon'
+
+import {CommunityTemplateInstallInstructionsIcon} from 'src/templates/components/CommunityTemplateInstallInstructionsIcon'
 
 interface Props {
   templateName: string
@@ -23,9 +24,7 @@ interface Props {
   onClickInstall?: () => void
 }
 
-import {} from 'react'
-
-const CommunityTemplateName: FC<Props> = ({
+export const CommunityTemplateInstallInstructions: FC<Props> = ({
   templateName,
   resourceCount,
   onClickInstall,
@@ -56,7 +55,7 @@ const CommunityTemplateName: FC<Props> = ({
         direction={FlexDirection.Row}
         alignItems={AlignItems.Center}
       >
-        <CommunityTemplateNameIcon
+        <CommunityTemplateInstallInstructionsIcon
           strokeWidth={2}
           strokeColor={InfluxColors.Neutrino}
           width={54}
@@ -87,5 +86,3 @@ const CommunityTemplateName: FC<Props> = ({
     </Panel>
   )
 }
-
-export default CommunityTemplateName

--- a/ui/src/templates/components/CommunityTemplateInstallInstructionsIcon.tsx
+++ b/ui/src/templates/components/CommunityTemplateInstallInstructionsIcon.tsx
@@ -8,7 +8,7 @@ interface Props {
   height: number
 }
 
-const CommunityTemplateNameIcon: FC<Props> = ({
+export const CommunityTemplateInstallInstructionsIcon: FC<Props> = ({
   strokeColor,
   fillColor = 'none',
   strokeWidth = 2,
@@ -73,5 +73,3 @@ const CommunityTemplateNameIcon: FC<Props> = ({
     </svg>
   )
 }
-
-export default CommunityTemplateNameIcon

--- a/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateInstallerOverlay.tsx
@@ -6,7 +6,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {Alignment, Orientation, Overlay, Tabs} from '@influxdata/clockface'
 import CommunityTemplateName from 'src/templates/components/CommunityTemplateName'
 import {CommunityTemplateReadme} from 'src/templates/components/CommunityTemplateReadme'
-import {CommunityTemplateContents} from 'src/templates/components/CommunityTemplateContents'
+import {CommunityTemplateOverlayContents} from 'src/templates/components/CommunityTemplateOverlayContents'
 
 // Types
 import {ComponentStatus} from '@influxdata/clockface'
@@ -78,7 +78,7 @@ class CommunityTemplateInstallerOverlayUnconnected extends PureComponent<
                 />
               </Tabs.Tabs>
               {this.state.activeTab === Tab.IncludedResources ? (
-                <CommunityTemplateContents />
+                <CommunityTemplateOverlayContents />
               ) : (
                 <CommunityTemplateReadme />
               )}

--- a/ui/src/templates/components/CommunityTemplateOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlay.tsx
@@ -34,10 +34,7 @@ type ActiveTab = Tab.IncludedResources | Tab.Readme
 
 type Props = OwnProps & RouteComponentProps<{orgID: string}>
 
-class CommunityTemplateInstallerOverlayUnconnected extends PureComponent<
-  Props,
-  State
-> {
+class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
   state: State = {
     activeTab: Tab.IncludedResources,
   }
@@ -102,6 +99,6 @@ class CommunityTemplateInstallerOverlayUnconnected extends PureComponent<
   }
 }
 
-export const CommunityTemplateInstallerOverlay = withRouter(
-  CommunityTemplateInstallerOverlayUnconnected
+export const CommunityTemplateOverlay = withRouter(
+  CommunityTemplateOverlayUnconnected
 )

--- a/ui/src/templates/components/CommunityTemplateOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlay.tsx
@@ -4,7 +4,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {Alignment, Orientation, Overlay, Tabs} from '@influxdata/clockface'
-import CommunityTemplateName from 'src/templates/components/CommunityTemplateName'
+import {CommunityTemplateInstallInstructions} from 'src/templates/components/CommunityTemplateInstallInstructions'
 import {CommunityTemplateReadme} from 'src/templates/components/CommunityTemplateReadme'
 import {CommunityTemplateOverlayContents} from 'src/templates/components/CommunityTemplateOverlayContents'
 
@@ -54,7 +54,7 @@ class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
             onDismiss={this.onDismiss}
           />
           <Overlay.Body>
-            <CommunityTemplateName
+            <CommunityTemplateInstallInstructions
               templateName={templateName}
               resourceCount={resourceCount}
               onClickInstall={onInstall}

--- a/ui/src/templates/components/CommunityTemplateOverlayContents.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlayContents.tsx
@@ -23,7 +23,7 @@ import {getResourceInstallCount} from 'src/templates/selectors'
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-class CommunityTemplateContentsUnconnected extends PureComponent<Props> {
+class CommunityTemplateOverlayContentsUnconnected extends PureComponent<Props> {
   render() {
     const {summary} = this.props
     if (!Object.keys(summary).length) {
@@ -228,6 +228,6 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export const CommunityTemplateContents = connector(
-  CommunityTemplateContentsUnconnected
+export const CommunityTemplateOverlayContents = connector(
+  CommunityTemplateOverlayContentsUnconnected
 )

--- a/ui/src/templates/components/CommunityTemplateOverlayContents.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlayContents.tsx
@@ -219,7 +219,7 @@ class CommunityTemplateOverlayContentsUnconnected extends PureComponent<Props> {
 }
 
 const mstp = (state: AppState) => {
-  return {summary: state.resources.templates.communityTemplateToInstall.summary}
+  return {summary: state.resources.templates.stagedCommunityTemplate.summary}
 }
 
 const mdtp = {

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -12,7 +12,6 @@ import TemplatesPage from 'src/templates/components/TemplatesPage'
 import GetResources from 'src/resources/components/GetResources'
 import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
 import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
-import {CommunityTemplateImportOverlay} from 'src/templates/components/CommunityTemplateImportOverlay'
 import TemplateViewOverlay from 'src/templates/components/TemplateViewOverlay'
 import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 
@@ -53,10 +52,6 @@ class TemplatesIndex extends Component<Props> {
           <Route
             path={`${templatesPath}/import`}
             component={TemplateImportOverlay}
-          />
-          <Route
-            path={`${templatesPath}/import/:templateName`}
-            component={CommunityTemplateImportOverlay}
           />
           <Route
             path={`${templatesPath}/:id/export`}

--- a/ui/src/templates/reducers/index.test.ts
+++ b/ui/src/templates/reducers/index.test.ts
@@ -42,10 +42,10 @@ const templateSummary = {
 
 const exportTemplate = {status, item: null}
 
-const communityTemplateToInstall: CommunityTemplate = {}
+const stagedCommunityTemplate: CommunityTemplate = {}
 
 const initialState = () => ({
-  communityTemplateToInstall,
+  stagedCommunityTemplate,
   status,
   byID: {
     ['1']: templateSummary,
@@ -98,7 +98,7 @@ describe('templates reducer', () => {
       byID,
       allIDs,
       exportTemplate,
-      communityTemplateToInstall,
+      stagedCommunityTemplate,
       stacks: [],
     }
     const actual = reducer(state, removeTemplateSummary(state.allIDs[1]))

--- a/ui/src/templates/reducers/index.ts
+++ b/ui/src/templates/reducers/index.ts
@@ -36,7 +36,7 @@ const defaultCommunityTemplate = (): CommunityTemplate => {
 }
 
 export const defaultState = (): TemplatesState => ({
-  communityTemplateToInstall: defaultCommunityTemplate(),
+  stagedCommunityTemplate: defaultCommunityTemplate(),
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
@@ -78,12 +78,12 @@ export const templatesReducer = (
       case SET_COMMUNITY_TEMPLATE_TO_INSTALL: {
         const {template} = action
 
-        const communityTemplateToInstall = {
+        const stagedCommunityTemplate = {
           ...defaultCommunityTemplate(),
           ...template,
         }
 
-        communityTemplateToInstall.summary.dashboards = (
+        stagedCommunityTemplate.summary.dashboards = (
           template.summary.dashboards || []
         ).map(dashboard => {
           if (!dashboard.hasOwnProperty('shouldInstall')) {
@@ -92,7 +92,7 @@ export const templatesReducer = (
           return dashboard
         })
 
-        communityTemplateToInstall.summary.telegrafConfigs = (
+        stagedCommunityTemplate.summary.telegrafConfigs = (
           template.summary.telegrafConfigs || []
         ).map(telegrafConfig => {
           if (!telegrafConfig.hasOwnProperty('shouldInstall')) {
@@ -101,7 +101,7 @@ export const templatesReducer = (
           return telegrafConfig
         })
 
-        communityTemplateToInstall.summary.buckets = (
+        stagedCommunityTemplate.summary.buckets = (
           template.summary.buckets || []
         ).map(bucket => {
           if (!bucket.hasOwnProperty('shouldInstall')) {
@@ -110,7 +110,7 @@ export const templatesReducer = (
           return bucket
         })
 
-        communityTemplateToInstall.summary.checks = (
+        stagedCommunityTemplate.summary.checks = (
           template.summary.checks || []
         ).map(check => {
           if (!check.hasOwnProperty('shouldInstall')) {
@@ -119,7 +119,7 @@ export const templatesReducer = (
           return check
         })
 
-        communityTemplateToInstall.summary.variables = (
+        stagedCommunityTemplate.summary.variables = (
           template.summary.variables || []
         ).map(variable => {
           if (!variable.hasOwnProperty('shouldInstall')) {
@@ -128,7 +128,7 @@ export const templatesReducer = (
           return variable
         })
 
-        communityTemplateToInstall.summary.notificationRules = (
+        stagedCommunityTemplate.summary.notificationRules = (
           template.summary.notificationRules || []
         ).map(notificationRule => {
           if (!notificationRule.hasOwnProperty('shouldInstall')) {
@@ -137,7 +137,7 @@ export const templatesReducer = (
           return notificationRule
         })
 
-        communityTemplateToInstall.summary.notificationEndpoints = (
+        stagedCommunityTemplate.summary.notificationEndpoints = (
           template.summary.notificationEndpoints || []
         ).map(notificationEndpoint => {
           if (!notificationEndpoint.hasOwnProperty('shouldInstall')) {
@@ -146,7 +146,7 @@ export const templatesReducer = (
           return notificationEndpoint
         })
 
-        communityTemplateToInstall.summary.labels = (
+        stagedCommunityTemplate.summary.labels = (
           template.summary.labels || []
         ).map(label => {
           if (!label.hasOwnProperty('shouldInstall')) {
@@ -155,7 +155,7 @@ export const templatesReducer = (
           return label
         })
 
-        communityTemplateToInstall.summary.summaryTask = (
+        stagedCommunityTemplate.summary.summaryTask = (
           template.summary.summaryTask || []
         ).map(summaryTask => {
           if (!summaryTask.hasOwnProperty('shouldInstall')) {
@@ -164,7 +164,7 @@ export const templatesReducer = (
           return summaryTask
         })
 
-        draftState.communityTemplateToInstall = communityTemplateToInstall
+        draftState.stagedCommunityTemplate = stagedCommunityTemplate
         return
       }
 
@@ -195,7 +195,7 @@ export const templatesReducer = (
       case TOGGLE_TEMPLATE_RESOURCE_INSTALL: {
         const {resourceType, shouldInstall, templateMetaName} = action
 
-        const templateToInstall = {...draftState.communityTemplateToInstall}
+        const templateToInstall = {...draftState.stagedCommunityTemplate}
 
         templateToInstall.summary[resourceType].forEach(resource => {
           if (resource.templateMetaName === templateMetaName) {
@@ -214,7 +214,7 @@ export const templatesReducer = (
           }
         })
 
-        draftState.communityTemplateToInstall = templateToInstall
+        draftState.stagedCommunityTemplate = templateToInstall
         return
       }
 

--- a/ui/src/types/templates.ts
+++ b/ui/src/types/templates.ts
@@ -35,7 +35,7 @@ export type CommunityTemplate = any
 
 export interface TemplatesState extends NormalizedState<TemplateSummary> {
   exportTemplate: {status: RemoteDataState; item: DocumentCreate}
-  communityTemplateToInstall: CommunityTemplate
+  stagedCommunityTemplate: CommunityTemplate
   stacks: InstalledStack[]
 }
 


### PR DESCRIPTION
Closes #19177 

- Renames files to be a little more clear about what they do
  - `CommunityTemplateContents` => `CommunityTemplateOverlayContents`
  - `CommunityTemplatesInstallerOverlay` => `CommunityTemplatesOverlay`
  - `CommunityTemplatesName` => `CommunityTemplatesInstallInstructions`
- Removes references to `CommunityTemplateOverlay` in `TemplateIndex`
- Changes default exports => named exports
- Renames redux model concept `communityTemplateToInstall` => `stagedCommunityTemplate` (idea from Alex Paxton)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
