### PR TITLE
fix: change mapping of /health and /ready to /api/v2/health and /api/v2/ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19446](https://github.com/influxdata/influxdb/pull/19446): Port TSM1 storage engine
 1. [19494](https://github.com/influxdata/influxdb/pull/19494): Changing the default port from 9999 to 8086
 1. [19636](https://github.com/influxdata/influxdb/pull/19636): Disable unimplemented delete with predicate API
+1. [19578](https://github.com/influxdata/influxdb/pull/19578): Change mapping of /health and /ready to /api/v2/health and /api/v2/ready
 
 ### Features
 

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -19,7 +19,7 @@ func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: flags.skipVerify},
 			},
 		}
-		url := flags.config().Host + "/health"
+		url := flags.config().Host + "/api/v2/health"
 		resp, err := c.Get(url)
 		if err != nil {
 			return err
@@ -44,8 +44,8 @@ func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 	}
 
 	cmd := opts.newCmd("ping", runE, true)
-	cmd.Short = "Check the InfluxDB /health endpoint"
-	cmd.Long = `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`
+	cmd.Short = "Check the InfluxDB /api/v2/health endpoint"
+	cmd.Long = `Checks the health of a running InfluxDB instance by querying /api/v2/health. Does not require valid token.`
 	f.registerFlags(cmd, "token")
 
 	return cmd

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -246,7 +246,7 @@ var apiLinks = map[string]interface{}{
 	"system": map[string]string{
 		"metrics": "/metrics",
 		"debug":   "/debug/pprof",
-		"health":  "/health",
+		"health":  "/api/v2/health",
 	},
 	"tasks":     "/api/v2/tasks",
 	"checks":    "/api/v2/checks",

--- a/http/handler.go
+++ b/http/handler.go
@@ -16,10 +16,10 @@ import (
 const (
 	// MetricsPath exposes the prometheus metrics over /metrics.
 	MetricsPath = "/metrics"
-	// ReadyPath exposes the readiness of the service over /ready.
-	ReadyPath = "/ready"
-	// HealthPath exposes the health of the service over /health.
-	HealthPath = "/health"
+	// ReadyPath exposes the readiness of the service over /api/v2/ready.
+	ReadyPath = "/api/v2/ready"
+	// HealthPath exposes the health of the service over /api/v2/health.
+	HealthPath = "/api/v2/health"
 	// DebugPath exposes /debug/pprof for go debugging.
 	DebugPath = "/debug"
 )

--- a/http/health_test.go
+++ b/http/health_test.go
@@ -23,7 +23,7 @@ func TestHealthHandler(t *testing.T) {
 		{
 			name: "health endpoint returns pass",
 			w:    httptest.NewRecorder(),
-			r:    httptest.NewRequest(http.MethodGet, "/health", nil),
+			r:    httptest.NewRequest(http.MethodGet, "/api/v2/health", nil),
 			wants: wants{
 				statusCode:  http.StatusOK,
 				contentType: "application/json; charset=utf-8",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1934,8 +1934,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /ready:
-    servers:
-      - url: /
     get:
       operationId: GetReady
       tags:
@@ -1957,8 +1955,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /health:
-    servers:
-      - url: /
     get:
       operationId: GetHealth
       tags:


### PR DESCRIPTION
Closes #19357

The Cloud version has exposed `health` and `ready` endpoint on `/api/v2` path:

- https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/health
- https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/ready

but OSS version on root path - `/`. 

The `swagger.yml` definition is used for both so We have to unify this.

### Influx CLI

`influx` CLI doesn't work against cloud instances:

```console
influx ping --host https://us-west-2-1.aws.cloud2.influxdata.com/

Error: Invalid character '<' looking for beginning of value.
See 'influx ping -h' for help
```

```console
influx ping --host https://us-west-2-1.aws.cloud2.influxdata.com/ --token luvwJXTn...

Error: unknown flag: --token
See 'influx ping -h' for help
```

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
