### PR TITLE
fix(flows): increase default height of raw data view in flux cells

### DIFF
--- a/ui/src/notebooks/pipes/Query/index.ts
+++ b/ui/src/notebooks/pipes/Query/index.ts
@@ -10,7 +10,7 @@ register({
   button: 'Flux Script',
   initial: {
     panelVisibility: 'visible',
-    panelHeight: 200,
+    panelHeight: 330,
     activeQuery: 0,
     queries: [
       {


### PR DESCRIPTION
https://github.com/influxdata/idpe/issues/8118

- Change initial height of script cells raw data from `200` to `320` which shows about 5.5 actual rows of data (not including headers)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
