### PR TITLE
fix(tsm1): "snapshot in progress" error during backup: restore loop with backoff

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1942,7 +1942,7 @@ func (e *Engine) WriteSnapshot() (err error) {
 // in-memory cache data when a previous snapshot is in progress
 func (e *Engine) CreateSnapshot(skipCacheOk bool) (string, error) {
 	err := e.WriteSnapshot()
-	for i := 0; (i < 3) && (err == ErrSnapshotInProgress) ; i += 1 {
+	for i := 0; (i < 3) && (err == ErrSnapshotInProgress); i += 1 {
 		backoff := time.Duration(math.Pow(32, float64(i))) * time.Millisecond
 		time.Sleep(backoff)
 		err = e.WriteSnapshot()


### PR DESCRIPTION
WIP

Loop with backoff in (*Engine).CreateSnapshot() to retry (*Engine).WriteSnapshot() up to 3 times if ErrSnapshotInPrgress is returned.  Then continue on no error or on SnapshotInProgress if skipCacheOk is true.

-- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
