### PR TITLE
perf: calculate and event dashboard visit => dashboard mount times

### DIFF
--- a/ui/src/perf/actions/index.ts
+++ b/ui/src/perf/actions/index.ts
@@ -5,6 +5,7 @@ export const SET_DASHBOARD_VISIT = 'SET_DASHBOARD_VISIT'
 export type Action =
   | ReturnType<typeof setScroll>
   | ReturnType<typeof setCellMount>
+  | ReturnType<typeof setDashboardVisit>
 
 export type ComponentKey = 'dashboard'
 export type ScrollState = 'not scrolled' | 'scrolled'
@@ -23,7 +24,7 @@ export const setCellMount = (cellID: string, mountStartMs: number) =>
     mountStartMs,
   } as const)
 
-export const dashboardVisit = (dashboardID: string, startVisitMs: number) =>
+export const setDashboardVisit = (dashboardID: string, startVisitMs: number) =>
   ({
     type: SET_DASHBOARD_VISIT,
     dashboardID,

--- a/ui/src/perf/actions/index.ts
+++ b/ui/src/perf/actions/index.ts
@@ -1,21 +1,13 @@
-export const SET_RENDER_ID = 'SET_RENDER_ID'
 export const SET_SCROLL = 'SET_SCROLL'
 export const SET_CELL_MOUNT = 'SET_CELL_MOUNT'
+export const SET_DASHBOARD_VISIT = 'SET_DASHBOARD_VISIT'
 
 export type Action =
-  | ReturnType<typeof setRenderID>
   | ReturnType<typeof setScroll>
   | ReturnType<typeof setCellMount>
 
 export type ComponentKey = 'dashboard'
 export type ScrollState = 'not scrolled' | 'scrolled'
-
-export const setRenderID = (component: ComponentKey, renderID: string) =>
-  ({
-    type: SET_RENDER_ID,
-    component,
-    renderID,
-  } as const)
 
 export const setScroll = (component: ComponentKey, scroll: ScrollState) =>
   ({
@@ -29,4 +21,11 @@ export const setCellMount = (cellID: string, mountStartMs: number) =>
     type: SET_CELL_MOUNT,
     cellID,
     mountStartMs,
+  } as const)
+
+export const dashboardVisit = (dashboardID: string, startVisitMs: number) =>
+  ({
+    type: SET_DASHBOARD_VISIT,
+    dashboardID,
+    startVisitMs,
   } as const)

--- a/ui/src/perf/components/CellEvent.tsx
+++ b/ui/src/perf/components/CellEvent.tsx
@@ -16,11 +16,10 @@ interface Props {
 const getState = (cellID: string) => (state: AppState) => {
   const {perf} = state
   const {dashboard, cells} = perf
-  const {scroll, renderID} = dashboard
+  const {scroll} = dashboard
 
   return {
     scroll,
-    renderID,
     cellMountStartMs: cells.byID[cellID]?.mountStartMs,
   }
 }
@@ -29,31 +28,14 @@ const CellEvent: FC<Props> = ({id, type}) => {
   const params = useParams<{dashboardID?: string}>()
   const dashboardID = params?.dashboardID
 
-  const {renderID, scroll, cellMountStartMs} = useSelector(getState(id))
-
-  useEffect(() => {
-    if (scroll === 'scrolled') {
-      return
-    }
-
-    const hasIDs = dashboardID && id && renderID
-
-    if (!hasIDs) {
-      return
-    }
-
-    const tags = {dashboardID, cellID: id, type}
-    const fields = {renderID}
-
-    event('Cell Visualized', tags, fields)
-  }, [dashboardID, id, renderID, type, scroll])
+  const {cellMountStartMs} = useSelector(getState(id))
 
   useEffect(() => {
     if (!cellMountStartMs) {
       return
     }
 
-    const hasIDs = dashboardID && id && renderID
+    const hasIDs = dashboardID && id
     if (!hasIDs) {
       return
     }
@@ -62,10 +44,10 @@ const CellEvent: FC<Props> = ({id, type}) => {
     const timeToAppearMs = visRenderedMs - cellMountStartMs
 
     const tags = {dashboardID, cellID: id, type}
-    const fields = {timeToAppearMs, renderID}
+    const fields = {timeToAppearMs}
 
     event('Cell Render Cycle', tags, fields)
-  }, [cellMountStartMs, dashboardID, id, renderID, type])
+  }, [cellMountStartMs, dashboardID, id, type])
 
   return null
 }

--- a/ui/src/perf/reducers/index.ts
+++ b/ui/src/perf/reducers/index.ts
@@ -61,6 +61,8 @@ const perfReducer = (
         }
 
         draftState.dashboard.byID[dashboardID].startVisitMs = startVisitMs
+
+        return
       }
 
       case SET_CELL_MOUNT: {

--- a/ui/src/perf/reducers/index.ts
+++ b/ui/src/perf/reducers/index.ts
@@ -3,7 +3,7 @@ import {produce} from 'immer'
 
 // Actions
 import {
-  SET_RENDER_ID,
+  SET_DASHBOARD_VISIT,
   SET_SCROLL,
   Action,
   SET_CELL_MOUNT,
@@ -12,7 +12,11 @@ import {
 export interface PerfState {
   dashboard: {
     scroll: 'not scrolled' | 'scrolled'
-    renderID: string
+    byID: {
+      [id: string]: {
+        startVisitMs: number
+      }
+    }
   }
   cells: {
     byID: {
@@ -26,7 +30,7 @@ export interface PerfState {
 const initialState = (): PerfState => ({
   dashboard: {
     scroll: 'not scrolled',
-    renderID: '',
+    byID: {},
   },
   cells: {
     byID: {},
@@ -39,18 +43,24 @@ const perfReducer = (
 ): PerfState =>
   produce(state, draftState => {
     switch (action.type) {
-      case SET_RENDER_ID: {
-        const {component, renderID} = action
-        draftState[component].renderID = renderID
-
-        return
-      }
-
       case SET_SCROLL: {
         const {component, scroll} = action
         draftState[component].scroll = scroll
 
         return
+      }
+
+      case SET_DASHBOARD_VISIT: {
+        const {dashboardID, startVisitMs} = action
+        const exists = draftState.dashboard.byID[dashboardID]
+
+        if (!exists) {
+          draftState.dashboard.byID[dashboardID] = {startVisitMs}
+
+          return
+        }
+
+        draftState.dashboard.byID[dashboardID].startVisitMs = startVisitMs
       }
 
       case SET_CELL_MOUNT: {

--- a/ui/src/shared/components/DashboardRoute.tsx
+++ b/ui/src/shared/components/DashboardRoute.tsx
@@ -7,7 +7,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 // Actions
 import {setDashboard} from 'src/shared/actions/currentDashboard'
 import {selectValue} from 'src/variables/actions/thunks'
-import {dashboardVisit as dashboardVisitAction} from 'src/perf/actions'
+import {setDashboardVisit} from 'src/perf/actions'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -126,7 +126,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
-  dashboardVisit: dashboardVisitAction,
+  dashboardVisit: setDashboardVisit,
   updateDashboard: setDashboard,
   selectValue: selectValue,
 }

--- a/ui/src/shared/components/DashboardRoute.tsx
+++ b/ui/src/shared/components/DashboardRoute.tsx
@@ -1,10 +1,21 @@
+// Libraries
 import React, {PureComponent} from 'react'
 import qs from 'qs'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
+
+// Actions
 import {setDashboard} from 'src/shared/actions/currentDashboard'
-import {getVariables} from 'src/variables/selectors'
 import {selectValue} from 'src/variables/actions/thunks'
+import {dashboardVisit as dashboardVisitAction} from 'src/perf/actions'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// Selector
+import {getVariables} from 'src/variables/selectors'
+
+// Types
 import {AppState} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -44,8 +55,10 @@ class DashboardRoute extends PureComponent<Props> {
   }
 
   componentDidMount() {
-    const {dashboard, updateDashboard, variables} = this.props
+    const {dashboard, updateDashboard, variables, dashboardVisit} = this.props
     const dashboardID = this.props.match.params.dashboardID
+    dashboardVisit(dashboardID, new Date().getTime())
+    event('Dashboard Visit', {dashboardID})
     const urlVars = qs.parse(this.props.location.search, {
       ignoreQueryPrefix: true,
     })
@@ -113,6 +126,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
+  dashboardVisit: dashboardVisitAction,
   updateDashboard: setDashboard,
   selectValue: selectValue,
 }


### PR DESCRIPTION
Closes influxdata/idpe#8152

### The Problem
We were not calculating the time it took to fetch all dashboard resources on initial render

### The Solution
Time the difference between when a dashboard is visited -> all the data is fetched (including variables) -> and a dashboard mounting.  This, combined with the `Cell Render Cycle` calculation can give us a decent approximation of how long it takes our users to visualize their data.  

![Screen Shot 2020-08-11 at 3 21 19 PM](https://user-images.githubusercontent.com/7582765/89954641-59932d00-dbe6-11ea-83c8-a529e16f87d7.png)

### Notes
This PR also removes the concept of `renderID`.  Turns out it's an unnecessary complication.  