### PR TITLE
tsdb/index/inmem: Ensure conversion from int to string yields a string

### DIFF
--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -175,11 +175,11 @@ func TestTagKeyValue_Concurrent(t *testing.T) {
 				case 1:
 					v.Cardinality()
 				case 2:
-					v.Contains(string(rand.Intn(52) + 65))
+					v.Contains(fmt.Sprint(rand.Intn(52) + 65))
 				case 3:
-					v.InsertSeriesIDByte([]byte(string(rand.Intn(52)+65)), rand.Uint64()%1000)
+					v.InsertSeriesIDByte([]byte(fmt.Sprint(rand.Intn(52)+65)), rand.Uint64()%1000)
 				case 4:
-					v.Load(string(rand.Intn(52) + 65))
+					v.Load(fmt.Sprint(rand.Intn(52) + 65))
 				case 5:
 					v.Range(func(tagValue string, a seriesIDs) bool {
 						return rand.Intn(10) == 0


### PR DESCRIPTION
With the release of go 1.15, the test-suite doesn't pass as `go vet` got
a new warning for improper `string(x)` usage.

https://golang.org/doc/go1.15#vet

    $ go test ./...
    # github.com/influxdata/influxdb/tsdb/index/inmem
    tsdb/index/inmem/meta_test.go:178:17: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
    tsdb/index/inmem/meta_test.go:180:34: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
    tsdb/index/inmem/meta_test.go:182:13: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
    [...]
    FAIL

This patch changes ensures we are utilizing `fmt.Sprint` instead as
recommended.

Signed-off-by: Morten Linderud <morten@linderud.pw>
