### PR TITLE
fix: detect non-amd64 arch and set noasm tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ SUBDIRS := http ui chronograf query storage
 export GOOS=$(shell go env GOOS)
 export GOARCH=$(shell go env GOARCH)
 
-GO_TAGS :=
-# noasm needed to avoid a panic in Flux for non-amd64.
-ifneq ($(GOARCH), amd64)
-	GO_TAGS += noasm
+ifeq ($(GOARCH), amd64)
+	GO_TAGS := assets
+else
+	# noasm needed to avoid a panic in Flux for non-amd64.
+	GO_TAGS := assets,noasm
 endif
 GO_ARGS := -tags '$(GO_TAGS)'
 ifeq ($(OS), Windows_NT)


### PR DESCRIPTION
Closes #20288 

I confirmed that this change fixed the panics on `make test-go` in my aarch64 docker image. The goreleaser config still needs updated to match, but I'll do that in my open Docker/release PR.