### PR TITLE
feat(task): Parse Task Options using Flux AST Helpers

### DIFF
--- a/kit/feature/middleware.go
+++ b/kit/feature/middleware.go
@@ -1,10 +1,10 @@
 package feature
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
-	"github.com/influxdata/influxdb/v2"
 	"go.uber.org/zap"
 )
 
@@ -44,8 +44,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// HTTPErrorHandler is an influxdb.HTTPErrorHandler. It's defined here instead
+// of referencing the other interface type, because we want to try our best to
+// avoid cyclical dependencies when feature package is used throughout the
+// codebase.
+type HTTPErrorHandler interface {
+	HandleHTTPError(ctx context.Context, err error, w http.ResponseWriter)
+}
+
 // NewFlagsHandler returns a handler that returns the map of computed feature flags on the request context.
-func NewFlagsHandler(errorHandler influxdb.HTTPErrorHandler, byKey ByKeyFn) http.Handler {
+func NewFlagsHandler(errorHandler HTTPErrorHandler, byKey ByKeyFn) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)

--- a/kv/task.go
+++ b/kv/task.go
@@ -707,7 +707,7 @@ func (s *Service) updateTask(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 
 	// update the flux script
 	if !upd.Options.IsZero() || upd.Flux != nil {
-		if err = upd.UpdateFlux(s.FluxLanguageService, task.Flux); err != nil {
+		if err = upd.UpdateFlux(ctx, s.FluxLanguageService, task.Flux); err != nil {
 			return nil, err
 		}
 		task.Flux = *upd.Flux

--- a/kv/task.go
+++ b/kv/task.go
@@ -1671,10 +1671,10 @@ func taskRunKey(taskID, runID influxdb.ID) ([]byte, error) {
 //
 // [1]: https://github.com/influxdata/influxdb/issues/17666
 func ExtractTaskOptions(ctx context.Context, lang influxdb.FluxLanguageService, flux string) (options.Options, error) {
-	if !feature.SimpleTaskOptionsExtraction().Enabled(ctx) {
-		return options.FromScript(lang, flux)
+	if feature.SimpleTaskOptionsExtraction().Enabled(ctx) {
+		return options.FromScriptAST(lang, flux)
 	}
-	return options.FromScriptAST(lang, flux)
+	return options.FromScript(lang, flux)
 }
 
 func (s *Service) maxPermissions(ctx context.Context, tx Tx, userID influxdb.ID) ([]influxdb.Permission, error) {

--- a/kv/task.go
+++ b/kv/task.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"encoding/json"
-	"regexp"
 	"strings"
 	"time"
 
@@ -1661,8 +1660,6 @@ func taskRunKey(taskID, runID influxdb.ID) ([]byte, error) {
 	return []byte(string(encodedID) + "/" + string(encodedRunID)), nil
 }
 
-var taskOptionsPattern = regexp.MustCompile(`option\s+task\s*=\s*{.*}`)
-
 // ExtractTaskOptions is a feature-flag driven switch between normal options
 // parsing and a more simplified variant.
 //
@@ -1677,21 +1674,7 @@ func ExtractTaskOptions(ctx context.Context, lang influxdb.FluxLanguageService, 
 	if !feature.SimpleTaskOptionsExtraction().Enabled(ctx) {
 		return options.FromScript(lang, flux)
 	}
-
-	matches := taskOptionsPattern.FindAllString(flux, -1)
-	if len(matches) == 0 {
-		return options.Options{}, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "no task options defined",
-		}
-	}
-	if len(matches) > 1 {
-		return options.Options{}, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "multiple task options defined",
-		}
-	}
-	return options.FromScript(lang, matches[0])
+	return options.FromScriptAST(lang, flux)
 }
 
 func (s *Service) maxPermissions(ctx context.Context, tx Tx, userID influxdb.ID) ([]influxdb.Permission, error) {

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -381,6 +381,14 @@ func TestExtractTaskOptions(t *testing.T) {
 			flux:   `doesntexist()`,
 			errMsg: "no task options defined",
 		},
+		{
+			name: "multiple assignments",
+			flux: `
+			option task = {name: "whatever", every: 1s, offset: 0s, concurrency: 2, retry: 2}
+			option task = {name: "whatever", every: 1s, offset: 0s, concurrency: 2, retry: 2}
+			`,
+			errMsg: "multiple task options defined",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -381,14 +381,6 @@ func TestExtractTaskOptions(t *testing.T) {
 			flux:   `doesntexist()`,
 			errMsg: "no task options defined",
 		},
-		{
-			name: "multiple assignments",
-			flux: `
-			option task = {name: "whatever", every: 1s, offset: 0s, concurrency: 2, retry: 2}
-			option task = {name: "whatever", every: 1s, offset: 0s, concurrency: 2, retry: 2}
-			`,
-			errMsg: "multiple task options defined",
-		},
 	}
 
 	for _, tc := range tcs {

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -265,9 +265,7 @@ func hasDuplicateOptions(file *ast.File, name string) bool {
 			assign := val.Assignment
 			if va, ok := assign.(*ast.VariableAssignment); ok {
 				if va.ID.Name == name {
-					if ok {
-						n++
-					}
+					n++
 				}
 			}
 		}

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -254,15 +254,6 @@ func FromScriptAST(lang FluxLanguageService, script string) (Options, error) {
 	return opts, nil
 }
 
-type unexpectedKindError struct {
-	Got      string
-	Expected string
-}
-
-func (err unexpectedKindError) Error() string {
-	return fmt.Sprintf("unexpected kind: got %q; expected %q", err.Got, err.Expected)
-}
-
 // hasDuplicateOptions determines whether or not there are multiple assignments
 // to the same option variable.
 //

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -230,7 +230,7 @@ func FromScriptAST(lang FluxLanguageService, script string) (Options, error) {
 	file := fluxAST.Files[0]
 	obj, err := edit.GetOption(file, "task")
 	if err != nil {
-		return opts, err
+		return opts, ErrNoTaskOptions
 	}
 
 	objExpr, ok := obj.(*ast.ObjectExpression)

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -289,26 +289,10 @@ func FromScriptAST(lang FluxLanguageService, script string) (Options, error) {
 	if offsetErr == nil {
 		switch offsetExprV := offsetExpr.(type) {
 		case *ast.UnaryExpression:
-			multiplier := int64(1)
-
-			switch operator := offsetExprV.Operator; operator {
-			case ast.AdditionOperator:
-			case ast.SubtractionOperator:
-				multiplier = -1
-			default:
-				return opts, fmt.Errorf("unexpected unary operator: %q", operator.String())
+			offsetDur, err := ParseSignedDuration(offsetExprV.Loc.Source)
+			if err != nil {
+				return opts, err
 			}
-
-			offsetDur, ok := offsetExprV.Argument.(*ast.DurationLiteral)
-			if !ok {
-				return opts, unexpectedKindError{
-					Got:      offsetExpr.Type(),
-					Expected: "DurationLiteral",
-				}
-			}
-
-			offsetDur.Values[0].Magnitude *= multiplier
-
 			opts.Offset = &Duration{Node: *offsetDur}
 		case *ast.DurationLiteral:
 			opts.Offset = &Duration{Node: *offsetExprV}

--- a/task/options/options_errors.go
+++ b/task/options/options_errors.go
@@ -5,26 +5,26 @@ import (
 	"fmt"
 )
 
-// ErrParseTaskOptionField is returned when we fail to parse a single field in
+// errParseTaskOptionField is returned when we fail to parse a single field in
 // task options.
-func ErrParseTaskOptionField(opt string) error {
+func errParseTaskOptionField(opt string) error {
 	return fmt.Errorf("failed to parse field '%s' in task options", opt)
 }
 
-// ErrMissingRequiredTaskOption is returned when we a required option is
+// errMissingRequiredTaskOption is returned when we a required option is
 // missing.
-func ErrMissingRequiredTaskOption(opt string) error {
+func errMissingRequiredTaskOption(opt string) error {
 	return fmt.Errorf("missing required option: %s", opt)
 }
 
-// ErrTaskInvalidDuration is returned when an "every" or "offset" option is invalid in a task.
-func ErrTaskInvalidDuration(err error) error {
+// errTaskInvalidDuration is returned when an "every" or "offset" option is invalid in a task.
+func errTaskInvalidDuration(err error) error {
 	return fmt.Errorf("invalid duration in task %s", err)
 }
 
-// ErrTaskOptionNotObjectExpression is returned when the type of an task option
+// errTaskOptionNotObjectExpression is returned when the type of an task option
 // value is not an object literal expression.
-func ErrTaskOptionNotObjectExpression(actualType string) error {
+func errTaskOptionNotObjectExpression(actualType string) error {
 	return fmt.Errorf("task option expected to be object literal, but found %q", actualType)
 }
 

--- a/task/options/options_errors.go
+++ b/task/options/options_errors.go
@@ -19,4 +19,5 @@ func ErrTaskInvalidDuration(err error) error {
 
 var (
 	ErrDuplicateIntervalField = fmt.Errorf("cannot use both cron and every in task options")
+	ErrNoTaskOptions          = fmt.Errorf("no task options defined")
 )

--- a/task/options/options_errors.go
+++ b/task/options/options_errors.go
@@ -1,13 +1,18 @@
 package options
 
 import (
+	"errors"
 	"fmt"
 )
 
+// ErrParseTaskOptionField is returned when we fail to parse a single field in
+// task options.
 func ErrParseTaskOptionField(opt string) error {
 	return fmt.Errorf("failed to parse field '%s' in task options", opt)
 }
 
+// ErrMissingRequiredTaskOption is returned when we a required option is
+// missing.
 func ErrMissingRequiredTaskOption(opt string) error {
 	return fmt.Errorf("missing required option: %s", opt)
 }
@@ -17,7 +22,15 @@ func ErrTaskInvalidDuration(err error) error {
 	return fmt.Errorf("invalid duration in task %s", err)
 }
 
+// ErrTaskOptionNotObjectExpression is returned when the type of an task option
+// value is not an object literal expression.
+func ErrTaskOptionNotObjectExpression(actualType string) error {
+	return fmt.Errorf("task option expected to be object literal, but found %q", actualType)
+}
+
 var (
-	ErrDuplicateIntervalField = fmt.Errorf("cannot use both cron and every in task options")
-	ErrNoTaskOptions          = fmt.Errorf("no task options defined")
+	ErrDuplicateIntervalField     = errors.New("cannot use both cron and every in task options")
+	ErrNoTaskOptionsDefined       = errors.New("no task options defined")
+	ErrMultipleTaskOptionsDefined = errors.New("multiple task options defined")
+	ErrNoASTFile                  = errors.New("expected parsed file, but found none")
 )

--- a/task/options/options_test.go
+++ b/task/options/options_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/influxdb/v2/pkg/pointer"
 	_ "github.com/influxdata/influxdb/v2/query/builtin"
 	"github.com/influxdata/influxdb/v2/query/fluxlang"
@@ -54,6 +56,72 @@ func TestNegDurations(t *testing.T) {
 	}
 	if d != -time.Minute {
 		t.Fatalf("expected duration to be -1m but was %s", d)
+	}
+}
+
+func TestFromScriptAST(t *testing.T) {
+	for _, c := range []struct {
+		script    string
+		exp       options.Options
+		shouldErr bool
+	}{
+		{script: scriptGenerator(options.Options{Name: "name0", Cron: "* * * * *", Concurrency: pointer.Int64(2), Retry: pointer.Int64(3), Offset: options.MustParseDuration("-1m")}, ""),
+			exp: options.Options{Name: "name0",
+				Cron:        "* * * * *",
+				Concurrency: pointer.Int64(2),
+				Retry:       pointer.Int64(3),
+				Offset:      options.MustParseDuration("-1m")}},
+		{script: scriptGenerator(options.Options{Name: "name1", Every: *(options.MustParseDuration("5s"))}, ""), exp: options.Options{Name: "name1", Every: *(options.MustParseDuration("5s")), Concurrency: pointer.Int64(1), Retry: pointer.Int64(1)}},
+		{script: scriptGenerator(options.Options{Name: "name2", Cron: "* * * * *"}, ""), exp: options.Options{Name: "name2", Cron: "* * * * *", Concurrency: pointer.Int64(1), Retry: pointer.Int64(1)}},
+		{script: scriptGenerator(options.Options{Name: "name3", Every: *(options.MustParseDuration("1h")), Cron: "* * * * *"}, ""), shouldErr: true},
+		{script: scriptGenerator(options.Options{Name: "name4", Concurrency: pointer.Int64(1000), Every: *(options.MustParseDuration("1h"))}, ""), shouldErr: true},
+		{script: "option task = {\n  name: \"name5\",\n  concurrency: 0,\n  every: 1m0s,\n\n}\n\nfrom(bucket: \"test\")\n    |> range(start:-1h)", shouldErr: true},
+		{script: "option task = {\n  name: \"name6\",\n  concurrency: 1,\n  every: 1,\n\n}\n\nfrom(bucket: \"test\")\n    |> range(start:-1h)", shouldErr: true},
+		{script: scriptGenerator(options.Options{Name: "name7", Retry: pointer.Int64(20), Every: *(options.MustParseDuration("1h"))}, ""), shouldErr: true},
+		{script: "option task = {\n  name: \"name8\",\n  retry: 0,\n  every: 1m0s,\n\n}\n\nfrom(bucket: \"test\")\n    |> range(start:-1h)", shouldErr: true},
+		{script: scriptGenerator(options.Options{Name: "name9"}, ""), shouldErr: true},
+		{script: scriptGenerator(options.Options{}, ""), shouldErr: true},
+		{script: `option task = {
+			name: "name10",
+			every: 1d,
+			offset: 1m,
+		}
+			from(bucket: "metrics")
+			|> range(start: now(), stop: 8w)
+		`,
+			exp: options.Options{Name: "name10", Every: *(options.MustParseDuration("1d")), Concurrency: pointer.Int64(1), Retry: pointer.Int64(1), Offset: options.MustParseDuration("1m")},
+		},
+		{script: `option task = {
+			name: "name11",
+			every: 1m,
+			offset: 1d,
+		}
+			from(bucket: "metrics")
+			|> range(start: now(), stop: 8w)
+
+		`,
+			exp: options.Options{Name: "name11", Every: *(options.MustParseDuration("1m")), Concurrency: pointer.Int64(1), Retry: pointer.Int64(1), Offset: options.MustParseDuration("1d")},
+		},
+		{script: "option task = {name:\"test_task_smoke_name\", every:30s} from(bucket:\"test_tasks_smoke_bucket_source\") |> range(start: -1h) |> map(fn: (r) => ({r with _time: r._time, _value:r._value, t : \"quality_rocks\"}))|> to(bucket:\"test_tasks_smoke_bucket_dest\", orgID:\"3e73e749495d37d5\")",
+			exp: options.Options{Name: "test_task_smoke_name", Every: *(options.MustParseDuration("30s")), Retry: pointer.Int64(1), Concurrency: pointer.Int64(1)}, shouldErr: false}, // TODO(docmerlin): remove this once tasks fully supports all flux duration units.
+
+	} {
+		o, err := options.FromScriptAST(fluxlang.DefaultService, c.script)
+		if c.shouldErr && err == nil {
+			t.Fatalf("script %q should have errored but didn't", c.script)
+		} else if !c.shouldErr && err != nil {
+			t.Fatalf("script %q should not have errored, but got %v", c.script, err)
+		}
+
+		if err != nil {
+			continue
+		}
+
+		ignoreLocation := cmpopts.IgnoreFields(ast.BaseNode{}, "Loc")
+
+		if !cmp.Equal(o, c.exp, ignoreLocation) {
+			t.Fatalf("script %q got unexpected result -got/+exp\n%s", c.script, cmp.Diff(o, c.exp))
+		}
 	}
 }
 

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -375,6 +375,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	if origID != f.ID {
 		t.Fatalf("task ID unexpectedly changed during update, from %s to %s", origID.String(), f.ID.String())
 	}
+
 	if f.Flux != newFlux {
 		t.Fatalf("wrong flux from update; want %q, got %q", newFlux, f.Flux)
 	}
@@ -426,7 +427,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	// Update task: switch to every.
 	newStatus = string(influxdb.TaskActive)
-	newFlux = "option task = {\n\tname: \"task-changed #98\",\n\tevery: 30s,\n\toffset: 5s,\n\tconcurrency: 100,\n}\n\nfrom(bucket: \"b\")\n\t|> to(bucket: \"two\", orgID: \"000000000000000\")"
+	newFlux = "option task = {\n\tname: \"task-changed #98\",\n\toffset: 5s,\n\tconcurrency: 100,\n\tevery: 30s,\n}\n\nfrom(bucket: \"b\")\n\t|> to(bucket: \"two\", orgID: \"000000000000000\")"
 	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Options: options.Options{Every: *(options.MustParseDuration("30s"))}})
 	if err != nil {
 		t.Fatal(err)
@@ -655,7 +656,7 @@ from(bucket: "b")
 		t.Fatal(err)
 	}
 	t.Run("update task and delete offset", func(t *testing.T) {
-		expectedFlux := `option task = {name: "task-Options-Update", every: 10s, concurrency: 100}
+		expectedFlux := `option task = {name: "task-Options-Update", concurrency: 100, every: 10s}
 
 from(bucket: "b")
 	|> to(bucket: "two", orgID: "000000000000000")`
@@ -675,8 +676,8 @@ from(bucket: "b")
 	t.Run("update task with different offset option", func(t *testing.T) {
 		expectedFlux := `option task = {
 	name: "task-Options-Update",
-	every: 10s,
 	concurrency: 100,
+	every: 10s,
 	offset: 10s,
 }
 
@@ -1738,14 +1739,14 @@ const (
 	concurrency: 100,
 }
 
-from(bucket:"b")
+from(bucket: "b")
 	|> to(bucket: "two", orgID: "000000000000000")`
 
 	scriptDifferentName = `option task = {
 	name: "task-changed #%d",
-	cron: "* * * * *",
 	offset: 5s,
 	concurrency: 100,
+	cron: "* * * * *",
 }
 
 from(bucket: "b")

--- a/task_test.go
+++ b/task_test.go
@@ -94,7 +94,7 @@ from(bucket: "x")
 			t.Error(err)
 		}
 		if op.Offset == nil || op.Offset.String() != "30s" {
-			t.Fatalf("expected every to be 30s but was %s", op.Every)
+			t.Fatalf("expected offset to be 30s but was %s", op.Offset)
 		}
 	})
 	t.Run("switching from every to cron", func(t *testing.T) {

--- a/task_test.go
+++ b/task_test.go
@@ -1,11 +1,14 @@
 package influxdb_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/feature"
+	"github.com/influxdata/influxdb/v2/mock"
 	_ "github.com/influxdata/influxdb/v2/query/builtin"
 	"github.com/influxdata/influxdb/v2/query/fluxlang"
 	"github.com/influxdata/influxdb/v2/task/options"
@@ -53,10 +56,26 @@ func TestOptionsMarshal(t *testing.T) {
 	}
 }
 
+func TestOptionsEditWithAST(t *testing.T) {
+	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
+		feature.SimpleTaskOptionsExtraction(): true,
+	})
+	testOptionsEdit(t, flagger)
+}
+
 func TestOptionsEdit(t *testing.T) {
+	flagger := mock.NewFlagger(map[feature.Flag]interface{}{
+		feature.SimpleTaskOptionsExtraction(): false,
+	})
+	testOptionsEdit(t, flagger)
+}
+
+func testOptionsEdit(t *testing.T, flagger feature.Flagger) {
+	ctx, _ := feature.Annotate(context.Background(), flagger)
+
 	tu := &platform.TaskUpdate{}
 	tu.Options.Every = *(options.MustParseDuration("10s"))
-	if err := tu.UpdateFlux(fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
+	if err := tu.UpdateFlux(ctx, fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("zeroing", func(t *testing.T) {
@@ -86,7 +105,7 @@ from(bucket: "x")
 	t.Run("add new option", func(t *testing.T) {
 		tu := &platform.TaskUpdate{}
 		tu.Options.Offset = options.MustParseDuration("30s")
-		if err := tu.UpdateFlux(fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
+		if err := tu.UpdateFlux(ctx, fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
 			t.Fatal(err)
 		}
 		op, err := options.FromScript(fluxlang.DefaultService, *tu.Flux)
@@ -100,7 +119,7 @@ from(bucket: "x")
 	t.Run("switching from every to cron", func(t *testing.T) {
 		tu := &platform.TaskUpdate{}
 		tu.Options.Cron = "* * * * *"
-		if err := tu.UpdateFlux(fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
+		if err := tu.UpdateFlux(ctx, fluxlang.DefaultService, `option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
 			t.Fatal(err)
 		}
 		op, err := options.FromScript(fluxlang.DefaultService, *tu.Flux)
@@ -117,7 +136,7 @@ from(bucket: "x")
 	t.Run("switching from cron to every", func(t *testing.T) {
 		tu := &platform.TaskUpdate{}
 		tu.Options.Every = *(options.MustParseDuration("10s"))
-		if err := tu.UpdateFlux(fluxlang.DefaultService, `option task = {cron: "* * * * *", name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
+		if err := tu.UpdateFlux(ctx, fluxlang.DefaultService, `option task = {cron: "* * * * *", name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
 			t.Fatal(err)
 		}
 		op, err := options.FromScript(fluxlang.DefaultService, *tu.Flux)
@@ -138,7 +157,7 @@ from(bucket: "x")
 
 from(bucket: "x")
 	|> range(start: -1h)`
-		if err := tu.UpdateFlux(fluxlang.DefaultService, `option task = {cron: "* * * * *", name: "foo", offset: 10s} from(bucket:"x") |> range(start:-1h)`); err != nil {
+		if err := tu.UpdateFlux(ctx, fluxlang.DefaultService, `option task = {cron: "* * * * *", name: "foo", offset: 10s} from(bucket:"x") |> range(start:-1h)`); err != nil {
 			t.Fatal(err)
 		}
 		op, err := options.FromScript(fluxlang.DefaultService, *tu.Flux)


### PR DESCRIPTION
Closes influxdata/idpe#8153

This makes use of new Flux helpers to perform Task options extraction and updating using only the AST representation. We parse Flux in a few different contexts, and some of those contexts don't always have the same libraries available at evaluation time. Parsing with AST enables us to extract options from scripts that were previously problematic.

A drawback of this approach is that option values in a `option task = { ... }` statement **must be value literals** (e.g. `1m`, `"string"`, etc). Given that `option` values are already restricted in the types of identifiers that can be used in them, this seems like an acceptable trade-off.

This removes the previous (hacky) experiment of extracting Task option assignment statements from a Flux script using regular expressions.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] Documentation updated or issue created
