### PR TITLE
fix(pkg/csv2lp): report actual line numbers

### DIFF
--- a/pkg/csv2lp/examples_test.go
+++ b/pkg/csv2lp/examples_test.go
@@ -149,8 +149,7 @@ cpu usage_user=2.7
 	},
 	{
 		"columnSeparator",
-		`
-sep=;
+		`sep=;
 m|measurement;available|boolean:y,Y:|n;dt|dateTime:number
 test;nil;1
 test;N;2
@@ -168,23 +167,28 @@ test available=true 5
 	},
 }
 
-func (example *csvExample) normalize() {
+func (example *csvExample) normalize() rune {
 	for len(example.lp) > 0 && example.lp[0] == '\n' {
 		example.lp = example.lp[1:]
 	}
+	if strings.HasPrefix(example.csv, "sep=") {
+		return (rune)(example.csv[4])
+	}
+	return ','
 }
 
 // Test_Examples tests examples of README.md file herein
 func Test_Examples(t *testing.T) {
 	for _, example := range examples {
-		example.normalize()
 		t.Run(example.name, func(t *testing.T) {
+			comma := example.normalize()
 			transformer := CsvToLineProtocol(strings.NewReader(example.csv))
 			transformer.SkipRowOnError(true)
 			result, err := ioutil.ReadAll(transformer)
 			if err != nil {
 				require.Nil(t, fmt.Sprintf("%s", err))
 			}
+			require.Equal(t, comma, transformer.Comma())
 			require.Equal(t, example.lp, string(result))
 		})
 	}

--- a/pkg/csv2lp/line_reader.go
+++ b/pkg/csv2lp/line_reader.go
@@ -1,0 +1,103 @@
+package csv2lp
+
+import (
+	"io"
+)
+
+const (
+	defaultBufSize = 4096
+)
+
+// LineReader wraps an io.Reader to count lines that go though read
+// function and returns at most one line during every invovation of
+// read. It provides a wrokaround to golang's CSV reader that
+// does not expose current line number at all
+// (see https://github.com/golang/go/issues/26679)
+//
+// At most one line is returned by every read in order to ensure that
+// golang's CSV reader buffers at most one single line into its nested
+// bufio.Reader, so that numbers reported are currect also for the
+// CSV reader.
+type LineReader struct {
+	// LineNumber of the next read operation, 0 is the first line by default, can be set to 0 to count from 1
+	LineNumber int
+	// LastLineNumber is the number of the last read row
+	LastLineNumber int
+
+	// rs is a wrapped reader
+	rd io.Reader // reader provided by the client
+	// buf contains last data read from rd
+	buf []byte
+	// readPos is a read position in the buffer
+	readPos int
+	// bufSize is the length of cached data in the buffer
+	bufSize int
+	// err contain the last error during read
+	err error
+}
+
+// NewLineReader returns a new LineReader that wraps an io.Reader
+func NewLineReader(rd io.Reader) *LineReader {
+	return NewLineReaderSize(rd, defaultBufSize)
+}
+
+// NewLineReaderSize returns a new Reader whose buffer has at least the specified
+// size.
+func NewLineReaderSize(rd io.Reader, size int) *LineReader {
+	if size < 2 {
+		size = 2
+	}
+	return &LineReader{
+		rd:  rd,
+		buf: make([]byte, size),
+	}
+}
+
+// Read reads data into p. It fills in data that either does
+// not contain \n or ends with \n.
+// It returns the number of bytes read into p.
+func (lr *LineReader) Read(p []byte) (n int, err error) {
+	n = len(p)
+	// handle patologic case of reading into empty array
+	if n == 0 {
+		if lr.readPos < lr.bufSize {
+			return 0, nil
+		}
+		return 0, lr.readErr()
+	}
+	// read data into buf
+	if lr.readPos == lr.bufSize {
+		if lr.err != nil {
+			return 0, lr.readErr()
+		}
+		lr.readPos = 0
+		lr.bufSize = 0
+		n, lr.err = lr.rd.Read(lr.buf)
+		if n == 0 {
+			return 0, lr.readErr()
+		}
+		lr.bufSize = n
+	}
+	// copy at most one line and don't overflow internal buffer or p
+	i := 0
+	for lr.readPos < lr.bufSize && i < n {
+		lr.LastLineNumber = lr.LineNumber
+		b := lr.buf[lr.readPos]
+		lr.readPos++
+		p[i] = b
+		i++
+		// read at most one line
+		if b == '\n' {
+			lr.LineNumber++
+			break
+		}
+	}
+	return i, nil
+}
+
+// readErr returns the last error
+func (lr *LineReader) readErr() error {
+	err := lr.err
+	lr.err = nil
+	return err
+}

--- a/pkg/csv2lp/line_reader.go
+++ b/pkg/csv2lp/line_reader.go
@@ -9,19 +9,19 @@ const (
 )
 
 // LineReader wraps an io.Reader to count lines that go though read
-// function and returns at most one line during every invovation of
-// read. It provides a wrokaround to golang's CSV reader that
+// function and returns at most one line during every invocation of
+// read. It provides a workaround to golang's CSV reader that
 // does not expose current line number at all
 // (see https://github.com/golang/go/issues/26679)
 //
 // At most one line is returned by every read in order to ensure that
 // golang's CSV reader buffers at most one single line into its nested
-// bufio.Reader, so that numbers reported are currect also for the
-// CSV reader.
+// bufio.Reader.
 type LineReader struct {
-	// LineNumber of the next read operation, 0 is the first line by default, can be set to 0 to count from 1
+	// LineNumber of the next read operation, 0 is the first line by default.
+	// It can be set to 1 start counting from 1.
 	LineNumber int
-	// LastLineNumber is the number of the last read row
+	// LastLineNumber is the number of the last read row.
 	LastLineNumber int
 
 	// rs is a wrapped reader
@@ -30,13 +30,13 @@ type LineReader struct {
 	buf []byte
 	// readPos is a read position in the buffer
 	readPos int
-	// bufSize is the length of cached data in the buffer
+	// bufSize is the length of data read from rd into buf
 	bufSize int
-	// err contain the last error during read
+	// err contains the last error during read
 	err error
 }
 
-// NewLineReader returns a new LineReader that wraps an io.Reader
+// NewLineReader returns a new LineReader.
 func NewLineReader(rd io.Reader) *LineReader {
 	return NewLineReaderSize(rd, defaultBufSize)
 }
@@ -80,8 +80,8 @@ func (lr *LineReader) Read(p []byte) (n int, err error) {
 	}
 	// copy at most one line and don't overflow internal buffer or p
 	i := 0
+	lr.LastLineNumber = lr.LineNumber
 	for lr.readPos < lr.bufSize && i < n {
-		lr.LastLineNumber = lr.LineNumber
 		b := lr.buf[lr.readPos]
 		lr.readPos++
 		p[i] = b
@@ -95,7 +95,7 @@ func (lr *LineReader) Read(p []byte) (n int, err error) {
 	return i, nil
 }
 
-// readErr returns the last error
+// readErr returns the last error and resets err status
 func (lr *LineReader) readErr() error {
 	err := lr.err
 	lr.err = nil

--- a/pkg/csv2lp/line_reader_test.go
+++ b/pkg/csv2lp/line_reader_test.go
@@ -2,7 +2,6 @@ package csv2lp_test
 
 import (
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -13,18 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testCloser struct {
-	errorMsg string
-}
-
-func (c testCloser) Close() error {
-	if c.errorMsg == "" {
-		return nil
-	}
-	return errors.New(c.errorMsg)
-}
-
-// TestLineReader tests correctness of line reporting and reader implementation
+// TestLineReader tests correctness of line reporting and reader implementation of LineReader
 func TestLineReader(t *testing.T) {
 	type TestInput = struct {
 		lines               [4]string
@@ -106,8 +94,8 @@ func TestLineReader(t *testing.T) {
 	}
 }
 
-// TestLineReader_viaCsv test correct line reporting when read through a CSV reader with various buffer sizes
-// to emulate multiple required reads on small data set
+// TestLineReader_viaCsv tests correct line reporting when read through a CSV reader with various buffer sizes
+// to emulate multiple required reads with a small test data set
 func TestLineReader_viaCsv(t *testing.T) {
 	type RowWithLine = struct {
 		row        []string

--- a/pkg/csv2lp/line_reader_test.go
+++ b/pkg/csv2lp/line_reader_test.go
@@ -1,0 +1,148 @@
+package csv2lp_test
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/influxdata/influxdb/v2/pkg/csv2lp"
+	"github.com/stretchr/testify/require"
+)
+
+type testCloser struct {
+	errorMsg string
+}
+
+func (c testCloser) Close() error {
+	if c.errorMsg == "" {
+		return nil
+	}
+	return errors.New(c.errorMsg)
+}
+
+// TestLineReader tests correctness of line reporting and reader implementation
+func TestLineReader(t *testing.T) {
+	type TestInput = struct {
+		lines               [4]string
+		withDataErrorReader bool
+	}
+	tests := []TestInput{
+		{
+			lines:               [4]string{"a\n", "\n", "\n", "bcxy"},
+			withDataErrorReader: false,
+		}, {
+			lines:               [4]string{"a\n", "\n", "\n", "bcxy"},
+			withDataErrorReader: true,
+		}, {
+			lines:               [4]string{"a\n", "\n", "\n", "bcx\n"},
+			withDataErrorReader: false,
+		}, {
+			lines:               [4]string{"a\n", "\n", "\n", "bcx\n"},
+			withDataErrorReader: true,
+		}}
+	for _, test := range tests {
+		lines := test.lines
+		input := strings.Join(lines[:], "")
+		withDataErrorReader := test.withDataErrorReader
+		t.Run(fmt.Sprintf("%s withDataErrorReader=%v", input, withDataErrorReader), func(t *testing.T) {
+			var reader io.Reader = strings.NewReader(input)
+			if withDataErrorReader {
+				// ensures that the reader reports the last EOF error also with data
+				reader = iotest.DataErrReader(reader)
+			}
+			lineReader := csv2lp.NewLineReaderSize(reader, 2)
+			var buf []byte = make([]byte, 4)
+			var err error
+			var read int
+
+			// patologic case: reading from empty buffer returns 0 without an error
+			read, err = lineReader.Read(buf[0:0])
+			require.Equal(t, 0, read)
+			require.Nil(t, err)
+			require.Equal(t, 0, lineReader.LastLineNumber)
+
+			// 1st line
+			read, err = lineReader.Read(buf)
+			require.Equal(t, []byte(lines[0]), buf[0:read])
+			require.Nil(t, err)
+			require.Equal(t, 0, lineReader.LastLineNumber)
+
+			// 2nd
+			read, err = lineReader.Read(buf)
+			require.Equal(t, []byte(lines[1]), buf[0:read])
+			require.Nil(t, err)
+			require.Equal(t, 1, lineReader.LastLineNumber)
+
+			// reading into empty does not change the game
+			read, err = lineReader.Read(buf[0:0])
+			require.Equal(t, 0, read)
+			require.Nil(t, err)
+			require.Equal(t, 1, lineReader.LastLineNumber)
+
+			// 3rd
+			read, err = lineReader.Read(buf)
+			require.Equal(t, []byte(lines[2]), buf[0:read])
+			require.Nil(t, err)
+			require.Equal(t, 2, lineReader.LastLineNumber)
+
+			// 4th line cannot be fully read, because buffer size is 2
+			read, err = lineReader.Read(buf)
+			require.Equal(t, []byte(lines[3][:2]), buf[0:read])
+			require.Nil(t, err)
+			require.Equal(t, 3, lineReader.LastLineNumber)
+			read, err = lineReader.Read(buf)
+			require.Equal(t, []byte(lines[3][2:]), buf[0:read])
+			require.Nil(t, err)
+			require.Equal(t, 3, lineReader.LastLineNumber)
+
+			// 5th line => error
+			_, err = lineReader.Read(buf)
+			require.NotNil(t, err)
+		})
+	}
+}
+
+// TestLineReader_viaCsv test correct line reporting when read through a CSV reader with various buffer sizes
+// to emulate multiple required reads on small data set
+func TestLineReader_viaCsv(t *testing.T) {
+	type RowWithLine = struct {
+		row        []string
+		lineNumber int
+	}
+
+	input := "a\n\nb\n\nc"
+	expected := []RowWithLine{
+		{[]string{"a"}, 1},
+		{[]string{"b"}, 3},
+		{[]string{"c"}, 5},
+	}
+
+	bufferSizes := []int{-1, 0, 2, 50}
+	for _, bufferSize := range bufferSizes {
+		t.Run(fmt.Sprintf("buffer size: %d", bufferSize), func(t *testing.T) {
+			var lineReader *csv2lp.LineReader
+			if bufferSize < 0 {
+				lineReader = csv2lp.NewLineReader(strings.NewReader(input))
+			} else {
+				lineReader = csv2lp.NewLineReaderSize(strings.NewReader(input), bufferSize)
+			}
+			lineReader.LineNumber = 1 // start with 1
+			csvReader := csv.NewReader(lineReader)
+
+			results := make([]RowWithLine, 0, 3)
+			for {
+				row, _ := csvReader.Read()
+				lineNumber := lineReader.LastLineNumber
+				if row == nil {
+					break
+				}
+				results = append(results, RowWithLine{row, lineNumber})
+			}
+			require.Equal(t, expected, results)
+		})
+	}
+}


### PR DESCRIPTION
Closes #19588 

This PR ensures that correct line numbers are reported when reportings error from CSV file. It introduces LineReader that provides a workaround to golang's CSV reader that does not expose current line number at all (https://github.com/golang/go/issues/26679), 

Moreover, the new LineReader ensures that at most one line is returned by every read in order to ensure that
golang's CSV reader buffers at most one single line into its nested bufio.Reader.

+ small improvements in tests

There were the following alternatives in the implementation, but the current with LineReader is IMHO the best
 - introduce a new CSV reader (extended golang's csv.Reader) that expose line numbers
 - use unsafe package to get an internal line number from golang's csv.Reader struct

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
