### PR TITLE
feat(cmd/influx/write): allow to limit write rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19640](https://github.com/influxdata/influxdb/pull/19640): Turn on Community Templates
 1. [19663](https://github.com/influxdata/influxdb/pull/19663): Added InfluxDB v2 Listener, NSD, OPC-UA, and Windows Event Log to the sources page
 1. [19662](https://github.com/influxdata/influxdb/pull/19662): Add `max-line-length` switch to `influx write` command to address `token too long` errors for large inputs
+1. [19660](https://github.com/influxdata/influxdb/pull/19660): Add --rate-limit option to `influx write`.
 
 ### Bug Fixes
 

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -234,6 +234,16 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			lines:  strings.Split(fileContents, "\n"),
 			lpData: true,
 		},
+		{
+			name: "read data from CSV file + transform to line protocol + throttle read to 1MB/min",
+			flags: writeFlagsType{
+				Files:     []string{csvFile1},
+				RateLimit: 1.0,
+			},
+			lines: []string{
+				"f1 b=f2,c=f3,d=f4",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -244,7 +254,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			defer closer.Close()
 			require.Nil(t, err)
 			require.NotNil(t, reader)
-			if !test.lpData {
+			if !test.lpData && test.flags.RateLimit == 0.0 {
 				csvToLineReader, ok := reader.(*csv2lp.CsvToLineReader)
 				require.True(t, ok)
 				require.Equal(t, csvToLineReader.LineNumber, test.firstLineCorrection)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/editorconfig-checker/editorconfig-checker v0.0.0-20190819115812-1474bdeaf2a2
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/fatih/color v1.9.0
+	github.com/fujiwara/shapeio v0.0.0-20170602072123-c073257dd745
 	github.com/getkin/kin-openapi v0.2.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fujiwara/shapeio v0.0.0-20170602072123-c073257dd745 h1:+tPNWeI7Uk5JKgSj4IYytZc0mdch+e3Yf8g1sGOg4hQ=
+github.com/fujiwara/shapeio v0.0.0-20170602072123-c073257dd745/go.mod h1:/WpqsrSkjgwEG2Es2qnZXbXwHDVbawpdlXJIjJMmnZs=
 github.com/getkin/kin-openapi v0.2.0 h1:PbHHtYZpjKwZtGlIyELgA2DploRrsaXztoNNx9HjwNY=
 github.com/getkin/kin-openapi v0.2.0/go.mod h1:V1z9xl9oF5Wt7v32ne4FmiF1alpS4dM6mNzoywPOXlk=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
Closes #19335

This PR adds a new flag to `influx write` :

```sh 
--rate-limit string      Throttles write, examples: "5 MB / 5 min" , "17kBs". "" (default) disables throttling.
```
- the rate is specified as: `COUNT(B|kB|MB)/TIME(s|sec|m|min)` with `/` and `TIME` being optional; COUNT is a decimal number, TIME is a positive whole number; spaces in the value are ignored.
  - "5MB / 5min" matches the current free tier in the cloud, it can be also expressed as `17476.266666667Bs`, `1MB/1min`, `1MB/min`, `1MBmin` or `1MBm`
- when an invalid rate is supplied, the tool prints out the format and also an exact regular expression to recognize format
- `--rate-limit` can be also used in `influx write dryrun`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
