### PR TITLE
fix(onboard): onboarding no longer add admin user

### DIFF
--- a/tenant/service_onboarding.go
+++ b/tenant/service_onboarding.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/v2"
+	icontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/kv"
 )
 
@@ -78,25 +79,17 @@ func (s *OnboardService) onboardUser(ctx context.Context, req *influxdb.Onboardi
 		s.service.SetPassword(ctx, user.ID, req.Password)
 	}
 
+	// set the new user in the context
+	ctx = icontext.SetAuthorizer(ctx, &influxdb.Authorization{
+		UserID: user.ID,
+	})
+
 	// create users org
 	org := &influxdb.Organization{
 		Name: req.Org,
 	}
 
 	if err := s.service.CreateOrganization(ctx, org); err != nil {
-		return nil, err
-	}
-
-	// create urm
-	err := s.service.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
-		UserID:       user.ID,
-		UserType:     influxdb.Owner,
-		MappingType:  influxdb.UserMappingType,
-		ResourceType: influxdb.OrgsResourceType,
-		ResourceID:   org.ID,
-	})
-
-	if err != nil {
 		return nil, err
 	}
 

--- a/tenant/service_onboarding_test.go
+++ b/tenant/service_onboarding_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	influxdb "github.com/influxdata/influxdb/v2"
+	icontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/tenant"
 	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
@@ -46,4 +47,39 @@ func initOnboardingService(s kv.Store, f influxdbtesting.OnboardingFields, t *te
 	}
 
 	return svc
+}
+
+func TestOnboardURM(t *testing.T) {
+	s, _, _ := NewTestInmemStore(t)
+	storage := tenant.NewStore(s)
+	ten := tenant.NewService(storage)
+
+	// we will need an auth service as well
+	svc := tenant.NewOnboardService(ten, kv.NewService(zaptest.NewLogger(t), s))
+
+	ctx := icontext.SetAuthorizer(context.Background(), &influxdb.Authorization{
+		UserID: 123,
+	})
+
+	onboard, err := svc.OnboardUser(ctx, &influxdb.OnboardingRequest{
+		User:   "name",
+		Org:    "name",
+		Bucket: "name",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	urms, _, err := ten.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{ResourceID: onboard.Org.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(urms) > 1 {
+		t.Fatal("additional URMs created")
+	}
+	if urms[0].UserID != onboard.User.ID {
+		t.Fatal("org assigned to the wrong user")
+	}
 }


### PR DESCRIPTION
The admin user should no longer be added to the new user created by
setup.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
