### PR TITLE
fix(swagger): add token to OnboardingRequest

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10843,6 +10843,8 @@ components:
           type: string
         retentionPeriodHrs:
           type: integer
+        token:
+          type: string
       required:
         - username
         - org

--- a/tenant/http_server_onboarding_test.go
+++ b/tenant/http_server_onboarding_test.go
@@ -25,6 +25,7 @@ func initOnboardHttpService(f itesting.OnboardingFields, t *testing.T) (influxdb
 	storage := tenant.NewStore(s)
 
 	authsvc := kv.NewService(zaptest.NewLogger(t), s)
+	authsvc.TokenGenerator = f.TokenGenerator
 
 	ten := tenant.NewService(storage)
 

--- a/tenant/service_onboarding_test.go
+++ b/tenant/service_onboarding_test.go
@@ -35,7 +35,9 @@ func initOnboardingService(s kv.Store, f influxdbtesting.OnboardingFields, t *te
 	ten := tenant.NewService(storage)
 
 	// we will need an auth service as well
-	svc := tenant.NewOnboardService(ten, kv.NewService(zaptest.NewLogger(t), s))
+	kvsvc := kv.NewService(zaptest.NewLogger(t), s)
+	kvsvc.TokenGenerator = f.TokenGenerator
+	svc := tenant.NewOnboardService(ten, kvsvc)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Users wants do onboarding the InfluxDB by our clients (https://github.com/influxdata/influxdb-client-java/issues/165), but the token is missing in the `OnboardingRequest` definition in swagger:

```yml
OnboardingRequest:
  type: object
  properties:
    username:
      type: string
    password:
      type: string
    org:
      type: string
    bucket:
      type: string
    retentionPeriodHrs:
      type: integer
  required:
    - username
    - org
    - bucket
```

The corresponding structure in `go`:
https://github.com/influxdata/influxdb/blob/8c0ff75c6df0148e1699c67f3b873b78dd160aef/onboarding.go#L27

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
