### PR TITLE
fix(http): fix /ready response content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [19853](https://github.com/influxdata/influxdb/pull/19853): Use updated HTTP client for authorization service
 1. [19886](https://github.com/influxdata/influxdb/pull/19886): Add Logger to constructor function to ensure log field is initialized
 1. [19885](https://github.com/influxdata/influxdb/pull/19885): Remove extra multiplication of retention policies in onboarding
+1. [19908](https://github.com/influxdata/influxdb/pull/19908): Fix /ready response content type
 
 ## v2.0.0-rc.3 [2020-10-29]
 

--- a/http/ready.go
+++ b/http/ready.go
@@ -13,6 +13,7 @@ import (
 func ReadyHandler() http.Handler {
 	up := time.Now()
 	fn := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 
 		var status = struct {

--- a/http/ready_test.go
+++ b/http/ready_test.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadyHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	ReadyHandler().ServeHTTP(w, r)
+	res := w.Result()
+	contentType := res.Header.Get("Content-Type")
+	body, _ := ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 200 {
+		t.Errorf("TestReadyHandler. ReadyHandler() StatusCode = %v, want 200", res.StatusCode)
+	}
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Errorf("TestReadyHandler. ReadyHandler() Content-Type = %v, want application/json", contentType)
+	}
+	var content map[string]interface{}
+	if err := json.Unmarshal(body, &content); err != nil {
+		t.Errorf("TestReadyHandler. ReadyHandler() error unmarshaling json body %v", err)
+		return
+	}
+	if val := content["status"]; val != "ready" {
+		t.Errorf("TestReadyHandler. ReadyHandler() .status = %v, want 'ready'", val)
+	}
+	if val := content["started"]; val == nil {
+		t.Errorf("TestReadyHandler. ReadyHandler() .started is not returned")
+	}
+	if val := content["up"]; val == nil {
+		t.Errorf("TestReadyHandler. ReadyHandler() .up is not returned")
+	}
+}


### PR DESCRIPTION

The [swagger `/ready` 200 response content type](https://docs.influxdata.com/influxdb/v2.0/api/#operation/GetReady)  is `application/json` , whereas the implementation returns 'text/plain'. This PR fixes the implementation.

Originally reported in https://github.com/influxdata/influxdb-client-js/issues/277. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
