### PR TITLE
feat: community template adding the new github raw readme fetch

### DIFF
--- a/ui/cypress/e2e/communityTemplates.test.ts
+++ b/ui/cypress/e2e/communityTemplates.test.ts
@@ -70,6 +70,10 @@ describe('Community Templates', () => {
 
     //and check that 0 resources pluralization is correct
     cy.getByTestID('template-install-title').should('contain', 'resources')
+
+    //check that valid read me appears
+    cy.getByTestID('readme-tab').click()
+    cy.get('.markdown-format').should('contain', 'Downsampling Template')
   })
 
   describe('Opening the install overlay', () => {

--- a/ui/cypress/e2e/communityTemplates.test.ts
+++ b/ui/cypress/e2e/communityTemplates.test.ts
@@ -72,7 +72,7 @@ describe('Community Templates', () => {
     cy.getByTestID('template-install-title').should('contain', 'resources')
 
     //check that valid read me appears
-    cy.getByTestID('readme-tab').click()
+    cy.getByTestID('community-templates-readme-tab').click()
     cy.get('.markdown-format').should('contain', 'Downsampling Template')
   })
 

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -440,3 +440,15 @@ export const updateStackName = async (stackID, name) => {
 
   return resp
 }
+
+export const fetchReadMe = async (directory: string) => {
+  const resp = await fetch(
+    `https://raw.githubusercontent.com/influxdata/community-templates/master/${directory}/README.md`
+  )
+
+  if (!resp.ok) {
+    throw new Error('Network response was not ok')
+  }
+
+  return resp.text()
+}

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -446,8 +446,8 @@ export const fetchReadMe = async (directory: string) => {
     `https://raw.githubusercontent.com/influxdata/community-templates/master/${directory}/README.md`
   )
 
-  if (!resp.ok) {
-    throw new Error('Network response was not ok')
+  if (resp.status >= 300) {
+    throw new Error('Network response was not ok' + resp.statusText)
   }
 
   return resp.text()

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -447,7 +447,7 @@ export const fetchReadMe = async (directory: string) => {
   )
 
   if (resp.status >= 300) {
-    throw new Error('Network response was not ok' + resp.statusText)
+    throw new Error(`Network response was not ok:' ${resp.statusText}`)
   }
 
   return resp.text()

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -63,16 +63,18 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
   }
 
   public render() {
+    const templateDetails = getTemplateNameFromUrl(this.props.stagedTemplateUrl)
+    const templateName = templateDetails.name
+    const templateDirectory = templateDetails.directory
+
     return (
       <CommunityTemplateOverlay
         onDismissOverlay={this.onDismiss}
         onInstall={this.handleInstallTemplate}
         resourceCount={this.props.resourceCount}
         status={this.state.status}
-        templateName={getTemplateNameFromUrl(this.props.stagedTemplateUrl).name}
-        templateDirectory={
-          getTemplateNameFromUrl(this.props.stagedTemplateUrl).directory
-        }
+        templateName={templateName}
+        templateDirectory={templateDirectory}
         updateStatus={this.updateOverlayStatus}
       />
     )

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -70,6 +70,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
         resourceCount={this.props.resourceCount}
         status={this.state.status}
         templateName={getTemplateNameFromUrl(this.props.stagedTemplateUrl).name}
+        templateDirectory={this.props.directory}
         updateStatus={this.updateOverlayStatus}
       />
     )

--- a/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -70,7 +70,9 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
         resourceCount={this.props.resourceCount}
         status={this.state.status}
         templateName={getTemplateNameFromUrl(this.props.stagedTemplateUrl).name}
-        templateDirectory={this.props.directory}
+        templateDirectory={
+          getTemplateNameFromUrl(this.props.stagedTemplateUrl).directory
+        }
         updateStatus={this.updateOverlayStatus}
       />
     )

--- a/ui/src/templates/components/CommunityTemplateOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlay.tsx
@@ -18,6 +18,7 @@ interface OwnProps {
   resourceCount: number
   status?: ComponentStatus
   templateName: string
+  templateDirectory: string
   updateStatus?: (status: ComponentStatus) => void
 }
 
@@ -44,7 +45,13 @@ class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {isVisible, onInstall, resourceCount, templateName} = this.props
+    const {
+      isVisible,
+      onInstall,
+      resourceCount,
+      templateName,
+      templateDirectory,
+    } = this.props
 
     return (
       <Overlay visible={isVisible}>
@@ -77,7 +84,7 @@ class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
               {this.state.activeTab === Tab.IncludedResources ? (
                 <CommunityTemplateOverlayContents />
               ) : (
-                <CommunityTemplateReadme />
+                <CommunityTemplateReadme directory={templateDirectory} />
               )}
             </Tabs.Container>
           </Overlay.Body>

--- a/ui/src/templates/components/CommunityTemplateOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlay.tsx
@@ -78,7 +78,7 @@ class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
                   active={this.state.activeTab === Tab.Readme}
                   id="readme"
                   text="Readme"
-                  testID="readme-tab"
+                  testID="community-templates-readme-tab"
                   onClick={this.setTabToReadme}
                 />
               </Tabs.Tabs>

--- a/ui/src/templates/components/CommunityTemplateOverlay.tsx
+++ b/ui/src/templates/components/CommunityTemplateOverlay.tsx
@@ -78,6 +78,7 @@ class CommunityTemplateOverlayUnconnected extends PureComponent<Props, State> {
                   active={this.state.activeTab === Tab.Readme}
                   id="readme"
                   text="Readme"
+                  testID="readme-tab"
                   onClick={this.setTabToReadme}
                 />
               </Tabs.Tabs>

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -2,6 +2,7 @@
 import React, {PureComponent} from 'react'
 import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 import {fetchReadMe} from 'src/templates/api'
+import {reportError} from 'src/shared/utils/errors'
 
 interface Props {
   directory: string
@@ -17,10 +18,10 @@ export class CommunityTemplateReadme extends PureComponent<Props> {
       const response = await fetchReadMe(this.props.directory)
       this.setState({readMeData: response})
     } catch (error) {
-      console.error(
-        'There has been a problem with your fetch operation:',
-        error
-      )
+      reportError(error, {
+        name: 'The community template fetch github readme failed',
+      })
+
       this.setState({
         readMeData: '## We cant find the readme associated with this template',
       })

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -23,7 +23,7 @@ export class CommunityTemplateReadme extends PureComponent<Props> {
       })
 
       this.setState({
-        readMeData: '## We can't find the readme associated with this template',
+        readMeData: "## We can't find the readme associated with this template",
       })
     }
   }

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -1,38 +1,40 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
+import {fetchReadMe} from 'src/templates/api'
 
-interface Props{directory:string}
+interface Props {
+  directory: string
+}
 
 const cloudImageRenderer = (): any =>
   "We don't support images in markdown for security purposes"
 
-export class CommunityTemplateReadme extends PureComponent<Props>{
+export class CommunityTemplateReadme extends PureComponent<Props> {
   state = {readMeData: ''}
   componentDidMount = async () => {
-    try{
-      const response =  await fetch(`https://raw.githubusercontent.com/influxdat/community-templates/master/${this.props.directory}/README.md`)
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        const readMeData = await response.text()
-        this.setState({readMeData: readMeData})
-
-    }catch(error){
-      console.error('There has been a problem with your fetch operation:', error);
-      this.setState({readMeData: "## No read me to display!"})
-    };
+    try {
+      const response = await fetchReadMe(this.props.directory)
+      this.setState({readMeData: response})
+    } catch (error) {
+      console.error(
+        'There has been a problem with your fetch operation:',
+        error
+      )
+      this.setState({readMeData: '## No read me to display!'})
+    }
   }
 
-  render =() => {
-    return (<MarkdownRenderer
-      text={this.state.readMeData}
-      className="markdown-format"
-      cloudRenderers={{
-        image: cloudImageRenderer,
-        imageReference: cloudImageRenderer,
-      }}
-    />)
+  render = () => {
+    return (
+      <MarkdownRenderer
+        text={this.state.readMeData}
+        className="markdown-format"
+        cloudRenderers={{
+          image: cloudImageRenderer,
+          imageReference: cloudImageRenderer,
+        }}
+      />
+    )
   }
-
 }

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -21,7 +21,9 @@ export class CommunityTemplateReadme extends PureComponent<Props> {
         'There has been a problem with your fetch operation:',
         error
       )
-      this.setState({readMeData: '## No read me to display!'})
+      this.setState({
+        readMeData: '## We cant find the readme associated with this template',
+      })
     }
   }
 

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -1,6 +1,38 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {PureComponent} from 'react'
+import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 
-export const CommunityTemplateReadme: FC = () => {
-  return <h3>Readme to go here</h3>
+interface Props{directory:string}
+
+const cloudImageRenderer = (): any =>
+  "We don't support images in markdown for security purposes"
+
+export class CommunityTemplateReadme extends PureComponent<Props>{
+  state = {readMeData: ''}
+  componentDidMount = async () => {
+    try{
+      const response =  await fetch(`https://raw.githubusercontent.com/influxdat/community-templates/master/${this.props.directory}/README.md`)
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const readMeData = await response.text()
+        this.setState({readMeData: readMeData})
+
+    }catch(error){
+      console.error('There has been a problem with your fetch operation:', error);
+      this.setState({readMeData: "## No read me to display!"})
+    };
+  }
+
+  render =() => {
+    return (<MarkdownRenderer
+      text={this.state.readMeData}
+      className="markdown-format"
+      cloudRenderers={{
+        image: cloudImageRenderer,
+        imageReference: cloudImageRenderer,
+      }}
+    />)
+  }
+
 }

--- a/ui/src/templates/components/CommunityTemplateReadme.tsx
+++ b/ui/src/templates/components/CommunityTemplateReadme.tsx
@@ -23,7 +23,7 @@ export class CommunityTemplateReadme extends PureComponent<Props> {
       })
 
       this.setState({
-        readMeData: '## We cant find the readme associated with this template',
+        readMeData: '## We can't find the readme associated with this template',
       })
     }
   }

