### PR TITLE
chore: add simple metrics related to installed templates

### DIFF
--- a/pkger/service.go
+++ b/pkger/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -933,6 +934,24 @@ type ImpactSummary struct {
 	StackID influxdb.ID
 	Diff    Diff
 	Summary Summary
+}
+
+var reCommunityTemplatesValidAddr = regexp.MustCompile(`(?:https://raw.githubusercontent.com/influxdata/community-templates/master/)(?P<name>\w+)(?:/.*)`)
+
+func (i *ImpactSummary) communityName() string {
+	if len(i.Sources) == 0 {
+		return "custom"
+	}
+
+	// pull name `name` from community url https://raw.githubusercontent.com/influxdata/community-templates/master/name/name_template.yml
+	for j := range i.Sources {
+		finds := reCommunityTemplatesValidAddr.FindStringSubmatch(i.Sources[j])
+		if len(finds) == 2 {
+			return finds[1]
+		}
+	}
+
+	return "custom"
 }
 
 // DryRun provides a dry run of the template application. The template will be marked verified


### PR DESCRIPTION
Closes #19688 

Although there are current metrics related to templates, this adds a simple count of community templates installed ("custom" if it's not an official template).

```
# current:
service_pkger_template_count{method="apply",org_id="ORGID",source="https://github.com/influxdata/community-templates/blob/master/linux_system/linux_system.yml",user_id="USERID"} 2

# new:
templates_installed_count{template="linux_system"} 2
```
