### PR TITLE
chore(ui): bump version in package.json so it displays correctly

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronograf-ui",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "private": false,
   "license": "AGPL-3.0",
   "description": "",


### PR DESCRIPTION
Relates to #20007 

The UI displays the version that was set in `package.json` at build time. We'll need to fix this "for real" as part of vendoring out the UI, but this will at least make the value correct for 2.0.2.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
