### PR TITLE
fix: update dashboard limits to 100

### DIFF
--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -54,6 +54,7 @@ import {getAll, getByID, getStatus} from 'src/resources/selectors'
 // Constants
 import * as copy from 'src/shared/copy/notifications'
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
+import {DASHBOARD_LIMIT} from 'src/resources/constants'
 
 // Types
 import {
@@ -225,7 +226,12 @@ export const getDashboards = () => async (
 
     const org = getOrg(state)
 
-    const resp = await api.getDashboards({query: {orgID: org.id}})
+    const resp = await api.getDashboards({
+        query: {
+            orgID: org.id,
+            limit: DASHBOARD_LIMIT
+        }
+    })
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/ui/src/dashboards/actions/thunks.ts
+++ b/ui/src/dashboards/actions/thunks.ts
@@ -227,10 +227,10 @@ export const getDashboards = () => async (
     const org = getOrg(state)
 
     const resp = await api.getDashboards({
-        query: {
-            orgID: org.id,
-            limit: DASHBOARD_LIMIT
-        }
+      query: {
+        orgID: org.id,
+        limit: DASHBOARD_LIMIT,
+      },
     })
 
     if (resp.status !== 200) {

--- a/ui/src/resources/constants/index.ts
+++ b/ui/src/resources/constants/index.ts
@@ -3,3 +3,4 @@
 export const LIMIT = 100
 export const BUCKET_LIMIT = 100
 export const RULE_LIMIT = 100
+export const DASHBOARD_LIMIT = 100


### PR DESCRIPTION
something went out a couple days ago that started enforcing a limit of 20 dashboards if the limit was not sent to the request. there's a max of 100. this is a quick work around to unblock our customers before following up with pagination and backend changes that revert the changes