### PR TITLE
fix(tsdb): exclude the stop time from the array cursor

### DIFF
--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -93,8 +93,6 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 		"holt_winters_panic": "Expected output is an empty table which breaks the testing framework (https://github.com/influxdata/influxdb/issues/14749)",
 		"map_nulls":          "to cannot write null values",
 
-		"range_stop": "pushed down range stop no longer exclusive https://github.com/influxdata/influxdb/issues/19564",
-
 		"to_time": "Flaky test https://github.com/influxdata/influxdb/issues/19577",
 	},
 	"experimental": {

--- a/tsdb/engine/tsm1/array_cursor.gen.go
+++ b/tsdb/engine/tsm1/array_cursor.gen.go
@@ -135,9 +135,9 @@ func (c *floatArrayAscendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -286,9 +286,9 @@ func (c *floatArrayDescendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -428,9 +428,9 @@ func (c *integerArrayAscendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -579,9 +579,9 @@ func (c *integerArrayDescendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -721,9 +721,9 @@ func (c *unsignedArrayAscendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -872,9 +872,9 @@ func (c *unsignedArrayDescendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -1014,9 +1014,9 @@ func (c *stringArrayAscendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -1165,9 +1165,9 @@ func (c *stringArrayDescendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -1307,9 +1307,9 @@ func (c *booleanArrayAscendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -1458,9 +1458,9 @@ func (c *booleanArrayDescendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
+++ b/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
@@ -134,9 +134,9 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -288,9 +288,9 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -39,9 +39,14 @@ import (
 	"go.uber.org/zap"
 )
 
+//go:generate -command tmpl go run github.com/benbjohnson/tmpl
 //go:generate tmpl -data=@iterator.gen.go.tmpldata iterator.gen.go.tmpl engine.gen.go.tmpl array_cursor.gen.go.tmpl array_cursor_iterator.gen.go.tmpl
-//go:generate go run ../../../_tools/tmpl/main.go -i -data=file_store.gen.go.tmpldata file_store.gen.go.tmpl=file_store.gen.go
-//go:generate go run ../../../_tools/tmpl/main.go -i -d isArray=y -data=file_store.gen.go.tmpldata file_store.gen.go.tmpl=file_store_array.gen.go
+// The file store generate uses a custom modified tmpl
+// to support adding templated data from the command line.
+// This can probably be worked into the upstream tmpl
+// but isn't at the moment.
+//go:generate go run ../../../tools/tmpl -i -data=file_store.gen.go.tmpldata file_store.gen.go.tmpl=file_store.gen.go
+//go:generate go run ../../../tools/tmpl -i -d isArray=y -data=file_store.gen.go.tmpldata file_store.gen.go.tmpl=file_store_array.gen.go
 //go:generate tmpl -data=@encoding.gen.go.tmpldata encoding.gen.go.tmpl
 //go:generate tmpl -data=@compact.gen.go.tmpldata compact.gen.go.tmpl
 //go:generate tmpl -data=@reader.gen.go.tmpldata reader.gen.go.tmpl

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1949,7 +1949,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 				Field:     "value",
 				Ascending: true,
 				StartTime: 2,
-				EndTime:   11,
+				EndTime:   12,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -2008,7 +2008,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 				Tags:      models.ParseTags([]byte("cpu,host=A")),
 				Field:     "value",
 				Ascending: false,
-				StartTime: 2,
+				StartTime: 1,
 				EndTime:   11,
 			})
 			if err != nil {


### PR DESCRIPTION
This is a backport of #14262 to the 1.x storage engine. The 1.x storage
engine is now the primary engine for open source so when we switched we
regressed to the old behavior.

This also fixes `go generate` for the tsm1 package by running `tmpl`
with `go run` instead of assuming the correct one is installed in the
path.

Fixes #19564.