### PR TITLE
fix: don't use a finished context for graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [20350](https://github.com/influxdata/influxdb/pull/20350): Ensure `config.toml` is initialized on fresh `influxdb2` installs.
 1. [20347](https://github.com/influxdata/influxdb/pull/20347): Include upgrade helper script in goreleaser manifest.
 1. [20376](https://github.com/influxdata/influxdb/pull/20376): Don't overwrite stack name/description on `influx stack update`.
+1. [20375](https://github.com/influxdata/influxdb/pull/20375): Fix timeout setup for `influxd` graceful shutdown.
 
 ## v2.0.3 [2020-12-14]
 ----------------------


### PR DESCRIPTION
Closes #20361 

Backports #20355. The diff isn't an exact match because of some refactoring on `master` that I haven't bothered to backport to `2.0`.