### PR TITLE
feat(cmd/influx/write): retry write upon error 

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -226,6 +226,11 @@ func (e *Error) MarshalJSON() (result []byte, err error) {
 	return json.Marshal(ee)
 }
 
+// Unwrap returns the wrapped error since golang 1.13
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
 // UnmarshalJSON recursively unmarshals the error stack.
 func (e *Error) UnmarshalJSON(b []byte) (err error) {
 	ee := new(errEncode)

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -142,8 +142,9 @@ func TestCheckError(t *testing.T) {
 			cmpopt := cmp.Transformer("error", func(e error) string {
 				if e, ok := e.(*influxdb.Error); ok {
 					out, _ := json.Marshal(e)
-					if e2, ok := e.Err.(http.RetriableError); ok {
-						return fmt.Sprintf("%s; Retry-After: %v", string(out), e2.RetryAfter())
+					var retryError *http.RetriableError
+					if stderrors.As(e, &retryError) {
+						return fmt.Sprintf("%s; Retry-After: %v", string(out), retryError.RetryAfter())
 					}
 					return string(out)
 				}

--- a/write/batcher.go
+++ b/write/batcher.go
@@ -27,7 +27,7 @@ var (
 // batcher is a write service that batches for another write service.
 var _ platform.WriteService = (*Batcher)(nil)
 
-// Batcher batches line protocol for sends to service.
+// Batcher batches line protocol for sends to platform.WriteService.
 type Batcher struct {
 	MaxFlushBytes    int                   // MaxFlushBytes is the maximum number of bytes to buffer before flushing
 	MaxFlushInterval time.Duration         // MaxFlushInterval is the maximum amount of time to wait before flushing

--- a/write/retry_strategy.go
+++ b/write/retry_strategy.go
@@ -1,0 +1,71 @@
+package write
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/http"
+)
+
+// RetryStrategy returns time to wait before retrying an operation. The return value is based
+// on the error supplied and the count of operation retry attempts that already failed. A zero return
+// value indicates that the operation shall not be retried. Note that the retry strategy is also
+// informed about a successful operation when called with nil error.
+type RetryStrategy func(err error, retryAttempt int) time.Duration
+
+var defaultDelays []time.Duration = []time.Duration{5 * time.Second, 25 * time.Second, 125 * time.Second}
+
+// DefaultRetryStrategy is an implementation of RetryStrategy that respects the server-imposed delay
+// sent in RetryAfter HTTP header. If no server-sent delay is available and the error indicates that another
+// attempt could be successful (500 or 503 HTTP errors), the delay depends on the retry attempt. 5,25 or
+// 125 seconds are used. It allows at most 3 retry attempts. A small jitter is added to
+// every returned possitive value.
+func DefaultRetryStrategy(err error, retryAttempt int) time.Duration {
+	if err == nil || retryAttempt >= len(defaultDelays) || err == context.Canceled {
+		// don't retry
+		return 0
+	}
+	retryAfter := http.RetryAfter(err)
+	if retryAfter == 0 {
+		// don't retry if the server requests so
+		return 0
+	}
+	if retryAfter > 0 {
+		return retryAfter + time.Duration(rand.Int63n(200))
+	}
+	// retry < 0, an explicit delay is not available
+	if pErr, ok := err.(*platform.Error); ok {
+		if pErr.Code == platform.EUnavailable || pErr.Code == platform.EInternal || pErr.Code == platform.ETooManyRequests {
+			return defaultDelays[retryAttempt] + time.Duration(rand.Int63n(200))
+		}
+	}
+	return 0
+}
+
+// Retry calls the supplied fn until it succeeds
+// and can be retried (retryStrategy returns positive value).
+func retry(ctx context.Context, retryStrategy RetryStrategy, fn func() error) (err error) {
+	retryAttempt := 0
+	for {
+		err = fn()
+		// respect the Retry-After value if found in the error
+		retryAfter := retryStrategy(err, retryAttempt)
+		if retryAfter == 0 {
+			// it cannot be retried anymore
+			break
+		}
+		retryAttempt++
+		fmt.Printf("WARN: Write to InfluxDB failed (attempts: %d), retrying after %v : %v\n",
+			retryAttempt, retryAfter, err)
+		// wait until it can be retried
+		select {
+		case <-time.After(retryAfter):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return err
+}

--- a/write/retry_strategy_test.go
+++ b/write/retry_strategy_test.go
@@ -1,0 +1,147 @@
+package write
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRetryStrategy(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		retryAttempt int
+		want         time.Duration // in seconds
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: 0,
+		},
+		{
+			name: "context cancelled",
+			err:  context.Canceled,
+			want: 0,
+		},
+		{
+			name: "unrecognized error",
+			err:  errors.New("whatever"),
+			want: 0,
+		},
+		{
+			name: "Internal Error (0)",
+			err: &platform.Error{
+				Code: platform.EInternal,
+			},
+			retryAttempt: 0,
+			want:         5,
+		},
+		{
+			name: "Too Many Requests (1)",
+			err: &platform.Error{
+				Code: platform.ETooManyRequests,
+			},
+			retryAttempt: 1,
+			want:         25,
+		},
+		{
+			name: "Service Not Available (2)",
+			err: &platform.Error{
+				Code: platform.EUnavailable,
+			},
+			retryAttempt: 2,
+			want:         125,
+		},
+		{
+			name: "Service Not Available (3)",
+			err: &platform.Error{
+				Code: platform.EUnavailable,
+			},
+			retryAttempt: 3,
+			want:         0,
+		},
+		{
+			name: "Respect Retry-After value",
+			err: &platform.Error{
+				Code: platform.ETooManyRequests,
+				Err:  http.NewRetriableError(nil, 12*time.Second),
+			},
+			retryAttempt: 1,
+			want:         12,
+		},
+		{
+			name: "Respect Zero Retry-After value",
+			err: &platform.Error{
+				Code: platform.EInternal,
+				Err:  http.NewRetriableError(nil, 0),
+			},
+			retryAttempt: 1,
+			want:         0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, DefaultRetryStrategy(tc.err, tc.retryAttempt)/time.Second)
+		})
+	}
+}
+
+func Test_retry(t *testing.T) {
+	fakeErr := errors.New("Some Error")
+	tests := []struct {
+		name      string
+		results   []error
+		callCount int
+		err       error
+	}{
+		{
+			name:      "no retry required",
+			results:   []error{nil},
+			callCount: 1,
+		},
+		{
+			name:      "one retry error",
+			results:   []error{fakeErr, nil},
+			callCount: 2,
+		},
+		{
+			name:      "context canceled",
+			results:   []error{fakeErr, context.Canceled, nil},
+			callCount: 2,
+			err:       context.Canceled,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			callCount := 0
+			start := time.Now()
+			err := retry(ctx, func(err error, attempt int) time.Duration {
+				if callCount == len(tc.results) {
+					return 0
+				}
+				if err == context.Canceled {
+					return time.Second // we shall not wait a second, because the context is canceled
+				}
+				return 1
+			}, func() error {
+				err := tc.results[callCount]
+				callCount++
+				if err == context.Canceled {
+					cancel()
+				}
+				return err
+			})
+			require.Less(t, int64(time.Since(start)), int64(time.Second))
+			require.Equal(t, tc.callCount, callCount)
+			require.Equal(t, tc.err, err)
+
+		})
+	}
+
+}


### PR DESCRIPTION
This PR adds a retry strategy to `influx write` as requested in #17006 and #18327. Write operation is retried:
- at most 3-times
- when  the server sends a positive `Retry-After` HTTP header, after a delay specified in the header value
- upon HTTP 500, 503, 429 response from the server (without Retry-After HTTP header) after a delay of 5, 25, and 125 seconds 


This PR helps in the communication with InfluxDB cloud. If `influx write` reaches the write limit of InfluxDB account (429 error), it retries the write after a number of seconds requested by the server. Also a generic 503 (node re-deployement) and 500 responses (failing instance that might be redeployed soon) will also be retried  ... these errors are retriable, other HTTP errors (<429) are not.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
