### PR TITLE
chore(docs): update PostDBRP docs to reflect mutual exclusive requirement of org vs orgID

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -11704,12 +11704,7 @@ components:
       type: string
       enum: ["slack", "pagerduty", "http", "telegram"]
     DBRP:
-      required:
-        - orgID
-        - org
-        - bucketID
-        - database
-        - retention_policy
+      type: object
       properties:
         id:
           type: string
@@ -11735,6 +11730,17 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: "#/components/schemas/Links"
+      oneOf:
+        - required:
+          - orgID
+          - bucketID
+          - database
+          - retention_policy
+        - required:
+          - org
+          - bucketID
+          - database
+          - retention_policy
     DBRPs:
       properties:
         notificationEndpoints:


### PR DESCRIPTION
I am unsure if I am doing this correctly. But this updates the PostDBRP docs to reflect the mutually exclusive requirement of `org` vs `orgID` when creating a DBRP mapping. Since only one or the other is actually required to create the mapping. But the docs currently state both are required.

My knowledge of OpenAPI Spec is a little lacking. But this is what I assertain is correct based on good old SO:

https://stackoverflow.com/questions/21134029/how-to-define-mutually-exclusive-query-parameters-in-swagger-openapi/49199240#49199240

- [x] ~[CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)~
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
