### PR TITLE
fix: adjust post-install logic to only display upgrade notice when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bug Fixes
 
 1. [20339](https://github.com/influxdata/influxdb/pull/20339): Include upgrade helper script in goreleaser manifest.
+1. [20348](https://github.com/influxdata/influxdb/pull/20348): Don't show the upgrade notice on fresh `influxdb2` installs.
+1. [20348](https://github.com/influxdata/influxdb/pull/20348): Ensure `config.toml` is initialized on fresh `influxdb2` installs.
 
 ## v2.0.3 [2020-12-14]
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -25,6 +25,23 @@ function install_chkconfig {
     chkconfig --add influxdb
 }
 
+function should_upgrade {
+    if [[ ! -s /etc/influxdb/influxdb.conf ]]; then
+        # No V1 config present, no upgrade needed.
+        return 1
+    fi
+
+    bolt_dir="/root/.influxdbv2 /var/lib/influxdb/.influxdbv2 /var/lib/influxdb"
+    for bolt in $bolt_dir; do
+        if [[ -s ${bolt}/influxd.bolt ]]; then
+            # Found a bolt file, assume previous v2 upgrade.
+            return 1
+        fi
+    done
+
+    return 0
+}
+
 function upgrade_notice {
 cat << EOF
 
@@ -51,12 +68,18 @@ https://docs.influxdata.com/influxdb/v2.0/get-started/
 EOF
 }
 
+function init_config {
+    mkdir -p $(dirname ${INFLUXD_CONFIG_PATH})
+    cat << EOF > ${INFLUXD_CONFIG_PATH}
+bolt-path = "/var/lib/influxdb/influxd.bolt"
+engine-path = "/var/lib/influxdb/engine"
+EOF
+}
+
 # Add defaults file, if it doesn't exist
 if [[ ! -s /etc/default/influxdb2 ]]; then
 cat << EOF > /etc/default/influxdb2
-INFLUXD_CONFIG_PATH=/etc/influxdb/config.toml
-INFLUXD_BOLT_PATH=/var/lib/influxdb/influxd.bolt
-INFLUXD_ENGINE_PATH=/var/lib/influxdb/engine
+INFLUXD_CONFIG_PATH=${INFLUXD_CONFIG_PATH}
 EOF
 fi
 
@@ -105,17 +128,8 @@ elif [[ -f /etc/os-release ]]; then
 fi
 
 # Check upgrade status
-if [[ ! -s /etc/influxdb/influxdb.conf ]]; then
-  # No V1 config present, nothing more to do.
-  exit 0
+if should_upgrade; then
+    upgrade_notice
+else
+    init_config
 fi
-
-bolt_dir="/root/.influxdbv2 /var/lib/influxdb/.influxdbv2 /var/lib/influxdb"
-for bolt in $bolt_dir; do
-  if [[ -s ${bolt}/influxd.bolt ]]; then
-    # Found a bolt file, assume previous v2 upgrade
-    exit 0
-  fi
-done
-
-upgrade_notice

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -105,9 +105,13 @@ elif [[ -f /etc/os-release ]]; then
 fi
 
 # Check upgrade status
+if [[ ! -s /etc/influxdb/influxdb.conf ]]; then
+  # No V1 config present, nothing more to do.
+  exit 0
+fi
+
 bolt_dir="/root/.influxdbv2 /var/lib/influxdb/.influxdbv2 /var/lib/influxdb"
-for bolt in $bolt_dir
-do
+for bolt in $bolt_dir; do
   if [[ -s ${bolt}/influxd.bolt ]]; then
     # Found a bolt file, assume previous v2 upgrade
     exit 0


### PR DESCRIPTION
Closes #20340

In addition to checking for V2 data, check for a V1 config file. Display the upgrade notice when V1 is present and V2 isn't.

To test this, I:
1. Built the .deb from my branch
2. Mounted the .deb into an ubuntu docker container
3. `dpkg -i`'d the .deb, and confirmed:
    1. The upgrade notice didn't show
    2. `config.toml` was populated with default paths for bolt and engine
4. `dpkg -r influxdb2 && rm /etc/influxdb/config.toml`
5. Set up the influxdata repo, then `apt-get install -y influxdb && apt-get remove -y influxdb`
6. `dpkg -i`'d the .deb, and confirmed the upgrade notice showed