### PR TITLE
feat: No need to compute point hash if there is only one shard

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -234,7 +234,7 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 			continue
 		}
 
-		sh := sg.ShardFor(p.HashID())
+		sh := sg.ShardFor(p)
 		mapping.MapPoint(&sh, p)
 	}
 	return mapping, nil

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1363,9 +1363,13 @@ func (sgi ShardGroupInfo) clone() ShardGroupInfo {
 	return other
 }
 
-// ShardFor returns the ShardInfo for a Point hash.
-func (sgi *ShardGroupInfo) ShardFor(hash uint64) ShardInfo {
-	return sgi.Shards[hash%uint64(len(sgi.Shards))]
+// ShardFor returns the ShardInfo for a Point.
+func (sgi *ShardGroupInfo) ShardFor(p models.Point) ShardInfo {
+	if len(sgi.Shards) == 1 {
+		return sgi.Shards[0]
+	}
+
+	return sgi.Shards[p.HashID()%uint64(len(sgi.Shards))]
 }
 
 // marshal serializes to a protobuf representation.


### PR DESCRIPTION
No need to compute point hash if there is only one shard contained in shard group. We can save a lot of computing resources because of two reason:
  1. In the OSS version of the single-node architecture, a shard group must only contain one shard.
  2. Each point in the write request needs to call the ShardFor method.


- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)