### PR TITLE
chore(ui): upgrade clockface dependency to 2.3.4

### DIFF
--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -40,6 +40,8 @@ describe('Buckets', () => {
       const labelName = 'l1'
       cy.getByTestID('inline-labels--popover--contents').type(labelName)
       cy.getByTestID('inline-labels--create-new').click()
+      // Wait for animation to complete
+      cy.wait(500)
       cy.getByTestID('create-label-form--submit').click()
 
       // Delete the label

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -210,7 +210,9 @@ describe('Checks', () => {
       cy.get('body').tab()
       cy.getByTestID('filter--input checks').should('have.focus')
 
-      cy.focused().tab()
+      cy.focused()
+        .tab()
+        .tab()
       cy.getByTestID('filter--input endpoints').should('have.focus')
 
       cy.focused().tab()

--- a/ui/package.json
+++ b/ui/package.json
@@ -132,7 +132,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "2.3.1",
+    "@influxdata/clockface": "2.3.4",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.11",
     "@influxdata/giraffe": "0.24.0",

--- a/ui/src/checks/components/CheckEOSaveButton.tsx
+++ b/ui/src/checks/components/CheckEOSaveButton.tsx
@@ -48,6 +48,7 @@ const CheckEOSaveButton: FunctionComponent<Props> = ({
         hideEvent={PopoverInteraction.None}
         color={ComponentColor.Secondary}
         appearance={Appearance.Outline}
+        forceToTop={true}
         contents={() => (
           <div className="query-checklist--popover">
             <p>{`To create a ${checkType} check, you must select:`}</p>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -747,10 +747,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.1.tgz#562a218e62b50ba16cd4a4e1e88b2e335289c595"
-  integrity sha512-NqPaCT/vUOCEnjAekfECAvUS3OiSwHREwG/5YuawCw5EoswcUc9h6sMSo2spPxXQuiVAB4RcsxeX3+hqP6pU7w==
+"@influxdata/clockface@2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.4.tgz#9c496601253e1d49cbeae29a7b9cfb54862785f6"
+  integrity sha512-mmz3YElK8Ho+1onEafuas6sVhIT638JA4NbDTO3bVJgK1TG7AnU4rQP+c6fj7vZSfvrIwtOwGaMONJTaww5o6w==
 
 "@influxdata/flux-lsp-browser@^0.5.11":
   version "0.5.11"


### PR DESCRIPTION
Borked my earlier PR https://github.com/influxdata/influxdb/pull/19349 and using this PR instead

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
