### PR TITLE
feat(task): Record last success and failure run times in the Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [19246](https://github.com/influxdata/influxdb/pull/19246): Redesign load data page to increase discovery and ease of use
 1. [19334](https://github.com/influxdata/influxdb/pull/19334): Add --active-config flag to influx to set config for single command
 1. [19219](https://github.com/influxdata/influxdb/pull/19219): List buckets via the API now supports after (ID) parameter as an alternative to offset.
+1. [19390](https://github.com/influxdata/influxdb/pull/19390): Record last success and failure run times in the Task
 
 ### Bug Fixes
 

--- a/kv/task.go
+++ b/kv/task.go
@@ -51,6 +51,8 @@ type kvTask struct {
 	Offset          influxdb.Duration      `json:"offset,omitempty"`
 	LatestCompleted time.Time              `json:"latestCompleted,omitempty"`
 	LatestScheduled time.Time              `json:"latestScheduled,omitempty"`
+	LatestSuccess   time.Time              `json:"latestSuccess,omitempty"`
+	LatestFailure   time.Time              `json:"latestFailure,omitempty"`
 	CreatedAt       time.Time              `json:"createdAt,omitempty"`
 	UpdatedAt       time.Time              `json:"updatedAt,omitempty"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`
@@ -74,6 +76,8 @@ func kvToInfluxTask(k *kvTask) *influxdb.Task {
 		Offset:          k.Offset.Duration,
 		LatestCompleted: k.LatestCompleted,
 		LatestScheduled: k.LatestScheduled,
+		LatestSuccess:   k.LatestSuccess,
+		LatestFailure:   k.LatestFailure,
 		CreatedAt:       k.CreatedAt,
 		UpdatedAt:       k.UpdatedAt,
 		Metadata:        k.Metadata,

--- a/kv/task.go
+++ b/kv/task.go
@@ -771,7 +771,7 @@ func (s *Service) updateTask(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 	}
 
 	if upd.LatestSuccess != nil {
-		// make sure we only update latest completed one way
+		// make sure we only update latest success one way
 		tlc := task.LatestSuccess
 		ulc := *upd.LatestSuccess
 
@@ -781,7 +781,7 @@ func (s *Service) updateTask(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 	}
 
 	if upd.LatestFailure != nil {
-		// make sure we only update latest completed one way
+		// make sure we only update latest failure one way
 		tlc := task.LatestFailure
 		ulc := *upd.LatestFailure
 

--- a/task.go
+++ b/task.go
@@ -65,6 +65,8 @@ type Task struct {
 	Offset          time.Duration          `json:"offset,omitempty"`
 	LatestCompleted time.Time              `json:"latestCompleted,omitempty"`
 	LatestScheduled time.Time              `json:"latestScheduled,omitempty"`
+	LatestSuccess   time.Time              `json:"latestSuccess,omitempty"`
+	LatestFailure   time.Time              `json:"latestFailure,omitempty"`
 	LastRunStatus   string                 `json:"lastRunStatus,omitempty"`
 	LastRunError    string                 `json:"lastRunError,omitempty"`
 	CreatedAt       time.Time              `json:"createdAt,omitempty"`
@@ -183,6 +185,8 @@ type TaskUpdate struct {
 	// LatestCompleted us to set latest completed on startup to skip task catchup
 	LatestCompleted *time.Time             `json:"-"`
 	LatestScheduled *time.Time             `json:"-"`
+	LatestSuccess   *time.Time             `json:"-"`
+	LatestFailure   *time.Time             `json:"-"`
 	LastRunStatus   *string                `json:"-"`
 	LastRunError    *string                `json:"-"`
 	Metadata        map[string]interface{} `json:"-"` // not to be set through a web request but rather used by a http service using tasks backend.


### PR DESCRIPTION
Part of https://github.com/influxdata/flux/issues/3080

We currently record the following "last run" information on the Task record:
- `LatestCompleted` (time)
- `LatestScheduled` (time)
- `LastRunStatus` (string)
- `LastRunError` (string)

This change introduces two new timestamps that reflect the last success and failure times of a Task (respectively):
- `LatestSuccess` (time)
- `LatestFailure` (time)

With these timestamps we will be able to compose new APIs for the Task system to make time-gap resilient (in the face of an arbitrary number of Task failures) easier to write. The next step will be to inject this information into Tasks as they get handed off to the Query layer to be run.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
