### PR TITLE
feat(cmd/influxd): use a better default for upgraded V2 config, and allow users to override it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## unreleased
 
+### Breaking Changes
+
+Previously, `influxd upgrade` would attempt to write upgraded `config.toml` files into the same directory as the source
+`influxdb.conf` file. If this failed, a warning would be logged and `config.toml` would be written into the `HOME` directory.
+
+This release breaks this behavior in two ways:
+1. By default, `config.toml` is now written into the same directory as the Bolt DB and engine files (`~/.influxdbv2/`)
+2. If writing upgraded config fails, the `upgrade` process exits with an error instead of falling back to the `HOME` directory
+
+Users can use the new `--v2-config-path` option to override the output path for upgraded config if they can't or don't
+want to use the default.
+
 ### Features
 
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth create`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth create`.
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
+1. [20110](https://github.com/influxdata/influxdb/pull/20110): Allow for users to specify where V2 config should be written in `influxd upgrade`
 
 ### Bug Fixes
+
+1. [20110](https://github.com/influxdata/influxdb/pull/20110): Use V2 directory for default V2 config path in `influxd upgrade`
 
 ## v2.0.2 [2020-11-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ want to use the default.
 
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth create`.
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
-1. [20110](https://github.com/influxdata/influxdb/pull/20110): Allow for users to specify where V2 config should be written in `influxd upgrade`
+1. [20110](https://github.com/influxdata/influxdb/pull/20110): Allow for users to specify where V2 config should be written in `influxd upgrade`.
 
 ### Bug Fixes
 
-1. [20110](https://github.com/influxdata/influxdb/pull/20110): Use V2 directory for default V2 config path in `influxd upgrade`
+1. [20110](https://github.com/influxdata/influxdb/pull/20110): Use V2 directory for default V2 config path in `influxd upgrade`.
 
 ## v2.0.2 [2020-11-19]
 

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -147,7 +147,7 @@ func (cu *configUpgrader) save(config map[string]interface{}, path string) error
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	outFile, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	outFile, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -152,7 +152,13 @@ func (cu *configUpgrader) save(config map[string]interface{}, path string) (stri
 		return "", err
 	}
 
-	err := ioutil.WriteFile(path, buf.Bytes(), 0666)
+	// Try writing config to the requested location.
+	var err error
+	err = os.MkdirAll(filepath.Dir(path), 0755)
+	if err == nil {
+		err = ioutil.WriteFile(path, buf.Bytes(), 0666)
+	}
+
 	if err != nil { // permission issue possible - try to save the file to home or current dir
 		cu.log.Warn(fmt.Sprintf("Could not save upgraded config to %s, trying to save it to user's home.", path), zap.Error(err))
 		path = filepath.Join(homeOrAnyDir(), filepath.Base(path))

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -1,13 +1,13 @@
 package upgrade
 
 import (
+	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
@@ -62,11 +62,8 @@ func TestConfigUpgrade(t *testing.T) {
 			if _, err = toml.Decode(tc.config1x, &rawV1Config); err != nil {
 				t.Fatal(err)
 			}
-			retval, err := upgradeConfig(rawV1Config, targetOtions, zaptest.NewLogger(t))
-			if err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, retval, configFileV2)
+			err = upgradeConfig(rawV1Config, targetOtions, zaptest.NewLogger(t))
+			assert.NoError(t, err)
 
 			var actual, expected map[string]interface{}
 			if _, err = toml.Decode(tc.config2x, &expected); err != nil {

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -1,13 +1,13 @@
 package upgrade
 
 import (
-	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb/v2/pkg/testing/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -239,6 +239,12 @@ func NewCommand(v *viper.Viper) *cobra.Command {
 			Desc:  "optional: Custom InfluxDB 1.x config file path, else the default config file",
 		},
 		{
+			DestP:   &options.target.configPath,
+			Flag:    "v2-config-path",
+			Default: filepath.Join(v2dir, "config.toml"),
+			Desc:    "optional: Custom path where upgraded 2.x config should be written",
+		},
+		{
 			DestP:   &options.logLevel,
 			Flag:    "log-level",
 			Default: zapcore.InfoLevel.String(),
@@ -355,8 +361,6 @@ func runUpgradeE(*cobra.Command, []string) error {
 		options.source.dataDir = v1Config.Data.Dir
 		options.source.walDir = v1Config.Data.WALDir
 		options.source.dbURL = v1Config.dbURL()
-
-		options.target.configPath = filepath.Join(filepath.Dir(options.source.configFile), "config.toml")
 	} else {
 		// Otherwise, assume a standard directory layout.
 		options.source.populateDirs()

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -375,15 +375,15 @@ func runUpgradeE(*cobra.Command, []string) error {
 
 	if genericV1ops != nil {
 		log.Info("Upgrading config file", zap.String("file", options.source.configFile))
-		v2ConfigPath, err := upgradeConfig(*genericV1ops, options.target, log)
-		if err != nil {
+		if err := upgradeConfig(*genericV1ops, options.target, log); err != nil {
 			return err
 		}
 		log.Info(
 			"Config file upgraded.",
 			zap.String("1.x config", options.source.configFile),
-			zap.String("2.x config", v2ConfigPath),
+			zap.String("2.x config", options.target.configPath),
 		)
+
 	} else {
 		log.Info("No InfluxDB 1.x config file specified, skipping its upgrade")
 	}


### PR DESCRIPTION
Closes #20104 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
