### PR TITLE
fix(kv): log migration events at debug level to avoid spam

### DIFF
--- a/kv/migration/migration.go
+++ b/kv/migration/migration.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	influxdb "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kv"
 	"go.uber.org/zap"
 )
@@ -148,6 +148,11 @@ func (m *Migrator) Up(ctx context.Context) error {
 		return wrapErr(err)
 	}
 
+	migrationsToDo := len(m.Specs[lastMigration:])
+	if migrationsToDo > 0 {
+		m.logger.Info("Bringing up metadata migrations", zap.Int("migration_count", migrationsToDo))
+	}
+
 	for idx, spec := range m.Specs[lastMigration:] {
 		startedAt := m.now()
 		migration := Migration{
@@ -218,7 +223,12 @@ func (m *Migrator) Down(ctx context.Context) (err error) {
 		return wrapErr(err)
 	}
 
-	for i := len(migrations) - 1; i >= 0; i-- {
+	migrationsToDo := len(migrations)
+	if migrationsToDo > 0 {
+		m.logger.Info("Tearing down metadata migrations", zap.Int("migration_count", migrationsToDo))
+	}
+
+	for i := migrationsToDo - 1; i >= 0; i-- {
 		migration := migrations[i]
 
 		m.logMigrationEvent(DownMigrationState, migration.Migration, "started")
@@ -238,7 +248,12 @@ func (m *Migrator) Down(ctx context.Context) (err error) {
 }
 
 func (m *Migrator) logMigrationEvent(state MigrationState, mig Migration, event string) {
-	m.logger.Info(fmt.Sprintf("Migration %q %s (%s)", mig.Name, event, state))
+	m.logger.Debug(
+		"Executing metadata migration",
+		zap.String("migration_name", mig.Name),
+		zap.String("target_state", state.String()),
+		zap.String("migration_event", event),
+	)
 }
 
 func (m *Migrator) walk(ctx context.Context, store kv.Store, fn func(id influxdb.ID, m Migration)) error {


### PR DESCRIPTION
Closes #20569

Before:
<img width="1128" alt="Screen Shot 2021-01-22 at 7 34 23 AM" src="https://user-images.githubusercontent.com/2755881/105511176-7a2add00-5c84-11eb-8585-697f6b3bf403.png">

After:
<img width="1118" alt="Screen Shot 2021-01-22 at 7 35 21 AM" src="https://user-images.githubusercontent.com/2755881/105511229-8747cc00-5c84-11eb-8c1c-b587c661ae4d.png">
