### PR TITLE
fix(cli): return error on failed resource addition

### DIFF
--- a/cmd/influx/template.go
+++ b/cmd/influx/template.go
@@ -895,9 +895,11 @@ func (b *cmdTemplateBuilder) stackUpdateRunEFn(cmd *cobra.Command, args []string
 		TemplateURLs: b.urls,
 	}
 
+	failedString := []string{}
 	for _, res := range b.updateStackOpts.addResources {
 		parts := strings.SplitN(res, "=", 2)
 		if len(parts) < 2 {
+			failedString = append(failedString, res)
 			continue
 		}
 
@@ -915,6 +917,10 @@ func (b *cmdTemplateBuilder) stackUpdateRunEFn(cmd *cobra.Command, args []string
 			ID:         *id,
 			Kind:       kind,
 		})
+	}
+
+	if len(failedString) > 0 {
+		return errors.New("invalid 'resourceType=resourceID' key value pair[s]: " + strings.Join(failedString, ";"))
 	}
 
 	stack, err := templateSVC.UpdateStack(context.Background(), update)


### PR DESCRIPTION
Closes #19148

This pr returns an error when `influx stacks update --addResource` fails due to bad input.

```
$ ./influx stacks update --stack-id abc123 --addResource badInput
Error: Invalid 'resourceType=resourceID' key value pair[s]: badInput.
See 'influx stacks update -h' for help
```

- [x] Rebased/mergeable
