### PR TITLE
fix: revert changes to API page-sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 1. [20036](https://github.com/influxdata/influxdb/pull/20036): Warn if V1 users are upgraded, but V1 auth wasn't enabled.
 1. [20039](https://github.com/influxdata/influxdb/pull/20039): Export 1.x CQs as part of `influxd upgrade`.
 1. [20067](https://github.com/influxdata/influxdb/pull/20067): Add DBRP cli commands as `influxd v1 dbrp`.
-1. [20083](https://github.com/influxdata/influxdb/pull/20083): Increased the API DefaultPageSize and MaxPageSize to 2000.
 
 ### Bug Fixes
 

--- a/paging.go
+++ b/paging.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	// TODO(docmerlin): change this when pagination is fixed
-	DefaultPageSize = 2000
-	MaxPageSize     = 2000
+	DefaultPageSize = 20
+	MaxPageSize     = 100
 )
 
 // PagingFilter represents a filter containing url query params.


### PR DESCRIPTION
The default/max are specified in our API spec, so we can't change them without coordinating with cloud.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
