### PR TITLE
fix(variables): use Update function for Put Variable

### DIFF
--- a/kv/variable.go
+++ b/kv/variable.go
@@ -215,9 +215,12 @@ func (s *Service) CreateVariable(ctx context.Context, v *influxdb.Variable) erro
 	})
 }
 
-// ReplaceVariable puts a variable in the store
+// ReplaceVariable replaces a variable that exists in the store or creates it if it does not
 func (s *Service) ReplaceVariable(ctx context.Context, v *influxdb.Variable) error {
 	return s.kv.Update(ctx, func(tx Tx) error {
+		if found, _ := s.findVariableByID(ctx, tx, v.ID); found != nil {
+			return s.putVariable(ctx, tx, v, PutUpdate())
+		}
 		return s.putVariable(ctx, tx, v, PutNew())
 	})
 }

--- a/testing/variable.go
+++ b/testing/variable.go
@@ -86,6 +86,10 @@ func VariableService(
 			fn:   UpdateVariable,
 		},
 		{
+			name: "ReplaceVariable",
+			fn:   ReplaceVariable,
+		},
+		{
 			name: "DeleteVariable",
 			fn:   DeleteVariable,
 		},
@@ -1117,6 +1121,114 @@ func UpdateVariable(init func(VariableFields, *testing.T) (influxdb.VariableServ
 
 			if variable != nil {
 				if tt.args.update.Name != "" && variable.Name != tt.args.update.Name {
+					t.Fatalf("variable name not updated")
+				}
+			}
+
+			variables, err := s.FindVariables(ctx, influxdb.VariableFilter{})
+			if err != nil {
+				t.Fatalf("failed to retrieve variables: %v", err)
+			}
+			if diff := cmp.Diff(variables, tt.wants.variables, variableCmpOptions...); diff != "" {
+				t.Fatalf("found unexpected variables -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+// ReplaceVariable tests influxdb.VariableService ReplaceVariable interface method
+func ReplaceVariable(init func(VariableFields, *testing.T) (influxdb.VariableService, string, func()), t *testing.T) {
+	type args struct {
+		id          influxdb.ID
+		newVariable *influxdb.Variable
+	}
+	type wants struct {
+		err       *influxdb.Error
+		variables []*influxdb.Variable
+	}
+
+	tests := []struct {
+		name   string
+		fields VariableFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "updating a variable's name",
+			fields: VariableFields{
+				TimeGenerator: fakeGenerator,
+				Variables: []*influxdb.Variable{
+					{
+						ID:             MustIDBase16(idA),
+						OrganizationID: influxdb.ID(7),
+						Name:           "existing-variable",
+						Arguments: &influxdb.VariableArguments{
+							Type:   "constant",
+							Values: influxdb.VariableConstantValues{},
+						},
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: oldFakeDate,
+							UpdatedAt: fakeDate,
+						},
+					},
+				},
+			},
+			args: args{
+				id: MustIDBase16(idB),
+				newVariable: &influxdb.Variable{
+					ID:             MustIDBase16(idA),
+					OrganizationID: influxdb.ID(7),
+					Name:           "renamed-variable",
+					Arguments: &influxdb.VariableArguments{
+						Type:   "constant",
+						Values: influxdb.VariableConstantValues{},
+					},
+					CRUDLog: influxdb.CRUDLog{
+						CreatedAt: oldFakeDate,
+						UpdatedAt: fakeDate,
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+				variables: []*influxdb.Variable{
+					{
+						ID:             MustIDBase16(idA),
+						OrganizationID: influxdb.ID(7),
+						Name:           "renamed-variable",
+						Arguments: &influxdb.VariableArguments{
+							Type:   "constant",
+							Values: influxdb.VariableConstantValues{},
+						},
+						CRUDLog: influxdb.CRUDLog{
+							CreatedAt: oldFakeDate,
+							UpdatedAt: fakeDate,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+
+			err := s.ReplaceVariable(ctx, tt.args.newVariable)
+			influxErrsEqual(t, tt.wants.err, err)
+			if err != nil {
+				return
+			}
+
+			variable, err := s.FindVariableByID(ctx, tt.args.id)
+			if err != nil {
+				return
+			}
+
+			if variable != nil {
+				if tt.args.newVariable.Name != "" && variable.Name != tt.args.newVariable.Name {
 					t.Fatalf("variable name not updated")
 				}
 			}


### PR DESCRIPTION
This line was supposed to go in https://github.com/influxdata/influxdb/pull/19368

The ReplaceVariable function needs to use `PutUpdate` instead of `PutNew`, otherwise it will return a "conflict" error. ReplaceVariable is also used to create new Variables for testing, so I added a condition that will allow it to create a Variable if it does not exist or replace it if it does exist.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
