### PR TITLE
fix(upgrade): check for existing 2.x CLI configs file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
 1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
 1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
+1. [19969](https://github.com/influxdata/influxdb/pull/19969): Check if CLI configs file already exists during upgrade
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influxd/upgrade/setup.go
+++ b/cmd/influxd/upgrade/setup.go
@@ -139,6 +139,12 @@ func saveLocalConfig(sourceOptions *optionsV1, targetOptions *optionsV2, log *za
 	if dPath == "" || dir == "" {
 		return errors.New("a valid configurations path must be provided")
 	}
+	_, err := os.Stat(dPath)
+	if !os.IsNotExist(err) {
+		log.Error("cannot save CLI config, file already exists", zap.String("path", dPath))
+		return errors.New("CLI configs file already exists")
+	}
+
 	localConfigSVC := config.NewLocalConfigSVC(dPath, dir)
 	p := config.DefaultConfig
 	p.Token = targetOptions.token

--- a/cmd/influxd/upgrade/setup_test.go
+++ b/cmd/influxd/upgrade/setup_test.go
@@ -1,7 +1,9 @@
 package upgrade
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -79,5 +81,44 @@ func TestLocalConfig(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
+	}
+}
+
+func TestLocalConfigErr(t *testing.T) {
+
+	type testCase struct {
+		name       string
+		sourceOpts *optionsV1
+		targetOpts *optionsV2
+		errMsg     string
+	}
+
+	tc := testCase{
+		name:       "default",
+		sourceOpts: &optionsV1{},
+		targetOpts: &optionsV2{
+			orgName: "my-org",
+			token:   "my-token",
+		},
+		errMsg: "file already exists",
+	}
+
+	dir := t.TempDir()
+	log := zaptest.NewLogger(t)
+	// adjust paths to runtime values
+	opts := tc.targetOpts
+	opts.boltPath = filepath.Join(dir, bolt.DefaultFilename)
+	opts.configsPath = filepath.Join(dir, "configs")
+	opts.enginePath = filepath.Join(dir, "engine")
+	// create configs file
+	f, err := os.Create(opts.configsPath)
+	require.NoError(t, err)
+	f.WriteString("[meta]\n[data]\n")
+	f.Close()
+	// execute op - error should occur
+	err = saveLocalConfig(tc.sourceOpts, opts, log)
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), tc.errMsg) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -181,7 +181,7 @@ func NewCommand() *cobra.Command {
 			DestP:   &options.target.configsPath,
 			Flag:    "influx-configs-path",
 			Default: filepath.Join(v2dir, "configs"),
-			Desc:    "path for CLI configurations",
+			Desc:    "path to 2.x CLI configurations file",
 			Short:   'c',
 		},
 		{

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -181,7 +181,7 @@ func NewCommand() *cobra.Command {
 			DestP:   &options.target.configsPath,
 			Flag:    "influx-configs-path",
 			Default: filepath.Join(v2dir, "configs"),
-			Desc:    "path to 2.x CLI configurations file",
+			Desc:    "path for 2.x CLI configurations file",
 			Short:   'c',
 		},
 		{


### PR DESCRIPTION
Closes #19968

Adds check for existence of 2.x CLI configs file. If it exists, `upgrade` fails with error.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
