### PR TITLE
chore: bring CHANGELOG up to date after 2.0.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ### Features
 
+### Bug Fixes
+
+### Refactoring & Build
+
+## v2.0.2 [2020-11-18]
+
+### Features
+
+1. [19979](https://github.com/influxdata/influxdb/pull/19979): Added functionality to filter task runs by time.
 1. [20036](https://github.com/influxdata/influxdb/pull/20036): Warn if V1 users are upgraded, but V1 auth wasn't enabled.
 1. [20039](https://github.com/influxdata/influxdb/pull/20039): Export 1.x CQs as part of `influxd upgrade`.
+1. [20053](https://github.com/influxdata/influxdb/pull/20053): Upgrade Flux to v0.95.0.
+1. [20058](https://github.com/influxdata/influxdb/pull/20058): UI: Upgrade flux-lsp-browser to v0.5.23.
 1. [20067](https://github.com/influxdata/influxdb/pull/20067): Add DBRP cli commands as `influxd v1 dbrp`.
 
 ### Bug Fixes
@@ -11,13 +22,23 @@
 1. [19987](https://github.com/influxdata/influxdb/pull/19987): Fix various typos. Thanks @kumakichi!
 1. [19991](https://github.com/influxdata/influxdb/pull/19991): Use --skip-verify flag for backup/restore CLI command.
 1. [19995](https://github.com/influxdata/influxdb/pull/19995): Don't auto-print help on influxd errors
-1. [20012](https://github.com/influxdata/influxdb/pull/20012): Validate input paths to `influxd upgrade` up-front
+1. [20008](https://github.com/influxdata/influxdb/pull/20008): Add locking during TSI iterator creation.
+1. [20012](https://github.com/influxdata/influxdb/pull/20012): Validate input paths to `influxd upgrade` up-front.
+1. [20015](https://github.com/influxdata/influxdb/pull/20015): Add same site strict flag to session cookie.
 1. [20017](https://github.com/influxdata/influxdb/pull/20017): Don't include duplicates for SHOW DATABASES
 1. [20064](https://github.com/influxdata/influxdb/pull/20064): Ensure Flux reads across all shards.
 1. [20047](https://github.com/influxdata/influxdb/pull/20047): Allow scraper to ignore insecure certificates on a target. Thanks @cmackenzie1!
 1. [20076](https://github.com/influxdata/influxdb/pull/20076): Remove internal `influxd upgrade` subcommands from help text.
 1. [20074](https://github.com/influxdata/influxdb/pull/20074): Use default DBRP mapping on V1 write when no RP is specified.
 1. [20091](https://github.com/influxdata/influxdb/pull/20091): Make the DBRP http API match the swagger spec.
+
+### Refactoring & Build
+
+1. [19878](https://github.com/influxdata/influxdb/pull/19878): Delete deprecated kv service code.
+1. [20002](https://github.com/influxdata/influxdb/pull/20002): Do not use global viper APIs, which breaks testing.
+1. [20003](https://github.com/influxdata/influxdb/pull/20003): Remove fragile NATS port assignment loop.
+1. [20004](https://github.com/influxdata/influxdb/pull/20004): Port pipeline test framework and InfluxQL tests from cloud.
+1. [20061](https://github.com/influxdata/influxdb/pull/20061): Build: Remove lint-feature-flag job from OSS.
 
 ## v2.0.1 [2020-11-10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Bug Fixes
 
-### Refactoring & Build
-
-## v2.0.2 [2020-11-18]
+## v2.0.2 [2020-11-19]
 
 ### Features
 
@@ -31,14 +29,6 @@
 1. [20076](https://github.com/influxdata/influxdb/pull/20076): Remove internal `influxd upgrade` subcommands from help text.
 1. [20074](https://github.com/influxdata/influxdb/pull/20074): Use default DBRP mapping on V1 write when no RP is specified.
 1. [20091](https://github.com/influxdata/influxdb/pull/20091): Make the DBRP http API match the swagger spec.
-
-### Refactoring & Build
-
-1. [19878](https://github.com/influxdata/influxdb/pull/19878): Delete deprecated kv service code.
-1. [20002](https://github.com/influxdata/influxdb/pull/20002): Do not use global viper APIs, which breaks testing.
-1. [20003](https://github.com/influxdata/influxdb/pull/20003): Remove fragile NATS port assignment loop.
-1. [20004](https://github.com/influxdata/influxdb/pull/20004): Port pipeline test framework and InfluxQL tests from cloud.
-1. [20061](https://github.com/influxdata/influxdb/pull/20061): Build: Remove lint-feature-flag job from OSS.
 
 ## v2.0.1 [2020-11-10]
 


### PR DESCRIPTION
I looked through the changes from #20095 and added lines here for things that weren't already covered by a line. PR links point at the original merges to master.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
