### PR TITLE
chore: remove Invites from swagger

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -8480,45 +8480,6 @@ components:
     TaskStatusType:
       type: string
       enum: [active, inactive]
-    Invite:
-      properties:
-        id:
-          description: the idpe id of the invite
-          readOnly: true
-          type: string
-        email:
-          type: string
-        role:
-          type: string
-          enum:
-            - member
-            - owner
-        expiresAt:
-          format: date-time
-          type: string
-        links:
-          type: object
-          readOnly: true
-          example:
-            self: "/api/v2/invites/1"
-          properties:
-            self:
-              type: string
-              format: uri
-      required: [id, email, role]
-    Invites:
-      type: object
-      properties:
-        links:
-          type: object
-          properties:
-            self:
-              type: string
-              format: uri
-        invites:
-          type: array
-          items:
-            $ref: "#/components/schemas/Invite"
     User:
       properties:
         id:


### PR DESCRIPTION
reference: https://github.com/influxdata/ui/pull/293

removes `Invite` and `Invites` components from `http/swagger.yml`