### PR TITLE
fix(kv): Reorganize bcrypt password hashing outside transactions

### DIFF
--- a/kv/passwords_test.go
+++ b/kv/passwords_test.go
@@ -158,9 +158,6 @@ func TestService_SetPassword(t *testing.T) {
 										}
 										return nil, kv.ErrKeyNotFound
 									},
-									PutFn: func(key, val []byte) error {
-										return nil
-									},
 								}, nil
 							},
 						}
@@ -192,9 +189,6 @@ func TestService_SetPassword(t *testing.T) {
 											return []byte(`{"id": "0000000000000001", "name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
-									},
-									PutFn: func(key, val []byte) error {
-										return nil
 									},
 								}, nil
 							},
@@ -230,9 +224,6 @@ func TestService_SetPassword(t *testing.T) {
 											return []byte(`{"id": "0000000000000001", "name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
-									},
-									PutFn: func(key, val []byte) error {
-										return nil
 									},
 								}, nil
 							},

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -124,7 +124,7 @@ func OnboardInitialUser(
 			},
 		},
 		{
-			name: "missing password should still work",
+			name: "missing password should fail",
 			fields: OnboardingFields{
 				IDGenerator: &loopIDGenerator{
 					s: []string{oneID, twoID, threeID, fourID},
@@ -134,50 +134,12 @@ func OnboardInitialUser(
 			},
 			args: args{
 				request: &platform.OnboardingRequest{
-					User:   "admin",
-					Org:    "org1",
-					Bucket: "bucket1",
+					User: "admin",
+					Org:  "org1",
 				},
 			},
 			wants: wants{
-				results: &platform.OnboardingResults{
-					User: &platform.User{
-						ID:     MustIDBase16(oneID),
-						Name:   "admin",
-						Status: platform.Active,
-					},
-					Org: &platform.Organization{
-						ID:   MustIDBase16(twoID),
-						Name: "org1",
-						CRUDLog: platform.CRUDLog{
-							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-						},
-					},
-					Bucket: &platform.Bucket{
-						ID:              MustIDBase16(threeID),
-						Name:            "bucket1",
-						OrgID:           MustIDBase16(twoID),
-						RetentionPeriod: 0,
-						CRUDLog: platform.CRUDLog{
-							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-						},
-					},
-					Auth: &platform.Authorization{
-						ID:          MustIDBase16(fourID),
-						Token:       oneToken,
-						Status:      platform.Active,
-						UserID:      MustIDBase16(oneID),
-						Description: "admin's Token",
-						OrgID:       MustIDBase16(twoID),
-						Permissions: platform.OperPermissions(),
-						CRUDLog: platform.CRUDLog{
-							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
-						},
-					},
-				},
+				errCode: platform.EEmptyValue,
 			},
 		},
 		{


### PR DESCRIPTION
Closes #19720

This ensures that transaction lifetimes are shorter to reduce lock contention.

Additionally, this PR removes the ability to set an empty password when running the initial on-boarding process. According to the original developer, this behavior was required to permit Cloud processes to complete. As this code is no longer shared, this security issue is corrected.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
