### PR TITLE
chore(ui): Upgrade flux-lsp-browser to v0.5.27

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -135,7 +135,7 @@
   "dependencies": {
     "@influxdata/clockface": "2.3.4",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.26",
+    "@influxdata/flux-lsp-browser": "^0.5.27",
     "@influxdata/giraffe": "0.29.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -752,10 +752,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.4.tgz#9c496601253e1d49cbeae29a7b9cfb54862785f6"
   integrity sha512-mmz3YElK8Ho+1onEafuas6sVhIT638JA4NbDTO3bVJgK1TG7AnU4rQP+c6fj7vZSfvrIwtOwGaMONJTaww5o6w==
 
-"@influxdata/flux-lsp-browser@^0.5.26":
-  version "0.5.26"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.26.tgz#cbcc927d5abb560b3fc8dd36e7a082439b1b0e63"
-  integrity sha512-It7KlZJHv2OXRlua1s36Js3IugnX2S8HZSKCTkGYsGVcVHT26gKjSQNUyzsUTox69GMaaNVglTxtjlkcwrJhwQ==
+"@influxdata/flux-lsp-browser@^0.5.27":
+  version "0.5.27"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.27.tgz#0527151e3b853f921b727937d948087fc0b10431"
+  integrity sha512-lZoPS72G7ir6dwoOK//0iMGTXzZX76frZFKv64oV29HXb87eRkmRvaxwil3VUw6Cx0itA/Vj44Vos46r3L69vA==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Upgrade flux-lsp-browser to [v0.5.27](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.27)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
