### PR TITLE
fix(write): Successful writes increment write error statistics incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v1.8.4 [unreleased]
 
 ### Bugfixes
 
+-   [#20101](https://github.com/influxdata/influxdb/pull/20101): fix(write): Successful writes increment write error statistics incorrectly
 -	[#19696](https://github.com/influxdata/influxdb/pull/19697): fix(flux): add durations to Flux logging
 
 v1.8.3 [2020-09-30]
@@ -15,7 +16,6 @@ v1.8.3 [2020-09-30]
 
 ### Bugfixes
 
--   [#20101](https://github.com/influxdata/influxdb/pull/20101): fix(write): Successful writes increment write error statistics incorrectly
 -	[#19409](https://github.com/influxdata/influxdb/pull/19409): chore: update uuid library from satori to gofrs.
 -	[#19439](https://github.com/influxdata/influxdb/pull/19439): fix(storage): ArrayFilterCursor truncation for multi-block data.
 -	[#19460](https://github.com/influxdata/influxdb/pull/19460): chore: Use latest version of influxql package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v1.8.3 [2020-09-30]
 
 ### Bugfixes
 
+-   [#20101](https://github.com/influxdata/influxdb/pull/20101): fix(write): Successful writes increment write error statistics incorrectly
 -	[#19409](https://github.com/influxdata/influxdb/pull/19409): chore: update uuid library from satori to gofrs.
 -	[#19439](https://github.com/influxdata/influxdb/pull/19439): fix(storage): ArrayFilterCursor truncation for multi-block data.
 -	[#19460](https://github.com/influxdata/influxdb/pull/19460): chore: Use latest version of influxql package.

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -447,11 +447,10 @@ func (w *PointsWriter) writeToShardWithContext(ctx context.Context, shard *meta.
 			atomic.AddInt64(&w.stats.WriteErr, 1)
 			return err
 		}
-	} else {
+	} else if err != nil {
 		atomic.AddInt64(&w.stats.WriteErr, 1)
 		return err
 	}
-
 	atomic.AddInt64(&w.stats.WriteOK, 1)
 	return nil
 }


### PR DESCRIPTION
In v1.8.3 and earlier, the write path through (*PointsWriter) writeToShardWithContext() always increments the WriteErr count in the debug variables, and does not increment the WriteOK count.
https://github.com/influxdata/influxdb/blob/v1.8.3/coordinator/points_writer.go line 450 should be an `else if err != nil { `instead of an `else`
This has been reported in a customer cloud instance, and verified under a debugger.

https://github.com/influxdata/influxdb/issues/20098
(cherry picked from commit 3d9f8b5020daf5e3759e6bf1570324d77a4cbe44)

Closes: https://github.com/influxdata/influxdb/issues/20099

Describe your proposed changes here.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass