### PR TITLE
feat: Port shard pre-creation service from InfluxDB 1.x

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -440,6 +440,16 @@ func launcherOpts(l *Launcher) []cli.Opt {
 			Flag:  "storage-retention-check-interval",
 			Desc:  "The interval of time when retention policy enforcement checks run.",
 		},
+		{
+			DestP: &l.StorageConfig.PrecreatorConfig.CheckInterval,
+			Flag:  "storage-shard-precreator-check-interval",
+			Desc:  "The interval of time when the check to pre-create new shards runs.",
+		},
+		{
+			DestP: &l.StorageConfig.PrecreatorConfig.AdvancePeriod,
+			Flag:  "storage-shard-precreator-advance-period",
+			Desc:  "The default period ahead of the endtime of a shard group that its successor group is created.",
+		},
 
 		// InfluxQL Coordinator Config
 		{

--- a/storage/config.go
+++ b/storage/config.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/influxdata/influxdb/v2/v1/services/precreator"
 	"github.com/influxdata/influxdb/v2/v1/services/retention"
 )
 
@@ -10,6 +11,7 @@ type Config struct {
 	Data tsdb.Config
 
 	RetentionService retention.Config
+	PrecreatorConfig precreator.Config
 }
 
 // NewConfig initialises a new config for an Engine.
@@ -17,5 +19,6 @@ func NewConfig() Config {
 	return Config{
 		Data:             tsdb.NewConfig(),
 		RetentionService: retention.NewConfig(),
+		PrecreatorConfig: precreator.NewConfig(),
 	}
 }

--- a/v1/services/precreator/README.md
+++ b/v1/services/precreator/README.md
@@ -1,0 +1,13 @@
+Shard Precreation
+============
+
+During normal operation when InfluxDB receives time-series data, it writes the data to files known as _shards_. Each shard only contains data for a specific range of time. Therefore, before data can be accepted by the system, the shards must exist and InfluxDB always checks that the required shards exist for every incoming data point. If the required shards do not exist, InfluxDB will create those shards. Because this requires a cluster to reach consensus, the process is not instantaneous and can temporarily impact write-throughput.
+
+Since almost all time-series data is written sequentially in time, the system has an excellent idea of the timestamps of future data. Shard precreation takes advantage of this fact by creating required shards ahead of time, thereby ensuring the required shards exist by the time new time-series data actually arrives. Write-throughput is therefore not affected when data is first received for a range of time that would normally trigger shard creation.
+
+Note that the shard-existence check must remain in place in the code, even with shard precreation. This is because while most data is written sequentially in time, this is not always the case. Data may be written with timestamps in the past, or farther in the future than shard precreation handles.
+
+## Configuration
+Shard precreation can be disabled if necessary, though this is not recommended. If it is disabled, then shards will be only be created when explicitly needed.
+
+The interval between runs of the shard precreation service, as well as the time-in-advance the shards are created, are also configurable. The defaults should work for most deployments.

--- a/v1/services/precreator/config.go
+++ b/v1/services/precreator/config.go
@@ -1,0 +1,65 @@
+package precreator
+
+import (
+	"errors"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/toml"
+	"github.com/influxdata/influxdb/v2/v1/monitor/diagnostics"
+)
+
+const (
+	// DefaultCheckInterval is the shard precreation check time if none is specified.
+	DefaultCheckInterval = 10 * time.Minute
+
+	// DefaultAdvancePeriod is the default period ahead of the endtime of a shard group
+	// that its successor group is created.
+	DefaultAdvancePeriod = 30 * time.Minute
+)
+
+// Config represents the configuration for shard precreation.
+type Config struct {
+	Enabled       bool          `toml:"enabled"`
+	CheckInterval toml.Duration `toml:"check-interval"`
+	AdvancePeriod toml.Duration `toml:"advance-period"`
+}
+
+// NewConfig returns a new Config with defaults.
+func NewConfig() Config {
+	return Config{
+		Enabled:       true,
+		CheckInterval: toml.Duration(DefaultCheckInterval),
+		AdvancePeriod: toml.Duration(DefaultAdvancePeriod),
+	}
+}
+
+// Validate returns an error if the Config is invalid.
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.CheckInterval <= 0 {
+		return errors.New("check-interval must be positive")
+	}
+	if c.AdvancePeriod <= 0 {
+		return errors.New("advance-period must be positive")
+	}
+
+	return nil
+}
+
+// Diagnostics returns a diagnostics representation of a subset of the Config.
+func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
+	if !c.Enabled {
+		return diagnostics.RowFromMap(map[string]interface{}{
+			"enabled": false,
+		}), nil
+	}
+
+	return diagnostics.RowFromMap(map[string]interface{}{
+		"enabled":        true,
+		"check-interval": c.CheckInterval,
+		"advance-period": c.AdvancePeriod,
+	}), nil
+}

