### PR TITLE
feat(query): enable the schema mutation optimizations

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -92,13 +92,6 @@
   contact: Query Team
   lifetime: temporary
 
-- name: Memory Optimized Schema Mutation
-  description: Enable the memory optimized schema mutation functions
-  key: memoryOptimizedSchemaMutation
-  default: false
-  contact: Query Team
-  lifetime: temporary
-
 - name: Simple Task Options Extraction
   description: Simplified task options extraction to avoid undefined functions when saving tasks
   key: simpleTaskOptionsExtraction

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -156,20 +156,6 @@ func MemoryOptimizedFill() BoolFlag {
 	return memoryOptimizedFill
 }
 
-var memoryOptimizedSchemaMutation = MakeBoolFlag(
-	"Memory Optimized Schema Mutation",
-	"memoryOptimizedSchemaMutation",
-	"Query Team",
-	false,
-	Temporary,
-	false,
-)
-
-// MemoryOptimizedSchemaMutation - Enable the memory optimized schema mutation functions
-func MemoryOptimizedSchemaMutation() BoolFlag {
-	return memoryOptimizedSchemaMutation
-}
-
 var simpleTaskOptionsExtraction = MakeBoolFlag(
 	"Simple Task Options Extraction",
 	"simpleTaskOptionsExtraction",
@@ -252,7 +238,6 @@ var all = []Flag{
 	hydratevars,
 	queryCacheForDashboards,
 	memoryOptimizedFill,
-	memoryOptimizedSchemaMutation,
 	simpleTaskOptionsExtraction,
 	useUserPermission,
 	mergeFiltersRule,
@@ -272,7 +257,6 @@ var byKey = map[string]Flag{
 	"hydratevars":                   hydratevars,
 	"queryCacheForDashboards":       queryCacheForDashboards,
 	"memoryOptimizedFill":           memoryOptimizedFill,
-	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,
 	"simpleTaskOptionsExtraction":   simpleTaskOptionsExtraction,
 	"useUserPermission":             useUserPermission,
 	"mergeFiltersRule":              mergeFiltersRule,

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -32,7 +32,6 @@ func init() {
 		GroupWindowAggregateTransposeRule{},
 		PushDownGroupAggregateRule{},
 		SwitchFillImplRule{},
-		SwitchSchemaMutationImplRule{},
 	)
 	plan.RegisterLogicalRules(
 		MergeFiltersRule{},
@@ -1155,26 +1154,6 @@ func (r SwitchFillImplRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Nod
 		}
 	}
 	return pn, false, nil
-}
-
-type SwitchSchemaMutationImplRule struct{}
-
-func (SwitchSchemaMutationImplRule) Name() string {
-	return "SwitchSchemaMutationImplRule"
-}
-
-func (SwitchSchemaMutationImplRule) Pattern() plan.Pattern {
-	return plan.Pat(universe.SchemaMutationKind, plan.Any())
-}
-
-func (r SwitchSchemaMutationImplRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
-	spec, ok := pn.ProcedureSpec().(*universe.DualImplProcedureSpec)
-	if !ok || spec.UseDeprecated {
-		return pn, false, nil
-	}
-
-	spec.UseDeprecated = !feature.MemoryOptimizedSchemaMutation().Enabled(ctx)
-	return pn, spec.UseDeprecated, nil
 }
 
 func asSchemaMutationProcedureSpec(spec plan.ProcedureSpec) *universe.SchemaMutationProcedureSpec {


### PR DESCRIPTION
This removes the feature flag that disabled schema mutation
optimizations so they are now permanently on.