### PR TITLE
fix(tsdb): minimize lock contention when adding new fields or measurements

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -760,11 +761,7 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) error
 		s.index.SetFieldName(f.Measurement, f.Field.Name)
 	}
 
-	if len(fieldsToCreate) > 0 {
-		return engine.MeasurementFieldSet().Save()
-	}
-
-	return nil
+	return engine.MeasurementFieldSet().Save()
 }
 
 // DeleteSeriesRange deletes all values from for seriesKeys between min and max (inclusive)
@@ -1647,16 +1644,20 @@ func (m *MeasurementFields) ForEachField(fn func(name string, typ influxql.DataT
 type MeasurementFieldSet struct {
 	mu     sync.RWMutex
 	fields map[string]*MeasurementFields
-
 	// path is the location to persist field sets
 	path string
+	// ephemeral counters for updating the file on disk
+	memoryVersion  uint64
+	writtenVersion uint64
 }
 
 // NewMeasurementFieldSet returns a new instance of MeasurementFieldSet.
 func NewMeasurementFieldSet(path string) (*MeasurementFieldSet, error) {
 	fs := &MeasurementFieldSet{
-		fields: make(map[string]*MeasurementFields),
-		path:   path,
+		fields:         make(map[string]*MeasurementFields),
+		path:           path,
+		memoryVersion:  0,
+		writtenVersion: 0,
 	}
 
 	// If there is a load error, return the error and an empty set so
@@ -1741,21 +1742,19 @@ func (fs *MeasurementFieldSet) IsEmpty() bool {
 	return len(fs.fields) == 0
 }
 
-func (fs *MeasurementFieldSet) Save() error {
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
-	return fs.saveNoLock()
-}
-
-func (fs *MeasurementFieldSet) saveNoLock() error {
-	// No fields left, remove the fields index file
-	if len(fs.fields) == 0 {
-		return os.RemoveAll(fs.path)
+func (fs *MeasurementFieldSet) Save() (err error) {
+	v, b, err := fs.marshalMeasurementFieldSet()
+	if err != nil {
+		return err
+	}
+	if b == nil {
+		return nil
 	}
 
 	// Write the new index to a temp file and rename when it's sync'd
-	path := fs.path + ".tmp"
+	// if it is still the most recent memoryVersion of the MeasurementFields
+	path := fs.path + "." + strconv.FormatUint(v, 10) + ".tmp"
+
 	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL|os.O_SYNC, 0666)
 	if err != nil {
 		return err
@@ -1763,28 +1762,6 @@ func (fs *MeasurementFieldSet) saveNoLock() error {
 	defer os.RemoveAll(path)
 
 	if _, err := fd.Write(fieldsIndexMagicNumber); err != nil {
-		return err
-	}
-
-	pb := internal.MeasurementFieldSet{
-		Measurements: make([]*internal.MeasurementFields, 0, len(fs.fields)),
-	}
-	for name, mf := range fs.fields {
-		fs := &internal.MeasurementFields{
-			Name:   []byte(name),
-			Fields: make([]*internal.Field, 0, mf.FieldN()),
-		}
-
-		mf.ForEachField(func(field string, typ influxql.DataType) bool {
-			fs.Fields = append(fs.Fields, &internal.Field{Name: []byte(field), Type: int32(typ)})
-			return true
-		})
-
-		pb.Measurements = append(pb.Measurements, fs)
-	}
-
-	b, err := proto.Marshal(&pb)
-	if err != nil {
 		return err
 	}
 
@@ -1801,11 +1778,67 @@ func (fs *MeasurementFieldSet) saveNoLock() error {
 		return err
 	}
 
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// Check if a later modification and save of fields has superseded ours
+	// If so, we are successfully done! We were beaten by a later call
+	// to this function
+	if fs.writtenVersion > v {
+		return nil
+	}
+
 	if err := file.RenameFile(path, fs.path); err != nil {
 		return err
 	}
 
-	return file.SyncDir(filepath.Dir(fs.path))
+	if err = file.SyncDir(filepath.Dir(fs.path)); err != nil {
+		return err
+	}
+	// Update the written version to the current version
+	fs.writtenVersion = v
+	return nil
+}
+
+func (fs *MeasurementFieldSet) marshalMeasurementFieldSet() (version uint64, marshalled []byte, err error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	fs.memoryVersion += 1
+
+	// No fields left, remove the fields index file
+	if len(fs.fields) == 0 {
+		if err := os.RemoveAll(fs.path); err != nil {
+			return version, nil, err
+		} else {
+			fs.writtenVersion = fs.memoryVersion
+			return fs.memoryVersion, nil, nil
+		}
+	}
+
+	pb := internal.MeasurementFieldSet{
+		Measurements: make([]*internal.MeasurementFields, 0, len(fs.fields)),
+	}
+
+	for name, mf := range fs.fields {
+		imf := &internal.MeasurementFields{
+			Name:   []byte(name),
+			Fields: make([]*internal.Field, 0, mf.FieldN()),
+		}
+
+		mf.ForEachField(func(field string, typ influxql.DataType) bool {
+			imf.Fields = append(imf.Fields, &internal.Field{Name: []byte(field), Type: int32(typ)})
+			return true
+		})
+
+		pb.Measurements = append(pb.Measurements, imf)
+	}
+	b, err := proto.Marshal(&pb)
+	if err != nil {
+		return fs.memoryVersion, nil, err
+	} else {
+		return fs.memoryVersion, b, nil
+	}
 }
 
 func (fs *MeasurementFieldSet) load() error {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1748,9 +1748,8 @@ func (fs *MeasurementFieldSet) Save() (err error) {
 	// Is the MeasurementFieldSet empty?
 	isEmpty := false
 	// marshaled MeasurementFieldSet
-	var b []byte
 
-	err = func() error {
+	b, err := func() ([]byte, error) {
 		fs.mu.Lock()
 		defer fs.mu.Unlock()
 		fs.memoryVersion += 1
@@ -1759,14 +1758,13 @@ func (fs *MeasurementFieldSet) Save() (err error) {
 		if len(fs.fields) == 0 {
 			isEmpty = true
 			if err := os.RemoveAll(fs.path); err != nil {
-				return err
+				return nil, err
 			} else {
 				fs.writtenVersion = fs.memoryVersion
-				return nil
+				return nil, nil
 			}
 		}
-		b, err = fs.marshalMeasurementFieldSetNoLock()
-		return err
+		return fs.marshalMeasurementFieldSetNoLock()
 	}()
 
 	if err != nil {

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -1738,7 +1738,7 @@ func TestMeasurementFieldSet_ConcurrentSave(t *testing.T) {
 		mf2 := mfs2.Fields([]byte(mt[i]))
 		for _, f := range fs {
 			if mf2.Field(f) == nil {
-				t.Fatalf("Created field not found on reload:ed MeasurementFieldSet %s", f)
+				t.Fatalf("Created field not found on reloaded MeasurementFieldSet %s", f)
 			}
 			if mf.Field(f) == nil {
 				t.Fatalf("Created field not found in original MeasureMentFieldSet: %s", f)


### PR DESCRIPTION
fields.idx frequent writes cause lock contention and fields.idx is recreated
when a field or measurement is added in a WritePointsWithContext()

Closes https://github.com/influxdata/influxdb/issues/20500

This eliminates locking during the actual file rewrite, and limits it to
the times when the MeasurementFieldSet is actually being read or written

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass