### PR TITLE
fix(tsi): close series id iterator after merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ RPM packages, which has been left unchanged.
 1. [20702](https://github.com/influxdata/influxdb/pull/20702): Fix loading config when `INFLUXD_CONFIG_PATH` points to a directory with `.` in its name.
 1. [20678](https://github.com/influxdata/influxdb/pull/20678): Fix infinite loop in Flux parser caused by invalid array expressions.
 1. [20360](https://github.com/influxdata/influxdb/pull/20360): Update API spec to document Flux dictionary features.
+1. [19936](https://github.com/influxdata/influxdb/pull/19936): Close series id iterator after merging
 
 ## v2.0.3 [2020-12-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ### Features
 
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
-1. [20621](https://github.com/influxdata/influxdb/pull/20621): Add Swift client library to the data loading section of the UI
+1. [20621](https://github.com/influxdata/influxdb/pull/20621): Add Swift client library to the data loading section of the UI.
 
 ### Bug Fixes
 
 1. [20705](https://github.com/influxdata/influxdb/pull/20705): Repair swagger to match implementation of DBRPs type.
+1. [19936](https://github.com/influxdata/influxdb/pull/19936): Fix use-after-free bug in series ID iterator. Thanks @foobar!
 
 ## v2.0.4 [2021-02-08]
 
@@ -86,7 +87,6 @@ RPM packages, which has been left unchanged.
 1. [20702](https://github.com/influxdata/influxdb/pull/20702): Fix loading config when `INFLUXD_CONFIG_PATH` points to a directory with `.` in its name.
 1. [20678](https://github.com/influxdata/influxdb/pull/20678): Fix infinite loop in Flux parser caused by invalid array expressions.
 1. [20360](https://github.com/influxdata/influxdb/pull/20360): Update API spec to document Flux dictionary features.
-1. [19936](https://github.com/influxdata/influxdb/pull/19936): Close series id iterator after merging
 
 ## v2.0.3 [2020-12-14]
 

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -557,9 +557,11 @@ func IntersectSeriesIDIterators(itr0, itr1 SeriesIDIterator) SeriesIDIterator {
 
 	// Create series id set, if available.
 	if a := NewSeriesIDSetIterators([]SeriesIDIterator{itr0, itr1}); a != nil {
+		ss := a[0].SeriesIDSet().And(a[1].SeriesIDSet())
+		// `a` holds references to itr0/itr1 so itr0/itr1 should not be closed when `a` is still in use
 		itr0.Close()
 		itr1.Close()
-		return NewSeriesIDSetIterator(a[0].SeriesIDSet().And(a[1].SeriesIDSet()))
+		return NewSeriesIDSetIterator(ss)
 	}
 
 	return &seriesIDIntersectIterator{itrs: [2]SeriesIDIterator{itr0, itr1}}
@@ -646,10 +648,11 @@ func UnionSeriesIDIterators(itr0, itr1 SeriesIDIterator) SeriesIDIterator {
 
 	// Create series id set, if available.
 	if a := NewSeriesIDSetIterators([]SeriesIDIterator{itr0, itr1}); a != nil {
-		itr0.Close()
-		itr1.Close()
 		ss := NewSeriesIDSet()
 		ss.Merge(a[0].SeriesIDSet(), a[1].SeriesIDSet())
+		// `a` holds references to itr0/itr1 so itr0/itr1 should not be closed when `a` is still in use
+		itr0.Close()
+		itr1.Close()
 		return NewSeriesIDSetIterator(ss)
 	}
 
@@ -733,9 +736,11 @@ func DifferenceSeriesIDIterators(itr0, itr1 SeriesIDIterator) SeriesIDIterator {
 
 	// Create series id set, if available.
 	if a := NewSeriesIDSetIterators([]SeriesIDIterator{itr0, itr1}); a != nil {
+		ss := a[0].SeriesIDSet().AndNot(a[1].SeriesIDSet())
+		// `a` holds references to itr0/itr1 so itr0/itr1 should not be closed when `a` is still in use
 		itr0.Close()
 		itr1.Close()
-		return NewSeriesIDSetIterator(a[0].SeriesIDSet().AndNot(a[1].SeriesIDSet()))
+		return NewSeriesIDSetIterator(ss)
 	}
 
 	return &seriesIDDifferenceIterator{itrs: [2]SeriesIDIterator{itr0, itr1}}


### PR DESCRIPTION
This use-after-free bug may lead to segfault. The iterators that have
reference to the underlying index files were closed too early while
the bitmaps were still used afterwards. If a compaction occurs
concurrently and removes the index files, it would result in accessing
unmap'd memory address. 