### PR TITLE
fix: don't use a finished context for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [20349](https://github.com/influxdata/influxdb/pull/20349): Ensure `influxdb` service sees default env variables when running under `init.d`.
 1. [20317](https://github.com/influxdata/influxdb/pull/20317): Don't ignore failures to set password during initial user onboarding.
 1. [20362](https://github.com/influxdata/influxdb/pull/20362): Don't overwrite stack name/description on `influx stack update`.
+1. [20355](https://github.com/influxdata/influxdb/pull/20355): Fix timeout setup for `influxd` graceful shutdown.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -87,7 +87,7 @@ func cmdRunE(ctx context.Context, o *InfluxdOpts) func() error {
 
 		return nil
 	}
-}x
+}
 
 // InfluxdOpts captures all arguments for running the InfluxDB server.
 type InfluxdOpts struct {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -167,7 +167,9 @@ func (m *Launcher) Engine() Engine {
 
 // Shutdown shuts down the HTTP server and waits for all services to clean up.
 func (m *Launcher) Shutdown(ctx context.Context) {
-	m.httpServer.Shutdown(ctx)
+	if err := m.httpServer.Shutdown(ctx); err != nil {
+		m.log.Error("Failed to close HTTP server", zap.Error(err))
+	}
 
 	m.log.Info("Stopping", zap.String("service", "task"))
 


### PR DESCRIPTION
Part of #19976 

Ayan noticed in a separate PR that we were misusing `ctx` values here, resulting in an immediate timeout of our graceful-shutdown code. Splitting out the fix to make it easy to review.