### PR TITLE
feat: Expose a subset of InfluxQL coordinator tuning options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19402](https://github.com/influxdata/influxdb/pull/19402): Inject Task's LatestSuccess Timestamp In Flux Extern
 1. [19433](https://github.com/influxdata/influxdb/pull/19433): Add option to dump raw query results in CLI
 1. [19506](https://github.com/influxdata/influxdb/pull/19506): Add TSM 1.x storage options as flags
+1. [19508](https://github.com/influxdata/influxdb/pull/19508): Add subset of InfluxQL coordinator options as flags
 
 ### Bug Fixes
 


### PR DESCRIPTION
Closes #19507

This PR adds a number of InfluxQL query engine options to the CLI interface of influxd.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
