### PR TITLE
chore: backport fixes to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Bug Fixes
 
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
-2. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
+1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
+1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
 
 ## v2.0.1 [2020-11-10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
+2. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 
 ## v2.0.1 [2020-11-10]
 

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -108,8 +108,9 @@ func (b *cmdBackupBuilder) backupRunE(cmd *cobra.Command, args []string) (err er
 
 	ac := flags.config()
 	b.backupService = &http.BackupService{
-		Addr:  ac.Host,
-		Token: ac.Token,
+		Addr:               ac.Host,
+		Token:              ac.Token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	// Back up Bolt database to file.

--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -113,8 +113,9 @@ func (b *cmdRestoreBuilder) restoreRunE(cmd *cobra.Command, args []string) (err 
 
 	ac := flags.config()
 	b.restoreService = &http.RestoreService{
-		Addr:  ac.Host,
-		Token: ac.Token,
+		Addr:               ac.Host,
+		Token:              ac.Token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	client, err := newHTTPClient()

--- a/cmd/influxd/inspect/export_index.go
+++ b/cmd/influxd/inspect/export_index.go
@@ -16,6 +16,7 @@ func NewExportIndexCommand() *cobra.Command {
 		Long: `
 This command will export all series in a TSI index to
 SQL format for easier inspection and debugging.`,
+		Args: cobra.NoArgs,
 	}
 
 	var seriesFilePath, dataPath string

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -9,6 +9,10 @@ func NewCommand() *cobra.Command {
 	base := &cobra.Command{
 		Use:   "inspect",
 		Short: "Commands for inspecting on-disk database data",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.PrintErrf("See '%s -h' for help\n", cmd.CommandPath())
+		},
 	}
 
 	// List of available sub-commands

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -22,7 +22,6 @@ import (
 	"github.com/influxdata/influxdb/v2/bolt"
 	"github.com/influxdata/influxdb/v2/checks"
 	"github.com/influxdata/influxdb/v2/chronograf/server"
-	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/v2/dashboards"
 	dashboardTransport "github.com/influxdata/influxdb/v2/dashboards/transport"
 	"github.com/influxdata/influxdb/v2/dbrp"
@@ -101,7 +100,7 @@ const (
 	MaxInt = 1<<uint(strconv.IntSize-1) - 1
 )
 
-func NewInfluxdCommand(ctx context.Context, subCommands ...*cobra.Command) *cobra.Command {
+func NewInfluxdCommand(ctx context.Context) *cobra.Command {
 	l := NewLauncher()
 
 	prog := cli.Program{
@@ -128,12 +127,13 @@ func NewInfluxdCommand(ctx context.Context, subCommands ...*cobra.Command) *cobr
 	runCmd := &cobra.Command{
 		Use:  "run",
 		RunE: cmd.RunE,
+		Args: cobra.NoArgs,
 	}
 	for _, c := range []*cobra.Command{cmd, runCmd} {
 		assignDescs(c)
 		setLauncherCMDOpts(l, c)
 	}
-	cmd.AddCommand(append(subCommands, runCmd)...)
+	cmd.AddCommand(runCmd)
 
 	return cmd
 }
@@ -178,7 +178,6 @@ var vaultConfig vault.Config
 
 func setLauncherCMDOpts(l *Launcher, cmd *cobra.Command) {
 	cli.BindOptions(cmd, launcherOpts(l))
-	cmd.AddCommand(inspect.NewCommand())
 }
 
 func launcherOpts(l *Launcher) []cli.Opt {

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	_ "net/http/pprof"
 	"os"
 	"time"
@@ -28,23 +29,25 @@ func main() {
 
 	influxdb.SetBuildInfo(version, commit, date)
 
-	rootCmd := launcher.NewInfluxdCommand(context.Background(),
-		// FIXME
-		//generate.Command,
-		//restore.Command,
-		&cobra.Command{
-			Use:   "version",
-			Short: "Print the influxd server version",
-			Run: func(cmd *cobra.Command, args []string) {
-				fmt.Printf("InfluxDB %s (git: %s) build_date: %s\n", version, commit, date)
-			},
-		},
-	)
-
+	rootCmd := launcher.NewInfluxdCommand(context.Background())
 	// upgrade binds options to env variables, so it must be added after rootCmd is initialized
 	rootCmd.AddCommand(upgrade.NewCommand())
+	rootCmd.AddCommand(inspect.NewCommand())
+	rootCmd.AddCommand(versionCmd())
 
+	rootCmd.SilenceUsage = true
 	if err := rootCmd.Execute(); err != nil {
+		rootCmd.PrintErrf("See '%s -h' for help\n", rootCmd.CommandPath())
 		os.Exit(1)
+	}
+}
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the influxd server version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("InfluxDB %s (git: %s) build_date: %s\n", version, commit, date)
+		},
 	}
 }

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -147,6 +147,7 @@ func NewCommand() *cobra.Command {
     Target 2.x database dir is specified by the --engine-path option. If changed, the bolt path should be changed as well.
 `,
 		RunE: runUpgradeE,
+		Args: cobra.NoArgs,
 	}
 
 	opts := []cli.Opt{

--- a/cmd/influxd/upgrade/v1_dump_meta.go
+++ b/cmd/influxd/upgrade/v1_dump_meta.go
@@ -13,6 +13,7 @@ import (
 var v1DumpMetaCommand = &cobra.Command{
 	Use:   "v1-dump-meta",
 	Short: "Dump InfluxDB 1.x meta.db",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fluxinit.FluxInit()
 		svc, err := newInfluxDBv1(&v1DumpMetaOptions)

--- a/cmd/influxd/upgrade/v2_dump_meta.go
+++ b/cmd/influxd/upgrade/v2_dump_meta.go
@@ -17,6 +17,7 @@ import (
 var v2DumpMetaCommand = &cobra.Command{
 	Use:   "v2-dump-meta",
 	Short: "Dump InfluxDB 2.x influxd.bolt",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fluxinit.FluxInit()
 		ctx := context.Background()


### PR DESCRIPTION
Closes #19993 
Closes #19994 

Backports #19991 and #19995 to the 2.0 branch.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
