### PR TITLE
fix: remove unnecessary replace directives from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,3 @@ require (
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
-
-replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.2.0
-
-replace github.com/influxdata/platform => /dev/null


### PR DESCRIPTION
From online discussion, the /dev/null replacement was "a hacky way to prevent
people from re-introducing a dependency on the then-deprecated platform repo",
and nothing in the module depends at all on the erroneously capitalized
logrus repo:

```
% go list -m
github.com/influxdata/influxdb/v2
% go mod why -m github.com/Sirupsen/logrus
(main module does not need module github.com/Sirupsen/logrus)
```

Replace directives are potentially dangerous as they can change
semantics for importers of public packages which won't inherit
the same replace directives, so it's best to avoid them if possible.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
