### PR TITLE
fix(kv): gaurd new org dashboard pagination with feature flag

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -157,7 +157,7 @@
   contact: Compute Team
 
 - name: Enforce Organization Dashboard Limits
-  description: Enforces the default limit params for the dashboards api when orgs are set 
+  description: Enforces the default limit params for the dashboards api when orgs are set
   key: enforceOrgDashboardLimits
   default: false
   contact: Compute Team

--- a/flags.yml
+++ b/flags.yml
@@ -155,3 +155,9 @@
   key: orgOnlyMemberList
   default: false
   contact: Compute Team
+
+- name: Enforce Organization Dashboard Limits
+  description: Enforces the default limit params for the dashboards api when orgs are set 
+  key: enforceOrgDashboardLimits
+  default: false
+  contact: Compute Team

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -282,6 +282,20 @@ func OrgOnlyMemberList() BoolFlag {
 	return orgOnlyMemberList
 }
 
+var enforceOrgDashboardLimits = MakeBoolFlag(
+	"Enforce Organization Dashboard Limits",
+	"enforceOrgDashboardLimits",
+	"Compute Team",
+	false,
+	Temporary,
+	false,
+)
+
+// EnforceOrganizationDashboardLimits - Enforces the default limit params for the dashboards api when orgs are set
+func EnforceOrganizationDashboardLimits() BoolFlag {
+	return enforceOrgDashboardLimits
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -303,6 +317,7 @@ var all = []Flag{
 	notebooks,
 	pushDownGroupAggregateMinMax,
 	orgOnlyMemberList,
+	enforceOrgDashboardLimits,
 }
 
 var byKey = map[string]Flag{
@@ -326,4 +341,5 @@ var byKey = map[string]Flag{
 	"notebooks":                     notebooks,
 	"pushDownGroupAggregateMinMax":  pushDownGroupAggregateMinMax,
 	"orgOnlyMemberList":             orgOnlyMemberList,
+	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
 }

--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -10,6 +10,7 @@ import (
 
 	influxdb "github.com/influxdata/influxdb/v2"
 	icontext "github.com/influxdata/influxdb/v2/context"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 )
 
 var (
@@ -224,6 +225,13 @@ func decodeOrgDashboardIndexKey(indexKey []byte) (orgID influxdb.ID, dashID infl
 }
 
 func (s *Service) findDashboards(ctx context.Context, tx Tx, filter influxdb.DashboardFilter, opts ...influxdb.FindOptions) ([]*influxdb.Dashboard, error) {
+	enforceOrgPagination := feature.EnforceOrganizationDashboardLimits().Enabled(ctx)
+	if !enforceOrgPagination {
+		if filter.OrganizationID != nil {
+			return s.findOrganizationDashboards(ctx, tx, *filter.OrganizationID)
+		}
+	}
+
 	var offset, limit, count int
 	var descending bool
 	if len(opts) > 0 {
@@ -232,26 +240,28 @@ func (s *Service) findDashboards(ctx context.Context, tx Tx, filter influxdb.Das
 		descending = opts[0].Descending
 	}
 
-	if filter.OrganizationID != nil {
-		orgDashboards, err := s.findOrganizationDashboards(ctx, tx, *filter.OrganizationID)
-		if err != nil {
-			return nil, &influxdb.Error{
-				Err: err,
+	if enforceOrgPagination {
+		if filter.OrganizationID != nil {
+			orgDashboards, err := s.findOrganizationDashboards(ctx, tx, *filter.OrganizationID)
+			if err != nil {
+				return nil, &influxdb.Error{
+					Err: err,
+				}
 			}
-		}
-		if offset > 0 && offset < len(orgDashboards) {
-			orgDashboards = orgDashboards[offset:]
-		}
-		if limit > 0 && limit < len(orgDashboards) {
-			orgDashboards = orgDashboards[:limit]
-		}
-		if descending {
-			for i, j := 0, len(orgDashboards)-1; i < j; i, j = i+1, j-1 {
-				orgDashboards[i], orgDashboards[j] = orgDashboards[j], orgDashboards[i]
+			if offset > 0 && offset < len(orgDashboards) {
+				orgDashboards = orgDashboards[offset:]
 			}
-		}
+			if limit > 0 && limit < len(orgDashboards) {
+				orgDashboards = orgDashboards[:limit]
+			}
+			if descending {
+				for i, j := 0, len(orgDashboards)-1; i < j; i, j = i+1, j-1 {
+					orgDashboards[i], orgDashboards[j] = orgDashboards[j], orgDashboards[i]
+				}
+			}
 
-		return orgDashboards, nil
+			return orgDashboards, nil
+		}
 	}
 
 	ds := []*influxdb.Dashboard{}

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -946,8 +946,6 @@ func FindDashboards(
 		t.Run(tt.name, func(t *testing.T) {
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
-			ctx := context.Background()
-
 			ctx, err := feature.Annotate(context.Background(), mock.NewFlagger(map[feature.Flag]interface{}{
 				feature.EnforceOrganizationDashboardLimits(): true,
 			}))

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/mock"
 )
 
@@ -946,6 +947,13 @@ func FindDashboards(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
+
+			ctx, err := feature.Annotate(context.Background(), mock.NewFlagger(map[feature.Flag]interface{}{
+				feature.EnforceOrganizationDashboardLimits(): true,
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			filter := platform.DashboardFilter{}
 			if tt.args.IDs != nil {


### PR DESCRIPTION
Describe your proposed changes here.

As of https://github.com/influxdata/influxdb/commit/ebaa32313be1d6b7e7c3663c38fe5be28642cbf3 we started respecting pagination options in `findDashboards` for organizations. This PR wraps that change in a feature flag.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
