### PR TITLE
fix(api/dashboards): FindOptions not working

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2433,6 +2433,9 @@ paths:
       summary: Get all dashboards
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Descending"
         - in: query
           name: owner
           description: The owner ID.

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -710,6 +710,44 @@ func FindDashboards(
 			},
 		},
 		{
+			name: "find all dashboards by offset and limit and org 1",
+			fields: DashboardFields{
+				Dashboards: []*platform.Dashboard{
+					{
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
+					},
+					{
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
+					},
+					{
+						ID:             MustIDBase16(dashThreeID),
+						OrganizationID: 1,
+						Name:           "321",
+					},
+				},
+			},
+			args: args{
+				findOptions: platform.FindOptions{
+					Limit:  1,
+					Offset: 1,
+				},
+				organizationID: idPtr(1),
+			},
+			wants: wants{
+				dashboards: []*platform.Dashboard{
+					{
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
+					},
+				},
+			},
+		},
+		{
 			name: "find all dashboards sorted by created at",
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{


### PR DESCRIPTION
Closes #19274

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed CLA (if not already signed)

Problem 1: If you specify `orgID` in `filter`, then the `findDashboards` function will ignore your `limit` and `offset` in `FindOptions`.

Problem2:  It seems that the swagger document does not expose params like `limit` and `offset` now, but front-ui will use it. 

