### PR TITLE
fix(task/executor): Use correct name for last success time extern

### DIFF
--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -25,8 +25,7 @@ const (
 	maxPromises       = 1000
 	defaultMaxWorkers = 100
 
-	latestSuccessOption = "tasks.latestSuccessTime"
-	latestFailureOption = "tasks.latestFailureTime"
+	lastSuccessOption = "tasks.lastSuccessTime"
 )
 
 var _ scheduler.Executor = (*Executor)(nil)
@@ -90,7 +89,7 @@ func (ts CompilerBuilderTimestamps) Extern() *ast.File {
 	if !ts.LatestSuccess.IsZero() {
 		body = append(body, &ast.OptionStatement{
 			Assignment: &ast.VariableAssignment{
-				ID: &ast.Identifier{Name: latestSuccessOption},
+				ID: &ast.Identifier{Name: lastSuccessOption},
 				Init: &ast.DateTimeLiteral{
 					Value: ts.LatestSuccess,
 				},

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -189,7 +189,7 @@ func TestTaskExecutor_QuerySuccessWithExternInjection(t *testing.T) {
 	extern := &ast.File{
 		Body: []ast.Statement{&ast.OptionStatement{
 			Assignment: &ast.VariableAssignment{
-				ID: &ast.Identifier{Name: latestSuccessOption},
+				ID: &ast.Identifier{Name: lastSuccessOption},
 				Init: &ast.DateTimeLiteral{
 					Value: latestSuccess,
 				},

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -189,7 +189,7 @@ func TestTaskExecutor_QuerySuccessWithExternInjection(t *testing.T) {
 	extern := &ast.File{
 		Body: []ast.Statement{&ast.OptionStatement{
 			Assignment: &ast.VariableAssignment{
-				ID: &ast.Identifier{Name: lastSuccessOption},
+				ID: &ast.Identifier{Name: "tasks.lastSuccessTime"},
 				Init: &ast.DateTimeLiteral{
 					Value: latestSuccess,
 				},


### PR DESCRIPTION
Looks like we had a bit of miscommunication about the naming of this Flux option that will be injected by the Task system. Renaming this to match the code that was recently merged in Flux project. This is still guarded by a feature flag so it shouldn't impact anything.

https://github.com/influxdata/flux/commit/15ebe46149e9a265a338e5511a150772bfd011be#diff-1261452e351aa821eab2dcb6ad8b88b8R98