### PR TITLE
fix(tsm1): fix ring and related test

### DIFF
--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -47,11 +47,14 @@ type ring struct {
 // power of 2, and for performance reasons should be larger than the number of
 // cores on the host. The supported set of values for n is:
 //
-//     {1, 2, 4, 8, 16, 32, 64, 128, 256}.
+//     {1, 2, 4, 8, 16}.
 //
 func newring(n int) (*ring, error) {
 	if n <= 0 || n > partitions {
-		return nil, fmt.Errorf("invalid number of paritions: %d", n)
+		return nil, fmt.Errorf("invalid number of partitions: %d", n)
+	}
+	if n&(n-1) != 0 {
+		return nil, fmt.Errorf("partitions %d is not a power of two", n)
 	}
 
 	r := ring{
@@ -78,7 +81,7 @@ func (r *ring) reset() {
 	for _, partition := range r.partitions {
 		partition.reset()
 	}
-	r.keysHint = 0
+	atomic.StoreInt64(&r.keysHint, 0)
 }
 
 // getPartition retrieves the hash ring partition associated with the provided
@@ -110,8 +113,12 @@ func (r *ring) add(key []byte, entry *entry) {
 // remove is safe for use by multiple goroutines.
 func (r *ring) remove(key []byte) {
 	r.getPartition(key).remove(key)
-	if r.keysHint > 0 {
-		atomic.AddInt64(&r.keysHint, -1)
+
+	for {
+		prev := atomic.LoadInt64(&r.keysHint)
+		if prev <= 0 || atomic.CompareAndSwapInt64(&r.keysHint, prev, prev-1) {
+			break
+		}
 	}
 }
 
@@ -129,6 +136,8 @@ func (r *ring) keys(sorted bool) [][]byte {
 	return keys
 }
 
+// count returns the count of values in the ring
+// count is not accurate since it doesn't use read lock when iterate over partitions
 func (r *ring) count() int {
 	var n int
 	for _, p := range r.partitions {
@@ -202,7 +211,6 @@ func (r *ring) applySerial(f func([]byte, *entry) error) error {
 }
 
 func (r *ring) split(n int) []storer {
-	var keys int
 	storers := make([]storer, n)
 	for i := 0; i < n; i++ {
 		storers[i], _ = newring(len(r.partitions))
@@ -211,7 +219,6 @@ func (r *ring) split(n int) []storer {
 	for i, p := range r.partitions {
 		r := storers[i%n].(*ring)
 		r.partitions[i] = p
-		keys += len(p.store)
 	}
 	return storers
 }

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -24,6 +24,9 @@ func TestRing_newRing(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
+		if example.returnErr {
+			t.Fatalf("[Example %d] got nil, expected error", i)
+		}
 
 		if got, exp := len(r.partitions), example.n; got != exp {
 			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
@@ -48,7 +51,7 @@ var strSliceRes [][]byte
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), nil)
+		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), &entry{})
 	}
 
 	b.ReportAllocs()
@@ -58,10 +61,10 @@ func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(256), 100) }
-func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
-func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
-func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(16), 100) }
+func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(16), 1000) }
+func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(16), 10000) }
+func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(16), 100000) }
 
 func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	vals := make([][]byte, keys)
@@ -79,9 +82,9 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_getPartition_100(b *testing.B) { benchmarkRingGetPartition(b, MustNewRing(256), 100) }
+func BenchmarkRing_getPartition_100(b *testing.B) { benchmarkRingGetPartition(b, MustNewRing(16), 100) }
 func BenchmarkRing_getPartition_1000(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 1000)
+	benchmarkRingGetPartition(b, MustNewRing(16), 1000)
 }
 
 func benchmarkRingWrite(b *testing.B, r *ring, n int) {
@@ -114,26 +117,18 @@ func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 	}
 }
 
