### PR TITLE
chore(tenant): point tests to new tenant service

### DIFF
--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -823,11 +823,6 @@ func initScraperService(f platformtesting.TargetFields, t *testing.T) (influxdb.
 			t.Fatalf("failed to populate scraper targets")
 		}
 	}
-	for _, m := range f.UserResourceMappings {
-		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
-			t.Fatalf("failed to populate user resource mapping")
-		}
-	}
 
 	for _, o := range f.Organizations {
 		if err := svc.PutOrganization(ctx, o); err != nil {

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -15,10 +15,14 @@ import (
 
 	"github.com/influxdata/httprouter"
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/authorization"
 	pcontext "github.com/influxdata/influxdb/v2/context"
 	kithttp "github.com/influxdata/influxdb/v2/kit/transport/http"
+	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/label"
 	"github.com/influxdata/influxdb/v2/mock"
 	_ "github.com/influxdata/influxdb/v2/query/builtin"
+	"github.com/influxdata/influxdb/v2/tenant"
 	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -1205,35 +1209,39 @@ func TestService_handlePostTaskLabel(t *testing.T) {
 // Test that org name to org ID translation happens properly in the HTTP layer.
 // Regression test for https://github.com/influxdata/influxdb/issues/12089.
 func TestTaskHandler_CreateTaskWithOrgName(t *testing.T) {
-	i := newInMemKVSVC(t)
+	i := NewTestInmemStore(t)
+
+	ts := tenant.NewService(tenant.NewStore(i))
+	aStore, _ := authorization.NewStore(i)
+	as := authorization.NewService(aStore, ts)
 	ctx := context.Background()
 
 	// Set up user and org.
 	u := &influxdb.User{Name: "u"}
-	if err := i.CreateUser(ctx, u); err != nil {
+	if err := ts.CreateUser(ctx, u); err != nil {
 		t.Fatal(err)
 	}
 	o := &influxdb.Organization{Name: "o"}
-	if err := i.CreateOrganization(ctx, o); err != nil {
+	if err := ts.CreateOrganization(ctx, o); err != nil {
 		t.Fatal(err)
 	}
 
 	// Source and destination buckets for use in task.
 	bSrc := influxdb.Bucket{OrgID: o.ID, Name: "b-src"}
-	if err := i.CreateBucket(ctx, &bSrc); err != nil {
+	if err := ts.CreateBucket(ctx, &bSrc); err != nil {
 		t.Fatal(err)
 	}
 	bDst := influxdb.Bucket{OrgID: o.ID, Name: "b-dst"}
-	if err := i.CreateBucket(ctx, &bDst); err != nil {
+	if err := ts.CreateBucket(ctx, &bDst); err != nil {
 		t.Fatal(err)
 	}
 
 	authz := influxdb.Authorization{OrgID: o.ID, UserID: u.ID, Permissions: influxdb.OperPermissions()}
-	if err := i.CreateAuthorization(ctx, &authz); err != nil {
+	if err := as.CreateAuthorization(ctx, &authz); err != nil {
 		t.Fatal(err)
 	}
 
-	ts := &mock.TaskService{
+	taskSvc := &mock.TaskService{
 		CreateTaskFn: func(_ context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
 			if tc.OrganizationID != o.ID {
 				t.Fatalf("expected task to be created with org ID %s, got %s", o.ID, tc.OrganizationID)
@@ -1243,16 +1251,17 @@ func TestTaskHandler_CreateTaskWithOrgName(t *testing.T) {
 		},
 	}
 
+	lStore, _ := label.NewStore(i)
 	h := NewTaskHandler(zaptest.NewLogger(t), &TaskBackend{
 		log: zaptest.NewLogger(t),
 
-		TaskService:                ts,
-		AuthorizationService:       i,
-		OrganizationService:        i,
-		UserResourceMappingService: i,
-		LabelService:               i,
-		UserService:                i,
-		BucketService:              i,
+		TaskService:                taskSvc,
+		AuthorizationService:       as,
+		OrganizationService:        ts,
+		UserResourceMappingService: ts,
+		LabelService:               label.NewService(lStore),
+		UserService:                ts,
+		BucketService:              ts,
 	})
 
 	const script = `option task = {name:"x", every:1m} from(bucket:"b-src") |> range(start:-1m) |> to(bucket:"b-dst", org:"o")`
@@ -1298,22 +1307,26 @@ func TestTaskHandler_CreateTaskWithOrgName(t *testing.T) {
 func TestTaskHandler_Sessions(t *testing.T) {
 	t.Skip("rework these")
 	// Common setup to get a working base for using tasks.
-	i := newInMemKVSVC(t)
+	st := NewTestInmemStore(t)
+	i := kv.NewService(zaptest.NewLogger(t), st)
+
+	tStore := tenant.NewStore(st)
+	tSvc := tenant.NewService(tStore)
 
 	ctx := context.Background()
 
 	// Set up user and org.
 	u := &influxdb.User{Name: "u"}
-	if err := i.CreateUser(ctx, u); err != nil {
+	if err := tSvc.CreateUser(ctx, u); err != nil {
 		t.Fatal(err)
 	}
 	o := &influxdb.Organization{Name: "o"}
-	if err := i.CreateOrganization(ctx, o); err != nil {
+	if err := tSvc.CreateOrganization(ctx, o); err != nil {
 		t.Fatal(err)
 	}
 
 	// Map user to org.
-	if err := i.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
+	if err := tSvc.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
 		ResourceType: influxdb.OrgsResourceType,
 		ResourceID:   o.ID,
 		UserID:       u.ID,
@@ -1324,11 +1337,11 @@ func TestTaskHandler_Sessions(t *testing.T) {
 
 	// Source and destination buckets for use in task.
 	bSrc := influxdb.Bucket{OrgID: o.ID, Name: "b-src"}
-	if err := i.CreateBucket(ctx, &bSrc); err != nil {
+	if err := tSvc.CreateBucket(ctx, &bSrc); err != nil {
 		t.Fatal(err)
 	}
 	bDst := influxdb.Bucket{OrgID: o.ID, Name: "b-dst"}
-	if err := i.CreateBucket(ctx, &bDst); err != nil {
+	if err := tSvc.CreateBucket(ctx, &bDst); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1345,11 +1358,11 @@ func TestTaskHandler_Sessions(t *testing.T) {
 
 			TaskService:                ts,
 			AuthorizationService:       i,
-			OrganizationService:        i,
-			UserResourceMappingService: i,
+			OrganizationService:        tSvc,
+			UserResourceMappingService: tSvc,
 			LabelService:               i,
-			UserService:                i,
-			BucketService:              i,
+			UserService:                tSvc,
+			BucketService:              tSvc,
 		})
 	}
 

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -1,9 +1,15 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
 	"net/http"
+	"strings"
 
 	"github.com/influxdata/influxdb/v2"
 )
@@ -91,4 +97,83 @@ func init() {
 	for k, v := range influxDBErrorToStatusCode {
 		httpStatusCodeToInfluxDBError[v] = k
 	}
+}
+
+// CheckErrorStatus for status and any error in the response.
+func CheckErrorStatus(code int, res *http.Response) error {
+	err := CheckError(res)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != code {
+		return fmt.Errorf("unexpected status code: %s", res.Status)
+	}
+
+	return nil
+}
+
+// CheckError reads the http.Response and returns an error if one exists.
+// It will automatically recognize the errors returned by Influx services
+// and decode the error into an internal error type. If the error cannot
+// be determined in that way, it will create a generic error message.
+//
+// If there is no error, then this returns nil.
+func CheckError(resp *http.Response) (err error) {
+	switch resp.StatusCode / 100 {
+	case 4, 5:
+		// We will attempt to parse this error outside of this block.
+	case 2:
+		return nil
+	default:
+		// TODO(jsternberg): Figure out what to do here?
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Msg:  fmt.Sprintf("unexpected status code: %d %s", resp.StatusCode, resp.Status),
+		}
+	}
+
+	perr := &influxdb.Error{
+		Code: StatusCodeToErrorCode(resp.StatusCode),
+	}
+
+	if resp.StatusCode == http.StatusUnsupportedMediaType {
+		perr.Msg = fmt.Sprintf("invalid media type: %q", resp.Header.Get("Content-Type"))
+		return perr
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		// Assume JSON if there is no content-type.
+		contentType = "application/json"
+	}
+	mediatype, _, _ := mime.ParseMediaType(contentType)
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		perr.Msg = "failed to read error response"
+		perr.Err = err
+		return perr
+	}
+
+	switch mediatype {
+	case "application/json":
+		if err := json.Unmarshal(buf.Bytes(), perr); err != nil {
+			perr.Msg = fmt.Sprintf("attempted to unmarshal error as JSON but failed: %q", err)
+			perr.Err = firstLineAsError(buf)
+		}
+	default:
+		perr.Err = firstLineAsError(buf)
+	}
+
+	if perr.Code == "" {
+		// given it was unset during attempt to unmarshal as JSON
+		perr.Code = StatusCodeToErrorCode(resp.StatusCode)
+	}
+
+	return perr
+}
+func firstLineAsError(buf bytes.Buffer) error {
+	line, _ := buf.ReadString('\n')
+	return errors.New(strings.TrimSuffix(line, "\n"))
 }

--- a/kv/scrapers.go
+++ b/kv/scrapers.go
@@ -172,13 +172,7 @@ func (s *Service) addTarget(ctx context.Context, tx Tx, target *influxdb.Scraper
 		return err
 	}
 
-	urm := &influxdb.UserResourceMapping{
-		ResourceID:   target.ID,
-		UserID:       userID,
-		UserType:     influxdb.Owner,
-		ResourceType: influxdb.ScraperResourceType,
-	}
-	return s.createUserResourceMapping(ctx, tx, urm)
+	return nil
 }
 
 // RemoveTarget removes a scraper target from the bucket.
@@ -215,10 +209,7 @@ func (s *Service) removeTarget(ctx context.Context, tx Tx, id influxdb.ID) error
 		return InternalScraperServiceError(err)
 	}
 
-	return s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
-		ResourceID:   id,
-		ResourceType: influxdb.ScraperResourceType,
-	})
+	return nil
 }
 
 // UpdateTarget updates a scraper target.

--- a/kv/scrapers_test.go
+++ b/kv/scrapers_test.go
@@ -38,12 +38,6 @@ func initScraperTargetStoreService(s kv.SchemaStore, f influxdbtesting.TargetFie
 		}
 	}
 
-	for _, m := range f.UserResourceMappings {
-		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
-			t.Fatalf("failed to populate user resource mapping")
-		}
-	}
-
 	for _, o := range f.Organizations {
 		if err := svc.PutOrganization(ctx, o); err != nil {
 			t.Fatalf("failed to populate organization")

--- a/scraper.go
+++ b/scraper.go
@@ -28,8 +28,6 @@ type ScraperTarget struct {
 
 // ScraperTargetStoreService defines the crud service for ScraperTarget.
 type ScraperTargetStoreService interface {
-	UserResourceMappingService
-	OrganizationService
 	ListTargets(ctx context.Context, filter ScraperTargetFilter) ([]ScraperTarget, error)
 	AddTarget(ctx context.Context, t *ScraperTarget, userID ID) error
 	GetTargetByID(ctx context.Context, id ID) (*ScraperTarget, error)

--- a/tenant/http_client_user.go
+++ b/tenant/http_client_user.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/influxdata/influxdb/v2"
-	ihttp "github.com/influxdata/influxdb/v2/http"
+	khttp "github.com/influxdata/influxdb/v2/kit/transport/http"
 	"github.com/influxdata/influxdb/v2/pkg/httpc"
 )
 
@@ -121,7 +121,7 @@ func (s *UserClientService) DeleteUser(ctx context.Context, id influxdb.ID) erro
 	return s.Client.
 		Delete(prefixUsers, id.String()).
 		StatusFn(func(resp *http.Response) error {
-			return ihttp.CheckErrorStatus(http.StatusNoContent, resp)
+			return khttp.CheckErrorStatus(http.StatusNoContent, resp)
 		}).
 		Do(ctx)
 }

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -54,10 +54,9 @@ var (
 
 // TargetFields will include the IDGenerator, and targets
 type TargetFields struct {
-	IDGenerator          influxdb.IDGenerator
-	Targets              []*influxdb.ScraperTarget
-	UserResourceMappings []*influxdb.UserResourceMapping
-	Organizations        []*influxdb.Organization
+	IDGenerator   influxdb.IDGenerator
+	Targets       []*influxdb.ScraperTarget
+	Organizations []*influxdb.Organization
 }
 
 var targetCmpOptions = cmp.Options{
@@ -124,9 +123,8 @@ func AddTarget(
 		target *influxdb.ScraperTarget
 	}
 	type wants struct {
-		err                  error
-		targets              []influxdb.ScraperTarget
-		userResourceMappings []*influxdb.UserResourceMapping
+		err     error
+		targets []influxdb.ScraperTarget
 	}
 	tests := []struct {
 		name   string
@@ -137,10 +135,9 @@ func AddTarget(
 		{
 			name: "create targets with empty set",
 			fields: TargetFields{
-				IDGenerator:          mock.NewIDGenerator(targetOneID, t),
-				Targets:              []*influxdb.ScraperTarget{},
-				UserResourceMappings: []*influxdb.UserResourceMapping{},
-				Organizations:        []*influxdb.Organization{&org1},
+				IDGenerator:   mock.NewIDGenerator(targetOneID, t),
+				Targets:       []*influxdb.ScraperTarget{},
+				Organizations: []*influxdb.Organization{&org1},
 			},
 			args: args{
 				userID: MustIDBase16(threeID),
@@ -153,14 +150,6 @@ func AddTarget(
 				},
 			},
 			wants: wants{
-				userResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						ResourceType: influxdb.ScraperResourceType,
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Owner,
-					},
-				},
 				targets: []influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -176,9 +165,8 @@ func AddTarget(
 		{
 			name: "create target with invalid org id",
 			fields: TargetFields{
-				IDGenerator:          mock.NewIDGenerator(targetTwoID, t),
-				UserResourceMappings: []*influxdb.UserResourceMapping{},
-				Organizations:        []*influxdb.Organization{&org1},
+				IDGenerator:   mock.NewIDGenerator(targetTwoID, t),
+				Organizations: []*influxdb.Organization{&org1},
 				Targets: []*influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -205,7 +193,6 @@ func AddTarget(
 					Msg:  "provided organization ID has invalid format",
 					Op:   influxdb.OpAddTarget,
 				},
-				userResourceMappings: []*influxdb.UserResourceMapping{},
 				targets: []influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -221,9 +208,8 @@ func AddTarget(
 		{
 			name: "create target with invalid bucket id",
 			fields: TargetFields{
-				IDGenerator:          mock.NewIDGenerator(targetTwoID, t),
-				UserResourceMappings: []*influxdb.UserResourceMapping{},
-				Organizations:        []*influxdb.Organization{&org1},
+				IDGenerator:   mock.NewIDGenerator(targetTwoID, t),
+				Organizations: []*influxdb.Organization{&org1},
 				Targets: []*influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -250,7 +236,6 @@ func AddTarget(
 					Msg:  "provided bucket ID has invalid format",
 					Op:   influxdb.OpAddTarget,
 				},
-				userResourceMappings: []*influxdb.UserResourceMapping{},
 				targets: []influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -278,14 +263,6 @@ func AddTarget(
 					},
 				},
 				Organizations: []*influxdb.Organization{&org1, &org2},
-				UserResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(targetOneID),
-						ResourceType: influxdb.ScraperResourceType,
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-					},
-				},
 			},
 			args: args{
 				userID: MustIDBase16(threeID),
@@ -299,20 +276,6 @@ func AddTarget(
 				},
 			},
 			wants: wants{
-				userResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						ResourceType: influxdb.ScraperResourceType,
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-					},
-					{
-						ResourceID:   MustIDBase16(twoID),
-						ResourceType: influxdb.ScraperResourceType,
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Owner,
-					},
-				},
 				targets: []influxdb.ScraperTarget{
 					{
 						Name:     "name1",
@@ -349,16 +312,6 @@ func AddTarget(
 			}
 			if diff := cmp.Diff(targets, tt.wants.targets, targetCmpOptions...); diff != "" {
 				t.Errorf("scraper targets are different -got/+want\ndiff %s", diff)
-			}
-			urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
-				UserID:       tt.args.userID,
-				ResourceType: influxdb.ScraperResourceType,
-			})
-			if err != nil {
-				t.Fatalf("failed to retrieve user resource mappings: %v", err)
-			}
-			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
-				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
 			}
 		})
 
@@ -678,9 +631,8 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 		userID influxdb.ID
 	}
 	type wants struct {
-		err                  error
-		userResourceMappings []*influxdb.UserResourceMapping
-		targets              []influxdb.ScraperTarget
+		err     error
+		targets []influxdb.ScraperTarget
 	}
 	tests := []struct {
 		name   string
@@ -692,20 +644,6 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 			name: "delete targets using exist id",
 			fields: TargetFields{
 				Organizations: []*influxdb.Organization{&org1},
-				UserResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Owner,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-					{
-						ResourceID:   MustIDBase16(twoID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-				},
 				Targets: []*influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
@@ -724,14 +662,6 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 				userID: MustIDBase16(threeID),
 			},
 			wants: wants{
-				userResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(twoID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-				},
 				targets: []influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetTwoID),
@@ -745,20 +675,6 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 			name: "delete targets using id that does not exist",
 			fields: TargetFields{
 				Organizations: []*influxdb.Organization{&org1},
-				UserResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Owner,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-					{
-						ResourceID:   MustIDBase16(twoID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-				},
 				Targets: []*influxdb.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
@@ -794,20 +710,6 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 						BucketID: idOne,
 					},
 				},
-				userResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Owner,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-					{
-						ResourceID:   MustIDBase16(twoID),
-						UserID:       MustIDBase16(threeID),
-						UserType:     influxdb.Member,
-						ResourceType: influxdb.ScraperResourceType,
-					},
-				},
 			},
 		},
 	}
@@ -825,16 +727,6 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 			}
 			if diff := cmp.Diff(targets, tt.wants.targets, targetCmpOptions...); diff != "" {
 				t.Errorf("targets are different -got/+want\ndiff %s", diff)
-			}
-			urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{
-				UserID:       tt.args.userID,
-				ResourceType: influxdb.ScraperResourceType,
-			})
-			if err != nil {
-				t.Fatalf("failed to retrieve user resource mappings: %v", err)
-			}
-			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
-				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #19157

Now that the tenant service is complete we should be using it for all
test instead of the `kv.Service`.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
