### PR TITLE
fix(tsdb): add a new timestamp encoding format

### DIFF
--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -67,7 +67,7 @@ func Test_TimeEncoder_One(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := b[0] >> 4; got != timeCompressedPackedSimple {
+	if got := b[0] >> 4; got != timeCompressedFromZero {
 		t.Fatalf("Wrong encoding used: expected uncompressed, got %v", got)
 	}
 
@@ -132,7 +132,7 @@ func Test_TimeEncoder_Three(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := b[0] >> 4; got != timeCompressedPackedSimple {
+	if got := b[0] >> 4; got != timeCompressedFromZero {
 		t.Fatalf("Wrong encoding used: expected rle, got %v", got)
 	}
 
@@ -514,7 +514,7 @@ func TestTimeEncoder_Count_Simple8(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := b[0] >> 4; got != timeCompressedPackedSimple {
+	if got := b[0] >> 4; got != timeCompressedFromZero {
 		t.Fatalf("Wrong encoding used: expected rle, got %v", got)
 	}
 


### PR DESCRIPTION
Add a new timestamp encoding format that is based on timeCompressedPackedSimple.
In many cases, the timestamp deltas are close but not the same.
So,subtracting their minimum value can optimize the compression ratio.