### PR TITLE
docs: OSX always needs pkg-config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,10 @@ Currently the project only depends on `git` and `bzr`.
 
 You need a recent stable version of Rust. We recommend using [rustup](https://rustup.rs/) to install Rust.
 
-You also need `protobuf`, `yarn`, and `make` installed.
+You also need `clang`, `make`, `pkg-config`, `protobuf`, and `yarn` installed.
 
-- OSX: `brew install protobuf yarn make`
-- Linux (Arch): `pacman -S protobuf yarn make`
+- OSX: `brew install make pkg-config protobuf yarn`
+- Linux (Arch): `pacman -S clang make pkgconf protobuf yarn`
 - Linux (Ubuntu, RHEL): See below
 
 #### Ubuntu-specific instructions:
@@ -134,7 +134,7 @@ sudo apt remove yarn cmdtest
 wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 sudo apt-add-repository "deb https://dl.yarnpkg.com/debian/ stable main"
 
-sudo apt install protobuf-compiler libprotobuf-dev yarn make
+sudo apt install make clang pkg-config protobuf-compiler libprotobuf-dev yarn
 ```
 
 #### Redhat-specific instructions
@@ -177,14 +177,7 @@ $ ./env go build ./cmd/influxd
 
 Another method is to configure the `pkg-config` utility. Follow the instructions [here](https://github.com/influxdata/flux#getting-started) to install and configure `pkg-config` and then the normal go commands will work.
 
-The first step is to install the `pkg-config` command.
-
-```bash
-# On Debian/Ubuntu
-$ sudo apt-get install -y clang pkg-config
-# On Mac OS X with Homebrew
-$ brew install pkg-config
-```
+You should have already installed the pkg-config commands when doing the regular 'make' build.
 
 Install the `pkg-config` wrapper utility of the same name to a different path that is earlier in the PATH.
 


### PR DESCRIPTION
Tiny PR to fix up the docs - OSX build appears to need pkg-config with normal 'make' build, so add it to the docs.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
