### PR TITLE
fix(models): correctly parse float as 64-bits

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1034,7 +1034,7 @@ func scanNumber(buf []byte, i int) (int, error) {
 	} else {
 		// Parse the float to check bounds if it's scientific or the number of digits could be larger than the max range
 		if scientific || len(buf[start:i]) >= maxFloat64Digits || len(buf[start:i]) >= minFloat64Digits {
-			if _, err := parseFloatBytes(buf[start:i], 10); err != nil {
+			if _, err := parseFloatBytes(buf[start:i], 64); err != nil {
 				return i, fmt.Errorf("invalid float")
 			}
 		}


### PR DESCRIPTION
Go tip now enforces that strconv.ParseFloat receives a bitSize parameter
of 32 or 64. Previously, any value that was not 32, was treated as 64.

The previous value of 10 was likely a copy-paste error from integer
parsing.
