### PR TITLE
fix: Allow self signed certificates to ScraperTarget (#20047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [20012](https://github.com/influxdata/influxdb/pull/20012): Validate input paths to `influxd upgrade` up-front
 1. [20017](https://github.com/influxdata/influxdb/pull/20017): Don't include duplicates for SHOW DATABASES
 1. [20064](https://github.com/influxdata/influxdb/pull/20064): Ensure Flux reads across all shards.
+1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
 
 ## v2.0.1 [2020-11-10]
 

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -62,7 +62,7 @@ func NewScheduler(
 
 	for i := 0; i < numScrapers; i++ {
 		err := s.Subscribe(promTargetSubject, "metrics", &handler{
-			Scraper:   new(prometheusScraper),
+			Scraper:   newPrometheusScraper(),
 			Publisher: p,
 			log:       log,
 		})

--- a/gather/scraper_test.go
+++ b/gather/scraper_test.go
@@ -123,7 +123,7 @@ func TestPrometheusScraper(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		scraper := new(prometheusScraper)
+		scraper := newPrometheusScraper()
 		var url string
 		if c.handler != nil {
 			ts := httptest.NewServer(c.handler)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -10264,6 +10264,10 @@ components:
         bucketID:
           type: string
           description: The ID of the bucket to write to.
+        allowInsecure:
+          type: boolean
+          description: Skip TLS verification on endpoint.
+          default: false
     ScraperTargetResponse:
       type: object
       allOf:

--- a/scraper.go
+++ b/scraper.go
@@ -18,12 +18,13 @@ const (
 
 // ScraperTarget is a target to scrape
 type ScraperTarget struct {
-	ID       ID          `json:"id,omitempty"`
-	Name     string      `json:"name"`
-	Type     ScraperType `json:"type"`
-	URL      string      `json:"url"`
-	OrgID    ID          `json:"orgID,omitempty"`
-	BucketID ID          `json:"bucketID,omitempty"`
+	ID            ID          `json:"id,omitempty"`
+	Name          string      `json:"name"`
+	Type          ScraperType `json:"type"`
+	URL           string      `json:"url"`
+	OrgID         ID          `json:"orgID,omitempty"`
+	BucketID      ID          `json:"bucketID,omitempty"`
+	AllowInsecure bool        `json:"allowInsecure,omitempty"`
 }
 
 // ScraperTargetStoreService defines the crud service for ScraperTarget.


### PR DESCRIPTION
Closes #20045 

Forward-ports #20047 to `master` (I didn't notice it was targeting `2.0` until after I merged)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
