### PR TITLE
feat(cmd/influx): add hints to ID-related errors in DBRP CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Features
+
+1. [20204](https://github.com/influxdata/influxdb/pull/20204): Improve ID-related error messages for `influx v1 dbrp` commands.
+
 ### Bug Fixes
 
 1. [20201](https://github.com/influxdata/influxdb/pull/20201): Optimize shard lookup in groups containing only one shard. Thanks @StoneYunZhao!

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -515,7 +515,7 @@ func (o *organization) getID(orgSVC influxdb.OrganizationService) (influxdb.ID, 
 	if o.id != "" {
 		influxOrgID, err := influxdb.IDFromString(o.id)
 		if err != nil {
-			return 0, fmt.Errorf("invalid org ID provided: %s", err.Error())
+			return 0, fmt.Errorf("invalid org ID '%s' provided: %w (did you pass an org name instead of an ID?)", o.id, err)
 		}
 		return *influxOrgID, nil
 	}

--- a/cmd/influx/v1_authorization.go
+++ b/cmd/influx/v1_authorization.go
@@ -144,7 +144,7 @@ func makeV1AuthorizationCreateE(opt genericCLIOpts) func(*cobra.Command, []strin
 			for _, p := range bp.perms {
 				var id influxdb.ID
 				if err := id.DecodeFromString(p); err != nil {
-					return err
+					return fmt.Errorf("invalid bucket ID '%s': %w (did you pass a bucket name instead of an ID?)", p, err)
 				}
 
 				p, err := influxdb.NewPermissionAtID(id, bp.action, influxdb.BucketsResourceType, orgID)
@@ -253,7 +253,7 @@ func v1AuthorizationFindF(cmd *cobra.Command, _ []string) error {
 	if v1AuthorizationFindFlags.userID != "" {
 		uID, err := influxdb.IDFromString(v1AuthorizationFindFlags.userID)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid user ID '%s': %w (did you pass a username instead of an ID?)", v1AuthorizationFindFlags.userID, err)
 		}
 		filter.UserID = uID
 	}
@@ -263,7 +263,7 @@ func v1AuthorizationFindF(cmd *cobra.Command, _ []string) error {
 	if v1AuthorizationFindFlags.org.id != "" {
 		oID, err := influxdb.IDFromString(v1AuthorizationFindFlags.org.id)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid org ID '%s': %w (did you pass an org name instead of an ID?)", v1AuthorizationFindFlags.org.id, err)
 		}
 		filter.OrgID = oID
 	}


### PR DESCRIPTION
Related to #20084 

This should hopefully help un-puzzle users if they type the wrong thing.