### PR TITLE
chore(swagger): add operationId to /delete

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1873,6 +1873,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /delete:
     post:
+      operationId: PostDelete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request


### PR DESCRIPTION
This PR adds `operationId` to swagger `POST /delete` operation. `operationId` is required for the [swagger API documentation](https://docs.influxdata.com/influxdb/v2.0/api/) to generate an anchor such as https://v2.docs.influxdata.com/v2.0/api/#operation/PostDelete`. Such links are used in the generated code and documentation of influxdb-client-js, see for example https://influxdata.github.io/influxdb-client-js/influxdb-client-apis.bucketsapi.html

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
