### PR TITLE
fix(storage): use methods to set storage engine loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [20354](https://github.com/influxdata/influxdb/pull/20354): Don't ignore failures to set password during initial user onboarding.
 1. [20402](https://github.com/influxdata/influxdb/pull/20402): Remove duplication from task error messages.
 1. [20403](https://github.com/influxdata/influxdb/pull/20403): Improve error message shown when `influx` CLI can't find an org by name.
+1. [20411](https://github.com/influxdata/influxdb/pull/20411): Fix logging initialization for storage engine.
 
 ## v2.0.3 [2020-12-14]
 ----------------------

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -138,13 +138,11 @@ func NewEngine(path string, c Config, options ...Option) *Engine {
 
 // WithLogger sets the logger on the Store. It must be called before Open.
 func (e *Engine) WithLogger(log *zap.Logger) {
-	fields := []zap.Field{}
-	fields = append(fields, zap.String("service", "storage-engine"))
-	e.logger = log.With(fields...)
+	e.logger = log.With(zap.String("service", "storage-engine"))
 
-	e.tsdbStore.Logger = e.logger
+	e.tsdbStore.WithLogger(e.logger)
 	if pw, ok := e.pointsWriter.(*coordinator.PointsWriter); ok {
-		pw.Logger = e.logger
+		pw.WithLogger(e.logger)
 	}
 
 	if e.retentionService != nil {


### PR DESCRIPTION
Closes #20410 

Backports part of #20313. The `WithLogger` methods do some extra work that was getting skipped.