### PR TITLE
feat(ui): change rate limit content for payg

### DIFF
--- a/ui/src/cloud/components/RateLimitAlert.tsx
+++ b/ui/src/cloud/components/RateLimitAlert.tsx
@@ -10,7 +10,6 @@ import {
   AlignItems,
   ComponentSize,
   IconFont,
-  JustifyContent,
   Gradients,
   InfluxColors,
   BannerPanel,
@@ -29,6 +28,7 @@ import {CLOUD} from 'src/shared/constants'
 // Types
 import {AppState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
+import RateLimitAlertContent from './RateLimitAlertContent'
 
 interface StateProps {
   resources: string[]
@@ -69,24 +69,7 @@ const RateLimitAlert: FC<Props> = ({
           hideMobileIcon={true}
           textColor={InfluxColors.Yeti}
         >
-          <div className="rate-alert--content">
-            <span>
-              You've reached the maximum{' '}
-              <a
-                href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
-                target="_blank"
-              >
-                series cardinality
-              </a>{' '}
-              available in your plan. Need to write more data?
-            </span>
-            <FlexBox
-              justifyContent={JustifyContent.Center}
-              className="rate-alert--button"
-            >
-              <CloudUpgradeButton />
-            </FlexBox>
-          </div>
+          <RateLimitAlertContent />
         </BannerPanel>
       </FlexBox>
     )

--- a/ui/src/cloud/components/RateLimitAlertContent.tsx
+++ b/ui/src/cloud/components/RateLimitAlertContent.tsx
@@ -83,7 +83,7 @@ const RateLimitAlertContent: FC<Props> = ({showUpgrade, className}) => {
           size={ComponentSize.Small}
           shape={ButtonShape.Default}
           href="https://support.influxdata.com/s/"
-          target="_self"
+          target="_blank"
           text="Contact Support"
         />
       </FlexBox>

--- a/ui/src/cloud/components/RateLimitAlertContent.tsx
+++ b/ui/src/cloud/components/RateLimitAlertContent.tsx
@@ -1,0 +1,109 @@
+// Libraries
+import React, {FC} from 'react'
+import {connect} from 'react-redux'
+import {get, find} from 'lodash'
+import classnames from 'classnames'
+
+// Components
+import {
+  FlexBox,
+  JustifyContent,
+  LinkButton,
+  ComponentColor,
+  ButtonShape,
+  ComponentSize,
+} from '@influxdata/clockface'
+import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+
+// Constants
+import {
+  HIDE_UPGRADE_CTA_KEY,
+  PAID_ORG_HIDE_UPGRADE_SETTING,
+} from 'src/cloud/constants'
+
+// Types
+import {AppState, OrgSetting} from 'src/types'
+
+interface StateProps {
+  showUpgrade: boolean
+}
+
+interface OwnProps {
+  className?: string
+}
+type Props = StateProps & OwnProps
+
+const RateLimitAlertContent: FC<Props> = ({showUpgrade, className}) => {
+  const rateLimitAlertContentClass = classnames('rate-alert--content', {
+    [`${className}`]: className,
+  })
+
+  if (showUpgrade) {
+    return (
+      <div className={`${rateLimitAlertContentClass} rate-alert--content_free`}>
+        <span>
+          You've reached the maximum{' '}
+          <a
+            href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
+            target="_blank"
+          >
+            series cardinality
+          </a>{' '}
+          available in your plan. Need to write more data?
+        </span>
+        <FlexBox
+          justifyContent={JustifyContent.Center}
+          className="rate-alert--button"
+        >
+          <CloudUpgradeButton />
+        </FlexBox>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`${rateLimitAlertContentClass} rate-alert--content_payg`}>
+      <span>
+        You've reached the maximum{' '}
+        <a
+          href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
+          target="_blank"
+        >
+          series cardinality
+        </a>{' '}
+        available in your plan. Need to write more data?
+      </span>
+      <FlexBox
+        justifyContent={JustifyContent.Center}
+        className="rate-alert--button"
+      >
+        <LinkButton
+          className="contact-support--button"
+          color={ComponentColor.Primary}
+          size={ComponentSize.Small}
+          shape={ButtonShape.Default}
+          href="https://support.influxdata.com/s/"
+          target="_self"
+          text="Contact Support"
+        />
+      </FlexBox>
+    </div>
+  )
+}
+
+const mstp = (state: AppState) => {
+  const settings = get(state, 'cloud.orgSettings.settings', [])
+  const hideUpgradeButtonSetting = find(
+    settings,
+    (setting: OrgSetting) => setting.key === HIDE_UPGRADE_CTA_KEY
+  )
+  if (
+    !hideUpgradeButtonSetting ||
+    hideUpgradeButtonSetting.value !== PAID_ORG_HIDE_UPGRADE_SETTING.value
+  ) {
+    return {showUpgrade: true}
+  }
+  return {showUpgrade: false}
+}
+
+export default connect<StateProps>(mstp)(RateLimitAlertContent)


### PR DESCRIPTION
Display different rate limit alert content to Free users and PAYG users.

**Free**
![image](https://user-images.githubusercontent.com/11937365/91600518-ef37f780-e91c-11ea-8b70-b45354aa3d22.png)

**PAYG**
![image](https://user-images.githubusercontent.com/11937365/91600461-da5b6400-e91c-11ea-955a-7db5b6829b9c.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
