### PR TITLE
fix(dbrp): use more specific messages for ID-related API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ want to use the default.
 1. [20110](https://github.com/influxdata/influxdb/pull/20110): Use V2 directory for default V2 config path in `influxd upgrade`.
 1. [20137](https://github.com/influxdata/influxdb/pull/20137): Fix panic when writing a point with 100 tags. Thanks @foobar!
 1. [20151](https://github.com/influxdata/influxdb/pull/20151): Don't log bodies of V1 write requests.
+1. [20165](https://github.com/influxdata/influxdb/pull/20165): Return more-specific error messages from create-DBRP API.
 
 ## v2.0.2 [2020-11-19]
 

--- a/dbrp/http_client_dbrp.go
+++ b/dbrp/http_client_dbrp.go
@@ -92,8 +92,8 @@ func (c *Client) Create(ctx context.Context, dbrp *influxdb.DBRPMappingV2) error
 			Database:        dbrp.Database,
 			RetentionPolicy: dbrp.RetentionPolicy,
 			Default:         dbrp.Default,
-			OrganizationID:  dbrp.OrganizationID,
-			BucketID:        dbrp.BucketID,
+			OrganizationID:  dbrp.OrganizationID.String(),
+			BucketID:        dbrp.BucketID.String(),
 		}, c.Prefix).
 		DecodeJSON(&newDBRP).
 		Do(ctx); err != nil {


### PR DESCRIPTION
Related to #20134 

1. Instead of errors like "invalid ID", say which ID is invalid
2. Explicitly check for and report missing org / bucket ID fields, instead of falling back to an "invalid ID" error on empty string