### PR TITLE
feat(cli): add option to dump the raw flux response from query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [19219](https://github.com/influxdata/influxdb/pull/19219): List buckets via the API now supports after (ID) parameter as an alternative to offset.
 1. [19390](https://github.com/influxdata/influxdb/pull/19390): Record last success and failure run times in the Task
 1. [19402](https://github.com/influxdata/influxdb/pull/19402): Inject Task's LatestSuccess Timestamp In Flux Extern
+1. [19433](https://github.com/influxdata/influxdb/pull/19433): Add option to dump raw query results in CLI
 
 ### Bug Fixes
 

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -23,6 +23,7 @@ import (
 var queryFlags struct {
 	org  organization
 	file string
+	raw  bool
 }
 
 func cmdQuery(f *globalFlags, opts genericCLIOpts) *cobra.Command {
@@ -34,6 +35,7 @@ func cmdQuery(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 	f.registerFlags(cmd)
 	queryFlags.org.register(cmd, true)
 	cmd.Flags().StringVarP(&queryFlags.file, "file", "f", "", "Path to Flux query file")
+	cmd.Flags().BoolVarP(&queryFlags.raw, "raw", "r", false, "Display raw query results")
 
 	return cmd
 }
@@ -123,6 +125,11 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if queryFlags.raw {
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	}
+
 	dec := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
 	results, err := dec.Decode(resp.Body)
 	if err != nil {
@@ -141,7 +148,6 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	results.Release()
 	return results.Err()
 }
 

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -148,6 +148,9 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	// It is safe and appropriate to call Release multiple times and must be
+	// called before checking the error on the next line.
+	results.Release()
 	return results.Err()
 }
 


### PR DESCRIPTION
Closes #19254 

Add an option to print raw flux response from `influx query`

```
$ ./influx query --org-id 061309063e504000 -f /tmp/thing.flux -r 
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double,dateTime:RFC3339
#group,false,false,true,true,true,true,true,false,false
#default,mean,,,,,,,,
,result,table,_start,_stop,_field,_measurement,version,_value,_time
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:12:00Z
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:13:00Z
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:14:00Z
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:15:00Z
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:16:00Z
,,0,2020-08-25T19:11:41.138618117Z,2020-08-25T19:16:41.138618117Z,gauge,go_info,go1.13.10,1,2020-08-25T19:16:41.138618117Z

$ ./influx query --org-id 061309063e504000 -f /tmp/thing.flux 
Result: mean
Table: keys: [_start, _stop, _field, _measurement, version]
                   _start:time                      _stop:time           _field:string     _measurement:string          version:string                  _value:float                      _time:time  
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ----------------------------  ------------------------------  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:12:00.000000000Z  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:13:00.000000000Z  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:14:00.000000000Z  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:15:00.000000000Z  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:16:00.000000000Z  
2020-08-25T19:11:44.161831113Z  2020-08-25T19:16:44.161831113Z                   gauge                 go_info               go1.13.10                             1  2020-08-25T19:16:44.161831113Z  
```

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Documentation updated or issue created (provide link to issue/pr)
