### PR TITLE
fix(cmd/influx): respect --skip-verify in `influx query`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20548](https://github.com/influxdata/influxdb/pull/20548): Prevent panic in `influxd upgrade` when V1 users exist and no V1 config is given.
 1. [20565](https://github.com/influxdata/influxdb/pull/20565): Set correct Content-Type on v1 query responses.
 1. [20565](https://github.com/influxdata/influxdb/pull/20565): Update V1 API spec to document all valid Accept headers and matching Content-Types.
+1. [20578](https://github.com/influxdata/influxdb/pull/20578): Respect the --skip-verify flag when running `influx query`.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -115,7 +115,8 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 	req.Header.Set("Authorization", "Token "+flags.config().Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := ihttp.NewClient(u.Scheme, flags.skipVerify)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #19782 

I tested this manually for now to avoid TLS setup headaches in our CI/CD process.