### PR TITLE
chore: Fix compilation errors and unit tests for newer Go compilers

### DIFF
--- a/authorization/http_server_test.go
+++ b/authorization/http_server_test.go
@@ -191,7 +191,7 @@ func TestService_handlePostAuthorization(t *testing.T) {
 				httprouter.Params{
 					{
 						Key:   "userID",
-						Value: string(tt.args.session.UserID),
+						Value: fmt.Sprintf("%d", tt.args.session.UserID),
 					},
 				}))
 

--- a/gather/scraper_test.go
+++ b/gather/scraper_test.go
@@ -266,7 +266,7 @@ func (s *mockStorage) UpdateTarget(ctx context.Context, update *influxdb.Scraper
 	defer s.Unlock()
 
 	for k, v := range s.Targets {
-		if v.ID.String() == string(update.ID) {
+		if v.ID.String() == update.ID.String() {
 			s.Targets[k] = *update
 			break
 		}

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -175,11 +175,11 @@ func TestTagKeyValue_Concurrent(t *testing.T) {
 				case 1:
 					v.Cardinality()
 				case 2:
-					v.Contains(string(rand.Intn(52) + 65))
+					v.Contains(fmt.Sprintf("%d", rand.Intn(52)+65))
 				case 3:
-					v.InsertSeriesIDByte([]byte(string(rand.Intn(52)+65)), rand.Uint64()%1000)
+					v.InsertSeriesIDByte([]byte(fmt.Sprintf("%d", rand.Intn(52)+65)), rand.Uint64()%1000)
 				case 4:
-					v.Load(string(rand.Intn(52) + 65))
+					v.Load(fmt.Sprintf("%d", rand.Intn(52)+65))
 				case 5:
 					v.Range(func(tagValue string, a seriesIDs) bool {
 						return rand.Intn(10) == 0


### PR DESCRIPTION
This PR resolves issues with newer versions of the Go compiler.

* casting an integer to a string results in a compilation error
* The string representation of url.Error has changed (quotes around the URL), so provide a more robust means for comparing the error

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
