### PR TITLE
build: fix test-result collection for grace_nighty job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,14 @@ workflows:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
+      # TODO: Remove after build fixed
+      - grace_nightly:
+          requires:
+            - build
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
       - litmus_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,6 @@ workflows:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
-      # TODO: Remove after build fixed
-      - grace_nightly:
-          requires:
-            - build
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
       - litmus_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,7 +777,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - quay_login
-      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -e TEST_RESULTS=~/project quay.io/influxdb/grace:latest
+      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/grace/test-results/grace-results quay.io/influxdb/grace:latest
       - store_artifacts:
           path: ~/project
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,12 +786,7 @@ jobs:
           at: ~/project
       - quay_login
       - run: mkdir -p ~/project/results
-      - run: >
-          docker run --net host
-            -v /var/run/docker.sock:/var/run/docker.sock
-            -v ~/project/results:/grace/test-results/grace-results
-            -e TEST_RESULTS=~/project/results
-            quay.io/influxdb/grace:latest
+      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project/results:/grace/test-results/grace-results -e TEST_RESULTS=~/project/results quay.io/influxdb/grace:latest
       - store_artifacts:
           path: ~/project/results
       - store_test_results:
@@ -807,11 +802,7 @@ jobs:
           command: ./bin/linux/influxd --store=memory --log-level=debug
           background: true
       - run: mkdir -p ~/project/results
-      - run: >
-          docker run --net host
-            -v /var/run/docker.sock:/var/run/docker.sock
-            -v ~/project/results:/grace/test-results/grace-results
-            quay.io/influxdb/grace:daily
+      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project/results:/grace/test-results/grace-results quay.io/influxdb/grace:daily
       - store_artifacts:
           path: ~/project/results
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,11 +785,17 @@ jobs:
       - attach_workspace:
           at: ~/project
       - quay_login
-      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/grace/test-results/grace-results quay.io/influxdb/grace:latest
+      - run: mkdir -p ~/project/results
+      - run: >
+          docker run --net host
+            -v /var/run/docker.sock:/var/run/docker.sock
+            -v ~/project/results:/grace/test-results/grace-results
+            -e TEST_RESULTS=~/project/results
+            quay.io/influxdb/grace:latest
       - store_artifacts:
-          path: ~/project
+          path: ~/project/results
       - store_test_results:
-          path: ~/project
+          path: ~/project/results
 
   grace_daily:
     machine: true
@@ -800,6 +806,13 @@ jobs:
       - run:
           command: ./bin/linux/influxd --store=memory --log-level=debug
           background: true
-      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/grace/test-results/grace-results quay.io/influxdb/grace:daily
+      - run: mkdir -p ~/project/results
+      - run: >
+          docker run --net host
+            -v /var/run/docker.sock:/var/run/docker.sock
+            -v ~/project/results:/grace/test-results/grace-results
+            quay.io/influxdb/grace:daily
       - store_artifacts:
-          path: ~/project
+          path: ~/project/results
+      - store_test_results:
+          path: ~/project/results


### PR DESCRIPTION
The nightly grace tests have been failing, but I can't tell why because report collection is broken.