### PR TITLE
fix(cmd/influxd): don't validate unused paths in `upgrade`

### DIFF
--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -128,6 +128,7 @@ func TestConfigLoadFile(t *testing.T) {
 			err := ioutil.WriteFile(configFile, []byte(tc.config1x), 0444)
 			require.NoError(t, err)
 			retval, _, err := loadV1Config(configFile)
+			require.NoError(t, err)
 
 			if diff := cmp.Diff(tc.retval, retval); diff != "" {
 				t.Fatal(diff)

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -1,13 +1,13 @@
 package upgrade
 
 import (
-	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -33,6 +33,8 @@ func TestPathValidations(t *testing.T) {
 		dbDir:      v1Dir,
 		configFile: "",
 	}
+	sourceOpts.populateDirs()
+
 	targetOpts := &optionsV2{
 		boltPath:       boltPath,
 		cliConfigsPath: configsPath,


### PR DESCRIPTION
Closes #20037 

The help text for `influxd upgrade` says `--v1-dir` is only used if `--config-file` isn't passed, but the validation logic I added in #20012 always validated `--v1-dir`. This fixes the behavior.

I had to refactor config-loading logic to support loading V1 config separately from translating it to V2, so we could still run all validation checks before writing any new files to disk.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
