### PR TITLE
chore(http): add response_code as label to http_api_* metrics

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -155,7 +155,7 @@ func (h *Handler) initMetrics() {
 	const namespace = "http"
 	const handlerSubsystem = "api"
 
-	labelNames := []string{"handler", "method", "path", "status", "user_agent"}
+	labelNames := []string{"handler", "method", "path", "status", "user_agent", "response_code"}
 	h.requests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: handlerSubsystem,

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -59,22 +59,24 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			}
 
 			c := promtest.MustFindMetric(t, mfs, "http_api_requests_total", map[string]string{
-				"handler":    "test",
-				"method":     "GET",
-				"path":       "/",
-				"status":     "2XX",
-				"user_agent": "ua1",
+				"handler":       "test",
+				"method":        "GET",
+				"path":          "/",
+				"status":        "2XX",
+				"user_agent":    "ua1",
+				"response_code": "200",
 			})
 			if got := c.GetCounter().GetValue(); got != 1 {
 				t.Fatalf("expected counter to be 1, got %v", got)
 			}
 
 			g := promtest.MustFindMetric(t, mfs, "http_api_request_duration_seconds", map[string]string{
-				"handler":    "test",
-				"method":     "GET",
-				"path":       "/",
-				"status":     "2XX",
-				"user_agent": "ua1",
+				"handler":       "test",
+				"method":        "GET",
+				"path":          "/",
+				"status":        "2XX",
+				"user_agent":    "ua1",
+				"response_code": "200",
 			})
 			if got := g.GetHistogram().GetSampleCount(); got != 1 {
 				t.Fatalf("expected histogram sample count to be 1, got %v", got)

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"strings"
@@ -42,11 +43,12 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 
 			defer func(start time.Time) {
 				label := prometheus.Labels{
-					"handler":    name,
-					"method":     r.Method,
-					"path":       normalizePath(r.URL.Path),
-					"status":     statusW.StatusCodeClass(),
-					"user_agent": UserAgent(r),
+					"handler":       name,
+					"method":        r.Method,
+					"path":          normalizePath(r.URL.Path),
+					"status":        statusW.StatusCodeClass(),
+					"response_code": fmt.Sprintf("%d", statusW.Code()),
+					"user_agent":    UserAgent(r),
 				}
 				durMetric.With(label).Observe(time.Since(start).Seconds())
 				reqMetric.With(label).Inc()


### PR DESCRIPTION
This was added so that we can distinguish between 4XX and 401 class
errors. It should have a minimal impact in overall cardinality.

Co-authored-by: Greg Linton  <greg@influxdata.com>

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
