### PR TITLE
feat(tasks): added functionality to filter runs by time

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -119,3 +119,10 @@
   key: enforceOrgDashboardLimits
   default: false
   contact: Compute Team
+
+- name: Time Filter Flags
+  description: Filter task run list based on before and after flags
+  key: timeFilterFlags
+  contact: Compute Team
+  default: false
+  expose: true

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -212,6 +212,20 @@ func EnforceOrganizationDashboardLimits() BoolFlag {
 	return enforceOrgDashboardLimits
 }
 
+var timeFilterFlags = MakeBoolFlag(
+	"Time Filter Flags",
+	"timeFilterFlags",
+	"Compute Team",
+	false,
+	Temporary,
+	true,
+)
+
+// TimeFilterFlags - Filter task run list based on before and after flags
+func TimeFilterFlags() BoolFlag {
+	return timeFilterFlags
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
@@ -228,6 +242,7 @@ var all = []Flag{
 	notebooks,
 	injectLatestSuccessTime,
 	enforceOrgDashboardLimits,
+	timeFilterFlags,
 }
 
 var byKey = map[string]Flag{
@@ -246,4 +261,5 @@ var byKey = map[string]Flag{
 	"notebooks":                     notebooks,
 	"injectLatestSuccessTime":       injectLatestSuccessTime,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
+	"timeFilterFlags":               timeFilterFlags,
 }

--- a/kv/task.go
+++ b/kv/task.go
@@ -954,7 +954,7 @@ func (s *Service) findRuns(ctx context.Context, tx Tx, filter influxdb.RunFilter
 	parsedFilterAfterTime := time.Time{}
 	parsedFilterBeforeTime := time.Now().UTC()
 	var err error
-	if filter.AfterTime != "" {
+	if len(filter.AfterTime) > 0 {
 		parsedFilterAfterTime, err = time.Parse(time.RFC3339, filter.AfterTime)
 		if err != nil {
 			return nil, 0, err
@@ -997,7 +997,6 @@ func (s *Service) findRuns(ctx context.Context, tx Tx, filter influxdb.RunFilter
 	}
 
 	return runs, len(runs), nil
-
 }
 
 // FindRunByID returns a single run.

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -153,25 +153,24 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 		filterPart = fmt.Sprintf(`|> filter(fn: (r) => r.runID > %q)`, filter.After.String())
 	}
 
-	parsedAfterTime := time.Time{}
-	parsedBeforeTime := time.Now()
 	constructedTimeFilter := ""
 	if feature.TimeFilterFlags().Enabled(ctx) {
+		parsedAfterTime := time.Time{}
+		parsedBeforeTime := time.Now()
+		var err error
 		if filter.AfterTime != "" {
-			tmpParsedAfter, err := time.Parse(time.RFC3339, filter.AfterTime)
+			parsedAfterTime, err = time.Parse(time.RFC3339, filter.AfterTime)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, fmt.Errorf("failed parsing after time: %s", err.Error())
 			}
-
-			parsedAfterTime = tmpParsedAfter
 
 		}
 		if filter.BeforeTime != "" {
-			tmpParsedBefore, err := time.Parse(time.RFC3339, filter.BeforeTime)
+			parsedBeforeTime, err = time.Parse(time.RFC3339, filter.BeforeTime)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, fmt.Errorf("failed parsing before time: %s", err.Error())
 			}
-			parsedBeforeTime = tmpParsedBefore
+
 		}
 		constructedTimeFilter = fmt.Sprintf(
 			`|> filter(fn: (r) =>time(v: r["scheduledFor"]) > %s and time(v: r["scheduledFor"]) < %s)`,

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -172,7 +172,7 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 
 		}
 		if !parsedBeforeTime.After(parsedAfterTime) {
-			return nil, 0, errors.New("Given after time must be prior to before time")
+			return nil, 0, errors.New("given after time must be prior to before time")
 		}
 
 		constructedTimeFilter = fmt.Sprintf(

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
 	icontext "github.com/influxdata/influxdb/v2/context"
+	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
 	"github.com/influxdata/influxdb/v2/inmem"
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/query"
-	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
 	"github.com/influxdata/influxdb/v2/query/control"
 	"github.com/influxdata/influxdb/v2/query/fluxlang"
 	stdlib "github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
@@ -78,6 +78,7 @@ func TestAnalyticalStore(t *testing.T) {
 					UserResourceMappingService: ts.UserResourceMappingService,
 					AuthorizationService:       authSvc,
 					Ctx:                        authCtx,
+					CallFinishRun:              true,
 				}, func() {
 					cancelFunc()
 					ab.Close(t)


### PR DESCRIPTION
Closes #19247


This PR will respect the before/after time filters for runs. 
Note that this mirrors the already (new) added functionality from idpe. See influxdata/idpe#8973

- [ ] Rebased/mergeable
- [x] Tests pass
- [x] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
