### PR TITLE
fix(pkg/csv2lp): warn about duplicate tag names #19453

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ need to update any InfluxDB CLI config profiles with the new port number.
 ### Bug Fixes
 
 1. [19331](https://github.com/influxdata/influxdb/pull/19331): Add description to auth influx command outputs.
-1. [19392](https://github.com/influxdata/influxdb/pull/19392) Include the edge of the boundary we are observing.
+1. [19392](https://github.com/influxdata/influxdb/pull/19392): Include the edge of the boundary we are observing.
+1. [19453](https://github.com/influxdata/influxdb/pull/19453): Warn about duplicate tag names during influx write csv.
 
 ## v2.0.0-beta.16 [2020-08-07]
 

--- a/pkg/csv2lp/csv_table_test.go
+++ b/pkg/csv2lp/csv_table_test.go
@@ -255,6 +255,15 @@ func Test_CsvTableProcessing(t *testing.T) {
 			"#default cpu,yes,0,1\n#datatype ,tag,,\n_measurement,test,col1,_time\n,,,",
 			"cpu,test=yes col1=0 1",
 		},
+		{
+			"no duplicate tags", // duplicate tags are ignored, the last column wins, https://github.com/influxdata/influxdb/issues/19453
+			"#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string,string,string,string,string\n" +
+				"#group,true,true,false,false,false,false,true,true,true,true,true,true,true,true,true,true\n" +
+				"#default,_result,,,,,,,,,,,,,,,\n" +
+				",result,table,_start,_stop,_time,_value,_field,_measurement,env,host,hostname,nodename,org,result,table,url\n" +
+				",,0,2020-08-26T23:10:54.023607624Z,2020-08-26T23:15:54.023607624Z,2020-08-26T23:11:00Z,0,0.001,something,host,pod,node,host,,success,role,http://127.0.0.1:8099/metrics\n",
+			"something,env=host,host=pod,hostname=node,nodename=host,result=success,table=role,url=http://127.0.0.1:8099/metrics 0.001=0 1598483460000000000",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #19453

A warning message 
```
WARNING: ignoring duplicate tag 'result' at column index 1, using column at index 14
```
is printed when the CSV data contains duplicate tag names (in a header row). The last column (of the same name) is then used.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
