### PR TITLE
fix: update comment about ReadWindowAggregate semantics

### DIFF
--- a/query/storage.go
+++ b/query/storage.go
@@ -55,6 +55,8 @@ type ReadTagValuesSpec struct {
 	TagKey string
 }
 
+// Window and the WindowEvery/Offset should be mutually exclusive. If you set either the WindowEvery or Offset with
+// nanosecond values, then the Window will be ignored
 type ReadWindowAggregateSpec struct {
 	ReadFilterSpec
 	WindowEvery int64


### PR DESCRIPTION
The rationale is to make the semantics of `ReadWindowAggregateSpec` clearer. 

This PR adds comments partially explaining semantics of `ReadWindowAggregate`. 

They are simply ported from this PR (InfluxDB internal) by @fchikwekwe 
 in [this PR](https://github.com/influxdata/idpe/pull/8636/files#diff-94c0a8d7e427e2d7abe49f01dced50ad776b65ec8f2c8fb2a2c8b90e2e377ed5R82) -- I found this information very useful while working on https://github.com/influxdata/influxdb_iox/issues/449 and wanted to make sure it was in OSS as well

