### PR TITLE
fix: enforce bounds on query-related CLI/config parameters to avoid startup panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ want to use the default.
 1. [20110](https://github.com/influxdata/influxdb/pull/20110): Use V2 directory for default V2 config path in `influxd upgrade`.
 1. [20137](https://github.com/influxdata/influxdb/pull/20137): Fix panic when writing a point with 100 tags. Thanks @foobar!
 1. [20151](https://github.com/influxdata/influxdb/pull/20151): Don't log bodies of V1 write requests.
+1. [20097](https://github.com/influxdata/influxdb/pull/20097): Ensure Index.Walk fetches matching foreign keys only.
+1. [20149](https://github.com/influxdata/influxdb/pull/20149): Enforce max value of 2147483647 on query concurrency to avoid startup panic.
 
 ## v2.0.2 [2020-11-19]
 
@@ -34,7 +36,6 @@ want to use the default.
 1. [20053](https://github.com/influxdata/influxdb/pull/20053): Upgrade Flux to v0.95.0.
 1. [20058](https://github.com/influxdata/influxdb/pull/20058): UI: Upgrade flux-lsp-browser to v0.5.23.
 1. [20067](https://github.com/influxdata/influxdb/pull/20067): Add DBRP cli commands as `influxd v1 dbrp`.
-1. [20097](https://github.com/influxdata/influxdb/pull/20097): Ensure Index.Walk fetches matching foreign keys only.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ want to use the default.
 1. [20151](https://github.com/influxdata/influxdb/pull/20151): Don't log bodies of V1 write requests.
 1. [20097](https://github.com/influxdata/influxdb/pull/20097): Ensure Index.Walk fetches matching foreign keys only.
 1. [20149](https://github.com/influxdata/influxdb/pull/20149): Enforce max value of 2147483647 on query concurrency to avoid startup panic.
+1. [20149](https://github.com/influxdata/influxdb/pull/20149): Enforce max value of 2147483647 on query queue size to avoid startup panic.
 
 ## v2.0.2 [2020-11-19]
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -508,7 +508,7 @@ type Launcher struct {
 	initialMemoryBytesQuotaPerQuery int
 	memoryBytesQuotaPerQuery        int
 	maxMemoryBytes                  int
-	queueSize                       int
+	queueSize                       int32
 
 	boltClient *bolt.Client
 	kvStore    kv.SchemaStore

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -504,7 +504,7 @@ type Launcher struct {
 	flagger      feature.Flagger
 
 	// Query options.
-	concurrencyQuota                int
+	concurrencyQuota                int32
 	initialMemoryBytesQuotaPerQuery int
 	memoryBytesQuotaPerQuery        int
 	maxMemoryBytes                  int

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -505,9 +505,9 @@ type Launcher struct {
 
 	// Query options.
 	concurrencyQuota                int32
-	initialMemoryBytesQuotaPerQuery int
-	memoryBytesQuotaPerQuery        int
-	maxMemoryBytes                  int
+	initialMemoryBytesQuotaPerQuery int64
+	memoryBytesQuotaPerQuery        int64
+	maxMemoryBytes                  int64
 	queueSize                       int32
 
 	boltClient *bolt.Client
@@ -900,9 +900,9 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	m.queryController, err = control.New(control.Config{
 		ConcurrencyQuota:                m.concurrencyQuota,
-		InitialMemoryBytesQuotaPerQuery: int64(m.initialMemoryBytesQuotaPerQuery),
-		MemoryBytesQuotaPerQuery:        int64(m.memoryBytesQuotaPerQuery),
-		MaxMemoryBytes:                  int64(m.maxMemoryBytes),
+		InitialMemoryBytesQuotaPerQuery: m.initialMemoryBytesQuotaPerQuery,
+		MemoryBytesQuotaPerQuery:        m.memoryBytesQuotaPerQuery,
+		MaxMemoryBytes:                  m.maxMemoryBytes,
 		QueueSize:                       m.queueSize,
 		Logger:                          m.log.With(zap.String("service", "storage-reads")),
 		ExecutorDependencies:            []flux.Dependency{deps},

--- a/kit/cli/viper.go
+++ b/kit/cli/viper.go
@@ -150,6 +150,58 @@ func BindOptions(v *viper.Viper, cmd *cobra.Command, opts []Opt) {
 			}
 			mustBindPFlag(v, o.Flag, flagset)
 			*destP = v.GetInt(envVar)
+		case *int32:
+			var d int32
+			if o.Default != nil {
+				// N.B. since our CLI kit types default values as interface{} and
+				// literal numbers get typed as int by default, it's very easy to
+				// create an int32 CLI flag with an int default value.
+				//
+				// The compiler doesn't know to complain in that case, so you end up
+				// with a runtime panic when trying to bind the CLI options.
+				//
+				// To avoid that headache, we support both int32 and int defaults
+				// for int32 fields. This introduces a new runtime bomb if somebody
+				// specifies an int default > math.MaxInt32, but that's hopefully
+				// less likely.
+				var ok bool
+				d, ok = o.Default.(int32)
+				if !ok {
+					d = int32(o.Default.(int))
+				}
+			}
+			if hasShort {
+				flagset.Int32VarP(destP, o.Flag, string(o.Short), d, o.Desc)
+			} else {
+				flagset.Int32Var(destP, o.Flag, d, o.Desc)
+			}
+			mustBindPFlag(v, o.Flag, flagset)
+			*destP = v.GetInt32(envVar)
+		case *int64:
+			var d int64
+			if o.Default != nil {
+				// N.B. since our CLI kit types default values as interface{} and
+				// literal numbers get typed as int by default, it's very easy to
+				// create an int64 CLI flag with an int default value.
+				//
+				// The compiler doesn't know to complain in that case, so you end up
+				// with a runtime panic when trying to bind the CLI options.
+				//
+				// To avoid that headache, we support both int64 and int defaults
+				// for int64 fields.
+				var ok bool
+				d, ok = o.Default.(int64)
+				if !ok {
+					d = int64(o.Default.(int))
+				}
+			}
+			if hasShort {
+				flagset.Int64VarP(destP, o.Flag, string(o.Short), d, o.Desc)
+			} else {
+				flagset.Int64Var(destP, o.Flag, d, o.Desc)
+			}
+			mustBindPFlag(v, o.Flag, flagset)
+			*destP = v.GetInt64(envVar)
 		case *bool:
 			var d bool
 			if o.Default != nil {

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path"
 	"testing"
@@ -40,6 +41,8 @@ func (c *customFlag) Type() string {
 func ExampleNewCommand() {
 	var monitorHost string
 	var number int
+	var smallerNumber int32
+	var longerNumber int64
 	var sleep bool
 	var duration time.Duration
 	var stringSlice []string
@@ -50,6 +53,7 @@ func ExampleNewCommand() {
 			for i := 0; i < number; i++ {
 				fmt.Printf("%d\n", i)
 			}
+			fmt.Println(longerNumber - int64(smallerNumber))
 			fmt.Println(sleep)
 			fmt.Println(duration)
 			fmt.Println(stringSlice)
@@ -69,6 +73,18 @@ func ExampleNewCommand() {
 				Flag:    "number",
 				Default: 2,
 				Desc:    "number of times to loop",
+			},
+			{
+				DestP:   &smallerNumber,
+				Flag:    "smaller-number",
+				Default: math.MaxInt32,
+				Desc:    "limited size number",
+			},
+			{
+				DestP:   &longerNumber,
+				Flag:    "longer-number",
+				Default: math.MaxInt64,
+				Desc:    "explicitly expanded-size number",
 			},
 			{
 				DestP:   &sleep,
@@ -104,6 +120,7 @@ func ExampleNewCommand() {
 	// http://localhost:8086
 	// 0
 	// 1
+	// 9223372034707292160
 	// true
 	// 1m0s
 	// [foo bar]
@@ -113,8 +130,10 @@ func ExampleNewCommand() {
 func Test_NewProgram(t *testing.T) {
 	testFilePath, cleanup := newConfigFile(t, map[string]string{
 		// config values should be same as flags
-		"foo":      "bar",
-		"shoe-fly": "yadon",
+		"foo":         "bar",
+		"shoe-fly":    "yadon",
+		"number":      "2147483647",
+		"long-number": "9223372036854775807",
 	})
 	defer cleanup()
 	defer setEnvVar("TEST_CONFIG_PATH", testFilePath)()
@@ -155,6 +174,8 @@ func Test_NewProgram(t *testing.T) {
 
 			var testVar string
 			var testFly string
+			var testNumber int32
+			var testLongNumber int64
 			program := &Program{
 				Name: "test",
 				Opts: []Opt{
@@ -167,6 +188,14 @@ func Test_NewProgram(t *testing.T) {
 						DestP: &testFly,
 						Flag:  "shoe-fly",
 					},
+					{
+						DestP: &testNumber,
+						Flag:  "number",
+					},
+					{
+						DestP: &testLongNumber,
+						Flag:  "long-number",
+					},
 				},
 				Run: func() error { return nil },
 			}
@@ -177,6 +206,8 @@ func Test_NewProgram(t *testing.T) {
 
 			require.Equal(t, tt.expected, testVar)
 			assert.Equal(t, "yadon", testFly)
+			assert.Equal(t, int32(math.MaxInt32), testNumber)
+			assert.Equal(t, int64(math.MaxInt64), testLongNumber)
 		}
 
 		t.Run(tt.name, fn)


### PR DESCRIPTION
Closes #20144 

`math.MaxInt32` is the biggest value that the `WaitGroup` wrapped in the query controller will accept without panicking. When I try running `influxd` with that parameter it takes a loooooong time to boot up, but I assume it'd be faster on a beefed-up VM.