### PR TITLE
fix: Add Logger to constructor function to ensure log field is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [19856](https://github.com/influxdata/influxdb/pull/19856): make tagKeys and tagValues work for edge cases involving _field
 1. [19853](https://github.com/influxdata/influxdb/pull/19853): Use updated HTTP client for authorization service
+1. [19886](https://github.com/influxdata/influxdb/pull/19886): Add Logger to constructor function to ensure log field is initialized
 
 ## v2.0.0-rc.3 [2020-10-29]
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -1122,7 +1122,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		labelSvc = label.NewLabelController(m.flagger, m.kvService, ls)
 	}
 
-	ts.BucketService = storage.NewBucketService(ts.BucketService, m.engine)
+	ts.BucketService = storage.NewBucketService(m.log, ts.BucketService, m.engine)
 	ts.BucketService = dbrp.NewBucketService(m.log, ts.BucketService, dbrpSvc)
 
 	var onboardOpts []tenant.OnboardServiceOptionFn

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -470,7 +470,7 @@ func newInfluxDBv2(ctx context.Context, opts *optionsV2, log *zap.Logger) (svc *
 		storage.WithMetaClient(svc.meta),
 	)
 
-	svc.ts.BucketService = storage.NewBucketService(svc.ts.BucketService, engine)
+	svc.ts.BucketService = storage.NewBucketService(log, svc.ts.BucketService, engine)
 	// on-boarding service (influx setup)
 	svc.onboardSvc = tenant.NewOnboardService(svc.ts, authSvc)
 

--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -28,9 +28,10 @@ type BucketService struct {
 
 // NewBucketService returns a new BucketService for the provided EngineSchema,
 // which typically will be an Engine.
-func NewBucketService(s influxdb.BucketService, engine EngineSchema) *BucketService {
+func NewBucketService(log *zap.Logger, s influxdb.BucketService, engine EngineSchema) *BucketService {
 	return &BucketService{
 		BucketService: s,
+		log:           log,
 		engine:        engine,
 	}
 }

--- a/storage/bucket_service_test.go
+++ b/storage/bucket_service_test.go
@@ -26,7 +26,9 @@ func TestBucketService(t *testing.T) {
 	engine := mocks.NewMockEngineSchema(ctrl)
 
 	inmemService := newInMemKVSVC(t)
-	service := storage.NewBucketService(inmemService, engine)
+
+	logger := zaptest.NewLogger(t)
+	service := storage.NewBucketService(logger, inmemService, engine)
 
 	if err := service.DeleteBucket(context.TODO(), *i); err == nil {
 		t.Fatal("expected error, got nil")
@@ -45,7 +47,7 @@ func TestBucketService(t *testing.T) {
 	engine.EXPECT().DeleteBucket(gomock.Any(), org.ID, bucket.ID)
 
 	// Test deleting a bucket calls into the deleter.
-	service = storage.NewBucketService(inmemService, engine)
+	service = storage.NewBucketService(logger, inmemService, engine)
 
 	if err := service.DeleteBucket(context.TODO(), bucket.ID); err != nil {
 		t.Fatal(err)

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -64,7 +64,7 @@ func TestAnalyticalStore(t *testing.T) {
 				svcStack = backend.NewAnalyticalRunStorage(logger, svc, ts.BucketService, svc, rr, ab.QueryService())
 			)
 
-			ts.BucketService = storage.NewBucketService(nil, ts.BucketService, ab.storageEngine)
+			ts.BucketService = storage.NewBucketService(logger, ts.BucketService, ab.storageEngine)
 
 			authCtx := icontext.SetAuthorizer(ctx, &influxdb.Authorization{
 				Permissions: influxdb.OperPermissions(),

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -64,7 +64,7 @@ func TestAnalyticalStore(t *testing.T) {
 				svcStack = backend.NewAnalyticalRunStorage(logger, svc, ts.BucketService, svc, rr, ab.QueryService())
 			)
 
-			ts.BucketService = storage.NewBucketService(ts.BucketService, ab.storageEngine)
+			ts.BucketService = storage.NewBucketService(nil, ts.BucketService, ab.storageEngine)
 
 			authCtx := icontext.SetAuthorizer(ctx, &influxdb.Authorization{
 				Permissions: influxdb.OperPermissions(),


### PR DESCRIPTION
Closes #19876 

Ensure the `log` field is initialized at construction of the `BucketService` to avoid panics.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
