### PR TITLE
refactor: allow newIndexSeriesCursor() to accept an influxql.Expr

### DIFF
--- a/v1/services/storage/series_cursor.go
+++ b/v1/services/storage/series_cursor.go
@@ -38,6 +38,18 @@ type indexSeriesCursor struct {
 }
 
 func newIndexSeriesCursor(ctx context.Context, predicate *datatypes.Predicate, shards []*tsdb.Shard) (*indexSeriesCursor, error) {
+	var expr influxql.Expr
+	if root := predicate.GetRoot(); root != nil {
+		var err error
+		if expr, err = reads.NodeToExpr(root, measurementRemap); err != nil {
+			return nil, err
+		}
+	}
+
+	return newIndexSeriesCursorInfluxQL(ctx, expr, shards)
+}
+
+func newIndexSeriesCursorInfluxQL(ctx context.Context, predicate influxql.Expr, shards []*tsdb.Shard) (*indexSeriesCursor, error) {
 	queries, err := tsdb.CreateCursorIterators(ctx, shards)
 	if err != nil {
 		return nil, err
@@ -61,10 +73,8 @@ func newIndexSeriesCursor(ctx context.Context, predicate *datatypes.Predicate, s
 	}
 	p := &indexSeriesCursor{row: reads.SeriesRow{Query: queries}}
 
-	if root := predicate.GetRoot(); root != nil {
-		if p.cond, err = reads.NodeToExpr(root, measurementRemap); err != nil {
-			return nil, err
-		}
+	if predicate != nil {
+		p.cond = predicate
 
 		p.hasFieldExpr, p.hasValueExpr = HasFieldKeyOrValue(p.cond)
 		if !(p.hasFieldExpr || p.hasValueExpr) {

--- a/v1/services/storage/series_cursor.go
+++ b/v1/services/storage/series_cursor.go
@@ -46,10 +46,10 @@ func newIndexSeriesCursor(ctx context.Context, predicate *datatypes.Predicate, s
 		}
 	}
 
-	return newIndexSeriesCursorInfluxQL(ctx, expr, shards)
+	return newIndexSeriesCursorInfluxQLPred(ctx, expr, shards)
 }
 
-func newIndexSeriesCursorInfluxQL(ctx context.Context, predicate influxql.Expr, shards []*tsdb.Shard) (*indexSeriesCursor, error) {
+func newIndexSeriesCursorInfluxQLPred(ctx context.Context, predicate influxql.Expr, shards []*tsdb.Shard) (*indexSeriesCursor, error) {
 	queries, err := tsdb.CreateCursorIterators(ctx, shards)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In order to let TagKeys and TagValues get the right answer,
sometimes they will need to examine their predicate and
see if using the index is possible, or if a block scan is needed.
For those cases we want to examine the predicate before creating
the index series cursor. This change allows us to create an
index series cursor with an already-deserialized influxql.Expr.

This just a refactoring and should have no effect on behavior.