### PR TITLE
feat(query): Hyper log log operators in influxql

### DIFF
--- a/pkg/estimator/hll/hll.go
+++ b/pkg/estimator/hll/hll.go
@@ -151,9 +151,10 @@ func (h *Plus) Add(v []byte) {
 
 		if uint32(len(h.tmpSet))*100 > h.m {
 			h.mergeSparse()
-			if uint32(h.sparseList.Len()) > h.m {
-				h.toNormal()
-			}
+		}
+		if uint32(h.sparseList.Len()) > h.m {
+			h.mergeSparse()
+			h.toNormal()
 		}
 	} else {
 		i := bextr(x, 64-h.p, h.p) // {x63,...,x64-p}
@@ -241,6 +242,10 @@ func (h *Plus) MarshalBinary() (data []byte, err error) {
 		return nil, nil
 	}
 
+	if h.sparse {
+		h.mergeSparse()
+	}
+
 	// Marshal a version marker.
 	data = append(data, version)
 
@@ -251,7 +256,7 @@ func (h *Plus) MarshalBinary() (data []byte, err error) {
 		// It's using the sparse representation.
 		data = append(data, byte(1))
 
-		// Add the tmp_set
+		// Add the tmp_set (should be empty)
 		tsdata, err := h.tmpSet.MarshalBinary()
 		if err != nil {
 			return nil, err

--- a/query/compile.go
+++ b/query/compile.go
@@ -295,6 +295,8 @@ func (c *compiledField) compileExpr(expr influxql.Expr) error {
 			return c.compileElapsed(expr.Args)
 		case "integral":
 			return c.compileIntegral(expr.Args)
+		case "count_hll":
+			return c.compileCountHll(expr.Args)
 		case "holt_winters", "holt_winters_with_fit":
 			withFit := expr.Name == "holt_winters_with_fit"
 			return c.compileHoltWinters(expr.Args, withFit)
@@ -380,7 +382,7 @@ func (c *compiledField) compileFunction(expr *influxql.Call) error {
 	switch expr.Name {
 	case "max", "min", "first", "last":
 		// top/bottom are not included here since they are not typical functions.
-	case "count", "sum", "mean", "median", "mode", "stddev", "spread":
+	case "count", "sum", "mean", "median", "mode", "stddev", "spread", "sum_hll":
 		// These functions are not considered selectors.
 		c.global.OnlySelectors = false
 	default:
@@ -769,6 +771,19 @@ func (c *compiledField) compileIntegral(args []influxql.Expr) error {
 
 	// Must be a variable reference, wildcard, or regexp.
 	return c.compileSymbol("integral", args[0])
+}
+
+func (c *compiledField) compileCountHll(args []influxql.Expr) error {
+	if exp, got := 1, len(args); exp != got {
+		return fmt.Errorf("invalid number of arguments for integral, expected %d, got %d", exp, got)
+	}
+	c.global.OnlySelectors = false
+	switch arg0 := args[0].(type) {
+	case *influxql.Call:
+		return c.compileExpr(arg0)
+	default:
+		return c.compileSymbol("count_hll", arg0)
+	}
 }
 
 func (c *compiledField) compileHoltWinters(args []influxql.Expr, withFit bool) error {

--- a/query/compile.go
+++ b/query/compile.go
@@ -775,7 +775,7 @@ func (c *compiledField) compileIntegral(args []influxql.Expr) error {
 
 func (c *compiledField) compileCountHll(args []influxql.Expr) error {
 	if exp, got := 1, len(args); exp != got {
-		return fmt.Errorf("invalid number of arguments for integral, expected %d, got %d", exp, got)
+		return fmt.Errorf("invalid number of arguments for count_hll, expected %d, got %d", exp, got)
 	}
 	c.global.OnlySelectors = false
 	switch arg0 := args[0].(type) {

--- a/query/functions.gen.go
+++ b/query/functions.gen.go
@@ -7,9 +7,13 @@
 package query
 
 import (
+	"bytes"
+	"encoding/binary"
 	"math/rand"
 	"sort"
 	"time"
+
+	"github.com/influxdata/influxdb/pkg/estimator/hll"
 )
 
 // FloatPointAggregator aggregates points to produce a single point.
@@ -20,20 +24,6 @@ type FloatPointAggregator interface {
 // FloatBulkPointAggregator aggregates multiple points at a time.
 type FloatBulkPointAggregator interface {
 	AggregateFloatBulk(points []FloatPoint)
-}
-
-// AggregateFloatPoints feeds a slice of FloatPoint into an
-// aggregator. If the aggregator is a FloatBulkPointAggregator, it will
-// use the AggregateBulk method.
-func AggregateFloatPoints(a FloatPointAggregator, points []FloatPoint) {
-	switch a := a.(type) {
-	case FloatBulkPointAggregator:
-		a.AggregateFloatBulk(points)
-	default:
-		for _, p := range points {
-			a.AggregateFloat(&p)
-		}
-	}
 }
 
 // FloatPointEmitter produces a single point from an aggregate.
@@ -391,6 +381,33 @@ func (r *FloatSliceFuncBooleanReducer) Emit() []BooleanPoint {
 	return r.fn(r.points)
 }
 
+// FloatSumHllReducer returns the HLL sketch for a series, in string form
+type FloatSumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func NewFloatSumHllReducer creates a new FloatSumHllReducer
+func NewFloatSumHllReducer() *FloatSumHllReducer {
+	return &FloatSumHllReducer{plus: hll.NewDefaultPlus()}
+}
+
+// AggregateFloat aggregates a point into the reducer.
+func (r *FloatSumHllReducer) AggregateFloat(p *FloatPoint) {
+
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, p.Value)
+	b := buf.Bytes()
+
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *FloatSumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
+}
+
 // FloatDistinctReducer returns the distinct points in a series.
 type FloatDistinctReducer struct {
 	m map[float64]FloatPoint
@@ -504,20 +521,6 @@ type IntegerPointAggregator interface {
 // IntegerBulkPointAggregator aggregates multiple points at a time.
 type IntegerBulkPointAggregator interface {
 	AggregateIntegerBulk(points []IntegerPoint)
-}
-
-// AggregateIntegerPoints feeds a slice of IntegerPoint into an
-// aggregator. If the aggregator is a IntegerBulkPointAggregator, it will
-// use the AggregateBulk method.
-func AggregateIntegerPoints(a IntegerPointAggregator, points []IntegerPoint) {
-	switch a := a.(type) {
-	case IntegerBulkPointAggregator:
-		a.AggregateIntegerBulk(points)
-	default:
-		for _, p := range points {
-			a.AggregateInteger(&p)
-		}
-	}
 }
 
 // IntegerPointEmitter produces a single point from an aggregate.
@@ -875,6 +878,33 @@ func (r *IntegerSliceFuncBooleanReducer) Emit() []BooleanPoint {
 	return r.fn(r.points)
 }
 
+// IntegerSumHllReducer returns the HLL sketch for a series, in string form
+type IntegerSumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func NewIntegerSumHllReducer creates a new IntegerSumHllReducer
+func NewIntegerSumHllReducer() *IntegerSumHllReducer {
+	return &IntegerSumHllReducer{plus: hll.NewDefaultPlus()}
+}
+
+// AggregateInteger aggregates a point into the reducer.
+func (r *IntegerSumHllReducer) AggregateInteger(p *IntegerPoint) {
+
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, p.Value)
+	b := buf.Bytes()
+
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *IntegerSumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
+}
+
 // IntegerDistinctReducer returns the distinct points in a series.
 type IntegerDistinctReducer struct {
 	m map[int64]IntegerPoint
@@ -988,20 +1018,6 @@ type UnsignedPointAggregator interface {
 // UnsignedBulkPointAggregator aggregates multiple points at a time.
 type UnsignedBulkPointAggregator interface {
 	AggregateUnsignedBulk(points []UnsignedPoint)
-}
-
-// AggregateUnsignedPoints feeds a slice of UnsignedPoint into an
-// aggregator. If the aggregator is a UnsignedBulkPointAggregator, it will
-// use the AggregateBulk method.
-func AggregateUnsignedPoints(a UnsignedPointAggregator, points []UnsignedPoint) {
-	switch a := a.(type) {
-	case UnsignedBulkPointAggregator:
-		a.AggregateUnsignedBulk(points)
-	default:
-		for _, p := range points {
-			a.AggregateUnsigned(&p)
-		}
-	}
 }
 
 // UnsignedPointEmitter produces a single point from an aggregate.
@@ -1359,6 +1375,33 @@ func (r *UnsignedSliceFuncBooleanReducer) Emit() []BooleanPoint {
 	return r.fn(r.points)
 }
 
+// UnsignedSumHllReducer returns the HLL sketch for a series, in string form
+type UnsignedSumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func NewUnsignedSumHllReducer creates a new UnsignedSumHllReducer
+func NewUnsignedSumHllReducer() *UnsignedSumHllReducer {
+	return &UnsignedSumHllReducer{plus: hll.NewDefaultPlus()}
+}
+
+// AggregateUnsigned aggregates a point into the reducer.
+func (r *UnsignedSumHllReducer) AggregateUnsigned(p *UnsignedPoint) {
+
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, p.Value)
+	b := buf.Bytes()
+
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *UnsignedSumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
+}
+
 // UnsignedDistinctReducer returns the distinct points in a series.
 type UnsignedDistinctReducer struct {
 	m map[uint64]UnsignedPoint
@@ -1472,20 +1515,6 @@ type StringPointAggregator interface {
 // StringBulkPointAggregator aggregates multiple points at a time.
 type StringBulkPointAggregator interface {
 	AggregateStringBulk(points []StringPoint)
-}
-
-// AggregateStringPoints feeds a slice of StringPoint into an
-// aggregator. If the aggregator is a StringBulkPointAggregator, it will
-// use the AggregateBulk method.
-func AggregateStringPoints(a StringPointAggregator, points []StringPoint) {
-	switch a := a.(type) {
-	case StringBulkPointAggregator:
-		a.AggregateStringBulk(points)
-	default:
-		for _, p := range points {
-			a.AggregateString(&p)
-		}
-	}
 }
 
 // StringPointEmitter produces a single point from an aggregate.
@@ -1843,6 +1872,31 @@ func (r *StringSliceFuncBooleanReducer) Emit() []BooleanPoint {
 	return r.fn(r.points)
 }
 
+// StringSumHllReducer returns the HLL sketch for a series, in string form
+type StringSumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func NewStringSumHllReducer creates a new StringSumHllReducer
+func NewStringSumHllReducer() *StringSumHllReducer {
+	return &StringSumHllReducer{plus: hll.NewDefaultPlus()}
+}
+
+// AggregateString aggregates a point into the reducer.
+func (r *StringSumHllReducer) AggregateString(p *StringPoint) {
+
+	b := []byte(p.Value)
+
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *StringSumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
+}
+
 // StringDistinctReducer returns the distinct points in a series.
 type StringDistinctReducer struct {
 	m map[string]StringPoint
@@ -1956,20 +2010,6 @@ type BooleanPointAggregator interface {
 // BooleanBulkPointAggregator aggregates multiple points at a time.
 type BooleanBulkPointAggregator interface {
 	AggregateBooleanBulk(points []BooleanPoint)
-}
-
-// AggregateBooleanPoints feeds a slice of BooleanPoint into an
-// aggregator. If the aggregator is a BooleanBulkPointAggregator, it will
-// use the AggregateBulk method.
-func AggregateBooleanPoints(a BooleanPointAggregator, points []BooleanPoint) {
-	switch a := a.(type) {
-	case BooleanBulkPointAggregator:
-		a.AggregateBooleanBulk(points)
-	default:
-		for _, p := range points {
-			a.AggregateBoolean(&p)
-		}
-	}
 }
 
 // BooleanPointEmitter produces a single point from an aggregate.
@@ -2325,6 +2365,33 @@ func (r *BooleanSliceFuncReducer) AggregateBooleanBulk(points []BooleanPoint) {
 // This method does not clear the points from the internal slice.
 func (r *BooleanSliceFuncReducer) Emit() []BooleanPoint {
 	return r.fn(r.points)
+}
+
+// BooleanSumHllReducer returns the HLL sketch for a series, in string form
+type BooleanSumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func NewBooleanSumHllReducer creates a new BooleanSumHllReducer
+func NewBooleanSumHllReducer() *BooleanSumHllReducer {
+	return &BooleanSumHllReducer{plus: hll.NewDefaultPlus()}
+}
+
+// AggregateBoolean aggregates a point into the reducer.
+func (r *BooleanSumHllReducer) AggregateBoolean(p *BooleanPoint) {
+
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, p.Value)
+	b := buf.Bytes()
+
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *BooleanSumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
 }
 
 // BooleanDistinctReducer returns the distinct points in a series.

--- a/query/functions.gen.go.tmpl
+++ b/query/functions.gen.go.tmpl
@@ -1,9 +1,13 @@
 package query
 
 import (
+"encoding/binary"
+"bytes"
 "sort"
 "time"
 "math/rand"
+
+"github.com/influxdata/influxdb/pkg/estimator/hll"
 )
 
 {{with $types := .}}{{range $k := $types}}
@@ -16,20 +20,6 @@ type {{$k.Name}}PointAggregator interface {
 // {{$k.Name}}BulkPointAggregator aggregates multiple points at a time.
 type {{$k.Name}}BulkPointAggregator interface {
 	Aggregate{{$k.Name}}Bulk(points []{{$k.Name}}Point)
-}
-
-// Aggregate{{$k.Name}}Points feeds a slice of {{$k.Name}}Point into an
-// aggregator. If the aggregator is a {{$k.Name}}BulkPointAggregator, it will
-// use the AggregateBulk method.
-func Aggregate{{$k.Name}}Points(a {{$k.Name}}PointAggregator, points []{{$k.Name}}Point) {
-	switch a := a.(type) {
-	case {{$k.Name}}BulkPointAggregator:
-		a.Aggregate{{$k.Name}}Bulk(points)
-	default:
-		for _, p := range points {
-			a.Aggregate{{$k.Name}}(&p)
-		}
-	}
 }
 
 // {{$k.Name}}PointEmitter produces a single point from an aggregate.
@@ -109,6 +99,35 @@ func (r *{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer)
 	return r.fn(r.points)
 }
 {{end}}
+
+// {{$k.Name}}SumHllReducer returns the HLL sketch for a series, in string form
+type {{$k.Name}}SumHllReducer struct {
+	plus *hll.Plus
+}
+
+// func New{{$k.Name}}SumHllReducer creates a new {{$k.Name}}SumHllReducer
+func New{{$k.Name}}SumHllReducer() *{{$k.Name}}SumHllReducer {
+	return &{{$k.Name}}SumHllReducer{plus:hll.NewDefaultPlus()}
+}
+
+// Aggregate{{$k.Name}} aggregates a point into the reducer.
+func (r *{{$k.Name}}SumHllReducer) Aggregate{{$k.Name}}(p *{{$k.Name}}Point) {
+	{{if eq $k.Type "string"}}
+	b := []byte(p.Value)
+	{{else}}
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, p.Value)
+	b := buf.Bytes()
+	{{end}}
+	r.plus.Add(b)
+}
+
+// Emit emits the distinct points that have been aggregated into the reducer.
+func (r *{{$k.Name}}SumHllReducer) Emit() []StringPoint {
+	return []StringPoint{
+		marshalPlus(r.plus, nil),
+	}
+}
 
 // {{$k.Name}}DistinctReducer returns the distinct points in a series.
 type {{$k.Name}}DistinctReducer struct {

--- a/query/functions.go
+++ b/query/functions.go
@@ -2223,7 +2223,13 @@ func marshalPlus(p *hll.Plus, err error) StringPoint {
 			Value: string(hllPrefix),
 		}
 	}
-	b, _ := p.MarshalBinary() // no possible errors
+	b, err := p.MarshalBinary()
+	if err != nil {
+		return StringPoint{
+			Time:  ZeroTime,
+			Value: string(hllErrorPrefix) + err.Error(),
+		}
+	}
 	hllValue := make([]byte, len(hllPrefix)+base64.StdEncoding.EncodedLen(len(b)))
 	copy(hllValue, hllPrefix)
 	base64.StdEncoding.Encode(hllValue[len(hllPrefix):], b)

--- a/query/functions_test.go
+++ b/query/functions_test.go
@@ -526,6 +526,9 @@ func TestHll_SumAndMergeHll(t *testing.T) {
 		s2.AggregateString(p)
 	}
 	point2 := s2.Emit()
+	// Demonstration of the input: repeatably seeded pseudorandom
+	// stringified integers (so we are testing the counting of unique strings,
+	// not unique integers).
 	require.Equal("17190211103962133664", input[2999].Value)
 
 	checkStringFingerprint := func(prefix string, length int, hash string, check string) {

--- a/query/functions_test.go
+++ b/query/functions_test.go
@@ -1,7 +1,11 @@
 package query_test
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"math"
+	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -9,6 +13,8 @@ import (
 	"github.com/influxdata/influxdb/pkg/deep"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxql"
+	tassert "github.com/stretchr/testify/assert"
+	trequire "github.com/stretchr/testify/require"
 )
 
 func almostEqual(got, exp float64) bool {
@@ -496,4 +502,77 @@ func TestSample_SampleSizeGreaterThanNumPoints(t *testing.T) {
 	if !deep.Equal(ps, points) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(points))
 	}
+}
+
+func TestHll_SumAndMergeHll(t *testing.T) {
+	assert := tassert.New(t)
+	require := trequire.New(t)
+
+	// Make 3000 random strings
+	r := rand.New(rand.NewSource(42))
+	input := make([]*query.StringPoint, 0, 3000)
+	for i := 0; i < 3000; i++ {
+		input = append(input, &query.StringPoint{Value: strconv.FormatUint(r.Uint64(), 10)})
+	}
+
+	// Insert overlapping sections of the same points array to different reducers
+	s1 := query.NewStringSumHllReducer()
+	for _, p := range input[:2000] {
+		s1.AggregateString(p)
+	}
+	point1 := s1.Emit()
+	s2 := query.NewStringSumHllReducer()
+	for _, p := range input[1000:] {
+		s2.AggregateString(p)
+	}
+	point2 := s2.Emit()
+	require.Equal("17190211103962133664", input[2999].Value)
+
+	checkStringFingerprint := func(prefix string, length int, hash string, check string) {
+		assert.Equal(length, len(check))
+		assert.Equal(prefix, check[:len(prefix)])
+		h := sha1.New()
+		h.Write([]byte(check))
+		assert.Equal(hash, fmt.Sprintf("%x", h.Sum(nil)))
+	}
+
+	require.Equal(len(point1), 1)
+	require.Equal(len(point2), 1)
+	checkStringFingerprint("HLL_AhABAAAAAAAAB9BIDQAJAAAUUaKsA4K/AtARkuMBsJwEyp8O",
+		6964, "c59fa799fe8e78ab5347de385bf2a7c5b8085882", point1[0].Value)
+	checkStringFingerprint("HLL_AhABAAAAAAAAB9Db0QAHAAAUaP6aAaSRAoK/Ap70B/xSysEE",
+		6996, "5f1696dfb455baab7fdb56ffd2197d27b09d6dcf", point2[0].Value)
+
+	m := query.NewStringMergeHllReducer()
+	m.AggregateString(&point1[0])
+	m.AggregateString(&point2[0])
+	merged := m.Emit()
+	require.Equal(1, len(merged))
+	checkStringFingerprint("HLL_AhAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAA",
+		87396, "e5320860aa322efe9af268e171df916d2186c75f", merged[0].Value)
+
+	m.AggregateString(&query.StringPoint{
+		Time:  query.ZeroTime,
+		Value: "some random string",
+	})
+	mergedError := m.Emit()
+	// mid-level errors are:
+	require.Equal(1, len(mergedError))
+	assert.Equal("HLLERROR Bad prefix for hll.Plus", mergedError[0].Value)
+
+	c := query.NewCountHllReducer()
+	c.AggregateString(&merged[0])
+	counted := c.Emit()
+	require.Equal(1, len(counted))
+	// Counted 4000 points, 3000 distinct points, answer is 2994 ≈ 3000
+	assert.Equal(uint64(2994), counted[0].Value)
+
+	c.AggregateString(&query.StringPoint{
+		Time:  query.ZeroTime,
+		Value: "HLLERROR Bad prefix for hll.Plus",
+	})
+	counted = c.Emit()
+	require.Equal(1, len(counted))
+	// When we hit marshal/unmarshal errors
+	assert.Equal(uint64(0), counted[0].Value)
 }

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -143,6 +143,13 @@ func (a Iterators) Merge(opt IteratorOptions) (Iterator, error) {
 			Args: call.Args,
 		}
 	}
+	// When merging the sum_hll() function, use merge_hll() to sum the counted points.
+	if call.Name == "sum_hll" {
+		opt.Expr = &influxql.Call{
+			Name: "merge_hll",
+			Args: call.Args,
+		}
+	}
 	return NewCallIterator(itr, opt)
 }
 

--- a/query/iterator_test.go
+++ b/query/iterator_test.go
@@ -1568,6 +1568,66 @@ func TestIterator_EncodeDecode(t *testing.T) {
 	}
 }
 
+// Test implementation of query.IntegerIterator
+type IntegerConstIterator struct {
+	numPoints int
+	time      int64
+	value     int64
+	Closed    bool
+	stats     query.IteratorStats
+	point     query.IntegerPoint
+}
+
+func BenchmarkIterator_Aggregator(b *testing.B) {
+	input := &IntegerConstIterator{
+		numPoints: b.N,
+		Closed:    false,
+		stats:     query.IteratorStats{},
+		point: query.IntegerPoint{
+			Name:  "constPoint",
+			Value: 1,
+		},
+	}
+	opt := query.IteratorOptions{
+		Interval: query.Interval{
+			Duration: 100 * time.Minute,
+		},
+		Expr: &influxql.Call{
+			Name: "count",
+		},
+	}
+
+	counter, err := query.NewCallIterator(input, opt)
+	if err != nil {
+		b.Fatalf("Bad counter: %v", err)
+	}
+
+	b.ResetTimer()
+	point, err := counter.(query.IntegerIterator).Next()
+	if err != nil {
+		b.Fatalf("Unexpected error %v", err)
+	}
+	if point == nil {
+		b.Fatal("Expected point not to be nil")
+	}
+	if point.Value != int64(b.N) {
+		b.Fatalf("Expected %v != %v points", b.N, point.Value)
+	}
+}
+
+func (itr *IntegerConstIterator) Stats() query.IteratorStats { return itr.stats }
+func (itr *IntegerConstIterator) Close() error               { itr.Closed = true; return nil }
+
+// Next returns the next value and shifts it off the beginning of the points slice.
+func (itr *IntegerConstIterator) Next() (*query.IntegerPoint, error) {
+	if itr.numPoints == 0 || itr.Closed {
+		return nil, nil
+	}
+	itr.numPoints--
+	itr.point.Time++
+	return &itr.point, nil
+}
+
 // Test implementation of influxql.FloatIterator
 type FloatIterator struct {
 	Context context.Context

--- a/query/select.go
+++ b/query/select.go
@@ -255,7 +255,7 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 		opt.Interval = Interval{}
 
 		return newHoltWintersIterator(input, opt, int(h.Val), int(m.Val), includeFitData, interval)
-	case "derivative", "non_negative_derivative", "difference", "non_negative_difference", "moving_average", "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_derivative", "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average", "chande_momentum_oscillator", "elapsed":
+	case "count_hll", "derivative", "non_negative_derivative", "difference", "non_negative_difference", "moving_average", "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_derivative", "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average", "chande_momentum_oscillator", "elapsed":
 		if !opt.Interval.IsZero() {
 			if opt.Ascending {
 				opt.StartTime -= int64(opt.Interval.Duration)
@@ -271,6 +271,8 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 		}
 
 		switch expr.Name {
+		case "count_hll":
+			return NewCountHllIterator(input, opt)
 		case "derivative", "non_negative_derivative":
 			interval := opt.DerivativeInterval()
 			isNonNegative := (expr.Name == "non_negative_derivative")
@@ -511,7 +513,7 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 				}
 			}
 			fallthrough
-		case "min", "max", "sum", "first", "last", "mean":
+		case "min", "max", "sum", "first", "last", "mean", "sum_hll", "merge_hll":
 			return b.callIterator(ctx, expr, opt)
 		case "median":
 			opt.Ordered = true

--- a/query/select_test.go
+++ b/query/select_test.go
@@ -17,6 +17,27 @@ import (
 // Second represents a helper for type converting durations.
 const Second = int64(time.Second)
 
+func randomFloatSlice(seed int64, length int) []float64 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]float64, 0, length)
+	for i := 0; i < 3000; i++ {
+		out = append(out, r.Float64())
+	}
+	return out
+}
+
+func floatIterator(fSlice []float64, name, tags string, startTime, step int64) *FloatIterator {
+	p := make([]query.FloatPoint, 0, len(fSlice))
+	currentTime := startTime
+	for _, f := range fSlice {
+		p = append(p, query.FloatPoint{Name: name, Tags: ParseTags(tags), Time: currentTime, Value: f})
+		currentTime += step
+	}
+	return &FloatIterator{
+		Points: p,
+	}
+}
+
 func TestSelect(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
@@ -53,6 +74,30 @@ func TestSelect(t *testing.T) {
 				{Time: 10 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{float64(2)}},
 				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{float64(100)}},
 				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{float64(10)}},
+			},
+		},
+		{
+			name: "count_hll",
+			q:    `SELECT count_hll(sum_hll(value)) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-02T00:00:00Z' GROUP BY time(10s), host fill(none)`,
+			typ:  influxql.Float,
+			itrs: []query.Iterator{
+				floatIterator(randomFloatSlice(42, 2000), "cpu", "region=west,host=A", 0*Second, 1),
+				&FloatIterator{Points: []query.FloatPoint{
+					{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 0 * Second, Value: 20},
+					{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 11 * Second, Value: 3},
+					{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 31 * Second, Value: 100},
+				}},
+				floatIterator(randomFloatSlice(42, 3000)[1000:], "cpu", "region=south,host=A", 0*Second, 1),
+				&FloatIterator{Points: []query.FloatPoint{
+					{Name: "cpu", Tags: ParseTags("region=east,host=B"), Time: 0 * Second, Value: 20},
+				}},
+			},
+			rows: []query.Row{
+				// Note that for the first aggregate there are 2000 points in each series, but only 3000 unique points, 2994 ≈ 3000
+				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{uint64(2994)}},
+				{Time: 10 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{uint64(1)}},
+				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{uint64(1)}},
+				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{uint64(1)}},
 			},
 		},
 		{

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2524,7 +2524,7 @@ func (e *Engine) createCallIterator(ctx context.Context, measurement string, cal
 	if e.index.Type() == tsdb.TSI1IndexName {
 		indexSet := tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
 		seriesOpt := opt
-		if len(opt.Dimensions) == 0 && call.Name == "count" {
+		if len(opt.Dimensions) == 0 && (call.Name == "count" || call.Name == "sum_hll") {
 			// no point ordering the series if we are just counting all of them
 			seriesOpt.Ordered = false
 		}


### PR DESCRIPTION
Closes #717

Adds HyperLogLog operator to influxql to allow computing count-distinct approximately.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)

