### PR TITLE
chore: kit/io: improve LimitedReadCloser

### DIFF
--- a/kit/io/limited_read_closer_test.go
+++ b/kit/io/limited_read_closer_test.go
@@ -5,14 +5,15 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
+	"errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLimitedReadCloser_Exceeded(t *testing.T) {
-	b := closer{bytes.NewBufferString("howdy")}
-	rc := NewLimitedReadCloser(b, 2)
+	b := &closer{Reader: bytes.NewBufferString("howdy")}
+	rc := NewLimitedReadCloser(b, 3)
 
 	out, err := ioutil.ReadAll(rc)
 	require.NoError(t, err)
@@ -21,7 +22,7 @@ func TestLimitedReadCloser_Exceeded(t *testing.T) {
 }
 
 func TestLimitedReadCloser_Happy(t *testing.T) {
-	b := closer{bytes.NewBufferString("ho")}
+	b := &closer{Reader: bytes.NewBufferString("ho")}
 	rc := NewLimitedReadCloser(b, 2)
 
 	out, err := ioutil.ReadAll(rc)
@@ -30,8 +31,57 @@ func TestLimitedReadCloser_Happy(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-type closer struct {
-	io.Reader
+func TestLimitedReadCloseWithErrorAndLimitExceeded(t *testing.T) {
+	b := &closer{
+		Reader: bytes.NewBufferString("howdy"),
+		err: errors.New("some error"),
+	}
+	rc := NewLimitedReadCloser(b, 3)
+
+	out, err := ioutil.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("how"), out)
+	// LimitExceeded error trumps the close error.
+	assert.Equal(t, ErrReadLimitExceeded, rc.Close())
 }
 
-func (c closer) Close() error { return nil }
+func TestLimitedReadCloseWithError(t *testing.T) {
+	closeErr := errors.New("some error")
+	b := &closer{
+		Reader: bytes.NewBufferString("howdy"),
+		err: closeErr,
+	}
+	rc := NewLimitedReadCloser(b, 10)
+
+	out, err := ioutil.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("howdy"), out)
+	assert.Equal(t, closeErr, rc.Close())
+}
+
+func TestMultipleCloseOnlyClosesOnce(t *testing.T) {
+	closeErr := errors.New("some error")
+	b := &closer{
+		Reader: bytes.NewBufferString("howdy"),
+		err: closeErr,
+	}
+	rc := NewLimitedReadCloser(b, 10)
+
+	out, err := ioutil.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("howdy"), out)
+	assert.Equal(t, closeErr, rc.Close())
+	assert.Equal(t, closeErr, rc.Close())
+	assert.Equal(t, 1, b.closeCount)
+}
+
+type closer struct {
+	io.Reader
+	err error
+	closeCount int
+}
+
+func (c *closer) Close() error {
+	c.closeCount++
+	return c.err
+}


### PR DESCRIPTION
A fairly minor change, but this saves two allocations every time
points are written to the API (one allocation for the embedded io.LimitReader,
and one allocation to create the `close` closure).

Also fix the code so that it actually limits to the exact requested number of bytes
rather than one more. We don't really need to layer on top of io.LimitReader,
as that code is fairly minimal.

This change also means that the `LimitedReadCloser` can be used without a constructor
function, the same way that `io.LimitedReader` can.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
