### PR TITLE
fix(cmd/influx): improve CLI error returned on org-not-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [20317](https://github.com/influxdata/influxdb/pull/20317): Don't ignore failures to set password during initial user onboarding.
 1. [20362](https://github.com/influxdata/influxdb/pull/20362): Don't overwrite stack name/description on `influx stack update`.
 1. [20355](https://github.com/influxdata/influxdb/pull/20355): Fix timeout setup for `influxd` graceful shutdown.
+1. [20387](https://github.com/influxdata/influxdb/pull/20387): Improve error message shown when `influx` CLI can't find an org by name.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -515,7 +515,7 @@ func (o *organization) getID(orgSVC influxdb.OrganizationService) (influxdb.ID, 
 	if o.id != "" {
 		influxOrgID, err := influxdb.IDFromString(o.id)
 		if err != nil {
-			return 0, fmt.Errorf("invalid org ID '%s' provided: %w (did you pass an org name instead of an ID?)", o.id, err)
+			return 0, fmt.Errorf("invalid org ID '%s' provided (did you pass an org name instead of an ID?): %w", o.id, err)
 		}
 		return *influxOrgID, nil
 	}
@@ -525,7 +525,7 @@ func (o *organization) getID(orgSVC influxdb.OrganizationService) (influxdb.ID, 
 			Name: &name,
 		})
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to get ID for org '%s' (do you have org-level read permission?): %w", name, err)
 		}
 		return org.ID, nil
 	}


### PR DESCRIPTION
Closes #20054 

This is a lame "fix", but I feel it's the best we can do without significant server-side API changes.