### PR TITLE
fix(upgrade): remove obsolete unused option (influx-command-path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
 1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
 1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
+1. [19972](https://github.com/influxdata/influxdb/pull/19972): Remove unused 'influx-command-path' option from upgrade command
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -89,17 +89,17 @@ func (o *optionsV1) checkDirs() error {
 }
 
 type optionsV2 struct {
-	boltPath           string
-	configsPath        string
-	enginePath         string
-	userName           string
-	password           string
-	orgName            string
-	bucket             string
-	orgID              influxdb.ID
-	userID             influxdb.ID
-	token              string
-	retention          string
+	boltPath    string
+	configsPath string
+	enginePath  string
+	userName    string
+	password    string
+	orgName     string
+	bucket      string
+	orgID       influxdb.ID
+	userID      influxdb.ID
+	token       string
+	retention   string
 }
 
 var options = struct {

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -44,16 +44,6 @@ func TestPathValidations(t *testing.T) {
 
 	cmd := NewCommand()
 	cmd.SetArgs(largs)
-
-	err = cmd.Execute()
-	require.NotNil(t, err, "Must fail")
-	assert.Contains(t, err.Error(), "influx command path not specified")
-
-	influxPath := "/usr/local/bin/influx" // fake
-	largs = append(largs, "--influx-command-path", influxPath)
-	cmd = NewCommand()
-	cmd.SetArgs(largs)
-
 	err = cmd.Execute()
 	require.NotNil(t, err, "Must fail")
 	assert.Contains(t, err.Error(), "1.x metadb error")


### PR DESCRIPTION
Closes #19973

Removes obsolete unused option `influx-command-path`. which was previously used in security upgrade, but since it is now done at runtime using v1 auth API, this option is obsolete and not used at all.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
