### PR TITLE
fix(models): reject measurements and keys with leading underscores

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -25,9 +25,7 @@ const (
 
 	// reserved tag keys which when present cause the point to be discarded
 	// and an error returned
-	reservedFieldTagKey       = "_field"
-	reservedMeasurementTagKey = "_measurement"
-	reservedTimeTagKey        = "time"
+	reservedTimeTagKey = "time"
 )
 
 var (
@@ -39,8 +37,6 @@ var (
 	reservedTagKeys = [][]byte{
 		FieldKeyTagKeyBytes,
 		MeasurementTagKeyBytes,
-		[]byte(reservedFieldTagKey),
-		[]byte(reservedMeasurementTagKey),
 		[]byte(reservedTimeTagKey),
 	}
 )
@@ -89,6 +85,7 @@ var (
 	ErrUnbalancedQuotes = errors.New("unbalanced quotes")
 
 	ErrUnderscoreMeasurement = errors.New("measurement name cannot start with '_'")
+	ErrUnderscoreTagKey      = errors.New("tag key name cannot start with '_'")
 )
 
 const (
@@ -553,6 +550,9 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 	for j := 0; j < commas; j++ {
 		_, key := scanTo(buf[indices[j]:indices[j+1]-1], 0, '=')
 
+		if key[0] == '_' {
+			return i, buf[start:i], ErrUnderscoreTagKey
+		}
 		for _, reserved := range reservedTagKeys {
 			if bytes.Equal(key, reserved) {
 				return i, buf[start:i], fmt.Errorf("cannot use reserved tag key %q", key)

--- a/models/points.go
+++ b/models/points.go
@@ -22,10 +22,6 @@ const (
 	// Values used to store the field key and measurement name as special internal tags.
 	FieldKeyTagKey    = "\xff"
 	MeasurementTagKey = "\x00"
-
-	// reserved tag keys which when present cause the point to be discarded
-	// and an error returned
-	reservedTimeTagKey = "time"
 )
 
 var (
@@ -37,7 +33,6 @@ var (
 	reservedTagKeys = [][]byte{
 		FieldKeyTagKeyBytes,
 		MeasurementTagKeyBytes,
-		[]byte(reservedTimeTagKey),
 	}
 )
 

--- a/models/points.go
+++ b/models/points.go
@@ -87,6 +87,8 @@ var (
 	ErrDuplicateTags    = errors.New("duplicate tags")
 	ErrEmptyFieldName   = errors.New("all fields must have non-empty names")
 	ErrUnbalancedQuotes = errors.New("unbalanced quotes")
+
+	ErrUnderscoreMeasurement = errors.New("measurement name cannot start with '_'")
 )
 
 const (
@@ -632,11 +634,14 @@ const (
 // scanMeasurement examines the measurement part of a Point, returning
 // the next state to move to, and the current location in the buffer.
 func scanMeasurement(buf []byte, i int) (int, int, error) {
-	// Check first byte of measurement, anything except a comma is fine.
+	// Check first byte of measurement, anything except a comma or underscore is fine.
 	// It can't be a space, since whitespace is stripped prior to this
 	// function call.
 	if i >= len(buf) || buf[i] == ',' {
 		return -1, i, ErrMissingMeasurement
+	}
+	if buf[i] == '_' {
+		return -1, i, ErrUnderscoreMeasurement
 	}
 
 	for {

--- a/models/points_internal_test.go
+++ b/models/points_internal_test.go
@@ -11,7 +11,7 @@ func TestMarshalPointNoFields(t *testing.T) {
 	// It's unclear how this can ever happen, but we've observed points that were marshalled without any fields.
 	points[0].(*point).fields = []byte{}
 
-	if _, err := points[0].MarshalBinary(); err != ErrPointMustHaveAField {
-		t.Fatalf("got error %v, exp %v", err, ErrPointMustHaveAField)
+	if _, err := points[0].MarshalBinary(); err != ErrMissingFields {
+		t.Fatalf("got error %v, exp %v", err, ErrMissingFields)
 	}
 }

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -489,6 +489,22 @@ func TestParsePointNoFields(t *testing.T) {
 	}
 }
 
+func TestParsePointUnderscoreField(t *testing.T) {
+	expectedSuffix := models.ErrUnderscoreFieldKey.Error()
+	examples := []string{
+		"cpu _field1=123",
+		"cpu field1=123,_field2=T",
+	}
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
+	}
+}
+
 func TestParsePointNoTimestamp(t *testing.T) {
 	test(t, "cpu value=1", NewTestPoint("cpu", nil, models.Fields{"value": 1.0}, time.Unix(0, 0)))
 }

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -113,10 +113,12 @@ func TestPoint_Tags(t *testing.T) {
 		{`cpu,ta\ g0=\, value=1`, models.NewTags(map[string]string{"ta g0": ","}), nil},
 		{`cpu,tag0=\,1 value=1`, models.NewTags(map[string]string{"tag0": ",1"}), nil},
 		{`cpu,tag0=1\"\",t=k value=1`, models.NewTags(map[string]string{"tag0": `1\"\"`, "t": "k"}), nil},
-		{"cpu,_measurement=v0,tag0=v0 value=1", nil, errors.New(`unable to parse 'cpu,_measurement=v0,tag0=v0 value=1': cannot use reserved tag key "_measurement"`)},
+		{"cpu,_measurement=v0,tag0=v0 value=1", nil, errors.New(`unable to parse 'cpu,_measurement=v0,tag0=v0 value=1': tag key name cannot start with '_'`)},
+		{"cpu,_start=v0 value=1", nil, errors.New(`unable to parse 'cpu,_start=v0 value=1': tag key name cannot start with '_'`)},
 		// the following are all unsorted tag keys to ensure this works for both cases
-		{"cpu,tag0=v0,_measurement=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_measurement=v0 value=1': cannot use reserved tag key "_measurement"`)},
-		{"cpu,tag0=v0,_field=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_field=v0 value=1': cannot use reserved tag key "_field"`)},
+		{"cpu,tag0=v0,_measurement=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_measurement=v0 value=1': tag key name cannot start with '_'`)},
+		{"cpu,tag0=v0,_field=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_field=v0 value=1': tag key name cannot start with '_'`)},
+		{"cpu,tag0=v0,_foo=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_foo=v0 value=1': tag key name cannot start with '_'`)},
 		{"cpu,tag0=v0,time=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,time=v0 value=1': cannot use reserved tag key "time"`)},
 	}
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -119,7 +119,6 @@ func TestPoint_Tags(t *testing.T) {
 		{"cpu,tag0=v0,_measurement=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_measurement=v0 value=1': tag key name cannot start with '_'`)},
 		{"cpu,tag0=v0,_field=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_field=v0 value=1': tag key name cannot start with '_'`)},
 		{"cpu,tag0=v0,_foo=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,_foo=v0 value=1': tag key name cannot start with '_'`)},
-		{"cpu,tag0=v0,time=v0 value=1", nil, errors.New(`unable to parse 'cpu,tag0=v0,time=v0 value=1': cannot use reserved tag key "time"`)},
 	}
 
 	for _, example := range examples {

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -446,6 +446,28 @@ func TestParsePointWhitespaceValue(t *testing.T) {
 	}
 }
 
+func TestParsePointNoMeasurement(t *testing.T) {
+	expectedSuffix := models.ErrMissingMeasurement.Error()
+	point := ",region=us-east-1 value=123"
+	_, err := models.ParsePointsString(point)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, point)
+	} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+		t.Errorf(`ParsePoints("%s") mismatch. got %q, exp suffix %q`, point, err, expectedSuffix)
+	}
+}
+
+func TestParsePointUnderscoreMeasurement(t *testing.T) {
+	expectedSuffix := models.ErrUnderscoreMeasurement.Error()
+	point := "_cpu value=123"
+	_, err := models.ParsePointsString(point)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, point)
+	} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+		t.Errorf(`ParsePoints("%s") mismatch. got %q, exp suffix %q`, point, err, expectedSuffix)
+	}
+}
+
 func TestParsePointNoFields(t *testing.T) {
 	expectedSuffix := "missing fields"
 	examples := []string{


### PR DESCRIPTION
Closes #20310 

This brings our implementation in line with the spec, and prevents panics when users override keys like `_start`. The first commit is a refactoring that I could split into a separate PR, if desired. The diff in the test file shows the impact of the actual fix.