### PR TITLE
feat(ui): templates polish

### DIFF
--- a/ui/cypress/e2e/communityTemplate.test.ts
+++ b/ui/cypress/e2e/communityTemplate.test.ts
@@ -157,68 +157,87 @@ describe('Community Templates', () => {
     })
 
     it('Can click on template resources', () => {
+      cy.getByTestID('template-resource-link').click()
       //buckets
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Bucket')
-        .click()
+        .siblings('td')
+        .click('left') // force a click on the far left of the target, in case the text is aligned left and short
       cy.url().should('include', 'load-data/buckets')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //telegraf
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Telegraf')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'load-data/telegrafs')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //check
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Check')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'alerting/checks')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //label
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Label')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'settings/labels')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //Dashboard
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Dashboard')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'dashboards')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //Notification Endpoint
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('NotificationEndpoint')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'alerting')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //Notification Rule
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('NotificationRule')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'alerting')
       cy.go('back')
 
+      cy.getByTestID('template-resource-link').click()
       //Variable
-      cy.getByTestID('template-resource-link')
+      cy.get('.community-templates--resources-table')
         .contains('Variable')
-        .click()
+        .siblings('td')
+        .click('left')
       cy.url().should('include', 'settings/variables')
       cy.go('back')
     })
 
-    it('Click on source takes you to github', () => {
-      cy.getByTestID('template-source-link').should(
-        'contain',
-        'https://github.com/influxdata/community-templates/blob/master/docker/docker.yml'
-      )
+    it('takes you to github when you click on the Community Templates link', () => {
+      cy.getByTestID('template-source-link').within(() => {
+        cy.contains('Community Templates').should(
+          'have.attr',
+          'href',
+          'https://github.com/influxdata/community-templates/blob/master/docker/docker.yml'
+        )
+      })
       //TODO: add the link from CLI
     })
 

--- a/ui/src/templates/components/CommunityTemplateHumanReadableResource.tsx
+++ b/ui/src/templates/components/CommunityTemplateHumanReadableResource.tsx
@@ -1,0 +1,141 @@
+// Libraries
+import React, {FC} from 'react'
+import {Link} from 'react-router-dom'
+import {connect, ConnectedProps} from 'react-redux'
+
+// Selectors
+import {getAll} from 'src/resources/selectors'
+
+// Types
+import {
+  AppState,
+  Dashboard,
+  Task,
+  Label,
+  Bucket,
+  Telegraf,
+  Variable,
+  ResourceType,
+  Check,
+  NotificationEndpoint,
+  NotificationRule,
+} from 'src/types'
+
+interface ComponentProps {
+  link: string
+  metaName: string
+  resourceID: string
+}
+
+type ReduxProps = ConnectedProps<typeof connector>
+
+type Props = ComponentProps & ReduxProps
+
+const CommunityTemplateHumanReadableResourceUnconnected: FC<Props> = ({
+  link,
+  metaName,
+  resourceID,
+  allResources,
+}) => {
+  const matchingResource = allResources.find(
+    resource => resource.id === resourceID
+  )
+
+  const humanName = matchingResource ? matchingResource.name : metaName
+
+  return (
+    <Link to={link}>
+      <code>{humanName}</code>
+    </Link>
+  )
+}
+
+const mstp = (state: AppState) => {
+  const labels = getAll<Label>(state, ResourceType.Labels)
+  const cleanedLabels = labels.map(label => ({
+    id: label.id,
+    name: label.name,
+  }))
+
+  const buckets = getAll<Bucket>(state, ResourceType.Buckets)
+  const cleanedBuckets = buckets.map(bucket => ({
+    id: bucket.id,
+    name: bucket.name,
+  }))
+
+  const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)
+  const cleanedTelegrafs = telegrafs.map(telegraf => ({
+    id: telegraf.id,
+    name: telegraf.name,
+  }))
+
+  const variables = getAll<Variable>(state, ResourceType.Variables)
+  const cleanedVariables = variables.map(variable => ({
+    id: variable.id,
+    name: variable.name,
+  }))
+
+  const dashboards = getAll<Dashboard>(state, ResourceType.Dashboards)
+  const cleanedDashboards = dashboards.map(dashboard => ({
+    id: dashboard.id,
+    name: dashboard.name,
+  }))
+
+  const tasks = getAll<Task>(state, ResourceType.Tasks)
+  const cleanedTasks = tasks.map(task => ({
+    id: task.id,
+    name: task.name,
+  }))
+
+  const checks = getAll<Check>(state, ResourceType.Checks)
+  const cleanedChecks = checks.map(check => ({
+    id: check.id,
+    name: check.name,
+  }))
+
+  const notificationEndpoints = getAll<NotificationEndpoint>(
+    state,
+    ResourceType.NotificationEndpoints
+  )
+  const cleanedNotificationEndpoints = notificationEndpoints.map(
+    notificationEndpoint => ({
+      id: notificationEndpoint.id,
+      name: notificationEndpoint.name,
+    })
+  )
+
+  const notificationRules = getAll<NotificationRule>(
+    state,
+    ResourceType.NotificationRules
+  )
+  const cleanedNotificationRules = notificationRules.map(notificationRule => {
+    if (notificationRule.id && notificationRule.name) {
+      return {
+        id: notificationRule.id,
+        name: notificationRule.name,
+      }
+    }
+  })
+
+  const allResources = [
+    ...cleanedLabels,
+    ...cleanedBuckets,
+    ...cleanedTelegrafs,
+    ...cleanedVariables,
+    ...cleanedDashboards,
+    ...cleanedTasks,
+    ...cleanedChecks,
+    ...cleanedNotificationEndpoints,
+    ...cleanedNotificationRules,
+  ]
+
+  return {
+    allResources,
+  }
+}
+
+const connector = connect(mstp)
+
+export const CommunityTemplateHumanReadableResource = connector(
+  CommunityTemplateHumanReadableResourceUnconnected
+)

--- a/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/ui/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {Link} from 'react-router-dom'
 
 // Components
 import {
@@ -11,7 +10,12 @@ import {
   ConfirmationButton,
   IconFont,
   Table,
+  LinkButton,
+  VerticalAlignment,
+  ButtonShape,
+  Alignment,
 } from '@influxdata/clockface'
+import {CommunityTemplatesResourceSummary} from 'src/templates/components/CommunityTemplatesResourceSummary'
 
 // Redux
 import {notify} from 'src/shared/actions/notifications'
@@ -40,7 +44,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 
 type Props = OwnProps & ReduxProps
 
-interface Resource {
+export interface Resource {
   apiVersion?: string
   resourceID?: string
   kind?: TemplateKind
@@ -61,137 +65,19 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
     }
   }
 
-  private renderStackResources(resources: Resource[]) {
-    return resources.map(resource => {
-      switch (resource.kind) {
-        case 'Bucket': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link to={`/orgs/${this.props.orgID}/load-data/buckets`}>
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Check':
-        case 'CheckDeadman':
-        case 'CheckThreshold': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/alerting/checks/${resource.resourceID}/edit`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Dashboard': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/dashboards/${resource.resourceID}`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Label': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link to={`/orgs/${this.props.orgID}/settings/labels`}>
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'NotificationEndpoint':
-        case 'NotificationEndpointHTTP':
-        case 'NotificationEndpointPagerDuty':
-        case 'NotificationEndpointSlack': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/alerting/endpoints/${resource.resourceID}/edit`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'NotificationRule': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/alerting/rules/${resource.resourceID}/edit`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Task': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/tasks/${resource.resourceID}/edit`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Telegraf': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/load-data/telegrafs/${resource.resourceID}/view`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        case 'Variable': {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              <Link
-                to={`/orgs/${this.props.orgID}/settings/variables/${resource.resourceID}/edit`}
-              >
-                {resource.kind} <code>{resource.templateMetaName}</code>
-              </Link>
-              <br />
-            </React.Fragment>
-          )
-        }
-        default: {
-          return (
-            <React.Fragment key={resource.templateMetaName}>
-              {resource.kind}
-              <br />
-            </React.Fragment>
-          )
-        }
-      }
-    })
-  }
-
   private renderStackSources(sources: string[]) {
     return sources.map(source => {
-      if (source.includes('github')) {
+      if (source.includes('github') && source.includes('influxdata')) {
         return (
-          <a key={source} href={source}>
-            {source}
-          </a>
+          <LinkButton
+            key={source}
+            text="Community Templates"
+            icon={IconFont.GitHub}
+            href={source}
+            size={ComponentSize.Small}
+            style={{display: 'inline-block'}}
+            target="_blank"
+          />
         )
       }
 
@@ -228,11 +114,21 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
         <Table striped={true} highlight={true}>
           <Table.Header>
             <Table.Row>
-              <Table.HeaderCell>Template Name</Table.HeaderCell>
-              <Table.HeaderCell>Resources Created</Table.HeaderCell>
-              <Table.HeaderCell>Install Date</Table.HeaderCell>
-              <Table.HeaderCell>Source</Table.HeaderCell>
-              <Table.HeaderCell>&nbsp;</Table.HeaderCell>
+              <Table.HeaderCell style={{width: '250px'}}>
+                Template Name
+              </Table.HeaderCell>
+              <Table.HeaderCell style={{width: 'calc(100% - 700px)'}}>
+                Installed Resources
+              </Table.HeaderCell>
+              <Table.HeaderCell style={{width: '180px'}}>
+                Install Date
+              </Table.HeaderCell>
+              <Table.HeaderCell style={{width: '210px'}}>
+                Source
+              </Table.HeaderCell>
+              <Table.HeaderCell style={{width: '60px'}}>
+                &nbsp;
+              </Table.HeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
@@ -242,19 +138,39 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
                   testID="installed-template-list"
                   key={`stack-${stack.id}`}
                 >
-                  <Table.Cell testID={`installed-template-${stack.name}`}>
-                    {stack.name}
+                  <Table.Cell
+                    testID={`installed-template-${stack.name}`}
+                    verticalAlignment={VerticalAlignment.Top}
+                  >
+                    <span className="community-templates--resources-table-item">
+                      {stack.name}
+                    </span>
                   </Table.Cell>
-                  <Table.Cell testID="template-resource-link">
-                    {this.renderStackResources(stack.resources)}
+                  <Table.Cell
+                    testID="template-resource-link"
+                    verticalAlignment={VerticalAlignment.Top}
+                  >
+                    <CommunityTemplatesResourceSummary
+                      resources={stack.resources}
+                      stackID={stack.id}
+                      orgID={this.props.orgID}
+                    />
                   </Table.Cell>
-                  <Table.Cell>
-                    {new Date(stack.createdAt).toDateString()}
+                  <Table.Cell verticalAlignment={VerticalAlignment.Top}>
+                    <span className="community-templates--resources-table-item">
+                      {new Date(stack.createdAt).toDateString()}
+                    </span>
                   </Table.Cell>
-                  <Table.Cell testID="template-source-link">
+                  <Table.Cell
+                    testID="template-source-link"
+                    verticalAlignment={VerticalAlignment.Top}
+                  >
                     {this.renderStackSources(stack.sources)}
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell
+                    verticalAlignment={VerticalAlignment.Top}
+                    horizontalAlignment={Alignment.Right}
+                  >
                     <ConfirmationButton
                       confirmationButtonText="Delete"
                       testID={`template-delete-button-${stack.name}`}
@@ -270,6 +186,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
                       color={ComponentColor.Danger}
                       size={ComponentSize.Small}
                       status={ComponentStatus.Default}
+                      shape={ButtonShape.Square}
                     />
                   </Table.Cell>
                 </Table.Row>

--- a/ui/src/templates/components/CommunityTemplatesResourceSummary.tsx
+++ b/ui/src/templates/components/CommunityTemplatesResourceSummary.tsx
@@ -1,0 +1,206 @@
+// Libraries
+import React, {FC, useState} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {Icon, IconFont} from '@influxdata/clockface'
+import {CommunityTemplateHumanReadableResource} from 'src/templates/components/CommunityTemplateHumanReadableResource'
+
+// Types
+import {Resource} from 'src/templates/components/CommunityTemplatesInstalledList'
+
+interface Props {
+  resources: Resource[]
+  stackID: string
+  orgID: string
+}
+
+export const CommunityTemplatesResourceSummary: FC<Props> = ({
+  resources,
+  stackID,
+  orgID,
+}) => {
+  const [summaryState, setSummaryState] = useState<'expanded' | 'collapsed'>(
+    'collapsed'
+  )
+
+  const toggleText = `${resources.length} Resource${
+    !!resources.length ? 's' : ''
+  }`
+
+  const handleToggleTable = (): void => {
+    if (summaryState === 'expanded') {
+      setSummaryState('collapsed')
+    } else {
+      setSummaryState('expanded')
+    }
+  }
+
+  const caretClassName = classnames(
+    'community-templates--resources-table-caret',
+    {
+      'community-templates--resources-table-caret__expanded':
+        summaryState === 'expanded',
+    }
+  )
+
+  const tableRows = resources.map(resource => {
+    switch (resource.kind) {
+      case 'Bucket': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/load-data/buckets`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Check':
+      case 'CheckDeadman':
+      case 'CheckThreshold': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/alerting/checks/${resource.resourceID}/edit`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Dashboard': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/dashboards/${resource.resourceID}`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Label': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/settings/labels`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'NotificationEndpoint':
+      case 'NotificationEndpointHTTP':
+      case 'NotificationEndpointPagerDuty':
+      case 'NotificationEndpointSlack': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/alerting/endpoints/${resource.resourceID}/edit`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'NotificationRule': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/alerting/rules/${resource.resourceID}/edit`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Task': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/tasks/${resource.resourceID}/edit`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Telegraf': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/load-data/telegrafs/${resource.resourceID}/view`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      case 'Variable': {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+            <td>
+              <CommunityTemplateHumanReadableResource
+                link={`/orgs/${orgID}/settings/variables/${resource.resourceID}/edit`}
+                metaName={resource.templateMetaName}
+                resourceID={resource.resourceID}
+              />
+            </td>
+          </tr>
+        )
+      }
+      default: {
+        return (
+          <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
+            <td>{resource.kind}</td>
+          </tr>
+        )
+      }
+    }
+  })
+
+  return (
+    <>
+      <div
+        className="community-templates--resources-table-toggle"
+        onClick={handleToggleTable}
+      >
+        <Icon className={caretClassName} glyph={IconFont.CaretRight} />
+        <h6>{toggleText}</h6>
+      </div>
+      {summaryState === 'expanded' && (
+        <table className="community-templates--resources-table">
+          <tbody>{tableRows}</tbody>
+        </table>
+      )}
+    </>
+  )
+}

--- a/ui/src/templates/containers/CommunityTemplates.scss
+++ b/ui/src/templates/containers/CommunityTemplates.scss
@@ -3,8 +3,22 @@
   grid-column-gap: $ix-marg-b;
   grid-row-gap: $ix-marg-b;
   grid-template-columns: 1fr;
-  grid-template-rows: 80px 150px;
   margin: $ix-marg-b 0;
+}
+
+/* The two styles below are a bandaid fix until the clockface dependency can be safely updated */
+.cf-panel.community-templates-panel
+  .cf-panel--symbol-header.cf-panel--symbol-header__sm {
+  padding-left: 46px;
+  padding-right: 46px;
+}
+
+@media screen and (min-width: $cf-grid--breakpoint-sm) {
+  .cf-panel.community-templates-panel
+    .cf-panel--symbol-header.cf-panel--symbol-header__sm {
+    padding-left: 70px;
+    padding-right: 70px;
+  }
 }
 
 .community-templates-template-url {
@@ -93,4 +107,39 @@
   .community-templates--list-group__expanded & > .cf-icon {
     transform: translate(-50%, -50%) rotate(90deg);
   }
+}
+
+.community-templates--resources-table {
+  & > tbody > tr > td {
+    padding-right: $cf-marg-b;
+    font-size: 13px;
+  }
+}
+
+.community-templates--resources-table-toggle {
+  display: flex;
+  align-items: center;
+
+  h6 {
+    margin: 0;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.community-templates--resources-table-caret {
+  margin-right: $cf-marg-b;
+  transition: transform 0.25s ease;
+}
+
+.community-templates--resources-table-caret__expanded {
+  transform: rotate(90deg);
+}
+
+.community-templates--resources-table-toggle h6,
+.community-templates--resources-table-item {
+  height: $cf-form-sm-height;
+  line-height: $cf-form-sm-height;
 }

--- a/ui/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/ui/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -26,12 +26,15 @@ import {
   LinkTarget,
   Page,
   Panel,
+  FlexDirection,
+  IconFont,
 } from '@influxdata/clockface'
 import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
 import SettingsHeader from 'src/settings/components/SettingsHeader'
 
 import {communityTemplatesImportPath} from 'src/templates/containers/TemplatesIndex'
 
+import GetResources from 'src/resources/components/GetResources'
 import {getOrg} from 'src/organizations/selectors'
 
 // Utils
@@ -44,7 +47,7 @@ import {reportError} from 'src/shared/utils/errors'
 
 import {communityTemplateUnsupportedFormatError} from 'src/shared/copy/notifications'
 // Types
-import {AppState} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 
 const communityTemplatesUrl =
   'https://github.com/influxdata/community-templates#templates'
@@ -94,7 +97,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
           <SettingsTabbedPage activeTab="templates" orgID={org.id}>
             {/* todo: maybe make this not a div */}
             <div className="community-templates-upload">
-              <Panel className="community-templates-upload-panel">
+              <Panel className="community-templates-panel">
                 <Panel.SymbolHeader
                   symbol={<Bullet text={1} size={ComponentSize.Medium} />}
                   title={
@@ -107,10 +110,11 @@ class UnconnectedTemplatesIndex extends Component<Props> {
                   <LinkButton
                     color={ComponentColor.Primary}
                     href={communityTemplatesUrl}
-                    size={ComponentSize.Small}
+                    size={ComponentSize.Large}
                     target={LinkTarget.Blank}
                     text="Browse Community Templates"
                     testID="browse-template-button"
+                    icon={IconFont.GitHub}
                   />
                 </Panel.SymbolHeader>
               </Panel>
@@ -122,28 +126,44 @@ class UnconnectedTemplatesIndex extends Component<Props> {
                       Paste the Template's Github URL below
                     </Heading>
                   }
-                  size={ComponentSize.Medium}
+                  size={ComponentSize.Small}
                 />
-                <Panel.Body size={ComponentSize.Large}>
-                  <div>
-                    <Input
-                      className="community-templates-template-url"
-                      onChange={this.handleTemplateChange}
-                      placeholder="Enter the URL of an InfluxDB Template..."
-                      style={{width: '80%'}}
-                      value={this.state.templateUrl}
-                      testID="lookup-template-input"
-                    />
-                    <Button
-                      onClick={this.startTemplateInstall}
-                      size={ComponentSize.Small}
-                      text="Lookup Template"
-                      testID="lookup-template-button"
-                    />
-                  </div>
+                <Panel.Body
+                  size={ComponentSize.Large}
+                  direction={FlexDirection.Row}
+                >
+                  <Input
+                    className="community-templates-template-url"
+                    onChange={this.handleTemplateChange}
+                    placeholder="Enter the URL of an InfluxDB Template..."
+                    style={{flex: '1 0 0'}}
+                    value={this.state.templateUrl}
+                    testID="lookup-template-input"
+                    size={ComponentSize.Large}
+                  />
+                  <Button
+                    onClick={this.startTemplateInstall}
+                    size={ComponentSize.Large}
+                    text="Lookup Template"
+                    testID="lookup-template-button"
+                  />
                 </Panel.Body>
               </Panel>
-              <CommunityTemplatesInstalledList orgID={org.id} />
+              <GetResources
+                resources={[
+                  ResourceType.Buckets,
+                  ResourceType.Checks,
+                  ResourceType.Dashboards,
+                  ResourceType.Labels,
+                  ResourceType.NotificationEndpoints,
+                  ResourceType.NotificationRules,
+                  ResourceType.Tasks,
+                  ResourceType.Telegrafs,
+                  ResourceType.Variables,
+                ]}
+              >
+                <CommunityTemplatesInstalledList orgID={org.id} />
+              </GetResources>
             </div>
           </SettingsTabbedPage>
         </Page>


### PR DESCRIPTION
Closes #19278 
Closes #19279 

![Screen Shot 2020-08-12 at 10 53 32 AM](https://user-images.githubusercontent.com/2433762/90068383-675bb780-dca5-11ea-8322-8f2a2008153a.png)

- Polish appearance of Installed Templates table:
  - Resources + types rendered in tinier and collapsible table
  - Changed github link to button to conserve space
  - Give each column a set width to prevent table jitter
- Make browse/lookup buttons & inputs large size

#### Note

- Attempted to update the version of Clockface to 2.3.3 (latest) and saw too many things breaking to safely make that change, so it was reverted

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
