### PR TITLE
fix: add upgrade helper script to nfpms manifest

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -60,6 +60,7 @@ nfpms:
       "scripts/init.sh": "/usr/lib/influxdb/scripts/init.sh"
       "scripts/influxdb.service": "/usr/lib/influxdb/scripts/influxdb.service"
       "scripts/logrotate": "/etc/logrotate.d/influxdb"
+      "scripts/influxdb2-upgrade.sh": "/usr/share/influxdb/influxdb2-upgrade.sh"
     scripts:
       preinstall:  "scripts/pre-install.sh"
       postinstall: "scripts/post-install.sh"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,7 @@ nfpms:
       "scripts/init.sh": "/usr/lib/influxdb/scripts/init.sh"
       "scripts/influxdb.service": "/usr/lib/influxdb/scripts/influxdb.service"
       "scripts/logrotate": "/etc/logrotate.d/influxdb"
+      "scripts/influxdb2-upgrade.sh": "/usr/share/influxdb/influxdb2-upgrade.sh"
     scripts:
       preinstall:  "scripts/pre-install.sh"
       postinstall: "scripts/post-install.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Bug Fixes
+
+1. [20339](https://github.com/influxdata/influxdb/pull/20339): Include upgrade helper script in goreleaser manifest.
+
 ## v2.0.3 [2020-12-14]
 
 ### ARM Support


### PR DESCRIPTION
Closes #20337 

Tested using these steps:
1. Ran our CI docker image
2. Cloned this branch
3. Ran `make nightly` to generate archives
4. Ran `dpkg -i` on the generated .deb
5. Copy-pasted the command to run the upgrade script, and confirmed it ran without modifications