### PR TITLE
fix: Properly lock err value

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -432,8 +432,9 @@ func (q *Task) Monitor(fn MonitorFunc) {
 // the query.
 func (q *Task) Error() error {
 	q.mu.Lock()
-	defer q.mu.Unlock()
-	return q.err
+	err := q.err
+	q.mu.Unlock()
+	return err
 }
 
 func (q *Task) setError(err error) {


### PR DESCRIPTION
Prior to this commit, Task.Error() would do something like the
following:

  func (q *Task) Error() error {
    q.mu.Lock()
    defer q.mu.Unlock()
    return q.err
  }

Unfortunately this doesn't actually protect q.err from concurrent access
since the mutex is unlocked before q.err is evaluated when returned.  So
the lock is effectively unused.

This patch stashes the value of q.err within the critical section and
returns that value like below:

  func (q *Task) Error() error {
    q.mu.Lock()
    err := q.err
    q.mu.Unlock()
    return err
  }

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
