### PR TITLE
chore(lsp): Upgrade flux-lsp-browser to v0.5.29

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -135,7 +135,7 @@
   "dependencies": {
     "@influxdata/clockface": "2.3.4",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.28",
+    "@influxdata/flux-lsp-browser": "^0.5.29",
     "@influxdata/giraffe": "0.29.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -752,10 +752,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.4.tgz#9c496601253e1d49cbeae29a7b9cfb54862785f6"
   integrity sha512-mmz3YElK8Ho+1onEafuas6sVhIT638JA4NbDTO3bVJgK1TG7AnU4rQP+c6fj7vZSfvrIwtOwGaMONJTaww5o6w==
 
-"@influxdata/flux-lsp-browser@^0.5.28":
-  version "0.5.28"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.28.tgz#a8af6474c7ee5dbcc156722755ea44d286dd3803"
-  integrity sha512-J1iH0cBmqiQZPDnASQQj/m7L/aPbDqwfgtD2gB2PodF7NBRbOQHYWjbYQU38n+8ZNb6/rAOdPJIH6WHKfBxvSw==
+"@influxdata/flux-lsp-browser@^0.5.29":
+  version "0.5.29"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.29.tgz#41d12069bda9b5c4d88c95c2f57f865ef153f9dc"
+  integrity sha512-RPwJXmGWJDEUr/HiXyt6uc3a2myBZ+rTse8I3JjG6poCOuD+MwuIG3r9P9CV1gvKrvj/sXaUwzZ+gNGS03xNAQ==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
[Flux LSP v0.5.29](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.29)
