### PR TITLE
fix: Use --skip-verify flag for backup/restore CLI command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
+2. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 
 ## v2.0.1 [2020-11-10]
 

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -108,8 +108,9 @@ func (b *cmdBackupBuilder) backupRunE(cmd *cobra.Command, args []string) (err er
 
 	ac := flags.config()
 	b.backupService = &http.BackupService{
-		Addr:  ac.Host,
-		Token: ac.Token,
+		Addr:               ac.Host,
+		Token:              ac.Token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	// Back up Bolt database to file.

--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -113,8 +113,9 @@ func (b *cmdRestoreBuilder) restoreRunE(cmd *cobra.Command, args []string) (err 
 
 	ac := flags.config()
 	b.restoreService = &http.RestoreService{
-		Addr:  ac.Host,
-		Token: ac.Token,
+		Addr:               ac.Host,
+		Token:              ac.Token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	client, err := newHTTPClient()


### PR DESCRIPTION
This pull request passes the `--skip-verify` flag to the underlying HTTP client in for the `BackupService` & `RestoreService`. This allows backup & restore to work on self-signed servers.

Fixes https://github.com/influxdata/influxdb/issues/19989

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
