### PR TITLE
fix(api): make the dbrp api match the swagger spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
 1. [20076](https://github.com/influxdata/influxdb/pull/20076): Remove internal `influxd upgrade` subcommands from help text.
 1. [20074](https://github.com/influxdata/influxdb/pull/20074): Use default DBRP mapping on V1 write when no RP is specified.
+1. [20091](https://github.com/influxdata/influxdb/pull/20091): Make the DBRP http API match the swagger spec.
 
 ## v2.0.1 [2020-11-10]
 

--- a/dbrp/http_server_dbrp.go
+++ b/dbrp/http_server_dbrp.go
@@ -59,9 +59,9 @@ type createDBRPRequest struct {
 	Database        string      `json:"database"`
 	RetentionPolicy string      `json:"retention_policy"`
 	Default         bool        `json:"default"`
-	Org             string      `json:"organization"`
-	OrganizationID  influxdb.ID `json:"organization_id"`
-	BucketID        influxdb.ID `json:"bucket_id"`
+	Org             string      `json:"org"`
+	OrganizationID  influxdb.ID `json:"orgID"`
+	BucketID        influxdb.ID `json:"bucketID"`
 }
 
 func (h *Handler) handlePostDBRP(w http.ResponseWriter, r *http.Request) {

--- a/dbrp/http_server_dbrp_test.go
+++ b/dbrp/http_server_dbrp_test.go
@@ -59,8 +59,8 @@ func Test_handlePostDBRP(t *testing.T) {
 		{
 			Name: "Create valid dbrp",
 			Input: strings.NewReader(`{
-	"bucket_id": "5555f7ed2a035555",
-	"organization_id": "059af7ed2a034000",
+	"bucketID": "5555f7ed2a035555",
+	"orgID": "059af7ed2a034000",
 	"database": "mydb",
 	"retention_policy": "autogen",
 	"default": false
@@ -72,8 +72,8 @@ func Test_handlePostDBRP(t *testing.T) {
 		{
 			Name: "Create valid dbrp by org name",
 			Input: strings.NewReader(`{
-	"bucket_id": "5555f7ed2a035555",
-	"organization": "org",
+	"bucketID": "5555f7ed2a035555",
+	"org": "org",
 	"database": "mydb",
 	"retention_policy": "autogen",
 	"default": false
@@ -85,8 +85,8 @@ func Test_handlePostDBRP(t *testing.T) {
 		{
 			Name: "Create with invalid orgID",
 			Input: strings.NewReader(`{
-	"bucket_id": "5555f7ed2a035555",
-	"organization_id": "invalid",
+	"bucketID": "5555f7ed2a035555",
+	"orgID": "invalid",
 	"database": "mydb",
 	"retention_policy": "autogen",
 	"default": false
@@ -100,8 +100,8 @@ func Test_handlePostDBRP(t *testing.T) {
 		{
 			Name: "Create with invalid org name",
 			Input: strings.NewReader(`{
-	"bucket_id": "5555f7ed2a035555",
-	"organization": "invalid",
+	"bucketID": "5555f7ed2a035555",
+	"org": "invalid",
 	"database": "mydb",
 	"retention_policy": "autogen",
 	"default": false

--- a/dbrp_mapping.go
+++ b/dbrp_mapping.go
@@ -33,8 +33,8 @@ type DBRPMappingV2 struct {
 	// Default indicates if this mapping is the default for the cluster and database.
 	Default bool `json:"default"`
 
-	OrganizationID ID `json:"organization_id"`
-	BucketID       ID `json:"bucket_id"`
+	OrganizationID ID `json:"orgID"`
+	BucketID       ID `json:"bucketID"`
 }
 
 // Validate reports any validation errors for the mapping.


### PR DESCRIPTION
This is to make the DBRP api match the swagger spec.
Closes #20087 