### PR TITLE
feat(templates): handle task as option and spec in template query

### DIFF
--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1602,15 +1602,14 @@ func (p *Template) parseQuery(prefix, source string, params, task []Resource) (q
 	mParams := make(map[string]*references)
 	tParams := make(map[string]*references)
 
-	opt, err := edit.GetOption(files[0], "params")
-	topt, err2 := edit.GetOption(files[0], "task") // parse the task out of the query. need to use these params to set the task bits
-	if err != nil && err2 != nil {
+	paramsOpt, paramsErr := edit.GetOption(files[0], "params")
+	taskOpt, taskErr := edit.GetOption(files[0], "task")
+	if paramsErr != nil && taskErr != nil {
 		return q, nil
 	}
 
-	// if params were found
-	if err == nil {
-		obj, ok := opt.(*ast.ObjectExpression)
+	if paramsErr == nil {
+		obj, ok := paramsOpt.(*ast.ObjectExpression)
 		if ok {
 			for _, p := range obj.Properties {
 				sl, ok := p.Key.(*ast.Identifier)
@@ -1627,9 +1626,8 @@ func (p *Template) parseQuery(prefix, source string, params, task []Resource) (q
 		}
 	}
 
-	// if tasks were found
-	if err2 == nil {
-		tobj, ok := topt.(*ast.ObjectExpression)
+	if taskErr == nil {
+		tobj, ok := taskOpt.(*ast.ObjectExpression)
 		if ok {
 			for _, p := range tobj.Properties {
 				sl, ok := p.Key.(*ast.Identifier)
@@ -1664,6 +1662,7 @@ func (p *Template) parseQuery(prefix, source string, params, task []Resource) (q
 		}
 	}
 
+	var err error
 	for _, pr := range task {
 		field := pr.stringShort(fieldKey)
 		if field == "" {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1044,10 +1044,11 @@ func (c colors) valid() []validationErr {
 type query struct {
 	Query  string `json:"query" yaml:"query"`
 	params []*references
+	task   []*references
 }
 
 func (q query) DashboardQuery() string {
-	if len(q.params) == 0 {
+	if len(q.params) == 0 && len(q.task) == 0 {
 		return q.Query
 	}
 
@@ -1057,24 +1058,36 @@ func (q query) DashboardQuery() string {
 	}
 
 	opt, err := edit.GetOption(files[0], "params")
-	if err != nil {
-		// no params option present in query
+	topt, err2 := edit.GetOption(files[0], "task")
+	if err2 != nil && err != nil {
 		return q.Query
 	}
 
-	obj, ok := opt.(*ast.ObjectExpression)
-	if !ok {
-		// params option present is invalid. Should always be an Object.
-		return q.Query
+	if err == nil {
+		obj, ok := opt.(*ast.ObjectExpression)
+		if ok {
+			for _, ref := range q.params {
+				parts := strings.Split(ref.EnvRef, ".")
+				key := parts[len(parts)-1]
+				edit.SetProperty(obj, key, ref.expression())
+			}
+
+			edit.SetOption(files[0], "params", obj)
+		}
 	}
 
-	for _, ref := range q.params {
-		parts := strings.Split(ref.EnvRef, ".")
-		key := parts[len(parts)-1]
-		edit.SetProperty(obj, key, ref.expression())
-	}
+	if err2 == nil {
+		tobj, ok := topt.(*ast.ObjectExpression)
+		if ok {
+			for _, ref := range q.task {
+				parts := strings.Split(ref.EnvRef, ".")
+				key := parts[len(parts)-1]
+				edit.SetProperty(tobj, key, ref.expression())
+			}
 
-	edit.SetOption(files[0], "params", obj)
+			edit.SetOption(files[0], "task", tobj)
+		}
+	}
 	return ast.Format(files[0])
 }
 
@@ -1805,6 +1818,7 @@ func toSummaryTagRules(tagRules []struct{ k, v, op string }) []SummaryTagRule {
 
 const (
 	fieldTaskCron = "cron"
+	fieldTask     = "task"
 )
 
 type task struct {
@@ -1857,9 +1871,15 @@ func (t *task) summarize() SummaryTask {
 		field := fmt.Sprintf("spec.params.%s", parts[len(parts)-1])
 		refs = append(refs, convertRefToRefSummary(field, ref))
 	}
+	for _, ref := range t.query.task {
+		parts := strings.Split(ref.EnvRef, ".")
+		field := fmt.Sprintf("spec.task.%s", parts[len(parts)-1])
+		refs = append(refs, convertRefToRefSummary(field, ref))
+	}
 	sort.Slice(refs, func(i, j int) bool {
 		return refs[i].EnvRefKey < refs[j].EnvRefKey
 	})
+
 	return SummaryTask{
 		SummaryIdentifier: SummaryIdentifier{
 			Kind:          KindTask,
@@ -1883,6 +1903,7 @@ func (t *task) valid() []validationErr {
 	if err, ok := isValidName(t.Name(), 1); !ok {
 		vErrs = append(vErrs, err)
 	}
+
 	if t.cron == "" && t.every == 0 {
 		vErrs = append(vErrs,
 			validationErr{
@@ -2169,7 +2190,7 @@ const (
 )
 
 type references struct {
-	EnvRef string
+	EnvRef string // key used to reference parameterized field
 	Secret string
 
 	val        interface{}
@@ -2295,7 +2316,11 @@ func astBoolFromIface(v interface{}) *ast.BooleanLiteral {
 func astDurationFromIface(v interface{}) *ast.DurationLiteral {
 	s, ok := v.(string)
 	if !ok {
-		return nil
+		d, ok := v.(time.Duration)
+		if !ok {
+			return nil
+		}
+		s = d.String()
 	}
 	dur, _ := parser.ParseSignedDuration(s)
 	return dur

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1063,6 +1063,7 @@ func (q query) DashboardQuery() string {
 		return q.Query
 	}
 
+	// if params were found
 	if err == nil {
 		obj, ok := opt.(*ast.ObjectExpression)
 		if ok {
@@ -1076,6 +1077,7 @@ func (q query) DashboardQuery() string {
 		}
 	}
 
+	// if tasks were found
 	if err2 == nil {
 		tobj, ok := topt.(*ast.ObjectExpression)
 		if ok {

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -1057,15 +1057,14 @@ func (q query) DashboardQuery() string {
 		return q.Query
 	}
 
-	opt, err := edit.GetOption(files[0], "params")
-	topt, err2 := edit.GetOption(files[0], "task")
-	if err2 != nil && err != nil {
+	paramsOpt, paramsErr := edit.GetOption(files[0], "params")
+	taskOpt, taskErr := edit.GetOption(files[0], "task")
+	if taskErr != nil && paramsErr != nil {
 		return q.Query
 	}
 
-	// if params were found
-	if err == nil {
-		obj, ok := opt.(*ast.ObjectExpression)
+	if paramsErr == nil {
+		obj, ok := paramsOpt.(*ast.ObjectExpression)
 		if ok {
 			for _, ref := range q.params {
 				parts := strings.Split(ref.EnvRef, ".")
@@ -1077,9 +1076,8 @@ func (q query) DashboardQuery() string {
 		}
 	}
 
-	// if tasks were found
-	if err2 == nil {
-		tobj, ok := topt.(*ast.ObjectExpression)
+	if taskErr == nil {
+		tobj, ok := taskOpt.(*ast.ObjectExpression)
 		if ok {
 			for _, ref := range q.task {
 				parts := strings.Split(ref.EnvRef, ".")

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -4778,7 +4778,7 @@ func newParsedTemplate(t *testing.T, fn ReaderFn, encoding Encoding, opts ...Val
 	require.NoError(t, err)
 
 	for _, k := range template.Objects {
-		require.Contains(t, "influxdata.com/v2alpha", k.APIVersion)
+		require.Contains(t, k.APIVersion, "influxdata.com/v2alpha")
 	}
 
 	require.True(t, template.isParsed)

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -4778,7 +4778,7 @@ func newParsedTemplate(t *testing.T, fn ReaderFn, encoding Encoding, opts ...Val
 	require.NoError(t, err)
 
 	for _, k := range template.Objects {
-		require.Contains(t, APIVersion, k.APIVersion)
+		require.Contains(t, "influxdata.com/v2alpha", k.APIVersion)
 	}
 
 	require.True(t, template.isParsed)

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3362,7 +3362,6 @@ spec:
 
 				for _, ta := range tasks {
 					assert.Equal(t, KindTask, ta.Kind)
-					fmt.Println("REFERENCES", ta.EnvReferences)
 				}
 
 				sort.Slice(tasks, func(i, j int) bool {
@@ -4778,9 +4777,9 @@ func newParsedTemplate(t *testing.T, fn ReaderFn, encoding Encoding, opts ...Val
 	template, err := Parse(encoding, fn, opts...)
 	require.NoError(t, err)
 
-	// for _, k := range template.Objects {
-	// 	require.Equal(t, APIVersion2, k.APIVersion)
-	// }
+	for _, k := range template.Objects {
+		require.Contains(t, APIVersion, k.APIVersion)
+	}
 
 	require.True(t, template.isParsed)
 	return template

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -24,6 +24,7 @@ import (
 
 // APIVersion marks the current APIVersion for influx packages.
 const APIVersion = "influxdata.com/v2alpha1"
+const APIVersion2 = "influxdata.com/v2alpha2"
 
 // Stack is an identifier for stateful application of a package(s). This stack
 // will map created resources from the template(s) to existing resources on the

--- a/pkger/testdata/task_v2.yml
+++ b/pkger/testdata/task_v2.yml
@@ -3,13 +3,6 @@ kind: Task
 metadata:
   name: task-1
 spec:
-  # task:
-  #   - key: name
-  #     default: "foo"
-  #     type: string
-  #   - key: every
-  #     default: 1m
-  #     type: duration
   description: desc_1
   query:  >
     option task = { name: "bar", every: 1m, offset: 3m }

--- a/pkger/testdata/task_v2.yml
+++ b/pkger/testdata/task_v2.yml
@@ -1,0 +1,21 @@
+apiVersion: influxdata.com/v2alpha2
+kind: Task
+metadata:
+  name: task-1
+spec:
+  # task:
+  #   - key: name
+  #     default: "foo"
+  #     type: string
+  #   - key: every
+  #     default: 1m
+  #     type: duration
+  description: desc_1
+  query:  >
+    option task = { name: "bar", every: 1m, offset: 3m }
+    from(bucket: "rucket_1")
+      |> range(start: -5d, stop: -1h)
+      |> filter(fn: (r) => r._measurement == "cpu")
+      |> filter(fn: (r) => r._field == "usage_idle")
+      |> aggregateWindow(every: 1m, fn: mean)
+      |> yield(name: "mean")

--- a/pkger/testdata/task_v2_params.yml
+++ b/pkger/testdata/task_v2_params.yml
@@ -1,0 +1,15 @@
+apiVersion: influxdata.com/v2alpha2
+kind: Task
+metadata:
+  name: task-1
+spec:
+  description: desc_1
+  every: 1m
+  query:  >
+    option params = { this: "foo" }
+    from(bucket: "rucket_1")
+      |> range(start: -5d, stop: -1h)
+      |> filter(fn: (r) => r._measurement == params.this)
+      |> filter(fn: (r) => r._field == "usage_idle")
+      |> aggregateWindow(every: 1m, fn: mean)
+      |> yield(name: "mean")

--- a/pkger/testdata/task_v2_taskSpec.yml
+++ b/pkger/testdata/task_v2_taskSpec.yml
@@ -1,0 +1,24 @@
+apiVersion: influxdata.com/v2alpha2
+kind: Task
+metadata:
+  name: task-1
+spec:
+  task:
+    - key: name
+      default: "foo"
+      type: string
+    - key: every
+      default: 1m0s
+      type: duration
+    - key: offset
+      default: 1m0s
+      type: duration
+  description: desc_1
+  query:  >
+    option task = { name: "bar", every: 1m, offset: 3m }
+    from(bucket: "rucket_1")
+      |> range(start: -5d, stop: -1h)
+      |> filter(fn: (r) => r._measurement == "cpu")
+      |> filter(fn: (r) => r._field == "usage_idle")
+      |> aggregateWindow(every: 1m, fn: mean)
+      |> yield(name: "mean")


### PR DESCRIPTION
Closes #19260

User wanted to specify tasks in a template as a query option, this makes that possible
```yaml
apiVersion: influxdata.com/v2alpha2
kind: Task
metadata:
  name: task-uuid
spec:
  task:
    - key: name
      default: "bar"
      type: string
    - key: every
      default: 1m
      type: duration
  params:
    - key: custom
      default: "bar"
      type: string
  query:  >
    option task = { name: "bar", every: 1m }
    option params = { custom: "param" }
    from(bucket: "rucket_1")
      |> range(start: -5d, stop: -1h)
      |> filter(fn: (r) => r._measurement == "cpu")
      |> filter(fn: (r) => r._field == "usage_idle")
      |> aggregateWindow(every: 1m, fn: mean)
      |> yield(name: "mean")
  status: inactive
  associations:
    - kind: Label
      name: label-1
```

- [x] Rebased/mergeable
- [x] Tests pass
