### PR TITLE
fix(upgrade): delete references to 'security script' in upgrade command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Bug Fixes
+
+1. [19924](https://github.com/influxdata/influxdb/pull/19924): Remove unused 'security-script' option from upgrade command
+
 ## v2.0.0-rc.4 [2020-11-05]
 
 ### Features

--- a/cmd/influxd/upgrade/security.go
+++ b/cmd/influxd/upgrade/security.go
@@ -25,7 +25,7 @@ func upgradeUsers(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, targetOpt
 	}
 
 	// get helper instance
-	helper := newSecurityScriptHelper(log)
+	helper := newSecurityUpgradeHelper(log)
 
 	// check if target buckets exists in 2.x
 	proceed := helper.checkDbBuckets(v1meta, dbBuckets)
@@ -104,20 +104,20 @@ func upgradeUsers(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, targetOpt
 	return nil
 }
 
-// securityScriptHelper is a helper used by `generate-security-script` command.
-type securityScriptHelper struct {
+// securityUpgradeHelper is a helper used by `upgrade` command.
+type securityUpgradeHelper struct {
 	log *zap.Logger
 }
 
-// newSecurityScriptHelper returns new security script helper instance for `generate-security-script` command.
-func newSecurityScriptHelper(log *zap.Logger) *securityScriptHelper {
-	helper := &securityScriptHelper{
+// newSecurityUpgradeHelper returns new security script helper instance for `upgrade` command.
+func newSecurityUpgradeHelper(log *zap.Logger) *securityUpgradeHelper {
+	helper := &securityUpgradeHelper{
 		log: log,
 	}
 
 	return helper
 }
-func (h *securityScriptHelper) checkDbBuckets(meta *meta.Client, databases map[string][]platform.ID) bool {
+func (h *securityUpgradeHelper) checkDbBuckets(meta *meta.Client, databases map[string][]platform.ID) bool {
 	ok := true
 	for _, row := range meta.Users() {
 		for database := range row.Privileges {
@@ -135,7 +135,7 @@ func (h *securityScriptHelper) checkDbBuckets(meta *meta.Client, databases map[s
 	return ok
 }
 
-func (h *securityScriptHelper) sortUserInfo(info []meta.UserInfo) []meta.UserInfo {
+func (h *securityUpgradeHelper) sortUserInfo(info []meta.UserInfo) []meta.UserInfo {
 	sort.Slice(info, func(i, j int) bool {
 		return info[i].Name < info[j].Name
 	})

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -76,7 +76,6 @@ type optionsV2 struct {
 	token              string
 	retention          string
 	influx2CommandPath string
-	securityScriptPath string
 }
 
 func (o *optionsV2) checkPaths() error {
@@ -122,7 +121,6 @@ func NewCommand() *cobra.Command {
     Upgrades a 1.x version of InfluxDB by performing the following actions:
       1. Reads the 1.x config file and creates a 2.x config file with matching options. Unsupported 1.x options are reported.
       2. Copies 1.x database files.
-      3. Generates a script that will create tokens with permissions equivalent to the 1.x users. This script needs to be revised and run manually after starting 2.x.
 
     If the config file is not available, 1.x db folder (--v1-dir options) is taken as an input.
     Target 2.x database dir is specified by the --engine-path option. If changed, the bolt path should be changed as well.
@@ -215,12 +213,6 @@ func NewCommand() *cobra.Command {
 			Flag:    "influx-command-path",
 			Default: influxExePathV2(),
 			Desc:    "path to influx command",
-		},
-		{
-			DestP:   &options.target.securityScriptPath,
-			Flag:    "security-script",
-			Default: filepath.Join(homeOrAnyDir(), "influxd-upgrade-security.sh"),
-			Desc:    "optional: generated security upgrade script path",
 		},
 		{
 			DestP:   &options.logPath,


### PR DESCRIPTION
Closes #19921 

"Security script" is unused / irrelevant since #19854 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
