### PR TITLE
fix: restore portable backup error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v1.8.5 [unreleased]
 -	[#20909](https://github.com/influxdata/influxdb/pull/20909): fix(tsm1): data race when accessing tombstone stats
 -	[#20912](https://github.com/influxdata/influxdb/pull/20912): fix(tsdb): minimize lock contention when adding new fields or measure
 -	[#20914](https://github.com/influxdata/influxdb/pull/20914): fix: infinite recursion bug (#20862)
+-	[#20115](https://github.com/influxdata/influxdb/pull/20115): fix: restore portable backup bug
 
 v1.8.4 [2021-01-27]
 -------------------
@@ -29,7 +30,6 @@ v1.8.4 [2021-01-27]
 ### Bugfixes
 
 -	[#19696](https://github.com/influxdata/influxdb/pull/19697): fix(flux): add durations to Flux logging
--	[#20115](https://github.com/influxdata/influxdb/pull/20115): fix: restore portable backup error
 
 v1.8.3 [2020-09-30]
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ v1.8.4 [2021-01-27]
 ### Bugfixes
 
 -	[#19696](https://github.com/influxdata/influxdb/pull/19697): fix(flux): add durations to Flux logging
+-	[#20115](https://github.com/influxdata/influxdb/pull/20115): fix: restore portable backup error
 
 v1.8.3 [2020-09-30]
 -------------------

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -37,6 +37,8 @@ type Service struct {
 	MetaClient interface {
 		encoding.BinaryMarshaler
 		Database(name string) *meta.DatabaseInfo
+		Data() meta.Data
+		SetData(data *meta.Data) error
 	}
 
 	TSDBStore interface {
@@ -180,7 +182,7 @@ func (s *Service) updateMetaStore(conn net.Conn, bits []byte, backupDBName, rest
 		return fmt.Errorf("failed to decode meta: %s", err)
 	}
 
-	data := s.MetaClient.(*meta.Client).Data()
+	data := s.MetaClient.Data()
 
 	IDMap, newDBs, err := data.ImportData(md, backupDBName, restoreDBName, backupRPName, restoreRPName)
 	if err != nil {
@@ -190,7 +192,7 @@ func (s *Service) updateMetaStore(conn net.Conn, bits []byte, backupDBName, rest
 		return err
 	}
 
-	err = s.MetaClient.(*meta.Client).SetData(&data)
+	err = s.MetaClient.SetData(&data)
 	if err != nil {
 		return err
 	}

--- a/services/snapshotter/service_test.go
+++ b/services/snapshotter/service_test.go
@@ -165,7 +165,7 @@ func TestSnapshotter_RequestMetastoreBackup(t *testing.T) {
 	}
 	defer l.Close()
 
-	s.MetaClient = &MetaClient{data: data}
+	s.MetaClient = &MetaClient{data: data.Clone()}
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected open error: %s", err)
 	}
@@ -214,7 +214,7 @@ func TestSnapshotter_RequestDatabaseInfo(t *testing.T) {
 		return "", fmt.Errorf("no such shard id: %d", id)
 	}
 
-	s.MetaClient = &MetaClient{data: data}
+	s.MetaClient = &MetaClient{data: data.Clone()}
 	s.TSDBStore = &tsdbStore
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected open error: %s", err)
@@ -269,7 +269,7 @@ func TestSnapshotter_RequestDatabaseInfo_ErrDatabaseNotFound(t *testing.T) {
 	}
 	defer l.Close()
 
-	s.MetaClient = &MetaClient{data: data}
+	s.MetaClient = &MetaClient{data: data.Clone()}
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected open error: %s", err)
 	}
@@ -332,7 +332,7 @@ func TestSnapshotter_RequestRetentionPolicyInfo(t *testing.T) {
 		return "", fmt.Errorf("no such shard id: %d", id)
 	}
 
-	s.MetaClient = &MetaClient{data: data}
+	s.MetaClient = &MetaClient{data: data.Clone()}
 	s.TSDBStore = &tsdbStore
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected open error: %s", err)
@@ -471,7 +471,7 @@ func NewTestService() (*snapshotter.Service, net.Listener, error) {
 
 type MetaClient struct {
 	mu   sync.RWMutex
-	data meta.Data
+	data *meta.Data
 }
 
 func (m *MetaClient) MarshalBinary() ([]byte, error) {
@@ -494,12 +494,12 @@ func (m *MetaClient) Database(name string) *meta.DatabaseInfo {
 func (m *MetaClient) Data() meta.Data {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.data
+	return *m.data.Clone()
 }
 
 func (m *MetaClient) SetData(data *meta.Data) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.data = *data.Clone()
+	m.data = data.Clone()
 	return nil
 }


### PR DESCRIPTION
This PR is to solve restore problem in influxdb 1.x

`
influxd restore -portable -host [host] -db [db] -newdb [newdb] [backup_path]
`

Restoring portable backup with this command may get error as below
```
2020/11/20 13:55:02 error updating meta: updating metadata on influxd service failed: err=read tcp x.x.x.x:52286->x.x.x.x:8088: read: connection reset by peer, n=16
restore: updating metadata on fctsdb service failed: err=read tcp x.x.x.x:52286->x.x.x.x:8088: read: connection reset by peer, n=16
```
Accordingly, the influxdb error log is as below
```
ts=2020-11-20T13:55:02.555262Z lvl=info msg="failed to decode meta: proto: meta.ShardInfo: illegal tag 0 (wire type 0)" log_id=0QQzP3qG000 service=snapshot
```
This problem happens at random, but more frequently in network with high latency. The `net.func (*TCPConn) Read` dose not promise that exactly len(buf) bytes is read when the call is returned, which leading this problem. Replacing the `net.func (*TCPConn) Read` with `io.ReadFull` could fix this.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
