### PR TITLE
fix(pkg/csv2lp): do not override existing line part in group annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19331](https://github.com/influxdata/influxdb/pull/19331): Add description to auth influx command outputs.
 1. [19392](https://github.com/influxdata/influxdb/pull/19392): Include the edge of the boundary we are observing.
 1. [19453](https://github.com/influxdata/influxdb/pull/19453): Warn about duplicate tag names during influx write csv.
+1. [19466](https://github.com/influxdata/influxdb/pull/19466): Do not override existing line part in group annotation.
 
 ## v2.0.0-beta.16 [2020-08-07]
 

--- a/pkg/csv2lp/csv_annotations.go
+++ b/pkg/csv2lp/csv_annotations.go
@@ -91,7 +91,10 @@ var supportedAnnotations = []annotationComment{
 		setupColumn: func(column *CsvTableColumn, value string) {
 			// standard flux query result annotation
 			if strings.HasSuffix(value, "true") {
-				column.LinePart = linePartTag
+				// setup column's line part unless it is already set (#19452)
+				if column.LinePart == 0 {
+					column.LinePart = linePartTag
+				}
 			}
 		},
 	},

--- a/pkg/csv2lp/csv_table.go
+++ b/pkg/csv2lp/csv_table.go
@@ -232,7 +232,7 @@ func (t *CsvTable) AddRow(row []string) bool {
 	// detect data row or table header row
 	if len(row[0]) == 0 || row[0][0] != '#' {
 		if !t.readTableData {
-			// row must a header row now
+			// expect a header row
 			t.lpColumnsValid = false // line protocol columns change
 			if t.partBits == 0 {
 				// create columns since no column anotations were processed


### PR DESCRIPTION
Closes #19452

This PR ensures that the #group annotation cannot override the existing line part (measurement, field, tag, time) of a CSV column if it is already set. It also means that all dateTime columns (including _start, _stop from flux query results) cannot become tags with #group annotation, since dateTime columns automatically have _time_ line part.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
