### PR TITLE
fix: stop backup temp file leakage

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -920,16 +920,17 @@ func (e *Engine) Free() error {
 func (e *Engine) Backup(w io.Writer, basePath string, since time.Time) error {
 	var err error
 	var path string
+L:
 	for i := 0; i < 3; i++ {
 		path, err = e.CreateSnapshot()
-		if err != nil {
-			switch err {
-			case ErrSnapshotInProgress:
-				backoff := time.Duration(math.Pow(32, float64(i))) * time.Millisecond
-				time.Sleep(backoff)
-			default:
-				return err
-			}
+		switch err {
+		case nil:
+			break L
+		case ErrSnapshotInProgress:
+			backoff := time.Duration(math.Pow(32, float64(i))) * time.Millisecond
+			time.Sleep(backoff)
+		default:
+			return err
 		}
 	}
 	if err == ErrSnapshotInProgress {


### PR DESCRIPTION
Since this loop does not exist on success, snapshot operation is
executed three times regardless, and once succesful it only cleans up
after the last run, leaving temporary files from the previous 2 runs
behind, on top of creating unnecessary load on the system.


- [ x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
