### PR TITLE
fix: enable write-only users to pass auth checks in the V1 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [19928](https://github.com/influxdata/influxdb/pull/19928): Fix parsing of retention policy CLI args in `influx setup` and `influxd upgrade`
 1. [19952](https://github.com/influxdata/influxdb/pull/19952): Use `db`/`rp` naming convention when migrating DBs to buckets
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
+1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -6,7 +6,7 @@ import (
 	"github.com/influxdata/influxdb/v2"
 )
 
-// AuthorizeFindDBRPs takes the given items and returns only the ones that the user is authorized to read.
+// AuthorizeFindDBRPs takes the given items and returns only the ones that the user is authorized to access.
 func AuthorizeFindDBRPs(ctx context.Context, rs []*influxdb.DBRPMappingV2) ([]*influxdb.DBRPMappingV2, int, error) {
 	// This filters without allocating
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating

--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -12,7 +12,12 @@ func AuthorizeFindDBRPs(ctx context.Context, rs []*influxdb.DBRPMappingV2) ([]*i
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 	rrs := rs[:0]
 	for _, r := range rs {
+		// N.B. we have to check both read and write permissions here to support the legacy write-path,
+		// which calls AuthorizeFindDBRPs when locating the bucket underlying a DBRP target.
 		_, _, err := AuthorizeRead(ctx, influxdb.BucketsResourceType, r.BucketID, r.OrganizationID)
+		if err != nil {
+			_, _, err = AuthorizeWrite(ctx, influxdb.BucketsResourceType, r.BucketID, r.OrganizationID)
+		}
 		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
 			return nil, 0, err
 		}

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -954,7 +954,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		}
 	}
 
-	// N.B. the BucketService used by the DBRP service doesn't perform authentication.
+	// N.B. the BucketService used by the DBRP service doesn't perform authorization.
 	dbrpSvc := dbrp.NewAuthorizedService(dbrp.NewService(ctx, ts.BucketService, m.kvStore))
 
 	cm := iqlcontrol.NewControllerMetrics([]string{})

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -954,8 +954,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		}
 	}
 
-	dbrpSvc := dbrp.NewService(ctx, authorizer.NewBucketService(ts.BucketService), m.kvStore)
-	dbrpSvc = dbrp.NewAuthorizedService(dbrpSvc)
+	// N.B. the BucketService used by the DBRP service doesn't perform authentication.
+	dbrpSvc := dbrp.NewAuthorizedService(dbrp.NewService(ctx, ts.BucketService, m.kvStore))
 
 	cm := iqlcontrol.NewControllerMetrics([]string{})
 	m.reg.MustRegister(cm.PrometheusCollectors()...)


### PR DESCRIPTION
Closes #19944 

Our V1 auth layer allows for write-only users, but our V1 write-path requires looking up buckets via DBRP mappings. That lookup currently performs multiple checks for bucket-read permission, causing failures.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
