### PR TITLE
fix(dbrp): Don't use record ID removing orgID index

### DIFF
--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -481,7 +481,7 @@ func (s *Service) Delete(ctx context.Context, orgID, id influxdb.ID) error {
 		return ErrInternalService(err)
 	}
 
-	encodedOrgID, err := id.Encode()
+	encodedOrgID, err := orgID.Encode()
 	if err != nil {
 		return ErrInternalService(err)
 	}


### PR DESCRIPTION
Noticed this while I was going through porting some of this to IDPE. The new Org-based index for DBRP mappings won't get cleaned up properly without this.