### PR TITLE
chore: remove arm6 from build and add private.key to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ vendor
 influxd.bolt
 *.db
 
+# GPG private keys
+private.key
+
 # Project distribution
 /dist
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
-    goarm:
-      - 6
 
     main: ./cmd/influx/
     flags:
@@ -31,9 +28,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
-    goarm:
-      - 6
 
     main: ./cmd/influxd/
     flags:


### PR DESCRIPTION
- Since a new private.key file is created during the release process, goreleaser is failing with below error
   ```
   git is currently in a dirty state, please check in your pipeline what can be changing the following files
   ```
   private.key files needs to be ignored and as such to be added to `.gitignore` file
- Recently `arm6` builds started to fail with 
  ```
   release failed after 161.43s error=failed to build for linux_arm_6: # github.com/influxdata/influxdb/v2/cmd/influx
   cmd/influx/setup.go:292:42: constant 3600000000000 overflows uint
   ``` 
   Not to block the RC release removing the arm6 builds. I will have an issue to fix the overflow problem filed.

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
