### PR TITLE
feat: update BandViewProperties

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -757,6 +757,7 @@ type BandViewProperties struct {
 	XColumn           string           `json:"xColumn"`
 	YColumn           string           `json:"yColumn"`
 	UpperColumn       string           `json:"upperColumn"`
+	MainColumn        string           `json:"mainColumn"`
 	LowerColumn       string           `json:"lowerColumn"`
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9004,6 +9004,8 @@ components:
           type: string
         upperColumn:
           type: string
+        mainColumn:
+          type: string
         lowerColumn:
           type: string
         hoverDimension:

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -692,6 +692,7 @@ func convertCellView(cell influxdb.Cell) chart {
 		ch.XCol = p.XColumn
 		ch.YCol = p.YColumn
 		ch.UpperColumn = p.UpperColumn
+		ch.MainColumn = p.MainColumn
 		ch.LowerColumn = p.LowerColumn
 	case influxdb.XYViewProperties:
 		setCommon(chartKindXY, p.ViewColors, influxdb.DecimalPlaces{}, p.Queries)
@@ -739,6 +740,9 @@ func convertChartToResource(ch chart) Resource {
 	}
 	if len(ch.UpperColumn) > 0 {
 		r[fieldChartUpperColumn] = ch.UpperColumn
+	}
+	if len(ch.MainColumn) > 0 {
+		r[fieldChartMainColumn] = ch.MainColumn
 	}
 	if len(ch.LowerColumn) > 0 {
 		r[fieldChartLowerColumn] = ch.LowerColumn

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -1467,6 +1467,7 @@ func (p *Template) parseChart(dashMetaName string, chartIdx int, r Resource) (*c
 		FillColumns:    r.slcStr(fieldChartFillColumns),
 		YSeriesColumns: r.slcStr(fieldChartYSeriesColumns),
 		UpperColumn:    r.stringShort(fieldChartUpperColumn),
+		MainColumn:     r.stringShort(fieldChartMainColumn),
 		LowerColumn:    r.stringShort(fieldChartLowerColumn),
 	}
 

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -555,6 +555,7 @@ const (
 	fieldChartTimeFormat     = "timeFormat"
 	fieldChartYSeriesColumns = "ySeriesColumns"
 	fieldChartUpperColumn    = "upperColumn"
+	fieldChartMainColumn     = "mainColumn"
 	fieldChartLowerColumn    = "lowerColumn"
 	fieldChartWidth          = "width"
 	fieldChartXCol           = "xCol"
@@ -584,6 +585,7 @@ type chart struct {
 	YSeriesColumns  []string
 	XCol, YCol      string
 	UpperColumn     string
+	MainColumn      string
 	LowerColumn     string
 	XPos, YPos      int
 	Height, Width   int
@@ -682,6 +684,7 @@ func (c *chart) properties() influxdb.ViewProperties {
 			XColumn:           c.XCol,
 			YColumn:           c.YCol,
 			UpperColumn:       c.UpperColumn,
+			MainColumn:        c.MainColumn,
 			LowerColumn:       c.LowerColumn,
 			Axes:              c.Axes.influxAxes(),
 			Geom:              c.Geom,

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -1315,6 +1315,7 @@ spec:
 						assert.True(t, props.ShowNoteWhenEmpty)
 						assert.Equal(t, "y", props.HoverDimension)
 						assert.Equal(t, "foo", props.UpperColumn)
+						assert.Equal(t, "baz", props.MainColumn)
 						assert.Equal(t, "bar", props.LowerColumn)
 
 						require.Len(t, props.ViewColors, 1)

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -2244,6 +2244,7 @@ func TestService(t *testing.T) {
 									XColumn:           "x",
 									YColumn:           "y",
 									UpperColumn:       "upper",
+									MainColumn:        "main",
 									LowerColumn:       "lower",
 									TimeFormat:        "",
 								},

--- a/pkger/testdata/dashboard_band.yml
+++ b/pkger/testdata/dashboard_band.yml
@@ -16,6 +16,7 @@ spec:
       xCol: _time
       yCol: _value
       upperColumn: foo
+      mainColumn: baz
       lowerColumn: bar
       hoverDimension: "y"
       geom: line


### PR DESCRIPTION
Closes idpe 8337

Band Plot needs to know explicitly the name of the aggregate function that should be rendered in order to properly group the "upper" and "lower" bands set by the user. Thus, we will add the "mainColumn" property.
