### PR TITLE
fix(cmd/influxd): remove internal subcommands of `upgrade` from help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [20017](https://github.com/influxdata/influxdb/pull/20017): Don't include duplicates for SHOW DATABASES
 1. [20064](https://github.com/influxdata/influxdb/pull/20064): Ensure Flux reads across all shards.
 1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
+1. [20076](https://github.com/influxdata/influxdb/pull/20076): Remove internal `influxd upgrade` subcommands from help text.
 
 ## v2.0.1 [2020-11-10]
 

--- a/cmd/influxd/upgrade/v1_dump_meta.go
+++ b/cmd/influxd/upgrade/v1_dump_meta.go
@@ -11,9 +11,10 @@ import (
 )
 
 var v1DumpMetaCommand = &cobra.Command{
-	Use:   "v1-dump-meta",
-	Short: "Dump InfluxDB 1.x meta.db",
-	Args:  cobra.NoArgs,
+	Use:    "v1-dump-meta",
+	Short:  "Dump InfluxDB 1.x meta.db",
+	Args:   cobra.NoArgs,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fluxinit.FluxInit()
 		svc, err := newInfluxDBv1(&v1DumpMetaOptions)

--- a/cmd/influxd/upgrade/v2_dump_meta.go
+++ b/cmd/influxd/upgrade/v2_dump_meta.go
@@ -15,9 +15,10 @@ import (
 )
 
 var v2DumpMetaCommand = &cobra.Command{
-	Use:   "v2-dump-meta",
-	Short: "Dump InfluxDB 2.x influxd.bolt",
-	Args:  cobra.NoArgs,
+	Use:    "v2-dump-meta",
+	Short:  "Dump InfluxDB 2.x influxd.bolt",
+	Args:   cobra.NoArgs,
+	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fluxinit.FluxInit()
 		ctx := context.Background()


### PR DESCRIPTION
Closes #20075 

cc/ @pierwill 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
