### PR TITLE
fix(cli): user may be created without password

### DIFF
--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -209,8 +209,10 @@ func (b *cmdUserBuilder) cmdCreateRunEFn(*cobra.Command, []string) error {
 		return err
 	}
 
-	if err := dep.passSVC.SetPassword(ctx, user.ID, pass); err != nil {
-		return err
+	if pass != "" {
+		if err := dep.passSVC.SetPassword(ctx, user.ID, pass); err != nil {
+			return err
+		}
 	}
 
 	return b.printUser(userPrintOpts{user: user})

--- a/cmd/influx/user_test.go
+++ b/cmd/influx/user_test.go
@@ -98,6 +98,18 @@ func TestCmdUser(t *testing.T) {
 				},
 			},
 			{
+				name: "without password",
+				flags: []string{
+					"--name=new name",
+					"--org=org name",
+				},
+				expected: userResult{
+					user: influxdb.User{
+						Name: "new name",
+					},
+				},
+			},
+			{
 				name: "shorts",
 				flags: []string{
 					"-n=new name",


### PR DESCRIPTION
`influx` should allow to create users within organization without password. This is requested eg. for users migrated from 1.x. As of now, when `--password` is not specified, `influx` creates the user but returns error code as it tries to set password. This PR fixes that.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
