### PR TITLE
test: replace influxlogger with zaptest logger

### DIFF
--- a/cmd/telemetryd/main.go
+++ b/cmd/telemetryd/main.go
@@ -15,13 +15,21 @@ import (
 )
 
 var (
-	log  = influxlogger.New(os.Stdout)
 	addr string
 )
 
 func main() {
+	logconf := influxlogger.NewConfig()
+	log, err := logconf.New(os.Stdout)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to configure logger: %v", err)
+		os.Exit(1)
+	}
+
 	prog := &cli.Program{
-		Run:  run,
+		Run: func() error {
+			return run(log)
+		},
 		Name: "telemetryd",
 		Opts: []cli.Opt{
 			{
@@ -32,6 +40,7 @@ func main() {
 			},
 		},
 	}
+
 	v := viper.New()
 	cmd := cli.NewCommand(v, prog)
 
@@ -49,8 +58,8 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func run() error {
-	log := log.With(zap.String("service", "telemetryd"))
+func run(log *zap.Logger) error {
+	log = log.With(zap.String("service", "telemetryd"))
 	store := telemetry.NewLogStore(log)
 	svc := telemetry.NewPushGateway(log, store)
 	// Print data as line protocol

--- a/gather/scheduler_test.go
+++ b/gather/scheduler_test.go
@@ -3,15 +3,14 @@ package gather
 import (
 	"context"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2"
-	influxlogger "github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/mock"
 	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestScheduler(t *testing.T) {
@@ -19,7 +18,7 @@ func TestScheduler(t *testing.T) {
 	totalGatherJobs := 3
 
 	// Create top level logger
-	logger := influxlogger.New(os.Stdout)
+	logger := zaptest.NewLogger(t)
 	ts := httptest.NewServer(&mockHTTPHandler{
 		responseMap: map[string]string{
 			"/metrics": sampleRespSmall,

--- a/http/legacy/router.go
+++ b/http/legacy/router.go
@@ -71,14 +71,17 @@ func (h baseHandler) panic(w http.ResponseWriter, r *http.Request, rcv interface
 	h.HandleHTTPError(ctx, pe, w)
 }
 
-var panicLogger *zap.Logger
+var panicLogger = zap.NewNop()
 var panicLoggerOnce sync.Once
 
 // getPanicLogger returns a logger for panicHandler.
 func getPanicLogger() *zap.Logger {
 	panicLoggerOnce.Do(func() {
-		panicLogger = influxlogger.New(os.Stderr)
-		panicLogger = panicLogger.With(zap.String("handler", "panic"))
+		conf := influxlogger.NewConfig()
+		logger, err := conf.New(os.Stderr)
+		if err == nil {
+			panicLogger = logger.With(zap.String("handler", "panic"))
+		}
 	})
 
 	return panicLogger

--- a/http/router.go
+++ b/http/router.go
@@ -129,14 +129,17 @@ func panicMW(api *kithttp.API) func(http.Handler) http.Handler {
 	}
 }
 
-var panicLogger *zap.Logger
+var panicLogger = zap.NewNop()
 var panicLoggerOnce sync.Once
 
 // getPanicLogger returns a logger for panicHandler.
 func getPanicLogger() *zap.Logger {
 	panicLoggerOnce.Do(func() {
-		panicLogger = influxlogger.New(os.Stderr)
-		panicLogger = panicLogger.With(zap.String("handler", "panic"))
+		conf := influxlogger.NewConfig()
+		logger, err := conf.New(os.Stderr)
+		if err == nil {
+			panicLogger = logger.With(zap.String("handler", "panic"))
+		}
 	})
 
 	return panicLogger

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,12 +13,6 @@ import (
 
 const TimeFormat = "2006-01-02T15:04:05.000000Z07:00"
 
-func New(w io.Writer) *zap.Logger {
-	config := NewConfig()
-	l, _ := config.New(w)
-	return l
-}
-
 func (c *Config) New(defaultOutput io.Writer) (*zap.Logger, error) {
 	w := defaultOutput
 	format := c.Format

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -21,20 +21,20 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2/influxql/query"
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/pkg/deep"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	"github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
 	"github.com/influxdata/influxql"
+	"go.uber.org/zap/zaptest"
 )
 
 // Ensure that deletes only sent to the WAL will clear out the data from the cache on restart
 func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			if err := e.WritePointsString(
@@ -70,7 +70,7 @@ func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
 func TestEngine_DeleteSeriesAfterCacheSnapshot(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			if err := e.WritePointsString(
@@ -174,7 +174,7 @@ func seriesExist(e *Engine, m string, dims []string) (int, error) {
 
 // Ensure that the engine can write & read shard digest files.
 func TestEngine_Digest(t *testing.T) {
-	e := MustOpenEngine(tsi1.IndexName)
+	e := MustOpenEngine(t, tsi1.IndexName)
 	defer e.Close()
 
 	if err := e.Open(); err != nil {
@@ -322,7 +322,7 @@ type span struct {
 
 // Ensure engine handles concurrent calls to Digest().
 func TestEngine_Digest_Concurrent(t *testing.T) {
-	e := MustOpenEngine(tsi1.IndexName)
+	e := MustOpenEngine(t, tsi1.IndexName)
 	defer e.Close()
 
 	if err := e.Open(); err != nil {
@@ -748,7 +748,7 @@ func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -805,7 +805,7 @@ func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -861,7 +861,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -919,7 +919,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -977,7 +977,7 @@ func TestEngine_CreateIterator_Aux(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -1037,7 +1037,7 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -1093,8 +1093,8 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 
 // Test that series id set gets updated and returned appropriately.
 func TestIndex_SeriesIDSet(t *testing.T) {
-	test := func(index string) error {
-		engine := MustOpenEngine(index)
+	test := func(t *testing.T, index string) error {
+		engine := MustOpenEngine(t, index)
 		defer engine.Close()
 
 		// Add some series.
@@ -1180,7 +1180,7 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			if err := test(index); err != nil {
+			if err := test(t, index); err != nil {
 				t.Error(err)
 			}
 		})
@@ -1197,7 +1197,7 @@ func TestEngine_DeleteSeries(t *testing.T) {
 			p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
 			p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1252,7 +1252,7 @@ func TestEngine_DeleteSeriesRange(t *testing.T) {
 			p7 := MustParsePointString("mem,host=C value=1.3 1000000000")  // Should not be deleted
 			p8 := MustParsePointString("disk,host=C value=1.3 1000000000") // Should not be deleted
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1362,7 +1362,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate(t *testing.T) {
 			p7 := MustParsePointString("mem,host=C value=1.3 1000000000")
 			p8 := MustParsePointString("disk,host=C value=1.3 1000000000") // Should not be deleted
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1488,7 +1488,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate_Nil(t *testing.T) {
 			p7 := MustParsePointString("mem,host=C value=1.3 1000000000")
 			p8 := MustParsePointString("disk,host=C value=1.3 1000000000") // Should not be deleted
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1574,7 +1574,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate_FlushBatch(t *testing.T) {
 			p7 := MustParsePointString("mem,host=C value=1.3 1000000000")
 			p8 := MustParsePointString("disk,host=C value=1.3 1000000000") // Should not be deleted
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1693,7 +1693,7 @@ func TestEngine_DeleteSeriesRange_OutsideTime(t *testing.T) {
 			// Create a few points.
 			p1 := MustParsePointString("cpu,host=A value=1.1 1000000000") // Should not be deleted
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1774,7 +1774,7 @@ func TestEngine_LastModified(t *testing.T) {
 			p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
 			p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1865,7 +1865,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 func TestEngine_ShouldCompactCache(t *testing.T) {
 	nowTime := time.Now()
 
-	e, err := NewEngine(tsi1.IndexName)
+	e, err := NewEngine(t, tsi1.IndexName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1910,7 +1910,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -1970,7 +1970,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -2052,7 +2052,7 @@ func TestEngine_DisableEnableCompactions_Concurrent(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			var wg sync.WaitGroup
@@ -2097,7 +2097,7 @@ func TestEngine_WritePoints_TypeConflict(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			if err := e.WritePointsString(
@@ -2133,7 +2133,7 @@ func TestEngine_WritePoints_Reload(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
 
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(t, index)
 			defer e.Close()
 
 			if err := e.WritePointsString(
@@ -2176,7 +2176,7 @@ func TestEngine_Invalid_UTF8(t *testing.T) {
 			field := []byte{255, 110, 101, 116}    // A known invalid UTF-8 string
 			p := MustParsePointString(fmt.Sprintf("%s,host=A %s=1.1 6000000000", name, field))
 
-			e, err := NewEngine(index)
+			e, err := NewEngine(t, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2207,7 +2207,7 @@ func BenchmarkEngine_WritePoints(b *testing.B) {
 	batchSizes := []int{10, 100, 1000, 5000, 10000}
 	for _, sz := range batchSizes {
 		for _, index := range tsdb.RegisteredIndexes() {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(b, index)
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
 			pp := make([]models.Point, 0, sz)
 			for i := 0; i < sz; i++ {
@@ -2233,7 +2233,7 @@ func BenchmarkEngine_WritePoints_Parallel(b *testing.B) {
 	batchSizes := []int{1000, 5000, 10000, 25000, 50000, 75000, 100000, 200000}
 	for _, sz := range batchSizes {
 		for _, index := range tsdb.RegisteredIndexes() {
-			e := MustOpenEngine(index)
+			e := MustOpenEngine(b, index)
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
 
 			cpus := runtime.GOMAXPROCS(0)
@@ -2412,7 +2412,7 @@ var benchmarkVariants = []struct {
 func BenchmarkEngine_CreateIterator(b *testing.B) {
 	engines := make([]*benchmarkEngine, len(sizes))
 	for i, size := range sizes {
-		engines[i] = MustInitDefaultBenchmarkEngine(size.name, size.sz)
+		engines[i] = MustInitDefaultBenchmarkEngine(b, size.name, size.sz)
 	}
 
 	for _, tt := range benchmarks {
@@ -2458,13 +2458,13 @@ var (
 // MustInitDefaultBenchmarkEngine creates a new engine using the default index
 // and fills it with points.  Reuses previous engine if the same parameters
 // were used.
-func MustInitDefaultBenchmarkEngine(name string, pointN int) *benchmarkEngine {
+func MustInitDefaultBenchmarkEngine(tb testing.TB, name string, pointN int) *benchmarkEngine {
 	const batchSize = 1000
 	if pointN%batchSize != 0 {
 		panic(fmt.Sprintf("point count (%d) must be a multiple of batch size (%d)", pointN, batchSize))
 	}
 
-	e := MustOpenEngine(tsdb.DefaultIndex)
+	e := MustOpenEngine(tb, tsdb.DefaultIndex)
 
 	// Initialize metadata.
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
@@ -2516,7 +2516,9 @@ type Engine struct {
 }
 
 // NewEngine returns a new instance of Engine at a temporary location.
-func NewEngine(index string) (*Engine, error) {
+func NewEngine(tb testing.TB, index string) (*Engine, error) {
+	tb.Helper()
+
 	root, err := ioutil.TempDir("", "tsm1-")
 	if err != nil {
 		panic(err)
@@ -2531,7 +2533,7 @@ func NewEngine(index string) (*Engine, error) {
 
 	// Setup series file.
 	sfile := tsdb.NewSeriesFile(filepath.Join(dbPath, tsdb.SeriesFileDirectory))
-	sfile.Logger = logger.New(os.Stdout)
+	sfile.Logger = zaptest.NewLogger(tb)
 	if err = sfile.Open(); err != nil {
 		return nil, err
 	}
@@ -2559,8 +2561,10 @@ func NewEngine(index string) (*Engine, error) {
 }
 
 // MustOpenEngine returns a new, open instance of Engine.
-func MustOpenEngine(index string) *Engine {
-	e, err := NewEngine(index)
+func MustOpenEngine(tb testing.TB, index string) *Engine {
+	tb.Helper()
+
+	e, err := NewEngine(tb, index)
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestFileStore_Read(t *testing.T) {
@@ -2964,9 +2964,7 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 	}
 
 	fs := tsm1.NewFileStore(dir)
-	if testing.Verbose() {
-		fs.WithLogger(logger.New(os.Stderr))
-	}
+	fs.WithLogger(zaptest.NewLogger(b))
 
 	if err := fs.Open(); err != nil {
 		b.Fatalf("opening file store %v", err)

--- a/tsdb/engine/tsm1/iterator_test.go
+++ b/tsdb/engine/tsm1/iterator_test.go
@@ -1,14 +1,13 @@
 package tsm1
 
 import (
-	"os"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/influxdata/influxdb/v2/influxql/query"
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxql"
+	"go.uber.org/zap/zaptest"
 )
 
 func BenchmarkIntegerIterator_Next(b *testing.B) {
@@ -71,7 +70,7 @@ func TestFinalizerIterator(t *testing.T) {
 		step3 = make(chan struct{})
 	)
 
-	l := logger.New(os.Stderr)
+	l := zaptest.NewLogger(t)
 	done := make(chan struct{})
 	func() {
 		itr := &testFinalizerIterator{

--- a/tsdb/index/tsi1/sql_index_exporter_test.go
+++ b/tsdb/index/tsi1/sql_index_exporter_test.go
@@ -2,12 +2,11 @@ package tsi1_test
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestSQLIndexExporter_ExportIndex(t *testing.T) {
@@ -40,7 +39,7 @@ COMMIT;
 	var buf bytes.Buffer
 	e := tsi1.NewSQLIndexExporter(&buf)
 	e.ShowSchema = false
-	e.Logger = logger.New(os.Stderr)
+	e.Logger = zaptest.NewLogger(t)
 	if err := e.ExportIndex(idx.Index); err != nil {
 		t.Fatal(err)
 	} else if err := e.Close(); err != nil {

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxql"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestShard_MapType(t *testing.T) {
 	var sh *TempShard
 
 	setup := func(index string) {
-		sh = NewTempShard(index)
+		sh = NewTempShard(t, index)
 
 		if err := sh.Open(); err != nil {
 			t.Fatal(err)
@@ -155,7 +155,7 @@ _reserved,region=uswest value="foo" 0
 func TestShard_MeasurementsByRegex(t *testing.T) {
 	var sh *TempShard
 	setup := func(index string) {
-		sh = NewTempShard(index)
+		sh = NewTempShard(t, index)
 		if err := sh.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -212,7 +212,9 @@ type TempShard struct {
 }
 
 // NewTempShard returns a new instance of TempShard with temp paths.
-func NewTempShard(index string) *TempShard {
+func NewTempShard(tb testing.TB, index string) *TempShard {
+	tb.Helper()
+
 	// Create temporary path for data and WAL.
 	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
 	if err != nil {
@@ -221,7 +223,7 @@ func NewTempShard(index string) *TempShard {
 
 	// Create series file.
 	sfile := NewSeriesFile(filepath.Join(dir, "db0", SeriesFileDirectory))
-	sfile.Logger = logger.New(os.Stdout)
+	sfile.Logger = zaptest.NewLogger(tb)
 	if err := sfile.Open(); err != nil {
 		panic(err)
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -37,7 +37,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -106,7 +106,7 @@ func TestShardRebuildIndex(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -184,7 +184,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -234,7 +234,7 @@ func TestWriteTimeTag(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -284,7 +284,7 @@ func TestWriteTimeField(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -319,7 +319,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -371,7 +371,7 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -459,7 +459,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -609,7 +609,7 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	opts := tsdb.NewEngineOptions()
@@ -649,7 +649,7 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 func TestShard_CreateIterator_Ascending(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {
-			sh := NewShard(index)
+			sh := NewShard(t, index)
 			defer sh.Close()
 
 			// Calling CreateIterator when the engine is not open will return
@@ -732,8 +732,8 @@ func TestShard_CreateIterator_Descending(t *testing.T) {
 	var sh *Shard
 	var itr query.Iterator
 
-	test := func(index string) {
-		sh = NewShard(index)
+	test := func(t *testing.T, index string) {
+		sh = NewShard(t, index)
 
 		// Calling CreateIterator when the engine is not open will return
 		// ErrEngineClosed.
@@ -808,7 +808,7 @@ cpu,host=serverB,region=uswest value=25  0
 	}
 
 	for _, index := range tsdb.RegisteredIndexes() {
-		t.Run(index, func(t *testing.T) { test(index) })
+		t.Run(index, func(t *testing.T) { test(t, index) })
 		sh.Close()
 		itr.Close()
 	}
@@ -834,8 +834,8 @@ func TestShard_CreateIterator_Series_Auth(t *testing.T) {
 		},
 	}
 
-	test := func(index string, v variant) error {
-		sh := MustNewOpenShard(index)
+	test := func(t *testing.T, index string, v variant) error {
+		sh := MustNewOpenShard(t, index)
 		defer sh.Close()
 		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
@@ -952,7 +952,7 @@ cpu,secret=foo value=100 0
 	for _, index := range tsdb.RegisteredIndexes() {
 		for _, example := range examples {
 			t.Run(index+"_"+example.name, func(t *testing.T) {
-				if err := test(index, example); err != nil {
+				if err := test(t, index, example); err != nil {
 					t.Fatal(err)
 				}
 			})
@@ -963,8 +963,8 @@ cpu,secret=foo value=100 0
 func TestShard_Disabled_WriteQuery(t *testing.T) {
 	var sh *Shard
 
-	test := func(index string) {
-		sh = NewShard(index)
+	test := func(t *testing.T, index string) {
+		sh = NewShard(t, index)
 		if err := sh.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1007,15 +1007,15 @@ func TestShard_Disabled_WriteQuery(t *testing.T) {
 	}
 
 	for _, index := range tsdb.RegisteredIndexes() {
-		t.Run(index, func(t *testing.T) { test(index) })
+		t.Run(index, func(t *testing.T) { test(t, index) })
 		sh.Close()
 	}
 }
 
 func TestShard_Closed_Functions(t *testing.T) {
 	var sh *Shard
-	test := func(index string) {
-		sh = NewShard(index)
+	test := func(t *testing.T, index string) {
+		sh = NewShard(t, index)
 		if err := sh.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1040,18 +1040,18 @@ func TestShard_Closed_Functions(t *testing.T) {
 	}
 
 	for _, index := range tsdb.RegisteredIndexes() {
-		t.Run(index, func(t *testing.T) { test(index) })
+		t.Run(index, func(t *testing.T) { test(t, index) })
 	}
 }
 
 func TestShard_FieldDimensions(t *testing.T) {
 	var sh *Shard
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	setup := func(index string) {
-		sh = NewShard(index)
+		sh = NewShard(t, index)
 
 		if err := sh.Open(); err != nil {
 			t.Fatal(err)
@@ -1167,7 +1167,7 @@ func TestShards_FieldKeysByMeasurement(t *testing.T) {
 	var shards Shards
 
 	setup := func(index string) {
-		shards = NewShards(index, 2)
+		shards = NewShards(t, index, 2)
 		shards.MustOpen()
 
 		shards[0].MustWritePointsString(`cpu,host=serverA,region=uswest a=2.2,b=33.3,value=100 0`)
@@ -1203,7 +1203,7 @@ func TestShards_FieldDimensions(t *testing.T) {
 	var shard1, shard2 *Shard
 
 	setup := func(index string) {
-		shard1 = NewShard(index)
+		shard1 = NewShard(t, index)
 		if err := shard1.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1214,7 +1214,7 @@ cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-		shard2 = NewShard(index)
+		shard2 = NewShard(t, index)
 		if err := shard2.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1328,7 +1328,7 @@ func TestShards_MapType(t *testing.T) {
 	var shard1, shard2 *Shard
 
 	setup := func(index string) {
-		shard1 = NewShard(index)
+		shard1 = NewShard(t, index)
 		if err := shard1.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1339,7 +1339,7 @@ cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-		shard2 = NewShard(index)
+		shard2 = NewShard(t, index)
 		if err := shard2.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1467,7 +1467,7 @@ func TestShards_MeasurementsByRegex(t *testing.T) {
 	var shard1, shard2 *Shard
 
 	setup := func(index string) {
-		shard1 = NewShard(index)
+		shard1 = NewShard(t, index)
 		if err := shard1.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1478,7 +1478,7 @@ cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-		shard2 = NewShard(index)
+		shard2 = NewShard(t, index)
 		if err := shard2.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -1828,7 +1828,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 	b.StopTimer()
 	b.ResetTimer()
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
 	// Run the benchmark loop.
@@ -1866,7 +1866,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 		}
 	}
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
 	shard, tmpDir, err := openShard(sfile)
@@ -1912,7 +1912,7 @@ func benchmarkWritePointsExistingSeriesFields(b *testing.B, mCnt, tkCnt, tvCnt, 
 		}
 	}
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer func() {
 		_ = sfile.Close()
 	}()
@@ -1957,7 +1957,7 @@ func benchmarkWritePointsExistingSeriesEqualBatches(b *testing.B, mCnt, tkCnt, t
 		}
 	}
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
 	shard, tmpDir, err := openShard(sfile)
@@ -2037,7 +2037,7 @@ func BenchmarkCreateIterator(b *testing.B) {
 		var shards Shards
 		for i := 1; i <= 5; i++ {
 			name := fmt.Sprintf("%s_shards_%d", index, i)
-			shards = NewShards(index, i)
+			shards = NewShards(b, index, i)
 			shards.MustOpen()
 
 			setup(index, shards)
@@ -2111,13 +2111,15 @@ type Shard struct {
 type Shards []*Shard
 
 // NewShard returns a new instance of Shard with temp paths.
-func NewShard(index string) *Shard {
-	return NewShards(index, 1)[0]
+func NewShard(tb testing.TB, index string) *Shard {
+	tb.Helper()
+	return NewShards(tb, index, 1)[0]
 }
 
 // MustNewOpenShard creates and opens a shard with the provided index.
-func MustNewOpenShard(index string) *Shard {
-	sh := NewShard(index)
+func MustNewOpenShard(tb testing.TB, index string) *Shard {
+	tb.Helper()
+	sh := NewShard(tb, index)
 	if err := sh.Open(); err != nil {
 		panic(err)
 	}
@@ -2136,14 +2138,16 @@ func (sh *Shard) Close() error {
 }
 
 // NewShards create several shards all sharing the same
-func NewShards(index string, n int) Shards {
+func NewShards(tb testing.TB, index string, n int) Shards {
+	tb.Helper()
+
 	// Create temporary path for data and WAL.
 	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
 	if err != nil {
 		panic(err)
 	}
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(tb)
 
 	var shards []*Shard
 	var idSets []*tsdb.SeriesIDSet

--- a/v1/services/precreator/service_test.go
+++ b/v1/services/precreator/service_test.go
@@ -2,14 +2,13 @@ package precreator_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/influxdata/influxdb/v2/internal"
-	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/toml"
 	"github.com/influxdata/influxdb/v2/v1/services/precreator"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestShardPrecreation(t *testing.T) {
@@ -25,7 +24,7 @@ func TestShardPrecreation(t *testing.T) {
 		return nil
 	}
 
-	s := NewTestService()
+	s := NewTestService(t)
 	s.MetaClient = &mc
 
 	if err := s.Open(context.Background()); err != nil {
@@ -46,11 +45,13 @@ func TestShardPrecreation(t *testing.T) {
 	}
 }
 
-func NewTestService() *precreator.Service {
+func NewTestService(tb testing.TB) *precreator.Service {
+	tb.Helper()
+
 	config := precreator.NewConfig()
 	config.CheckInterval = toml.Duration(10 * time.Millisecond)
 
 	s := precreator.NewService(config)
-	s.WithLogger(logger.New(os.Stderr))
+	s.WithLogger(zaptest.NewLogger(tb))
 	return s
 }


### PR DESCRIPTION
Related to #20579 

The ultimate goal is to adjust the implementation / APIs in the `logger` package for more consistency across our CLI commands. When I started making changes I noticed many tests stopped building.

I think this is a nice stand-alone win. Zaptest's logger automatically sets debug-level logging, and only shows the logs for a test if the test fail or `-v` is passed to `go test`.