### PR TITLE
build: fix cache key used by godeps job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,14 +291,14 @@ jobs:
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
-            - influxdb-gomod-{{ checksum "go.mod" }}
+            - influxdb-gomod-{{ checksum "go.sum" }}
             - influxdb-gomod-
       - run:
           name: Install Dependencies
           command: go mod download -x
       - save_cache:
           name: Save GOPATH/pkg/mod
-          key: influxdb-gomod-{{ checksum "go.mod" }}
+          key: influxdb-gomod-{{ checksum "go.sum" }}
           paths:
             - /go/pkg/mod
 


### PR DESCRIPTION
_facepalms_

This fixes the key of the `godeps` job to match the key expected by all downstream jobs. Important because `godeps` is the step that generates the cache for everything else!