### PR TITLE
build: more fixes for CircleCI cross-build setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ commands:
             sudo apt-get install -y --no-install-recommends \
               cmake \
               gnupg \
+              jq \
               libssl-dev \
               libxml2-dev \
               llvm-dev \
@@ -234,9 +235,14 @@ commands:
       - run:
           name: Set up Docker cross-builder
           command: |
+            # Uninstall any emulators provided by the system.
+            emulators=($(docker run --rm --privileged tonistiigi/binfmt:latest) | jq -r .emulators[])
+            for e in ${emulators[@]}; do
+              docker run --rm --privileged tonistiigi/binfmt:latest --uninstall ${e}
+            done
+
             # Install the QEMU emulators we need to cross-build.
             docker run --rm --privileged tonistiigi/binfmt:latest --install all
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
             # Create a new buildx context using the freshly-installed emulators.
             docker buildx create --name cross-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,22 +218,27 @@ commands:
             echo 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl-cross/bin/aarch64-unknown-linux-musl-gcc' >> $BASH_ENV
             echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/local/osxcross/target/bin/x86_64-apple-darwin15-clang' >> $BASH_ENV
       - run:
-          name: Install Docker cross-build kit and emulators
-          environment:
-            DOCKER_BUILDX_VERSION: 0.5.1
+          name: Install updated Docker
           command: |
-            set -euo pipefail
+            export BUILDKIT_PROGRESS=plain
+            export DOCKER_BUILDKIT=1
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            echo 'export BUILDKIT_PROGRESS=plain' >> $BASH_ENV
+            echo 'export DOCKER_BUILDKIT=1' >> $BASH_ENV
+            echo 'export DOCKER_CLI_EXPERIMENTAL=enabled' >> $BASH_ENV
 
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo add-apt-repository \
+              "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+              $(lsb_release -cs) \
+              stable"
+            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+      - run:
+          name: Set up Docker cross-builder
+          command: |
             # Install the QEMU emulators we need to cross-build.
             docker run --rm --privileged tonistiigi/binfmt:latest --install arm64
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-            mkdir -p ${HOME}/.docker/cli-plugins
-            curl -sfL -o ${HOME}/.docker/cli-plugins/docker-buildx \
-              https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64
-            chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            echo 'export DOCKER_CLI_EXPERIMENTAL=enabled' >> $BASH_ENV
 
             # Create a new buildx context using the freshly-installed emulators.
             docker buildx create --name cross-builder --platform linux/amd64,linux/arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,7 @@ jobs:
 
   cross_build:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-1604:202010-01
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache
@@ -600,7 +600,7 @@ jobs:
 
   deploy_nightly:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-1604:202010-01
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,7 @@ jobs:
 
   cross_build:
     machine:
-      image: ubuntu-1604:202010-01
+      image: ubuntu-2004:202010-01
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache
@@ -601,7 +601,7 @@ jobs:
 
   deploy_nightly:
     machine:
-      image: ubuntu-1604:202010-01
+      image: ubuntu-2004:202010-01
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,6 @@ workflows:
       - cross_build:
           requires:
             - build
-#          filters:
-#            branches:
-#              only:
-#                - master
-      - deploy_nightly:
-          requires:
-            - cross_build
       - litmus_integration:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,15 @@ workflows:
                 - /^(?!pull\/).*$/
       - cross_build:
           requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
+            - godeps
+#            - build
+#          filters:
+#            branches:
+#              only:
+#                - master
+      - deploy_nightly:
+          requires:
+            - godeps
       - litmus_integration:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,8 +580,6 @@ jobs:
           keys:
             - influxdb-cross-build-{{ .Branch }}-{{ .Revision }}
             - influxdb-cross-build-{{ .Branch }}-
-            - influxdb-build-{{ .Branch }}-{{ .Revision }}
-            - influxdb-build-{{ .Branch }}-
       - restore_cache:
           name: Restore Yarn Cache
           keys:
@@ -615,11 +613,7 @@ jobs:
           name: Restore GOCACHE
           keys:
             - influxdb-nightly-{{ .Branch }}-{{ .Revision }}
-            - influxdb-cross-build-{{ .Branch }}-{{ .Revision }}
             - influxdb-nightly-{{ .Branch }}-
-            - influxdb-cross-build-{{ .Branch }}-
-            - influxdb-build-{{ .Branch }}-{{ .Revision }}
-            - influxdb-build-{{ .Branch }}-
       - restore_cache:
           name: Restore Yarn Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ workflows:
           requires:
             - godeps
             - jsdeps
+      - cross_build:
+          requires:
+            - godeps
+            - jsdeps
       - e2e:
           requires:
             - build
@@ -41,9 +45,6 @@ workflows:
             branches:
               only:
                 - /^(?!pull\/).*$/
-      - cross_build:
-          requires:
-            - build
       - litmus_integration:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,14 @@ workflows:
                 - /^(?!pull\/).*$/
       - cross_build:
           requires:
-            - godeps
-#            - build
+            - build
 #          filters:
 #            branches:
 #              only:
 #                - master
       - deploy_nightly:
           requires:
-            - godeps
+            - cross_build
       - litmus_integration:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,11 +242,11 @@ commands:
           name: Set up Docker cross-builder
           command: |
             # Install the QEMU emulators we need to cross-build.
-            docker run --rm --privileged tonistiigi/binfmt:latest --install arm64
+            docker run --rm --privileged tonistiigi/binfmt:latest --install all
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
             # Create a new buildx context using the freshly-installed emulators.
-            docker buildx create --name cross-builder --platform linux/amd64,linux/arm64
+            docker buildx create --name cross-builder
             docker buildx use --default cross-builder
             docker buildx inspect --bootstrap
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,7 @@ commands:
               $(lsb_release -cs) \
               stable"
             sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+            sudo service docker restart
       - run:
           name: Set up Docker cross-builder
           command: |


### PR DESCRIPTION
Closes #20479 

Even with #20484 I was seeing intermittent failures on `master`. I haven't seen a failure (yet) with these changes, so fingers crossed...

* Upgrade the Docker installation on the executor instead of bolting the `buildx` plugin onto whatever happens to be there
* Install all binfmt platforms instead of just `arm64`
* Don't hard-code specific platforms when creating the `buildx` builder
* Don't share as many caches between jobs