### PR TITLE
feat(build): Add s390x as a build target

### DIFF
--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ targets = {
 supported_builds = {
     'darwin': [ "amd64" ],
     'windows': [ "amd64" ],
-    'linux': [ "amd64", "i386", "armhf", "arm64", "armel", "static_i386", "static_amd64" ]
+    'linux': [ "amd64", "i386", "armhf", "arm64", "armel", "static_i386", "static_amd64", "s390x" ]
 }
 
 supported_packages = {


### PR DESCRIPTION
This change will allow `.rpm` and `.deb` distributions and binary tarball to be built for s390x.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
