### PR TITLE
fix(cmd/influxd): improve `influxd upgrade` logging, and require manual confirmation of data copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20313](https://github.com/influxdata/influxdb/pull/20313): Automatically build `tsi1` indexes for shards that need it instead of falling back to `inmem`.
 1. [20313](https://github.com/influxdata/influxdb/pull/20313): Fix logging initialization for storage engine.
 1. [20442](https://github.com/influxdata/influxdb/pull/20442): Don't return 500 codes for partial write failures.
+1. [20440](https://github.com/influxdata/influxdb/pull/20440): Add confirmation step w/ file sizes before copying data files in `influxd upgrade`.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influxd/upgrade/database.go
+++ b/cmd/influxd/upgrade/database.go
@@ -49,11 +49,7 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 	if err != nil {
 		return nil, fmt.Errorf("error getting info of disk %s: %w", v2dir, err)
 	}
-	if options.verbose {
-		log.Info("Disk space info",
-			zap.String("Free space", humanize.Bytes(diskInfo.Free)),
-			zap.String("Requested space", humanize.Bytes(size)))
-	}
+	log.Info("Disk space info", zap.String("Free space", humanize.Bytes(diskInfo.Free)), zap.String("Requested space", humanize.Bytes(size)))
 	if size > diskInfo.Free {
 		return nil, fmt.Errorf("not enough space on target disk of %s: need %d, available %d ", v2dir, size, diskInfo.Free)
 	}
@@ -71,15 +67,10 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 	// export any continuous queries
 	for _, db := range v1.meta.Databases() {
 		if db.Name == "_internal" {
-			if options.verbose {
-				log.Info("Skipping _internal ")
-			}
+			log.Debug("Skipping _internal ")
 			continue
 		}
-		if options.verbose {
-			log.Info("Upgrading database ",
-				zap.String("database", db.Name))
-		}
+		log.Debug("Upgrading database", zap.String("database", db.Name))
 
 		// db to buckets IDs mapping
 		db2BucketIds[db.Name] = make([]influxdb.ID, 0, len(db.RetentionPolicies))
@@ -95,10 +86,7 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 				RetentionPolicyName: rp.Name,
 				RetentionPeriod:     rp.Duration,
 			}
-			if options.verbose {
-				log.Info("Creating bucket ",
-					zap.String("Bucket", bucket.Name))
-			}
+			log.Debug("Creating bucket", zap.String("Bucket", bucket.Name))
 			err = v2.bucketSvc.CreateBucket(ctx, bucket)
 			if err != nil {
 				return nil, fmt.Errorf("error creating bucket %s: %w", bucket.Name, err)
@@ -106,10 +94,7 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 			}
 
 			db2BucketIds[db.Name] = append(db2BucketIds[db.Name], bucket.ID)
-			if options.verbose {
-				log.Info("Creating database with retention policy",
-					zap.String("database", bucket.ID.String()))
-			}
+			log.Debug("Creating database with retention policy", zap.String("database", bucket.ID.String()))
 			spec := rp.ToSpec()
 			spec.Name = meta.DefaultRetentionPolicyName
 			dbv2, err := v2.meta.CreateDatabaseWithRetentionPolicy(bucket.ID.String(), spec)
@@ -124,25 +109,25 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 				OrganizationID:  orgID,
 				BucketID:        bucket.ID,
 			}
-			if options.verbose {
-				log.Info("Creating mapping",
-					zap.String("database", mapping.Database),
-					zap.String("retention policy", mapping.RetentionPolicy),
-					zap.String("orgID", mapping.OrganizationID.String()),
-					zap.String("bucketID", mapping.BucketID.String()))
-			}
+			log.Debug(
+				"Creating mapping",
+				zap.String("database", mapping.Database),
+				zap.String("retention policy", mapping.RetentionPolicy),
+				zap.String("orgID", mapping.OrganizationID.String()),
+				zap.String("bucketID", mapping.BucketID.String()),
+			)
 			err = v2.dbrpSvc.Create(ctx, mapping)
 			if err != nil {
 				return nil, fmt.Errorf("error creating mapping  %s/%s -> Org %s, bucket %s: %w", mapping.Database, mapping.RetentionPolicy, mapping.OrganizationID.String(), mapping.BucketID.String(), err)
 			}
 			shardsNum := 0
 			for _, sg := range rp.ShardGroups {
-				if options.verbose {
-					log.Info("Creating shard group",
-						zap.String("database", dbv2.Name),
-						zap.String("retention policy", dbv2.DefaultRetentionPolicy),
-						zap.Time("time", sg.StartTime))
-				}
+				log.Debug(
+					"Creating shard group",
+					zap.String("database", dbv2.Name),
+					zap.String("retention policy", dbv2.DefaultRetentionPolicy),
+					zap.Time("time", sg.StartTime),
+				)
 				shardsNum += len(sg.Shards)
 				_, err := v2.meta.CreateShardGroupWithShards(dbv2.Name, dbv2.DefaultRetentionPolicy, sg.StartTime, sg.Shards)
 				if err != nil {
@@ -152,11 +137,11 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 			//empty retention policy doesn't have data
 			if shardsNum > 0 {
 				targetPath := filepath.Join(targetDataPath, dbv2.Name, spec.Name)
-				if options.verbose {
-					log.Info("Copying data",
-						zap.String("source", sourcePath),
-						zap.String("target", targetPath))
-				}
+				log.Debug(
+					"Copying data",
+					zap.String("source", sourcePath),
+					zap.String("target", targetPath),
+				)
 				err = CopyDir(sourcePath,
 					targetPath,
 					nil,
@@ -167,11 +152,11 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 				}
 				sourcePath = filepath.Join(v1opts.walDir, db.Name, rp.Name)
 				targetPath = filepath.Join(targetWalPath, dbv2.Name, spec.Name)
-				if options.verbose {
-					log.Info("Copying wal",
-						zap.String("source", sourcePath),
-						zap.String("target", targetPath))
-				}
+				log.Debug(
+					"Copying wal",
+					zap.String("source", sourcePath),
+					zap.String("target", targetPath),
+				)
 				err = CopyDir(sourcePath,
 					targetPath,
 					nil,
@@ -204,9 +189,7 @@ func upgradeDatabases(ctx context.Context, v1 *influxDBv1, v2 *influxDBv2, v1opt
 		}
 
 		for _, cq := range db.ContinuousQueries {
-			if options.verbose {
-				log.Info("Exporting CQ", zap.String("db", db.Name), zap.String("cq_name", cq.Name))
-			}
+			log.Debug("Exporting CQ", zap.String("db", db.Name), zap.String("cq_name", cq.Name))
 			padding := maxNameLen - len(cq.Name) + 1
 
 			_, err := cqFile.WriteString(fmt.Sprintf("%s%s%s\n", cq.Name, strings.Repeat(" ", padding), cq.Query))

--- a/cmd/influxd/upgrade/database_test.go
+++ b/cmd/influxd/upgrade/database_test.go
@@ -61,8 +61,8 @@ func TestUpgradeRealDB(t *testing.T) {
 	v2, err := newInfluxDBv2(ctx, v2opts, zap.NewNop())
 	require.Nil(t, err)
 
-	options.target = *v2opts
-	req, err := nonInteractive()
+	opts := &options{target: *v2opts}
+	req, err := nonInteractive(opts)
 	require.Nil(t, err)
 	assert.Equal(t, req.RetentionPeriod, humanize.Week, "Retention policy should pass through")
 

--- a/cmd/influxd/upgrade/setup.go
+++ b/cmd/influxd/upgrade/setup.go
@@ -25,7 +25,7 @@ func setupAdmin(ctx context.Context, v2 *influxDBv2, req *influxdb.OnboardingReq
 	return res, nil
 }
 
-func isInteractive() bool {
+func isInteractive(options *options) bool {
 	return !options.force ||
 		options.target.userName == "" ||
 		options.target.password == "" ||
@@ -33,14 +33,14 @@ func isInteractive() bool {
 		options.target.bucket == ""
 }
 
-func onboardingRequest() (*influxdb.OnboardingRequest, error) {
-	if isInteractive() {
-		return interactive()
+func onboardingRequest(options *options) (*influxdb.OnboardingRequest, error) {
+	if isInteractive(options) {
+		return interactive(options)
 	}
-	return nonInteractive()
+	return nonInteractive(options)
 }
 
-func nonInteractive() (*influxdb.OnboardingRequest, error) {
+func nonInteractive(options *options) (*influxdb.OnboardingRequest, error) {
 	if len(options.target.password) < internal.MinPasswordLen {
 		return nil, internal.ErrPasswordIsTooShort
 	}
@@ -63,7 +63,7 @@ func nonInteractive() (*influxdb.OnboardingRequest, error) {
 	return req, nil
 }
 
-func interactive() (req *influxdb.OnboardingRequest, err error) {
+func interactive(options *options) (req *influxdb.OnboardingRequest, err error) {
 	ui := &input.UI{
 		Writer: os.Stdout,
 		Reader: os.Stdin,

--- a/cmd/influxd/upgrade/setup.go
+++ b/cmd/influxd/upgrade/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -33,9 +32,9 @@ func isInteractive(options *options) bool {
 		options.target.bucket == ""
 }
 
-func onboardingRequest(options *options) (*influxdb.OnboardingRequest, error) {
+func onboardingRequest(ui *input.UI, options *options) (*influxdb.OnboardingRequest, error) {
 	if isInteractive(options) {
-		return interactive(options)
+		return interactive(ui, options)
 	}
 	return nonInteractive(options)
 }
@@ -63,11 +62,7 @@ func nonInteractive(options *options) (*influxdb.OnboardingRequest, error) {
 	return req, nil
 }
 
-func interactive(options *options) (req *influxdb.OnboardingRequest, err error) {
-	ui := &input.UI{
-		Writer: os.Stdout,
-		Reader: os.Stdin,
-	}
+func interactive(ui *input.UI, options *options) (req *influxdb.OnboardingRequest, err error) {
 	req = new(influxdb.OnboardingRequest)
 	fmt.Println(string(internal.PromptWithColor(`Welcome to InfluxDB 2.0 upgrade!`, internal.ColorYellow)))
 	if options.target.userName != "" {
@@ -119,8 +114,7 @@ func interactive(options *options) (req *influxdb.OnboardingRequest, err error) 
 			if req.RetentionPeriod > 0 {
 				rp = fmt.Sprintf("%d hrs", req.RetentionPeriod/time.Hour)
 			}
-			return fmt.Sprintf(`
-You have entered:
+			return fmt.Sprintf(`You have entered:
   Username:          %s
   Organization:      %s
   Bucket:            %s


### PR DESCRIPTION
Closes #20383

Before this patch, we were:
1. Calculating expected disk size needed to make a full copy of V1 data
2. Logging the info, but only in `verbose` mode
3. Auto-proceeding with the copy if the disk had enough space

After this patch:
1. `verbose` is deprecated/hidden in favor of debug-level logging (reduce the number of levers users need to pull to get useful diagnostics)
2. Most verbose-level logs are now debug, but the size-log is info
3. Add an explicit y/n input point before copying data (skippable by using `--force`)