### PR TITLE
chore: Do not use global viper APIs, which breaks testing

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -27,11 +27,11 @@ func cmdAuth(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Run = seeHelp
 
 	cmd.AddCommand(
-		authActiveCmd(f),
-		authCreateCmd(f),
-		authDeleteCmd(f),
-		authFindCmd(f),
-		authInactiveCmd(f),
+		authActiveCmd(f, opt),
+		authCreateCmd(f, opt),
+		authDeleteCmd(f, opt),
+		authFindCmd(f, opt),
+		authInactiveCmd(f, opt),
 	)
 
 	return cmd
@@ -82,19 +82,19 @@ var authCreateFlags struct {
 	readDBRPPermission  bool
 }
 
-func authCreateCmd(f *globalFlags) *cobra.Command {
+func authCreateCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create authorization",
 		RunE:  checkSetupRunEMiddleware(&flags)(authorizationCreateF),
 	}
 
-	f.registerFlags(cmd)
-	authCreateFlags.org.register(cmd, false)
+	f.registerFlags(opt.viper, cmd)
+	authCreateFlags.org.register(opt.viper, cmd, false)
 
 	cmd.Flags().StringVarP(&authCreateFlags.description, "description", "d", "", "Token description")
 	cmd.Flags().StringVarP(&authCreateFlags.user, "user", "u", "", "The user name")
-	registerPrintOptions(cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
+	registerPrintOptions(opt.viper, cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
 
 	cmd.Flags().BoolVarP(&authCreateFlags.writeUserPermission, "write-user", "", false, "Grants the permission to perform mutative actions against organization users")
 	cmd.Flags().BoolVarP(&authCreateFlags.readUserPermission, "read-user", "", false, "Grants the permission to perform read actions against organization users")
@@ -308,7 +308,7 @@ var authorizationFindFlags struct {
 	userID string
 }
 
-func authFindCmd(f *globalFlags) *cobra.Command {
+func authFindCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List authorizations",
@@ -316,9 +316,9 @@ func authFindCmd(f *globalFlags) *cobra.Command {
 		RunE:    checkSetupRunEMiddleware(&flags)(authorizationFindF),
 	}
 
-	f.registerFlags(cmd)
-	authorizationFindFlags.org.register(cmd, false)
-	registerPrintOptions(cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	authorizationFindFlags.org.register(opt.viper, cmd, false)
+	registerPrintOptions(opt.viper, cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
 	cmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "The user")
 	cmd.Flags().StringVarP(&authorizationFindFlags.userID, "user-id", "", "", "The user ID")
 
@@ -402,15 +402,15 @@ func authorizationFindF(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func authDeleteCmd(f *globalFlags) *cobra.Command {
+func authDeleteCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete authorization",
 		RunE:  checkSetupRunEMiddleware(&flags)(authorizationDeleteF),
 	}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
 	cmd.Flags().StringVarP(&authCRUDFlags.id, "id", "i", "", "The authorization ID (required)")
 	cmd.MarkFlagRequired("id")
 
@@ -469,15 +469,15 @@ func authorizationDeleteF(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func authActiveCmd(f *globalFlags) *cobra.Command {
+func authActiveCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "active",
 		Short: "Active authorization",
 		RunE:  checkSetupRunEMiddleware(&flags)(authorizationActiveF),
 	}
-	f.registerFlags(cmd)
+	f.registerFlags(opt.viper, cmd)
 
-	registerPrintOptions(cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
+	registerPrintOptions(opt.viper, cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
 	cmd.Flags().StringVarP(&authCRUDFlags.id, "id", "i", "", "The authorization ID (required)")
 	cmd.MarkFlagRequired("id")
 
@@ -537,15 +537,15 @@ func authorizationActiveF(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func authInactiveCmd(f *globalFlags) *cobra.Command {
+func authInactiveCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inactive",
 		Short: "Inactive authorization",
 		RunE:  checkSetupRunEMiddleware(&flags)(authorizationInactiveF),
 	}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &authCRUDFlags.hideHeaders, &authCRUDFlags.json)
 	cmd.Flags().StringVarP(&authCRUDFlags.id, "id", "i", "", "The authorization ID (required)")
 	cmd.MarkFlagRequired("id")
 

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -53,7 +53,7 @@ func newCmdBackupBuilder(f *globalFlags, opts genericCLIOpts) *cmdBackupBuilder 
 
 func (b *cmdBackupBuilder) cmdBackup() *cobra.Command {
 	cmd := b.newCmd("backup", b.backupRunE)
-	b.org.register(cmd, true)
+	b.org.register(b.viper, cmd, true)
 	cmd.Flags().StringVar(&b.bucketID, "bucket-id", "", "The ID of the bucket to backup")
 	cmd.Flags().StringVarP(&b.bucketName, "bucket", "b", "", "The name of the bucket to backup")
 	cmd.Use = "backup [flags] path"
@@ -331,6 +331,6 @@ func (b *cmdBackupBuilder) writeManifest(ctx context.Context) error {
 func (b *cmdBackupBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
 	b.genericCLIOpts.registerPrintOptions(cmd)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -69,11 +69,11 @@ func (b *cmdBucketBuilder) cmdCreate() *cobra.Command {
 			Required: true,
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	cmd.Flags().StringVarP(&b.description, "description", "d", "", "Description of bucket that will be created")
 	cmd.Flags().StringVarP(&b.retention, "retention", "r", "", "Duration bucket will retain data. 0 is infinite. Default is 0.")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -117,7 +117,7 @@ func (b *cmdBucketBuilder) cmdDelete() *cobra.Command {
 
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "The bucket ID, required if name isn't provided")
 	cmd.Flags().StringVarP(&b.name, "name", "n", "", "The bucket name, org or org-id will be required by choosing this")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -180,9 +180,9 @@ func (b *cmdBucketBuilder) cmdList() *cobra.Command {
 			Desc:   "The bucket name",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "The bucket ID")
 
@@ -244,7 +244,7 @@ func (b *cmdBucketBuilder) cmdUpdate() *cobra.Command {
 			Desc:   "New bucket name",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	b.registerPrintFlags(cmd)
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "The bucket ID (required)")
@@ -292,12 +292,12 @@ func (b *cmdBucketBuilder) cmdUpdateRunEFn(cmd *cobra.Command, args []string) er
 
 func (b *cmdBucketBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 
 func (b *cmdBucketBuilder) registerPrintFlags(cmd *cobra.Command) {
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 }
 
 type bucketPrintOpt struct {

--- a/cmd/influx/config.go
+++ b/cmd/influx/config.go
@@ -317,11 +317,11 @@ func (b *cmdConfigBuilder) registerConfigSettingFlags(cmd *cobra.Command) {
 }
 
 func (b *cmdConfigBuilder) registerFilepath(cmd *cobra.Command) {
-	b.globalFlags.registerFlags(cmd, "host", "token", "skip-verify", "trace-debug-id")
+	b.globalFlags.registerFlags(b.viper, cmd, "host", "token", "skip-verify", "trace-debug-id")
 }
 
 func (b *cmdConfigBuilder) registerPrintFlags(cmd *cobra.Command) {
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 }
 
 func (b *cmdConfigBuilder) printConfigs(opts configPrintOpts) error {

--- a/cmd/influx/dashboard.go
+++ b/cmd/influx/dashboard.go
@@ -51,7 +51,7 @@ func (b *cmdDashboardBuilder) cmdDashboards() *cobra.Command {
 		influx dashboards -i $ID1 -i $ID2
 `
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	cmd.Flags().StringArrayVarP(&b.ids, "id", "i", nil, "Dashboard ID to retrieve.")
 
 	return cmd
@@ -134,7 +134,7 @@ func writeDashboardRows(tabW *internal.TabWriter, dashboards ...*influxdb.Dashbo
 func (b *cmdDashboardBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
 	b.genericCLIOpts.registerPrintOptions(cmd)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 

--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -58,7 +58,7 @@ func (b *cmdDeleteBuilder) cmd() *cobra.Command {
 			Persistent: true,
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	cmd.PersistentFlags().StringVar(&b.flags.Start, "start", "", "the start time in RFC3339Nano format, exp 2009-01-02T23:00:00Z")
 	cmd.PersistentFlags().StringVar(&b.flags.Stop, "stop", "", "the stop time in RFC3339Nano format, exp 2009-01-02T23:00:00Z")
@@ -102,6 +102,6 @@ func (b *cmdDeleteBuilder) fluxDeleteF(cmd *cobra.Command, args []string) error 
 
 func (b *cmdDeleteBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -99,7 +99,7 @@ func (b *cmdOrgBuilder) cmdDelete() *cobra.Command {
 			Desc:   "The organization ID",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -153,7 +153,7 @@ func (b *cmdOrgBuilder) cmdFind() *cobra.Command {
 			Desc:   "The organization ID",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -214,7 +214,7 @@ func (b *cmdOrgBuilder) cmdUpdate() *cobra.Command {
 			Desc:   "The organization name",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -320,7 +320,7 @@ func (b *cmdOrgBuilder) cmdMemberList() *cobra.Command {
 			Desc:   "The organization ID",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 	b.registerPrintFlags(cmd)
 	return cmd
 }
@@ -385,7 +385,7 @@ func (b *cmdOrgBuilder) cmdMemberAdd() *cobra.Command {
 			Desc:   "The organization ID",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	return cmd
 }
@@ -458,7 +458,7 @@ func (b *cmdOrgBuilder) cmdMemberRemove() *cobra.Command {
 			Desc:   "The organization ID",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	cmd.Flags().StringVarP(&b.memberID, "member", "m", "", "The member ID")
 	cmd.MarkFlagRequired("member")
@@ -511,12 +511,12 @@ func (b *cmdOrgBuilder) membersRemoveRunEFn(cmd *cobra.Command, args []string) e
 
 func (b *cmdOrgBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 
 func (b *cmdOrgBuilder) registerPrintFlags(cmd *cobra.Command) {
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 }
 
 func newOrgServices() (influxdb.OrganizationService, influxdb.UserResourceMappingService, influxdb.UserService, error) {

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -46,7 +46,7 @@ func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 	cmd := opts.newCmd("ping", runE, true)
 	cmd.Short = "Check the InfluxDB /health endpoint"
 	cmd.Long = `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`
-	f.registerFlags(cmd, "token")
+	f.registerFlags(opts.viper, cmd, "token")
 
 	return cmd
 }

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -32,8 +32,8 @@ func cmdQuery(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 	cmd.Long = `Execute a Flux query provided via the first argument or a file or stdin`
 	cmd.Args = cobra.MaximumNArgs(1)
 
-	f.registerFlags(cmd)
-	queryFlags.org.register(cmd, true)
+	f.registerFlags(opts.viper, cmd)
+	queryFlags.org.register(opts.viper, cmd, true)
 	cmd.Flags().StringVarP(&queryFlags.file, "file", "f", "", "Path to Flux query file")
 	cmd.Flags().BoolVarP(&queryFlags.raw, "raw", "r", false, "Display raw query results")
 

--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -60,7 +60,7 @@ func newCmdRestoreBuilder(f *globalFlags, opts genericCLIOpts) *cmdRestoreBuilde
 
 func (b *cmdRestoreBuilder) cmdRestore() *cobra.Command {
 	cmd := b.newCmd("restore", b.restoreRunE)
-	b.org.register(cmd, true)
+	b.org.register(b.viper, cmd, true)
 	cmd.Flags().BoolVar(&b.full, "full", false, "Fully restore and replace all data on server")
 	cmd.Flags().StringVar(&b.bucketID, "bucket-id", "", "The ID of the bucket to restore")
 	cmd.Flags().StringVarP(&b.bucketName, "bucket", "b", "", "The name of the bucket to restore")
@@ -395,6 +395,6 @@ func (b *cmdRestoreBuilder) loadIncremental() error {
 func (b *cmdRestoreBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
 	b.genericCLIOpts.registerPrintOptions(cmd)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }

--- a/cmd/influx/secret.go
+++ b/cmd/influx/secret.go
@@ -58,7 +58,7 @@ func (b *cmdSecretBuilder) cmdUpdate() *cobra.Command {
 	cmd.Flags().StringVarP(&b.key, "key", "k", "", "The secret key (required)")
 	cmd.Flags().StringVarP(&b.value, "value", "v", "", "Optional secret value for scripting convenience, using this might expose the secret to your local history")
 	cmd.MarkFlagRequired("key")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -108,7 +108,7 @@ func (b *cmdSecretBuilder) cmdDelete() *cobra.Command {
 
 	cmd.Flags().StringVarP(&b.key, "key", "k", "", "The secret key (required)")
 	cmd.MarkFlagRequired("key")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -143,7 +143,7 @@ func (b *cmdSecretBuilder) cmdFind() *cobra.Command {
 	cmd.Short = "List secrets"
 	cmd.Aliases = []string{"find", "ls"}
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -180,12 +180,12 @@ func (b *cmdSecretBuilder) cmdFindRunEFn(cmd *cobra.Command, args []string) erro
 
 func (b *cmdSecretBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 
 func (b *cmdSecretBuilder) registerPrintFlags(cmd *cobra.Command) {
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 }
 
 func (b *cmdSecretBuilder) printSecrets(opt secretPrintOpt) error {

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -36,7 +36,7 @@ func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.RunE = setupF
 	cmd.Short = "Setup instance with initial user, org, bucket"
 
-	f.registerFlags(cmd, "token")
+	f.registerFlags(opt.viper, cmd, "token")
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
 	cmd.Flags().StringVarP(&setupFlags.password, "password", "p", "", "password for username")
 	cmd.Flags().StringVarP(&setupFlags.token, "token", "t", "", "token for username, else auto-generated")
@@ -45,7 +45,7 @@ func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Flags().StringVarP(&setupFlags.name, "name", "n", "", "config name, only required if you already have existing configs")
 	cmd.Flags().StringVarP(&setupFlags.retention, "retention", "r", "", "Duration bucket will retain data. 0 is infinite. Default is 0.")
 	cmd.Flags().BoolVarP(&setupFlags.force, "force", "f", false, "skip confirmation prompt")
-	registerPrintOptions(cmd, &setupFlags.hideHeaders, &setupFlags.json)
+	registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json)
 
 	cmd.AddCommand(
 		cmdSetupUser(f, opt),
@@ -58,7 +58,7 @@ func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.RunE = setupUserF
 	cmd.Short = "Setup instance with user, org, bucket"
 
-	f.registerFlags(cmd, "token")
+	f.registerFlags(opt.viper, cmd, "token")
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
 	cmd.Flags().StringVarP(&setupFlags.password, "password", "p", "", "password for username")
 	cmd.Flags().StringVarP(&setupFlags.token, "token", "t", "", "token for username, else auto-generated")
@@ -67,7 +67,7 @@ func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Flags().StringVarP(&setupFlags.name, "name", "n", "", "config name, only required if you already have existing configs")
 	cmd.Flags().StringVarP(&setupFlags.retention, "retention", "r", "", "Duration bucket will retain data. 0 is infinite. Default is 0.")
 	cmd.Flags().BoolVarP(&setupFlags.force, "force", "f", false, "skip confirmation prompt")
-	registerPrintOptions(cmd, &setupFlags.hideHeaders, &setupFlags.json)
+	registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json)
 
 	return cmd
 }

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -50,10 +50,10 @@ func taskCreateCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "Create task"
 	cmd.Long = `Create a task with a Flux script provided via the first argument or a file or stdin`
 
-	f.registerFlags(cmd)
+	f.registerFlags(opt.viper, cmd)
 	cmd.Flags().StringVarP(&taskCreateFlags.file, "file", "f", "", "Path to Flux script file")
-	taskCreateFlags.org.register(cmd, false)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	taskCreateFlags.org.register(opt.viper, cmd, false)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 
 	return cmd
 }
@@ -121,9 +121,9 @@ func taskFindCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "List tasks"
 	cmd.Aliases = []string{"find", "ls"}
 
-	taskFindFlags.org.register(cmd, false)
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	taskFindFlags.org.register(opt.viper, cmd, false)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 	cmd.Flags().StringVarP(&taskFindFlags.id, "id", "i", "", "task ID")
 	cmd.Flags().StringVarP(&taskFindFlags.user, "user-id", "n", "", "task owner ID")
 	cmd.Flags().IntVarP(&taskFindFlags.limit, "limit", "", influxdb.TaskDefaultPageSize, "the number of tasks to find")
@@ -213,8 +213,8 @@ func taskUpdateCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "Update task"
 	cmd.Long = `Update task status or script. Provide a Flux script via the first argument or a file. Use '-' argument to read from stdin.`
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 	cmd.Flags().StringVarP(&taskUpdateFlags.id, "id", "i", "", "task ID (required)")
 	cmd.Flags().StringVarP(&taskUpdateFlags.status, "status", "", "", "update task status")
 	cmd.Flags().StringVarP(&taskUpdateFlags.file, "file", "f", "", "Path to Flux script file")
@@ -275,8 +275,8 @@ func taskDeleteCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := opt.newCmd("delete", taskDeleteF, true)
 	cmd.Short = "Delete task"
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 	cmd.Flags().StringVarP(&taskDeleteFlags.id, "id", "i", "", "task id (required)")
 	cmd.MarkFlagRequired("id")
 
@@ -391,8 +391,8 @@ func taskLogFindCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "List logs for task"
 	cmd.Aliases = []string{"find", "ls"}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 	cmd.Flags().StringVarP(&taskLogFindFlags.taskID, "task-id", "", "", "task id (required)")
 	cmd.Flags().StringVarP(&taskLogFindFlags.runID, "run-id", "", "", "run id")
 	cmd.MarkFlagRequired("task-id")
@@ -478,8 +478,8 @@ func taskRunFindCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "List runs for a task"
 	cmd.Aliases = []string{"find", "ls"}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &taskPrintFlags.hideHeaders, &taskPrintFlags.json)
 	cmd.Flags().StringVarP(&taskRunFindFlags.taskID, "task-id", "", "", "task id (required)")
 	cmd.Flags().StringVarP(&taskRunFindFlags.runID, "run-id", "", "", "run id")
 	cmd.Flags().StringVarP(&taskRunFindFlags.afterTime, "after", "", "", "after time for filtering")
@@ -582,7 +582,7 @@ func taskRunRetryCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := opt.newCmd("retry", runRetryF, true)
 	cmd.Short = "retry a run"
 
-	f.registerFlags(cmd)
+	f.registerFlags(opt.viper, cmd)
 	cmd.Flags().StringVarP(&runRetryFlags.taskID, "task-id", "i", "", "task id (required)")
 	cmd.Flags().StringVarP(&runRetryFlags.runID, "run-id", "r", "", "run id (required)")
 	cmd.MarkFlagRequired("task-id")

--- a/cmd/influx/telegraf.go
+++ b/cmd/influx/telegraf.go
@@ -57,7 +57,7 @@ func (b *cmdTelegrafBuilder) cmdTelegrafs() *cobra.Command {
 		influx telegrafs -i $ID
 `
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "Telegraf configuration ID to retrieve.")
 
 	cmd.AddCommand(
@@ -123,7 +123,7 @@ func (b *cmdTelegrafBuilder) cmdCreate() *cobra.Command {
 		cat $CONFIG_FILE | influx telegrafs create -n $CFG_NAME -d $CFG_DESC
 `
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerTelegrafCfgFlags(cmd)
 
 	return cmd
@@ -223,7 +223,7 @@ func (b *cmdTelegrafBuilder) cmdUpdate() *cobra.Command {
 		cat $CONFIG_FILE | influx telegrafs update -i $ID  -n $CFG_NAME -d $CFG_DESC
 `
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerTelegrafCfgFlags(cmd)
 	cmd.Flags().StringVarP(&b.id, "id", "i", "", "Telegraf configuration id to update")
 	cmd.MarkFlagRequired("id")
@@ -326,7 +326,7 @@ func (b *cmdTelegrafBuilder) readConfig(file string) (string, error) {
 func (b *cmdTelegrafBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
 	b.genericCLIOpts.registerPrintOptions(cmd)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 

--- a/cmd/influx/template.go
+++ b/cmd/influx/template.go
@@ -172,7 +172,7 @@ func (b *cmdTemplateBuilder) cmdApply() *cobra.Command {
 	https://github.com/influxdata/community-templates.
 `
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerTemplateFileFlags(cmd)
 	b.registerTemplatePrintOpts(cmd)
 	cmd.Flags().BoolVarP(&b.quiet, "quiet", "q", false, "Disable output printing")
@@ -480,7 +480,7 @@ func (b *cmdTemplateBuilder) cmdExportAll() *cobra.Command {
 	cmd.Flags().StringVarP(&b.file, "file", "f", "", "output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding")
 	cmd.Flags().StringArrayVar(&b.filters, "filter", nil, "Filter exported resources by labelName or resourceKind (format: --filter=labelName=example)")
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 
 	return cmd
 }
@@ -547,7 +547,7 @@ func (b *cmdTemplateBuilder) cmdExportStack() *cobra.Command {
 	cmd.Args = cobra.ExactValidArgs(1)
 
 	cmd.Flags().StringVarP(&b.file, "file", "f", "", "output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 
 	return cmd
 }
@@ -612,9 +612,9 @@ func (b *cmdTemplateBuilder) cmdStacks() *cobra.Command {
 	cmd := b.newCmd("stacks [flags]", b.stackListRunEFn)
 	cmd.Flags().StringArrayVar(&b.stackIDs, "stack-id", nil, "Stack ID to filter by")
 	cmd.Flags().StringArrayVar(&b.names, "stack-name", nil, "Stack name to filter by")
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 
 	cmd.Short = "List stack(s) and associated templates. Subcommands manage stacks."
 	cmd.Long = `
@@ -675,9 +675,9 @@ func (b *cmdTemplateBuilder) cmdStackInit() *cobra.Command {
 	cmd.Flags().StringVarP(&b.name, "stack-name", "n", "", "Name given to created stack")
 	cmd.Flags().StringVarP(&b.description, "stack-description", "d", "", "Description given to created stack")
 	cmd.Flags().StringArrayVarP(&b.urls, "template-url", "u", nil, "Template urls to associate with new stack")
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 
 	return cmd
 }
@@ -756,9 +756,9 @@ func (b *cmdTemplateBuilder) cmdStackRemove() *cobra.Command {
 	cmd.Flags().StringArrayVar(&b.stackIDs, "stack-id", nil, "Stack IDs to be removed")
 	cmd.Flags().BoolVar(&b.force, "force", false, "Remove stack without confirmation prompt")
 	cmd.MarkFlagRequired("stack-id")
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 
 	return cmd
 }
@@ -872,7 +872,7 @@ func (b *cmdTemplateBuilder) cmdStackUpdate() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&b.urls, "template-url", "u", nil, "Template urls to associate with stack")
 	cmd.Flags().StringArrayVar(&b.updateStackOpts.addResources, "addResource", nil, "Additional resources to associate with stack")
 	cmd.Flags().StringVarP(&b.file, "export-file", "f", "", "Destination for exported template")
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 
 	return cmd
 }
@@ -968,14 +968,14 @@ func (b *cmdTemplateBuilder) writeStack(stack pkger.Stack) error {
 
 func (b *cmdTemplateBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 
 func (b *cmdTemplateBuilder) registerTemplatePrintOpts(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&b.disableColor, "disable-color", false, "Disable color in output")
 	cmd.Flags().BoolVar(&b.disableTableBorders, "disable-table-borders", false, "Disable table borders")
-	registerPrintOptions(cmd, nil, &b.json)
+	registerPrintOptions(b.viper, cmd, nil, &b.json)
 }
 
 func (b *cmdTemplateBuilder) registerTemplateFileFlags(cmd *cobra.Command) {

--- a/cmd/influx/transpile.go
+++ b/cmd/influx/transpile.go
@@ -34,7 +34,7 @@ The transpiled query will be written for absolute time ranges using the provided
 			Desc:  "An RFC3339Nano formatted time to use as the now() time. Defaults to the current time",
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(opt.viper, cmd)
 
 	return cmd
 }

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -158,10 +158,10 @@ func (b *cmdUserBuilder) cmdCreate() *cobra.Command {
 			Required: true,
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(b.viper, cmd)
 
 	cmd.Flags().StringVarP(&b.password, "password", "p", "", "The user password")
-	b.org.register(cmd, false)
+	b.org.register(b.viper, cmd, false)
 	b.registerPrintFlags(cmd)
 
 	return cmd
@@ -295,12 +295,12 @@ func (b *cmdUserBuilder) cmdDeleteRunEFn(cmd *cobra.Command, args []string) erro
 
 func (b *cmdUserBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(cmd)
+	b.globalFlags.registerFlags(b.viper, cmd)
 	return cmd
 }
 
 func (b *cmdUserBuilder) registerPrintFlags(cmd *cobra.Command) {
-	registerPrintOptions(cmd, &b.hideHeaders, &b.json)
+	registerPrintOptions(b.viper, cmd, &b.hideHeaders, &b.json)
 }
 
 func (b *cmdUserBuilder) printUser(opt userPrintOpts) error {

--- a/cmd/influx/v1_authorization.go
+++ b/cmd/influx/v1_authorization.go
@@ -11,6 +11,7 @@ import (
 	cinternal "github.com/influxdata/influxdb/v2/cmd/internal"
 	"github.com/influxdata/influxdb/v2/v1/authorization"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/tcnksm/go-input"
 )
 
@@ -32,10 +33,10 @@ func cmdV1Auth(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 
 	cmd.AddCommand(
 		v1AuthCreateCmd(f, opt),
-		v1AuthDeleteCmd(f),
-		v1AuthFindCmd(f),
-		v1AuthSetActiveCmd(f),
-		v1AuthSetInactiveCmd(f),
+		v1AuthDeleteCmd(f, opt),
+		v1AuthFindCmd(f, opt),
+		v1AuthSetActiveCmd(f, opt),
+		v1AuthSetInactiveCmd(f, opt),
 		v1AuthSetPasswordCmd(f, opt),
 	)
 
@@ -61,14 +62,14 @@ func v1AuthCreateCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 		RunE:  checkSetupRunEMiddleware(&flags)(makeV1AuthorizationCreateE(opt)),
 	}
 
-	f.registerFlags(cmd)
-	v1AuthCreateFlags.org.register(cmd, false)
+	f.registerFlags(opt.viper, cmd)
+	v1AuthCreateFlags.org.register(opt.viper, cmd, false)
 
 	cmd.Flags().StringVar(&v1AuthCreateFlags.username, "username", "", "The username to identify this token")
 	_ = cmd.MarkFlagRequired("username")
 	cmd.Flags().StringVarP(&v1AuthCreateFlags.description, "description", "d", "", "Token description")
 	cmd.Flags().BoolVar(&v1AuthCreateFlags.noPassword, "no-password", false, "Don't prompt for a password. You must use v1 auth set-password command before using the token.")
-	registerPrintOptions(cmd, &v1AuthCreateFlags.hideHeaders, &v1AuthCreateFlags.json)
+	registerPrintOptions(opt.viper, cmd, &v1AuthCreateFlags.hideHeaders, &v1AuthCreateFlags.json)
 
 	cmd.Flags().StringArrayVarP(&v1AuthCreateFlags.writeBucketPermissions, "write-bucket", "", []string{}, "The bucket id")
 	cmd.Flags().StringArrayVarP(&v1AuthCreateFlags.readBucketPermissions, "read-bucket", "", []string{}, "The bucket id")
@@ -202,7 +203,7 @@ var v1AuthorizationFindFlags struct {
 	userID      string
 }
 
-func v1AuthFindCmd(f *globalFlags) *cobra.Command {
+func v1AuthFindCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List authorizations",
@@ -210,12 +211,12 @@ func v1AuthFindCmd(f *globalFlags) *cobra.Command {
 		RunE:    checkSetupRunEMiddleware(&flags)(v1AuthorizationFindF),
 	}
 
-	f.registerFlags(cmd)
-	v1AuthorizationFindFlags.org.register(cmd, false)
-	registerPrintOptions(cmd, &v1AuthorizationFindFlags.hideHeaders, &v1AuthorizationFindFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	v1AuthorizationFindFlags.org.register(opt.viper, cmd, false)
+	registerPrintOptions(opt.viper, cmd, &v1AuthorizationFindFlags.hideHeaders, &v1AuthorizationFindFlags.json)
 	cmd.Flags().StringVarP(&v1AuthorizationFindFlags.user, "user", "u", "", "The user")
 	cmd.Flags().StringVarP(&v1AuthorizationFindFlags.userID, "user-id", "", "", "The user ID")
-	v1AuthorizationFindFlags.lookup.register(cmd, false)
+	v1AuthorizationFindFlags.lookup.register(opt.viper, cmd, false)
 
 	return cmd
 }
@@ -302,17 +303,17 @@ var v1AuthDeleteFlags struct {
 	json        bool
 }
 
-func v1AuthDeleteCmd(f *globalFlags) *cobra.Command {
+func v1AuthDeleteCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete authorization",
 		RunE:  checkSetupRunEMiddleware(&flags)(v1AuthorizationDeleteF),
 	}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &v1AuthDeleteFlags.hideHeaders, &v1AuthDeleteFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &v1AuthDeleteFlags.hideHeaders, &v1AuthDeleteFlags.json)
 	v1AuthDeleteFlags.lookup.required = true
-	v1AuthDeleteFlags.lookup.register(cmd, false)
+	v1AuthDeleteFlags.lookup.register(opt.viper, cmd, false)
 
 	return cmd
 }
@@ -375,17 +376,17 @@ var v1AuthActivateFlags struct {
 	json        bool
 }
 
-func v1AuthSetActiveCmd(f *globalFlags) *cobra.Command {
+func v1AuthSetActiveCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-active",
 		Short: "Change the status of an authorization to active",
 		RunE:  checkSetupRunEMiddleware(&flags)(v1AuthorizationSetActiveF),
 	}
-	f.registerFlags(cmd)
+	f.registerFlags(opt.viper, cmd)
 
-	registerPrintOptions(cmd, &v1AuthActivateFlags.hideHeaders, &v1AuthActivateFlags.json)
+	registerPrintOptions(opt.viper, cmd, &v1AuthActivateFlags.hideHeaders, &v1AuthActivateFlags.json)
 	v1AuthActivateFlags.lookup.required = true
-	v1AuthActivateFlags.lookup.register(cmd, false)
+	v1AuthActivateFlags.lookup.register(opt.viper, cmd, false)
 
 	return cmd
 }
@@ -450,17 +451,17 @@ var v1AuthDeactivateFlags struct {
 	json        bool
 }
 
-func v1AuthSetInactiveCmd(f *globalFlags) *cobra.Command {
+func v1AuthSetInactiveCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-inactive",
 		Short: "Change the status of an authorization to inactive",
 		RunE:  checkSetupRunEMiddleware(&flags)(v1AuthorizationSetInactiveF),
 	}
 
-	f.registerFlags(cmd)
-	registerPrintOptions(cmd, &v1AuthDeactivateFlags.hideHeaders, &v1AuthDeactivateFlags.json)
+	f.registerFlags(opt.viper, cmd)
+	registerPrintOptions(opt.viper, cmd, &v1AuthDeactivateFlags.hideHeaders, &v1AuthDeactivateFlags.json)
 	v1AuthDeactivateFlags.lookup.required = true
-	v1AuthDeactivateFlags.lookup.register(cmd, false)
+	v1AuthDeactivateFlags.lookup.register(opt.viper, cmd, false)
 
 	return cmd
 }
@@ -546,7 +547,7 @@ type v1AuthLookupFlags struct {
 	required bool // required when set to true determines whether validate expects either id or username to be set
 }
 
-func (f *v1AuthLookupFlags) register(cmd *cobra.Command, persistent bool) {
+func (f *v1AuthLookupFlags) register(v *viper.Viper, cmd *cobra.Command, persistent bool) {
 	opts := flagOpts{
 		{
 			DestP:      &f.id,
@@ -561,7 +562,7 @@ func (f *v1AuthLookupFlags) register(cmd *cobra.Command, persistent bool) {
 			Persistent: persistent,
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(v, cmd)
 }
 
 func (f *v1AuthLookupFlags) validate() error {
@@ -600,8 +601,8 @@ func v1AuthSetPasswordCmd(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 		RunE:  checkSetupRunEMiddleware(&flags)(makeV1AuthorizationSetPasswordF(opt)),
 	}
 
-	f.registerFlags(cmd)
-	v1AuthSetPasswordFlags.lookup.register(cmd, false)
+	f.registerFlags(opt.viper, cmd)
+	v1AuthSetPasswordFlags.lookup.register(opt.viper, cmd, false)
 
 	return cmd
 }

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -55,8 +55,8 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Short = "Write points to InfluxDB"
 	cmd.Long = `Write data to InfluxDB via stdin, or add an entire file specified with the -f flag`
 
-	f.registerFlags(cmd)
-	writeFlags.org.register(cmd, true)
+	f.registerFlags(opt.viper, cmd)
+	writeFlags.org.register(opt.viper, cmd, true)
 	opts := flagOpts{
 		{
 			DestP:      &writeFlags.BucketID,
@@ -81,7 +81,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 			Persistent: true,
 		},
 	}
-	opts.mustRegister(cmd)
+	opts.mustRegister(opt.viper, cmd)
 	cmd.PersistentFlags().StringVar(&writeFlags.Format, "format", "", "Input format, either lp (Line Protocol) or csv (Comma Separated Values). Defaults to lp unless '.csv' extension")
 	cmd.PersistentFlags().StringArrayVar(&writeFlags.Headers, "header", []string{}, "Header prepends lines to input data; Example --header HEADER1 --header HEADER2")
 	cmd.PersistentFlags().StringArrayVarP(&writeFlags.Files, "file", "f", []string{}, "The path to the file to import")
@@ -101,7 +101,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmdDryRun.Args = cobra.MaximumNArgs(1)
 	cmdDryRun.Short = "Write to stdout instead of InfluxDB"
 	cmdDryRun.Long = `Write protocol lines to stdout instead of InfluxDB. Troubleshoot conversion from CSV to line protocol.`
-	f.registerFlags(cmdDryRun)
+	f.registerFlags(opt.viper, cmdDryRun)
 	cmd.AddCommand(cmdDryRun)
 	return cmd
 }

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/v2/pkg/csv2lp"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -248,7 +249,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			command := cmdWrite(&globalFlags{}, genericCLIOpts{in: test.stdIn})
+			command := cmdWrite(&globalFlags{}, genericCLIOpts{in: test.stdIn, viper: viper.New()})
 			reader, closer, err := test.flags.createLineReader(context.Background(), command, test.arguments)
 			require.NotNil(t, closer)
 			defer closer.Close()
@@ -327,7 +328,7 @@ func Test_writeFlags_createLineReader_errors(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader("")})
+			command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(""), viper: viper.New()})
 			_, closer, err := test.flags.createLineReader(context.Background(), command, []string{})
 			require.NotNil(t, closer)
 			defer closer.Close()
@@ -342,7 +343,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 	t.Run("process and transform csv data without problems to stdout", func(t *testing.T) {
 		stdInContents := "i,j,_measurement,k\nstdin1,stdin2,stdin3,stdin4"
 		out := bytes.Buffer{}
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out), viper: viper.New()})
 		command.SetArgs([]string{"dryrun", "--format", "csv"})
 		err := command.Execute()
 		require.Nil(t, err)
@@ -352,7 +353,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 	t.Run("dryrun fails on unsupported data format", func(t *testing.T) {
 		stdInContents := "i,j,_measurement,k\nstdin1,stdin2,stdin3,stdin4"
 		out := bytes.Buffer{}
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out), viper: viper.New()})
 		command.SetArgs([]string{"dryrun", "--format", "csvx"})
 		err := command.Execute()
 		require.NotNil(t, err)
@@ -362,7 +363,7 @@ func Test_fluxWriteDryrunF(t *testing.T) {
 	t.Run("dryrun fails on malformed CSV data while reading them", func(t *testing.T) {
 		stdInContents := "i,j,l,k\nstdin1,stdin2,stdin3,stdin4"
 		out := bytes.Buffer{}
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out), viper: viper.New()})
 		command.SetArgs([]string{"dryrun", "--format", "csv"})
 		err := command.Execute()
 		require.NotNil(t, err)
@@ -406,7 +407,7 @@ func Test_fluxWriteF(t *testing.T) {
 	t.Run("validates that --org or --org-id must be specified", func(t *testing.T) {
 		t.Skip(`this test is hard coded to global variables and one small tweak causes a lot of downstream test failures changes else, skipping for now`)
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "org")
@@ -414,7 +415,7 @@ func Test_fluxWriteF(t *testing.T) {
 
 	t.Run("validates that either --bucket or --bucket-id must be specified", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket", "my-bucket", "--bucket-id", "my-bucket"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "bucket") // bucket or bucket-id, but not both
@@ -422,7 +423,7 @@ func Test_fluxWriteF(t *testing.T) {
 
 	t.Run("validates --precision", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket", "my-bucket", "--precision", "pikosec"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "precision") // invalid precision
@@ -432,7 +433,7 @@ func Test_fluxWriteF(t *testing.T) {
 		t.Skip(`this test is hard coded to global variables and one small tweak causes a lot of downstream test failures changes else, skipping for now`)
 		useTestServer()
 		flags.host = ""
-		command := cmdWrite(&flags, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&flags, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket", "my-bucket"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "host")
@@ -440,7 +441,7 @@ func Test_fluxWriteF(t *testing.T) {
 
 	t.Run("validates decoding of bucket-id", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket-id", "my-bucket"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "bucket-id")
@@ -448,7 +449,7 @@ func Test_fluxWriteF(t *testing.T) {
 
 	t.Run("validates decoding of org-id", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org-id", "my-org", "--bucket", "my-bucket"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "org-id")
@@ -456,7 +457,7 @@ func Test_fluxWriteF(t *testing.T) {
 
 	t.Run("validates error when failed to retrieve buckets", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket", "my-error-bucket"})
 		require.Nil(t, command.Execute())
 	})
@@ -464,7 +465,7 @@ func Test_fluxWriteF(t *testing.T) {
 	// validation: no such bucket found
 	t.Run("validates no such bucket found", func(t *testing.T) {
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-empty-org", "--bucket", "my-bucket"})
 		require.Nil(t, command.Execute())
 	})
@@ -473,7 +474,7 @@ func Test_fluxWriteF(t *testing.T) {
 	t.Run("validates no such bucket-id found", func(t *testing.T) {
 		t.Skip(`this test is hard coded to global variables and one small tweak causes a lot of downstream test failures changes else, skipping for now`)
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		// note: my-empty-org parameter causes the test server to return no buckets
 		command.SetArgs([]string{"--format", "csv", "--org", "my-empty-org", "--bucket-id", "4f14589c26df8286"})
 		err := command.Execute()
@@ -483,7 +484,7 @@ func Test_fluxWriteF(t *testing.T) {
 	t.Run("validates unsupported line reader format", func(t *testing.T) {
 		t.Skip(`this test is hard coded to global variables and one small tweak causes a lot of downstream test failures changes else, skipping for now`)
 		useTestServer()
-		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard})
+		command := cmdWrite(&globalFlags{}, genericCLIOpts{w: ioutil.Discard, viper: viper.New()})
 		command.SetArgs([]string{"--format", "csvx", "--org", "my-org", "--bucket-id", "4f14589c26df8286"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "format")
@@ -493,8 +494,9 @@ func Test_fluxWriteF(t *testing.T) {
 		t.Skip(`this test is hard coded to global variables and one small tweak causes a lot of downstream test failures changes else, skipping for now`)
 		useTestServer()
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{
-			in: strings.NewReader("a,b\nc,d"),
-			w:  ioutil.Discard})
+			in:    strings.NewReader("a,b\nc,d"),
+			w:     ioutil.Discard,
+			viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket-id", "4f14589c26df8286"})
 		err := command.Execute()
 		require.Contains(t, fmt.Sprintf("%s", err), "measurement") // no measurement found in CSV data
@@ -505,8 +507,9 @@ func Test_fluxWriteF(t *testing.T) {
 		// read data from CSV transformation, send them to server and validate the created protocol line
 		useTestServer()
 		command := cmdWrite(&globalFlags{}, genericCLIOpts{
-			in: strings.NewReader("i,j,_measurement,k\nstdin1,stdin2,stdin3,stdin4"),
-			w:  ioutil.Discard})
+			in:    strings.NewReader("i,j,_measurement,k\nstdin1,stdin2,stdin3,stdin4"),
+			w:     ioutil.Discard,
+			viper: viper.New()})
 		command.SetArgs([]string{"--format", "csv", "--org", "my-org", "--bucket-id", "4f14589c26df8286"})
 		err := command.Execute()
 		require.Nil(t, err)
@@ -520,7 +523,7 @@ func Test_writeFlags_errorsFile(t *testing.T) {
 	errorsFile := createTempFile("errors", []byte{})
 	stdInContents := "_measurement,a|long:strict\nm,1\nm,1.1"
 	out := bytes.Buffer{}
-	command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out)})
+	command := cmdWrite(&globalFlags{}, genericCLIOpts{in: strings.NewReader(stdInContents), w: bufio.NewWriter(&out), viper: viper.New()})
 	command.SetArgs([]string{"dryrun", "--format", "csv", "--errors-file", errorsFile})
 	err := command.Execute()
 	require.Nil(t, err)

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -2,10 +2,11 @@ package inspect
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // NewCommand creates the new command.
-func NewCommand() *cobra.Command {
+func NewCommand(_ *viper.Viper) *cobra.Command {
 	base := &cobra.Command{
 		Use:   "inspect",
 		Short: "Commands for inspecting on-disk database data",

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -2,11 +2,10 @@ package inspect
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // NewCommand creates the new command.
-func NewCommand(_ *viper.Viper) *cobra.Command {
+func NewCommand() *cobra.Command {
 	base := &cobra.Command{
 		Use:   "inspect",
 		Short: "Commands for inspecting on-disk database data",

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -55,8 +55,8 @@ type TestLauncher struct {
 }
 
 // NewTestLauncher returns a new instance of TestLauncher.
-func NewTestLauncher(flagger feature.Flagger) *TestLauncher {
-	l := &TestLauncher{Launcher: NewLauncher()}
+func NewTestLauncher(flagger feature.Flagger, opts ...Option) *TestLauncher {
+	l := &TestLauncher{Launcher: NewLauncher(opts...)}
 	l.Launcher.Stdin = &l.Stdin
 	l.Launcher.Stdout = &l.Stdout
 	l.Launcher.Stderr = &l.Stderr

--- a/cmd/influxd/launcher/launcher_option.go
+++ b/cmd/influxd/launcher/launcher_option.go
@@ -1,0 +1,46 @@
+package launcher
+
+import (
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+type Option interface {
+	applyInit(l *Launcher)
+	applyConfig(l *Launcher)
+}
+
+func WithLogger(log *zap.Logger) Option {
+	return &launcherOption{
+		applyConfigFn: func(l *Launcher) {
+			l.log = log
+		},
+	}
+}
+
+func WithViper(v *viper.Viper) Option {
+	return &launcherOption{
+		applyInitFn: func(l *Launcher) {
+			l.Viper = v
+		},
+	}
+}
+
+type launcherOption struct {
+	applyInitFn   func(*Launcher)
+	applyConfigFn func(*Launcher)
+}
+
+var _ Option = launcherOption{}
+
+func (o launcherOption) applyConfig(l *Launcher) {
+	if o.applyConfigFn != nil {
+		o.applyConfigFn(l)
+	}
+}
+
+func (o launcherOption) applyInit(l *Launcher) {
+	if o.applyInitFn != nil {
+		o.applyInitFn(l)
+	}
+}

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -3,17 +3,18 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	_ "net/http/pprof"
 	"os"
 	"time"
 
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/upgrade"
 	_ "github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	_ "github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -29,10 +30,11 @@ func main() {
 
 	influxdb.SetBuildInfo(version, commit, date)
 
-	rootCmd := launcher.NewInfluxdCommand(context.Background())
+	v := viper.New()
+	rootCmd := launcher.NewInfluxdCommand(context.Background(), v)
 	// upgrade binds options to env variables, so it must be added after rootCmd is initialized
-	rootCmd.AddCommand(upgrade.NewCommand())
-	rootCmd.AddCommand(inspect.NewCommand())
+	rootCmd.AddCommand(upgrade.NewCommand(v))
+	rootCmd.AddCommand(inspect.NewCommand(v))
 	rootCmd.AddCommand(versionCmd())
 
 	rootCmd.SilenceUsage = true

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -34,7 +34,7 @@ func main() {
 	rootCmd := launcher.NewInfluxdCommand(context.Background(), v)
 	// upgrade binds options to env variables, so it must be added after rootCmd is initialized
 	rootCmd.AddCommand(upgrade.NewCommand(v))
-	rootCmd.AddCommand(inspect.NewCommand(v))
+	rootCmd.AddCommand(inspect.NewCommand())
 	rootCmd.AddCommand(versionCmd())
 
 	rootCmd.SilenceUsage = true

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxdb/v2/v1/services/meta"
 	"github.com/influxdata/influxdb/v2/v1/services/meta/filestore"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -120,7 +121,7 @@ var options = struct {
 	force bool
 }{}
 
-func NewCommand() *cobra.Command {
+func NewCommand(v *viper.Viper) *cobra.Command {
 
 	// source flags
 	v1dir, err := influxDirV1()
@@ -258,7 +259,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
-	cli.BindOptions(cmd, opts)
+	cli.BindOptions(v, cmd, opts)
 	// add sub commands
 	cmd.AddCommand(v1DumpMetaCommand)
 	cmd.AddCommand(v2DumpMetaCommand)

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2/bolt"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestPathValidations(t *testing.T) {
 	largs = append(largs, "--engine-path", enginePath)
 	largs = append(largs, "--config-file", "")
 
-	cmd := NewCommand()
+	cmd := NewCommand(viper.New())
 	cmd.SetArgs(largs)
 	err = cmd.Execute()
 	require.NotNil(t, err, "Must fail")
@@ -54,7 +55,7 @@ func TestPathValidations(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(v1Dir, "meta", "meta.db"), []byte{1}, 0777)
 	require.Nil(t, err)
 
-	cmd = NewCommand()
+	cmd = NewCommand(viper.New())
 	cmd.SetArgs(largs)
 
 	err = cmd.Execute()

--- a/cmd/telemetryd/main.go
+++ b/cmd/telemetryd/main.go
@@ -10,6 +10,7 @@ import (
 	influxlogger "github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/prometheus"
 	"github.com/influxdata/influxdb/v2/telemetry"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
@@ -31,7 +32,8 @@ func main() {
 			},
 		},
 	}
-	cmd := cli.NewCommand(prog)
+	v := viper.New()
+	cmd := cli.NewCommand(v, prog)
 
 	var exitCode int
 	if err := cmd.Execute(); err != nil {

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func ExampleNewCommand() {
 	var duration time.Duration
 	var stringSlice []string
 	var fancyBool customFlag
-	cmd := NewCommand(&Program{
+	cmd := NewCommand(viper.New(), &Program{
 		Run: func() error {
 			fmt.Println(monitorHost)
 			for i := 0; i < number; i++ {
@@ -170,7 +171,7 @@ func Test_NewProgram(t *testing.T) {
 				Run: func() error { return nil },
 			}
 
-			cmd := NewCommand(program)
+			cmd := NewCommand(viper.New(), program)
 			cmd.SetArgs(append([]string{}, tt.args...))
 			require.NoError(t, cmd.Execute())
 


### PR DESCRIPTION
This PR removes the use of global viper state, by passing instances of `viper.Viper` throughout the CLI tools. This change is required to enable the `TestLauncher` to be used reliably and without data races when running test suites in parallel.

This is the first step in 3 PRs to bring the full pipeline test suite into OSS in order to close #19998.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
