### PR TITLE
fix(variables): add id to put variable request

### DIFF
--- a/http/variable_test.go
+++ b/http/variable_test.go
@@ -595,6 +595,109 @@ func TestVariableService_handlePostVariable(t *testing.T) {
 	}
 }
 
+func TestVariableService_handlePutVariable(t *testing.T) {
+	type fields struct {
+		VariableService platform.VariableService
+	}
+	type args struct {
+		id       string
+		variable string
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "PUT a variable",
+			fields: fields{
+				&mock.VariableService{
+					ReplaceVariableF: func(ctx context.Context, m *platform.Variable) error {
+						m.ID = itesting.MustIDBase16("75650d0a636f6d70")
+						m.OrganizationID = platform.ID(1)
+						m.UpdatedAt = faketime
+						m.CreatedAt = faketime
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: "75650d0a636f6d70",
+				variable: `
+{
+  "name": "my-great-variable",
+  "orgID": "0000000000000001",
+  "arguments": {
+    "type": "constant",
+    "values": [
+      "bar",
+      "foo"
+    ]
+  },
+  "selected": [
+    "'foo'"
+  ],
+	"createdAt": "2006-05-04T01:02:03Z",
+	"updatedAt": "2006-05-04T01:02:03Z"
+}
+`,
+			},
+			wants: wants{
+				statusCode:  200,
+				contentType: "application/json; charset=utf-8",
+				body: `{"id":"75650d0a636f6d70","orgID":"0000000000000001","name":"my-great-variable","description":"","selected":["'foo'"],"arguments":{"type":"constant","values":["bar","foo"]},"createdAt":"2006-05-04T01:02:03Z","updatedAt":"2006-05-04T01:02:03Z","labels":[],"links":{"self":"/api/v2/variables/75650d0a636f6d70","labels":"/api/v2/variables/75650d0a636f6d70/labels","org":"/api/v2/orgs/0000000000000001"}}
+`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variableBackend := NewMockVariableBackend(t)
+			variableBackend.HTTPErrorHandler = kithttp.ErrorHandler(0)
+			variableBackend.VariableService = tt.fields.VariableService
+			h := NewVariableHandler(zaptest.NewLogger(t), variableBackend)
+			r := httptest.NewRequest("GET", "http://howdy.tld", bytes.NewReader([]byte(tt.args.variable)))
+			r = r.WithContext(context.WithValue(
+				context.TODO(),
+				httprouter.ParamsKey,
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: tt.args.id,
+					},
+				}))
+			w := httptest.NewRecorder()
+
+			h.handlePutVariable(w, r)
+
+			res := w.Result()
+			contentType := res.Header.Get("Content-Type")
+			bodyBytes, _ := ioutil.ReadAll(res.Body)
+			body := string(bodyBytes[:])
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("got = %v, want %v", res.StatusCode, tt.wants.statusCode)
+			}
+			if contentType != tt.wants.contentType {
+				t.Errorf("got = %v, want %v", contentType, tt.wants.contentType)
+			}
+			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
+				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+			} else if tt.wants.body != "" && !eq {
+				t.Errorf("%q. ***%s***", tt.name, diff)
+			}
+		})
+	}
+}
+
 func TestVariableService_handlePatchVariable(t *testing.T) {
 	type fields struct {
 		VariableService platform.VariableService

--- a/mock/variable_service.go
+++ b/mock/variable_service.go
@@ -3,68 +3,68 @@ package mock
 import (
 	"context"
 
-	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2"
 )
 
-var _ platform.VariableService = &VariableService{}
+var _ influxdb.VariableService = &VariableService{}
 
 type VariableService struct {
-	CreateVariableF       func(context.Context, *platform.Variable) error
+	CreateVariableF       func(context.Context, *influxdb.Variable) error
 	CreateVariableCalls   SafeCount
-	DeleteVariableF       func(context.Context, platform.ID) error
+	DeleteVariableF       func(context.Context, influxdb.ID) error
 	DeleteVariableCalls   SafeCount
-	FindVariableByIDF     func(context.Context, platform.ID) (*platform.Variable, error)
+	FindVariableByIDF     func(context.Context, influxdb.ID) (*influxdb.Variable, error)
 	FindVariableByIDCalls SafeCount
-	FindVariablesF        func(context.Context, platform.VariableFilter, ...platform.FindOptions) ([]*platform.Variable, error)
+	FindVariablesF        func(context.Context, influxdb.VariableFilter, ...influxdb.FindOptions) ([]*influxdb.Variable, error)
 	FindVariablesCalls    SafeCount
-	ReplaceVariableF      func(context.Context, *platform.Variable) error
+	ReplaceVariableF      func(context.Context, *influxdb.Variable) error
 	ReplaceVariableCalls  SafeCount
-	UpdateVariableF       func(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error)
+	UpdateVariableF       func(ctx context.Context, id influxdb.ID, update *influxdb.VariableUpdate) (*influxdb.Variable, error)
 	UpdateVariableCalls   SafeCount
 }
 
 // NewVariableService returns a mock of VariableService where its methods will return zero values.
 func NewVariableService() *VariableService {
 	return &VariableService{
-		CreateVariableF:   func(context.Context, *platform.Variable) error { return nil },
-		DeleteVariableF:   func(context.Context, platform.ID) error { return nil },
-		FindVariableByIDF: func(context.Context, platform.ID) (*platform.Variable, error) { return nil, nil },
-		FindVariablesF: func(context.Context, platform.VariableFilter, ...platform.FindOptions) ([]*platform.Variable, error) {
+		CreateVariableF:   func(context.Context, *influxdb.Variable) error { return nil },
+		DeleteVariableF:   func(context.Context, influxdb.ID) error { return nil },
+		FindVariableByIDF: func(context.Context, influxdb.ID) (*influxdb.Variable, error) { return nil, nil },
+		FindVariablesF: func(context.Context, influxdb.VariableFilter, ...influxdb.FindOptions) ([]*influxdb.Variable, error) {
 			return nil, nil
 		},
-		ReplaceVariableF: func(context.Context, *platform.Variable) error { return nil },
-		UpdateVariableF: func(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error) {
+		ReplaceVariableF: func(context.Context, *influxdb.Variable) error { return nil },
+		UpdateVariableF: func(ctx context.Context, id influxdb.ID, update *influxdb.VariableUpdate) (*influxdb.Variable, error) {
 			return nil, nil
 		},
 	}
 }
 
-func (s *VariableService) CreateVariable(ctx context.Context, variable *platform.Variable) error {
+func (s *VariableService) CreateVariable(ctx context.Context, variable *influxdb.Variable) error {
 	defer s.CreateVariableCalls.IncrFn()()
 	return s.CreateVariableF(ctx, variable)
 }
 
-func (s *VariableService) ReplaceVariable(ctx context.Context, variable *platform.Variable) error {
+func (s *VariableService) ReplaceVariable(ctx context.Context, variable *influxdb.Variable) error {
 	defer s.ReplaceVariableCalls.IncrFn()()
 	return s.ReplaceVariableF(ctx, variable)
 }
 
-func (s *VariableService) FindVariables(ctx context.Context, filter platform.VariableFilter, opts ...platform.FindOptions) ([]*platform.Variable, error) {
+func (s *VariableService) FindVariables(ctx context.Context, filter influxdb.VariableFilter, opts ...influxdb.FindOptions) ([]*influxdb.Variable, error) {
 	defer s.FindVariablesCalls.IncrFn()()
 	return s.FindVariablesF(ctx, filter, opts...)
 }
 
-func (s *VariableService) FindVariableByID(ctx context.Context, id platform.ID) (*platform.Variable, error) {
+func (s *VariableService) FindVariableByID(ctx context.Context, id influxdb.ID) (*influxdb.Variable, error) {
 	defer s.FindVariableByIDCalls.IncrFn()()
 	return s.FindVariableByIDF(ctx, id)
 }
 
-func (s *VariableService) DeleteVariable(ctx context.Context, id platform.ID) error {
+func (s *VariableService) DeleteVariable(ctx context.Context, id influxdb.ID) error {
 	defer s.DeleteVariableCalls.IncrFn()()
 	return s.DeleteVariableF(ctx, id)
 }
 
-func (s *VariableService) UpdateVariable(ctx context.Context, id platform.ID, update *platform.VariableUpdate) (*platform.Variable, error) {
+func (s *VariableService) UpdateVariable(ctx context.Context, id influxdb.ID, update *influxdb.VariableUpdate) (*influxdb.Variable, error) {
 	defer s.UpdateVariableCalls.IncrFn()()
 	return s.UpdateVariableF(ctx, id, update)
 }

--- a/testing/variable.go
+++ b/testing/variable.go
@@ -631,7 +631,7 @@ func FindVariableByID(init func(VariableFields, *testing.T) (influxdb.VariableSe
 				return
 			}
 
-			if diff := cmp.Diff(variable, tt.wants.variable); diff != "" {
+			if diff := cmp.Diff(variable, tt.wants.variable, variableCmpOptions...); diff != "" {
 				t.Fatalf("found unexpected variable -got/+want\ndiff %s", diff)
 			}
 		})


### PR DESCRIPTION
This PR fixes the Put route for Variables by adding ID as a parameter. The ID is passed through instead of being taken off the Variable object because it does not come through the HTTP route on the object for some reason, which you can see from the Update route.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
