### PR TITLE
fix: cp.Mux.Serve() closes all net.Listener instances silently on error.

### DIFF
--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -79,7 +79,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 			continue
 		}
 		if err != nil {
-			mux.Logger.Printf("Listener at %s failed failed to accept a connection, closing all listeners - %s", ln.Addr(), err)
+			mux.Logger.Printf("tcp.Mux: Listener at %s failed failed to accept a connection, closing all listeners - %s", ln.Addr(), err)
 			// Wait for all connections to be demux
 			mux.wg.Wait()
 
@@ -92,7 +92,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 				go func(ln *listener) {
 					defer wg.Done()
 					if err := ln.Close(); err != nil {
-						mux.Logger.Printf("Closing the listener at %s failed - %s", ln.Addr().String(), err)
+						mux.Logger.Printf("tcp.Mux: Closing the listener at %s failed - %s", ln.Addr().String(), err)
 					}
 				}(ln)
 			}
@@ -104,7 +104,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 			mux.mu.RUnlock()
 			if dl != nil {
 				if closeErr := dl.Close(); closeErr != nil {
-					mux.Logger.Printf("Closing the default listener at %s failed - %s", ln.Addr().String(), closeErr)
+					mux.Logger.Printf("tcp.Mux: Closing the default listener at %s failed - %s", ln.Addr().String(), closeErr)
 				}
 			}
 			return err

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -79,7 +79,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 			continue
 		}
 		if err != nil {
-			mux.Logger.Printf("tcp.Mux.Serve: call to Accept() at %s failed, closing all listeners - %s", ln.Addr(), err)
+			mux.Logger.Printf("Listener at %s failed failed to accept a connection, closing all listeners - %s", ln.Addr(), err)
 			// Wait for all connections to be demux
 			mux.wg.Wait()
 
@@ -92,7 +92,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 				go func(ln *listener) {
 					defer wg.Done()
 					if err := ln.Close(); err != nil {
-						mux.Logger.Printf("tcp.Mux.Serve: Closing listener at %s failed - %s", ln.Addr().String(), err)
+						mux.Logger.Printf("Closing the listener at %s failed - %s", ln.Addr().String(), err)
 					}
 				}(ln)
 			}
@@ -104,7 +104,7 @@ func (mux *Mux) Serve(ln net.Listener) error {
 			mux.mu.RUnlock()
 			if dl != nil {
 				if closeErr := dl.Close(); closeErr != nil {
-					mux.Logger.Printf("tcp.Mux.Serve: Closing default listener at %s failed - %s", ln.Addr().String(), closeErr)
+					mux.Logger.Printf("Closing the default listener at %s failed - %s", ln.Addr().String(), closeErr)
 				}
 			}
 			return err

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -65,7 +65,6 @@ func NewMux() *Mux {
 
 // Serve handles connections from ln and multiplexes then across registered listeners.
 func (mux *Mux) Serve(ln net.Listener) error {
-	specialerr := errors.New("Special stupid Err")
 	mux.mu.Lock()
 	mux.ln = ln
 	mux.mu.Unlock()


### PR DESCRIPTION
    A customer has seen a rash of "connection refused" errors to the meta node.
    This fix ensures that when net.Listener instances are closed because of an
    error in Accept(), influxdb logs the error which caused the closures, as well
    as any errors in closing the Listeners.
    
    Fixes https://github.com/influxdata/influxdb/issues/20256

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass