### PR TITLE
fix(error): SELECT INTO doesn't return error with unsupported value

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -215,11 +215,12 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 			MetaClient: s.MetaClient,
 			TSDBStore:  coordinator.LocalTSDBStore{Store: s.TSDBStore},
 		},
-		Monitor:           s.Monitor,
-		PointsWriter:      s.PointsWriter,
-		MaxSelectPointN:   c.Coordinator.MaxSelectPointN,
-		MaxSelectSeriesN:  c.Coordinator.MaxSelectSeriesN,
-		MaxSelectBucketsN: c.Coordinator.MaxSelectBucketsN,
+		StrictErrorHandling: s.TSDBStore.EngineOptions.Config.StrictErrorHandling,
+		Monitor:             s.Monitor,
+		PointsWriter:        s.PointsWriter,
+		MaxSelectPointN:     c.Coordinator.MaxSelectPointN,
+		MaxSelectSeriesN:    c.Coordinator.MaxSelectSeriesN,
+		MaxSelectBucketsN:   c.Coordinator.MaxSelectBucketsN,
 	}
 	s.QueryExecutor.TaskManager.QueryTimeout = time.Duration(c.Coordinator.QueryTimeout)
 	s.QueryExecutor.TaskManager.LogQueriesAfter = time.Duration(c.Coordinator.LogQueriesAfter)

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -67,6 +67,10 @@
   # log any sensitive data contained within a query.
   # query-log-enabled = true
 
+  # Provides more error checking. For example, SELECT INTO will err out inserting an +/-Inf value
+  # rather than silently failing.
+  # strict-error-handling = false
+
   # Validates incoming writes to ensure keys only have valid unicode characters.
   # This setting will incur a small overhead because every key must be checked.
   # validate-keys = false

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	// Enables unicode validation on series keys on write.
 	ValidateKeys bool `toml:"validate-keys"`
 
+	// Enables strict error handling. For example, forces SELECT INTO to err out on INF values.
+	StrictErrorHandling bool `toml:"strict-error-handling"`
+
 	// Query logging
 	QueryLogEnabled bool `toml:"query-log-enabled"`
 
@@ -155,7 +158,8 @@ func NewConfig() Config {
 		Engine: DefaultEngine,
 		Index:  DefaultIndex,
 
-		QueryLogEnabled: true,
+		StrictErrorHandling: false,
+		QueryLogEnabled:     true,
 
 		CacheMaxMemorySize:             toml.Size(DefaultCacheMaxMemorySize),
 		CacheSnapshotMemorySize:        toml.Size(DefaultCacheSnapshotMemorySize),
@@ -229,6 +233,7 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"dir":                                    c.Dir,
 		"wal-dir":                                c.WALDir,
 		"wal-fsync-delay":                        c.WALFsyncDelay,
+		"strict-error-handling":                  c.StrictErrorHandling,
 		"cache-max-memory-size":                  c.CacheMaxMemorySize,
 		"cache-snapshot-memory-size":             c.CacheSnapshotMemorySize,
 		"cache-snapshot-write-cold-duration":     c.CacheSnapshotWriteColdDuration,


### PR DESCRIPTION
When a SELECT INTO query generates an illegal value that cannot be inserted,
like +/- Inf, it should return an error, rather than failing silently.
This adds a boolean parameter to the [data] section of influxdb.conf:
* strict-error-handling

When false, the default, the old behavior is preserved.  When true,
unsupported values will return an error from SELECT INTO queries

Closes https://github.com/influxdata/influxdb/issues/20426

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass