### PR TITLE
chore(task): clean up old maxPermission code

### DIFF
--- a/checks/service_external_test.go
+++ b/checks/service_external_test.go
@@ -158,7 +158,6 @@ var taskCmpOptions = cmp.Options{
 	// skip comparing permissions
 	cmpopts.IgnoreFields(
 		influxdb.Task{},
-		"Authorization",
 		"LatestCompleted",
 		"LatestScheduled",
 		"CreatedAt",

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -86,21 +86,19 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					FindTasksFn: func(ctx context.Context, f influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 						tasks := []*influxdb.Task{
 							{
-								ID:              1,
-								Name:            "task1",
-								Description:     "A little Task",
-								OrganizationID:  1,
-								OwnerID:         1,
-								Organization:    "test",
-								AuthorizationID: 0x100,
+								ID:             1,
+								Name:           "task1",
+								Description:    "A little Task",
+								OrganizationID: 1,
+								OwnerID:        1,
+								Organization:   "test",
 							},
 							{
-								ID:              2,
-								Name:            "task2",
-								OrganizationID:  2,
-								OwnerID:         2,
-								Organization:    "test",
-								AuthorizationID: 0x200,
+								ID:             2,
+								Name:           "task2",
+								OrganizationID: 2,
+								OwnerID:        2,
+								Organization:   "test",
 							},
 						}
 						return tasks, len(tasks), nil
@@ -195,12 +193,11 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					FindTasksFn: func(ctx context.Context, f influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 						tasks := []*influxdb.Task{
 							{
-								ID:              2,
-								Name:            "task2",
-								OrganizationID:  2,
-								OwnerID:         2,
-								Organization:    "test",
-								AuthorizationID: 0x200,
+								ID:             2,
+								Name:           "task2",
+								OrganizationID: 2,
+								OwnerID:        2,
+								Organization:   "test",
 							},
 						}
 						return tasks, len(tasks), nil
@@ -269,12 +266,11 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					FindTasksFn: func(ctx context.Context, f influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 						tasks := []*influxdb.Task{
 							{
-								ID:              2,
-								Name:            "task2",
-								OrganizationID:  2,
-								OwnerID:         2,
-								Organization:    "test2",
-								AuthorizationID: 0x200,
+								ID:             2,
+								Name:           "task2",
+								OrganizationID: 2,
+								OwnerID:        2,
+								Organization:   "test2",
 							},
 						}
 						return tasks, len(tasks), nil
@@ -342,20 +338,18 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					FindTasksFn: func(ctx context.Context, f influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 						tasks := []*influxdb.Task{
 							{
-								ID:              1,
-								Name:            "task1",
-								OrganizationID:  1,
-								OwnerID:         1,
-								Organization:    "test2",
-								AuthorizationID: 0x100,
+								ID:             1,
+								Name:           "task1",
+								OrganizationID: 1,
+								OwnerID:        1,
+								Organization:   "test2",
 							},
 							{
-								ID:              2,
-								Name:            "task2",
-								OrganizationID:  2,
-								OwnerID:         2,
-								Organization:    "test2",
-								AuthorizationID: 0x200,
+								ID:             2,
+								Name:           "task2",
+								OrganizationID: 2,
+								OwnerID:        2,
+								Organization:   "test2",
 							},
 						}
 						return tasks, len(tasks), nil
@@ -1245,7 +1239,7 @@ func TestTaskHandler_CreateTaskWithOrgName(t *testing.T) {
 				t.Fatalf("expected task to be created with org ID %s, got %s", o.ID, tc.OrganizationID)
 			}
 
-			return &influxdb.Task{ID: 9, OrganizationID: o.ID, OwnerID: o.ID, AuthorizationID: authz.ID, Name: "x", Flux: tc.Flux}, nil
+			return &influxdb.Task{ID: 9, OrganizationID: o.ID, OwnerID: o.ID, Name: "x", Flux: tc.Flux}, nil
 		},
 	}
 
@@ -1388,9 +1382,8 @@ func TestTaskHandler_Sessions(t *testing.T) {
 				}
 
 				return &influxdb.Task{
-					ID:              taskID,
-					OrganizationID:  o.ID,
-					AuthorizationID: taskAuth.ID,
+					ID:             taskID,
+					OrganizationID: o.ID,
 				}, nil
 			},
 		}
@@ -1482,9 +1475,8 @@ func TestTaskHandler_Sessions(t *testing.T) {
 				}
 
 				return &influxdb.Task{
-					ID:              taskID,
-					OrganizationID:  o.ID,
-					AuthorizationID: taskAuth.ID,
+					ID:             taskID,
+					OrganizationID: o.ID,
 				}, nil
 			},
 		}
@@ -1578,9 +1570,8 @@ func TestTaskHandler_Sessions(t *testing.T) {
 				}
 
 				return &influxdb.Task{
-					ID:              taskID,
-					OrganizationID:  o.ID,
-					AuthorizationID: taskAuth.ID,
+					ID:             taskID,
+					OrganizationID: o.ID,
 				}, nil
 			},
 		}
@@ -1673,9 +1664,8 @@ func TestTaskHandler_Sessions(t *testing.T) {
 				}
 
 				return &influxdb.Task{
-					ID:              taskID,
-					OrganizationID:  o.ID,
-					AuthorizationID: taskAuth.ID,
+					ID:             taskID,
+					OrganizationID: o.ID,
 				}, nil
 			},
 		}

--- a/kv/service.go
+++ b/kv/service.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"context"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -50,8 +49,6 @@ type Service struct {
 	variableStore *IndexStore
 
 	urmByUserIndex *Index
-
-	disableAuthorizationsForMaxPermissions func(context.Context) bool
 }
 
 // NewService returns an instance of a Service.
@@ -71,9 +68,6 @@ func NewService(log *zap.Logger, kv Store, configs ...ServiceConfig) *Service {
 		endpointStore:  newEndpointStore(),
 		variableStore:  newVariableStore(),
 		urmByUserIndex: NewIndex(URMByUserIndexMapping, WithIndexReadPathEnabled),
-		disableAuthorizationsForMaxPermissions: func(context.Context) bool {
-			return false
-		},
 	}
 
 	if len(configs) > 0 {
@@ -109,11 +103,4 @@ func (s *Service) WithResourceLogger(audit resource.Logger) {
 // Should only be used in tests for mocking.
 func (s *Service) WithStore(store Store) {
 	s.kv = store
-}
-
-// WithMaxPermissionFunc sets the useAuthorizationsForMaxPermissions function
-// which can trigger whether or not max permissions uses the users authorizations
-// to derive maximum permissions.
-func (s *Service) WithMaxPermissionFunc(fn func(context.Context) bool) {
-	s.disableAuthorizationsForMaxPermissions = fn
 }

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -165,7 +165,6 @@ func TestRetrieveTaskWithBadAuth(t *testing.T) {
 			return err
 		}
 		task.OwnerID = influxdb.ID(1)
-		task.AuthorizationID = influxdb.ID(132) // bad id or an id that doesnt match any auth
 		tbyte, err := json.Marshal(task)
 		if err != nil {
 			return err

--- a/task.go
+++ b/task.go
@@ -29,32 +29,12 @@ var (
 	TaskSystemType = "system"
 )
 
-type contextKey string
-
-const (
-	taskAuthKey contextKey = "taskAuth"
-)
-
-// TODO: these are temporary functions until we can work through optimizing auth
-// FindTaskWithAuth adds a auth hint for lookup of tasks
-func FindTaskWithoutAuth(ctx context.Context) context.Context {
-	return context.WithValue(ctx, taskAuthKey, "omit")
-}
-
-// FindTaskAuthRequired retrieves the taskAuth hint
-func FindTaskAuthRequired(ctx context.Context) bool {
-	val, ok := ctx.Value(taskAuthKey).(string)
-	return !(ok && val == "omit")
-}
-
 // Task is a task. 🎊
 type Task struct {
 	ID              ID                     `json:"id"`
 	Type            string                 `json:"type,omitempty"`
 	OrganizationID  ID                     `json:"orgID"`
 	Organization    string                 `json:"org"`
-	AuthorizationID ID                     `json:"-"`
-	Authorization   *Authorization         `json:"-"`
 	OwnerID         ID                     `json:"ownerID"`
 	Name            string                 `json:"name"`
 	Description     string                 `json:"description,omitempty"`

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -70,7 +70,7 @@ type AnalyticalStorage struct {
 func (as *AnalyticalStorage) FinishRun(ctx context.Context, taskID, runID influxdb.ID) (*influxdb.Run, error) {
 	run, err := as.TaskControlService.FinishRun(ctx, taskID, runID)
 	if run != nil && run.ID.String() != "" {
-		task, err := as.TaskService.FindTaskByID(influxdb.FindTaskWithoutAuth(ctx), run.TaskID)
+		task, err := as.TaskService.FindTaskByID(ctx, run.TaskID)
 		if err != nil {
 			return run, err
 		}

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -280,8 +280,6 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		LatestScheduled: tsk.LatestScheduled,
 		OrganizationID:  cr.OrgID,
 		Organization:    cr.Org,
-		AuthorizationID: tsk.AuthorizationID,
-		Authorization:   tsk.Authorization,
 		OwnerID:         tsk.OwnerID,
 		Name:            "task #0",
 		Cron:            "* * * * *",
@@ -290,10 +288,6 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		Flux:            fmt.Sprintf(scriptFmt, 0),
 		Type:            influxdb.TaskSystemType,
 	}
-
-	// tasks sets user id on authorization to that
-	// of the tasks owner
-	want.Authorization.UserID = tsk.OwnerID
 
 	for fn, f := range found {
 		if diff := cmp.Diff(f, want); diff != "" {


### PR DESCRIPTION
Tasks no longer uses the max permission system to pupulate an
authorization. We can safely remove this dead code.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
