### PR TITLE
fix: sync log before process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v1.8.4 [unreleased]
 
 ### Bugfixes
 
+-	[#20422](https://github.com/influxdata/influxdb/pull/20422): fix(log): Call Sync before progress exit.
 -	[#20101](https://github.com/influxdata/influxdb/pull/20101): fix(write): Successful writes increment write error statistics incorrectly.
 -	[#19696](https://github.com/influxdata/influxdb/pull/19697): fix(flux): add durations to Flux logging.
 -	[#20276](https://github.com/influxdata/influxdb/pull/20276): fix(error): unsupported value: +Inf" error not handled gracefully.

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -103,6 +103,8 @@ func (m *Main) Run(args ...string) error {
 			cmd.Logger.Info("Server shutdown completed")
 		}
 
+		cmd.Logger.Sync()
+
 		// goodbye.
 
 	case "backup":


### PR DESCRIPTION
Since zap's low-level APIs allow buffering, calling Sync before letting your process exit is a good habit.

Influxdb version 2.X fixed this problem: [launcher.go, line 650](https://github.com/influxdata/influxdb/blob/2.0/cmd/influxd/launcher/launcher.go)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
