### PR TITLE
fix: various improvements to setup command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ want to use the default.
 1. [20149](https://github.com/influxdata/influxdb/pull/20149): Enforce max value of 2147483647 on query queue size to avoid startup panic.
 1. [20168](https://github.com/influxdata/influxdb/pull/20168): Auto-migrate existing DBRP mappings from old schema to avoid panic.
 1. [20201](https://github.com/influxdata/influxdb/pull/20201): Optimize shard lookup in groups containing only one shard. Thanks @StoneYunZhao!
+1. [20155](https://github.com/influxdata/influxdb/pull/20155): Respect the `--name` option in `influx setup` whether configs already exist or not.
+1. [20155](https://github.com/influxdata/influxdb/pull/20155): Allow for 0 (infinite) values for `--retention` in `influx setup`.
 
 ## v2.0.2 [2020-11-19]
 

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -141,27 +141,13 @@ func setupF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("instance at %q has already been setup", activeConfig.Host)
 	}
 
-	if _, err := os.Stat(dPath); err == nil {
-		existingConfigs, _ := localConfigSVC.ListConfigs()
-		if len(existingConfigs) > 0 {
-			// If there are existing configs then require that a name be
-			// spcified in order to distinguish this new config from what's
-			// there already.
-			if setupFlags.name == "" {
-				return errors.New("flag name is required if you already have existing configs")
-			}
-			if _, ok := existingConfigs[setupFlags.name]; ok {
-				return &influxdb.Error{
-					Code: influxdb.EConflict,
-					Msg:  fmt.Sprintf("config name %q already existed", setupFlags.name),
-				}
-			}
-		}
+	if err := validateNoNameCollision(localConfigSVC, setupFlags.name); err != nil {
+		return err
 	}
 
 	req, err := onboardingRequest()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve data to setup instance: %v", err)
+		return fmt.Errorf("failed to setup instance: %v", err)
 	}
 
 	result, err := s.OnboardInitialUser(context.Background(), req)
@@ -205,6 +191,29 @@ func setupF(cmd *cobra.Command, args []string) error {
 		"Organization": result.Org.Name,
 		"Bucket":       result.Bucket.Name,
 	})
+
+	return nil
+}
+
+// validateNoNameCollision asserts that there isn't already a local config with a given name.
+func validateNoNameCollision(localConfigSvc config.Service, configName string) error {
+	existingConfigs, err := localConfigSvc.ListConfigs()
+	if err != nil {
+		return fmt.Errorf("error checking existing configs: %v", err)
+	}
+	if len(existingConfigs) == 0 {
+		return nil
+	}
+
+	// If there are existing configs then require that a name be
+	// specified in order to distinguish this new config from what's
+	// there already.
+	if configName == "" {
+		return errors.New("flag name is required if you already have existing configs")
+	}
+	if _, ok := existingConfigs[configName]; ok {
+		return fmt.Errorf("config name %q already exists", configName)
+	}
 
 	return nil
 }


### PR DESCRIPTION
When checking for existing configs, check the length of the array after
parsing. There could be an empty config file present.

If --name was specified then use that as the configuration name, regardless of
whether or not there are existing configs.

Allow a 0 (infinite) retention to be specified with --retention when in
interactive mode.