### PR TITLE
fix(e2e): update chromedriver version

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,7 +22,7 @@
     "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "chai-match": "^1.1.1",
-    "chromedriver": "^83.0.0",
+    "chromedriver": "^85.0.0",
     "copy-paste": "^1.3.0",
     "csv": "^5.3.1",
     "cucumber": "^5.1.0",


### PR DESCRIPTION
Nightly selenium tests were failing to run due to chromedriver only supporting chrome 83. somewhere a docker image was updated where that version got bumped. this update allows the tests to run.

The error in the nightly tests was:
```
✖ failed
  SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 83
      at Object.throwDecodedError (/home/circleci/project/e2e/node_modules/selenium-webdriver/lib/error.js:550:15)
      at parseHttpResponse (/home/circleci/project/e2e/node_modules/selenium-webdriver/lib/http.js:565:13)
      at Executor.execute (/home/circleci/project/e2e/node_modules/selenium-webdriver/lib/http.js:491:26)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```


(sorry for the assignment/review spam, must be nearing end of day :wink:)