### PR TITLE
chore: remove feature flag for task executor

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -106,13 +106,6 @@
   contact: Brett Buddin
   lifetime: temporary
 
-- name: Use User Permission
-  description: When enabled we will use the new user service permission function
-  key: useUserPermission
-  default: false
-  contact: Lyon Hill
-  lifetime: temporary
-
 - name: Merged Filters Rule
   description: Create one filter combining multiple single return statements
   key: mergeFiltersRule

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -184,20 +184,6 @@ func SimpleTaskOptionsExtraction() BoolFlag {
 	return simpleTaskOptionsExtraction
 }
 
-var useUserPermission = MakeBoolFlag(
-	"Use User Permission",
-	"useUserPermission",
-	"Lyon Hill",
-	false,
-	Temporary,
-	false,
-)
-
-// UseUserPermission - When enabled we will use the new user service permission function
-func UseUserPermission() BoolFlag {
-	return useUserPermission
-}
-
 var mergeFiltersRule = MakeBoolFlag(
 	"Merged Filters Rule",
 	"mergeFiltersRule",
@@ -296,7 +282,6 @@ var all = []Flag{
 	memoryOptimizedFill,
 	memoryOptimizedSchemaMutation,
 	simpleTaskOptionsExtraction,
-	useUserPermission,
 	mergeFiltersRule,
 	bandPlotType,
 	mosaicGraphType,
@@ -319,7 +304,6 @@ var byKey = map[string]Flag{
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,
 	"simpleTaskOptionsExtraction":   simpleTaskOptionsExtraction,
-	"useUserPermission":             useUserPermission,
 	"mergeFiltersRule":              mergeFiltersRule,
 	"bandPlotType":                  bandPlotType,
 	"mosaicGraphType":               mosaicGraphType,

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -292,16 +292,9 @@ func (e *Executor) createPromise(ctx context.Context, run *influxdb.Run) (*promi
 		return nil, err
 	}
 
-	var perm influxdb.PermissionSet
-	if e.flagger != nil && feature.UseUserPermission().Enabled(ctx, e.flagger) {
-		perm, err = e.ps.FindPermissionForUser(ctx, t.OwnerID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if perm == nil {
-		perm = t.Authorization.Permissions
+	perm, err := e.ps.FindPermissionForUser(ctx, t.OwnerID)
+	if err != nil {
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
We now default task execution to pull from the user service a permission
set.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
