### PR TITLE
fix: Allow self signed certificates to ScraperTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
-1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow InsecureSkipVerify to be specified on ScraperTarget's
+1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target 
 
 ## v2.0.1 [2020-11-10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
+1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow InsecureSkipVerify to be specified on ScraperTarget's
 
 ## v2.0.1 [2020-11-10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
-1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target 
+1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
 
 ## v2.0.1 [2020-11-10]
 

--- a/gather/prometheus.go
+++ b/gather/prometheus.go
@@ -2,6 +2,7 @@ package gather
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math"
@@ -21,7 +22,11 @@ type prometheusScraper struct{}
 
 // Gather parse metrics from a scraper target url.
 func (p *prometheusScraper) Gather(ctx context.Context, target influxdb.ScraperTarget) (collected MetricsCollection, err error) {
-	resp, err := http.Get(target.URL)
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: target.AllowInsecure}
+	client := &http.Client{Transport: customTransport}
+
+	resp, err := client.Get(target.URL)
 	if err != nil {
 		return collected, err
 	}

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -62,7 +62,7 @@ func NewScheduler(
 
 	for i := 0; i < numScrapers; i++ {
 		err := s.Subscribe(promTargetSubject, "metrics", &handler{
-			Scraper:   new(prometheusScraper),
+			Scraper:   newPrometheusScraper(),
 			Publisher: p,
 			log:       log,
 		})

--- a/gather/scraper_test.go
+++ b/gather/scraper_test.go
@@ -123,7 +123,7 @@ func TestPrometheusScraper(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		scraper := new(prometheusScraper)
+		scraper := newPrometheusScraper()
 		var url string
 		if c.handler != nil {
 			ts := httptest.NewServer(c.handler)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10265,7 +10265,7 @@ components:
           type: string
           description: The ID of the bucket to write to.
         allowInsecure:
-          type: bool
+          type: boolean
           description: Skip TLS verification on endpoint.
           default: false
     ScraperTargetResponse:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10264,6 +10264,10 @@ components:
         bucketID:
           type: string
           description: The ID of the bucket to write to.
+        allowInsecure:
+          type: bool
+          description: Skip TLS verification on endpoint.
+          default: false
     ScraperTargetResponse:
       type: object
       allOf:

--- a/scraper.go
+++ b/scraper.go
@@ -18,12 +18,13 @@ const (
 
 // ScraperTarget is a target to scrape
 type ScraperTarget struct {
-	ID       ID          `json:"id,omitempty"`
-	Name     string      `json:"name"`
-	Type     ScraperType `json:"type"`
-	URL      string      `json:"url"`
-	OrgID    ID          `json:"orgID,omitempty"`
-	BucketID ID          `json:"bucketID,omitempty"`
+	ID            ID          `json:"id,omitempty"`
+	Name          string      `json:"name"`
+	Type          ScraperType `json:"type"`
+	URL           string      `json:"url"`
+	OrgID         ID          `json:"orgID,omitempty"`
+	BucketID      ID          `json:"bucketID,omitempty"`
+	AllowInsecure bool        `json:"allowInsecure,omitempty"`
 }
 
 // ScraperTargetStoreService defines the crud service for ScraperTarget.


### PR DESCRIPTION
Closes #20045

- Adding a new optional field, `allowInsecure` with the default value of `false` to the API `POST /api/v2/scrapers`

- Using the new `allowInsecure` field to the `Gather()` method

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
- [X] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [X] Documentation updated or issue created (provide link to issue/pr)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)