-func BenchmarkRing_write_1_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(1), 100) }
-func BenchmarkRing_write_1_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 1000) }
-func BenchmarkRing_write_1_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 10000) }
-func BenchmarkRing_write_1_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 100000) }
-func BenchmarkRing_write_4_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(4), 100) }
-func BenchmarkRing_write_4_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 1000) }
-func BenchmarkRing_write_4_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 10000) }
-func BenchmarkRing_write_4_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 100000) }
-func BenchmarkRing_write_32_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(32), 100) }
-func BenchmarkRing_write_32_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(32), 1000) }
-func BenchmarkRing_write_32_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(32), 10000) }
-func BenchmarkRing_write_32_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(32), 100000) }
-func BenchmarkRing_write_128_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(128), 100) }
-func BenchmarkRing_write_128_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(128), 1000) }
-func BenchmarkRing_write_128_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(128), 10000) }
-func BenchmarkRing_write_128_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
-func BenchmarkRing_write_256_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(256), 100) }
-func BenchmarkRing_write_256_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(256), 1000) }
-func BenchmarkRing_write_256_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(256), 10000) }
-func BenchmarkRing_write_256_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
+func BenchmarkRing_write_1_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 100) }
+func BenchmarkRing_write_1_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 1000) }
+func BenchmarkRing_write_1_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 10000) }
+func BenchmarkRing_write_1_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(1), 100000) }
+func BenchmarkRing_write_4_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 100) }
+func BenchmarkRing_write_4_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 1000) }
+func BenchmarkRing_write_4_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 10000) }
+func BenchmarkRing_write_4_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(4), 100000) }
+func BenchmarkRing_write_16_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(16), 100) }
+func BenchmarkRing_write_16_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(16), 1000) }
+func BenchmarkRing_write_16_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(16), 10000) }
+func BenchmarkRing_write_16_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(16), 100000) }
 
 func MustNewRing(n int) *ring {
 	r, err := newring(n)


### PR DESCRIPTION
I accidentally found that ring.go is not rigorous。I opened two identical PRs before, one of the PR's circleci test failed but another succeed.

1. [failed circleci](https://app.circleci.com/pipelines/github/influxdata/influxdb/15858/workflows/0d1ce4c9-f0c6-400a-8c65-a26a28df0fd7/jobs/158630) triggered by #20117 .
2. [succeed circleci](https://app.circleci.com/pipelines/github/influxdata/influxdb/16024/workflows/b3f7375b-4c3c-46ef-9825-92b8266932a0/jobs/159176) triggered by #20118 .

I'm pretty sure that it's not my commit who caused the failure after read ring.go. I did some fix work for it.

1. [e9db11a](https://github.com/influxdata/influxdb/commit/e9db11a) changed the max partition to 16, but not change benchmark test, so the benchmark test will failed if the partition larger than 16.
2. `newring()` doesn't check the partition if is the power of two, and `TestRing_newRing` can't test that case.
3. `add()` should not add a nil entry in `benchmarkRingkeys`, because it will cause panic when call `keys()`.
4. reset keysHint must use atomic in `reset()`. If not, it will cause the below failure at a very small chance.
5. `remove()` is safe for use by multiple goroutines, so we must ensure `keysHint` not be negative in `remove()`. If negative , may cause panic because it used in the way `make([][]byte, 0, atomic.LoadInt64(&r.keysHint))`

Below is the error log in circleci: 

```=== RUN   TestShard_WritePoints_FieldConflictConcurrent
==================
WARNING: DATA RACE
Write at 0x00c00039c300 by goroutine 90:
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*ring).reset()
      /root/influxdb/tsdb/engine/tsm1/ring.go:81 +0xac
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Cache).ClearSnapshot()
      /root/influxdb/tsdb/engine/tsm1/cache.go:449 +0x3b1
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).WriteSnapshot()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1934 +0x5e2
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).CreateSnapshot()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1959 +0xbd
  github.com/influxdata/influxdb/tsdb.(*Shard).CreateSnapshot()
      /root/influxdb/tsdb/shard.go:1185 +0xa6
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrent.func2()
      /root/influxdb/tsdb/shard_test.go:475 +0x1ef

Previous read at 0x00c00039c300 by goroutine 100:
  sync/atomic.LoadInt64()
      /usr/local/go/src/runtime/race_amd64.s:211 +0xb
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*ring).keys()
      /root/influxdb/tsdb/engine/tsm1/ring.go:121 +0x52
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Cache).Keys()
      /root/influxdb/tsdb/engine/tsm1/cache.go:504 +0x97
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).deleteSeriesRange()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1694 +0x7f8
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).DeleteSeriesRangeWithPredicate()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1527 +0x8ff
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).DeleteSeriesRange()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1419 +0x91
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).DeleteMeasurement()
      /root/influxdb/tsdb/engine/tsm1/engine.go:1870 +0x30f
  github.com/influxdata/influxdb/tsdb.(*Shard).DeleteMeasurement()
      /root/influxdb/tsdb/shard.go:795 +0xb0
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrent.func1()
      /root/influxdb/tsdb/shard_test.go:453 +0xfa

Goroutine 90 (running) created at:
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrent()
      /root/influxdb/tsdb/shard_test.go:466 +0xec6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 100 (running) created at:
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrent()
      /root/influxdb/tsdb/shard_test.go:450 +0xe60
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
FAIL	github.com/influxdata/influxdb/tsdb	23.041s
```

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
