### PR TITLE
fix: ensure init.d-style install sees our default environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [20339](https://github.com/influxdata/influxdb/pull/20339): Include upgrade helper script in goreleaser manifest.
 1. [20348](https://github.com/influxdata/influxdb/pull/20348): Don't show the upgrade notice on fresh `influxdb2` installs.
 1. [20348](https://github.com/influxdata/influxdb/pull/20348): Ensure `config.toml` is initialized on fresh `influxdb2` installs.
+1. [20349](https://github.com/influxdata/influxdb/pull/20349): Ensure `influxdb` service sees default env variables when running under `init.d`.
 
 ## v2.0.3 [2020-12-14]
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -72,7 +72,10 @@ fi
 
 # Override init script variables with DEFAULT values
 if [ -r $DEFAULT ]; then
+    # set -a causes all variables to be auto-exported.
+    set -a
     source $DEFAULT
+    set +a
 fi
 
 function log_failure_msg() {

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -10,9 +10,9 @@
 
 # If you modify this, please make sure to also edit influxdb.service
 
-# Command-line options that can be set in /etc/default/influxdb.  These will override
-# any config file values.
-DEFAULT=/etc/default/influxdb
+# Environment variables can be set in /etc/default/influxdb2. These will override
+# any corresponding config file values.
+DEFAULT=/etc/default/influxdb2
 
 # Daemon options
 INFLUXD_OPTS=


### PR DESCRIPTION
Addresses #20132 

I think the `set` trick will work since the shebang on the script points at `/bin/bash`, let me know if it's not portable.

Tested by building the package & installing into a fresh ubuntu VM. Without these changes, I see this in the logs:
```
ts=2020-12-15T22:52:12.224551Z lvl=info msg="Resources opened" log_id=0R69W2FG000 service=bolt path=/var/lib/influxdb/.influxdbv2/influxd.bolt
```
After this change, I see:
```
ts=2020-12-15T22:56:05.258672Z lvl=info msg="Resources opened" log_id=0R69jGY0000 service=bolt path=/var/lib/influxdb/influxd.bolt
```

With these env / config file contents:
```
$ cat /etc/default/influxdb2
INFLUXD_CONFIG_PATH=/etc/influxdb/config.toml

$ cat /etc/influxdb/config.toml
bolt-path = "/var/lib/influxdb/influxd.bolt"
engine-path = "/var/lib/influxdb/engine"
```