### PR TITLE
fix(dbrp): Don't use record ID removing orgID index

### DIFF
--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -481,7 +481,7 @@ func (s *Service) Delete(ctx context.Context, orgID, id influxdb.ID) error {
 		return ErrInternalService(err)
 	}
 
-	encodedOrgID, err := id.Encode()
+	encodedOrgID, err := orgID.Encode()
 	if err != nil {
 		return ErrInternalService(err)
 	}


### PR DESCRIPTION
Backports #20203 

This is a fix for other unreleased logic sitting in the `2.0` branch.