### PR TITLE
feat: Create initial stubs for influxd upgrade command

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/upgrade"
 	_ "github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	_ "github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func main() {
 		// FIXME
 		//generate.Command,
 		//restore.Command,
+		upgrade.Command,
 		&cobra.Command{
 			Use:   "version",
 			Short: "Print the influxd server version",

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -1,0 +1,221 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/authorizer"
+	"github.com/influxdata/influxdb/v2/bolt"
+	"github.com/influxdata/influxdb/v2/dbrp"
+	"github.com/influxdata/influxdb/v2/internal/fs"
+	"github.com/influxdata/influxdb/v2/kit/metric"
+	"github.com/influxdata/influxdb/v2/kit/prom"
+	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/kv/migration"
+	"github.com/influxdata/influxdb/v2/kv/migration/all"
+	"github.com/influxdata/influxdb/v2/tenant"
+	"github.com/influxdata/influxdb/v2/v1/services/meta"
+	"github.com/influxdata/influxdb/v2/v1/services/meta/filestore"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var Command = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade a 1.x version of InfluxDB",
+	RunE:  runUpgradeE,
+}
+
+type optionsV1 struct {
+	metaDir string
+}
+
+type optionsV2 struct {
+	boltPath string
+}
+
+var options = struct {
+	// flags for source InfluxDB
+	source optionsV1
+
+	// flags for target InfluxDB
+	target optionsV2
+}{}
+
+func init() {
+	flags := Command.Flags()
+
+	// source flags
+	v1dir, err := influxDirV1()
+	if err != nil {
+		panic("error fetching default InfluxDB 1.x dir: " + err.Error())
+	}
+
+	flags.StringVar(&options.source.metaDir, "v1-meta-dir", filepath.Join(v1dir, "meta"), "Path to 1.x meta.db directory")
+
+	// target flags
+	v2dir, err := fs.InfluxDir()
+	if err != nil {
+		panic("error fetching default InfluxDB 2.0 dir: " + err.Error())
+	}
+
+	flags.StringVar(&options.target.boltPath, "v2-bolt-path", filepath.Join(v2dir, "influxd.bolt"), "Path to 2.0 metadata")
+
+	// add sub commands
+	Command.AddCommand(v1DumpMetaCommand)
+	Command.AddCommand(v2DumpMetaCommand)
+}
+
+type influxDBv1 struct {
+	meta *meta.Client
+}
+
+type influxDBv2 struct {
+	boltClient  *bolt.Client
+	store       *bolt.KVStore
+	kvStore     kv.SchemaStore
+	tenantStore *tenant.Store
+	ts          *tenant.Service
+	dbrpSvc     influxdb.DBRPMappingServiceV2
+	onboardSvc  influxdb.OnboardingService
+	kvService   *kv.Service
+	meta        *meta.Client
+}
+
+func runUpgradeE(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	v1, err := newInfluxDBv1(&options.source)
+	if err != nil {
+		return err
+	}
+	_ = v1
+
+	v2, err := newInfluxDBv2(ctx, &options.target)
+	if err != nil {
+		return err
+	}
+	_ = v2
+
+	// 1. Onboard the initial admin user
+	// v2.onboardSvc.OnboardInitialUser()
+
+	// 2. read each database / retention policy from v1.meta and create bucket db-name/rp-name
+	// newBucket := v2.ts.CreateBucket(ctx, Bucket{})
+	//
+	// 3. create database in v2.meta
+	// v2.meta.CreateDatabase(newBucket.ID.String())
+	// copy shard info from v1.meta
+
+	return nil
+}
+
+func newInfluxDBv1(opts *optionsV1) (svc *influxDBv1, err error) {
+	svc = &influxDBv1{}
+	svc.meta, err = openV1Meta(opts.metaDir)
+	if err != nil {
+		return nil, fmt.Errorf("error opening 1.x meta.db: %w", err)
+	}
+
+	return svc, nil
+}
+
+func newInfluxDBv2(ctx context.Context, opts *optionsV2) (svc *influxDBv2, err error) {
+	log := zap.NewNop()
+	reg := prom.NewRegistry(log.With(zap.String("service", "prom_registry")))
+
+	svc = &influxDBv2{}
+
+	// *********************
+	// V2 specific services
+	serviceConfig := kv.ServiceConfig{}
+
+	// Create BoltDB store and K/V service
+	svc.boltClient = bolt.NewClient(log.With(zap.String("service", "bolt")))
+	svc.boltClient.Path = opts.boltPath
+	if err := svc.boltClient.Open(ctx); err != nil {
+		log.Error("Failed opening bolt", zap.Error(err))
+		return nil, err
+	}
+
+	svc.store = bolt.NewKVStore(log.With(zap.String("service", "kvstore-bolt")), opts.boltPath)
+	svc.store.WithDB(svc.boltClient.DB())
+	svc.kvStore = svc.store
+	svc.kvService = kv.NewService(log.With(zap.String("store", "kv")), svc.store, serviceConfig)
+
+	// ensure migrator is run
+	migrator, err := migration.NewMigrator(
+		log.With(zap.String("service", "migrations")),
+		svc.kvStore,
+		all.Migrations[:]...,
+	)
+	if err != nil {
+		log.Error("Failed to initialize kv migrator", zap.Error(err))
+		return nil, err
+	}
+
+	// apply migrations to metadata store
+	if err := migrator.Up(ctx); err != nil {
+		log.Error("Failed to apply migrations", zap.Error(err))
+		return nil, err
+	}
+
+	// other required services
+	var (
+		authSvc influxdb.AuthorizationService = svc.kvService
+	)
+
+	// Create Tenant service (orgs, buckets, )
+	svc.tenantStore = tenant.NewStore(svc.kvStore)
+	svc.ts = tenant.NewSystem(svc.tenantStore, log.With(zap.String("store", "new")), reg, metric.WithSuffix("new"))
+
+	svc.meta = meta.NewClient(meta.NewConfig(), svc.kvStore)
+	if err := svc.meta.Open(); err != nil {
+		return nil, err
+	}
+
+	// DB/RP service
+	svc.dbrpSvc = dbrp.NewService(ctx, authorizer.NewBucketService(svc.ts.BucketService), svc.kvStore)
+
+	// on-boarding service (influx setup)
+	svc.onboardSvc = tenant.NewOnboardService(svc.ts, authSvc)
+
+	return svc, nil
+}
+
+func openV1Meta(dir string) (*meta.Client, error) {
+	cfg := meta.NewConfig()
+	cfg.Dir = dir
+	store := filestore.New(cfg.Dir, string(meta.BucketName), "meta.db")
+	c := meta.NewClient(cfg, store)
+	if err := c.Open(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// influxDirV1 retrieves the influxdb directory.
+func influxDirV1() (string, error) {
+	var dir string
+	// By default, store meta and data files in current users home directory
+	u, err := user.Current()
+	if err == nil {
+		dir = u.HomeDir
+	} else if home := os.Getenv("HOME"); home != "" {
+		dir = home
+	} else {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		dir = wd
+	}
+	dir = filepath.Join(dir, ".influxdb")
+
+	return dir, nil
+}

--- a/cmd/influxd/upgrade/v1_dump_meta.go
+++ b/cmd/influxd/upgrade/v1_dump_meta.go
@@ -1,0 +1,63 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var v1DumpMetaCommand = &cobra.Command{
+	Use:   "v1-dump-meta",
+	Short: "Dump InfluxDB 1.x meta.db",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc, err := newInfluxDBv1(&v1DumpMetaOptions)
+		if err != nil {
+			return fmt.Errorf("error opening 1.x meta.db: %w", err)
+		}
+		meta := svc.meta
+
+		tw := tabwriter.NewWriter(os.Stdout, 15, 4, 1, ' ', 0)
+
+		showBool := func(b bool) string {
+			if b {
+				return "✓"
+			}
+			return ""
+		}
+
+		fmt.Fprintln(os.Stdout, "Databases")
+		fmt.Fprintln(os.Stdout, "---------")
+		fmt.Fprintf(tw, "%s\t%s\n", "Name", "Default RP")
+		for _, row := range meta.Databases() {
+			fmt.Fprintf(tw, "%s\t%s\n", row.Name, row.DefaultRetentionPolicy)
+		}
+		_ = tw.Flush()
+		fmt.Fprintln(os.Stdout)
+
+		fmt.Fprintln(os.Stdout, "Users")
+		fmt.Fprintln(os.Stdout, "-----")
+		fmt.Fprintf(tw, "%s\t%s\n", "Name", "Admin")
+		for _, row := range meta.Users() {
+			fmt.Fprintf(tw, "%s\t%s\n", row.Name, showBool(row.Admin))
+		}
+		_ = tw.Flush()
+
+		return nil
+	},
+}
+
+var v1DumpMetaOptions = optionsV1{}
+
+func init() {
+	flags := v1DumpMetaCommand.Flags()
+
+	v1dir, err := influxDirV1()
+	if err != nil {
+		panic("error fetching default InfluxDB 1.x dir: " + err.Error())
+	}
+
+	flags.StringVar(&v1DumpMetaOptions.metaDir, "v1-meta-dir", filepath.Join(v1dir, "meta"), "Path to meta.db directory")
+}

--- a/cmd/influxd/upgrade/v2_dump_meta.go
+++ b/cmd/influxd/upgrade/v2_dump_meta.go
@@ -1,0 +1,81 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/internal/fs"
+	"github.com/spf13/cobra"
+)
+
+var v2DumpMetaCommand = &cobra.Command{
+	Use:   "v2-dump-meta",
+	Short: "Dump InfluxDB 2.x influxd.bolt",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		svc, err := newInfluxDBv2(ctx, &v2DumpMetaOptions)
+		if err != nil {
+			return fmt.Errorf("error opening InfluxDB 2.0: %w", err)
+		}
+
+		tw := tabwriter.NewWriter(os.Stdout, 15, 4, 1, ' ', 0)
+
+		fmt.Fprintln(os.Stdout, "Orgs")
+		fmt.Fprintln(os.Stdout, "----")
+		fmt.Fprintf(tw, "%s\t%s\n", "ID", "Name")
+		orgs, _, err := svc.ts.FindOrganizations(ctx, influxdb.OrganizationFilter{})
+		if err != nil {
+			return err
+		}
+		for _, row := range orgs {
+			fmt.Fprintf(tw, "%s\t%s\n", row.ID.String(), row.Name)
+		}
+		_ = tw.Flush()
+		fmt.Fprintln(os.Stdout)
+
+		fmt.Fprintln(os.Stdout, "Users")
+		fmt.Fprintln(os.Stdout, "-----")
+		fmt.Fprintf(tw, "%s\t%s\n", "ID", "Name")
+		users, _, err := svc.ts.FindUsers(ctx, influxdb.UserFilter{})
+		if err != nil {
+			return err
+		}
+		for _, row := range users {
+			fmt.Fprintf(tw, "%s\t%s\n", row.ID.String(), row.Name)
+		}
+		_ = tw.Flush()
+		fmt.Fprintln(os.Stdout)
+
+		fmt.Fprintln(os.Stdout, "Buckets")
+		fmt.Fprintln(os.Stdout, "-------")
+		fmt.Fprintf(tw, "%s\t%s\n", "ID", "Name")
+		buckets, _, err := svc.ts.FindBuckets(ctx, influxdb.BucketFilter{})
+		if err != nil {
+			return err
+		}
+		for _, row := range buckets {
+			fmt.Fprintf(tw, "%s\t%s\n", row.ID.String(), row.Name)
+		}
+		_ = tw.Flush()
+		fmt.Fprintln(os.Stdout)
+
+		return nil
+	},
+}
+
+var v2DumpMetaOptions = optionsV2{}
+
+func init() {
+	flags := v2DumpMetaCommand.Flags()
+
+	v2dir, err := fs.InfluxDir()
+	if err != nil {
+		panic("error fetching default InfluxDB 2.0 dir: " + err.Error())
+	}
+
+	flags.StringVar(&v2DumpMetaOptions.boltPath, "v2-bolt-path", filepath.Join(v2dir, "influxd.bolt"), "Path to 2.0 metadata")
+}


### PR DESCRIPTION
Includes some example sub commands for dumping v1 and v2 metadata

* `influxd upgrade` (stubs only)
* example `influxd upgrade v1-dump-meta` dumps some InfluxDB 1.x meta data
* example `influxd upgrade v2-dump-meta` dumps some InfluxDB 2.x meta data

The example `dump` commands are not expected in the final release

Closes #19495