### PR TITLE
fix: Disable unimplemented delete with predicate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 
 1. [19446](https://github.com/influxdata/influxdb/pull/19446): Port TSM1 storage engine
 1. [19494](https://github.com/influxdata/influxdb/pull/19494): Changing the default port from 9999 to 8086
+1. [19636](https://github.com/influxdata/influxdb/pull/19636): Disable unimplemented delete with predicate API
 
 ### Features
 

--- a/cmd/influxd/launcher/engine.go
+++ b/cmd/influxd/launcher/engine.go
@@ -120,7 +120,6 @@ func (t *TemporaryEngine) SeriesCardinality(orgID, bucketID influxdb.ID) int64 {
 // DeleteBucketRangePredicate will delete a bucket from the range and predicate.
 func (t *TemporaryEngine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID influxdb.ID, min, max int64, pred influxdb.Predicate) error {
 	return t.engine.DeleteBucketRangePredicate(ctx, orgID, bucketID, min, max, pred)
-
 }
 
 func (t *TemporaryEngine) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {

--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,7 @@ import (
 // Any time this set of constants changes, you must also update the swagger for Error.properties.code.enum.
 const (
 	EInternal            = "internal error"
+	ENotImplemented      = "not implemented"
 	ENotFound            = "not found"
 	EConflict            = "conflict"             // action cannot be performed
 	EInvalid             = "invalid"              // validation failed

--- a/http/delete_handler.go
+++ b/http/delete_handler.go
@@ -114,24 +114,16 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// send delete points request to storage
-	err = h.DeleteService.DeleteBucketRangePredicate(ctx,
-		dr.Org.ID,
-		dr.Bucket.ID,
-		dr.Start,
-		dr.Stop,
-		dr.Predicate,
-	)
-	if err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
+	h.HandleHTTPError(r.Context(), &influxdb.Error{
+		Code: influxdb.ENotImplemented,
+		Op:   "http/handleDelete",
+		Msg:  "Not implemented",
+	}, w)
+
 	h.log.Debug("Deleted",
 		zap.String("orgID", fmt.Sprint(dr.Org.ID.String())),
 		zap.String("buketID", fmt.Sprint(dr.Bucket.ID.String())),
 	)
-
-	w.WriteHeader(http.StatusNoContent)
 }
 
 func decodeDeleteRequest(ctx context.Context, r *http.Request, orgSvc influxdb.OrganizationService, bucketSvc influxdb.BucketService) (*deleteRequest, error) {

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -226,7 +226,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wants: wants{
-				statusCode: http.StatusNoContent,
+				statusCode: http.StatusNotImplemented,
 				body:       ``,
 			},
 		},
@@ -331,7 +331,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wants: wants{
-				statusCode: http.StatusNoContent,
+				statusCode: http.StatusNotImplemented,
 				body:       ``,
 			},
 		},

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -78,6 +78,7 @@ func ErrorCodeToStatusCode(ctx context.Context, code string) int {
 // influxDBErrorToStatusCode is a mapping of ErrorCode to http status code.
 var influxDBErrorToStatusCode = map[string]int{
 	influxdb.EInternal:            http.StatusInternalServerError,
+	influxdb.ENotImplemented:      http.StatusNotImplemented,
 	influxdb.EInvalid:             http.StatusBadRequest,
 	influxdb.EUnprocessableEntity: http.StatusUnprocessableEntity,
 	influxdb.EEmptyValue:          http.StatusBadRequest,

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -27,9 +27,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// ErrEngineClosed is returned when a caller attempts to use the engine while
-// it's closed.
-var ErrEngineClosed = errors.New("engine is closed")
+var (
+	// ErrEngineClosed is returned when a caller attempts to use the engine while
+	// it's closed.
+	ErrEngineClosed = errors.New("engine is closed")
+
+	// ErrNotImplemented is returned for APIs that are temporarily not implemented.
+	ErrNotImplemented = errors.New("not implemented")
+)
 
 type Engine struct {
 	config Config
@@ -292,44 +297,13 @@ func (e *Engine) DeleteBucket(ctx context.Context, orgID, bucketID influxdb.ID) 
 
 // DeleteBucketRange deletes an entire range of data from the storage engine.
 func (e *Engine) DeleteBucketRange(ctx context.Context, orgID, bucketID influxdb.ID, min, max int64) error {
-	span, _ := tracing.StartSpanFromContext(ctx)
-	defer span.Finish()
-
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	if e.closing == nil {
-		return ErrEngineClosed
-	}
-
-	// TODO(edd): create an influxql.Expr that represents the min and max time...
-	return e.tsdbStore.DeleteSeries(bucketID.String(), nil, nil)
+	return ErrNotImplemented
 }
 
 // DeleteBucketRangePredicate deletes data within a bucket from the storage engine. Any data
 // deleted must be in [min, max], and the key must match the predicate if provided.
 func (e *Engine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID influxdb.ID, min, max int64, pred influxdb.Predicate) error {
-	span, _ := tracing.StartSpanFromContext(ctx)
-	defer span.Finish()
-
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	if e.closing == nil {
-		return ErrEngineClosed
-	}
-
-	var predData []byte
-	var err error
-	if pred != nil {
-		// Marshal the predicate to add it to the WAL.
-		predData, err = pred.Marshal()
-		if err != nil {
-			return err
-		}
-	}
-	_ = predData
-
-	// TODO - edd convert the predicate into an influxql.Expr
-	return e.tsdbStore.DeleteSeries(bucketID.String(), nil, nil)
+	return ErrNotImplemented
 }
 
 // CreateBackup creates a "snapshot" of all TSM data in the Engine.


### PR DESCRIPTION
Closes #19580

This PR disables the `/api/v2/delete` API and returns a `501 Not implemented`, as there is no available implementation of the feature via the 1.x `tsdb` storage engine. Follow up issue #19635 was created to track the future implementation of this functionality.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
