### PR TITLE
fix: check write permission in legacy write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 1. [19972](https://github.com/influxdata/influxdb/pull/19972): Remove unused 'influx-command-path' option from upgrade command
 1. [19969](https://github.com/influxdata/influxdb/pull/19969): Check if CLI configs file already exists during upgrade
 1. [19967](https://github.com/influxdata/influxdb/pull/19967): Add 'log-level' option to upgrade command
+1. [19980](https://github.com/influxdata/influxdb/pull/19980): Fix authorization checks in the V1 /write API
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -954,8 +954,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		}
 	}
 
-	// N.B. the BucketService used by the DBRP service doesn't perform authorization.
-	dbrpSvc := dbrp.NewAuthorizedService(dbrp.NewService(ctx, ts.BucketService, m.kvStore))
+	dbrpSvc := dbrp.NewAuthorizedService(dbrp.NewService(ctx, authorizer.NewBucketService(ts.BucketService), m.kvStore))
 
 	cm := iqlcontrol.NewControllerMetrics([]string{})
 	m.reg.MustRegister(cm.PrometheusCollectors()...)

--- a/http/legacy/write_handler.go
+++ b/http/legacy/write_handler.go
@@ -2,6 +2,7 @@ package legacy
 
 import (
 	"context"
+	"github.com/influxdata/influxdb/v2/authorizer"
 	"io"
 	"net/http"
 
@@ -155,7 +156,15 @@ func (h *WriteHandler) findBucket(ctx context.Context, orgID influxdb.ID, db, rp
 		return nil, err
 	}
 
-	return h.BucketService.FindBucketByID(ctx, mapping.BucketID)
+	bucket, err := h.BucketService.FindBucketByID(ctx, mapping.BucketID)
+	if err != nil {
+		return nil, err
+	}
+	_, _, err = authorizer.AuthorizeWrite(ctx, influxdb.BucketsResourceType, bucket.ID, bucket.OrgID)
+	if err != nil {
+		return nil, err
+	}
+	return bucket, nil
 }
 
 // findMapping finds a DBRPMappingV2 for the database and retention policy

--- a/http/legacy/write_handler_test.go
+++ b/http/legacy/write_handler_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/influxdata/influxdb/v2"
-	"github.com/influxdata/influxdb/v2/authorizer"
 	pcontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/dbrp"
 	"github.com/influxdata/influxdb/v2/http/mocks"
@@ -82,7 +81,7 @@ func TestWriteHandler_BucketAndMappingExists(t *testing.T) {
 		recordWriteEvent,
 	)
 
-	perms := newPermissions(influxdb.BucketsResourceType, &orgID, nil)
+	perms := newPermissions(influxdb.WriteAction, influxdb.BucketsResourceType, &orgID, nil)
 	auth := newAuthorization(orgID, perms...)
 	ctx := pcontext.SetAuthorizer(context.Background(), auth)
 	r := newWriteRequest(ctx, lineProtocolBody)
@@ -94,7 +93,7 @@ func TestWriteHandler_BucketAndMappingExists(t *testing.T) {
 	handler := NewWriterHandler(&PointsWriterBackend{
 		HTTPErrorHandler:   DefaultErrorHandler,
 		Logger:             zaptest.NewLogger(t),
-		BucketService:      authorizer.NewBucketService(bucketService),
+		BucketService:      bucketService,
 		DBRPMappingService: dbrp.NewAuthorizedService(dbrpMappingSvc),
 		PointsWriter:       pointsWriter,
 		EventRecorder:      eventRecorder,
@@ -103,6 +102,84 @@ func TestWriteHandler_BucketAndMappingExists(t *testing.T) {
 	handler.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.Equal(t, "", w.Body.String())
+}
+
+func TestWriteHandler_BucketAndMappingExistsNoPermissions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		// Mocked Services
+		eventRecorder  = mocks.NewMockEventRecorder(ctrl)
+		dbrpMappingSvc = mocks.NewMockDBRPMappingServiceV2(ctrl)
+		bucketService  = mocks.NewMockBucketService(ctrl)
+		pointsWriter   = mocks.NewMockPointsWriter(ctrl)
+
+		// Found Resources
+		orgID  = generator.ID()
+		bucket = &influxdb.Bucket{
+			ID:                  generator.ID(),
+			OrgID:               orgID,
+			Name:                "mydb/autogen",
+			RetentionPolicyName: "autogen",
+			RetentionPeriod:     72 * time.Hour,
+		}
+		mapping = &influxdb.DBRPMappingV2{
+			OrganizationID:  orgID,
+			BucketID:        bucket.ID,
+			Database:        "mydb",
+			RetentionPolicy: "autogen",
+		}
+
+		lineProtocolBody = "m,t1=v1 f1=2 100"
+	)
+
+	findAutogenMapping := dbrpMappingSvc.
+		EXPECT().
+		FindMany(gomock.Any(), influxdb.DBRPMappingFilterV2{
+			OrgID:    &mapping.OrganizationID,
+			Database: &mapping.Database,
+		}).Return([]*influxdb.DBRPMappingV2{mapping}, 1, nil)
+
+	findBucketByID := bucketService.
+		EXPECT().
+		FindBucketByID(gomock.Any(), bucket.ID).Return(bucket, nil)
+
+	recordWriteEvent := eventRecorder.EXPECT().
+		Record(gomock.Any(), gomock.Any())
+
+	gomock.InOrder(
+		findAutogenMapping,
+		findBucketByID,
+		recordWriteEvent,
+	)
+
+	perms := newPermissions(influxdb.ReadAction, influxdb.BucketsResourceType, &orgID, nil)
+	auth := newAuthorization(orgID, perms...)
+	ctx := pcontext.SetAuthorizer(context.Background(), auth)
+	r := newWriteRequest(ctx, lineProtocolBody)
+	params := r.URL.Query()
+	params.Set("db", "mydb")
+	params.Set("rp", "")
+	r.URL.RawQuery = params.Encode()
+
+	handler := NewWriterHandler(&PointsWriterBackend{
+		HTTPErrorHandler:   DefaultErrorHandler,
+		Logger:             zaptest.NewLogger(t),
+		BucketService:      bucketService,
+		DBRPMappingService: dbrp.NewAuthorizedService(dbrpMappingSvc),
+		PointsWriter:       pointsWriter,
+		EventRecorder:      eventRecorder,
+	})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	expectedBody := fmt.Sprintf(
+		"{\"code\":\"unauthorized\",\"message\":\"write:orgs/%s/buckets/%s is unauthorized\"}",
+		orgID.String(),
+		bucket.ID.String(),
+	)
+	assert.Equal(t, expectedBody, w.Body.String())
 }
 
 func TestWriteHandler_MappingNotExists(t *testing.T) {
@@ -150,7 +227,7 @@ func TestWriteHandler_MappingNotExists(t *testing.T) {
 		recordWriteEvent,
 	)
 
-	perms := newPermissions(influxdb.BucketsResourceType, &orgID, nil)
+	perms := newPermissions(influxdb.WriteAction, influxdb.BucketsResourceType, &orgID, nil)
 	auth := newAuthorization(orgID, perms...)
 	ctx := pcontext.SetAuthorizer(context.Background(), auth)
 	r := newWriteRequest(ctx, lineProtocolBody)
@@ -162,7 +239,7 @@ func TestWriteHandler_MappingNotExists(t *testing.T) {
 	handler := NewWriterHandler(&PointsWriterBackend{
 		HTTPErrorHandler:   DefaultErrorHandler,
 		Logger:             zaptest.NewLogger(t),
-		BucketService:      authorizer.NewBucketService(bucketService),
+		BucketService:      bucketService,
 		DBRPMappingService: dbrp.NewAuthorizedService(dbrpMappingSvc),
 		PointsWriter:       pointsWriter,
 		EventRecorder:      eventRecorder,
@@ -230,18 +307,10 @@ func (m pointsMatcher) String() string {
 	return fmt.Sprintf("%#v", m.points)
 }
 
-func newPermissions(resourceType influxdb.ResourceType, orgID, id *influxdb.ID) []influxdb.Permission {
+func newPermissions(action influxdb.Action, resourceType influxdb.ResourceType, orgID, id *influxdb.ID) []influxdb.Permission {
 	return []influxdb.Permission{
 		{
-			Action: influxdb.WriteAction,
-			Resource: influxdb.Resource{
-				Type:  resourceType,
-				OrgID: orgID,
-				ID:    id,
-			},
-		},
-		{
-			Action: influxdb.ReadAction,
+			Action: action,
 			Resource: influxdb.Resource{
 				Type:  resourceType,
 				OrgID: orgID,

--- a/http/legacy/write_handler_test.go
+++ b/http/legacy/write_handler_test.go
@@ -173,13 +173,8 @@ func TestWriteHandler_BucketAndMappingExistsNoPermissions(t *testing.T) {
 	})
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	expectedBody := fmt.Sprintf(
-		"{\"code\":\"unauthorized\",\"message\":\"write:orgs/%s/buckets/%s is unauthorized\"}",
-		orgID.String(),
-		bucket.ID.String(),
-	)
-	assert.Equal(t, expectedBody, w.Body.String())
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "{\"code\":\"forbidden\",\"message\":\"insufficient permissions for write\"}", w.Body.String())
 }
 
 func TestWriteHandler_MappingNotExists(t *testing.T) {


### PR DESCRIPTION
Closes #19974 

This is a big of a hack, it doesn't fit how we structure our auth checks elsewhere. Suggestions appreciated!

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
