### PR TITLE
fix(http/legacy): filter on Default=true when no RP given in V1 write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [20064](https://github.com/influxdata/influxdb/pull/20064): Ensure Flux reads across all shards.
 1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
 1. [20076](https://github.com/influxdata/influxdb/pull/20076): Remove internal `influxd upgrade` subcommands from help text.
+1. [20074](https://github.com/influxdata/influxdb/pull/20074): Use default DBRP mapping on V1 write when no RP is specified.
 
 ## v2.0.1 [2020-11-10]
 

--- a/http/legacy/write_handler.go
+++ b/http/legacy/write_handler.go
@@ -196,6 +196,9 @@ func (h *WriteHandler) findMapping(ctx context.Context, orgID influxdb.ID, db, r
 	}
 	if rp != "" {
 		filter.RetentionPolicy = &rp
+	} else {
+		b := true // Can't get a direct pointer to `true`...
+		filter.Default = &b
 	}
 
 	mappings, count, err := h.DBRPMappingService.FindMany(ctx, filter)


### PR DESCRIPTION
Closes #20070 

If no RP is specified on a V1 write, the system should find & use the default DBRP mapping, not _any_ DBRP mapping.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
