### PR TITLE
fix(upgrade): add log-level option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
 1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
 1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
-1. [19967](https://github.com/influxdata/influxdb/pull/19967): Add 'security-script' option to upgrade command
+1. [19967](https://github.com/influxdata/influxdb/pull/19967): Add 'log-level' option to upgrade command
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
 1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
 1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
+1. [19967](https://github.com/influxdata/influxdb/pull/19967): Add 'security-script' option to upgrade command
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -237,7 +237,6 @@ func NewCommand() *cobra.Command {
 			Desc:    "optional: Custom InfluxDB 1.x config file path, else the default config file",
 		},
 		{
-		{
 			DestP:   &options.logLevel,
 			Flag:    "log-level",
 			Default: zapcore.InfoLevel.String(),


### PR DESCRIPTION
Closes #19923

Adds `--log-level` option to `upgrade` command with the same default level as `run` ie. _info_.

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
