### PR TITLE
fix(upgrade): use db/rp naming convention when upgrading DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [19924](https://github.com/influxdata/influxdb/pull/19924): Remove unused 'security-script' option from upgrade command
 1. [19928](https://github.com/influxdata/influxdb/pull/19928): Fix parsing of retention policy CLI args in `influx setup` and `influxd upgrade`
+1. [19952](https://github.com/influxdata/influxdb/pull/19952): Use `db`/`rp` naming convention when migrating DBs to buckets
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influxd/upgrade/database.go
+++ b/cmd/influxd/upgrade/database.go
@@ -80,7 +80,7 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 			bucket := &influxdb.Bucket{
 				OrgID:               orgID,
 				Type:                influxdb.BucketTypeUser,
-				Name:                db.Name + "-" + rp.Name,
+				Name:                db.Name + "/" + rp.Name,
 				Description:         fmt.Sprintf("Upgraded from v1 database %s with retention policy %s", db.Name, rp.Name),
 				RetentionPolicyName: rp.Name,
 				RetentionPeriod:     rp.Duration,

--- a/cmd/influxd/upgrade/database_test.go
+++ b/cmd/influxd/upgrade/database_test.go
@@ -114,7 +114,7 @@ func TestUpgradeRealDB(t *testing.T) {
 	buckets, _, err := v2.ts.FindBuckets(ctx, influxdb.BucketFilter{})
 	require.Nil(t, err)
 
-	bucketNames := []string{"my-bucket", "_tasks", "_monitoring", "mydb-autogen", "mydb-1week", "test-autogen", "empty-autogen"}
+	bucketNames := []string{"my-bucket", "_tasks", "_monitoring", "mydb/autogen", "mydb/1week", "test/autogen", "empty/autogen"}
 	myDbAutogenBucketId := ""
 	myDb1weekBucketId := ""
 	testBucketId := ""


### PR DESCRIPTION
Closes #19951 

Use / instead of - to separate DB and RP when upgrading to 2.x buckets. The comments & error messages were already using /.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
