### PR TITLE
fix: detect s390x arch and exclude noasm tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ export GOPATH=$(shell go env GOPATH)
 export GOOS=$(shell go env GOOS)
 export GOARCH=$(shell go env GOARCH)
 
-ifeq ($(GOARCH), amd64)
+ifneq (,$(filter $(GOARCH),amd64 s390x))
 	# Including the assets tag requires the UI to be built for compilation to succeed.
 	# Don't force it for running tests.
 	GO_TEST_TAGS :=
 	GO_BUILD_TAGS := assets
 else
-	# noasm needed to avoid a panic in Flux for non-amd64.
+	# noasm needed to avoid a panic in Flux for non-amd64, non-s390x.
 	GO_TEST_TAGS := noasm
 	GO_BUILD_TAGS := assets,noasm
 endif


### PR DESCRIPTION
Commit https://github.com/influxdata/influxdb/commit/074cd24a60ddd5aa2a851a7d04faaef5c126562a added a fix to compile with the go noasm build tag for all non-amd64 arch because arm64 tests panic without it. This also makes s390x compile with noasm even though the tests run fine on s390x without noasm. 
This change adds s390x to the list of architectures that should not set noasm.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
