### PR TITLE
feat: Add TSM 1.x storage options as flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19390](https://github.com/influxdata/influxdb/pull/19390): Record last success and failure run times in the Task
 1. [19402](https://github.com/influxdata/influxdb/pull/19402): Inject Task's LatestSuccess Timestamp In Flux Extern
 1. [19433](https://github.com/influxdata/influxdb/pull/19433): Add option to dump raw query results in CLI
+1. [19506](https://github.com/influxdata/influxdb/pull/19506): Add TSM 1.x storage options as flags
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -372,6 +372,69 @@ func launcherOpts(l *Launcher) []cli.Opt {
 			Flag:  "feature-flags",
 			Desc:  "feature flag overrides",
 		},
+
+		// storage configuration
+		{
+			DestP: &l.StorageConfig.Data.WALFsyncDelay,
+			Flag:  "storage-wal-fsync-delay",
+			Desc:  "The amount of time that a write will wait before fsyncing. A duration greater than 0 can be used to batch up multiple fsync calls. This is useful for slower disks or when WAL write contention is seen.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.ValidateKeys,
+			Flag:  "storage-validate-keys",
+			Desc:  "Validates incoming writes to ensure keys only have valid unicode characters.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.CacheMaxMemorySize,
+			Flag:  "storage-cache-max-memory-size",
+			Desc:  "The maximum size a shard's cache can reach before it starts rejecting writes.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.CacheSnapshotMemorySize,
+			Flag:  "storage-cache-snapshot-memory-size",
+			Desc:  "The size at which the engine will snapshot the cache and write it to a TSM file, freeing up memory.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.CacheSnapshotWriteColdDuration,
+			Flag:  "storage-cache-snapshot-write-cold-duration",
+			Desc:  "The length of time at which the engine will snapshot the cache and write it to a new TSM file if the shard hasn't received writes or deletes.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.CompactFullWriteColdDuration,
+			Flag:  "storage-compact-full-write-cold-duration",
+			Desc:  "The duration at which the engine will compact all TSM files in a shard if it hasn't received a write or delete.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.CompactThroughputBurst,
+			Flag:  "storage-compact-throughput-burst",
+			Desc:  "The rate limit in bytes per second that we will allow TSM compactions to write to disk.",
+		},
+		// limits
+		{
+			DestP: &l.StorageConfig.Data.MaxConcurrentCompactions,
+			Flag:  "storage-max-concurrent-compactions",
+			Desc:  "The maximum number of concurrent full and level compactions that can run at one time.  A value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.  Any number greater than 0 limits compactions to that value.  This setting does not apply to cache snapshotting.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.MaxIndexLogFileSize,
+			Flag:  "storage-max-index-log-file-size",
+			Desc:  "The threshold, in bytes, when an index write-ahead log file will compact into an index file. Lower sizes will cause log files to be compacted more quickly and result in lower heap usage at the expense of write throughput.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.SeriesIDSetCacheSize,
+			Flag:  "storage-series-id-set-cache-size",
+			Desc:  "The size of the internal cache used in the TSI index to store previously calculated series results.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.SeriesFileMaxConcurrentSnapshotCompactions,
+			Flag:  "storage-series-file-max-concurrent-snapshot-compactions",
+			Desc:  "The maximum number of concurrent snapshot compactions that can be running at one time across all series partitions in a database.",
+		},
+		{
+			DestP: &l.StorageConfig.Data.TSMWillNeed,
+			Flag:  "storage-tsm-use-madv-willneed",
+			Desc:  "Controls whether we hint to the kernel that we intend to page in mmap'd sections of TSM files.",
+		},
 	}
 }
 
@@ -410,7 +473,8 @@ type Launcher struct {
 	boltClient *bolt.Client
 	kvStore    kv.SchemaStore
 	kvService  *kv.Service
-	//TODO fix
+
+	// storage engine
 	engine        Engine
 	StorageConfig storage.Config
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8
 	github.com/docker/docker v1.13.1 // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/editorconfig-checker/editorconfig-checker v0.0.0-20190819115812-1474bdeaf2a2
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/fatih/color v1.9.0
@@ -119,7 +120,3 @@ require (
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
-
-replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.2.0
-
-replace github.com/influxdata/platform => /dev/null

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -22,27 +22,28 @@ func TestSize_UnmarshalText(t *testing.T) {
 		{"1", 1},
 		{"10", 10},
 		{"100", 100},
-		{"1k", 1 << 10},
-		{"10k", 10 << 10},
-		{"100k", 100 << 10},
-		{"1K", 1 << 10},
-		{"10K", 10 << 10},
-		{"100K", 100 << 10},
-		{"1m", 1 << 20},
-		{"10m", 10 << 20},
-		{"100m", 100 << 20},
-		{"1M", 1 << 20},
-		{"10M", 10 << 20},
-		{"100M", 100 << 20},
-		{"1g", 1 << 30},
-		{"1G", 1 << 30},
-		{fmt.Sprint(uint64(math.MaxUint64) - 1), math.MaxUint64 - 1},
+		{"1kib", 1 << 10},
+		{"10kib", 10 << 10},
+		{"100kib", 100 << 10},
+		{"1Kib", 1 << 10},
+		{"10Kib", 10 << 10},
+		{"100Kib", 100 << 10},
+		{"1mib", 1 << 20},
+		{"10mib", 10 << 20},
+		{"100mib", 100 << 20},
+		{"1Mib", 1 << 20},
+		{"10Mib", 10 << 20},
+		{"100Mib", 100 << 20},
+		{"1gib", 1 << 30},
+		{"1Gib", 1 << 30},
+		{"100Gib", 100 << 30},
+		{"1tib", 1 << 40},
 	} {
 		if err := s.UnmarshalText([]byte(test.str)); err != nil {
-			t.Fatalf("unexpected error: %s", err)
+			t.Errorf("unexpected error: %s", err)
 		}
 		if s != itoml.Size(test.want) {
-			t.Fatalf("wanted: %d got: %d", test.want, s)
+			t.Errorf("wanted: %d got: %d", test.want, s)
 		}
 	}
 
@@ -50,13 +51,12 @@ func TestSize_UnmarshalText(t *testing.T) {
 		fmt.Sprintf("%dk", uint64(math.MaxUint64-1)),
 		"10000000000000000000g",
 		"abcdef",
-		"1KB",
 		"√m",
 		"a1",
 		"",
 	} {
 		if err := s.UnmarshalText([]byte(str)); err == nil {
-			t.Fatalf("input should have failed: %s", str)
+			t.Errorf("input should have failed: %s", str)
 		}
 	}
 }

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -118,8 +118,8 @@ func TestConfig_HumanReadableSizes(t *testing.T) {
 dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
 wal-fsync-delay = "10s"
-cache-max-memory-size = "5g"
-cache-snapshot-memory-size = "100m"
+cache-max-memory-size = "5gib"
+cache-snapshot-memory-size = "100mib"
 `, &c); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #19505

This PR primarily is focused on adding a number of TSM / TSI engine options to the CLI interface of `influxd`.

In addition, it complete a little housekeeping:

* ✅ Remove redundant `replace` directives from `go.mod`
* ✅ Enhances toml package types to implement viper's `pflag.Value` interface for use a CLI arguments
* ✅ Removes `page-fault-rate` flag, which is not available in TSM 1.x

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
