### PR TITLE
fix(onboarding): don't ignore failures to set initial password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [20348](https://github.com/influxdata/influxdb/pull/20348): Don't show the upgrade notice on fresh `influxdb2` installs.
 1. [20348](https://github.com/influxdata/influxdb/pull/20348): Ensure `config.toml` is initialized on fresh `influxdb2` installs.
 1. [20349](https://github.com/influxdata/influxdb/pull/20349): Ensure `influxdb` service sees default env variables when running under `init.d`.
+1. [20317](https://github.com/influxdata/influxdb/pull/20317): Don't ignore failures to set password during initial user onboarding.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -653,15 +653,16 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	ts.BucketService = storage.NewBucketService(m.log, ts.BucketService, m.engine)
 	ts.BucketService = dbrp.NewBucketService(m.log, ts.BucketService, dbrpSvc)
 
-	var onboardOpts []tenant.OnboardServiceOptionFn
+	onboardingLogger := m.log.With(zap.String("handler", "onboard"))
+	onboardOpts := []tenant.OnboardServiceOptionFn{tenant.WithOnboardingLogger(onboardingLogger)}
 	if opts.TestingAlwaysAllowSetup {
 		onboardOpts = append(onboardOpts, tenant.WithAlwaysAllowInitialUser())
 	}
 
-	onboardSvc := tenant.NewOnboardService(ts, authSvc, onboardOpts...)                               // basic service
-	onboardSvc = tenant.NewAuthedOnboardSvc(onboardSvc)                                               // with auth
-	onboardSvc = tenant.NewOnboardingMetrics(m.reg, onboardSvc, metric.WithSuffix("new"))             // with metrics
-	onboardSvc = tenant.NewOnboardingLogger(m.log.With(zap.String("handler", "onboard")), onboardSvc) // with logging
+	onboardSvc := tenant.NewOnboardService(ts, authSvc, onboardOpts...)                   // basic service
+	onboardSvc = tenant.NewAuthedOnboardSvc(onboardSvc)                                   // with auth
+	onboardSvc = tenant.NewOnboardingMetrics(m.reg, onboardSvc, metric.WithSuffix("new")) // with metrics
+	onboardSvc = tenant.NewOnboardingLogger(onboardingLogger, onboardSvc)                 // with logging
 
 	var (
 		authorizerV1 platform.AuthorizerV1

--- a/cmd/influxd/upgrade/security_test.go
+++ b/cmd/influxd/upgrade/security_test.go
@@ -184,7 +184,7 @@ func TestUpgradeSecurity(t *testing.T) {
 			// onboard admin
 			oReq := &influxdb.OnboardingRequest{
 				User:            "admin",
-				Password:        "12345",
+				Password:        "12345678",
 				Org:             "testers",
 				Bucket:          "def",
 				RetentionPeriod: influxdb.InfiniteRetention,

--- a/tenant/error_user.go
+++ b/tenant/error_user.go
@@ -6,6 +6,8 @@ import (
 	"github.com/influxdata/influxdb/v2"
 )
 
+const MinPasswordLen int = 8
+
 var (
 	// ErrUserNotFound is used when the user is not found.
 	ErrUserNotFound = &influxdb.Error{
@@ -31,7 +33,7 @@ var (
 	// acceptable password length.
 	EShortPassword = &influxdb.Error{
 		Code: influxdb.EInvalid,
-		Msg:  "passwords must be at least 8 characters long",
+		Msg:  fmt.Sprintf("passwords must be at least %d characters long", MinPasswordLen),
 	}
 )
 

--- a/tenant/middleware_onboarding_logging.go
+++ b/tenant/middleware_onboarding_logging.go
@@ -28,7 +28,7 @@ func (l *OnboardingLogger) IsOnboarding(ctx context.Context) (available bool, er
 	defer func(start time.Time) {
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
-			l.logger.Debug("failed to check onboarding", zap.Error(err), dur)
+			l.logger.Error("failed to check onboarding", zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("is onboarding", dur)
@@ -41,7 +41,7 @@ func (l *OnboardingLogger) OnboardInitialUser(ctx context.Context, req *influxdb
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to onboard user %s", req.User)
-			l.logger.Debug(msg, zap.Error(err), dur)
+			l.logger.Error(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("onboard initial user", dur)
@@ -54,7 +54,7 @@ func (l *OnboardingLogger) OnboardUser(ctx context.Context, req *influxdb.Onboar
 		dur := zap.Duration("took", time.Since(start))
 		if err != nil {
 			msg := fmt.Sprintf("failed to onboard user %s", req.User)
-			l.logger.Debug(msg, zap.Error(err), dur)
+			l.logger.Error(msg, zap.Error(err), dur)
 			return
 		}
 		l.logger.Debug("onboard user", dur)

--- a/tenant/service_user.go
+++ b/tenant/service_user.go
@@ -177,7 +177,7 @@ func (s *UserSvc) FindPermissionForUser(ctx context.Context, uid influxdb.ID) (i
 
 // SetPassword overrides the password of a known user.
 func (s *UserSvc) SetPassword(ctx context.Context, userID influxdb.ID, password string) error {
-	if len(password) < 8 {
+	if len(password) < MinPasswordLen {
 		return EShortPassword
 	}
 	passHash, err := encryptPassword(password)

--- a/v1/authorization/service_password.go
+++ b/v1/authorization/service_password.go
@@ -37,7 +37,7 @@ func (s *Service) SetPasswordHash(ctx context.Context, authID influxdb.ID, passH
 
 // SetPassword overrides the password of a known user.
 func (s *Service) SetPassword(ctx context.Context, authID influxdb.ID, password string) error {
-	if len(password) < 8 {
+	if len(password) < tenant.MinPasswordLen {
 		return tenant.EShortPassword
 	}
 	passHash, err := encryptPassword(password)


### PR DESCRIPTION
Fixes #20088 

This was the most obvious problem with the onboarding path's handling of passwords. There's also a lot of duplication in the CLI with slight differences between the onboarding paths for interactive vs. noninteractive runs and the `influx setup` vs. `influxd upgrade` runs, but I'm leaving that refactor for a follow-up PR.