### PR TITLE
refactor: save field set after restoring

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1182,6 +1182,12 @@ func (e *Engine) overlay(r io.Reader, basePath string, asNew bool) error {
 			return err
 		}
 	}
+
+	// Save the field set index so we don't have to rebuild it next time
+	if err := e.fieldset.Save(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR is to remove the extra rebuilding of engine's field set in the process of `Restore()/Import()`. 
The engine would load the `.tsm` file to rebuild the field set when `Restore()/Import()` is called, while the field set data is not persisted after the operation is done. After `Restore()/Import()`, the engine would be reopen,  in which the engine would load data and rebuild the field set again.
The second rebuilding is unnecessary and could be avoided via saving the engine's field set to `fields.idx`.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
