### PR TITLE
feat(cmd/influx): allow for setting v1 passwords via CLI args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### Features
 
-1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth create`.
-1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
+1. [20128](https://github.com/influxdata/influxdb/pull/20128): Allow password to be specified as a CLI option in `influx v1 auth create`.
+1. [20128](https://github.com/influxdata/influxdb/pull/20128): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
 
 ## v2.0.2 [2020-11-18]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## v2.0.3 [unreleased]
 ----------------------
 
+### Features
+
+1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth create`.
+1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
+
 ## v2.0.2 [2020-11-18]
 ----------------------
 


### PR DESCRIPTION
Closes #20107 

Backports #20123 to `2.0`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
