### PR TITLE
feat: Change names of `influx auth create` flags and variables

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -51,11 +51,11 @@ var authCreateFlags struct {
 	writeUserPermission bool
 	readUserPermission  bool
 
-	writeBucketsPermission bool
-	readBucketsPermission  bool
+	writeAllBucketsPermission bool
+	readAllBucketsPermission  bool
 
-	writeBucketPermissions []string
-	readBucketPermissions  []string
+	writeBucketsPermissions []string
+	readBucketsPermissions  []string
 
 	writeTasksPermission bool
 	readTasksPermission  bool
@@ -99,11 +99,11 @@ func authCreateCmd(f *globalFlags) *cobra.Command {
 	cmd.Flags().BoolVarP(&authCreateFlags.writeUserPermission, "write-user", "", false, "Grants the permission to perform mutative actions against organization users")
 	cmd.Flags().BoolVarP(&authCreateFlags.readUserPermission, "read-user", "", false, "Grants the permission to perform read actions against organization users")
 
-	cmd.Flags().BoolVarP(&authCreateFlags.writeBucketsPermission, "write-buckets", "", false, "Grants the permission to perform mutative actions against organization buckets")
-	cmd.Flags().BoolVarP(&authCreateFlags.readBucketsPermission, "read-buckets", "", false, "Grants the permission to perform read actions against organization buckets")
+	cmd.Flags().BoolVarP(&authCreateFlags.writeAllBucketsPermission, "write-all-buckets", "", false, "Grants the permission to perform mutative actions against *all* organization buckets")
+	cmd.Flags().BoolVarP(&authCreateFlags.readAllBucketsPermission, "read-all-buckets", "", false, "Grants the permission to perform read actions against *all* organization buckets")
 
-	cmd.Flags().StringArrayVarP(&authCreateFlags.writeBucketPermissions, "write-bucket", "", []string{}, "The bucket id")
-	cmd.Flags().StringArrayVarP(&authCreateFlags.readBucketPermissions, "read-bucket", "", []string{}, "The bucket id")
+	cmd.Flags().StringArrayVarP(&authCreateFlags.writeBucketsPermissions, "write-buckets", "", []string{}, "Grants permission to write to specified bucket IDs")
+	cmd.Flags().StringArrayVarP(&authCreateFlags.readBucketsPermissions, "read-buckets", "", []string{}, "Grants permission to read specified bucket IDs")
 
 	cmd.Flags().BoolVarP(&authCreateFlags.writeTasksPermission, "write-tasks", "", false, "Grants the permission to create tasks")
 	cmd.Flags().BoolVarP(&authCreateFlags.readTasksPermission, "read-tasks", "", false, "Grants the permission to read tasks")
@@ -156,8 +156,8 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 		action platform.Action
 		perms  []string
 	}{
-		{action: platform.ReadAction, perms: authCreateFlags.readBucketPermissions},
-		{action: platform.WriteAction, perms: authCreateFlags.writeBucketPermissions},
+		{action: platform.ReadAction, perms: authCreateFlags.readBucketsPermissions},
+		{action: platform.WriteAction, perms: authCreateFlags.writeBucketsPermissions},
 	}
 
 	var permissions []platform.Permission
@@ -182,8 +182,8 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 		ResourceType        platform.ResourceType
 	}{
 		{
-			readPerm:     authCreateFlags.readBucketsPermission,
-			writePerm:    authCreateFlags.writeBucketsPermission,
+			readPerm:     authCreateFlags.readAllBucketsPermission,
+			writePerm:    authCreateFlags.writeAllBucketsPermission,
 			ResourceType: platform.BucketsResourceType,
 		},
 		{


### PR DESCRIPTION
This is to make clear the distinction between the `--(read|write)-bucket(s)` flags.

The idea for this PR came from working on https://github.com/influxdata/docs-v2/pull/1713. It's just a suggestion. Happy to close in favor of "ain't broke don't fix it" or "we'll take it from here". 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
