### PR TITLE
fix: Don't include duplicates for SHOW DATABASES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
 1. [20012](https://github.com/influxdata/influxdb/pull/20012): Validate input paths to `influxd upgrade` up-front
+1. [20017](https://github.com/influxdata/influxdb/pull/20017): Don't include duplicates for SHOW DATABASES
 
 ## v2.0.1 [2020-11-10]
 

--- a/influxql/_v1tests/server_helpers.go
+++ b/influxql/_v1tests/server_helpers.go
@@ -160,7 +160,7 @@ func (qt *Test) init(ctx context.Context, t *testing.T, p *tests.DefaultPipeline
 	fx = pipeline.NewBaseFixture(t, p.Pipeline, qt.orgID, qt.bucketID)
 
 	if !qt.noWrites {
-		require.GreaterOrEqual(t, len(qt.writes), 0)
+		require.Greater(t, len(qt.writes), 0)
 		qt.writeTestData(ctx, t, fx.Admin)
 		p.Flush()
 	}


### PR DESCRIPTION
Closes #19984 

This PR ensures correct behaviour of `SHOW DATABASES`, such that it does not return duplicates for the same database name. Unit tests were added to verify this expectation.

Requires #20004 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
