### PR TITLE
fix(launcher): Switch to AuthorizationService from authorization package

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -55,13 +55,6 @@
   default: false
   contact: Query Team
 
-- name: New Auth Package
-  description: Enables the refactored authorization api
-  key: newAuth
-  default: false
-  contact: Alirie Gray
-  lifetime: temporaryc
-
 - name: New Label Package
   description: Enables the refactored labels api
   key: newLabels

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -86,20 +86,6 @@ func GroupWindowAggregateTranspose() BoolFlag {
 	return groupWindowAggregateTranspose
 }
 
-var newAuth = MakeBoolFlag(
-	"New Auth Package",
-	"newAuth",
-	"Alirie Gray",
-	false,
-	Temporary,
-	false,
-)
-
-// NewAuthPackage - Enables the refactored authorization api
-func NewAuthPackage() BoolFlag {
-	return newAuth
-}
-
 var newLabels = MakeBoolFlag(
 	"New Label Package",
 	"newLabels",
@@ -275,7 +261,6 @@ var all = []Flag{
 	frontendExample,
 	pushDownWindowAggregateMean,
 	groupWindowAggregateTranspose,
-	newAuth,
 	newLabels,
 	memoryOptimizedFill,
 	memoryOptimizedSchemaMutation,
@@ -297,7 +282,6 @@ var byKey = map[string]Flag{
 	"frontendExample":               frontendExample,
 	"pushDownWindowAggregateMean":   pushDownWindowAggregateMean,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
-	"newAuth":                       newAuth,
 	"newLabels":                     newLabels,
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,


### PR DESCRIPTION
Closes #19762

This commit ensures OSS is using the new implementation of the AuthorizationService from the authorization package.

It also removes the associated feature flag.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
