### PR TITLE
Use tsdb DeleteDatabase API to remove a bucket

### DIFF
--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -187,6 +187,11 @@ func testFlux(t testing.TB, l *launcher.TestLauncher, file *ast.File) {
 	if err := s.CreateBucket(context.Background(), b); err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := s.DeleteBucket(context.Background(), b.ID); err != nil {
+			t.Logf("Failed to delete bucket: %s", err)
+		}
+	}()
 
 	// Define bucket and org options
 	bucketOpt := &ast.OptionStatement{

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -284,7 +284,7 @@ func (e *Engine) UpdateBucketRetentionPeriod(ctx context.Context, bucketID influ
 func (e *Engine) DeleteBucket(ctx context.Context, orgID, bucketID influxdb.ID) error {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
-	return e.tsdbStore.DeleteRetentionPolicy(bucketID.String(), meta.DefaultRetentionPolicyName)
+	return e.tsdbStore.DeleteDatabase(bucketID.String())
 }
 
 // DeleteBucketRange deletes an entire range of data from the storage engine.


### PR DESCRIPTION
Closes #19600

The tsdb storage engine represents a bucket as a single database and retention policy. In order to correctly clean up a bucket when it is deleted, the `DeleteDatabase` API must be called. This guarantees everything, including the `_series` structure is closed and removed.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
