### PR TITLE
fix: increase notification rule limit

### DIFF
--- a/ui/cypress/index.d.ts
+++ b/ui/cypress/index.d.ts
@@ -32,6 +32,7 @@ import {
   createEndpoint,
   createDashWithCell,
   createDashWithViewAndVar,
+  createRule,
 } from './support/commands'
 
 declare global {
@@ -67,6 +68,7 @@ declare global {
       createToken: typeof createToken
       writeData: typeof writeData
       createEndpoint: typeof createEndpoint
+      createRule: typeof createRule
     }
   }
 }

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -359,6 +359,50 @@ export const createTelegraf = (
   })
 }
 
+export const createRule = (
+  orgID: string,
+  endpointID: string,
+  name = ''
+): Cypress.Chainable<Cypress.Response> => {
+  return cy.request({
+    method: 'POST',
+    url: 'api/v2/notificationRules',
+    body: genRule({endpointID, orgID, name}),
+  })
+}
+
+type RuleArgs = {
+  endpointID: string
+  orgID: string
+  type?: string
+  name?: string
+}
+
+const genRule = ({
+  endpointID,
+  orgID,
+  type = 'slack',
+  name = 'r1',
+}: RuleArgs) => ({
+  type,
+  every: '20m',
+  offset: '1m',
+  url: '',
+  orgID,
+  name,
+  activeStatus: 'active',
+  status: 'active',
+  endpointID,
+  tagRules: [],
+  labels: [],
+  statusRules: [
+    {currentLevel: 'CRIT', period: '1h', count: 1, previousLevel: 'INFO'},
+  ],
+  description: '',
+  messageTemplate: 'im a message',
+  channel: '',
+})
+
 /*
 [{action: 'write', resource: {type: 'views'}},
       {action: 'write', resource: {type: 'documents'}},
@@ -478,6 +522,8 @@ export const createEndpoint = (
 /* eslint-disable */
 // notification endpoints
 Cypress.Commands.add('createEndpoint', createEndpoint)
+// notification rules
+Cypress.Commands.add('createRule', createRule)
 
 // assertions
 Cypress.Commands.add('fluxEqual', fluxEqual)

--- a/ui/src/buckets/actions/thunks.ts
+++ b/ui/src/buckets/actions/thunks.ts
@@ -50,13 +50,13 @@ import {
   addBucketLabelFailed,
   removeBucketLabelFailed,
 } from 'src/shared/copy/notifications'
-import {LIMIT} from 'src/resources/constants'
+import {BUCKET_LIMIT} from 'src/resources/constants'
 
 type Action = BucketAction | NotifyAction
 
 export const fetchAllBuckets = async (orgID: string) => {
   const resp = await api.getBuckets({
-    query: {orgID, limit: LIMIT},
+    query: {orgID, limit: BUCKET_LIMIT},
   })
 
   if (resp.status !== 200) {

--- a/ui/src/notifications/rules/actions/thunks.ts
+++ b/ui/src/notifications/rules/actions/thunks.ts
@@ -48,7 +48,7 @@ import {
 } from 'src/types'
 
 // Constants
-import {LIMIT} from 'src/resources/constants'
+import {RULE_LIMIT} from 'src/resources/constants'
 
 export const getNotificationRules = () => async (
   dispatch: Dispatch<
@@ -67,7 +67,9 @@ export const getNotificationRules = () => async (
 
     const {id: orgID} = getOrg(state)
 
-    const resp = await api.getNotificationRules({query: {orgID, limit: LIMIT}})
+    const resp = await api.getNotificationRules({
+      query: {orgID, limit: RULE_LIMIT},
+    })
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/notifications/rules/actions/thunks.ts
+++ b/ui/src/notifications/rules/actions/thunks.ts
@@ -32,6 +32,7 @@ import {setLabelOnResource} from 'src/labels/actions/creators'
 import {draftRuleToPostRule} from 'src/notifications/rules/utils'
 import {getOrg} from 'src/organizations/selectors'
 import {getAll, getStatus} from 'src/resources/selectors'
+import {incrementCloneName} from 'src/utils/naming'
 
 // Types
 import {
@@ -45,7 +46,9 @@ import {
   RuleEntities,
   ResourceType,
 } from 'src/types'
-import {incrementCloneName} from 'src/utils/naming'
+
+// Constants
+import {LIMIT} from 'src/resources/constants'
 
 export const getNotificationRules = () => async (
   dispatch: Dispatch<
@@ -64,7 +67,7 @@ export const getNotificationRules = () => async (
 
     const {id: orgID} = getOrg(state)
 
-    const resp = await api.getNotificationRules({query: {orgID}})
+    const resp = await api.getNotificationRules({query: {orgID, limit: LIMIT}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/resources/constants/index.ts
+++ b/ui/src/resources/constants/index.ts
@@ -1,2 +1,5 @@
 // TODO: temporary fix until we implement pagination https://github.com/influxdata/influxdb/pull/17336
+// Different resources *might* have different limits
 export const LIMIT = 100
+export const BUCKET_LIMIT = 100
+export const RULE_LIMIT = 100


### PR DESCRIPTION
Closes #18684 

### The Problem
User was only seeing 20 of their notification rules.

### The Temporary Solution
Increase the limit to max (100). This should unblock the user until...

### The Real Solution
Dedicate resources to pagination throughout the UI.  

![Kapture 2020-08-13 at 10 22 05](https://user-images.githubusercontent.com/7582765/90166723-84e55b80-dd4f-11ea-890c-ec41c4037f8a.gif)

