### PR TITLE
fix(templates): allow same duration unit identifiers that the tasks api allows

### DIFF
--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -21,6 +21,7 @@ import (
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/pkg/jsonnet"
+	"github.com/influxdata/influxdb/v2/task/options"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1837,7 +1838,12 @@ func (r Resource) boolShort(key string) bool {
 }
 
 func (r Resource) duration(key string) (time.Duration, bool) {
-	dur, err := time.ParseDuration(r.stringShort(key))
+	astDur, err := options.ParseSignedDuration(r.stringShort(key))
+	if err != nil {
+		return time.Duration(0), false
+	}
+
+	dur, err := ast.DurationFrom(astDur, time.Time{})
 	return dur, err == nil
 }
 

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3409,7 +3409,7 @@ spec:
 
 				task1 := tasks[1]
 				baseEqual(t, 0, influxdb.Inactive, task1)
-				assert.Equal(t, (10 * time.Minute).String(), task1.Every)
+				assert.Equal(t, (25 * time.Hour).String(), task1.Every)
 				assert.Equal(t, (15 * time.Second).String(), task1.Offset)
 			})
 		})

--- a/pkger/testdata/tasks.json
+++ b/pkger/testdata/tasks.json
@@ -15,7 +15,7 @@
     "spec": {
       "name": "task-0",
       "description": "desc_0",
-      "every": "10m",
+      "every": "1d1h",
       "offset": "15s",
       "query": "from(bucket: \"rucket_1\")\n  |> range(start: -5d, stop: -1h)\n  |> filter(fn: (r) => r._measurement == \"cpu\")\n  |> filter(fn: (r) => r._field == \"usage_idle\")\n  |> aggregateWindow(every: 1m, fn: mean)\n  |> yield(name: \"mean\")",
       "status": "inactive",

--- a/pkger/testdata/tasks.yml
+++ b/pkger/testdata/tasks.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   name: task-0
   description: desc_0
-  every: 10m
+  every: 1d1h
   offset: 15s
   query:  >
     from(bucket: "rucket_1")


### PR DESCRIPTION
Closes #18939 

This pr utilizes the same duration parsing method that the tasks api does, extending support for such identifiers as `d`, `w`, `mo`, and `y` (for day, week, month, and year; complete list [here](https://github.com/influxdata/flux/blob/12684f51bd0eee66900f0ca59101a136f03cd722/ast/ast.go#L1537-L1548)). 

- [x] Tests pass
