### PR TITLE
fix(error): unsupported value: +Inf" error not handled gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.8.4 [unreleased]
 
 -	[#20101](https://github.com/influxdata/influxdb/pull/20101): fix(write): Successful writes increment write error statistics incorrectly
 -	[#19696](https://github.com/influxdata/influxdb/pull/19697): fix(flux): add durations to Flux logging
+	[#20276](https://github.com/influxdata/influxdb/pull/20276): fix(error): unsupported value: +Inf" error not handled gracefully
 
 v1.8.3 [2020-09-30]
 -------------------


### PR DESCRIPTION
JSON marshalling errors should be returned properly formatted in JSON
like other errors.

Fixes https://github.com/influxdata/influxdb/issues/20249

(cherry picked from commit 240707757671f1680838169325adccdd8ef20290)

Closes https://github.com/influxdata/influxdb/issues/20251

This fix formats marshalling errors the same wayinfluxdb formats other query errors.

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
