### PR TITLE
fix(cli): workaround for cloud api to return a single telegraf config if specified

### DIFF
--- a/cmd/influx/telegraf.go
+++ b/cmd/influx/telegraf.go
@@ -82,19 +82,23 @@ func (b *cmdTelegrafBuilder) listRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	var filter influxdb.UserResourceMappingFilter
 	if b.id != "" {
 		id, err := influxdb.IDFromString(b.id)
 		if err != nil {
 			return err
 		}
-		filter.ResourceID = *id
-		filter.ResourceType = influxdb.TelegrafsResourceType
+
+		cfg, err := svc.FindTelegrafConfigByID(context.Background(), *id)
+		if err != nil {
+			return err
+		}
+
+		return b.writeTelegrafConfig(cfg)
 	}
 
 	cfgs, _, err := svc.FindTelegrafConfigs(context.Background(), influxdb.TelegrafConfigFilter{
 		OrgID:                     &orgID,
-		UserResourceMappingFilter: filter,
+		UserResourceMappingFilter: influxdb.UserResourceMappingFilter{ResourceType: influxdb.TelegrafsResourceType},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #19626 

This pr works around an irregularity in the cloud api* by retrieving a telegraf config by id, rather than listing all telegraf configs with a filter for the id.

*issue is that the `resourceID` query parameter is not being respected

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

