### PR TITLE
fix(upgrade): proper default 2.x config filename

### DIFF
--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -83,7 +83,7 @@ func upgradeConfig(configFile string, targetOptions optionsV2, log *zap.Logger) 
 	cu.updateV2Config(cTransformed, targetOptions)
 
 	// save new config
-	configFileV2 := strings.TrimSuffix(configFile, filepath.Ext(configFile)) + ".toml"
+	configFileV2 := filepath.Join(filepath.Dir(configFile), "config.toml")
 	configFileV2, err = cu.save(cTransformed, configFileV2)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Current config upgrade saves upgraded configuration to `influxdb.toml`,  but 2.x looks for `config.json|toml|yaml` by default. This tiny PR fixes it. 
Also the related test has been slightly improved and simplified.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
