### PR TITLE
fix(notification/rule): Include the edge of the boundary we are observing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [19331](https://github.com/influxdata/influxdb/pull/19331): Add description to auth influx command outputs.
+1. [19392](https://github.com/influxdata/influxdb/pull/19392) Include the edge of the boundary we are observing.
 
 ## v2.0.0-beta.16 [2020-08-07]
 

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -33,7 +33,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: endpoint(mapFn: (r) => {
@@ -102,7 +102,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: endpoint(mapFn: (r) => {
@@ -177,7 +177,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: endpoint(mapFn: (r) => {
@@ -250,7 +250,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 5s)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 5s)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: endpoint(mapFn: (r) => {

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -83,7 +83,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
@@ -166,7 +166,7 @@ info_to_crit = statuses
 	|> monitor["stateChanges"](fromLevel: "info", toLevel: "crit")
 all_statuses = info_to_crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
@@ -256,7 +256,7 @@ ok_to_warn = statuses
 all_statuses = union(tables: [crit, ok_to_warn])
 	|> sort(columns: ["_time"])
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>

--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -136,16 +136,17 @@ func (b *Base) generateLevelChecks() []ast.Statement {
 	now := flux.Call(flux.Identifier("now"), flux.Object())
 	timeFilter := flux.Function(
 		flux.FunctionParams("r"),
-		flux.GreaterThan(
-			flux.Member("r", "_time"),
-			flux.Call(
+		&ast.BinaryExpression{
+			Operator: ast.GreaterThanEqualOperator,
+			Left:     flux.Member("r", "_time"),
+			Right: flux.Call(
 				flux.Member("experimental", "subDuration"),
 				flux.Object(
 					flux.Property("from", now),
 					flux.Property("d", (*ast.DurationLiteral)(b.Every)),
 				),
 			),
-		),
+		},
 	)
 
 	var pipe *ast.PipeExpression

--- a/notification/rule/slack_test.go
+++ b/notification/rule/slack_test.go
@@ -61,7 +61,7 @@ any = statuses
 		(true))
 all_statuses = any
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: slack_endpoint(mapFn: (r) =>
@@ -133,7 +133,7 @@ info_to_warn = statuses
 all_statuses = union(tables: [crit, info_to_warn])
 	|> sort(columns: ["_time"])
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: slack_endpoint(mapFn: (r) =>
@@ -210,7 +210,7 @@ info_to_warn = statuses
 all_statuses = union(tables: [crit, info_to_warn])
 	|> sort(columns: ["_time"])
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: slack_endpoint(mapFn: (r) =>
@@ -289,7 +289,7 @@ info_to_warn = statuses
 all_statuses = union(tables: [crit, info_to_warn])
 	|> sort(columns: ["_time"])
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: slack_endpoint(mapFn: (r) =>

--- a/notification/rule/telegram_test.go
+++ b/notification/rule/telegram_test.go
@@ -125,7 +125,7 @@ crit = statuses
 		(r["_level"] == "crit"))
 all_statuses = crit
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: telegram_endpoint(mapFn: (r) =>
@@ -197,7 +197,7 @@ any = statuses
 		(true))
 all_statuses = any
 	|> filter(fn: (r) =>
-		(r["_time"] > experimental["subDuration"](from: now(), d: 1h)))
+		(r["_time"] >= experimental["subDuration"](from: now(), d: 1h)))
 
 all_statuses
 	|> monitor["notify"](data: notification, endpoint: telegram_endpoint(mapFn: (r) =>


### PR DESCRIPTION
We've been witnessing some failed observations of Check triggers in Notification Tasks. In `from(start: -10m, stop: now())`, the `stop` is **exclusive** to the time range—this is so consecutive windows like `A -> B`, `B -> C`, don't have overlap. If a Notification Task's schedule boundaries align with Check trigger observations, we will miss observations if they occur on that boundary.

This change includes the left-hand boundary in what the Notification Task sees of Check triggers.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass