### PR TITLE
build(ui): Update flux-lsp-browser dependency to latest release

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -134,7 +134,7 @@
   "dependencies": {
     "@influxdata/clockface": "2.3.4",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.11",
+    "@influxdata/flux-lsp-browser": "0.5.20",
     "@influxdata/giraffe": "0.29.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -752,10 +752,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.4.tgz#9c496601253e1d49cbeae29a7b9cfb54862785f6"
   integrity sha512-mmz3YElK8Ho+1onEafuas6sVhIT638JA4NbDTO3bVJgK1TG7AnU4rQP+c6fj7vZSfvrIwtOwGaMONJTaww5o6w==
 
-"@influxdata/flux-lsp-browser@^0.5.11":
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.11.tgz#65168541edf57bbbee86161524bd57dc87950ebe"
-  integrity sha512-lpU8v3HY5cUzG/XrDnyR509WdQouhZ4l/+rRoJHvC1neyhHIPEjZYN0gwMuPuAFnvzdOFyTbn6X5TAOhC53AWw==
+"@influxdata/flux-lsp-browser@0.5.20":
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.20.tgz#150d261bab869e130f6d00ee73ea4e859e8969e4"
+  integrity sha512-gUy19t/QndkJPmyv7Lb56zXxaW5v7R9TslTHt0hB0GJjo7lmYkRfkD7DELdFHrD2e/CLtcNQBnczIMIGkII8Bw==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Closes #19677 

Upgrade the `flux-lsp-browser` in `ui/package/json` to the latest release.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