--- a/ui/src/templates/utils/index.test.ts
+++ b/ui/src/templates/utils/index.test.ts
@@ -61,11 +61,11 @@ describe('the Community Template url utilities', () => {
 
   it('returns the template name and extension from the official community templates github repo', () => {
     const {name, extension, directory} = getTemplateNameFromUrl(
-      'https://github.com/influxdata/community-templates/blob/master/csgo/csgo.yml'
+      'https://github.com/influxdata/community-templates/blob/master/hooray/csgo.yml'
     )
     expect(name).toBe('csgo')
     expect(extension).toBe('yml')
-    expect(directory).toBe('csgo')
+    expect(directory).toBe('hooray')
   })
 
   it('returns the template name and extension from the official community templates github repo when the extension is not yml', () => {
@@ -88,10 +88,10 @@ describe('the Community Template url utilities', () => {
 
   it('handles non secure arbitrary urls', () => {
     const {name, extension, directory} = getTemplateNameFromUrl(
-      'http://www.example.com/blog/cats/catstuff/memes/csgo/downsampling.yml'
+      'http://www.example.com/blog/cats/catstuff/memes/-------/downsampling.yml'
     )
     expect(name).toBe('downsampling')
     expect(extension).toBe('yml')
-    expect(directory).toBe('csgo')
+    expect(directory).toBe('-------')
   })
 })

--- a/ui/src/templates/utils/index.test.ts
+++ b/ui/src/templates/utils/index.test.ts
@@ -49,43 +49,49 @@ describe('Templates utils', () => {
 })
 
 describe('the Community Template url utilities', () => {
-  it('returns the template name and extension from an arbitrary url', () => {
-    const {name, extension} = getTemplateNameFromUrl(
+  it('returns the template name, directory, and extension from an arbitrary url', () => {
+    const {name, extension, directory} = getTemplateNameFromUrl(
       'https://github.com/influxdata/influxdb/blob/master/pkger/testdata/dashboard_params.yml'
     )
+
     expect(name).toBe('dashboard_params')
     expect(extension).toBe('yml')
+    expect(directory).toBe('testdata')
   })
 
   it('returns the template name and extension from the official community templates github repo', () => {
-    const {name, extension} = getTemplateNameFromUrl(
+    const {name, extension, directory} = getTemplateNameFromUrl(
       'https://github.com/influxdata/community-templates/blob/master/csgo/csgo.yml'
     )
     expect(name).toBe('csgo')
     expect(extension).toBe('yml')
+    expect(directory).toBe('csgo')
   })
 
   it('returns the template name and extension from the official community templates github repo when the extension is not yml', () => {
-    const {name, extension} = getTemplateNameFromUrl(
+    const {name, extension, directory} = getTemplateNameFromUrl(
       'https://github.com/influxdata/community-templates/blob/master/csgo/csgo.json'
     )
     expect(name).toBe('csgo')
     expect(extension).toBe('json')
+    expect(directory).toBe('csgo')
   })
 
   it('returns the template name and extension from arbitrary urls', () => {
-    const {name, extension} = getTemplateNameFromUrl(
+    const {name, extension, directory} = getTemplateNameFromUrl(
       'https://www.example.com/csgo/csgo.json'
     )
     expect(name).toBe('csgo')
     expect(extension).toBe('json')
+    expect(directory).toBe('csgo')
   })
 
   it('handles non secure arbitrary urls', () => {
-    const {name, extension} = getTemplateNameFromUrl(
+    const {name, extension, directory} = getTemplateNameFromUrl(
       'http://www.example.com/blog/cats/catstuff/memes/csgo/downsampling.yml'
     )
     expect(name).toBe('downsampling')
     expect(extension).toBe('yml')
+    expect(directory).toBe('csgo')
   })
 })

--- a/ui/src/templates/utils/index.ts
+++ b/ui/src/templates/utils/index.ts
@@ -100,10 +100,12 @@ const getTemplateDetailsFromFileSource = (_source: string): TemplateDetails => {
 
 export const getTemplateNameFromUrl = (
   url: string
-): {name: string; extension: string} => {
-  const fullName = url.split('/').pop()
+): {name: string; extension: string; directory: string} => {
+  const urlSplit = url.split('/')
+  const fullName = urlSplit.pop()
+  const directory = urlSplit.pop()
   const [name, extension] = fullName.split('.')
-  return {name, extension}
+  return {name, extension, directory}
 }
 
 export const getTemplateDetails = (source: string): TemplateDetails => {


### PR DESCRIPTION
Closes #8199

With these the read me tab will now feed in the read me from github. If there is no github read me we currently have a bioler plate response that will eventually need to be changed

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
