### PR TITLE
feat(tsdb): Implement delete with predicate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ want to use the default.
 1. [20123](https://github.com/influxdata/influxdb/pull/20123): Allow password to be specified as a CLI option in `influx v1 auth set-password`.
 1. [20110](https://github.com/influxdata/influxdb/pull/20110): Allow for users to specify where V2 config should be written in `influxd upgrade`.
 1. [20204](https://github.com/influxdata/influxdb/pull/20204): Improve ID-related error messages for `influx v1 dbrp` commands.
+1. [20236](https://github.com/influxdata/influxdb/pull/20236): Delete with predicate.
 
 ### Bug Fixes
 

--- a/http/delete_handler.go
+++ b/http/delete_handler.go
@@ -114,16 +114,22 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.HandleHTTPError(r.Context(), &influxdb.Error{
-		Code: influxdb.ENotImplemented,
-		Op:   "http/handleDelete",
-		Msg:  "Not implemented",
-	}, w)
+	if err := h.DeleteService.DeleteBucketRangePredicate(r.Context(), dr.Org.ID, dr.Bucket.ID, dr.Start, dr.Stop, dr.Predicate); err != nil {
+		h.HandleHTTPError(ctx, &influxdb.Error{
+			Code: influxdb.EInternal,
+			Op:   "http/handleDelete",
+			Msg:  fmt.Sprintf("unable to delete: %v", err),
+			Err:  err,
+		}, w)
+		return
+	}
 
 	h.log.Debug("Deleted",
 		zap.String("orgID", fmt.Sprint(dr.Org.ID.String())),
 		zap.String("bucketID", fmt.Sprint(dr.Bucket.ID.String())),
 	)
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func decodeDeleteRequest(ctx context.Context, r *http.Request, orgSvc influxdb.OrganizationService, bucketSvc influxdb.BucketService) (*deleteRequest, error) {

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -228,7 +228,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wants: wants{
-				statusCode: http.StatusNotImplemented,
+				statusCode: http.StatusNoContent,
 				body:       ``,
 			},
 		},
@@ -333,7 +333,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wants: wants{
-				statusCode: http.StatusNotImplemented,
+				statusCode: http.StatusNoContent,
 				body:       ``,
 			},
 		},

--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -16,6 +16,7 @@ func New(n Node) (influxdb.Predicate, error) {
 	if n == nil {
 		return nil, nil
 	}
+
 	dt, err := n.ToDataType()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Overview

This pull request implements the "delete with predicate" API that was previously disabled. It works by implementing a new `tsdb.Store.DeleteSeriesWithPredicate()` function that operates on a predicate directly instead of an `influxql.Expr`. This PR also adds a `PredicateSeriesIDIterator` that filters an underlying iterator by predicate.

Note: The predicate does not currently support `OR`. That will need to be implemented separately.

Closes https://github.com/influxdata/influxdb/issues/19635


## Usage

#### Write two points into the `influx` bucket:

```sh
$ influx write -b influx "cpu,region=us-east-1 value=1"
$ influx write -b influx "cpu,region=us-west-1 value=1"
```

#### Query to verify points exist.

```sh
$ influx query 'from(bucket:"influx")|>range(start:0)' 
Result: _result
Table: keys: [_start, _stop, _field, _measurement, region]
                   _start:time                      _stop:time           _field:string     _measurement:string           region:string                      _time:time                  _value:float  
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------  
1970-01-01T00:00:00.000000000Z  2020-12-02T17:00:07.917155000Z                   value                     cpu               us-east-1  2020-12-02T17:00:03.448750000Z                             1  
Table: keys: [_start, _stop, _field, _measurement, region]
                   _start:time                      _stop:time           _field:string     _measurement:string           region:string                      _time:time                  _value:float  
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------  
1970-01-01T00:00:00.000000000Z  2020-12-02T17:00:07.917155000Z                   value                     cpu               us-west-1  2020-12-02T17:00:06.027808000Z                             1  
```


#### Delete point in `us-west-1` using predicate:

```sh
$ influx delete --org influx --bucket influx --start 2020-12-01T00:00:00Z --stop 2020-12-31T00:00:00Z --predicate '_measurement="cpu" AND region="us-west-1"'
```

#### Query again to verify only one point exists:

```
$ influx query 'from(bucket:"influx")|>range(start:0)' 
Result: _result
Table: keys: [_start, _stop, _field, _measurement, region]
                   _start:time                      _stop:time           _field:string     _measurement:string           region:string                      _time:time                  _value:float  
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------  
1970-01-01T00:00:00.000000000Z  2020-12-02T17:01:17.979115000Z                   value                     cpu               us-east-1  2020-12-02T17:00:03.448750000Z                             1  
```


## TODO

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
