### PR TITLE
fix: Remove bucket and mapping auto-creation from /write API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [19952](https://github.com/influxdata/influxdb/pull/19952): Use `db`/`rp` naming convention when migrating DBs to buckets
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
 1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
+1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/http/legacy/write_handler.go
+++ b/http/legacy/write_handler.go
@@ -151,11 +151,11 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 // retention policy combination.
 func (h *WriteHandler) findBucket(ctx context.Context, orgID influxdb.ID, db, rp string) (*influxdb.Bucket, error) {
 	mapping, err := h.findMapping(ctx, orgID, db, rp)
-	if err == nil {
-		return h.BucketService.FindBucketByID(ctx, mapping.BucketID)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return h.BucketService.FindBucketByID(ctx, mapping.BucketID)
 }
 
 // findMapping finds a DBRPMappingV2 for the database and retention policy

--- a/http/legacy/write_handler_test.go
+++ b/http/legacy/write_handler_test.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorizer"
 	pcontext "github.com/influxdata/influxdb/v2/context"
@@ -230,22 +228,6 @@ func (m pointsMatcher) Matches(x interface{}) bool {
 
 func (m pointsMatcher) String() string {
 	return fmt.Sprintf("%#v", m.points)
-}
-
-type bucketMatcher struct {
-	*influxdb.Bucket
-}
-
-func (m bucketMatcher) Matches(x interface{}) bool {
-	other, ok := x.(*influxdb.Bucket)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(m.Bucket, other, cmpopts.IgnoreFields(influxdb.Bucket{}, "CRUDLog"))
-}
-
-func (m bucketMatcher) String() string {
-	return fmt.Sprintf("%#v", m.Bucket)
 }
 
 func newPermissions(resourceType influxdb.ResourceType, orgID, id *influxdb.ID) []influxdb.Permission {


### PR DESCRIPTION
Closes #19954

This PR remove the automatic creation of buckets and DB/RP mappings when processing V1 `/write` requests.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