--- a/v1/services/precreator/config_test.go
+++ b/v1/services/precreator/config_test.go
@@ -1,0 +1,67 @@
+package precreator_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdata/influxdb/v2/v1/services/precreator"
+)
+
+func TestConfig_Parse(t *testing.T) {
+	// Parse configuration.
+	var c precreator.Config
+	if _, err := toml.Decode(`
+enabled = true
+check-interval = "2m"
+advance-period = "10m"
+`, &c); err != nil {
+
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if !c.Enabled {
+		t.Fatalf("unexpected enabled state: %v", c.Enabled)
+	} else if time.Duration(c.CheckInterval) != 2*time.Minute {
+		t.Fatalf("unexpected check interval: %s", c.CheckInterval)
+	} else if time.Duration(c.AdvancePeriod) != 10*time.Minute {
+		t.Fatalf("unexpected advance period: %s", c.AdvancePeriod)
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	c := precreator.NewConfig()
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected validation fail from NewConfig: %s", err)
+	}
+
+	c = precreator.NewConfig()
+	c.CheckInterval = 0
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for check-interval = 0, got nil")
+	}
+
+	c = precreator.NewConfig()
+	c.CheckInterval *= -1
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for negative check-interval, got nil")
+	}
+
+	c = precreator.NewConfig()
+	c.AdvancePeriod = 0
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for advance-period = 0, got nil")
+	}
+
+	c = precreator.NewConfig()
+	c.AdvancePeriod *= -1
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for negative advance-period, got nil")
+	}
+
+	c.Enabled = false
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected validation fail from disabled config: %s", err)
+	}
+}

--- a/v1/services/precreator/service.go
+++ b/v1/services/precreator/service.go
@@ -1,0 +1,93 @@
+// Package precreator provides the shard precreation service.
+package precreator // import "github.com/influxdata/influxdb/v2/v1/services/precreator"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/logger"
+	"go.uber.org/zap"
+)
+
+// Service manages the shard precreation service.
+type Service struct {
+	checkInterval time.Duration
+	advancePeriod time.Duration
+
+	Logger *zap.Logger
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	MetaClient interface {
+		PrecreateShardGroups(now, cutoff time.Time) error
+	}
+}
+
+// NewService returns an instance of the precreation service.
+func NewService(c Config) *Service {
+	return &Service{
+		checkInterval: time.Duration(c.CheckInterval),
+		advancePeriod: time.Duration(c.AdvancePeriod),
+		Logger:        zap.NewNop(),
+	}
+}
+
+// WithLogger sets the logger for the service.
+func (s *Service) WithLogger(log *zap.Logger) {
+	s.Logger = log.With(zap.String("service", "shard-precreation"))
+}
+
+// Open starts the precreation service.
+func (s *Service) Open(ctx context.Context) error {
+	if s.cancel != nil {
+		return nil
+	}
+
+	s.Logger.Info("Starting precreation service",
+		logger.DurationLiteral("check_interval", s.checkInterval),
+		logger.DurationLiteral("advance_period", s.advancePeriod))
+
+	ctx, s.cancel = context.WithCancel(ctx)
+
+	s.wg.Add(1)
+	go s.runPrecreation(ctx)
+	return nil
+}
+
+// Close stops the precreation service.
+func (s *Service) Close() error {
+	if s.cancel == nil {
+		return nil
+	}
+
+	s.cancel()
+	s.wg.Wait()
+	s.cancel = nil
+
+	return nil
+}
+
+// runPrecreation continually checks if resources need precreation.
+func (s *Service) runPrecreation(ctx context.Context) {
+	defer s.wg.Done()
+
+	for {
+		select {
+		case <-time.After(s.checkInterval):
+			if err := s.precreate(time.Now().UTC()); err != nil {
+				s.Logger.Info("Failed to precreate shards", zap.Error(err))
+			}
+		case <-ctx.Done():
+			s.Logger.Info("Terminating precreation service")
+			return
+		}
+	}
+}
+
+// precreate performs actual resource precreation.
+func (s *Service) precreate(now time.Time) error {
+	cutoff := now.Add(s.advancePeriod).UTC()
+	return s.MetaClient.PrecreateShardGroups(now, cutoff)
+}

--- a/v1/services/precreator/service_test.go
+++ b/v1/services/precreator/service_test.go
@@ -1,0 +1,56 @@
+package precreator_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/logger"
+	"github.com/influxdata/influxdb/v2/toml"
+	"github.com/influxdata/influxdb/v2/v1/internal"
+	"github.com/influxdata/influxdb/v2/v1/services/precreator"
+)
+
+func TestShardPrecreation(t *testing.T) {
+	done := make(chan struct{})
+	precreate := false
+
+	var mc internal.MetaClientMock
+	mc.PrecreateShardGroupsFn = func(now, cutoff time.Time) error {
+		if !precreate {
+			close(done)
+			precreate = true
+		}
+		return nil
+	}
+
+	s := NewTestService()
+	s.MetaClient = &mc
+
+	if err := s.Open(context.Background()); err != nil {
+		t.Fatalf("unexpected open error: %s", err)
+	}
+	defer s.Close() // double close should not cause a panic
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-done:
+		timer.Stop()
+	case <-timer.C:
+		t.Errorf("timeout exceeded while waiting for precreate")
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("unexpected close error: %s", err)
+	}
+}
+
+func NewTestService() *precreator.Service {
+	config := precreator.NewConfig()
+	config.CheckInterval = toml.Duration(10 * time.Millisecond)
+
+	s := precreator.NewService(config)
+	s.WithLogger(logger.New(os.Stderr))
+	return s
+}


### PR DESCRIPTION
Closes #19520

This PR copies the shard precreator package from InfluxDB 1.x to enable shard pre-creation support. It makes minor modifications to take a `context.Context` for the `Open` function.

In order to configure the service, the following parameters have been exposed:

```
--storage-shard-precreator-advance-period Duration              The default period ahead of the endtime of a shard group that its successor group is created. (default 30m0s)
--storage-shard-precreator-check-interval Duration              The interval of time when the check to pre-create new shards runs. (default 10m0s)
```
- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
