### PR TITLE
fix: refactor legacy buckets api

### DIFF
--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -1246,7 +1246,7 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (influxdb.B
 }
 
 func TestBucketService(t *testing.T) {
-	platformtesting.BucketService(initBucketService, t)
+	platformtesting.BucketService(initBucketService, t, platformtesting.WithLegacySystemBuckets())
 }
 
 func mustNewHTTPClient(t *testing.T, addr, token string) *httpc.Client {

--- a/kv/bucket_test.go
+++ b/kv/bucket_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBoltBucketService(t *testing.T) {
-	influxdbtesting.BucketService(initBoltBucketService, t)
+	influxdbtesting.BucketService(initBoltBucketService, t, influxdbtesting.WithLegacySystemBuckets())
 }
 
 func initBoltBucketService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {

--- a/tenant/service_bucket.go
+++ b/tenant/service_bucket.go
@@ -14,6 +14,8 @@ type BucketSvc struct {
 	svc   *Service
 }
 
+const NumLegacyBuckets = 2
+
 func NewBucketSvc(st *Store, svc *Service) *BucketSvc {
 	return &BucketSvc{
 		store: st,
@@ -102,8 +104,89 @@ func (s *BucketSvc) FindBuckets(ctx context.Context, filter influxdb.BucketFilte
 		filter.OrganizationID = &org.ID
 	}
 
+	if len(opt) == 0 {
+		opt = append(opt, influxdb.FindOptions{
+			Limit: influxdb.DefaultPageSize,
+		})
+	}
+	o := opt[0]
+	if o.Limit > influxdb.MaxPageSize || o.Limit == 0 {
+		o.Limit = influxdb.MaxPageSize
+	}
+
+	// handle legacy buckets
+	needsLegacyTasks := false
+	needsLegacyMonitoring := false
+	var err error
 	var buckets []*influxdb.Bucket
-	err := s.store.View(ctx, func(tx kv.Tx) error {
+
+	if filter.OrganizationID != nil && filter.Name == nil {
+		err = s.store.View(ctx, func(tx kv.Tx) error {
+			_, e := s.store.GetBucketByName(ctx, tx, *filter.OrganizationID, influxdb.TasksSystemBucketName)
+			if e != nil && e.Error() == ErrBucketNotFoundByName(influxdb.TasksSystemBucketName).Error() {
+				needsLegacyTasks = true
+			} else if e != nil {
+				return e
+			}
+
+			_, e = s.store.GetBucketByName(ctx, tx, *filter.OrganizationID, influxdb.MonitoringSystemBucketName)
+			if e != nil && e.Error() == ErrBucketNotFoundByName(influxdb.MonitoringSystemBucketName).Error() {
+				needsLegacyMonitoring = true
+			} else if e != nil {
+				return e
+			}
+
+			return nil
+		})
+	}
+
+	if err != nil {
+		return []*influxdb.Bucket{}, 0, err
+	}
+
+	if needsLegacyTasks {
+		tb := &influxdb.Bucket{
+			ID:              influxdb.TasksSystemBucketID,
+			Type:            influxdb.BucketTypeSystem,
+			Name:            influxdb.TasksSystemBucketName,
+			RetentionPeriod: influxdb.TasksSystemBucketRetention,
+			Description:     "System bucket for task logs",
+		}
+
+		// if request includes the first bucket, then add the legacy system bucket to
+		// the beginning of response and adjust the limit
+		// because this is the first bucket in the list, only return it if there is no After field
+		// the offset is after the first bucket, then decrement offset to account for the "extra" bucket on first page
+		if o.Offset < NumLegacyBuckets && o.After == nil {
+			buckets = append(buckets, tb)
+			o.Limit = o.Limit - 1
+		} else {
+			o.Offset = o.Offset - 1
+		}
+	}
+
+	if needsLegacyMonitoring {
+		mb := &influxdb.Bucket{
+			ID:              influxdb.MonitoringSystemBucketID,
+			Type:            influxdb.BucketTypeSystem,
+			Name:            influxdb.MonitoringSystemBucketName,
+			RetentionPeriod: influxdb.MonitoringSystemBucketRetention,
+			Description:     "System bucket for monitoring logs",
+		}
+
+		// because this is the second bucket in the list, if there is an After field it will only be returned
+		// if it's After the Task bucket
+		if o.Offset < NumLegacyBuckets+1 {
+			if o.After == nil || *o.After == influxdb.TasksSystemBucketID {
+				buckets = append(buckets, mb)
+				o.Limit = o.Limit - 1
+			}
+		} else {
+			o.Offset = o.Offset - 1
+		}
+	}
+
+	err = s.store.View(ctx, func(tx kv.Tx) error {
 		if filter.Name != nil && filter.OrganizationID != nil {
 			b, err := s.store.GetBucketByName(ctx, tx, *filter.OrganizationID, *filter.Name)
 			if err != nil {
@@ -116,58 +199,16 @@ func (s *BucketSvc) FindBuckets(ctx context.Context, filter influxdb.BucketFilte
 		bs, err := s.store.ListBuckets(ctx, tx, BucketFilter{
 			Name:           filter.Name,
 			OrganizationID: filter.OrganizationID,
-		}, opt...)
+		}, o)
 		if err != nil {
 			return err
 		}
-		buckets = bs
+		buckets = append(buckets, bs...)
 		return nil
 	})
 
 	if err != nil {
 		return nil, 0, err
-	}
-
-	if len(opt) > 0 && len(buckets) >= opt[0].Limit {
-		// if we have reached the limit we will not add system buckets
-		return buckets, len(buckets), nil
-	}
-
-	// if a name is provided dont fill in system buckets
-	if filter.Name != nil {
-		return buckets, len(buckets), nil
-	}
-
-	// NOTE: this is a remnant of the old system.
-	// There are org that do not have system buckets stored, but still need to be displayed.
-	needsSystemBuckets := true
-	for _, b := range buckets {
-		if b.Type == influxdb.BucketTypeSystem {
-			needsSystemBuckets = false
-			break
-		}
-	}
-
-	if needsSystemBuckets {
-		tb := &influxdb.Bucket{
-			ID:              influxdb.TasksSystemBucketID,
-			Type:            influxdb.BucketTypeSystem,
-			Name:            influxdb.TasksSystemBucketName,
-			RetentionPeriod: influxdb.TasksSystemBucketRetention,
-			Description:     "System bucket for task logs",
-		}
-
-		buckets = append(buckets, tb)
-
-		mb := &influxdb.Bucket{
-			ID:              influxdb.MonitoringSystemBucketID,
-			Type:            influxdb.BucketTypeSystem,
-			Name:            influxdb.MonitoringSystemBucketName,
-			RetentionPeriod: influxdb.MonitoringSystemBucketRetention,
-			Description:     "System bucket for monitoring logs",
-		}
-
-		buckets = append(buckets, mb)
 	}
 
 	return buckets, len(buckets), nil

--- a/tenant/storage_bucket_test.go
+++ b/tenant/storage_bucket_test.go
@@ -15,17 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// type Bucket struct {
-// 	ID                  ID            `json:"id,omitempty"`
-// 	OrgID               ID            `json:"bucketID,omitempty"`
-// 	Type                BucketType    `json:"type"`
-// 	Name                string        `json:"name"`
-// 	Description         string        `json:"description"`
-// 	RetentionPolicyName string        `json:"rp,omitempty"` // This to support v1 sources
-// 	RetentionPeriod     time.Duration `json:"retentionPeriod"`
-// 	CRUDLog
-// }
-
 const (
 	firstBucketID influxdb.ID = (iota + 1)
 	secondBucketID

--- a/testing/tenant.go
+++ b/testing/tenant.go
@@ -869,7 +869,7 @@ func Delete(t *testing.T, init func(*testing.T, TenantFields) (influxdb.TenantSe
 		if err != nil {
 			t.Fatal(err)
 		}
-		if nbs != baseNBuckets {
+		if nbs != 0 {
 			t.Errorf("expected buckets to be deleted, got: %+v", bs)
 		}
 	})


### PR DESCRIPTION
Closes #19226

This PR changes the way we handle legacy system buckets. If the system buckets are not found on lookup on the first page only, we add them and adjust the limit and offset accordingly. This prevents a bug we had previously where legacy system buckets would sometimes appear multiple times when getting multiple pages of Buckets.

I have opted to put this new change only in the new tenant code, not in the old kv code which is soon to be deprecated. Accordingly, I have tests using the old code ignore the new tests.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
