### PR TITLE
fix(api): raise API pagesizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Features
 
-1. [20036](https://github.com/influxdata/influxdb/pull/20036): Warn if V1 users are upgraded, but V1 auth wasn't enabled
-1. [20039](https://github.com/influxdata/influxdb/pull/20039): Export 1.x CQs as part of `influxd upgrade`
-1. [20067](https://github.com/influxdata/influxdb/pull/20067): Add DBRP cli commands as `influxd v1 dbrp`
+1. [20036](https://github.com/influxdata/influxdb/pull/20036): Warn if V1 users are upgraded, but V1 auth wasn't enabled.
+1. [20039](https://github.com/influxdata/influxdb/pull/20039): Export 1.x CQs as part of `influxd upgrade`.
+1. [20067](https://github.com/influxdata/influxdb/pull/20067): Add DBRP cli commands as `influxd v1 dbrp`.
+1. [20083](https://github.com/influxdata/influxdb/pull/20083): Increased the API DefaultPageSize and MaxPageSize to 2000.
 
 ### Bug Fixes
 

--- a/dashboards/transport/http_test.go
+++ b/dashboards/transport/http_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -144,7 +145,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/dashboards?descending=false&limit=20&offset=0"
+    "self": "/api/v2/dashboards?descending=false&limit=` + strconv.Itoa(influxdb.DefaultPageSize) + `&offset=0"
   },
   "dashboards": [
     {
@@ -241,7 +242,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/dashboards?descending=false&limit=20&offset=0"
+    "self": "/api/v2/dashboards?descending=false&limit=` + strconv.Itoa(influxdb.DefaultPageSize) + `&offset=0"
   },
   "dashboards": []
 }`,
@@ -303,7 +304,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/dashboards?descending=false&limit=20&offset=0&orgID=0000000000000001"
+    "self": "/api/v2/dashboards?descending=false&limit=` + strconv.Itoa(influxdb.DefaultPageSize) + `&offset=0&orgID=0000000000000001"
   },
   "dashboards": [
     {

--- a/http/variable_test.go
+++ b/http/variable_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -110,7 +111,7 @@ func TestVariableService_handleGetVariables(t *testing.T) {
 				contentType: "application/json; charset=utf-8",
 				body: `{
 					"links":{
-					   "self":"/api/v2/variables?descending=false&limit=20&offset=0"
+					   "self":"/api/v2/variables?descending=false&limit=` + strconv.Itoa(platform.DefaultPageSize) + `&offset=0"
 					},
 					"variables":[
 					   {
@@ -254,7 +255,7 @@ func TestVariableService_handleGetVariables(t *testing.T) {
 				contentType: "application/json; charset=utf-8",
 				body: `{
 					"links": {
-					  "self": "/api/v2/variables?descending=false&limit=20&offset=0&orgID=0000000000000001"
+					  "self": "/api/v2/variables?descending=false&limit=` + strconv.Itoa(platform.DefaultPageSize) + `&offset=0&orgID=0000000000000001"
 					},
 					"variables": [
 					  {

--- a/paging.go
+++ b/paging.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	DefaultPageSize = 20
-	MaxPageSize     = 100
+	// TODO(docmerlin): change this when pagination is fixed
+	DefaultPageSize = 2000
+	MaxPageSize     = 2000
 )
 
 // PagingFilter represents a filter containing url query params.


### PR DESCRIPTION
Currently, in the API, pagination is not working; to mitigate this, we
can drastically increase the page size.