### PR TITLE
fix: in non cloud environments, show actual errors, rather than HB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### UI Improvements
 1. [19231](https://github.com/influxdata/influxdb/pull/19231): Alerts page filter inputs now have tab indices for keyboard navigation
+1. [19364](https://github.com/influxdata/influxdb/pull/19364): Errors in OSS are now properly printed to the console
 
 ## v2.0.0-beta.15 [2020-07-23]
 

--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -55,11 +55,7 @@ export const reportError = (
 
     event('ui error', {error: errorType}, {errorCount: 1})
   } else {
-    const honeyBadgerContext = (HoneyBadger as any).context
-    /* eslint-disable no-console */
-    console.log('Context that would have been sent to HoneyBadger:')
-    console.table({...honeyBadgerContext, ...context, ...options})
-    /* eslint-enable no-console */
+    console.error(error)
   }
 }
 


### PR DESCRIPTION
Rather than showing unhelpful HB context that would have been sent, just show the error that caused the issue.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
