### PR TITLE
fix: misuse of reflect.SliceHeader

### DIFF
--- a/id.go
+++ b/id.go
@@ -3,7 +3,6 @@ package influxdb
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"reflect"
 	"strconv"
 	"unsafe"
 )
@@ -83,13 +82,7 @@ func (i *ID) Decode(b []byte) error {
 }
 
 func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
+	return *(*string)(unsafe.Pointer(&in))
 }
 
 // DecodeFromString parses s as a hex-encoded string.

--- a/models/inline_strconv_parse.go
+++ b/models/inline_strconv_parse.go
@@ -1,7 +1,6 @@
 package models // import "github.com/influxdata/influxdb/models"
 
 import (
-	"reflect"
 	"strconv"
 	"unsafe"
 )
@@ -30,15 +29,6 @@ func parseBoolBytes(b []byte) (bool, error) {
 }
 
 // unsafeBytesToString converts a []byte to a string without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
 func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
+	return *(*string)(unsafe.Pointer(&in))
 }


### PR DESCRIPTION
Currently, unsafeBytesToString function violates the 6th rule of unsafe
pointer usage. That is, reflect.SliceHeader/String header should never
be used as plain struct. This misuse can lead to silent memory
corruption, which can be difficult to track down when problem occurred.

Instead, use the more (right) idiom to convert slice of byte to string
without heap allocation.

```
goos: linux
goarch: amd64
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkInvalid-8   	1000000000	         0.497 ns/op	       0 B/op	       0 allocs/op
BenchmarkValid-8     	1000000000	         0.239 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	0.815s
```
Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
