### PR TITLE
fix(cmd/influxd): validate all input paths to `upgrade` up-front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
+1. [20012](https://github.com/influxdata/influxdb/pull/20012): Validate input paths to `influxd upgrade` up-front
 
 ## v2.0.1 [2020-11-10]
 

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -61,6 +61,10 @@ var configValueTransforms = map[string]func(interface{}) interface{}{
 	},
 }
 
+func translateV1ConfigPath(configFile string) string {
+	return filepath.Join(filepath.Dir(configFile), "config.toml")
+}
+
 // upgradeConfig upgrades existing 1.x (ie. typically influxdb.conf) configuration file to 2.x influxdb.toml file.
 func upgradeConfig(configFile string, targetOptions optionsV2, log *zap.Logger) (*configV1, error) {
 	// create and initialize helper
@@ -100,7 +104,7 @@ func upgradeConfig(configFile string, targetOptions optionsV2, log *zap.Logger) 
 	cu.updateV2Config(cTransformed, targetOptions)
 
 	// save new config
-	configFileV2 := filepath.Join(filepath.Dir(configFile), "config.toml")
+	configFileV2 := translateV1ConfigPath(configFile)
 	configFileV2, err = cu.save(cTransformed, configFileV2)
 	if err != nil {
 		return nil, err

--- a/cmd/influxd/upgrade/database_test.go
+++ b/cmd/influxd/upgrade/database_test.go
@@ -39,9 +39,7 @@ func TestUpgradeRealDB(t *testing.T) {
 	enginePath := filepath.Join(tl.Path, "engine")
 
 	v1opts := &optionsV1{dbDir: tmpdir + "/v1db"}
-
-	err = v1opts.checkDirs()
-	require.Nil(t, err)
+	v1opts.populateDirs()
 
 	v1, err := newInfluxDBv1(v1opts)
 	require.Nil(t, err)

--- a/cmd/influxd/upgrade/setup.go
+++ b/cmd/influxd/upgrade/setup.go
@@ -135,14 +135,9 @@ You have entered:
 }
 
 func saveLocalConfig(sourceOptions *optionsV1, targetOptions *optionsV2, log *zap.Logger) error {
-	dPath, dir := targetOptions.configsPath, filepath.Dir(targetOptions.configsPath)
+	dPath, dir := targetOptions.cliConfigsPath, filepath.Dir(targetOptions.cliConfigsPath)
 	if dPath == "" || dir == "" {
 		return errors.New("a valid configurations path must be provided")
-	}
-	_, err := os.Stat(dPath)
-	if !os.IsNotExist(err) {
-		log.Error("cannot save CLI config, file already exists", zap.String("path", dPath))
-		return errors.New("CLI configs file already exists")
 	}
 
 	localConfigSVC := config.NewLocalConfigSVC(dPath, dir)

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2/bolt"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,37 +29,43 @@ func TestPathValidations(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
 	require.Nil(t, err)
 
-	largs := make([]string, 0)
-	largs = append(largs, "--username", "my-user")
-	largs = append(largs, "--password", "my-password")
-	largs = append(largs, "--org", "my-org")
-	largs = append(largs, "--bucket", "my-bucket")
-	largs = append(largs, "--retention", "7d")
-	largs = append(largs, "--token", "my-token")
-	largs = append(largs, "--v1-dir", v1Dir)
-	largs = append(largs, "--bolt-path", boltPath)
-	largs = append(largs, "--influx-configs-path", configsPath)
-	largs = append(largs, "--engine-path", enginePath)
-	largs = append(largs, "--config-file", "")
+	sourceOpts := &optionsV1{
+		dbDir:      v1Dir,
+		configFile: "",
+	}
+	targetOpts := &optionsV2{
+		boltPath:       boltPath,
+		cliConfigsPath: configsPath,
+		enginePath:     enginePath,
+	}
 
-	cmd := NewCommand(viper.New())
-	cmd.SetArgs(largs)
-	err = cmd.Execute()
+	err = validatePaths(sourceOpts, targetOpts)
 	require.NotNil(t, err, "Must fail")
-	assert.Contains(t, err.Error(), "1.x metadb error")
+	assert.Contains(t, err.Error(), "1.x DB dir")
 
 	err = os.MkdirAll(filepath.Join(v1Dir, "meta"), 0777)
 	require.Nil(t, err)
 
+	err = validatePaths(sourceOpts, targetOpts)
+	require.NotNil(t, err, "Must fail")
+	assert.Contains(t, err.Error(), "1.x meta.db")
+
 	err = ioutil.WriteFile(filepath.Join(v1Dir, "meta", "meta.db"), []byte{1}, 0777)
 	require.Nil(t, err)
 
-	cmd = NewCommand(viper.New())
-	cmd.SetArgs(largs)
-
-	err = cmd.Execute()
+	err = validatePaths(sourceOpts, targetOpts)
 	require.NotNil(t, err, "Must fail")
-	assert.Contains(t, err.Error(), "target engine path")
+	assert.Contains(t, err.Error(), "2.x engine")
+
+	err = os.Remove(filepath.Join(enginePath, "db"))
+	assert.Nil(t, err)
+
+	err = ioutil.WriteFile(configsPath, []byte{1}, 0777)
+	require.Nil(t, err)
+
+	err = validatePaths(sourceOpts, targetOpts)
+	require.NotNil(t, err, "Must fail")
+	assert.Contains(t, err.Error(), "2.x CLI configs")
 }
 
 func TestDbURL(t *testing.T) {


### PR DESCRIPTION
Part of #19985

Validate existence / nonexistence of source and target paths provided to the `upgrade` command before doing any work, to avoid annoyance.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
