### PR TITLE
fix(system-vars-mapping): updated variable mapping for system variabes to register changes in system variables

### DIFF
--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -106,6 +106,9 @@ const DashboardHeader: FC<Props> = ({
   }
 
   const handleChooseTimeRange = (timeRange: TimeRange) => {
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      resetQueryCache()
+    }
     setDashboardTimeRange(dashboard.id, timeRange)
     updateQueryParams({
       lower: timeRange.lower,

--- a/ui/src/shared/apis/queryCache.ts
+++ b/ui/src/shared/apis/queryCache.ts
@@ -20,6 +20,9 @@ import {WINDOW_PERIOD} from 'src/variables/constants'
 export const TIME_INVALIDATION = 1000 * 60 * 10 // 10 minutes
 
 const asSimplyKeyValueVariables = (vari: Variable) => {
+  if (vari.arguments?.type === 'system') {
+    return [vari.name]: vari.arguments.values || []
+  }
   return {
     [vari.name]: vari.selected || [],
   }
@@ -158,7 +161,9 @@ export const getCachedResultsOrRunQuery = (
   event('Starting Query Cache Process ', {context: 'queryCache', queryID})
   const usedVars = filterUnusedVarsBasedOnQuery(getAllVariables(state), [query])
   const variables = sortBy(usedVars, ['name'])
+  console.log('variables', variables)
   const simplifiedVariables = variables.map(v => asSimplyKeyValueVariables(v))
+  console.log('simplifiedVariables: ', simplifiedVariables)
   const stringifiedVars = JSON.stringify(simplifiedVariables)
   // create the queryID based on the query & vars
   const hashedVariables = `${hashCode(stringifiedVars)}`

--- a/ui/src/shared/apis/queryCache.ts
+++ b/ui/src/shared/apis/queryCache.ts
@@ -161,9 +161,7 @@ export const getCachedResultsOrRunQuery = (
   event('Starting Query Cache Process ', {context: 'queryCache', queryID})
   const usedVars = filterUnusedVarsBasedOnQuery(getAllVariables(state), [query])
   const variables = sortBy(usedVars, ['name'])
-  console.log('variables', variables)
   const simplifiedVariables = variables.map(v => asSimplyKeyValueVariables(v))
-  console.log('simplifiedVariables: ', simplifiedVariables)
   const stringifiedVars = JSON.stringify(simplifiedVariables)
   // create the queryID based on the query & vars
   const hashedVariables = `${hashCode(stringifiedVars)}`

--- a/ui/src/shared/apis/queryCache.ts
+++ b/ui/src/shared/apis/queryCache.ts
@@ -21,7 +21,7 @@ export const TIME_INVALIDATION = 1000 * 60 * 10 // 10 minutes
 
 const asSimplyKeyValueVariables = (vari: Variable) => {
   if (vari.arguments?.type === 'system') {
-    return [vari.name]: vari.arguments.values || []
+    return {[vari.name]: vari.arguments.values || []}
   }
   return {
     [vari.name]: vari.selected || [],


### PR DESCRIPTION
Closes #19346

### Problem

Changing the timeRange in the dashboard page does not issue a new query for the newly selected timerange

### Solution

The issue here is that the system variables stored selected values differently than other variables so we are writing a condition to map system variables differently. This PR also clears the cache whenever the timerange selection is updated 

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)

