### PR TITLE
fix: make influxd help more specific

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -121,7 +121,7 @@ func NewInfluxdCommand(ctx context.Context, subCommands ...*cobra.Command) *cobr
 
 	A config file can be provided via the INFLUXD_CONFIG_PATH env var. If a file is
 	not provided via an env var, influxd will look in the current directory for a
-	config.yaml file. If one does not exist, then it will continue unchanged.`
+	config.{json|toml|yaml|yml} file. If one does not exist, then it will continue unchanged.`
 	}
 
 	cmd := cli.NewCommand(&prog)


### PR DESCRIPTION
Closes #19929 

The help text for `influxd` says that `config.yaml` will be used as a default, if found. As far as I can tell from reading [this](https://github.com/influxdata/influxdb/blob/master/kit/cli/viper.go#L78-L81), the CLI will actually find any of `config.{json|toml|yaml|yml}`.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
