### PR TITLE
fix(cli): update annotation order to match UI

### DIFF
--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -105,7 +105,7 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 		"query": q,
 		"type":  "flux",
 		"dialect": map[string]interface{}{
-			"annotations": []string{"datatype", "group", "default"},
+			"annotations": []string{"group", "datatype", "default"},
 			"delimiter":   ",",
 			"header":      true,
 		},


### PR DESCRIPTION
Updates the annotation headers to be in the same order as the UI: https://github.com/influxdata/influxdb/blob/d3c86e8f4ca85c4f38b37acb7bf57a0a8efd0ba6/ui/src/shared/apis/query.ts#L52

would help with issues like this: https://github.com/influxdata/influxdb/issues/19452

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
