### PR TITLE
fix: ignore a harmless error to avoid a confusing log message

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -201,9 +201,12 @@ func (m *Launcher) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	if err := m.log.Sync(); err != nil {
-		errs = append(errs, err.Error())
-	}
+	// N.B. We ignore any errors here because Sync is known to fail with EINVAL
+	// when logging to Stdout on certain OS's.
+	//
+	// Uber made the same change within the core of the logger implementation.
+	// See: https://github.com/uber-go/zap/issues/328
+	_ = m.log.Sync()
 
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to shut down server: [%s]", strings.Join(errs, ","))


### PR DESCRIPTION
Preemptive fix for unreleased code.

While running `influxd` in Docker I noticed a new error message on shutdown: `sync /dev/stdout: invalid argument`. uber-go/zap#328 shows the error is known, and the internal "fix" was just to ignore it.