### PR TITLE
fix: use fluxinit package to init flux library instead of builtin

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/fluxinit"
 	platform "github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
 	"github.com/influxdata/influxdb/v2/authorizer"
@@ -136,6 +137,8 @@ func NewInfluxdCommand(ctx context.Context, subCommands ...*cobra.Command) *cobr
 
 func cmdRunE(ctx context.Context, l *Launcher) func() error {
 	return func() error {
+		fluxinit.FluxInit()
+
 		// exit with SIGINT and SIGTERM
 		ctx = signals.WithStandardSignals(ctx)
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/fluxinit"
 	platform "github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
 	"github.com/influxdata/influxdb/v2/authorizer"
@@ -25,6 +24,7 @@ import (
 	"github.com/influxdata/influxdb/v2/chronograf/server"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/v2/dbrp"
+	"github.com/influxdata/influxdb/v2/fluxinit"
 	"github.com/influxdata/influxdb/v2/gather"
 	"github.com/influxdata/influxdb/v2/http"
 	iqlcontrol "github.com/influxdata/influxdb/v2/influxql/control"

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/upgrade"
-	_ "github.com/influxdata/influxdb/v2/query/builtin"
 	_ "github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	_ "github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
 	"github.com/spf13/cobra"

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/bolt"
 	"github.com/influxdata/influxdb/v2/dbrp"
+	"github.com/influxdata/influxdb/v2/fluxinit"
 	"github.com/influxdata/influxdb/v2/internal/fs"
 	"github.com/influxdata/influxdb/v2/kit/cli"
 	"github.com/influxdata/influxdb/v2/kit/metric"

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/bolt"
 	"github.com/influxdata/influxdb/v2/dbrp"
@@ -278,7 +279,15 @@ func (i *influxDBv2) close() error {
 	return nil
 }
 
+var fluxInitialized bool
+
 func runUpgradeE(*cobra.Command, []string) error {
+	// This command is executed multiple times by test code. Initialization can happen only once.
+	if !fluxInitialized {
+		fluxinit.FluxInit()
+		fluxInitialized = true
+	}
+
 	ctx := context.Background()
 	config := zap.NewProductionConfig()
 	config.OutputPaths = append(config.OutputPaths, options.logPath)

--- a/cmd/influxd/upgrade/v1_dump_meta.go
+++ b/cmd/influxd/upgrade/v1_dump_meta.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/influxdata/flux/fluxinit"
+	"github.com/influxdata/influxdb/v2/fluxinit"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/influxd/upgrade/v1_dump_meta.go
+++ b/cmd/influxd/upgrade/v1_dump_meta.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/influxdata/flux/fluxinit"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,7 @@ var v1DumpMetaCommand = &cobra.Command{
 	Use:   "v1-dump-meta",
 	Short: "Dump InfluxDB 1.x meta.db",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fluxinit.FluxInit()
 		svc, err := newInfluxDBv1(&v1DumpMetaOptions)
 		if err != nil {
 			return fmt.Errorf("error opening 1.x meta.db: %w", err)

--- a/cmd/influxd/upgrade/v2_dump_meta.go
+++ b/cmd/influxd/upgrade/v2_dump_meta.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/internal/fs"
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ var v2DumpMetaCommand = &cobra.Command{
 	Use:   "v2-dump-meta",
 	Short: "Dump InfluxDB 2.x influxd.bolt",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		fluxinit.FluxInit()
 		ctx := context.Background()
 		svc, err := newInfluxDBv2(ctx, &v2DumpMetaOptions, zap.NewNop())
 		if err != nil {

--- a/cmd/influxd/upgrade/v2_dump_meta.go
+++ b/cmd/influxd/upgrade/v2_dump_meta.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/fluxinit"
 	"github.com/influxdata/influxdb/v2/internal/fs"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"

--- a/fluxinit/init.go
+++ b/fluxinit/init.go
@@ -1,0 +1,20 @@
+package fluxinit
+
+import (
+	"github.com/influxdata/flux/runtime"
+
+	_ "github.com/influxdata/flux/stdlib"
+	_ "github.com/influxdata/influxdb/v2/query/stdlib" // Import the stdlib
+)
+
+// FluxInit() prepares the runtime for compilation and execution of flux. This
+// is a costly step and should only be performed if the intention is to compile
+// and execute flux code.
+//
+// Importing this package and calling FluxInit is equivalent to importing the
+// "builtin" package. It draws in the standard library functions, which
+// register themselves in init() functions, then performs the final steps
+// necessary to prepare for executing flux.
+func FluxInit() {
+	runtime.FinalizeBuiltIns()
+}


### PR DESCRIPTION
The builtin package performs costly initialization work in the go init()
function, which causes the work to be performed for all paths of the main
executables that need it, including help screens. This patch uses the fluxinit
package, which requires a call to do the costly work. It allows help screens
and other code paths to execute quickly.

Closes ##9714