### PR TITLE
refactor: Replace ctx.Done() calls with ctx.Err() when we're not multiplexing channels

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -465,13 +465,13 @@ func (e *StatementExecutor) executeExplainAnalyzeStatement(q *influxql.ExplainSt
 		row, _, err = em.Emit()
 		if err != nil {
 			goto CLEANUP
-		} else if row == nil {
+		}
+
+		if row == nil {
 			// Check if the query was interrupted while emitting.
-			select {
-			case <-ectx.Done():
-				err = ectx.Err()
+			if e := ectx.Err(); e != nil {
+				err = e
 				goto CLEANUP
-			default:
 			}
 			break
 		}
@@ -561,12 +561,12 @@ func (e *StatementExecutor) executeSelectStatement(stmt *influxql.SelectStatemen
 		row, partial, err := em.Emit()
 		if err != nil {
 			return err
-		} else if row == nil {
+		}
+
+		if row == nil {
 			// Check if the query was interrupted while emitting.
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 			break
 		}

--- a/query/execution_context.go
+++ b/query/execution_context.go
@@ -76,8 +76,9 @@ func (ctx *ExecutionContext) Done() <-chan struct{} {
 
 func (ctx *ExecutionContext) Err() error {
 	ctx.mu.RLock()
-	defer ctx.mu.RUnlock()
-	return ctx.err
+	rc := ctx.err
+	ctx.mu.RUnlock()
+	return rc
 }
 
 func (ctx *ExecutionContext) Value(key interface{}) interface{} {

--- a/query/executor.go
+++ b/query/executor.go
@@ -354,15 +354,7 @@ LOOP:
 		}
 
 		// Check if the query was interrupted during an uninterruptible statement.
-		interrupted := false
-		select {
-		case <-ctx.Done():
-			interrupted = true
-		default:
-			// Query has not been interrupted.
-		}
-
-		if interrupted {
+		if ctx.Err() != nil {
 			break
 		}
 	}


### PR DESCRIPTION
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
