### PR TITLE
feat: allow disable compaction per shard

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -87,6 +87,9 @@ const (
 
 	// deleteFlushThreshold is the size in bytes of a batch of series keys to delete.
 	deleteFlushThreshold = 50 * 1024 * 1024
+
+	// DoNotCompactFile is the name of the file that disables compactions.
+	DoNotCompactFile = "do_not_compact"
 )
 
 // Statistics gathered by the engine.
@@ -2055,6 +2058,8 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
 
+	var nextDisabledMsg time.Time
+
 	for {
 		e.mu.RLock()
 		quit := e.done
@@ -2065,6 +2070,17 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			return
 
 		case <-t.C:
+			// See if compactions are disabled.
+			doNotCompactFile := filepath.Join(e.Path(), DoNotCompactFile)
+			_, err := os.Stat(doNotCompactFile)
+			if err == nil {
+				now := time.Now()
+				if now.After(nextDisabledMsg) {
+					e.logger.Info("TSM compaction disabled", logger.Shard(e.id), zap.String("reason", doNotCompactFile))
+					nextDisabledMsg = now.Add(time.Minute * 15)
+				}
+				continue
+			}
 
 			// Find our compaction plans
 			level1Groups := e.CompactionPlan.PlanLevel(1)
@@ -2229,7 +2245,7 @@ func (s *compactionStrategy) Apply() {
 // compactGroup executes the compaction strategy against a single CompactionGroup.
 func (s *compactionStrategy) compactGroup() {
 	group := s.group
-	log, logEnd := logger.NewOperation(s.logger, "TSM compaction", "tsm1_compact_group")
+	log, logEnd := logger.NewOperation(s.logger, "TSM compaction", "tsm1_compact_group", logger.Shard(s.engine.id))
 	defer logEnd()
 
 	log.Info("Beginning compaction", zap.Int("tsm1_files_n", len(group)))


### PR DESCRIPTION
This feature allows compaction to be disabled on a per-shard basis by
creating a file named `do_not_compact` in a shard's directory. When
disabled, a message is logged every 15 minutes with the reason for
compaction being disabled (existance of the file). This makes it easy to
know if compaction has been disabled for any shards by searching the log
for `compaction disabled` or running `find path/to/data -type f -name
do_not_compact`.

Example log message:
```
2020-10-06T13:12:02.200598Z     info    TSM compaction disabled {"log_id": "0PgWKQ1W000", "engine": "tsm1", "db_shard_id": 9, "reason": "/home/dgnorton/.influxdb/data/stress/autogen/9/do_not_compact"}
```