### PR TITLE
fix: Type-convert fs.Bavail for portability

### DIFF
--- a/pkg/fs/fs_unix.go
+++ b/pkg/fs/fs_unix.go
@@ -71,14 +71,14 @@ func CreateFile(newpath string) (*os.File, error) {
 
 // DiskUsage returns disk usage of disk of path
 func DiskUsage(path string) (*DiskStatus, error) {
-	var disk DiskStatus
 	fs := unix.Statfs_t{}
-	err := unix.Statfs(path, &fs)
-	if err != nil {
+	if err := unix.Statfs(path, &fs); err != nil {
 		return nil, err
 	}
+
+	var disk DiskStatus
 	disk.All = fs.Blocks * uint64(fs.Bsize)
-	disk.Avail = fs.Bavail * uint64(fs.Bsize)
+	disk.Avail = uint64(fs.Bavail) * uint64(fs.Bsize)
 	disk.Free = fs.Bfree * uint64(fs.Bsize)
 	disk.Used = disk.All - disk.Free
 	return &disk, nil


### PR DESCRIPTION
Prior to this patch, DiskUsage() would calculate bytes available
by multiplying blocks available by block size in bytes:

  disk.Avail = fs.Bavail * uint64(fs.Bsize)

Under some versions of Unix, fs.Bavail is of type uint64 and on
others (like FreeBSD) it is of type int64.

This causes a compile time error:
```
  $ go build
  # github.com/influxdata/influxdb/v2/pkg/fs
  ./fs_unix.go:81:25: invalid operation: fs.Bavail * uint64(fs.Bsize) (mismatched types int64 and uint64)
```
This patch type-converts fs.Bavail to unit64 to ensure that all
types in the expression align.

This prevents compile time errors under FreeBSD and other platforms
where fs.Bavail isn't uint64.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
