### PR TITLE
feat(cmd/influxd): add `nats-max-payload-bytes` config option to influxd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20473](https://github.com/influxdata/influxdb/pull/20473): Add `--overwrite-existing-v2` flag to `influxd upgrade` to overwrite existing files at output paths (instead of aborting).
 1. [20524](https://github.com/influxdata/influxdb/pull/20524): Add `influxd print-config` command to support automated config inspection.
 1. [20561](https://github.com/influxdata/influxdb/pull/20561): Add `nats-port` config option for `influxd` server.
+1. [20564](https://github.com/influxdata/influxdb/pull/20564): Add `nats-max-payload-bytes` config option for `influxd` server.
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/influxdb/v2/storage"
 	"github.com/influxdata/influxdb/v2/v1/coordinator"
 	"github.com/influxdata/influxdb/v2/vault"
+	natsserver "github.com/nats-io/gnatsd/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap/zapcore"
@@ -128,7 +129,8 @@ type InfluxdOpts struct {
 	SessionLength        int // in minutes
 	SessionRenewDisabled bool
 
-	NatsPort int
+	NatsPort            int
+	NatsMaxPayloadBytes int
 
 	NoTasks      bool
 	FeatureFlags map[string]string
@@ -174,7 +176,8 @@ func newOpts(viper *viper.Viper) *InfluxdOpts {
 		StoreType:   BoltStore,
 		SecretStore: BoltStore,
 
-		NatsPort: nats.RandomPort,
+		NatsPort:            nats.RandomPort,
+		NatsMaxPayloadBytes: natsserver.MAX_PAYLOAD_SIZE,
 
 		NoTasks: false,
 
@@ -484,6 +487,12 @@ func (o *InfluxdOpts) bindCliOpts() []cli.Opt {
 			Flag:    "nats-port",
 			Desc:    fmt.Sprintf("Port that should be bound by the NATS streaming server. A value of %d will cause a random port to be selected.", nats.RandomPort),
 			Default: o.NatsPort,
+		},
+		{
+			DestP:   &o.NatsMaxPayloadBytes,
+			Flag:    "nats-max-payload-bytes",
+			Desc:    "The maximum number of bytes allowed in a NATS message payload.",
+			Default: o.NatsMaxPayloadBytes,
 		},
 	}
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -573,6 +573,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	// NATS streaming server
 	natsOpts := nats.NewDefaultServerOptions()
 	natsOpts.Port = opts.NatsPort
+	natsOpts.MaxPayload = opts.NatsMaxPayloadBytes
 	m.natsServer = nats.NewServer(&natsOpts)
 	if err := m.natsServer.Open(); err != nil {
 		m.log.Error("Failed to start nats streaming server", zap.Error(err))


### PR DESCRIPTION
Closes #19713 

I went with raw bytes instead of a `toml.Size` for simplicity, but I could be convinced to change it.