### PR TITLE
chore: Use updated HTTP client for authorization service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [19856](https://github.com/influxdata/influxdb/pull/19856): make tagKeys and tagValues work for edge cases involving _field
+1. [19853](https://github.com/influxdata/influxdb/pull/19853): Use updated HTTP client for authorization service
 
 ## v2.0.0-rc.3 [2020-10-29]
 

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -5,8 +5,8 @@ import (
 	"io"
 
 	platform "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/authorization"
 	"github.com/influxdata/influxdb/v2/cmd/influx/internal"
-	"github.com/influxdata/influxdb/v2/http"
 	"github.com/spf13/cobra"
 )
 
@@ -668,7 +668,7 @@ func newAuthorizationService() (platform.AuthorizationService, error) {
 		return nil, err
 	}
 
-	return &http.AuthorizationService{
+	return &authorization.AuthorizationClientService{
 		Client: httpClient,
 	}, nil
 }


### PR DESCRIPTION
This PR updates the `influx auth` subcommand to use the HTTP client from the `authorization` package rather than the old one.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
