### PR TITLE
fix: return empty iterator instead of null in tagValues

### DIFF
--- a/v1/services/storage/store.go
+++ b/v1/services/storage/store.go
@@ -602,7 +602,7 @@ func (s *Store) tagValuesSlow(ctx context.Context, mqAttrs *metaqueryAttributes,
 	if ic, err := newIndexSeriesCursorInfluxQLPred(ctx, mqAttrs.pred, s.TSDBStore.Shards(shardIDs)); err != nil {
 		return nil, err
 	} else if ic == nil {
-		return nil, nil
+		return cursors.EmptyStringIterator, nil
 	} else {
 		cur = ic
 	}


### PR DESCRIPTION
Fixes influxdata/flux#3300.

We were returning `nil` instead of an empty iterator, and callers expect a non-nil result set for any non-error return.

I added a regression test for this here: influxdata/flux#3303.

