### PR TITLE
chore(ui): bump UI version in prep for 2.0.4 release

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronograf-ui",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": false,
   "license": "AGPL-3.0",
   "description": "",


### PR DESCRIPTION
Works around #20007
Closes #20373 

The UI build process hard-codes the `version` value from `package.json` into its output, to set the value displayed on the login page.