### PR TITLE
fix(auth): use init to read envvar once

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -219,9 +219,15 @@ type Permission struct {
 	Resource Resource `json:"resource"`
 }
 
+var newMatchBehavior bool
+
+func init() {
+	_, newMatchBehavior = os.LookupEnv("MATCHER_BEHAVIOR")
+}
+
 // Matches returns whether or not one permission matches the other.
 func (p Permission) Matches(perm Permission) bool {
-	if _, set := os.LookupEnv("MATCHER_BEHAVIOR"); set {
+	if newMatchBehavior {
 		return p.matchesV2(perm)
 	}
 	return p.matchesV1(perm)

--- a/authz.go
+++ b/authz.go
@@ -240,13 +240,6 @@ func (p Permission) matchesV1(perm Permission) bool {
 		return true
 	}
 
-	if p.Resource.OrgID != nil && perm.Resource.OrgID != nil && p.Resource.ID != nil && perm.Resource.ID != nil {
-		if *p.Resource.OrgID != *perm.Resource.OrgID && *p.Resource.ID == *perm.Resource.ID {
-			fmt.Printf("Old match used: p.Resource.OrgID=%s perm.Resource.OrgID=%s p.Resource.ID=%s",
-				*p.Resource.OrgID, *perm.Resource.OrgID, *p.Resource.ID)
-		}
-	}
-
 	if p.Resource.OrgID != nil && p.Resource.ID == nil {
 		pOrgID := *p.Resource.OrgID
 		if perm.Resource.OrgID != nil {

--- a/authz.go
+++ b/authz.go
@@ -246,6 +246,13 @@ func (p Permission) matchesV1(perm Permission) bool {
 		return true
 	}
 
+	if p.Resource.OrgID != nil && perm.Resource.OrgID != nil && p.Resource.ID != nil && perm.Resource.ID != nil {
+		if *p.Resource.OrgID != *perm.Resource.OrgID && *p.Resource.ID == *perm.Resource.ID {
+			fmt.Printf("v1: old match used: p.Resource.OrgID=%s perm.Resource.OrgID=%s p.Resource.ID=%s",
+				*p.Resource.OrgID, *perm.Resource.OrgID, *p.Resource.ID)
+		}
+	}
+
 	if p.Resource.OrgID != nil && p.Resource.ID == nil {
 		pOrgID := *p.Resource.OrgID
 		if perm.Resource.OrgID != nil {
@@ -280,6 +287,13 @@ func (p Permission) matchesV2(perm Permission) bool {
 
 	if p.Resource.OrgID == nil && p.Resource.ID == nil {
 		return true
+	}
+
+	if p.Resource.OrgID != nil && perm.Resource.OrgID != nil && p.Resource.ID != nil && perm.Resource.ID != nil {
+		if *p.Resource.OrgID != *perm.Resource.OrgID && *p.Resource.ID == *perm.Resource.ID {
+			fmt.Printf("v2: old match used: p.Resource.OrgID=%s perm.Resource.OrgID=%s p.Resource.ID=%s",
+				*p.Resource.OrgID, *perm.Resource.OrgID, *p.Resource.ID)
+		}
 	}
 
 	if p.Resource.OrgID != nil {


### PR DESCRIPTION
Only check the `MATCHER_BEHAVIOR` flag once in `init` rather than every match call, since it was unnecessary and causing tests to break.