### PR TITLE
fix: bufio.Scanner: token too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19508](https://github.com/influxdata/influxdb/pull/19508): Add subset of InfluxQL coordinator options as flags
 1. [19457](https://github.com/influxdata/influxdb/pull/19457): Add ability to export resources by name via the CLI
 1. [19640](https://github.com/influxdata/influxdb/pull/19640): Turn on Community Templates
+1. [19662](https://github.com/influxdata/influxdb/pull/19662): Add `max-line-length` switch to `influx write` command to address `token too long` errors for large inputs
 
 ### Bug Fixes
 

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -37,6 +37,7 @@ type writeFlagsType struct {
 	Debug                      bool
 	SkipRowOnError             bool
 	SkipHeader                 int
+	MaxLineLength              int
 	IgnoreDataTypeInColumnName bool
 	Encoding                   string
 	ErrorsFile                 string
@@ -84,6 +85,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&writeFlags.Debug, "debug", false, "Log CSV columns to stderr before reading data rows")
 	cmd.PersistentFlags().BoolVar(&writeFlags.SkipRowOnError, "skipRowOnError", false, "Log CSV data errors to stderr and continue with CSV processing")
 	cmd.PersistentFlags().IntVar(&writeFlags.SkipHeader, "skipHeader", 0, "Skip the first <n> rows from input data")
+	cmd.PersistentFlags().IntVar(&writeFlags.MaxLineLength, "max-line-length", 16_000_000, "Specifies the maximum number of bytes that can be read for a single line")
 	cmd.Flag("skipHeader").NoOptDefVal = "1" // skipHeader flag value is optional, skip the first header when unspecified
 	cmd.PersistentFlags().BoolVar(&writeFlags.IgnoreDataTypeInColumnName, "xIgnoreDataTypeInColumnName", false, "Ignores dataType which could be specified after ':' in column name")
 	cmd.PersistentFlags().MarkHidden("xIgnoreDataTypeInColumnName") // should be used only upon explicit advice
@@ -319,6 +321,7 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 			Precision:          writeFlags.Precision,
 			InsecureSkipVerify: flags.skipVerify,
 		},
+		MaxLineLength: writeFlags.MaxLineLength,
 	}
 	if err := s.Write(ctx, orgID, bucketID, r); err != nil && err != context.Canceled {
 		return fmt.Errorf("failed to write data: %v", err)

--- a/pkg/csv2lp/line_reader.go
+++ b/pkg/csv2lp/line_reader.go
@@ -56,10 +56,9 @@ func NewLineReaderSize(rd io.Reader, size int) *LineReader {
 // Read reads data into p. It fills in data that either does
 // not contain \n or ends with \n.
 // It returns the number of bytes read into p.
-func (lr *LineReader) Read(p []byte) (n int, err error) {
-	n = len(p)
-	// handle patologic case of reading into empty array
-	if n == 0 {
+func (lr *LineReader) Read(p []byte) (int, error) {
+	// handle pathological case of reading into empty array
+	if len(p) == 0 {
 		if lr.readPos < lr.bufSize {
 			return 0, nil
 		}
@@ -71,17 +70,15 @@ func (lr *LineReader) Read(p []byte) (n int, err error) {
 			return 0, lr.readErr()
 		}
 		lr.readPos = 0
-		lr.bufSize = 0
-		n, lr.err = lr.rd.Read(lr.buf)
-		if n == 0 {
+		lr.bufSize, lr.err = lr.rd.Read(lr.buf)
+		if lr.bufSize == 0 {
 			return 0, lr.readErr()
 		}
-		lr.bufSize = n
 	}
 	// copy at most one line and don't overflow internal buffer or p
 	i := 0
 	lr.LastLineNumber = lr.LineNumber
-	for lr.readPos < lr.bufSize && i < n {
+	for lr.readPos < lr.bufSize && i < len(p) {
 		b := lr.buf[lr.readPos]
 		lr.readPos++
 		p[i] = b

--- a/pkg/csv2lp/line_reader_test.go
+++ b/pkg/csv2lp/line_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/iotest"
 
 	"github.com/influxdata/influxdb/v2/pkg/csv2lp"
+	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,6 +93,18 @@ func TestLineReader(t *testing.T) {
 			require.NotNil(t, err)
 		})
 	}
+}
+
+// TestLineReader_Read_BufferOverflow ensures calling Read into
+// a slice does not panic. Fixes https://github.com/influxdata/influxdb/issues/19586
+func TestLineReader_Read_BufferOverflow(t *testing.T) {
+	sr := strings.NewReader("foo\nbar")
+	rd := csv2lp.NewLineReader(sr)
+	buf := make([]byte, 2)
+
+	n, err := rd.Read(buf)
+	assert.Equal(t, n, 2)
+	assert.NoError(t, err)
 }
 
 // TestLineReader_viaCsv tests correct line reporting when read through a CSV reader with various buffer sizes

--- a/write/batcher.go
+++ b/write/batcher.go
@@ -66,13 +66,6 @@ func (b *Batcher) Write(ctx context.Context, org, bucket platform.ID, r io.Reade
 	return nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // read will close the line channel when there is no more data, or an error occurs.
 // it is possible for an io.Reader to block forever; Write's context can be
 // used to cancel, but, it's possible there will be dangling read go routines.
@@ -85,9 +78,7 @@ func (b *Batcher) read(ctx context.Context, r io.Reader, lines chan<- []byte, er
 	if b.MaxLineLength > 0 {
 		maxLineLength = b.MaxLineLength
 	}
-
-	// limit the initial size of the buffer to a maximum of bufio.MaxScanTokenSize bytes
-	scanner.Buffer(make([]byte, min(bufio.MaxScanTokenSize, maxLineLength)), maxLineLength)
+	scanner.Buffer(nil, maxLineLength)
 
 	for scanner.Scan() {
 		// exit early if the context is done


### PR DESCRIPTION
Closes #19586

This PR fixes two issues. 

* Fixes a panic that was introduced with a new `LineReader` type.
* Adds an option to override the maximum line length in `write.Batcher` to support line lengths greater than the default 64KiB for a new `bufio.Scanner`
* Adds a CLI argument, `max-line-length`, to configure the maximum line length. The default is 16MB, which should cover the majority of use cases.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
