### PR TITLE
fix: inject more specific error message for bolt on shared FS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20442](https://github.com/influxdata/influxdb/pull/20442): Don't return 500 codes for partial write failures.
 1. [20440](https://github.com/influxdata/influxdb/pull/20440): Add confirmation step w/ file sizes before copying data files in `influxd upgrade`.
 1. [20409](https://github.com/influxdata/influxdb/pull/20409): Improve messages in DBRP API validation errors.
+1. [20489](https://github.com/influxdata/influxdb/pull/20489): Improve error message when opening BoltDB with unsupported file system options.
 
 ## v2.0.3 [2020-12-14]
 

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -56,7 +56,16 @@ func (c *Client) Open(ctx context.Context) error {
 	// Open database file.
 	db, err := bolt.Open(c.Path, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		return fmt.Errorf("unable to open boltdb; is there a chronograf already running?  %v", err)
+		// Hack to give a slightly nicer error message for a known failure mode when bolt calls
+		// mmap on a file system that doesn't support the MAP_SHARED option.
+		//
+		// See: https://github.com/boltdb/bolt/issues/272
+		// See: https://stackoverflow.com/a/18421071
+		if err.Error() == "invalid argument" {
+			return fmt.Errorf("unable to open boltdb: the filesystem for %q may not support mmap with the MAP_SHARED option", c.Path)
+		}
+
+		return fmt.Errorf("unable to open boltdb: %w", err)
 	}
 	c.db = db
 

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -62,7 +62,7 @@ func (c *Client) Open(ctx context.Context) error {
 		// See: https://github.com/boltdb/bolt/issues/272
 		// See: https://stackoverflow.com/a/18421071
 		if err.Error() == "invalid argument" {
-			return fmt.Errorf("unable to open boltdb: the filesystem for %q may not support mmap with the MAP_SHARED option", c.Path)
+			return fmt.Errorf("unable to open boltdb: mmap of %q may not support the MAP_SHARED option", c.Path)
 		}
 
 		return fmt.Errorf("unable to open boltdb: %w", err)


### PR DESCRIPTION
Closes #20051 

Kinda lame, but I think it's the best we can do without modifying `bolt` itself.