### PR TITLE
fix: don't divide RPs provided over the CLI by a factor of an hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [19924](https://github.com/influxdata/influxdb/pull/19924): Remove unused 'security-script' option from upgrade command
+1. [19928](https://github.com/influxdata/influxdb/pull/19928): Fix parsing of retention policy CLI args in `influx setup` and `influxd upgrade`
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -240,7 +240,7 @@ func nonInteractive() (*influxdb.OnboardingRequest, error) {
 		return nil, err
 	}
 	if dur > 0 {
-		req.RetentionPeriod = dur / time.Hour
+		req.RetentionPeriod = dur
 	}
 	return req, nil
 }
@@ -283,7 +283,7 @@ func interactive() (req *influxdb.OnboardingRequest, err error) {
 	}
 
 	if dur > 0 {
-		req.RetentionPeriod = dur / time.Hour
+		req.RetentionPeriod = dur
 	} else {
 		for {
 			rpStr := internal2.GetInput(ui, "Please type your retention period in hours.\r\nOr press ENTER for infinite.", strconv.Itoa(influxdb.InfiniteRetention))

--- a/cmd/influxd/upgrade/setup.go
+++ b/cmd/influxd/upgrade/setup.go
@@ -97,7 +97,7 @@ func interactive() (req *influxdb.OnboardingRequest, err error) {
 	}
 
 	if dur > 0 {
-		req.RetentionPeriod = dur / time.Hour
+		req.RetentionPeriod = dur
 	} else {
 		for {
 			rpStr := internal.GetInput(ui, "Please type your retention period in hours.\r\nOr press ENTER for infinite.", strconv.Itoa(influxdb.InfiniteRetention))


### PR DESCRIPTION
Closes #19926 

Prior to #19885, `influxd` would multiply RPs from onboarding requests by a factor of an hour. This caused overflows in many cases, so I removed the multiplication. The tests didn't catch all the places where the CLI was anticipating that multiplication...

The 3 lines changed here mirror the fix I made to [non-interactive upgrade](https://github.com/influxdata/influxdb/pull/19885/files#diff-ec11f92a3df5beb5cc1657892bfc169a49bed091ce94ebd1fae3d989a8c6eceeL57-R57) as part of the original PR.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
