### PR TITLE
fix(UI): nav highlighting boards when open

### DIFF
--- a/ui/src/pageLayout/constants/navigationHierarchy.ts
+++ b/ui/src/pageLayout/constants/navigationHierarchy.ts
@@ -130,7 +130,7 @@ export const generateNavItems = (orgID: string): NavItem[] => {
         type: 'link',
         location: `${orgPrefix}/dashboards-list`,
       },
-      activeKeywords: ['dashboards'],
+      activeKeywords: ['dashboards', 'dashboards-list'],
     },
     {
       id: 'tasks',


### PR DESCRIPTION
# Boards not highlighted in nav while page is open

| Current state |  Fixed state |
|-|-|
| ![current](https://user-images.githubusercontent.com/39964450/92876206-1d800180-f40a-11ea-9d0b-212804d70181.png) | ![fixed](https://user-images.githubusercontent.com/39964450/92876210-1e189800-f40a-11ea-8a40-278b133b4c40.png) |


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/)