### PR TITLE
feat(cmd/influxd): add `nats-port` config option to influxd server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [20473](https://github.com/influxdata/influxdb/pull/20473): Add `--overwrite-existing-v2` flag to `influxd upgrade` to overwrite existing files at output paths (instead of aborting).
 1. [20524](https://github.com/influxdata/influxdb/pull/20524): Add `influxd print-config` command to support automated config inspection.
+1. [20561](https://github.com/influxdata/influxdb/pull/20561): Add `nats-port` config option for `influxd` server.
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/cli"
 	"github.com/influxdata/influxdb/v2/kit/signals"
 	influxlogger "github.com/influxdata/influxdb/v2/logger"
+	"github.com/influxdata/influxdb/v2/nats"
 	"github.com/influxdata/influxdb/v2/storage"
 	"github.com/influxdata/influxdb/v2/v1/coordinator"
 	"github.com/influxdata/influxdb/v2/vault"
@@ -127,6 +128,8 @@ type InfluxdOpts struct {
 	SessionLength        int // in minutes
 	SessionRenewDisabled bool
 
+	NatsPort int
+
 	NoTasks      bool
 	FeatureFlags map[string]string
 
@@ -170,6 +173,8 @@ func newOpts(viper *viper.Viper) *InfluxdOpts {
 
 		StoreType:   BoltStore,
 		SecretStore: BoltStore,
+
+		NatsPort: nats.RandomPort,
 
 		NoTasks: false,
 
@@ -471,6 +476,14 @@ func (o *InfluxdOpts) bindCliOpts() []cli.Opt {
 			DestP: &o.CoordinatorConfig.MaxSelectBucketsN,
 			Flag:  "influxql-max-select-buckets",
 			Desc:  "The maximum number of group by time bucket a SELECT can create. A value of zero will max the maximum number of buckets unlimited.",
+		},
+
+		// NATS config
+		{
+			DestP:   &o.NatsPort,
+			Flag:    "nats-port",
+			Desc:    fmt.Sprintf("Port that should be bound by the NATS streaming server. A value of %d will cause a random port to be selected.", nats.RandomPort),
+			Default: o.NatsPort,
 		},
 	}
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -572,13 +572,14 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 
 	// NATS streaming server
 	natsOpts := nats.NewDefaultServerOptions()
-	natsOpts.Port = nats.RandomPort
+	natsOpts.Port = opts.NatsPort
 	m.natsServer = nats.NewServer(&natsOpts)
 	if err := m.natsServer.Open(); err != nil {
 		m.log.Error("Failed to start nats streaming server", zap.Error(err))
 		return err
 	}
-	m.natsPort = natsOpts.Port // updated with random port
+	// If a random port was used, the opts will be updated to include the selected value.
+	m.natsPort = natsOpts.Port
 	publisher := nats.NewAsyncPublisher(m.log, fmt.Sprintf("nats-publisher-%d", m.natsPort), m.NatsURL())
 	if err := publisher.Open(); err != nil {
 		m.log.Error("Failed to connect to streaming server", zap.Error(err))


### PR DESCRIPTION
Closes #16442

Relevant git archeology:
* `nats.NewDefaultServerOptions()` returns a struct with `Port` set to `4222`
* Unit tests that used the `influxd` launcher sometimes failed with port conflicts because of NATS
* 047afcfc10fec049e09b4abd396b9cd104203886 added a hacky loop that would try to find an unused port closest to `4222`
* fab99c9512f86bd013fbd0c933865bbf17e9bfe7 replaced the loop with a built-in marker for random port selection

Random isn't very good for running in Docker, so we add a config parameter to support setting a specific value. I left the default as random just in case.