### PR TITLE
chore: backport fixes to CHANGELOG and typos to the 2.0.x line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,40 @@
-v2.0.2 [unreleased]
--------------------
+## v2.0.2 [unreleased]
 
-v2.0.1 [2020-11-10]
-------------------
+## v2.0.1 [2020-11-10]
 
 ### Bug Fixes
 
--	[19918](https://github.com/influxdata/influxdb/pull/19918): Swagger: add operationId to /delete
--	[19967](https://github.com/influxdata/influxdb/pull/19967): Upgrade: add log-level option
--	[19969](https://github.com/influxdata/influxdb/pull/19969): Check for existing 2.x CLI configs file
--	[19971](https://github.com/influxdata/influxdb/pull/19971): Swagger: remove Invites from swagger
--	[19972](https://github.com/influxdata/influxdb/pull/19972): Remove obsolete unused option (influx-command-path)
--	[19980](https://github.com/influxdata/influxdb/pull/19980): check write permission in legacy write path
+1. [19918](https://github.com/influxdata/influxdb/pull/19918): Swagger: add operationId to /delete
+1. [19967](https://github.com/influxdata/influxdb/pull/19967): Upgrade: add log-level option
+1. [19969](https://github.com/influxdata/influxdb/pull/19969): Check for existing 2.x CLI configs file
+1. [19971](https://github.com/influxdata/influxdb/pull/19971): Swagger: remove Invites from swagger
+1. [19972](https://github.com/influxdata/influxdb/pull/19972): Remove obsolete unused option (influx-command-path)
+1. [19980](https://github.com/influxdata/influxdb/pull/19980): check write permission in legacy write path
 
-v2.0.0 [2020-11-09]
--------------------
+## v2.0.0 [2020-11-09]
 
 ### Features
 
--	[19935](https://github.com/influxdata/influxdb/pull/19935): Improve the UI for the influx v1 auth commands
--	[19940](https://github.com/influxdata/influxdb/pull/19940): Update Flux to v0.94.0
--	[19943](https://github.com/influxdata/influxdb/pull/19943): Upgrade flux-lsp-browser to v0.5.22
--	[19946](https://github.com/influxdata/influxdb/pull/19946): Adding RAS telegraf input
+1. [19935](https://github.com/influxdata/influxdb/pull/19935): Improve the UI for the influx v1 auth commands
+1. [19940](https://github.com/influxdata/influxdb/pull/19940): Update Flux to v0.94.0
+1. [19943](https://github.com/influxdata/influxdb/pull/19943): Upgrade flux-lsp-browser to v0.5.22
+1. [19946](https://github.com/influxdata/influxdb/pull/19946): Adding RAS telegraf input
 
 ### Bug Fixes
 
--	[19924](https://github.com/influxdata/influxdb/pull/19924): Remove unused 'security-script' option from upgrade command
--	[19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
--	[19928](https://github.com/influxdata/influxdb/pull/19928): Fix parsing of retention policy CLI args in `influx setup` and `influxd upgrade`
--	[19930](https://github.com/influxdata/influxdb/pull/19930): Replace 0 with MaxInt when upgrading query-concurrency
--	[19937](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs
--	[19939](https://github.com/influxdata/influxdb/pull/19939): Make influxd help more specific
--	[19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
--	[19947](https://github.com/influxdata/influxdb/pull/19947): Updating v1 auth description
--	[19952](https://github.com/influxdata/influxdb/pull/19952): Use `db`/`rp` naming convention when migrating DBs to buckets
--	[19956](https://github.com/influxdata/influxdb/pull/19956): Improve help for --no-password switch
--	[19959](https://github.com/influxdata/influxdb/pull/19959): Use 10 instead of MaxInt when rewriting query-concurrency
--	[19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
--	[19885](https://github.com/influxdata/influxdb/pull/19875): Misuse of reflect.SliceHeader
+1. [19924](https://github.com/influxdata/influxdb/pull/19924): Remove unused 'security-script' option from upgrade command
+1. [19925](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs in `influxd upgrade`
+1. [19928](https://github.com/influxdata/influxdb/pull/19928): Fix parsing of retention policy CLI args in `influx setup` and `influxd upgrade`
+1. [19930](https://github.com/influxdata/influxdb/pull/19930): Replace 0 with MaxInt when upgrading query-concurrency
+1. [19937](https://github.com/influxdata/influxdb/pull/19937): Create CLI configs
+1. [19939](https://github.com/influxdata/influxdb/pull/19939): Make influxd help more specific
+1. [19945](https://github.com/influxdata/influxdb/pull/19945): Allow write-only V1 tokens to find DBRPs
+1. [19947](https://github.com/influxdata/influxdb/pull/19947): Updating v1 auth description
+1. [19952](https://github.com/influxdata/influxdb/pull/19952): Use `db`/`rp` naming convention when migrating DBs to buckets
+1. [19956](https://github.com/influxdata/influxdb/pull/19956): Improve help for --no-password switch
+1. [19959](https://github.com/influxdata/influxdb/pull/19959): Use 10 instead of MaxInt when rewriting query-concurrency
+1. [19960](https://github.com/influxdata/influxdb/pull/19960): Remove bucket and mapping auto-creation from v1 /write API
+1. [19885](https://github.com/influxdata/influxdb/pull/19875): Misuse of reflect.SliceHeader
 
 ## v2.0.0-rc.4 [2020-11-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v2.0.2 [unreleased]
 
+### Bug Fixes
+
+1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
+
 ## v2.0.1 [2020-11-10]
 
 ### Bug Fixes

--- a/authorization/http_server_test.go
+++ b/authorization/http_server_test.go
@@ -383,7 +383,7 @@ func TestService_handleGetAuthorization(t *testing.T) {
 				t.Errorf("%q. handleGetAuthorization() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if diff, err := jsonDiff(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handleGetAuthorization. error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetAuthorization. error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && diff != "" {
 				t.Errorf("%q. handleGetAuthorization() = -got/+want %s**", tt.name, diff)
 			}
@@ -829,7 +829,7 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 
 			if tt.wants.body != "" {
 				if diff, err := jsonDiff(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteAuthorization(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteAuthorization(). error unmarshalling json %v", tt.name, err)
 				} else if diff != "" {
 					t.Errorf("%q. handleDeleteAuthorization() = ***%s***", tt.name, diff)
 				}

--- a/authorization/middleware_logging.go
+++ b/authorization/middleware_logging.go
@@ -81,7 +81,7 @@ func (l *AuthLogger) UpdateAuthorization(ctx context.Context, id influxdb.ID, up
 			l.logger.Debug("failed to update authorization", zap.Error(err), dur)
 			return
 		}
-		l.logger.Debug("authorizationauthorization update", dur)
+		l.logger.Debug("authorization update", dur)
 	}(time.Now())
 	return l.authService.UpdateAuthorization(ctx, id, upd)
 }

--- a/authorization/service.go
+++ b/authorization/service.go
@@ -109,7 +109,7 @@ func (s *Service) FindAuthorizationByToken(ctx context.Context, n string) (*infl
 	return a, nil
 }
 
-// FindAuthorizations retrives all authorizations that match an arbitrary authorization filter.
+// FindAuthorizations retrieves all authorizations that match an arbitrary authorization filter.
 // Filters using ID, or Token should be efficient.
 // Other filters will do a linear scan across all authorizations searching for a match.
 func (s *Service) FindAuthorizations(ctx context.Context, filter influxdb.AuthorizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Authorization, int, error) {

--- a/authorizer/auth.go
+++ b/authorizer/auth.go
@@ -15,7 +15,7 @@ type AuthorizationService struct {
 	s influxdb.AuthorizationService
 }
 
-// NewAuthorizationService constructs an instance of an authorizing authorization serivce.
+// NewAuthorizationService constructs an instance of an authorizing authorization service.
 func NewAuthorizationService(s influxdb.AuthorizationService) *AuthorizationService {
 	return &AuthorizationService{
 		s: s,

--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -15,7 +15,7 @@ type BucketService struct {
 	s influxdb.BucketService
 }
 
-// NewBucketService constructs an instance of an authorizing bucket serivce.
+// NewBucketService constructs an instance of an authorizing bucket service.
 func NewBucketService(s influxdb.BucketService) *BucketService {
 	return &BucketService{
 		s: s,

--- a/authorizer/check.go
+++ b/authorizer/check.go
@@ -17,7 +17,7 @@ type CheckService struct {
 	influxdb.TaskService
 }
 
-// NewCheckService constructs an instance of an authorizing check serivce.
+// NewCheckService constructs an instance of an authorizing check service.
 func NewCheckService(s influxdb.CheckService, urm influxdb.UserResourceMappingService, org influxdb.OrganizationService) *CheckService {
 	return &CheckService{
 		s:                          s,

--- a/authorizer/dashboard.go
+++ b/authorizer/dashboard.go
@@ -14,7 +14,7 @@ type DashboardService struct {
 	s influxdb.DashboardService
 }
 
-// NewDashboardService constructs an instance of an authorizing dashboard serivce.
+// NewDashboardService constructs an instance of an authorizing dashboard service.
 func NewDashboardService(s influxdb.DashboardService) *DashboardService {
 	return &DashboardService{
 		s: s,

--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -15,7 +15,7 @@ type LabelService struct {
 	orgIDResolver OrgIDResolver
 }
 
-// NewLabelServiceWithOrg constructs an instance of an authorizing label serivce.
+// NewLabelServiceWithOrg constructs an instance of an authorizing label service.
 // Replaces NewLabelService.
 func NewLabelServiceWithOrg(s influxdb.LabelService, orgIDResolver OrgIDResolver) *LabelService {
 	return &LabelService{

--- a/authorizer/notification_endpoint.go
+++ b/authorizer/notification_endpoint.go
@@ -16,7 +16,7 @@ type NotificationEndpointService struct {
 	influxdb.OrganizationService
 }
 
-// NewNotificationEndpointService constructs an instance of an authorizing notification endpoint serivce.
+// NewNotificationEndpointService constructs an instance of an authorizing notification endpoint service.
 func NewNotificationEndpointService(
 	s influxdb.NotificationEndpointService,
 	urm influxdb.UserResourceMappingService,

--- a/authorizer/notification_rule.go
+++ b/authorizer/notification_rule.go
@@ -16,7 +16,7 @@ type NotificationRuleStore struct {
 	influxdb.OrganizationService
 }
 
-// NewNotificationRuleStore constructs an instance of an authorizing notification rule serivce.
+// NewNotificationRuleStore constructs an instance of an authorizing notification rule service.
 func NewNotificationRuleStore(s influxdb.NotificationRuleStore, urm influxdb.UserResourceMappingService, org influxdb.OrganizationService) *NotificationRuleStore {
 	return &NotificationRuleStore{
 		s:                          s,

--- a/authorizer/org.go
+++ b/authorizer/org.go
@@ -15,7 +15,7 @@ type OrgService struct {
 	s influxdb.OrganizationService
 }
 
-// NewOrgService constructs an instance of an authorizing org serivce.
+// NewOrgService constructs an instance of an authorizing org service.
 func NewOrgService(s influxdb.OrganizationService) *OrgService {
 	return &OrgService{
 		s: s,

--- a/authorizer/password.go
+++ b/authorizer/password.go
@@ -11,7 +11,7 @@ type PasswordService struct {
 	next influxdb.PasswordsService
 }
 
-// NewPasswordService wraps an existing password service with auth middlware.
+// NewPasswordService wraps an existing password service with auth middleware.
 func NewPasswordService(svc influxdb.PasswordsService) *PasswordService {
 	return &PasswordService{next: svc}
 }

--- a/authorizer/scraper.go
+++ b/authorizer/scraper.go
@@ -16,7 +16,7 @@ type ScraperTargetStoreService struct {
 	s influxdb.ScraperTargetStoreService
 }
 
-// NewScraperTargetStoreService constructs an instance of an authorizing scraper target store serivce.
+// NewScraperTargetStoreService constructs an instance of an authorizing scraper target store service.
 func NewScraperTargetStoreService(s influxdb.ScraperTargetStoreService,
 	urm influxdb.UserResourceMappingService,
 	org influxdb.OrganizationService,

--- a/authorizer/secret.go
+++ b/authorizer/secret.go
@@ -14,7 +14,7 @@ type SecretService struct {
 	s influxdb.SecretService
 }
 
-// NewSecretService constructs an instance of an authorizing secret serivce.
+// NewSecretService constructs an instance of an authorizing secret service.
 func NewSecretService(s influxdb.SecretService) *SecretService {
 	return &SecretService{
 		s: s,

--- a/authorizer/telegraf.go
+++ b/authorizer/telegraf.go
@@ -15,7 +15,7 @@ type TelegrafConfigService struct {
 	influxdb.UserResourceMappingService
 }
 
-// NewTelegrafConfigService constructs an instance of an authorizing telegraf serivce.
+// NewTelegrafConfigService constructs an instance of an authorizing telegraf service.
 func NewTelegrafConfigService(s influxdb.TelegrafConfigStore, urm influxdb.UserResourceMappingService) *TelegrafConfigService {
 	return &TelegrafConfigService{
 		s:                          s,

--- a/authorizer/user.go
+++ b/authorizer/user.go
@@ -14,7 +14,7 @@ type UserService struct {
 	s influxdb.UserService
 }
 
-// NewUserService constructs an instance of an authorizing user serivce.
+// NewUserService constructs an instance of an authorizing user service.
 func NewUserService(s influxdb.UserService) *UserService {
 	return &UserService{
 		s: s,

--- a/checks/service.go
+++ b/checks/service.go
@@ -131,7 +131,7 @@ func (s *Service) findCheckByName(ctx context.Context, tx kv.Tx, orgID influxdb.
 	return chVal.(influxdb.Check), nil
 }
 
-// FindCheck retrives a check using an arbitrary check filter.
+// FindCheck retrieves a check using an arbitrary check filter.
 // Filters using ID, or OrganizationID and check Name should be efficient.
 // Other filters will do a linear scan across checks until it finds a match.
 func (s *Service) FindCheck(ctx context.Context, filter influxdb.CheckFilter) (influxdb.Check, error) {

--- a/chronograf/.kapacitor/data_test.go
+++ b/chronograf/.kapacitor/data_test.go
@@ -41,7 +41,7 @@ func TestData(t *testing.T) {
 	q := chronograf.QueryConfig{}
 	err := json.Unmarshal([]byte(config), &q)
 	if err != nil {
-		t.Errorf("Error unmarshaling %v", err)
+		t.Errorf("Error unmarshalling %v", err)
 	}
 	alert := chronograf.AlertRule{
 		Trigger: "deadman",

--- a/chronograf/bolt/change_interval_to_duration.go
+++ b/chronograf/bolt/change_interval_to_duration.go
@@ -35,7 +35,7 @@ var up = func(db *bolt.DB) error {
 
 			err := proto.Unmarshal(data, board)
 			if err != nil {
-				log.Fatal("unmarshaling error: ", err)
+				log.Fatal("unmarshalling error: ", err)
 			}
 
 			// Migrate the dashboard
@@ -77,7 +77,7 @@ var down = func(db *bolt.DB) error {
 	This isolates the migration from the codebase, and prevents a future change
 	to a type definition from invalidating the migration functions.
 */
-var dashboardBucket = []byte("Dashoard")
+var dashboardBucket = []byte("Dashoard") // N.B. leave the misspelling for backwards-compat!
 
 type Source struct {
 	ID                 int64  `protobuf:"varint,1,opt,name=ID,proto3" json:"ID,omitempty"`

--- a/chronograf/bolt/dashboards.go
+++ b/chronograf/bolt/dashboards.go
@@ -13,7 +13,7 @@ import (
 var _ chronograf.DashboardsStore = &DashboardsStore{}
 
 // DashboardsBucket is the bolt bucket dashboards are stored in
-var DashboardsBucket = []byte("Dashoard")
+var DashboardsBucket = []byte("Dashoard") // N.B. leave the misspelling for backwards-compat!
 
 // DashboardsStore is the bolt implementation of storing dashboards
 type DashboardsStore struct {

--- a/chronograf/bolt/internal/internal_test.go
+++ b/chronograf/bolt/internal/internal_test.go
@@ -207,7 +207,7 @@ func Test_MarshalDashboard(t *testing.T) {
 	if buf, err := internal.MarshalDashboard(dashboard); err != nil {
 		t.Fatal("Error marshaling dashboard: err", err)
 	} else if err := internal.UnmarshalDashboard(buf, &actual); err != nil {
-		t.Fatal("Error unmarshaling dashboard: err:", err)
+		t.Fatal("Error unmarshalling dashboard: err:", err)
 	} else if !cmp.Equal(dashboard, actual) {
 		t.Fatalf("Dashboard protobuf copy error: diff follows:\n%s", cmp.Diff(dashboard, actual))
 	}
@@ -330,7 +330,7 @@ func Test_MarshalDashboard_WithLegacyBounds(t *testing.T) {
 	if buf, err := internal.MarshalDashboard(dashboard); err != nil {
 		t.Fatal("Error marshaling dashboard: err", err)
 	} else if err := internal.UnmarshalDashboard(buf, &actual); err != nil {
-		t.Fatal("Error unmarshaling dashboard: err:", err)
+		t.Fatal("Error unmarshalling dashboard: err:", err)
 	} else if !cmp.Equal(expected, actual) {
 		t.Fatalf("Dashboard protobuf copy error: diff follows:\n%s", cmp.Diff(expected, actual))
 	}
@@ -445,7 +445,7 @@ func Test_MarshalDashboard_WithEmptyLegacyBounds(t *testing.T) {
 	if buf, err := internal.MarshalDashboard(dashboard); err != nil {
 		t.Fatal("Error marshaling dashboard: err", err)
 	} else if err := internal.UnmarshalDashboard(buf, &actual); err != nil {
-		t.Fatal("Error unmarshaling dashboard: err:", err)
+		t.Fatal("Error unmarshalling dashboard: err:", err)
 	} else if !cmp.Equal(expected, actual) {
 		t.Fatalf("Dashboard protobuf copy error: diff follows:\n%s", cmp.Diff(expected, actual))
 	}
@@ -481,7 +481,7 @@ func Test_MarshalDashboard_WithEmptyCellType(t *testing.T) {
 	if buf, err := internal.MarshalDashboard(dashboard); err != nil {
 		t.Fatal("Error marshaling dashboard: err", err)
 	} else if err := internal.UnmarshalDashboard(buf, &actual); err != nil {
-		t.Fatal("Error unmarshaling dashboard: err:", err)
+		t.Fatal("Error unmarshalling dashboard: err:", err)
 	} else if !cmp.Equal(expected, actual) {
 		t.Fatalf("Dashboard protobuf copy error: diff follows:\n%s", cmp.Diff(expected, actual))
 	}

--- a/chronograf/bolt/sources.go
+++ b/chronograf/bolt/sources.go
@@ -214,7 +214,7 @@ func (s *SourcesStore) get(ctx context.Context, id int, tx *bolt.Tx) (chronograf
 }
 
 func (s *SourcesStore) update(ctx context.Context, src chronograf.Source, tx *bolt.Tx) error {
-	// Get an existing soource with the same ID.
+	// Get an existing source with the same ID.
 	b := tx.Bucket(SourcesBucket)
 	if v := b.Get(itob(src.ID)); v == nil {
 		return chronograf.ErrSourceNotFound

--- a/chronograf/chronograf.go
+++ b/chronograf/chronograf.go
@@ -741,7 +741,7 @@ type OrganizationQuery struct {
 //
 // While not necessary for the app to function correctly, it is
 // expected that Implementors of the OrganizationsStore will take
-// care to guarantee that the Organization.Name is unqiue. Allowing
+// care to guarantee that the Organization.Name is unique. Allowing
 // for duplicate names creates a confusing UX experience for the User.
 type OrganizationsStore interface {
 	// Add creates a new Organization.

--- a/chronograf/docs/dashboards.md
+++ b/chronograf/docs/dashboards.md
@@ -62,7 +62,7 @@ Older chronograf dashboards had the following features:
 * View Dashboard
 * Add new visualization to dashboard
 * Add existing visualization to dashboard
-* Remove visualizatoin from dashboard
+* Remove visualization from dashboard
 * Naming of dashboards
 * Delete dashboard
 * Edit visualization in dashboard

--- a/chronograf/enterprise/enterprise_test.go
+++ b/chronograf/enterprise/enterprise_test.go
@@ -127,7 +127,7 @@ func Test_Enterprise_NewClientWithURL(t *testing.T) {
 			url:  "http://localhost:8086",
 		},
 		{
-			name: "tls sholuld have no error",
+			name: "tls should have no error",
 			url:  "https://localhost:8086",
 		},
 		{
@@ -192,11 +192,11 @@ func Test_Enterprise_ComplainsIfNotOpened(t *testing.T) {
 		},
 		false, false, chronograf.TimeSeries(m1))
 	if err != nil {
-		t.Error("Expected ErrUnitialized, but was this err:", err)
+		t.Error("Expected nil, but was this err:", err)
 	}
 	_, err = cl.Query(context.Background(), chronograf.Query{Command: "show shards", DB: "_internal", RP: "autogen"})
 	if err != chronograf.ErrUninitialized {
-		t.Error("Expected ErrUnitialized, but was this err:", err)
+		t.Error("Expected ErrUninitialized, but was this err:", err)
 	}
 }
 

--- a/chronograf/filestore/dashboards.go
+++ b/chronograf/filestore/dashboards.go
@@ -21,7 +21,7 @@ var _ chronograf.DashboardsStore = &Dashboards{}
 // Dashboards are JSON dashboards stored in the filesystem
 type Dashboards struct {
 	Dir     string                                      // Dir is the directory containing the dashboards.
-	Load    func(string, interface{}) error             // Load loads string name and dashbaord passed in as interface
+	Load    func(string, interface{}) error             // Load loads string name and dashboard passed in as interface
 	Create  func(string, interface{}) error             // Create will write dashboard to file.
 	ReadDir func(dirname string) ([]os.FileInfo, error) // ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
 	Remove  func(name string) error                     // Remove file

--- a/chronograf/filestore/kapacitors.go
+++ b/chronograf/filestore/kapacitors.go
@@ -19,7 +19,7 @@ var _ chronograf.ServersStore = &Kapacitors{}
 // Kapacitors are JSON kapacitors stored in the filesystem
 type Kapacitors struct {
 	Dir     string                                      // Dir is the directory containing the kapacitors.
-	Load    func(string, interface{}) error             // Load loads string name and dashbaord passed in as interface
+	Load    func(string, interface{}) error             // Load loads string name and dashboard passed in as interface
 	Create  func(string, interface{}) error             // Create will write kapacitor to file.
 	ReadDir func(dirname string) ([]os.FileInfo, error) // ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
 	Remove  func(name string) error                     // Remove file

--- a/chronograf/filestore/sources.go
+++ b/chronograf/filestore/sources.go
@@ -19,7 +19,7 @@ var _ chronograf.SourcesStore = &Sources{}
 // Sources are JSON sources stored in the filesystem
 type Sources struct {
 	Dir     string                                      // Dir is the directory containing the sources.
-	Load    func(string, interface{}) error             // Load loads string name and dashbaord passed in as interface
+	Load    func(string, interface{}) error             // Load loads string name and dashboard passed in as interface
 	Create  func(string, interface{}) error             // Create will write source to file.
 	ReadDir func(dirname string) ([]os.FileInfo, error) // ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
 	Remove  func(name string) error                     // Remove file

--- a/chronograf/influx/query.go
+++ b/chronograf/influx/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/influxql"
 )
 
-// TimeRangeAsEpochNano extracs the min and max epoch times from the expression
+// TimeRangeAsEpochNano extracts the min and max epoch times from the expression
 func TimeRangeAsEpochNano(expr influxql.Expr, now time.Time) (min, max int64, err error) {
 	// TODO(desa): is this OK?
 	_, trange, err := influxql.ConditionExpr(expr, nil)

--- a/chronograf/kapacitor.go
+++ b/chronograf/kapacitor.go
@@ -9,7 +9,7 @@ type AlertNodes struct {
 	Posts              []*Post      `json:"post"`             // HTTPPost  will post the JSON alert data to the specified URLs.
 	TCPs               []*TCP       `json:"tcp"`              // TCP  will send the JSON alert data to the specified endpoint via TCP.
 	Email              []*Email     `json:"email"`            // Email  will send alert data to the specified emails.
-	Exec               []*Exec      `json:"exec"`             // Exec  will run shell commandss when an alert triggers
+	Exec               []*Exec      `json:"exec"`             // Exec  will run shell commands when an alert triggers
 	Log                []*Log       `json:"log"`              // Log  will log JSON alert data to files in JSON lines format.
 	VictorOps          []*VictorOps `json:"victorOps"`        // VictorOps  will send alert to all VictorOps
 	PagerDuty          []*PagerDuty `json:"pagerDuty"`        // PagerDuty  will send alert to all PagerDuty

--- a/chronograf/memdb/sources.go
+++ b/chronograf/memdb/sources.go
@@ -28,7 +28,7 @@ func (store *SourcesStore) All(ctx context.Context) ([]chronograf.Source, error)
 	return nil, nil
 }
 
-// Delete removes the SourcesStore.Soruce if it matches the provided Source
+// Delete removes the SourcesStore.Source if it matches the provided Source
 func (store *SourcesStore) Delete(ctx context.Context, src chronograf.Source) error {
 	if store.Source == nil || store.Source.ID != src.ID {
 		return fmt.Errorf("unable to find Source with id %d", src.ID)

--- a/chronograf/oauth2/generic_test.go
+++ b/chronograf/oauth2/generic_test.go
@@ -47,7 +47,7 @@ func TestGenericGroup_withNotEmail(t *testing.T) {
 
 	got, err := prov.Group(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	want := "pinheads.rok"
@@ -93,7 +93,7 @@ func TestGenericGroup_withEmail(t *testing.T) {
 
 	got, err := prov.Group(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	want := "pinheads.rok"
@@ -139,7 +139,7 @@ func TestGenericPrincipalID(t *testing.T) {
 
 	got, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	want := "martymcfly@pinheads.rok"
@@ -191,7 +191,7 @@ func TestGenericPrincipalIDDomain(t *testing.T) {
 
 	got, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 	want := "martymcfly@pinheads.rok"
 	if got != want {

--- a/chronograf/oauth2/github_test.go
+++ b/chronograf/oauth2/github_test.go
@@ -49,7 +49,7 @@ func TestGithubPrincipalID(t *testing.T) {
 
 	email, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	if got, want := email, "martymcfly@example.com"; got != want {
@@ -106,7 +106,7 @@ func TestGithubPrincipalIDOrganization(t *testing.T) {
 
 	email, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	if email != expectedUser[0].Email {

--- a/chronograf/oauth2/google.go
+++ b/chronograf/oauth2/google.go
@@ -75,7 +75,7 @@ func (g *Google) PrincipalID(provider *http.Client) (string, error) {
 		g.Logger.Error("Unable to retrieve Google email ", err.Error())
 		return "", err
 	}
-	// No domain filtering required, so, the user is autenticated.
+	// No domain filtering required, so, the user is authenticated.
 	if len(g.Domains) == 0 {
 		return info.Email, nil
 	}

--- a/chronograf/oauth2/google_test.go
+++ b/chronograf/oauth2/google_test.go
@@ -45,7 +45,7 @@ func TestGooglePrincipalID(t *testing.T) {
 
 	email, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	if email != expected.Email {
@@ -91,7 +91,7 @@ func TestGooglePrincipalIDDomain(t *testing.T) {
 
 	email, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	if email != expectedUser.Email {

--- a/chronograf/oauth2/heroku_test.go
+++ b/chronograf/oauth2/heroku_test.go
@@ -46,7 +46,7 @@ func Test_Heroku_PrincipalID_ExtractsEmailAddress(t *testing.T) {
 
 	email, err := prov.PrincipalID(tc)
 	if err != nil {
-		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+		t.Fatal("Unexpected error while retrieving PrincipalID: err:", err)
 	}
 
 	if email != expected.Email {

--- a/chronograf/roles/sources.go
+++ b/chronograf/roles/sources.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NOTE:
-// This code is currently unused. however, it has been left in place because we aniticipate
+// This code is currently unused. however, it has been left in place because we anticipate
 // that it may be used in the future. It was originally developed as a misunderstanding of
 // https://github.com/influxdata/influxdb/chronograf/issues/1915
 

--- a/chronograf/server/cells_test.go
+++ b/chronograf/server/cells_test.go
@@ -265,7 +265,7 @@ func Test_Service_DashboardCells(t *testing.T) {
 			}
 
 			if err := json.NewDecoder(resp.Body).Decode(&respFrame); err != nil {
-				t.Fatalf("%q - Error unmarshaling response body: err: %s", test.name, err)
+				t.Fatalf("%q - Error unmarshalling response body: err: %s", test.name, err)
 			}
 
 			// extract actual

--- a/chronograf/server/context.go
+++ b/chronograf/server/context.go
@@ -10,7 +10,7 @@ type serverContextKey string
 // server is making the requet via context
 const ServerContextKey = serverContextKey("server")
 
-// hasServerContext speficies if the context contains
+// hasServerContext specifies if the context contains
 // the ServerContextKey and that the value stored there is true
 func hasServerContext(ctx context.Context) bool {
 	// prevents panic in case of nil context

--- a/chronograf/server/layout_test.go
+++ b/chronograf/server/layout_test.go
@@ -174,7 +174,7 @@ func Test_Layouts(t *testing.T) {
 			// decode resp into respFrame
 			resp := rr.Result()
 			if err := json.NewDecoder(resp.Body).Decode(&respFrame); err != nil {
-				t.Fatalf("%q - Error unmarshaling JSON: err: %s", test.name, err.Error())
+				t.Fatalf("%q - Error unmarshalling JSON: err: %s", test.name, err.Error())
 			}
 
 			// compare actual and expected

--- a/chronograf/server/mapping.go
+++ b/chronograf/server/mapping.go
@@ -137,7 +137,7 @@ func newMappingsResponse(ms []chronograf.Mapping) *mappingsResponse {
 	}
 }
 
-// Mappings retrives all mappings
+// Mappings retrieves all mappings
 func (s *Service) Mappings(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/chronograf/server/org_config.go
+++ b/chronograf/server/org_config.go
@@ -122,7 +122,7 @@ func (s *Service) ReplaceOrganizationLogViewerConfig(w http.ResponseWriter, r *h
 
 // validLogViewerConfig ensures that the request body log viewer UI config is valid
 // to be valid, it must: not be empty, have at least one column, not have multiple
-// columns with the same name or position value, each column must have a visbility
+// columns with the same name or position value, each column must have a visibility
 // of either "visible" or "hidden" and if a column is of type severity, it must have
 // at least one severity format of type icon, text, or both
 func validLogViewerConfig(c chronograf.LogViewerConfig) error {

--- a/chronograf/server/routes.go
+++ b/chronograf/server/routes.go
@@ -38,7 +38,7 @@ type getRoutesResponse struct {
 	Mappings           string                             `json:"mappings"`         // Location of the application mappings endpoint
 	Sources            string                             `json:"sources"`          // Location of the sources endpoint
 	Me                 string                             `json:"me"`               // Location of the me endpoint
-	Environment        string                             `json:"environment"`      // Location of the environement endpoint
+	Environment        string                             `json:"environment"`      // Location of the environment endpoint
 	Dashboards         string                             `json:"dashboards"`       // Location of the dashboards endpoint
 	Config             getConfigLinksResponse             `json:"config"`           // Location of the config endpoint and its various sections
 	Cells              string                             `json:"cells"`            // Location of the v2 cells

--- a/chronograf/server/stores.go
+++ b/chronograf/server/stores.go
@@ -52,7 +52,7 @@ type userContextKey string
 // UserContextKey is the context key for retrieving the user off of context
 const UserContextKey = userContextKey("user")
 
-// hasUserContext speficies if the context contains
+// hasUserContext specifies if the context contains
 // the UserContextKey and that the value stored there is chronograf.User
 func hasUserContext(ctx context.Context) (*chronograf.User, bool) {
 	// prevents panic in case of nil context
@@ -70,7 +70,7 @@ func hasUserContext(ctx context.Context) (*chronograf.User, bool) {
 	return u, true
 }
 
-// hasSuperAdminContext speficies if the context contains
+// hasSuperAdminContext specifies if the context contains
 // the UserContextKey user is a super admin
 func hasSuperAdminContext(ctx context.Context) bool {
 	u, ok := hasUserContext(ctx)
@@ -146,7 +146,7 @@ func (s *Store) Layouts(ctx context.Context) chronograf.LayoutsStore {
 // is returned.
 // If there is an organization specified on context, then an organizations.UsersStore
 // is returned.
-// If niether are specified, a noop.UsersStore is returned.
+// If neither are specified, a noop.UsersStore is returned.
 func (s *Store) Users(ctx context.Context) chronograf.UsersStore {
 	if isServer := hasServerContext(ctx); isServer {
 		return s.UsersStore
@@ -256,7 +256,7 @@ func (s *DirectStore) Layouts(ctx context.Context) chronograf.LayoutsStore {
 // is returned.
 // If there is an organization specified on context, then an organizations.UsersStore
 // is returned.
-// If niether are specified, a noop.UsersStore is returned.
+// If neither are specified, a noop.UsersStore is returned.
 func (s *DirectStore) Users(ctx context.Context) chronograf.UsersStore {
 	return s.UsersStore
 }

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -397,7 +397,7 @@ func ToBytesPerSecond(rateLimit string) (float64, error) {
 			return 0, fmt.Errorf("invalid rate limit %q: time is out of range: %v", strVal, err)
 		}
 		if int64Val <= 0 {
-			return 0, fmt.Errorf("invalid rate limit %q: possitive time expected but %v supplied", strVal, matches[3])
+			return 0, fmt.Errorf("invalid rate limit %q: positive time expected but %v supplied", strVal, matches[3])
 		}
 		time = float64(int64Val)
 	}

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -56,7 +56,7 @@ func readLines(reader io.Reader) []string {
 
 func createTempFile(suffix string, contents []byte) string {
 	file, err := ioutil.TempFile("", "influx_writeTest*."+suffix)
-	file.Close() // Close immediatelly, since we need only a file name
+	file.Close() // Close immediately, since we need only a file name
 	if err != nil {
 		log.Fatal(err)
 		return "unknown.file"
@@ -454,7 +454,7 @@ func Test_fluxWriteF(t *testing.T) {
 		require.Contains(t, fmt.Sprintf("%s", err), "org-id")
 	})
 
-	t.Run("validates error when failed to retrive buckets", func(t *testing.T) {
+	t.Run("validates error when failed to retrieve buckets", func(t *testing.T) {
 		useTestServer()
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket", "my-error-bucket"})
@@ -566,7 +566,7 @@ func Test_ToBytesPerSecond(t *testing.T) {
 		},
 		{
 			in:    "1B0s",
-			error: `invalid rate limit "1B0s": possitive time expected but 0 supplied`,
+			error: `invalid rate limit "1B0s": positive time expected but 0 supplied`,
 		},
 		{
 			in:    "1MB/42949672950s",

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -133,7 +133,7 @@ func TestLauncher_SetupWithUsers(t *testing.T) {
 	}{}
 	err = json.Unmarshal(body, &exp)
 	if err != nil {
-		t.Fatalf("unexpected error unmarshaling user: %v", err)
+		t.Fatalf("unexpected error unmarshalling user: %v", err)
 	}
 	if len(exp.Users) != 2 {
 		t.Fatalf("unexpected 2 users: %#+v", exp)

--- a/dashboards/service.go
+++ b/dashboards/service.go
@@ -167,7 +167,7 @@ func filterDashboardsFn(filter influxdb.DashboardFilter) func(d *influxdb.Dashbo
 	}
 }
 
-// FindDashboards retrives all dashboards that match an arbitrary dashboard filter.
+// FindDashboards retrieves all dashboards that match an arbitrary dashboard filter.
 func (s *Service) FindDashboards(ctx context.Context, filter influxdb.DashboardFilter, opts influxdb.FindOptions) ([]*influxdb.Dashboard, int, error) {
 	ds := []*influxdb.Dashboard{}
 	if len(filter.IDs) == 1 {

--- a/dashboards/transport/http_test.go
+++ b/dashboards/transport/http_test.go
@@ -387,7 +387,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 				t.Errorf("%q. handleGetDashboards() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handleGetDashboards(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetDashboards(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handleGetDashboards() = ***%s***", tt.name, diff)
 			}
@@ -816,7 +816,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 				t.Errorf("%q. handleGetDashboard() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && err != nil {
-				t.Errorf("%q, handleGetDashboard(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetDashboard(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handleGetDashboard() = ***%s***", tt.name, diff)
 			}
@@ -1080,7 +1080,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 				t.Errorf("%q. handlePostDashboard() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostDashboard(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostDashboard(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostDashboard() = ***%s***", tt.name, diff)
 			}
@@ -1180,7 +1180,7 @@ func TestService_handleDeleteDashboard(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteDashboard(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteDashboard(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteDashboard() = ***%s***", tt.name, diff)
 				}
@@ -1371,7 +1371,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchDashboard(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchDashboard(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchDashboard() = ***%s***", tt.name, diff)
 				}
@@ -1542,7 +1542,7 @@ func TestService_handlePostDashboardCell(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(tt.wants.body, string(body)); err != nil {
-					t.Errorf("%q, handlePostDashboardCell(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostDashboardCell(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostDashboardCell() = ***%s***", tt.name, diff)
 				}
@@ -1624,7 +1624,7 @@ func TestService_handleDeleteDashboardCell(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteDashboardCell(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteDashboardCell(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteDashboardCell() = ***%s***", tt.name, diff)
 				}
@@ -1752,7 +1752,7 @@ func TestService_handlePatchDashboardCell(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchDashboardCell(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchDashboardCell(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchDashboardCell() = ***%s***", tt.name, diff)
 				}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -49,7 +49,7 @@ npm test -- headless=true activeConf=nightly -t "@feature-signin"
 
 **Environment Variable Overrides**
 
-Configuration properties can be overridden by `E2E` environment variables. The basic pattern for exporting an enviornment variable to be picked up for test configuration is the token `E2E` followed by an underscore, then the path to the property to be modified as defined by the configuration tree in `e2e.conf.json`.  Each node in the tree is declared in uppercase and separated by an underscore. 
+Configuration properties can be overridden by `E2E` environment variables. The basic pattern for exporting an environment variable to be picked up for test configuration is the token `E2E` followed by an underscore, then the path to the property to be modified as defined by the configuration tree in `e2e.conf.json`.  Each node in the tree is declared in uppercase and separated by an underscore. 
 
 For example, to declare the `influx_url` property in the `development` configuration export the environment variable `E2E_DEVELOPMENT_INFLUX_URL`.
 
@@ -149,9 +149,9 @@ caps.set('enableVideo', true);
 
 Then rerun the script `selenoid.sh` with the argument `-debug`. 
 
-### Light Weight Perfomance checks
+### Light Weight Performance checks
 
-For tests against the cloud a light weigh perfomance utility has been added. It currently exports only one method for tests: `execTimed( func, maxDelay, failMsg, successMsg)`.  This method will execute the passed function and expect it to resolve by `maxDelay` milliseconds.  Failures are thrown to cucumber and results are stored in a performance log buffer.  This log is then dumped to the console after all tests have been run.  They are also written to a CSV report file: `./report/performance.csv`.
+For tests against the cloud a light weigh performance utility has been added. It currently exports only one method for tests: `execTimed( func, maxDelay, failMsg, successMsg)`.  This method will execute the passed function and expect it to resolve by `maxDelay` milliseconds.  Failures are thrown to cucumber and results are stored in a performance log buffer.  This log is then dumped to the console after all tests have been run.  They are also written to a CSV report file: `./report/performance.csv`.
 
 For example, here is how it is used to check the redirect to the login page. 
 

--- a/e2e/features/dashboards/cellEdit.feature
+++ b/e2e/features/dashboards/cellEdit.feature
@@ -147,7 +147,7 @@ Feature: Dashboards - Dashboard - Cell Edit
   qa,_monitoring,_tasks
   """
     When click the time machine bucket selector item "_monitoring"
-    Then time machine bulider card "1" contains the empty tag message
+    Then time machine builder card "1" contains the empty tag message
     When click the time machine bucket selector item "qa"
     Then there are "1" time machine builder cards
     Then time machine builder card "1" contains:

--- a/e2e/hooks.js
+++ b/e2e/hooks.js
@@ -147,7 +147,7 @@ AfterAll(async function ( ) {
 
     if(perfUtils.performanceLog.length > 0){
         await perfUtils.writePerformanceLog();
-        await perfUtils.writePerfomanceReport();
+        await perfUtils.writePerformanceReport();
     }
 });
 

--- a/e2e/src/pages/basePage.js
+++ b/e2e/src/pages/basePage.js
@@ -83,7 +83,7 @@ class basePage{
                 await this.driver.wait(until.elementLocated(By.xpath(selectors[i].selector)), 5000);
                 break;
             default:
-                throw `Unkown selector type ${JSON.stringify(selectors[i])}`;
+                throw `Unknown selector type ${JSON.stringify(selectors[i])}`;
             }
 
             // TODO - implement other selector types
@@ -143,7 +143,7 @@ class basePage{
                     });
                     break;
                 default:
-                    throw `Unkown selector type ${JSON.stringify(selector)}`;
+                    throw `Unknown selector type ${JSON.stringify(selector)}`;
                 }
                 await resultElem.isEnabled();
             } catch (e) {
@@ -171,7 +171,7 @@ class basePage{
                     return elements.length === 0;
                 });
             default:
-                throw `Unkown selector type ${JSON.stringify(selector)}`;
+                throw `Unknown selector type ${JSON.stringify(selector)}`;
             }
         });
     }

--- a/e2e/src/pages/onboarding/splashPage.js
+++ b/e2e/src/pages/onboarding/splashPage.js
@@ -12,7 +12,7 @@ class splashPage extends basePage {
     }
 
     async getHeadMain(){
-        //promises 201 - passing promisses between methods
+        //promises 201 - passing promises between methods
         //N.B. returns a promise wrapping the element
         return await this.driver.findElement(By.css(headMain));
     }

--- a/e2e/src/step_definitions/dashboards/cellOverlayStepDefs.js
+++ b/e2e/src/step_definitions/dashboards/cellOverlayStepDefs.js
@@ -224,7 +224,7 @@ Then(/^the item "(.*)" in builder card "(.*)" is selected$/, async (item,index) 
    await celOvSteps.verifyItemSelectedInBuilderCard(index, item);
 })
 
-Then(/^time machine bulider card "(.*)" contains the empty tag message$/, async index => {
+Then(/^time machine builder card "(.*)" contains the empty tag message$/, async index => {
     await celOvSteps.verifyEmptyTagsInBuilderCard(index);
 });
 

--- a/e2e/src/step_definitions/dashboards/dashboardStepDefs.js
+++ b/e2e/src/step_definitions/dashboards/dashboardStepDefs.js
@@ -246,7 +246,7 @@ When(/^move horizontally to "(.*)" of graph cell named "(.*)"$/, async (fraction
 });
 
 When(/^drag horizontally to "(.*)" of graph cell named "(.*)"$/, async (fraction, name) => {
-    await dbdSteps.dragToHorizonatlFractionOfGraphCell(fraction, name);
+    await dbdSteps.dragToHorizontalFractionOfGraphCell(fraction, name);
 });
 
 When(/^move vertically to "(.*)" of graph cell named "(.*)"$/, async (fraction, name) => {

--- a/e2e/src/step_definitions/dashboards/dashboardsStepDefs.js
+++ b/e2e/src/step_definitions/dashboards/dashboardsStepDefs.js
@@ -107,7 +107,7 @@ When(/^enter "(.*)" in the popover label selector filter$/, async text => {
 });
 
 Then(/^there are "(.*)" label pills in the select label popover$/, async count => {
-    await dbdsSteps.verifyDasboardAddLabelsPillCount(count);
+    await dbdsSteps.verifyDashboardAddLabelsPillCount(count);
 });
 
 Then(/^the create new label item is not visible in the popover$/, async () => {
@@ -127,7 +127,7 @@ Then(/^the dashboard card "(.*)" has the label "(.*)"$/, async (name, label) => 
 });
 
 When(/^click the add label button for the dashboard card "(.*)"$/, async name => {
-    await dbdsSteps.clickDasboardCardAddLabel(name);
+    await dbdsSteps.clickDashboardCardAddLabel(name);
 });
 
 When(/^hover over the label "(.*)" of the dashboard card "(.*)"$/, async (label,name) => {

--- a/e2e/src/step_definitions/dataExplorer/dataExplorerStepDefs.js
+++ b/e2e/src/step_definitions/dataExplorer/dataExplorerStepDefs.js
@@ -42,7 +42,7 @@ When(/^move horizontally to "(.*)" of the graph$/, async (fraction) => {
 });
 
 When(/^drag horizontally to "(.*)" of the graph$/, async (fraction) => {
-    await deSteps.dragToHorizonatalFractionOfGraph(fraction);
+    await deSteps.dragToHorizontalFractionOfGraph(fraction);
 });
 
 Then(/^the graph has changed$/, async() => {

--- a/e2e/src/steps/createOrgSteps.js
+++ b/e2e/src/steps/createOrgSteps.js
@@ -13,7 +13,7 @@ class createOrgSteps extends baseSteps {
         await this.createOrgPage.isLoaded();
     }
 
-    //for assrtions
+    //for assertions
     async verifyIsLoaded(){
         this.assertVisible(await this.createOrgPage.getInputOrgName());
         this.assertVisible(await this.createOrgPage.getInputBucketName());

--- a/e2e/src/steps/dashboards/dashboardSteps.js
+++ b/e2e/src/steps/dashboards/dashboardSteps.js
@@ -263,7 +263,7 @@ class dashboardSteps extends influxSteps {
     async clickDashboardPopOverlayAddNote(){
         await this.clickAndWait(await this.dbdPage.getCellPopoverContentsAddNote(), async () => {
             //await this.driver.wait(
-            //until.elementLocated(By.css(basePage.getPopupBodySelector().selector)) // not working consistentlly
+            //until.elementLocated(By.css(basePage.getPopupBodySelector().selector)) // not working consistently
             //);
             await this.driver.sleep(1000); //sometimes slow and then overrun by downstream steps
         });
@@ -524,7 +524,7 @@ class dashboardSteps extends influxSteps {
         });
     }
 
-    async dragToHorizonatlFractionOfGraphCell(fraction, name){
+    async dragToHorizontalFractionOfGraphCell(fraction, name){
         let fract = fraction.split('/');
         let denom = fract[1];
         let numer = fract[0];

--- a/e2e/src/steps/dashboards/dashboardsSteps.js
+++ b/e2e/src/steps/dashboards/dashboardsSteps.js
@@ -132,7 +132,7 @@ class dashboardsSteps extends influxSteps {
         await this.typeTextAndWait(await this.dbdsPage.getAddLabelsPopoverFilter(), text);
     }
 
-    async verifyDasboardAddLabelsPillCount(count){
+    async verifyDashboardAddLabelsPillCount(count){
         await this.dbdsPage.getAddLabelsLabelPills().then(async pills => {
             expect(pills.length).to.equal(parseInt(count));
         });
@@ -155,7 +155,7 @@ class dashboardsSteps extends influxSteps {
         await this.assertVisible(await this.dbdsPage.getDashboardCardLabelPill(name, label));
     }
 
-    async clickDasboardCardAddLabel(name){
+    async clickDashboardCardAddLabel(name){
         await this.clickAndWait(await this.dbdsPage.getDashboardCardAddLabels(name));
     }
 

--- a/e2e/src/steps/dataExplorer/dataExplorerSteps.js
+++ b/e2e/src/steps/dataExplorer/dataExplorerSteps.js
@@ -153,7 +153,7 @@ class dataExplorerSteps extends influxSteps {
         });
     }
 
-    async dragToHorizonatalFractionOfGraph(fraction){
+    async dragToHorizontalFractionOfGraph(fraction){
         let fract = fraction.split('/');
         let denom = fract[1];
         let numer = fract[0];
@@ -418,7 +418,7 @@ class dataExplorerSteps extends influxSteps {
                 elem = await this.dePage.getSaveAsPopupTabVar();
                 break;
             default:
-                throw `Unkown menu item ${item}`;
+                throw `Unknown menu item ${item}`;
         }
 
         return elem;

--- a/e2e/src/steps/influx/influxSteps.js
+++ b/e2e/src/steps/influx/influxSteps.js
@@ -68,7 +68,7 @@ class influxSteps extends baseSteps {
             elem = await this.influxPage.getNavMenuUser();
             break;
         default:
-            throw `Unkown menu item ${item}`;
+            throw `Unknown menu item ${item}`;
         }
 
         return elem;
@@ -87,7 +87,7 @@ class influxSteps extends baseSteps {
                 elem = await this.influxPage.getUserMenuItem('logout');
                 break;
             default:
-                throw `Unkown menu item ${item}`;
+                throw `Unknown menu item ${item}`;
         }
 
         return elem;
@@ -103,7 +103,7 @@ class influxSteps extends baseSteps {
         }else if(state === 'visible'){
             this.assertVisible(await this.getNavMenuElem(item));
         }else{
-            throw `unkown menu state ${state}`;
+            throw `unknown menu state ${state}`;
         }
     }
 
@@ -113,7 +113,7 @@ class influxSteps extends baseSteps {
         }else if(state === 'visible'){
             this.assertVisible(await this.getUserMenuElem(item));
         }else{
-            throw `unkown menu state ${state}`;
+            throw `unknown menu state ${state}`;
         }
     }
 

--- a/e2e/src/steps/signin/signinSteps.js
+++ b/e2e/src/steps/signin/signinSteps.js
@@ -103,7 +103,7 @@ class signinSteps extends baseSteps {
         await this.driver.wait(until.elementIsVisible(await this.signinPage.getNameInput()), timeout,
             `Waited ${timeout} milliseconds to locate signin name input`);
         await this.driver.wait(until.elementIsVisible(await this.signinPage.getPasswordInput()), timeout,
-            `Waited ${timeout} milliseconds to locate signin pasword input`);
+            `Waited ${timeout} milliseconds to locate signin password input`);
     }
 
     async signin(user){

--- a/e2e/src/utils/htmlReport.js
+++ b/e2e/src/utils/htmlReport.js
@@ -9,7 +9,7 @@ var options = {
     launchReport: false,
     metadata: {
         'App Version':'2.0.0-alpha',
-        'Test Environment': 'Deveolop',
+        'Test Environment': 'Develop',
         'Browser': 'Chrome  74',
         'Platform': 'Ubuntu 16.04',
         'Parallel': 'Scenarios',

--- a/e2e/src/utils/influxUtils.js
+++ b/e2e/src/utils/influxUtils.js
@@ -218,7 +218,7 @@ const setupNewUser = async(newUser) => {
                 `at ${__config.host}.  User should already exist there` );
             break;
         default:
-            throw `Unkown create user method ${__config.create_method}`
+            throw `Unknown create user method ${__config.create_method}`
     }
 
     putUser(user);

--- a/e2e/src/utils/performanceUtils.js
+++ b/e2e/src/utils/performanceUtils.js
@@ -111,7 +111,7 @@ const writePerformanceLog = async () => {
   console.log()
 };
 
-const writePerfomanceReport = async (filename = performanceRecFile) => {
+const writePerformanceReport = async (filename = performanceRecFile) => {
 
     let header = [];
 
@@ -145,5 +145,5 @@ module.exports = {
     execTimed,
     performanceLog,
     writePerformanceLog,
-    writePerfomanceReport
+    writePerformanceReport
 };

--- a/errors.md
+++ b/errors.md
@@ -24,7 +24,7 @@ This is inspired from Ben Johnson's blog post [Failure is Your Domain](https://m
 
 ## Use Case Example
 
-We inplement the following interface
+We implement the following interface
 
 ```go
 

--- a/gather/handler.go
+++ b/gather/handler.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// handler implents nats Handler interface.
+// handler implements nats Handler interface.
 type handler struct {
 	Scraper   Scraper
 	Publisher nats.Publisher

--- a/gather/metrics_test.go
+++ b/gather/metrics_test.go
@@ -193,10 +193,10 @@ func TestMetricsMarshal(t *testing.T) {
 		result := make([]Metrics, 0)
 		err = json.Unmarshal(b, &result)
 		if err != nil {
-			t.Fatalf("error in unmarshaling metrics: b: %s, %v", string(b), err)
+			t.Fatalf("error in unmarshalling metrics: b: %s, %v", string(b), err)
 		}
 		if diff := cmp.Diff(c.ms, result, nil); diff != "" {
-			t.Fatalf("unmarshaling metrics is incorrect, want %v, got %v", c.ms, result)
+			t.Fatalf("unmarshalling metrics is incorrect, want %v, got %v", c.ms, result)
 		}
 	}
 }

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -24,7 +24,7 @@ type Scheduler struct {
 	Targets influxdb.ScraperTargetStoreService
 	// Interval is between each metrics gathering event.
 	Interval time.Duration
-	// Timeout is the maxisium time duration allowed by each TCP request
+	// Timeout is the maximum time duration allowed by each TCP request
 	Timeout time.Duration
 
 	// Publisher will send the gather requests and gathered metrics to the queue.

--- a/http/api_handler_test.go
+++ b/http/api_handler_test.go
@@ -75,7 +75,7 @@ func TestAPIHandler_NotFound(t *testing.T) {
 				t.Errorf("%q. get %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -362,7 +362,7 @@ func TestService_handleGetAuthorizations(t *testing.T) {
 				t.Errorf("%q. handleGetAuthorizations() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handleGetAuthorizations(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetAuthorizations(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handleGetAuthorizations() = ***%s***", tt.name, diff)
 			}
@@ -551,7 +551,7 @@ func TestService_handleGetAuthorization(t *testing.T) {
 				t.Errorf("%q. handleGetAuthorization() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handleGetAuthorization. error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetAuthorization. error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handleGetAuthorization() = -got/+want %s**", tt.name, diff)
 			}
@@ -732,7 +732,7 @@ func TestService_handlePostAuthorization(t *testing.T) {
 				t.Errorf("%q. handlePostAuthorization() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostAuthorization(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostAuthorization(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostAuthorization() = ***%s***", tt.name, diff)
 			}
@@ -845,7 +845,7 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteAuthorization(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteAuthorization(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteAuthorization() = ***%s***", tt.name, diff)
 				}

--- a/http/bucket_service_test.go
+++ b/http/bucket_service_test.go
@@ -356,7 +356,7 @@ func TestService_handleGetBucket(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetBucket(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetBucket(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetBucket() = ***%s***", tt.name, diff)
 				}
@@ -517,7 +517,7 @@ func TestService_handlePostBucket(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostBucket(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostBucket(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostBucket() = ***%s***", tt.name, diff)
 				}
@@ -621,7 +621,7 @@ func TestService_handleDeleteBucket(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteBucket(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteBucket(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteBucket() = ***%s***", tt.name, diff)
 				}
@@ -1002,7 +1002,7 @@ func TestService_handlePatchBucket(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchBucket(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchBucket(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchBucket() = ***%s***", tt.name, diff)
 				}
@@ -1097,7 +1097,7 @@ func TestService_handlePostBucketMember(t *testing.T) {
 				t.Errorf("%q. handlePostBucketMember() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostBucketMember(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostBucketMember(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostBucketMember() = ***%s***", tt.name, diff)
 			}
@@ -1191,7 +1191,7 @@ func TestService_handlePostBucketOwner(t *testing.T) {
 				t.Errorf("%q. handlePostBucketOwner() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostBucketOwner(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostBucketOwner(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostBucketOwner() = ***%s***", tt.name, diff)
 			}

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -599,7 +599,7 @@ func TestService_handleGetCheck(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetCheck(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetCheck(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetCheck() = ***%s***", tt.name, diff)
 				}
@@ -759,7 +759,7 @@ func TestService_handlePostCheck(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostCheck(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostCheck(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostCheck() = ***%s***", tt.name, diff)
 				}
@@ -868,7 +868,7 @@ func TestService_handleDeleteCheck(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteCheck(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteCheck(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteCheck() = ***%s***", tt.name, diff)
 				}
@@ -1044,7 +1044,7 @@ func TestService_handlePatchCheck(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchCheck(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchCheck(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchCheck() = ***%s***", tt.name, diff)
 				}
@@ -1233,7 +1233,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePutCheck(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePutCheck(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePutCheck() = ***%s***", tt.name, diff)
 				}
@@ -1333,7 +1333,7 @@ func TestService_handlePostCheckMember(t *testing.T) {
 				t.Errorf("%q. handlePostCheckMember() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostCheckMember(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostCheckMember(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostCheckMember() = ***%s***", tt.name, diff)
 			}
@@ -1427,7 +1427,7 @@ func TestService_handlePostCheckOwner(t *testing.T) {
 				t.Errorf("%q. handlePostCheckOwner() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostCheckOwner(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostCheckOwner(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostCheckOwner() = ***%s***", tt.name, diff)
 			}

--- a/http/delete_handler.go
+++ b/http/delete_handler.go
@@ -55,7 +55,7 @@ const (
 	prefixDelete = "/api/v2/delete"
 )
 
-// NewDeleteHandler creates a new handler at /api/v2/delete to recieve delete requests.
+// NewDeleteHandler creates a new handler at /api/v2/delete to receive delete requests.
 func NewDeleteHandler(log *zap.Logger, b *DeleteBackend) *DeleteHandler {
 	h := &DeleteHandler{
 		HTTPErrorHandler: b.HTTPErrorHandler,
@@ -122,7 +122,7 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 
 	h.log.Debug("Deleted",
 		zap.String("orgID", fmt.Sprint(dr.Org.ID.String())),
-		zap.String("buketID", fmt.Sprint(dr.Bucket.ID.String())),
+		zap.String("bucketID", fmt.Sprint(dr.Bucket.ID.String())),
 	)
 }
 

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -372,7 +372,7 @@ func TestDelete(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDelete(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDelete(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDelete() = ***%s***", tt.name, diff)
 				}

--- a/http/document_test.go
+++ b/http/document_test.go
@@ -325,7 +325,7 @@ func TestService_handleDeleteDocumentLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteDocumentLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteDocumentLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteDocumentLabel() = ***%s***", tt.name, diff)
 				}
@@ -507,7 +507,7 @@ func TestService_handlePostDocumentLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostDocumentLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostDocumentLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostDocumentLabel() = ***%s***", tt.name, diff)
 				}
@@ -619,7 +619,7 @@ func TestService_handleGetDocumentLabels(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetDocumentLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetDocumentLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetDocumentLabel() = ***%s***", tt.name, diff)
 				}
@@ -740,7 +740,7 @@ func TestService_handleGetDocuments(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetDocuments(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetDocuments(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetDocuments() = ***%s***", tt.name, diff)
 				}
@@ -950,7 +950,7 @@ func TestService_handlePostDocuments(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(tt.wants.body, string(body)); err != nil {
-					t.Errorf("%q, handlePostDocument(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostDocument(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostDocument() = ***%s***", tt.name, diff)
 				}

--- a/http/handler.go
+++ b/http/handler.go
@@ -143,7 +143,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.r.ServeHTTP(w, r)
 }
 
-// PrometheusCollectors satisifies prom.PrometheusCollector.
+// PrometheusCollectors satisfies prom.PrometheusCollector.
 func (h *Handler) PrometheusCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		h.requests,

--- a/http/health_test.go
+++ b/http/health_test.go
@@ -46,7 +46,7 @@ func TestHealthHandler(t *testing.T) {
 			}
 			var content map[string]interface{}
 			if err := json.Unmarshal(body, &content); err != nil {
-				t.Errorf("%q, HealthHandler(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, HealthHandler(). error unmarshalling json %v", tt.name, err)
 				return
 			}
 			if _, found := content["name"]; !found {

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -123,7 +123,7 @@ func (h *LabelHandler) handleGetLabels(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	h.log.Debug("Labels retrived", zap.String("labels", fmt.Sprint(labels)))
+	h.log.Debug("Labels retrieved", zap.String("labels", fmt.Sprint(labels)))
 	err = encodeResponse(ctx, w, http.StatusOK, newLabelsResponse(labels))
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -249,7 +249,7 @@ func TestService_handleGetLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetLabel() = ***%s***", tt.name, diff)
 				}
@@ -435,7 +435,7 @@ func TestService_handleDeleteLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostLabel() = ***%s***", tt.name, diff)
 				}
@@ -584,7 +584,7 @@ func TestService_handlePatchLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchLabel() = ***%s***", tt.name, diff)
 				}

--- a/http/notification_endpoint_test.go
+++ b/http/notification_endpoint_test.go
@@ -391,7 +391,7 @@ func TestService_handleGetNotificationEndpoint(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetNotificationEndpoint(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetNotificationEndpoint(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetNotificationEndpoint() = ***%s***", tt.name, diff)
 				}
@@ -501,7 +501,7 @@ func TestService_handlePostNotificationEndpoint(t *testing.T) {
 				ExpectBody(func(body *bytes.Buffer) {
 					if tt.wants.body != "" {
 						if eq, diff, err := jsonEqual(body.String(), tt.wants.body); err != nil {
-							t.Errorf("%q, handlePostNotificationEndpoint(). error unmarshaling json %v", tt.name, err)
+							t.Errorf("%q, handlePostNotificationEndpoint(). error unmarshalling json %v", tt.name, err)
 						} else if !eq {
 							t.Errorf("%q. handlePostNotificationEndpoint() = ***%s***", tt.name, diff)
 						}
@@ -586,7 +586,7 @@ func TestService_handleDeleteNotificationEndpoint(t *testing.T) {
 				ExpectBody(func(buf *bytes.Buffer) {
 					if tt.wants.body != "" {
 						if eq, diff, err := jsonEqual(buf.String(), tt.wants.body); err != nil {
-							t.Errorf("%q, handleDeleteNotificationEndpoint(). error unmarshaling json %v", tt.name, err)
+							t.Errorf("%q, handleDeleteNotificationEndpoint(). error unmarshalling json %v", tt.name, err)
 						} else if !eq {
 							t.Errorf("%q. handleDeleteNotificationEndpoint() = ***%s***", tt.name, diff)
 						}
@@ -740,7 +740,7 @@ func TestService_handlePatchNotificationEndpoint(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchNotificationEndpoint(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchNotificationEndpoint(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchNotificationEndpoint() = ***%s***", tt.name, diff)
 				}
@@ -859,7 +859,7 @@ func TestService_handleUpdateNotificationEndpoint(t *testing.T) {
 				ExpectBody(func(body *bytes.Buffer) {
 					if tt.wants.body != "" {
 						if eq, diff, err := jsonEqual(body.String(), tt.wants.body); err != nil {
-							t.Errorf("%q, handlePutNotificationEndpoint(). error unmarshaling json %v", tt.name, err)
+							t.Errorf("%q, handlePutNotificationEndpoint(). error unmarshalling json %v", tt.name, err)
 						} else if !eq {
 							t.Errorf("%q. handlePutNotificationEndpoint() = ***%s***", tt.name, diff)
 						}
@@ -959,7 +959,7 @@ func TestService_handlePostNotificationEndpointMember(t *testing.T) {
 				t.Errorf("%q. handlePostNotificationEndpointMember() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostNotificationEndpointMember(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostNotificationEndpointMember(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostNotificationEndpointMember() = ***%s***", tt.name, diff)
 			}
@@ -1053,7 +1053,7 @@ func TestService_handlePostNotificationEndpointOwner(t *testing.T) {
 				t.Errorf("%q. handlePostNotificationEndpointOwner() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handlePostNotificationEndpointOwner(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handlePostNotificationEndpointOwner(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handlePostNotificationEndpointOwner() = ***%s***", tt.name, diff)
 			}

--- a/http/org_service_test.go
+++ b/http/org_service_test.go
@@ -247,7 +247,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetSecrets(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetSecrets(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetSecrets() = ***%s***", tt.name, diff)
 				}
@@ -329,7 +329,7 @@ func TestSecretService_handlePatchSecrets(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchSecrets(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchSecrets(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchSecrets() = ***%s***", tt.name, diff)
 				}
@@ -415,7 +415,7 @@ func TestSecretService_handleDeleteSecrets(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteSecrets(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteSecrets(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteSecrets() = ***%s***", tt.name, diff)
 				}

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -238,7 +238,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetScraperTargets(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetScraperTargets(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetScraperTargets() = ***%s***", tt.name, diff)
 				}
@@ -377,7 +377,7 @@ func TestService_handleGetScraperTarget(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetScraperTarget(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetScraperTarget(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetScraperTarget() = ***%s***", tt.name, diff)
 				}
@@ -483,7 +483,7 @@ func TestService_handleDeleteScraperTarget(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteScraperTarget(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteScraperTarget(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteScraperTarget() = ***%s***", tt.name, diff)
 				}
@@ -611,7 +611,7 @@ func TestService_handlePostScraperTarget(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostScraperTarget(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostScraperTarget(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostScraperTarget() = ***%s***", tt.name, diff)
 				}
@@ -803,7 +803,7 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchScraperTarget(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchScraperTarget(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchScraperTarget() = ***%s***", tt.name, diff)
 				}

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -491,7 +491,7 @@ func (h *TaskHandler) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	h.log.Debug("Tasks retrived", zap.String("tasks", fmt.Sprint(tasks)))
+	h.log.Debug("Tasks retrieved", zap.String("tasks", fmt.Sprint(tasks)))
 	if err := encodeResponse(ctx, w, http.StatusOK, newTasksResponse(ctx, tasks, req.filter, h.LabelService)); err != nil {
 		logEncodingError(h.log, r, err)
 		return

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -409,7 +409,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(tt.wants.body, string(body)); err != nil {
-					t.Errorf("%q, handleGetTasks(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetTasks(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetTasks() = ***%s***", tt.name, diff)
 				}
@@ -575,7 +575,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(tt.wants.body, string(body)); err != nil {
-					t.Errorf("%q, handlePostTask(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostTask(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostTask() = ***%s***", tt.name, diff)
 				}
@@ -689,7 +689,7 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetRun(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetRun(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetRun() = ***%s***", tt.name, diff)
 				}
@@ -807,7 +807,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetRuns(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetRuns(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetRuns() = ***%s***", tt.name, diff)
 				}
@@ -1197,7 +1197,7 @@ func TestService_handlePostTaskLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePostTaskLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePostTaskLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePostTaskLabel() = ***%s***", tt.name, diff)
 				}

--- a/http/telegraf_test.go
+++ b/http/telegraf_test.go
@@ -185,7 +185,7 @@ func TestTelegrafHandler_handleGetTelegrafs(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetTelegrafs(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetTelegrafs(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetTelegrafs() = ***%s***", tt.name, diff)
 				}

--- a/http/user_resource_mapping_test.go
+++ b/http/user_resource_mapping_test.go
@@ -377,7 +377,7 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 					t.Errorf("%q. PostMembersHandler() = %v, want %v", tt.name, content, tt.wants.contentType)
 				}
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, PostMembersHandler(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, PostMembersHandler(). error unmarshalling json %v", tt.name, err)
 				} else if tt.wants.body != "" && !eq {
 					t.Errorf("%q. PostMembersHandler() = ***%s***", tt.name, diff)
 				}

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -624,7 +624,7 @@ func (s *PasswordService) ComparePassword(ctx context.Context, userID influxdb.I
 	panic("not implemented")
 }
 
-// CompareAndSetPassword compares the old and new password and submits the new password if possoble.
+// CompareAndSetPassword compares the old and new password and submits the new password if possible.
 // Note: is not implemented.
 func (s *PasswordService) CompareAndSetPassword(ctx context.Context, userID influxdb.ID, old string, new string) error {
 	panic("not implemented")

--- a/http/variable_test.go
+++ b/http/variable_test.go
@@ -326,7 +326,7 @@ func TestVariableService_handleGetVariables(t *testing.T) {
 				t.Errorf("%q. handleGetVariables() = %v, want %v", tt.name, contentType, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, handleGetDashboards(). error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, handleGetDashboards(). error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. handleGetDashboards() = ***%s***", tt.name, diff)
 			}
@@ -457,7 +457,7 @@ func TestVariableService_handleGetVariable(t *testing.T) {
 				t.Errorf("got = %v, want %v", contentType, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}
@@ -587,7 +587,7 @@ func TestVariableService_handlePostVariable(t *testing.T) {
 				t.Errorf("got = %v, want %v", contentType, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}
@@ -690,7 +690,7 @@ func TestVariableService_handlePutVariable(t *testing.T) {
 				t.Errorf("got = %v, want %v", contentType, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}
@@ -799,7 +799,7 @@ func TestVariableService_handlePatchVariable(t *testing.T) {
 				t.Errorf("got = %v, want %v", contentType, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}
@@ -983,7 +983,7 @@ func TestService_handlePostVariableLabel(t *testing.T) {
 				t.Errorf("got %v, want %v", content, tt.wants.contentType)
 			}
 			if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-				t.Errorf("%q, error unmarshaling json %v", tt.name, err)
+				t.Errorf("%q, error unmarshalling json %v", tt.name, err)
 			} else if tt.wants.body != "" && !eq {
 				t.Errorf("%q. ***%s***", tt.name, diff)
 			}

--- a/influxql/query/point.go
+++ b/influxql/query/point.go
@@ -29,7 +29,7 @@ type Point interface {
 	// The value at the given time.
 	value() interface{}
 
-	// Auxillary values passed along with the value.
+	// Auxiliary values passed along with the value.
 	aux() []interface{}
 }
 
@@ -64,7 +64,7 @@ func (a Points) Clone() []Point {
 }
 
 // Tags represent a map of keys and values.
-// It memoizes its key so it can be used efficiently during query execution.
+// It memorizes its key so it can be used efficiently during query execution.
 type Tags struct {
 	id string
 	m  map[string]string

--- a/influxql/query/select.go
+++ b/influxql/query/select.go
@@ -827,7 +827,7 @@ func buildAuxIterator(ctx context.Context, ic IteratorCreator, sources influxql.
 		return nil, err
 	}
 
-	// Merge iterators to read auxilary fields.
+	// Merge iterators to read auxiliary fields.
 	input, err := Iterators(inputs).Merge(opt)
 	if err != nil {
 		Iterators(inputs).Close()

--- a/inmem/source.go
+++ b/inmem/source.go
@@ -86,7 +86,7 @@ func (s *Service) FindSourceByID(ctx context.Context, id platform.ID) (*platform
 	return src, nil
 }
 
-// FindSources retrives all sources that match an arbitrary source filter.
+// FindSources retrieves all sources that match an arbitrary source filter.
 // Filters using ID, or OrganizationID and source Name should be efficient.
 // Other filters will do a linear scan across all sources searching for a match.
 func (s *Service) FindSources(ctx context.Context, opt platform.FindOptions) ([]*platform.Source, int, error) {

--- a/kit/metric/metrics_options.go
+++ b/kit/metric/metrics_options.go
@@ -8,7 +8,7 @@ import (
 )
 
 type (
-	// CollectFnOpts provides arugments to the collect operation of a metric.
+	// CollectFnOpts provides arguments to the collect operation of a metric.
 	CollectFnOpts struct {
 		Method          string
 		Start           time.Time

--- a/kit/transport/http/api.go
+++ b/kit/transport/http/api.go
@@ -68,7 +68,7 @@ func WithEncodeGZIP() APIOptFn {
 	}
 }
 
-// WithUnmarshalErrFn sets the error handler for errors that occur when unmarshaling
+// WithUnmarshalErrFn sets the error handler for errors that occur when unmarshalling
 // the request body.
 func WithUnmarshalErrFn(fn func(encoding string, err error) error) APIOptFn {
 	return func(api *API) {
@@ -232,7 +232,7 @@ func (a *API) Err(w http.ResponseWriter, r *http.Request, err error) {
 		a.logErr("failed to write err to response writer", zap.Error(err))
 		a.Respond(w, r, http.StatusInternalServerError, ErrBody{
 			Code: "internal error",
-			Msg:  "an unexpected error occured",
+			Msg:  "an unexpected error occurred",
 		})
 		return
 	}

--- a/kit/transport/http/api_test.go
+++ b/kit/transport/http/api_test.go
@@ -85,7 +85,7 @@ func Test_API(t *testing.T) {
 			}
 		})
 
-		t.Run("unmarshal err fn wraps unmarshaling error", func(t *testing.T) {
+		t.Run("unmarshal err fn wraps unmarshalling error", func(t *testing.T) {
 			t.Run("json", func(t *testing.T) {
 				invalidBody := []byte("[}-{]")
 
@@ -290,7 +290,7 @@ func (v *validatFoo) OK() error {
 		errs = append(errs, "foo must be at least 1 char")
 	}
 	if v.Bar < 0 {
-		errs = append(errs, "bar must be a postive real number")
+		errs = append(errs, "bar must be a positive real number")
 	}
 	return errs.toError()
 }

--- a/kit/transport/http/feature_controller.go
+++ b/kit/transport/http/feature_controller.go
@@ -12,7 +12,7 @@ type Enabler interface {
 	Enabled(ctx context.Context, flagger ...feature.Flagger) bool
 }
 
-// FeatureHandler is used to switch requests between an exisiting and a feature flagged
+// FeatureHandler is used to switch requests between an existing and a feature flagged
 // HTTP Handler on a per-request basis
 type FeatureHandler struct {
 	enabler    Enabler

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -207,7 +207,7 @@ func filterAuthorizationsFn(filter influxdb.AuthorizationFilter) func(a *influxd
 	return func(a *influxdb.Authorization) bool { return true }
 }
 
-// FindAuthorizations retrives all authorizations that match an arbitrary authorization filter.
+// FindAuthorizations retrieves all authorizations that match an arbitrary authorization filter.
 // Filters using ID, or Token should be efficient.
 // Other filters will do a linear scan across all authorizations searching for a match.
 func (s *Service) FindAuthorizations(ctx context.Context, filter influxdb.AuthorizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Authorization, int, error) {

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -198,7 +198,7 @@ func (s *Service) findBucketByName(ctx context.Context, tx Tx, orgID influxdb.ID
 	return s.findBucketByID(ctx, tx, id)
 }
 
-// FindBucket retrives a bucket using an arbitrary bucket filter.
+// FindBucket retrieves a bucket using an arbitrary bucket filter.
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across buckets until it finds a match.
 func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
@@ -285,7 +285,7 @@ func filterBucketsFn(filter influxdb.BucketFilter) func(b *influxdb.Bucket) bool
 	return func(b *influxdb.Bucket) bool { return true }
 }
 
-// FindBuckets retrives all buckets that match an arbitrary bucket filter.
+// FindBuckets retrieves all buckets that match an arbitrary bucket filter.
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across all buckets searching for a match.
 func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {

--- a/kv/index.go
+++ b/kv/index.go
@@ -240,7 +240,7 @@ type IndexDiff struct {
 	// MissingFromIndex is a map of foreign key to associated primary keys
 	// missing from the index given the source bucket.
 	// These items could be due to the fact an index populate migration has
-	// not yet occured, the index populate code is incorrect or the write path
+	// not yet occurred, the index populate code is incorrect or the write path
 	// for your resource type does not yet insert into the index as well (Create actions).
 	MissingFromIndex map[string]map[string]struct{}
 	// MissingFromSource is a map of foreign key to associated primary keys

--- a/kv/org.go
+++ b/kv/org.go
@@ -145,7 +145,7 @@ func (s *Service) findOrganizationByName(ctx context.Context, tx Tx, n string) (
 	return s.findOrganizationByID(ctx, tx, id)
 }
 
-// FindOrganization retrives a organization using an arbitrary organization filter.
+// FindOrganization retrieves a organization using an arbitrary organization filter.
 // Filters using ID, or Name should be efficient.
 // Other filters will do a linear scan across organizations until it finds a match.
 func (s *Service) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
@@ -196,7 +196,7 @@ func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.
 	return func(o *influxdb.Organization) bool { return true }
 }
 
-// FindOrganizations retrives all organizations that match an arbitrary organization filter.
+// FindOrganizations retrieves all organizations that match an arbitrary organization filter.
 // Filters using ID, or Name should be efficient.
 // Other filters will do a linear scan across all organizations searching for a match.
 func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {

--- a/kv/source.go
+++ b/kv/source.go
@@ -123,7 +123,7 @@ func (s *Service) findSourceByID(ctx context.Context, tx Tx, id influxdb.ID) (*i
 	return &sr, nil
 }
 
-// FindSources retrives all sources that match an arbitrary source filter.
+// FindSources retrieves all sources that match an arbitrary source filter.
 // Filters using ID, or OrganizationID and source Name should be efficient.
 // Other filters will do a linear scan across all sources searching for a match.
 func (s *Service) FindSources(ctx context.Context, opt influxdb.FindOptions) ([]*influxdb.Source, int, error) {

--- a/kv/user.go
+++ b/kv/user.go
@@ -136,7 +136,7 @@ func (s *Service) findUserByName(ctx context.Context, tx Tx, n string) (*influxd
 	return s.findUserByID(ctx, tx, id)
 }
 
-// FindUser retrives a user using an arbitrary user filter.
+// FindUser retrieves a user using an arbitrary user filter.
 // Filters using ID, or Name should be efficient.
 // Other filters will do a linear scan across users until it finds a match.
 func (s *Service) FindUser(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
@@ -171,7 +171,7 @@ func filterUsersFn(filter influxdb.UserFilter) func(u *influxdb.User) bool {
 	return func(u *influxdb.User) bool { return true }
 }
 
-// FindUsers retrives all users that match an arbitrary user filter.
+// FindUsers retrieves all users that match an arbitrary user filter.
 // Filters using ID, or Name should be efficient.
 // Other filters will do a linear scan across all users searching for a match.
 func (s *Service) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {

--- a/label/http_client.go
+++ b/label/http_client.go
@@ -111,7 +111,7 @@ func (s *LabelClientService) DeleteLabel(ctx context.Context, id influxdb.ID) er
 
 // ******* Label Mappings ******* //
 
-// CreateLabelMapping will create a labbel mapping
+// CreateLabelMapping will create a label mapping
 func (s *LabelClientService) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
 	if err := m.Validate(); err != nil {
 		return err

--- a/label/http_server.go
+++ b/label/http_server.go
@@ -145,7 +145,7 @@ func (h *LabelHandler) handleGetLabels(w http.ResponseWriter, r *http.Request) {
 		h.api.Err(w, r, err)
 		return
 	}
-	h.log.Debug("Labels retrived", zap.String("labels", fmt.Sprint(labels)))
+	h.log.Debug("Labels retrieved", zap.String("labels", fmt.Sprint(labels)))
 
 	h.api.Respond(w, r, http.StatusOK, newLabelsResponse(labels))
 }

--- a/label/http_server_test.go
+++ b/label/http_server_test.go
@@ -215,7 +215,7 @@ func TestService_handleGetLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleGetLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleGetLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleGetLabel() = ***%s***", tt.name, diff)
 				}
@@ -478,7 +478,7 @@ func TestService_handlePatchLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handlePatchLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handlePatchLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handlePatchLabel() = ***%s***", tt.name, diff)
 				}
@@ -574,7 +574,7 @@ func TestService_handleDeleteLabel(t *testing.T) {
 			}
 			if tt.wants.body != "" {
 				if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil {
-					t.Errorf("%q, handleDeleteLabel(). error unmarshaling json %v", tt.name, err)
+					t.Errorf("%q, handleDeleteLabel(). error unmarshalling json %v", tt.name, err)
 				} else if !eq {
 					t.Errorf("%q. handleDeleteLabel() = ***%s***", tt.name, diff)
 				}

--- a/mock/dashboard_service.go
+++ b/mock/dashboard_service.go
@@ -28,9 +28,9 @@ type DashboardService struct {
 	GetDashboardCellViewCalls    SafeCount
 	UpdateDashboardCellViewF     func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error)
 	UpdateDashboardCellViewCalls SafeCount
-	UpdateDashboardCellF         func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error)
+	UpdateDashboardCellF         func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error)
 	UpdateDashboardCellCalls     SafeCount
-	CopyDashboardCellF           func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID) (*platform.Cell, error)
+	CopyDashboardCellF           func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) (*platform.Cell, error)
 	CopyDashboardCellCalls       SafeCount
 	ReplaceDashboardCellsF       func(ctx context.Context, id platform.ID, cs []*platform.Cell) error
 	ReplaceDashboardCellsCalls   SafeCount
@@ -59,10 +59,10 @@ func NewDashboardService() *DashboardService {
 		UpdateDashboardCellViewF: func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.ViewUpdate) (*platform.View, error) {
 			return nil, nil
 		},
-		UpdateDashboardCellF: func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
+		UpdateDashboardCellF: func(ctx context.Context, dashboardID platform.ID, cellID platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
 			return nil, nil
 		},
-		CopyDashboardCellF: func(ctx context.Context, dashbaordID platform.ID, cellID platform.ID) (*platform.Cell, error) {
+		CopyDashboardCellF: func(ctx context.Context, dashboardID platform.ID, cellID platform.ID) (*platform.Cell, error) {
 			return nil, nil
 		},
 		ReplaceDashboardCellsF: func(ctx context.Context, id platform.ID, cs []*platform.Cell) error { return nil },

--- a/mock/nats.go
+++ b/mock/nats.go
@@ -34,11 +34,11 @@ func NewNats() (nats.Publisher, nats.Subscriber) {
 		server: server,
 	}
 
-	subcriber := &NatsSubscriber{
+	subscriber := &NatsSubscriber{
 		server: server,
 	}
 
-	return publisher, subcriber
+	return publisher, subscriber
 }
 
 // NatsPublisher is a mocked nats publisher.
@@ -58,7 +58,7 @@ type NatsSubscriber struct {
 	server *NatsServer
 }
 
-// Subscribe implements nats.Subscriber inteferface.
+// Subscribe implements nats.Subscriber interface.
 func (s *NatsSubscriber) Subscribe(subject, group string, handler nats.Handler) error {
 	ch, err := s.server.initSubject(subject)
 	if err != nil {

--- a/mock/session_service.go
+++ b/mock/session_service.go
@@ -35,12 +35,12 @@ func (s *SessionService) FindSession(ctx context.Context, key string) (*platform
 	return s.FindSessionFn(ctx, key)
 }
 
-// CreateSession creates a sesion for a user with the users maximal privileges.
+// CreateSession creates a session for a user with the users maximal privileges.
 func (s *SessionService) CreateSession(ctx context.Context, user string) (*platform.Session, error) {
 	return s.CreateSessionFn(ctx, user)
 }
 
-// ExpireSession exires the session provided at key.
+// ExpireSession expires the session provided at key.
 func (s *SessionService) ExpireSession(ctx context.Context, key string) error {
 	return s.ExpireSessionFn(ctx, key)
 }

--- a/notification/check/check_test.go
+++ b/notification/check/check_test.go
@@ -141,7 +141,7 @@ func TestValidCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "bad thredshold",
+			name: "bad threshold",
 			src: &check.Threshold{
 				Base: goodBase,
 				Thresholds: []check.ThresholdConfig{

--- a/notification/check/custom_test.go
+++ b/notification/check/custom_test.go
@@ -178,10 +178,10 @@ data
 					t.Errorf("expected:\n%v\n\ngot:\n%v\n", exp, got)
 				}
 			} else if (exp == nil || got == nil) && got != exp {
-				//either exp or got are nill
+				//either exp or got are nil
 				t.Errorf("expected:\n%v\n\ngot:\n%v\n", exp, got)
 			} else {
-				// neither errs are nill check that scripts match
+				// neither errs are nil check that scripts match
 				if exp, got := tt.wants.script, tt.args.custom.Query.Text; exp != got {
 					t.Errorf("\n\nStrings do not match:\n\n%s", diff.LineDiff(exp, got))
 				}

--- a/notification/check/threshold.go
+++ b/notification/check/threshold.go
@@ -244,21 +244,21 @@ func getFields(pkg *ast.Package) []string {
 
 func assignPipelineToData(f *ast.File) error {
 	if len(f.Body) != 1 {
-		return fmt.Errorf("expected there to be a single statement in the flux script body, recieved %d", len(f.Body))
+		return fmt.Errorf("expected there to be a single statement in the flux script body, received %d", len(f.Body))
 	}
 
 	stmt := f.Body[0]
 
 	e, ok := stmt.(*ast.ExpressionStatement)
 	if !ok {
-		return fmt.Errorf("statement is not an *ast.Expression statement, recieved %T", stmt)
+		return fmt.Errorf("statement is not an *ast.Expression statement, received %T", stmt)
 	}
 
 	exp := e.Expression
 
 	pipe, ok := exp.(*ast.PipeExpression)
 	if !ok {
-		return fmt.Errorf("expression is not an *ast.PipeExpression statement, recieved %T", exp)
+		return fmt.Errorf("expression is not an *ast.PipeExpression statement, received %T", exp)
 	}
 
 	if id, ok := pipe.Call.Callee.(*ast.Identifier); ok && id.Name == "yield" {

--- a/notification/endpoint/service/service_test.go
+++ b/notification/endpoint/service/service_test.go
@@ -54,9 +54,9 @@ func newSecretService(t *testing.T, ctx context.Context, logger *zap.Logger, s k
 	return kv.NewService(logger, s)
 }
 
-// TestEndpointService_cummulativeSecrets tests that secrets are cummulatively added/updated and removed upon delete
+// TestEndpointService_cumulativeSecrets tests that secrets are cumulatively added/updated and removed upon delete
 // see https://github.com/influxdata/influxdb/pull/19082 for details
-func TestEndpointService_cummulativeSecrets(t *testing.T) {
+func TestEndpointService_cumulativeSecrets(t *testing.T) {
 	ctx := context.Background()
 	store := inmem.NewKVStore()
 	logger := zaptest.NewLogger(t)

--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -122,7 +122,7 @@ func Call(fn ast.Expression, args *ast.ObjectExpression) *ast.CallExpression {
 	}
 }
 
-// ExpressionStatement returns an *ast.ExpressionStagement of e.
+// ExpressionStatement returns an *ast.ExpressionStatement of e.
 func ExpressionStatement(e ast.Expression) *ast.ExpressionStatement {
 	return &ast.ExpressionStatement{Expression: e}
 }

--- a/notification/status.go
+++ b/notification/status.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// StatusRule includes parametes of status rules.
+// StatusRule includes parameters of status rules.
 type StatusRule struct {
 	CurrentLevel  CheckLevel  `json:"currentLevel"`
 	PreviousLevel *CheckLevel `json:"previousLevel"`

--- a/pkg/csv2lp/csv_annotations.go
+++ b/pkg/csv2lp/csv_annotations.go
@@ -117,7 +117,7 @@ func concatSetupTable(table *CsvTable, row []string) error {
 			if placeholderColumn := table.Column(columnLabel); placeholderColumn == nil {
 				return CsvColumnError{
 					Column: col.Label,
-					Err: fmt.Errorf("'%s' references an uknown column '%s', available columns are: %v",
+					Err: fmt.Errorf("'%s' references an unknown column '%s', available columns are: %v",
 						template, columnLabel, strings.Join(table.ColumnLabels(), ",")),
 				}
 			}

--- a/pkg/csv2lp/csv_annotations_test.go
+++ b/pkg/csv2lp/csv_annotations_test.go
@@ -216,7 +216,7 @@ func Test_ConcatAnnotation(t *testing.T) {
 		require.Equal(t, 1, len(table.validators))
 		require.NotNil(t, table.validators[0](table))
 		require.Equal(t,
-			"column 'fN': 'a${y}-${x}z' references an uknown column 'y', available columns are: x",
+			"column 'fN': 'a${y}-${x}z' references an unknown column 'y', available columns are: x",
 			table.validators[0](table).Error())
 		// columns
 		require.Equal(t, 1, len(table.extraColumns))

--- a/pkg/csv2lp/csv_table.go
+++ b/pkg/csv2lp/csv_table.go
@@ -252,7 +252,7 @@ func (t *CsvTable) AddRow(row []string) bool {
 			// expect a header row
 			t.lpColumnsValid = false // line protocol columns change
 			if t.partBits == 0 {
-				// create columns since no column anotations were processed
+				// create columns since no column annotations were processed
 				t.columns = createColumns(len(row))
 			}
 			// assign column labels for the header row

--- a/pkg/csv2lp/data_conversion.go
+++ b/pkg/csv2lp/data_conversion.go
@@ -84,14 +84,14 @@ func escapeString(val string) string {
 }
 
 // normalizeNumberString normalizes the supplied value according to the supplied format.
-// This normalization is intended to convert number strings of different locales to a strconv-parseable value.
+// This normalization is intended to convert number strings of different locales to a strconv-parsable value.
 //
 // The format's first character is a fraction delimiter character.  Next characters in the format
 // are simply removed, they are typically used to visually separate groups in large numbers.
 // The removeFraction parameter controls whether the returned value can contain also the fraction part.
 // An empty format means ". \n\t\r_"
 //
-// For example, to get a strconv-parseable float from a Spanish value '3.494.826.157,123', use format ",." .
+// For example, to get a strconv-parsable float from a Spanish value '3.494.826.157,123', use format ",." .
 func normalizeNumberString(value string, format string, removeFraction bool) (normalized string, truncated bool) {
 	if len(format) == 0 {
 		format = ". \n\t\r_"

--- a/pkg/httpc/req.go
+++ b/pkg/httpc/req.go
@@ -207,7 +207,7 @@ func StatusIn(code int, rest ...int) func(*http.Response) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("recieved unexpected status: %s %d", resp.Status, resp.StatusCode)
+		return fmt.Errorf("received unexpected status: %s %d", resp.Status, resp.StatusCode)
 	}
 }
 

--- a/pkg/tracing/wire/binary.pb.go
+++ b/pkg/tracing/wire/binary.pb.go
@@ -1242,7 +1242,7 @@ func skipBinary(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthBinary = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrInvalidLengthBinary = fmt.Errorf("proto: negative length found during unmarshalling")
 	ErrIntOverflowBinary   = fmt.Errorf("proto: integer overflow")
 )
 

--- a/pkger/README.md
+++ b/pkger/README.md
@@ -602,7 +602,7 @@ If a user has put a lot of effort in creating dashboards, notifications, and tel
 
 Resources can be exported all at once, via the export by organization, by specific resource IDs, a combination of the above, and advanced filtering (i.e. by label name or resource type). You can read up more on the export options [here](https://github.com/influxdata/influxdb/blob/c926accb42d87c407bcac6bbda753f9a03f9ec95/pkger/service.go#L280-L330). 
 
-Each resouce that is exported is assigned a uniq `metadata.name` entry. The names are generated and are not strictly required to remain in that shape. If a user decides to use `metadata.name` as the name of the resource, they are free to do so. The only requirement is that within a package every resource type has a unique `metadata.name` per its type. For example each resource kind `metadata.name` field should have be unique amongst all resources of the same kind within a package. 
+Each resource that is exported is assigned a uniq `metadata.name` entry. The names are generated and are not strictly required to remain in that shape. If a user decides to use `metadata.name` as the name of the resource, they are free to do so. The only requirement is that within a package every resource type has a unique `metadata.name` per its type. For example each resource kind `metadata.name` field should have be unique amongst all resources of the same kind within a package. 
 
 > Each label should have a unique `metadata.name` field amongst all labels in the package.
 

--- a/pkger/http_server_stack.go
+++ b/pkger/http_server_stack.go
@@ -62,7 +62,7 @@ type (
 		CreatedAt time.Time        `json:"createdAt"`
 		Events    []RespStackEvent `json:"events"`
 
-		// maintain same interface for backward compatability
+		// maintain same interface for backward compatibility
 		RespStackEvent
 	}
 

--- a/pkger/parser_models.go
+++ b/pkger/parser_models.go
@@ -2205,8 +2205,8 @@ func (v *variable) summarize() SummaryVariable {
 
 func (v *variable) influxVarArgs() *influxdb.VariableArguments {
 	// this zero value check is for situations where we want to marshal/unmarshal
-	// a variable and not have the invalid args blow up during unmarshaling. When
-	// that validation is decoupled from the unmarshaling, we can clean this up.
+	// a variable and not have the invalid args blow up during unmarshalling. When
+	// that validation is decoupled from the unmarshalling, we can clean this up.
 	if v.Type == "" {
 		return nil
 	}

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -4740,7 +4740,7 @@ func testTemplateErrors(t *testing.T, k Kind, tt testTemplateResourceError) {
 
 		defer func() {
 			if t.Failed() {
-				t.Logf("recieved unexpected err: %s", pErr)
+				t.Logf("received unexpected err: %s", pErr)
 			}
 		}()
 

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -68,7 +68,7 @@ type (
 		Resources    []StackResource
 	}
 
-	// StackResource is a record for an individual resource side effect genereated from
+	// StackResource is a record for an individual resource side effect generated from
 	// applying a template.
 	StackResource struct {
 		APIVersion   string

--- a/query/README.md
+++ b/query/README.md
@@ -186,7 +186,7 @@ from(bucket: "telegraf/autogen") |> range(start: -5m)
     |> map(fn: (r) => {_value: r._value / 100})
 ```
 
-The function passed into map must return an object. An object is a key/value structure. By default, the `map` function will merge any columns within the grouping key into the new row so you do not have to specify all of the existing columns that you do not want to modify. If you do not want to automtaically merge those columns, you can use `mergeKey: false` as a parameter to `map`.
+The function passed into map must return an object. An object is a key/value structure. By default, the `map` function will merge any columns within the grouping key into the new row so you do not have to specify all of the existing columns that you do not want to modify. If you do not want to automatically merge those columns, you can use `mergeKey: false` as a parameter to `map`.
 
 **Note:** Math support is limited right now and the filter is required because the query engine will throw an error if the value is of different types with different series. So you must filter the results so only fields with a single type are selected at the moment.
 

--- a/query/influxql/dialect.go
+++ b/query/influxql/dialect.go
@@ -82,7 +82,7 @@ type EncodingFormat int
 const (
 	// JSON marshals the response to JSON octets.
 	JSON EncodingFormat = iota
-	// JSONPretty marshals the response to JSON octets with idents.
+	// JSONPretty marshals the response to JSON octets with indents.
 	JSONPretty
 	// CSV marshals the response to CSV.
 	CSV

--- a/query/query.go
+++ b/query/query.go
@@ -134,7 +134,7 @@ type FloatPoint struct {
 }
 
 // Tags represent a map of keys and values.
-// It memoizes its key so it can be used efficiently during query execution.
+// It memorizes its key so it can be used efficiently during query execution.
 type Tags struct{}
 
 // Iterator represents a generic interface for all Iterators.

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -164,7 +164,7 @@ option testing.loadStorage = (csv) => {
 `
 
 // This options definition is for the second run, the test run. It loads the
-// data from previously written bucket. We check the results after runnig this
+// data from previously written bucket. We check the results after running this
 // second pass and report on them.
 var readOptSource = `
 import "testing"

--- a/secret/service.go
+++ b/secret/service.go
@@ -11,7 +11,7 @@ type Service struct {
 	s *Storage
 }
 
-// NewService creates a new service implementaiton for secrets
+// NewService creates a new service implementation for secrets
 func NewService(s *Storage) *Service {
 	return &Service{s}
 }

--- a/session.go
+++ b/session.go
@@ -28,8 +28,8 @@ var (
 	OpRenewSession = "RenewSession"
 )
 
-// SessionAuthorizionKind defines the type of authorizer
-const SessionAuthorizionKind = "session"
+// SessionAuthorizationKind defines the type of authorizer
+const SessionAuthorizationKind = "session"
 
 // Session is a user session.
 type Session struct {
@@ -67,7 +67,7 @@ func (s *Session) PermissionSet() (PermissionSet, error) {
 }
 
 // Kind returns session and is used for auditing.
-func (s *Session) Kind() string { return SessionAuthorizionKind }
+func (s *Session) Kind() string { return SessionAuthorizationKind }
 
 // Identifier returns the sessions ID and is used for auditing.
 func (s *Session) Identifier() ID { return s.ID }

--- a/session/errors.go
+++ b/session/errors.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// ErrUnauthorized when a session request is unauthorized
-	// usually due to password missmatch
+	// usually due to password mismatch
 	ErrUnauthorized = &influxdb.Error{
 		Code: influxdb.EUnauthorized,
 		Msg:  "unauthorized access",

--- a/session/http_server.go
+++ b/session/http_server.go
@@ -49,7 +49,7 @@ type resourceHandler struct {
 // Prefix is necessary to mount the router as a resource handler
 func (r resourceHandler) Prefix() string { return r.prefix }
 
-// SignInResourceHandler allows us to return 2 different rousource handler
+// SignInResourceHandler allows us to return 2 different resource handler
 // for the appropriate mounting location
 func (h SessionHandler) SignInResourceHandler() *resourceHandler {
 	h.Router = chi.NewRouter()
@@ -62,7 +62,7 @@ func (h SessionHandler) SignInResourceHandler() *resourceHandler {
 	return &resourceHandler{prefix: prefixSignIn, SessionHandler: &h}
 }
 
-// SignOutResourceHandler allows us to return 2 different rousource handler
+// SignOutResourceHandler allows us to return 2 different resource handler
 // for the appropriate mounting location
 func (h SessionHandler) SignOutResourceHandler() *resourceHandler {
 	h.Router = chi.NewRouter()

--- a/storage/reads/datatypes/predicate.pb.go
+++ b/storage/reads/datatypes/predicate.pb.go
@@ -1331,7 +1331,7 @@ func skipPredicate(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthPredicate        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrInvalidLengthPredicate        = fmt.Errorf("proto: negative length found during unmarshalling")
 	ErrIntOverflowPredicate          = fmt.Errorf("proto: integer overflow")
 	ErrUnexpectedEndOfGroupPredicate = fmt.Errorf("proto: unexpected end of group")
 )

--- a/storage/reads/datatypes/storage_common.pb.go
+++ b/storage/reads/datatypes/storage_common.pb.go
@@ -8154,7 +8154,7 @@ func skipStorageCommon(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthStorageCommon        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrInvalidLengthStorageCommon        = fmt.Errorf("proto: negative length found during unmarshalling")
 	ErrIntOverflowStorageCommon          = fmt.Errorf("proto: integer overflow")
 	ErrUnexpectedEndOfGroupStorageCommon = fmt.Errorf("proto: unexpected end of group")
 )

--- a/task/backend/check_task_error.go
+++ b/task/backend/check_task_error.go
@@ -17,7 +17,7 @@ func IsUnrecoverable(err error) bool {
 		return true
 	}
 
-	// unparseable Flux requires user intervention to resolve
+	// unparsable Flux requires user intervention to resolve
 	if strings.Contains(errString, "could not parse Flux script") {
 		return true
 	}

--- a/task/backend/coordinator_test.go
+++ b/task/backend/coordinator_test.go
@@ -35,7 +35,7 @@ func Test_NotifyCoordinatorOfCreated(t *testing.T) {
 	var (
 		coordinator = &coordinator{}
 		tasks       = &taskService{
-			// paginated reponses
+			// paginated responses
 			pageOne: []*influxdb.Task{taskOne},
 			otherPages: map[influxdb.ID][]*influxdb.Task{
 				one:   []*influxdb.Task{taskTwo, taskThree},

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -599,7 +599,7 @@ func (p *promise) Cancel(ctx context.Context) {
 	}
 }
 
-// Done provides a channel that closes on completion of a rpomise
+// Done provides a channel that closes on completion of a promise
 func (p *promise) Done() <-chan struct{} {
 	return p.done
 }
@@ -620,7 +620,7 @@ func exhaustResultIterators(res flux.Result) error {
 	})
 }
 
-// NewASTCompiler parses a Flux query string into an AST representatation.
+// NewASTCompiler parses a Flux query string into an AST representation.
 func NewASTCompiler(ctx context.Context, query string, ts CompilerBuilderTimestamps) (flux.Compiler, error) {
 	pkg, err := runtime.ParseToJSON(query)
 	if err != nil {

--- a/task/backend/executor/executor_test.go
+++ b/task/backend/executor/executor_test.go
@@ -578,7 +578,7 @@ func TestPromiseFailure(t *testing.T) {
 	}
 
 	if promise != nil {
-		t.Fatalf("expected no promise but recieved one: %+v", promise)
+		t.Fatalf("expected no promise but received one: %+v", promise)
 	}
 
 	runs, _, err := tes.i.FindRuns(context.Background(), influxdb.RunFilter{Task: task.ID})

--- a/task/backend/middleware/middleware.go
+++ b/task/backend/middleware/middleware.go
@@ -87,7 +87,7 @@ func (s *CoordinatingTaskService) DeleteTask(ctx context.Context, id influxdb.ID
 	return s.TaskService.DeleteTask(ctx, id)
 }
 
-// CancelRun Cancel the run and publish the cancelation.
+// CancelRun Cancel the run and publish the cancellation.
 func (s *CoordinatingTaskService) CancelRun(ctx context.Context, taskID, runID influxdb.ID) error {
 	if err := s.TaskService.CancelRun(ctx, taskID, runID); err != nil {
 		return err

--- a/task/backend/scheduler/treescheduler.go
+++ b/task/backend/scheduler/treescheduler.go
@@ -100,7 +100,7 @@ func WithMaxConcurrentWorkers(n int) treeSchedulerOptFunc {
 	}
 }
 
-// WithTime is an optiom for NewScheduler that allows you to inject a clock.Clock from ben johnson's github.com/benbjohnson/clock library, for testing purposes.
+// WithTime is an option for NewScheduler that allows you to inject a clock.Clock from ben johnson's github.com/benbjohnson/clock library, for testing purposes.
 func WithTime(t clock.Clock) treeSchedulerOptFunc {
 	return func(sch *TreeScheduler) error {
 		sch.time = t
@@ -209,7 +209,7 @@ func (s *TreeScheduler) Stop() {
 	s.wg.Wait()
 }
 
-// itemList is a list of items for deleting and inserting.  We have to do them seperately instead of just a re-add,
+// itemList is a list of items for deleting and inserting.  We have to do them separately instead of just a re-add,
 // because usually the items key must be changed between the delete and insert
 type itemList struct {
 	toInsert []Item

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -571,7 +571,7 @@ func (o *Options) EffectiveCronString() string {
 	if o.Cron != "" {
 		return o.Cron
 	}
-	every, _ := o.Every.DurationFrom(time.Now()) // we can ignore errors here because we have alreach checked for validity.
+	every, _ := o.Every.DurationFrom(time.Now()) // we can ignore errors here because we have already checked for validity.
 	if every > 0 {
 		return "@every " + o.Every.String()
 	}

--- a/task/options/options_test.go
+++ b/task/options/options_test.go
@@ -321,7 +321,7 @@ func TestEffectiveCronString(t *testing.T) {
 }
 
 func TestDurationMarshaling(t *testing.T) {
-	t.Run("unmarshaling", func(t *testing.T) {
+	t.Run("unmarshalling", func(t *testing.T) {
 		now := time.Now().UTC() /* to guarantee 24 hour days*/
 		dur1 := options.Duration{}
 		if err := dur1.UnmarshalText([]byte("1d1h10m3s")); err != nil {

--- a/telegraf/plugins/outputs/file.go
+++ b/telegraf/plugins/outputs/file.go
@@ -13,7 +13,7 @@ type File struct {
 	Files []FileConfig `json:"files"`
 }
 
-// FileConfig is the config settings of outpu file plugin.
+// FileConfig is the config settings of output file plugin.
 type FileConfig struct {
 	Typ  string `json:"type"`
 	Path string `json:"path"`

--- a/telegraf/plugins/plugins.go
+++ b/telegraf/plugins/plugins.go
@@ -841,8 +841,8 @@ var availableInputs = `{
     {
       "type": "input",
       "name": "puppetagent",
-      "description": "Reads last_run_summary.yaml file and converts to measurments",
-      "config": "# Reads last_run_summary.yaml file and converts to measurments\n[[inputs.puppetagent]]\n  # alias=\"puppetagent\"\n  ## Location of puppet last run summary file\n  location = \"/var/lib/puppet/state/last_run_summary.yaml\"\n\n"
+      "description": "Reads last_run_summary.yaml file and converts to measurements",
+      "config": "# Reads last_run_summary.yaml file and converts to measurements\n[[inputs.puppetagent]]\n  # alias=\"puppetagent\"\n  ## Location of puppet last run summary file\n  location = \"/var/lib/puppet/state/last_run_summary.yaml\"\n\n"
     },
     {
       "type": "input",
@@ -1177,8 +1177,8 @@ var availableInputs = `{
     {
       "type": "input",
       "name": "marklogic",
-      "description": "Retrives information on a specific host in a MarkLogic Cluster",
-      "config": "# Retrives information on a specific host in a MarkLogic Cluster\n[[inputs.marklogic]]\n  # alias=\"marklogic\"\n  ## Base URL of the MarkLogic HTTP Server.\n  url = \"http://localhost:8002\"\n\n  ## List of specific hostnames to retrieve information. At least (1) required.\n  # hosts = [\"hostname1\", \"hostname2\"]\n\n  ## Using HTTP Basic Authentication. Management API requires 'manage-user' role privileges\n  # username = \"myuser\"\n  # password = \"mypassword\"\n\n  ## Optional TLS Config\n  # tls_ca = \"/etc/telegraf/ca.pem\"\n  # tls_cert = \"/etc/telegraf/cert.pem\"\n  # tls_key = \"/etc/telegraf/key.pem\"\n  ## Use TLS but skip chain \u0026 host verification\n  # insecure_skip_verify = false\n\n"
+      "description": "Retrieves information on a specific host in a MarkLogic Cluster",
+      "config": "# Retrieves information on a specific host in a MarkLogic Cluster\n[[inputs.marklogic]]\n  # alias=\"marklogic\"\n  ## Base URL of the MarkLogic HTTP Server.\n  url = \"http://localhost:8002\"\n\n  ## List of specific hostnames to retrieve information. At least (1) required.\n  # hosts = [\"hostname1\", \"hostname2\"]\n\n  ## Using HTTP Basic Authentication. Management API requires 'manage-user' role privileges\n  # username = \"myuser\"\n  # password = \"mypassword\"\n\n  ## Optional TLS Config\n  # tls_ca = \"/etc/telegraf/ca.pem\"\n  # tls_cert = \"/etc/telegraf/cert.pem\"\n  # tls_key = \"/etc/telegraf/key.pem\"\n  ## Use TLS but skip chain \u0026 host verification\n  # insecure_skip_verify = false\n\n"
     },
     {
       "type": "input",

--- a/telegraf_test.go
+++ b/telegraf_test.go
@@ -32,7 +32,7 @@ var telegrafCmpOptions = cmp.Options{
 	}),
 }
 
-// tests backwards compatibillity with the current plugin aware system.
+// tests backwards compatibility with the current plugin aware system.
 func TestTelegrafConfigJSONDecodeWithoutID(t *testing.T) {
 	s := `{
 		"name": "config 2",
@@ -171,7 +171,7 @@ func TestTelegrafConfigJSONDecodeWithoutID(t *testing.T) {
 	}
 }
 
-// tests forwards compatibillity with the new plugin unaware system.
+// tests forwards compatibility with the new plugin unaware system.
 func TestTelegrafConfigJSONDecodeTOML(t *testing.T) {
 	s := `{
 		"name": "config 2",

--- a/tenant/http_client_user.go
+++ b/tenant/http_client_user.go
@@ -160,7 +160,7 @@ func (s *PasswordClientService) ComparePassword(ctx context.Context, userID infl
 	panic("not implemented")
 }
 
-// CompareAndSetPassword compares the old and new password and submits the new password if possoble.
+// CompareAndSetPassword compares the old and new password and submits the new password if possible.
 // Note: is not implemented.
 func (s *PasswordClientService) CompareAndSetPassword(ctx context.Context, userID influxdb.ID, old string, new string) error {
 	panic("not implemented")

--- a/tenant/http_server_bucket.go
+++ b/tenant/http_server_bucket.go
@@ -19,7 +19,7 @@ type BucketHandler struct {
 	api       *kithttp.API
 	log       *zap.Logger
 	bucketSvc influxdb.BucketService
-	labelSvc  influxdb.LabelService // we may need this for now but we dont want it perminantly
+	labelSvc  influxdb.LabelService // we may need this for now but we dont want it permanently
 }
 
 const (

--- a/tenant/middleware_bucket_auth.go
+++ b/tenant/middleware_bucket_auth.go
@@ -18,7 +18,7 @@ type AuthedBucketService struct {
 	s influxdb.BucketService
 }
 
-// NewAuthedBucketService constructs an instance of an authorizing bucket serivce.
+// NewAuthedBucketService constructs an instance of an authorizing bucket service.
 func NewAuthedBucketService(s influxdb.BucketService) *AuthedBucketService {
 	return &AuthedBucketService{
 		s: s,

--- a/tenant/middleware_onboarding_auth.go
+++ b/tenant/middleware_onboarding_auth.go
@@ -17,7 +17,7 @@ type AuthedOnboardSvc struct {
 	s influxdb.OnboardingService
 }
 
-// NewAuthedOnboardSvc constructs an instance of an authorizing org serivce.
+// NewAuthedOnboardSvc constructs an instance of an authorizing org service.
 func NewAuthedOnboardSvc(s influxdb.OnboardingService) *AuthedOnboardSvc {
 	return &AuthedOnboardSvc{
 		s: s,

--- a/tenant/middleware_org_auth.go
+++ b/tenant/middleware_org_auth.go
@@ -18,7 +18,7 @@ type AuthedOrgService struct {
 	s influxdb.OrganizationService
 }
 
-// NewAuthedOrgService constructs an instance of an authorizing org serivce.
+// NewAuthedOrgService constructs an instance of an authorizing org service.
 func NewAuthedOrgService(s influxdb.OrganizationService) *AuthedOrgService {
 	return &AuthedOrgService{
 		s: s,

--- a/tenant/middleware_user_auth.go
+++ b/tenant/middleware_user_auth.go
@@ -17,7 +17,7 @@ type AuthedUserService struct {
 	s influxdb.UserService
 }
 
-// NewAuthedUserService constructs an instance of an authorizing user serivce.
+// NewAuthedUserService constructs an instance of an authorizing user service.
 func NewAuthedUserService(s influxdb.UserService) *AuthedUserService {
 	return &AuthedUserService{
 		s: s,
@@ -91,7 +91,7 @@ type AuthedPasswordService struct {
 	s influxdb.PasswordsService
 }
 
-// NewAuthedPasswordService wraps an existing password service with auth middlware.
+// NewAuthedPasswordService wraps an existing password service with auth middleware.
 func NewAuthedPasswordService(svc influxdb.PasswordsService) *AuthedPasswordService {
 	return &AuthedPasswordService{s: svc}
 }

--- a/tenant/service_onboarding.go
+++ b/tenant/service_onboarding.go
@@ -57,7 +57,7 @@ func (s *OnboardService) IsOnboarding(ctx context.Context) (bool, error) {
 	return allowed, err
 }
 
-// OnboardInitialUser allows us to onboard a new user if is onboarding is allowd
+// OnboardInitialUser allows us to onboard a new user if is onboarding is allowed
 func (s *OnboardService) OnboardInitialUser(ctx context.Context, req *influxdb.OnboardingRequest) (*influxdb.OnboardingResults, error) {
 	allowed, err := s.IsOnboarding(ctx)
 	if err != nil {

--- a/tenant/service_user_test.go
+++ b/tenant/service_user_test.go
@@ -129,7 +129,7 @@ func TestFindPermissionsFromUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// pull the permisssions for this user
+	// pull the permissions for this user
 	perms, err := svc.FindPermissionForUser(ctx, u.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -57,7 +57,7 @@ func (d Duration) MarshalText() (text []byte, err error) {
 	return []byte(d.String()), nil
 }
 
-// Size represents a TOML parseable file size.
+// Size represents a TOML parsable file size.
 // Users can specify size using "k" or "K" for kibibytes, "m" or "M" for mebibytes,
 // and "g" or "G" for gibibytes. If a size suffix isn't specified then bytes are assumed.
 type Size uint64

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -112,7 +112,7 @@ type Config struct {
 	MaxSeriesPerDatabase int `toml:"max-series-per-database"`
 
 	// MaxValuesPerTag is the maximum number of tag values a single tag key can have within
-	// a measurement.  When the limit is execeeded, writes return an error.
+	// a measurement.  When the limit is exceeded, writes return an error.
 	// A value of 0 disables the limit.
 	MaxValuesPerTag int `toml:"max-values-per-tag"`
 
@@ -135,7 +135,7 @@ type Config struct {
 
 	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions
 	// that can be running at one time across all series partitions in a database. Snapshots scheduled
-	// to run when the limit is reached are blocked until a running snaphsot completes.  Only snapshot
+	// to run when the limit is reached are blocked until a running snapshot completes.  Only snapshot
 	// compactions are affected by this limit. A value of 0 limits snapshot compactions to the lesser of
 	// 8 (series file partition quantity) and runtime.GOMAXPROCS(0).
 	SeriesFileMaxConcurrentSnapshotCompactions int `toml:"series-file-max-concurrent-snapshot-compactions"`

--- a/tsdb/engine/tsm1/batch_float.go
+++ b/tsdb/engine/tsm1/batch_float.go
@@ -27,7 +27,7 @@ func FloatArrayEncodeAll(src []float64, b []byte) ([]byte, error) {
 	if len(src) > 0 && math.IsNaN(src[0]) {
 		return nil, fmt.Errorf("unsupported value: NaN")
 	} else if len(src) == 0 {
-		first = math.NaN() // Write sentinal value to terminate batch.
+		first = math.NaN() // Write sentinel value to terminate batch.
 		finished = true
 	} else {
 		first = src[0]
@@ -53,7 +53,7 @@ func FloatArrayEncodeAll(src []float64, b []byte) ([]byte, error) {
 			x = src[i]
 			sum += x
 		} else {
-			// Encode sentinal value to terminate batch
+			// Encode sentinel value to terminate batch
 			x = math.NaN()
 			finished = true
 		}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -869,7 +869,7 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 }
 
 // TestStore implements the storer interface and can be used to mock out a
-// Cache's storer implememation.
+// Cache's storer implementation.
 type TestStore struct {
 	entryf       func(key []byte) *entry
 	writef       func(key []byte, values Values) (bool, error)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -3045,7 +3045,7 @@ func (e *Engine) IteratorCost(measurement string, opt query.IteratorOptions) (qu
 }
 
 // Type returns FieldType for a series.  If the series does not
-// exist, ErrUnkownFieldType is returned.
+// exist, ErrUnknownFieldType is returned.
 func (e *Engine) Type(series []byte) (models.FieldType, error) {
 	if typ, err := e.Cache.Type(series); err == nil {
 		return typ, nil

--- a/tsdb/engine/tsm1/predicate.go
+++ b/tsdb/engine/tsm1/predicate.go
@@ -480,7 +480,7 @@ func (p *predicateNodeOr) Clone(state *predicateState) predicateNode {
 }
 
 // Update checks if either the left and right nodes are true. If both nodes
-// are false, then the node is definitely fasle. Otherwise, it needs more information.
+// are false, then the node is definitely false. Otherwise, it needs more information.
 func (p *predicateNodeOr) Update() predicateResponse {
 	if resp, ok := p.Cached(); ok {
 		return resp

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -1086,7 +1086,7 @@ func TestIndirectIndex_Entries(t *testing.T) {
 
 	indirect := NewIndirectIndex()
 	if err := indirect.UnmarshalBinary(b); err != nil {
-		t.Fatalf("unexpected error unmarshaling index: %v", err)
+		t.Fatalf("unexpected error unmarshalling index: %v", err)
 	}
 
 	entries := indirect.Entries([]byte("cpu"))
@@ -1126,7 +1126,7 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 
 	indirect := NewIndirectIndex()
 	if err := indirect.UnmarshalBinary(b); err != nil {
-		t.Fatalf("unexpected error unmarshaling index: %v", err)
+		t.Fatalf("unexpected error unmarshalling index: %v", err)
 	}
 
 	// mem has not been added to the index so we should get no entries back
@@ -1884,7 +1884,7 @@ func BenchmarkIndirectIndex_UnmarshalBinary(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := indirect.UnmarshalBinary(bytes); err != nil {
-			b.Fatalf("unexpected error unmarshaling index: %v", err)
+			b.Fatalf("unexpected error unmarshalling index: %v", err)
 		}
 	}
 }

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -167,7 +167,7 @@ func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
 		}
 	}
 
-	// Seek back to the beinning of the file for reading
+	// Seek back to the beginning of the file for reading
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		fatal(t, "seek", err)
 	}
@@ -294,7 +294,7 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 		fatal(t, "flush", err)
 	}
 
-	// Seek back to the beinning of the file for reading
+	// Seek back to the beginning of the file for reading
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		fatal(t, "seek", err)
 	}
@@ -393,7 +393,7 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 		fatal(t, "flush", err)
 	}
 
-	// Seek back to the beinning of the file for reading
+	// Seek back to the beginning of the file for reading
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		fatal(t, "seek", err)
 	}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -39,7 +39,7 @@ the min and max time for the block, the offset into the file where the block
 is located and the the size of the block.
 
 The index structure can provide efficient access to all blocks as well as the
-ability to determine the cost associated with acessing a given key.  Given a key
+ability to determine the cost associated with accessing a given key.  Given a key
 and timestamp, we can determine whether a file contains the block for that
 timestamp as well as where that block resides and how much data to read to
 retrieve the block.  If we know we need to read all or multiple blocks in a
@@ -526,7 +526,7 @@ func (d *directIndex) Close() error {
 	return os.Remove(d.fd.Name())
 }
 
-// Remove removes the index from any tempory storage
+// Remove removes the index from any temporary storage
 func (d *directIndex) Remove() error {
 	if d.fd == nil {
 		return nil

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -768,7 +768,7 @@ func (i *Index) dropMeasurement(name string) error {
 }
 
 // DropMeasurementIfSeriesNotExist drops a measurement only if there are no more
-// series for the measurment.
+// series for the measurement.
 func (i *Index) DropMeasurementIfSeriesNotExist(name []byte) (bool, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -1136,7 +1136,7 @@ func (idx *ShardIndex) DropSeries(seriesID uint64, key []byte, _ bool) error {
 }
 
 // DropMeasurementIfSeriesNotExist drops a measurement only if there are no more
-// series for the measurment.
+// series for the measurement.
 func (idx *ShardIndex) DropMeasurementIfSeriesNotExist(name []byte) (bool, error) {
 	idx.seriesIDSet.Lock()
 	curr := idx.measurements[string(name)]

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -32,7 +32,7 @@ type measurement struct {
 	seriesByID          map[uint64]*series      // lookup table for series by their id
 	seriesByTagKeyValue map[string]*tagKeyValue // map from tag key to value to sorted set of series ids
 
-	// lazyily created sorted series IDs
+	// lazily created sorted series IDs
 	sortedSeriesIDs seriesIDs // sorted list of series IDs in this measurement
 
 	// Indicates whether the seriesByTagKeyValueMap needs to be rebuilt as it contains deleted series

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -134,7 +134,7 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 		goto EVICT
 	}
 
-	// No map for the measurement - first tag key for the measurment.
+	// No map for the measurement - first tag key for the measurement.
 	c.cache[string(name)] = map[string]map[string]*list.Element{
 		string(key): map[string]*list.Element{string(value): listElement},
 	}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -781,7 +781,7 @@ func (i *Index) InitializeSeries(keys, names [][]byte, tags []models.Tags) error
 }
 
 // DropSeries drops the provided series from the index.  If cascade is true
-// and this is the last series to the measurement, the measurment will also be dropped.
+// and this is the last series to the measurement, the measurement will also be dropped.
 func (i *Index) DropSeries(seriesID uint64, key []byte, cascade bool) error {
 	// Remove from partition.
 	if err := i.partition(key).DropSeries(seriesID); err != nil {
@@ -828,7 +828,7 @@ func (i *Index) DropSeries(seriesID uint64, key []byte, cascade bool) error {
 func (i *Index) DropSeriesGlobal(key []byte) error { return nil }
 
 // DropMeasurementIfSeriesNotExist drops a measurement only if there are no more
-// series for the measurment.
+// series for the measurement.
 func (i *Index) DropMeasurementIfSeriesNotExist(name []byte) (bool, error) {
 	// Check if that was the last series for the measurement in the entire index.
 	if ok, err := i.MeasurementHasSeries(name); err != nil {

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -350,7 +350,7 @@ type MeasurementBlockElem struct {
 
 	seriesIDSet *tsdb.SeriesIDSet
 
-	// size in bytes, set after unmarshaling.
+	// size in bytes, set after unmarshalling.
 	size int
 }
 

--- a/tsdb/internal/meta.pb.go
+++ b/tsdb/internal/meta.pb.go
@@ -1199,7 +1199,7 @@ func skipMeta(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthMeta = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrInvalidLengthMeta = fmt.Errorf("proto: negative length found during unmarshalling")
 	ErrIntOverflowMeta   = fmt.Errorf("proto: integer overflow")
 )
 

--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -120,7 +120,7 @@ func (s *SeriesSegment) Path() string { return s.path }
 // InitForWrite initializes a write handle for the segment.
 // This is only used for the last segment in the series file.
 func (s *SeriesSegment) InitForWrite() (err error) {
-	// Only calculcate segment data size if writing.
+	// Only calculate segment data size if writing.
 	for s.size = uint32(SeriesSegmentHeaderSize); s.size < uint32(len(s.data)); {
 		flag, _, _, sz := ReadSeriesEntry(s.data[s.size:])
 		if !IsValidSeriesEntryFlag(flag) {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -73,7 +73,7 @@ var (
 	// ErrUnknownFieldType is returned when the type of a field cannot be determined.
 	ErrUnknownFieldType = errors.New("unknown field type")
 
-	// ErrShardNotIdle is returned when an operation requring the shard to be idle/cold is
+	// ErrShardNotIdle is returned when an operation requiring the shard to be idle/cold is
 	// attempted on a hot shard.
 	ErrShardNotIdle = errors.New("shard not idle")
 
@@ -476,7 +476,7 @@ func (s *Shard) SetCompactionsEnabled(enabled bool) {
 func (s *Shard) DiskSize() (int64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	// We don't use engine() becuase we still want to report the shard's disk
+	// We don't use engine() because we still want to report the shard's disk
 	// size even if the shard has been disabled.
 	if s._engine == nil {
 		return 0, ErrEngineClosed
@@ -1675,7 +1675,7 @@ func (fs *MeasurementFieldSet) Fields(name []byte) *MeasurementFields {
 	return mf
 }
 
-// FieldsByString returns fields for a measurment by name.
+// FieldsByString returns fields for a measurement by name.
 func (fs *MeasurementFieldSet) FieldsByString(name string) *MeasurementFields {
 	fs.mu.RLock()
 	mf := fs.fields[name]

--- a/ui/cypress/e2e/notificationRules.test.ts
+++ b/ui/cypress/e2e/notificationRules.test.ts
@@ -34,7 +34,7 @@ describe('NotificationRules', () => {
     it('should route the user to the alerting index page', () => {
       const nonexistentID = '04984be058066088'
 
-      // visitng the rules edit overlay
+      // visiting the rules edit overlay
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs, alerting, rules}) => {
           cy.visit(`${orgs}/${id}${alerting}${rules}/${nonexistentID}/edit`)
@@ -47,7 +47,7 @@ describe('NotificationRules', () => {
     })
   })
 
-  describe('numeric input validation in Theshold Checks', () => {
+  describe('numeric input validation in Threshold Checks', () => {
     beforeEach(() => {
       cy.getByTestID('page-contents').within(() => {
         cy.getByTestID('dropdown').click()

--- a/ui/src/alerting/utils/customCheck.test.ts
+++ b/ui/src/alerting/utils/customCheck.test.ts
@@ -14,7 +14,7 @@ const bc1: BuilderConfig = {
 const ab1: AlertBuilderState = {
   activeStatus: 'active',
   status: RemoteDataState.Done,
-  statusMessageTemplate: 'this is staus message',
+  statusMessageTemplate: 'this is status message',
   tags: [{key: 'k1', value: 'v1'}],
   id: '2',
   name: 'name of thing',
@@ -35,7 +35,7 @@ const ab1: AlertBuilderState = {
 const ab2: AlertBuilderState = {
   activeStatus: 'active',
   status: RemoteDataState.Done,
-  statusMessageTemplate: 'this is staus message',
+  statusMessageTemplate: 'this is status message',
   tags: [{key: 'k1', value: 'v1'}],
   id: '2',
   name: 'name of thing',
@@ -57,12 +57,12 @@ const TESTS = [
   [
     bc1,
     ab1,
-    'package main\nimport "influxdata/influxdb/monitor"\nimport "experimental"\nimport "influxdata/influxdb/v1"\n\ncheck = {\n  _check_id: "2",\n  _check_name: "name of thing",\n  _type: "custom",\n  tags: {k1: "v1"},\n  every: 2d\n}\n\noption task = {\n  name: "name of thing",\n  every: 2d, // expected to match check.every\n  offset: 10m\n}\n\ninfo = (r) => (r.dead)\n\nmessageFn = (r) =>("this is staus message")\n\ndata = from(bucket: "bestBuck")\n  |> range(start: -lala)\n  |> filter(fn: (r) => r.k1 == "v1")\n  |> filter(fn: (r) => r._field == "v2")\n\ndata\n  |> v1.fieldsAsCols()\n  |> monitor.deadman(t: experimental.subDuration(from: now(), d: 10m))\n  |> monitor.check(data: check, messageFn: messageFn,info:info)',
+    'package main\nimport "influxdata/influxdb/monitor"\nimport "experimental"\nimport "influxdata/influxdb/v1"\n\ncheck = {\n  _check_id: "2",\n  _check_name: "name of thing",\n  _type: "custom",\n  tags: {k1: "v1"},\n  every: 2d\n}\n\noption task = {\n  name: "name of thing",\n  every: 2d, // expected to match check.every\n  offset: 10m\n}\n\ninfo = (r) => (r.dead)\n\nmessageFn = (r) =>("this is status message")\n\ndata = from(bucket: "bestBuck")\n  |> range(start: -lala)\n  |> filter(fn: (r) => r.k1 == "v1")\n  |> filter(fn: (r) => r._field == "v2")\n\ndata\n  |> v1.fieldsAsCols()\n  |> monitor.deadman(t: experimental.subDuration(from: now(), d: 10m))\n  |> monitor.check(data: check, messageFn: messageFn,info:info)',
   ],
   [
     bc1,
     ab2,
-    'package main\nimport "influxdata/influxdb/monitor"\nimport "influxdata/influxdb/v1"\n\ncheck = {\n  _check_id: "2",\n  _check_name: "name of thing",\n  _type: "custom",\n  tags: {k1: "v1"},\n  every: 2d\n}\n\noption task = {\n  name: "name of thing",\n  every: 2d, // expected to match check.every\n  offset: 10m\n}\n\ninfo = (r) =>(r.v2 > 45)\nok = (r) =>(r.v2 < 15)\nwarn = (r) =>(r.v2 < 2 and r.v2 > 10)\n\nmessageFn = (r) =>("this is staus message")\n\ndata = from(bucket: "bestBuck")\n  |> range(start: -check.every)\n  |> filter(fn: (r) => r.k1 == "v1")\n  |> filter(fn: (r) => r._field == "v2")\n  |> aggregateWindow(every: check.every, fn: mean, createEmpty: false)\n\ndata\n  |> v1.fieldsAsCols()\n  |> monitor.check(data: check, messageFn: messageFn, info:info, ok:ok, warn:warn)',
+    'package main\nimport "influxdata/influxdb/monitor"\nimport "influxdata/influxdb/v1"\n\ncheck = {\n  _check_id: "2",\n  _check_name: "name of thing",\n  _type: "custom",\n  tags: {k1: "v1"},\n  every: 2d\n}\n\noption task = {\n  name: "name of thing",\n  every: 2d, // expected to match check.every\n  offset: 10m\n}\n\ninfo = (r) =>(r.v2 > 45)\nok = (r) =>(r.v2 < 15)\nwarn = (r) =>(r.v2 < 2 and r.v2 > 10)\n\nmessageFn = (r) =>("this is status message")\n\ndata = from(bucket: "bestBuck")\n  |> range(start: -check.every)\n  |> filter(fn: (r) => r.k1 == "v1")\n  |> filter(fn: (r) => r._field == "v2")\n  |> aggregateWindow(every: check.every, fn: mean, createEmpty: false)\n\ndata\n  |> v1.fieldsAsCols()\n  |> monitor.check(data: check, messageFn: messageFn, info:info, ok:ok, warn:warn)',
   ],
 ]
 

--- a/ui/src/checks/utils/index.ts
+++ b/ui/src/checks/utils/index.ts
@@ -4,7 +4,7 @@ import {PostCheck} from 'src/client'
 
 // Utils
 import {checkThresholdsValid} from './checkValidate'
-import {isDurationParseable} from 'src/shared/utils/duration'
+import {isDurationParsable} from 'src/shared/utils/duration'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {getOrg} from 'src/organizations/selectors'
 
@@ -57,7 +57,7 @@ const toDeadManPostCheck = (
     activeStatus,
   } = alertBuilder
 
-  if (!isDurationParseable(timeSince) || !isDurationParseable(staleTime)) {
+  if (!isDurationParsable(timeSince) || !isDurationParsable(staleTime)) {
     throw new Error('Duration fields must contain valid duration')
   }
 
@@ -102,11 +102,11 @@ const toThresholdPostCheck = (
 }
 
 const validateBuilder = (alertBuilder: AlertBuilder) => {
-  if (!isDurationParseable(alertBuilder.offset)) {
+  if (!isDurationParsable(alertBuilder.offset)) {
     throw new Error('Check offset must be a valid duration')
   }
 
-  if (!isDurationParseable(alertBuilder.every)) {
+  if (!isDurationParsable(alertBuilder.every)) {
     throw new Error('Check every must be a valid duration')
   }
 }

--- a/ui/src/dashboards/utils/time.ts
+++ b/ui/src/dashboards/utils/time.ts
@@ -1,7 +1,7 @@
 import {CustomTimeRange, TimeRange, DurationTimeRange} from 'src/types/queries'
 
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
-import {isDurationWithNowParseable} from 'src/shared/utils/duration'
+import {isDurationWithNowParsable} from 'src/shared/utils/duration'
 
 interface InputTimeRange {
   seconds?: number
@@ -56,7 +56,7 @@ export const validateAndTypeRange = (timeRange: {
     } as CustomTimeRange
   }
 
-  if (isDurationWithNowParseable(lower)) {
+  if (isDurationWithNowParsable(lower)) {
     const selectableTimeRange = SELECTABLE_TIME_RANGES.find(
       r => r.lower === lower
     )

--- a/ui/src/eventViewer/components/EventViewer.reducer.ts
+++ b/ui/src/eventViewer/components/EventViewer.reducer.ts
@@ -24,7 +24,7 @@ export interface State {
 
   // A parsed representation of the whichever search input is currently being
   // used to filter results (not necessarily derived from the current text
-  // input, which may not be valid / parseable)
+  // input, which may not be valid / parsable)
   searchExpr: SearchExpr | null
 
   // A timeout ID used to debounce performing the search on user input

--- a/ui/src/members/components/Members.test.tsx
+++ b/ui/src/members/components/Members.test.tsx
@@ -6,11 +6,11 @@ import {shallow} from 'enzyme'
 import MemberList from 'src/members/components/MemberList'
 
 // Constants
-import {resouceOwner} from 'src/members/dummyData'
+import {resourceOwner} from 'src/members/dummyData'
 
 const setup = (override?) => {
   const props = {
-    members: resouceOwner,
+    members: resourceOwner,
     emptyState: <></>,
     ...override,
   }

--- a/ui/src/members/dummyData.ts
+++ b/ui/src/members/dummyData.ts
@@ -1,6 +1,6 @@
 import {ResourceOwner, User} from '@influxdata/influx'
 
-export const resouceOwner: ResourceOwner[] = [
+export const resourceOwner: ResourceOwner[] = [
   {
     id: '1',
     name: 'John',

--- a/ui/src/notebooks/index.ts
+++ b/ui/src/notebooks/index.ts
@@ -26,7 +26,7 @@ export interface FluxResult {
   source: string // the query that was used to generate the flux
   raw: string // the result from the API
   parsed: FromFluxResult // the parsed result
-  error?: string // any error that might have happend while fetching
+  error?: string // any error that might have happened while fetching
 }
 
 interface DataLookup<T> {

--- a/ui/src/notifications/rules/components/RulesColumn.tsx
+++ b/ui/src/notifications/rules/components/RulesColumn.tsx
@@ -73,7 +73,7 @@ const NotificationRulesColumn: FunctionComponent<Props> = ({
 
   const buttonTitleText = !!endpoints.length
     ? 'Create a Notification Rule'
-    : 'You need at least 1 Notifcation Endpoint to create a Notification Rule'
+    : 'You need at least 1 Notification Endpoint to create a Notification Rule'
 
   const createButton = (
     <Button

--- a/ui/src/shared/components/DashboardRoute.tsx
+++ b/ui/src/shared/components/DashboardRoute.tsx
@@ -76,7 +76,7 @@ class DashboardRoute extends PureComponent<Props> {
 
     // resource is still loading
     // we have to wait for it so that we can filter out arbitrary user input
-    // from the redux state before commiting it back to localstorage
+    // from the redux state before committing it back to localstorage
     if (!variables.length) {
       this.pendingVars = urlVars.vars
       return

--- a/ui/src/shared/components/DeleteDataForm/DeleteButton.tsx
+++ b/ui/src/shared/components/DeleteDataForm/DeleteButton.tsx
@@ -31,7 +31,7 @@ const DeleteButton: FunctionComponent<Props> = ({status, valid, onClick}) => {
     return (
       <div className="delete-data-button delete-data-button--error">
         <Icon glyph={IconFont.Remove} />
-        An error occured and has been reported.
+        An error occurred and has been reported.
       </div>
     )
   }

--- a/ui/src/shared/components/DurationInput.tsx
+++ b/ui/src/shared/components/DurationInput.tsx
@@ -8,7 +8,7 @@ import {
   ClickOutside,
   ComponentStatus,
 } from '@influxdata/clockface'
-import {isDurationParseable} from 'src/shared/utils/duration'
+import {isDurationParsable} from 'src/shared/utils/duration'
 
 const SUGGESTION_CLASS = 'duration-input--suggestion'
 
@@ -61,7 +61,7 @@ const DurationInput: FC<Props> = ({
   }
 
   const isValid = (i: string): boolean =>
-    isDurationParseable(i) || validFunction(i)
+    isDurationParsable(i) || validFunction(i)
 
   let inputStatus = controlledStatus || ComponentStatus.Default
 

--- a/ui/src/shared/components/EventMarkers.scss
+++ b/ui/src/shared/components/EventMarkers.scss
@@ -12,7 +12,7 @@ $event-marker-z-index: 2;
   opacity: 0.5;
   z-index: $event-marker-z-index;
 
-  // Psuedo elements
+  // Pseudo elements
   &:after,
   &:before {
     content: '';

--- a/ui/src/shared/components/ThresholdSetting.tsx
+++ b/ui/src/shared/components/ThresholdSetting.tsx
@@ -60,7 +60,7 @@ const ThresholdSetting: FunctionComponent<Props> = ({
     label = 'Value is >='
   }
 
-  const isRemoveable =
+  const isRemovable =
     !isBaseThreshold && type !== COLOR_TYPE_MIN && type !== COLOR_TYPE_MAX
 
   const inputStatus = error ? ComponentStatus.Error : ComponentStatus.Default
@@ -100,7 +100,7 @@ const ThresholdSetting: FunctionComponent<Props> = ({
           onChoose={({name, hex}) => onChangeColor(name, hex)}
           style={dropdownStyle}
         />
-        {isRemoveable && (
+        {isRemovable && (
           <SquareButton
             icon={IconFont.Remove}
             onClick={onRemove}

--- a/ui/src/shared/components/ThresholdsSettings.test.tsx
+++ b/ui/src/shared/components/ThresholdsSettings.test.tsx
@@ -113,14 +113,14 @@ describe('ThresholdSettings', () => {
 
   test('broadcasts edited thresholds only when changes are valid', async () => {
     const handleSetThresholdsSpy = jest.fn()
-    const testShresholds: Color[] = [
+    const testThresholds: Color[] = [
       {id: '0', type: 'min', name: 'thunder', hex: '', value: 20},
       {id: '1', type: 'threshold', name: 'fire', hex: '', value: 30},
       {id: '2', type: 'max', name: 'ruby', hex: '', value: 60},
     ]
 
     const TestWrapper = () => {
-      const [thresholds, setThresholds] = useState<Color[]>(testShresholds)
+      const [thresholds, setThresholds] = useState<Color[]>(testThresholds)
 
       const [didRerender, setDidRerender] = useState(false)
 
@@ -143,7 +143,7 @@ describe('ThresholdSettings', () => {
 
     const {getByTestId} = render(<TestWrapper />)
 
-    const input1 = getByTestId(`threshold-${testShresholds[1].id}-input`)
+    const input1 = getByTestId(`threshold-${testThresholds[1].id}-input`)
 
     // Enter an invalid value in the input
     fireEvent.change(input1, {

--- a/ui/src/shared/components/cloud/OSSEnv.tsx
+++ b/ui/src/shared/components/cloud/OSSEnv.tsx
@@ -13,7 +13,7 @@ describe('If not Cloud', () => {
     expect(wrapper.children().exists()).toBe(false)
   })
 
-  it('CloudExclude renders chilren', () => {
+  it('CloudExclude renders children', () => {
     jest.mock('src/shared/constants', () => ({CLOUD: false}))
     const CloudExclude = require('src/shared/components/cloud/CloudExclude.tsx')
       .default

--- a/ui/src/shared/reducers/notifications.test.ts
+++ b/ui/src/shared/reducers/notifications.test.ts
@@ -38,7 +38,7 @@ describe('Shared.Reducers.notifications', () => {
   })
 
   describe('adding more than one notification', () => {
-    it('should put the new notification at the beggining of the list', () => {
+    it('should put the new notification at the beginning of the list', () => {
       const newNotification = {
         style: NotificationStyle.Error,
         message: 'new notification',

--- a/ui/src/shared/reducers/schema.ts
+++ b/ui/src/shared/reducers/schema.ts
@@ -7,7 +7,7 @@ import {
 // Types
 import {RemoteDataState, Schema} from 'src/types'
 
-export const TEN_MINUTES = 10 * 60 * 1000 // 10 muinutes in ms
+export const TEN_MINUTES = 10 * 60 * 1000 // 10 minutes in ms
 export interface BucketSchema {
   schema: Schema
   exp: number

--- a/ui/src/shared/utils/duration.test.tsx
+++ b/ui/src/shared/utils/duration.test.tsx
@@ -3,8 +3,8 @@ import {
   durationToMilliseconds,
   areDurationsEqual,
   millisecondsToDuration,
-  isDurationWithNowParseable,
-  isDurationParseable,
+  isDurationWithNowParsable,
+  isDurationParsable,
 } from 'src/shared/utils/duration'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 
@@ -88,33 +88,33 @@ describe('millisecondsToDuration', () => {
   })
 })
 
-describe('isDurationWithNowParseable', () => {
+describe('isDurationWithNowParsable', () => {
   test('returns false when passed invalid durations', () => {
-    expect(isDurationWithNowParseable('1h')).toBe(false)
-    expect(isDurationWithNowParseable('moo')).toBe(false)
-    expect(isDurationWithNowParseable('123')).toBe(false)
-    expect(isDurationWithNowParseable('now()')).toBe(false)
+    expect(isDurationWithNowParsable('1h')).toBe(false)
+    expect(isDurationWithNowParsable('moo')).toBe(false)
+    expect(isDurationWithNowParsable('123')).toBe(false)
+    expect(isDurationWithNowParsable('now()')).toBe(false)
   })
 
   test.each(SELECTABLE_TIME_RANGES)(
     'returns true when passed valid duration',
     ({lower}) => {
-      expect(isDurationWithNowParseable(lower)).toEqual(true)
+      expect(isDurationWithNowParsable(lower)).toEqual(true)
     }
   )
 })
 
-describe('isDurationParseable', () => {
+describe('isDurationParsable', () => {
   test('returns false when passed invalid durations', () => {
-    expect(isDurationParseable('moo')).toBe(false)
-    expect(isDurationParseable('123')).toBe(false)
-    expect(isDurationParseable('now()-1h')).toBe(false)
+    expect(isDurationParsable('moo')).toBe(false)
+    expect(isDurationParsable('123')).toBe(false)
+    expect(isDurationParsable('now()-1h')).toBe(false)
   })
 
   test.each(TEST_CASES)(
     'returns true when passed valid duration',
     (input, _) => {
-      expect(isDurationParseable(input)).toEqual(true)
+      expect(isDurationParsable(input)).toEqual(true)
     }
   )
 })

--- a/ui/src/shared/utils/duration.ts
+++ b/ui/src/shared/utils/duration.ts
@@ -7,7 +7,7 @@ import {TIME_RANGE_FORMAT} from 'src/shared/constants/timeRanges'
 export const removeSpacesAndNow = (input: string): string =>
   input.replace(/\s/g, '').replace(/now\(\)-/, '')
 
-export const isDurationWithNowParseable = (lower: string): boolean => {
+export const isDurationWithNowParsable = (lower: string): boolean => {
   const durationRegExp = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)/g
   if (!lower || !lower.includes('now()')) {
     return false
@@ -18,7 +18,7 @@ export const isDurationWithNowParseable = (lower: string): boolean => {
   return !!removedLower.match(durationRegExp)
 }
 
-export const isDurationParseable = (duration: string): boolean => {
+export const isDurationParsable = (duration: string): boolean => {
   if (typeof duration !== 'string') {
     return false
   }

--- a/ui/src/shared/utils/errors.ts
+++ b/ui/src/shared/utils/errors.ts
@@ -61,7 +61,7 @@ export const reportError = (
 
 /*
   Parse React's error boundary info message to provide the name of the
-  component an error occured in.
+  component an error occurred in.
 
   For example, given the following info message:
 

--- a/ui/src/shared/utils/fromFlux.test.ts
+++ b/ui/src/shared/utils/fromFlux.test.ts
@@ -18,7 +18,7 @@ describe('fromFlux', () => {
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,2,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,thirty,usage_guest,cpu,cpu0,oox4k.local
-,,3,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,fourty,usage_guest,cpu,cpu0,oox4k.local`
+,,3,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,forty,usage_guest,cpu,cpu0,oox4k.local`
 
     const actual = fromFlux(CSV)
 
@@ -61,7 +61,7 @@ describe('fromFlux', () => {
       undefined,
       undefined,
       'thirty',
-      'fourty',
+      'forty',
     ])
 
     expect(actual.table.columns['_field'].data).toEqual([

--- a/ui/src/timeMachine/reducers/index.test.ts
+++ b/ui/src/timeMachine/reducers/index.test.ts
@@ -214,7 +214,7 @@ describe('the Time Machine reducer', () => {
 
   // Fix for: https://github.com/influxdata/influxdb/issues/17364
   describe('editing a table view', () => {
-    it('does not overwrite internal TableViewProperites when files is an empty array', () => {
+    it('does not overwrite internal TableViewProperties when files is an empty array', () => {
       const initial = initialState()
 
       const store = createStore(timeMachinesReducer, initial)

--- a/ui/src/utils/env.test.ts
+++ b/ui/src/utils/env.test.ts
@@ -1,6 +1,6 @@
 const {formatStatic, formatBase} = require('./env')
 
-describe('enviroment normalization', () => {
+describe('environment normalization', () => {
   describe('static path formatter', () => {
     it('should strip the first slash', () => {
       expect(formatStatic('/neateo/')).toBe('neateo/')

--- a/ui/src/utils/lineWriter.test.ts
+++ b/ui/src/utils/lineWriter.test.ts
@@ -357,7 +357,7 @@ describe('batched writes', () => {
     })
   })
 
-  it('waits 10 seconds (by default) to send an HTTP reqeust', () => {
+  it('waits 10 seconds (by default) to send an HTTP request', () => {
     const measurement = 'performance'
     const timestamp = 1585163446
 

--- a/ui/src/utils/lineWriter.ts
+++ b/ui/src/utils/lineWriter.ts
@@ -103,7 +103,7 @@ export class LineWriter {
       if (typeof fieldValue === 'string') {
         printableFieldValue = fieldValue
           .replace(/\n/g, '') // remove newlines
-          .replace(/\\/g, '\\') // replace single backslach with an escaped backslash
+          .replace(/\\/g, '\\') // replace single backslash with an escaped backslash
           .replace(/"/g, '\\"') // replace double quotes with escaped double quotes
       }
 

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -547,7 +547,7 @@ export const hydrateVars = (
       node.variable.selected = node.variable.selected || []
 
       // ensure that the selected value defaults propegate for
-      // nested queryies.
+      // nested queries.
       if (
         node.variable.arguments.type === 'query' ||
         node.variable.arguments.type === 'constant'

--- a/ui/src/writeData/components/telegrafPlugins/redis.md
+++ b/ui/src/writeData/components/telegrafPlugins/redis.md
@@ -63,7 +63,7 @@ Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate) a
     - maxmemory_policy(string)
     - mem_fragmentation_ratio(float, number)
 
-    **Persistance**
+    **Persistence**
     - loading(int,flag)
     - rdb_changes_since_last_save(int, number)
     - rdb_bgsave_in_progress(int, flag)

--- a/ui/src/writeData/components/telegrafPlugins/sqlserver.md
+++ b/ui/src/writeData/components/telegrafPlugins/sqlserver.md
@@ -176,7 +176,7 @@ The new (version 2) metrics provide:
   - *Memory*: PLE, Page reads/sec, Page writes/sec, + more
   - *TempDB*: Free space, Version store usage, Active temp tables, temp table creation rate, + more
   - *Resource Governor*: CPU Usage, Requests/sec, Queued Requests, and Blocked tasks per workload group + more
-- *Server properties*: Number of databases in all possible states (online, offline, suspect, etc.), cpu count, physical memory, SQL Server service uptime, and SQL Server version. In the case of Azure SQL relevent properties such as Tier, #Vcores, Memory etc.
+- *Server properties*: Number of databases in all possible states (online, offline, suspect, etc.), cpu count, physical memory, SQL Server service uptime, and SQL Server version. In the case of Azure SQL relevant properties such as Tier, #Vcores, Memory etc.
 - *Wait stats*: Wait time in ms, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store.
 - *Schedulers* - This captures `sys.dm_os_schedulers`.
 - *SqlRequests* - This captures a snapshot of `sys.dm_exec_requests` and `sys.dm_exec_sessions` that gives you running requests as well as wait types and
@@ -205,7 +205,7 @@ These are metrics for Azure SQL Database (single database) and are very similar 
 - AzureSQLDBMemoryClerks: Memory clerk breakdown from `sys.dm_os_memory_clerks`.
 = AzureSQLDBResourceGovernance: Relevant properties indicatign resource limits from `sys.dm_user_db_resource_governance`
 - AzureSQLDBPerformanceCounters: A select list of performance counters from `sys.dm_os_performance_counters` including cloud specific counters for SQL Hyperscale.
-- AzureSQLDBServerProperties: Relevant Azure SQL relevent properties from  such as Tier, #Vcores, Memory etc, storage, etc.
+- AzureSQLDBServerProperties: Relevant Azure SQL relevant properties from  such as Tier, #Vcores, Memory etc, storage, etc.
 - AzureSQLDBWaitstats: Wait time in ms from `sys.dm_db_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected only as of the end of the a statement. and for a specific database only.
 - *AzureSQLOsWaitstats*: Wait time in ms from `sys.dm_os_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected as they occur and instance wide
 - *AzureSQLDBRequests: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`
@@ -218,7 +218,7 @@ These are metrics for Azure SQL Managed instance, are very similar to version 2 
 - AzureSQLMIMemoryClerks: Memory clerk breakdown from `sys.dm_os_memory_clerks`.
 - AzureSQLMIResourceGovernance: Relevant properties indicatign resource limits from `sys.dm_instance_resource_governance`
 - AzureSQLMIPerformanceCounters: A select list of performance counters from `sys.dm_os_performance_counters` including cloud specific counters for SQL Hyperscale.
-- AzureSQLMIServerProperties: Relevant Azure SQL relevent properties such as Tier, #Vcores, Memory etc, storage, etc.
+- AzureSQLMIServerProperties: Relevant Azure SQL relevant properties such as Tier, #Vcores, Memory etc, storage, etc.
 - AzureSQLMIOsWaitstats: Wait time in ms from `sys.dm_os_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected as they occur and instance wide
 - AzureSQLMIRequests: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`
 - AzureSQLMISchedulers - This captures `sys.dm_os_schedulers` snapshots.
@@ -233,7 +233,7 @@ These are metrics for Azure SQL Managed instance, are very similar to version 2 
   - *Memory*: PLE, Page reads/sec, Page writes/sec, + more
   - *TempDB*: Free space, Version store usage, Active temp tables, temp table creation rate, + more
   - *Resource Governor*: CPU Usage, Requests/sec, Queued Requests, and Blocked tasks per workload group + more
-- SQLServerProperties: Number of databases in all possible states (online, offline, suspect, etc.), cpu count, physical memory, SQL Server service uptime, and SQL Server version. In the case of Azure SQL relevent properties such as Tier, #Vcores, Memory etc.
+- SQLServerProperties: Number of databases in all possible states (online, offline, suspect, etc.), cpu count, physical memory, SQL Server service uptime, and SQL Server version. In the case of Azure SQL relevant properties such as Tier, #Vcores, Memory etc.
 - SQLServerWaitStatsCategorized: Wait time in ms, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store.
 - SQLServerSchedulers - This captures `sys.dm_os_schedulers`.
 - SQLServerRequests - This captures a snapshot of `sys.dm_exec_requests` and `sys.dm_exec_sessions` that gives you running requests as well as wait types and

--- a/ui/src/writeData/components/telegrafPlugins/win_perf_counters.md
+++ b/ui/src/writeData/components/telegrafPlugins/win_perf_counters.md
@@ -65,7 +65,7 @@ Example:
 
 _Deprecated. Necessary features on Windows Vista and newer are checked dynamically_
 
-Bool, if set to `true`, the plugin will use the localized PerfCounter interface that has been present since before Vista for backwards compatability.
+Bool, if set to `true`, the plugin will use the localized PerfCounter interface that has been present since before Vista for backwards compatibility.
 
 It is recommended NOT to use this on OSes starting with Vista and newer because it requires more configuration to use this than the newer interface present since Vista.
 

--- a/v1/coordinator/points_writer.go
+++ b/v1/coordinator/points_writer.go
@@ -276,12 +276,12 @@ func (l sgList) Append(sgi meta.ShardGroupInfo) sgList {
 	return next
 }
 
-// WritePoints writes the data to the underlying storage. consitencyLevel and user are only used for clustered scenarios
+// WritePoints writes the data to the underlying storage. consistencyLevel and user are only used for clustered scenarios
 func (w *PointsWriter) WritePoints(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, user meta.User, points []models.Point) error {
 	return w.WritePointsPrivileged(database, retentionPolicy, consistencyLevel, points)
 }
 
-// WritePointsPrivileged writes the data to the underlying storage, consitencyLevel is only used for clustered scenarios
+// WritePointsPrivileged writes the data to the underlying storage, consistencyLevel is only used for clustered scenarios
 func (w *PointsWriter) WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 	atomic.AddInt64(&w.stats.WriteReq, 1)
 	atomic.AddInt64(&w.stats.PointWriteReq, int64(len(points)))

--- a/v1/monitor/README.md
+++ b/v1/monitor/README.md
@@ -1,7 +1,7 @@
 # System Monitoring
 _This functionality should be considered experimental and is subject to change._
 
-_System Monitoring_ means all statistical and diagnostic information made availabe to the user of InfluxDB system, about the system itself. Its purpose is to assist with troubleshooting and performance analysis of the database itself.
+_System Monitoring_ means all statistical and diagnostic information made available to the user of InfluxDB system, about the system itself. Its purpose is to assist with troubleshooting and performance analysis of the database itself.
 
 ## Statistics vs. Diagnostics
 A distinction is made between _statistics_ and _diagnostics_ for the purposes of monitoring. Generally a statistical quality is something that is being counted, and for which it makes sense to store persistently for historical analysis. Diagnostic information is not necessarily numerical, and may not make sense to store.
@@ -9,7 +9,7 @@ A distinction is made between _statistics_ and _diagnostics_ for the purposes of
 An example of statistical information would be the number of points received over UDP, or the number of queries executed. Examples of diagnostic information would be a list of current Graphite TCP connections, the version of InfluxDB, or the uptime of the process.
 
 ## System Statistics
-`SHOW STATS [FOR <module>]` displays statisics about subsystems within the running `influxd` process. Statistics include points received, points indexed, bytes written to disk, TCP connections handled etc. These statistics are all zero when the InfluxDB process starts. If _module_ is specified, it must be single-quoted. For example `SHOW STATS FOR 'httpd'`.
+`SHOW STATS [FOR <module>]` displays statistics about subsystems within the running `influxd` process. Statistics include points received, points indexed, bytes written to disk, TCP connections handled etc. These statistics are all zero when the InfluxDB process starts. If _module_ is specified, it must be single-quoted. For example `SHOW STATS FOR 'httpd'`.
 
 All statistics are written, by default, by each node to a "monitor" database within the InfluxDB system, allowing analysis of aggregated statistical data using the standard InfluxQL language. This allows users to track the performance of their system. Importantly, this allows cluster-level statistics to be viewed, since by querying the monitor database, statistics from all nodes may be queried. This can be a very powerful approach for troubleshooting your InfluxDB system and understanding its behaviour.
 

--- a/v1/services/meta/client_test.go
+++ b/v1/services/meta/client_test.go
@@ -419,7 +419,7 @@ func TestMetaClient_DefaultRetentionPolicy(t *testing.T) {
 
 	db := c.Database("db0")
 	if db == nil {
-		t.Fatal("datbase not found")
+		t.Fatal("database not found")
 	} else if db.Name != "db0" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
@@ -635,7 +635,7 @@ func TestMetaClient_CreateUser(t *testing.T) {
 		t.Fatalf("failed to authenticate")
 	}
 
-	// Auth for unkonwn user should fail
+	// Auth for unknown user should fail
 	u, err = c.Authenticate("foo", "")
 	if u != nil || err != meta.ErrUserNotFound {
 		t.Fatalf("authentication should fail with %s", meta.ErrUserNotFound)
@@ -907,7 +907,7 @@ func TestMetaClient_Subscriptions_Drop(t *testing.T) {
 		t.Fatalf("got: %s, exp: %s", got, exp)
 	}
 
-	// DROP SUBSCRIPTION drops the subsciption if it can find it.
+	// DROP SUBSCRIPTION drops the subscription if it can find it.
 	err = c.DropSubscription("db0", "autogen", "sub0")
 	if got := err; got != nil {
 		t.Fatalf("got: %s, exp: %v", got, nil)

--- a/v1/services/meta/data_test.go
+++ b/v1/services/meta/data_test.go
@@ -74,7 +74,7 @@ func Test_Data_DropDatabase(t *testing.T) {
 func Test_Data_CreateDatabase(t *testing.T) {
 	data := meta.Data{}
 
-	// Test creating a database succeedes.
+	// Test creating a database succeeds.
 	if err := data.CreateDatabase("foo"); err != nil {
 		t.Fatal(err)
 	}

--- a/v1/services/storage/source.pb.go
+++ b/v1/services/storage/source.pb.go
@@ -343,7 +343,7 @@ func skipSource(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthSource = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrInvalidLengthSource = fmt.Errorf("proto: negative length found during unmarshalling")
 	ErrIntOverflowSource   = fmt.Errorf("proto: integer overflow")
 )
 


### PR DESCRIPTION
Backports #19988 and #19987 to the 2.0.x line. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
