### PR TITLE
fix(write): Successful writes increment write error statistics incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ v1.8.0 [unreleased]
 
 ### Bugfixes
 
--   [#20100](https://github.com/influxdata/influxdb/pull/20100): fix(write): Successful writes increment write error statistics incorrectly
 -	[#10503](https://github.com/influxdata/influxdb/pull/10503): Delete rebuilds series index when series to be deleted are only found in cache.
 -	[#10504](https://github.com/influxdata/influxdb/issue/10504): Delete rebuilds series index when series to be deleted are outside timerange.
 -	[#14485](https://github.com/influxdata/influxdb/pull/14485): Parse Accept header correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ v1.8.0 [unreleased]
 
 ### Bugfixes
 
+-   [#20100](https://github.com/influxdata/influxdb/pull/20100): fix(write): Successful writes increment write error statistics incorrectly
 -	[#10503](https://github.com/influxdata/influxdb/pull/10503): Delete rebuilds series index when series to be deleted are only found in cache.
 -	[#10504](https://github.com/influxdata/influxdb/issue/10504): Delete rebuilds series index when series to be deleted are outside timerange.
 -	[#14485](https://github.com/influxdata/influxdb/pull/14485): Parse Accept header correctly.

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -447,11 +447,10 @@ func (w *PointsWriter) writeToShardWithContext(ctx context.Context, shard *meta.
 			atomic.AddInt64(&w.stats.WriteErr, 1)
 			return err
 		}
-	} else {
+	} else if err != nil {
 		atomic.AddInt64(&w.stats.WriteErr, 1)
 		return err
 	}
-
 	atomic.AddInt64(&w.stats.WriteOK, 1)
 	return nil
 }


### PR DESCRIPTION
In v1.8.3 and earlier, the write path through (*PointsWriter) writeToShardWithContext() always increments the WriteErr count in the debug variables, and does not increment the WriteOK count.
https://github.com/influxdata/influxdb/blob/v1.8.3/coordinator/points_writer.go line 450 should be an `else if err != nil {` instead of an `else`
This has been reported in a customer cloud instance, and verified under a debugger.

Closes: https://github.com/influxdata/influxdb/issues/20098

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass