### PR TITLE
fix: possible deadlock when set meta data

### DIFF
--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -931,14 +931,13 @@ func (c *Client) DropSubscription(database, rp, name string) error {
 // SetData overwrites the underlying data in the meta store.
 func (c *Client) SetData(data *Data) error {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	d := data.Clone()
 
 	if err := c.commit(d); err != nil {
 		return err
 	}
-
-	c.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Deadlock is possible when `meta.SetData()` is called

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
