### PR TITLE
fix: chronograf/organizations: avoid nil context with WithValue

### DIFF
--- a/chronograf/organizations/dashboards_test.go
+++ b/chronograf/organizations/dashboards_test.go
@@ -25,7 +25,6 @@ func TestDashboards_All(t *testing.T) {
 	}
 	type args struct {
 		organization string
-		ctx          context.Context
 	}
 	tests := []struct {
 		name    string
@@ -65,7 +64,6 @@ func TestDashboards_All(t *testing.T) {
 			},
 			args: args{
 				organization: "1337",
-				ctx:          context.Background(),
 			},
 			want: []chronograf.Dashboard{
 				{
@@ -76,18 +74,20 @@ func TestDashboards_All(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		s := organizations.NewDashboardsStore(tt.fields.DashboardsStore, tt.args.organization)
-		tt.args.ctx = context.WithValue(tt.args.ctx, organizations.ContextKey, tt.args.organization)
-		gots, err := s.All(tt.args.ctx)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("%q. DashboardsStore.All() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-			continue
-		}
-		for i, got := range gots {
-			if diff := cmp.Diff(got, tt.want[i], dashboardCmpOptions...); diff != "" {
-				t.Errorf("%q. DashboardsStore.All():\n-got/+want\ndiff %s", tt.name, diff)
+		t.Run(tt.name, func(t *testing.T) {
+			s := organizations.NewDashboardsStore(tt.fields.DashboardsStore, tt.args.organization)
+			ctx := context.WithValue(context.Background(), organizations.ContextKey, tt.args.organization)
+			gots, err := s.All(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%q. DashboardsStore.All() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
 			}
-		}
+			for i, got := range gots {
+				if diff := cmp.Diff(got, tt.want[i], dashboardCmpOptions...); diff != "" {
+					t.Errorf("%q. DashboardsStore.All():\n-got/+want\ndiff %s", tt.name, diff)
+				}
+			}
+		})
 	}
 }
 

--- a/chronograf/organizations/organizations_test.go
+++ b/chronograf/organizations/organizations_test.go
@@ -25,7 +25,6 @@ func TestOrganizations_All(t *testing.T) {
 	}
 	type args struct {
 		organization string
-		ctx          context.Context
 	}
 	tests := []struct {
 		name    string
@@ -77,7 +76,6 @@ func TestOrganizations_All(t *testing.T) {
 			},
 			args: args{
 				organization: "1337",
-				ctx:          context.Background(),
 			},
 			want: []chronograf.Organization{
 				{
@@ -93,8 +91,8 @@ func TestOrganizations_All(t *testing.T) {
 	}
 	for _, tt := range tests {
 		s := organizations.NewOrganizationsStore(tt.fields.OrganizationsStore, tt.args.organization)
-		tt.args.ctx = context.WithValue(tt.args.ctx, organizations.ContextKey, tt.args.organization)
-		gots, err := s.All(tt.args.ctx)
+		ctx := context.WithValue(context.Background(), organizations.ContextKey, tt.args.organization)
+		gots, err := s.All(ctx)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. OrganizationsStore.All() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue

--- a/chronograf/organizations/servers_test.go
+++ b/chronograf/organizations/servers_test.go
@@ -26,7 +26,6 @@ func TestServers_All(t *testing.T) {
 	}
 	type args struct {
 		organization string
-		ctx          context.Context
 	}
 	tests := []struct {
 		name    string
@@ -66,7 +65,6 @@ func TestServers_All(t *testing.T) {
 			},
 			args: args{
 				organization: "1337",
-				ctx:          context.Background(),
 			},
 			want: []chronograf.Server{
 				{
@@ -78,8 +76,8 @@ func TestServers_All(t *testing.T) {
 	}
 	for _, tt := range tests {
 		s := organizations.NewServersStore(tt.fields.ServersStore, tt.args.organization)
-		tt.args.ctx = context.WithValue(tt.args.ctx, organizations.ContextKey, tt.args.organization)
-		gots, err := s.All(tt.args.ctx)
+		ctx := context.WithValue(context.Background(), organizations.ContextKey, tt.args.organization)
+		gots, err := s.All(ctx)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. ServersStore.All() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue

--- a/chronograf/organizations/sources_test.go
+++ b/chronograf/organizations/sources_test.go
@@ -26,7 +26,6 @@ func TestSources_All(t *testing.T) {
 	}
 	type args struct {
 		organization string
-		ctx          context.Context
 	}
 	tests := []struct {
 		name    string
@@ -66,7 +65,6 @@ func TestSources_All(t *testing.T) {
 			},
 			args: args{
 				organization: "1337",
-				ctx:          context.Background(),
 			},
 			want: []chronograf.Source{
 				{
@@ -78,8 +76,8 @@ func TestSources_All(t *testing.T) {
 	}
 	for _, tt := range tests {
 		s := organizations.NewSourcesStore(tt.fields.SourcesStore, tt.args.organization)
-		tt.args.ctx = context.WithValue(tt.args.ctx, organizations.ContextKey, tt.args.organization)
-		gots, err := s.All(tt.args.ctx)
+		ctx := context.WithValue(context.Background(), organizations.ContextKey, tt.args.organization)
+		gots, err := s.All(ctx)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. SourcesStore.All() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue


### PR DESCRIPTION
Under later Go versions, the tests panic because it's not OK to pass a nil Context to `context.WithValue`.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
