### PR TITLE
feat(task): Inject Task's LatestSuccess Timestamp In Flux Extern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [19334](https://github.com/influxdata/influxdb/pull/19334): Add --active-config flag to influx to set config for single command
 1. [19219](https://github.com/influxdata/influxdb/pull/19219): List buckets via the API now supports after (ID) parameter as an alternative to offset.
 1. [19390](https://github.com/influxdata/influxdb/pull/19390): Record last success and failure run times in the Task
+1. [19402](https://github.com/influxdata/influxdb/pull/19402): Inject Task's LatestSuccess Timestamp In Flux Extern
 
 ### Bug Fixes
 

--- a/flags.yml
+++ b/flags.yml
@@ -154,3 +154,9 @@
   key: enforceOrgDashboardLimits
   default: false
   contact: Compute Team
+
+- name: Inject Latest Success Time
+  description: Inject the latest successful task run timestamp into a Task query extern when executing.
+  key: injectLatestSuccessTime
+  default: false
+  contact: Compute Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -282,6 +282,20 @@ func EnforceOrganizationDashboardLimits() BoolFlag {
 	return enforceOrgDashboardLimits
 }
 
+var injectLatestSuccessTime = MakeBoolFlag(
+	"Inject Latest Success Time",
+	"injectLatestSuccessTime",
+	"Compute Team",
+	false,
+	Temporary,
+	false,
+)
+
+// InjectLatestSuccessTime - Inject the latest successful task run timestamp into a Task query extern when executing.
+func InjectLatestSuccessTime() BoolFlag {
+	return injectLatestSuccessTime
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -303,6 +317,7 @@ var all = []Flag{
 	pushDownGroupAggregateMinMax,
 	orgOnlyMemberList,
 	enforceOrgDashboardLimits,
+	injectLatestSuccessTime,
 }
 
 var byKey = map[string]Flag{
@@ -326,4 +341,5 @@ var byKey = map[string]Flag{
 	"pushDownGroupAggregateMinMax":  pushDownGroupAggregateMinMax,
 	"orgOnlyMemberList":             orgOnlyMemberList,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
+	"injectLatestSuccessTime":       injectLatestSuccessTime,
 }

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -82,7 +82,6 @@ type CompilerBuilderFunc func(ctx context.Context, query string, ts CompilerBuil
 type CompilerBuilderTimestamps struct {
 	Now           time.Time
 	LatestSuccess time.Time
-	LatestFailure time.Time
 }
 
 func (ts CompilerBuilderTimestamps) Extern() *ast.File {
@@ -94,17 +93,6 @@ func (ts CompilerBuilderTimestamps) Extern() *ast.File {
 				ID: &ast.Identifier{Name: latestSuccessOption},
 				Init: &ast.DateTimeLiteral{
 					Value: ts.LatestSuccess,
-				},
-			},
-		})
-	}
-
-	if !ts.LatestFailure.IsZero() {
-		body = append(body, &ast.OptionStatement{
-			Assignment: &ast.VariableAssignment{
-				ID: &ast.Identifier{Name: latestFailureOption},
-				Init: &ast.DateTimeLiteral{
-					Value: ts.LatestFailure,
 				},
 			},
 		})
@@ -513,7 +501,6 @@ func (w *worker) executeQuery(p *promise) {
 	compiler, err := buildCompiler(ctx, p.task.Flux, CompilerBuilderTimestamps{
 		Now:           p.run.ScheduledFor,
 		LatestSuccess: p.task.LatestSuccess,
-		LatestFailure: p.task.LatestFailure,
 	})
 	if err != nil {
 		w.finish(p, influxdb.RunFail, influxdb.ErrFluxParseError(err))

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -85,19 +85,7 @@ func taskExecutorSystem(t *testing.T) tes {
 	}
 }
 
-func TestTaskExecutor(t *testing.T) {
-	t.Run("QuerySuccess", testQuerySuccess)
-	t.Run("QueryFailure", testQueryFailure)
-	t.Run("ManualRun", testManualRun)
-	t.Run("ResumeRun", testResumingRun)
-	t.Run("WorkerLimit", testWorkerLimit)
-	t.Run("LimitFunc", testLimitFunc)
-	t.Run("Metrics", testMetrics)
-	t.Run("IteratorFailure", testIteratorFailure)
-	t.Run("ErrorHandling", testErrorHandling)
-}
-
-func testQuerySuccess(t *testing.T) {
+func TestTaskExecutor_QuerySuccess(t *testing.T) {
 	t.Parallel()
 
 	tes := taskExecutorSystem(t)
@@ -165,7 +153,7 @@ func testQuerySuccess(t *testing.T) {
 	}
 }
 
-func testQueryFailure(t *testing.T) {
+func TestTaskExecutor_QueryFailure(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -201,7 +189,7 @@ func testQueryFailure(t *testing.T) {
 	}
 }
 
-func testManualRun(t *testing.T) {
+func TestManualRun(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -248,7 +236,7 @@ func testManualRun(t *testing.T) {
 	}
 }
 
-func testResumingRun(t *testing.T) {
+func TestTaskExecutor_ResumingRun(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -291,7 +279,7 @@ func testResumingRun(t *testing.T) {
 	}
 }
 
-func testWorkerLimit(t *testing.T) {
+func TestTaskExecutor_WorkerLimit(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -321,7 +309,7 @@ func testWorkerLimit(t *testing.T) {
 	}
 }
 
-func testLimitFunc(t *testing.T) {
+func TestTaskExecutor_LimitFunc(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -360,7 +348,7 @@ func testLimitFunc(t *testing.T) {
 	}
 }
 
-func testMetrics(t *testing.T) {
+func TestTaskExecutor_Metrics(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 	metrics := tes.metrics
@@ -457,7 +445,7 @@ func testMetrics(t *testing.T) {
 
 }
 
-func testIteratorFailure(t *testing.T) {
+func TestTaskExecutor_IteratorFailure(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -505,7 +493,7 @@ func testIteratorFailure(t *testing.T) {
 	}
 }
 
-func testErrorHandling(t *testing.T) {
+func TestTaskExecutor_ErrorHandling(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
@@ -551,7 +539,7 @@ func testErrorHandling(t *testing.T) {
 	*/
 }
 
-func TestPromiseFailure(t *testing.T) {
+func TestTaskExecutor_PromiseFailure(t *testing.T) {
 	t.Parallel()
 
 	tes := taskExecutorSystem(t)

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -12,14 +12,17 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/influxdb/v2"
 	icontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/inmem"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/kit/prom"
 	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
 	tracetest "github.com/influxdata/influxdb/v2/kit/tracing/testing"
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
+	influxdbmock "github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/query"
 	"github.com/influxdata/influxdb/v2/query/fluxlang"
 	"github.com/influxdata/influxdb/v2/task/backend"
@@ -121,8 +124,108 @@ func TestTaskExecutor_QuerySuccess(t *testing.T) {
 		t.Fatalf("did not correctly set RunAt value, got: %v", run.RunAt)
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.SucceedQuery(script)
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.SucceedQuery(script, nil)
+
+	<-promise.Done()
+
+	if got := promise.Error(); got != nil {
+		t.Fatal(got)
+	}
+
+	// confirm run is removed from in-mem store
+	run, err = tes.i.FindRunByID(context.Background(), task.ID, run.ID)
+	if run != nil || err == nil || !strings.Contains(err.Error(), "run not found") {
+		t.Fatal("run was returned when it should have been removed from kv")
+	}
+
+	// ensure the run returned by TaskControlService.FinishRun(...)
+	// has run logs formatted as expected
+	if run = tes.tcs.run; run == nil {
+		t.Fatal("expected run returned by FinishRun to not be nil")
+	}
+
+	if len(run.Log) < 3 {
+		t.Fatalf("expected 3 run logs, found %d", len(run.Log))
+	}
+
+	sctx := span.Context().(jaeger.SpanContext)
+	expectedMessage := fmt.Sprintf("trace_id=%s is_sampled=true", sctx.TraceID())
+	if expectedMessage != run.Log[1].Message {
+		t.Errorf("expected %q, found %q", expectedMessage, run.Log[1].Message)
+	}
+}
+
+func TestTaskExecutor_QuerySuccessWithExternInjection(t *testing.T) {
+	t.Parallel()
+
+	tes := taskExecutorSystem(t)
+
+	var (
+		script = fmt.Sprintf(fmtTestScript, t.Name())
+		ctx    = icontext.SetAuthorizer(context.Background(), tes.tc.Auth)
+		span   = opentracing.GlobalTracer().StartSpan("test-span")
+	)
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	task, err := tes.i.CreateTask(ctx, influxdb.TaskCreate{
+		OrganizationID: tes.tc.OrgID,
+		OwnerID:        tes.tc.Auth.GetUserID(),
+		Flux:           script,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate previous run to establish a timestamp
+	latestSuccess := time.Now().UTC()
+	task, err = tes.i.UpdateTask(ctx, task.ID, influxdb.TaskUpdate{
+		LatestSuccess: &latestSuccess,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	extern := &ast.File{
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				ID: &ast.Identifier{Name: latestSuccessOption},
+				Init: &ast.DateTimeLiteral{
+					Value: latestSuccess,
+				},
+			},
+		},
+		},
+	}
+
+	ctx, err = feature.Annotate(ctx, influxdbmock.NewFlagger(map[feature.Flag]interface{}{
+		feature.InjectLatestSuccessTime(): true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	promise, err := tes.ex.PromisedExecute(ctx, scheduler.ID(task.ID), time.Unix(123, 0), time.Unix(126, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	promiseID := influxdb.ID(promise.ID())
+
+	run, err := tes.i.FindRunByID(context.Background(), task.ID, promiseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if run.ID != promiseID {
+		t.Fatal("promise and run dont match")
+	}
+
+	if run.RunAt != time.Unix(126, 0).UTC() {
+		t.Fatalf("did not correctly set RunAt value, got: %v", run.RunAt)
+	}
+
+	tes.svc.WaitForQueryLive(t, script, extern)
+	tes.svc.SucceedQuery(script, extern)
 
 	<-promise.Done()
 
@@ -179,8 +282,8 @@ func TestTaskExecutor_QueryFailure(t *testing.T) {
 		t.Fatal("promise and run dont match")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.FailQuery(script, errors.New("blargyblargblarg"))
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.FailQuery(script, nil, errors.New("blargyblargblarg"))
 
 	<-promise.Done()
 
@@ -228,8 +331,8 @@ func TestManualRun(t *testing.T) {
 		t.Fatal("promise and run and manual run dont match")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.SucceedQuery(script)
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.SucceedQuery(script, nil)
 
 	if got := promise.Error(); got != nil {
 		t.Fatal(got)
@@ -271,8 +374,8 @@ func TestTaskExecutor_ResumingRun(t *testing.T) {
 		t.Fatal("promise and run and manual run dont match")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.SucceedQuery(script)
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.SucceedQuery(script, nil)
 
 	if got := promise.Error(); got != nil {
 		t.Fatal(got)
@@ -299,8 +402,8 @@ func TestTaskExecutor_WorkerLimit(t *testing.T) {
 		t.Fatal("expected a worker to be started")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.FailQuery(script, errors.New("blargyblargblarg"))
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.FailQuery(script, nil, errors.New("blargyblargblarg"))
 
 	<-promise.Done()
 
@@ -383,7 +486,7 @@ func TestTaskExecutor_Metrics(t *testing.T) {
 		t.Fatal("promise and run dont match")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
+	tes.svc.WaitForQueryLive(t, script, nil)
 
 	mg = promtest.MustGather(t, reg)
 	m = promtest.MustFindMetric(t, mg, "task_executor_total_runs_active", nil)
@@ -391,7 +494,7 @@ func TestTaskExecutor_Metrics(t *testing.T) {
 		t.Fatalf("expected 1 total runs active, got %v", got)
 	}
 
-	tes.svc.SucceedQuery(script)
+	tes.svc.SucceedQuery(script, nil)
 	<-promise.Done()
 
 	mg = promtest.MustGather(t, reg)
@@ -483,8 +586,8 @@ func TestTaskExecutor_IteratorFailure(t *testing.T) {
 		t.Fatal("promise and run dont match")
 	}
 
-	tes.svc.WaitForQueryLive(t, script)
-	tes.svc.SucceedQuery(script)
+	tes.svc.WaitForQueryLive(t, script, nil)
+	tes.svc.SucceedQuery(script, nil)
 
 	<-promise.Done()
 

--- a/task/backend/executor/support_test.go
+++ b/task/backend/executor/support_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -31,14 +32,24 @@ type fakeQueryService struct {
 
 var _ query.AsyncQueryService = (*fakeQueryService)(nil)
 
-func makeAST(q string) lang.ASTCompiler {
+func makeAST(q string, extern *ast.File) lang.ASTCompiler {
 	pkg, err := runtime.ParseToJSON(q)
 	if err != nil {
 		panic(err)
 	}
+
+	var externBytes []byte
+	if extern != nil && len(extern.Body) > 0 {
+		var err error
+		externBytes, err = json.Marshal(extern)
+		if err != nil {
+			panic(err)
+		}
+	}
 	return lang.ASTCompiler{
-		AST: pkg,
-		Now: time.Unix(123, 0),
+		AST:    pkg,
+		Now:    time.Unix(123, 0),
+		Extern: externBytes,
 	}
 }
 
@@ -85,12 +96,12 @@ func (s *fakeQueryService) Query(ctx context.Context, req *query.Request) (flux.
 }
 
 // SucceedQuery allows the running query matching the given script to return on its Ready channel.
-func (s *fakeQueryService) SucceedQuery(script string) {
+func (s *fakeQueryService) SucceedQuery(script string, extern *ast.File) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// Unblock the flux.
-	ast := makeAST(script)
+	ast := makeAST(script, extern)
 	spec := makeASTString(ast)
 	fq, ok := s.queries[spec]
 	if !ok {
@@ -103,12 +114,12 @@ func (s *fakeQueryService) SucceedQuery(script string) {
 }
 
 // FailQuery closes the running query's Ready channel and sets its error to the given value.
-func (s *fakeQueryService) FailQuery(script string, forced error) {
+func (s *fakeQueryService) FailQuery(script string, extern *ast.File, forced error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// Unblock the flux.
-	ast := makeAST(script)
+	ast := makeAST(script, nil)
 	spec := makeASTString(ast)
 	fq, ok := s.queries[spec]
 	if !ok {
@@ -129,12 +140,12 @@ func (s *fakeQueryService) FailNextQuery(forced error) {
 // WaitForQueryLive ensures that the query has made it into the service.
 // This is particularly useful for the synchronous executor,
 // because the execution starts on a separate goroutine.
-func (s *fakeQueryService) WaitForQueryLive(t *testing.T, script string) {
+func (s *fakeQueryService) WaitForQueryLive(t *testing.T, script string, extern *ast.File) {
 	t.Helper()
 
 	const attempts = 10
-	ast := makeAST(script)
-	astUTC := makeAST(script)
+	ast := makeAST(script, extern)
+	astUTC := makeAST(script, extern)
 	astUTC.Now = ast.Now.UTC()
 	spec := makeASTString(ast)
 	specUTC := makeASTString(astUTC)


### PR DESCRIPTION
Part of https://github.com/influxdata/flux/issues/3080
Continuation of https://github.com/influxdata/influxdb/pull/19390

Now that we're recording these timestamps, use them in the Task executor by injecting them as part of the Flux `Extern`. This sets the `option tasks.latestSuccessTime = ...` option on the query so that it can be used by some new APIs we're working on.

Will need to be rebased once influxdata/influxdb#19390 is merged.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
