### PR TITLE
fix: Ensure orgID and bucketID are passed to WritePoints API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### Bug Fixes
+
+1. [#19679](https://github.com/influxdata/influxdb/issues/19679): Scrapers not working in RC0
+
+
 ## v2.0.0-rc.0 [2020-09-29]
 
 ### Breaking Changes

--- a/gather/recorder.go
+++ b/gather/recorder.go
@@ -21,7 +21,7 @@ func (s PointWriter) Record(collected MetricsCollection) error {
 		return err
 	}
 
-	return s.Writer.WritePoints(context.TODO(), 0, 0, ps)
+	return s.Writer.WritePoints(context.Background(), collected.OrgID, collected.BucketID, ps)
 }
 
 // Recorder record the metrics of a time based.


### PR DESCRIPTION
Fixes #19679

This PR fixes an issue with scrapers not writing data, which occurred during the transition to TSM 1.x.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
