### PR TITLE
feat: add measurement-level disk usage stats

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// Query logging
 	QueryLogEnabled bool `toml:"query-log-enabled"`
 
+	// Whether to track stats (disk usage) by measurement
+	MeasurementStatsEnabled bool `toml:"measurement-stats-enabled"`
+
 	// Compaction options for tsm1 (descriptions above with defaults)
 	CacheMaxMemorySize             toml.Size     `toml:"cache-max-memory-size"`
 	CacheSnapshotMemorySize        toml.Size     `toml:"cache-snapshot-memory-size"`

--- a/tsdb/engine/tsm1/file_store_key_iterator_test.go
+++ b/tsdb/engine/tsm1/file_store_key_iterator_test.go
@@ -179,6 +179,7 @@ func (*mockTSMFile) Unref()                                          { panic("im
 func (*mockTSMFile) Stats() FileStat                                 { panic("implement me") }
 func (*mockTSMFile) BlockIterator() *BlockIterator                   { panic("implement me") }
 func (*mockTSMFile) Free() error                                     { panic("implement me") }
+func (*mockTSMFile) MeasurementStats() (MeasurementStats, error)     { panic("implement me") }
 
 func (*mockTSMFile) ReadFloatBlockAt(*IndexEntry, *[]FloatValue) ([]FloatValue, error) {
 	panic("implement me")

--- a/tsdb/engine/tsm1/stats.go
+++ b/tsdb/engine/tsm1/stats.go
@@ -1,0 +1,222 @@
+package tsm1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb"
+	"hash/crc32"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/influxdata/influxdb/pkg/binaryutil"
+)
+
+const (
+	// MeasurementMagicNumber is written as the first 4 bytes of a data file to
+	// identify the file as a tsm1 stats file.
+	MeasurementStatsMagicNumber string = "TSS1"
+
+	// MeasurementStatsVersion indicates the version of the TSS1 file format.
+	MeasurementStatsVersion byte = 1
+)
+
+// MeasurementStats represents a set of measurement sizes.
+type MeasurementStats tsdb.MeasurementStats
+
+// NewStats returns a new instance of Stats.
+func NewMeasurementStats() MeasurementStats {
+	return make(MeasurementStats)
+}
+
+// MeasurementNames returns a list of sorted measurement names.
+func (s MeasurementStats) MeasurementNames() []string {
+	a := make([]string, 0, len(s))
+	for name := range s {
+		a = append(a, name)
+	}
+	sort.Strings(a)
+	return a
+}
+
+// Add adds the values of all measurements in other to s.
+func (s MeasurementStats) Add(other MeasurementStats) {
+	for name, v := range other {
+		s[name] += v
+	}
+}
+
+// Sub subtracts the values of all measurements in other from s.
+func (s MeasurementStats) Sub(other MeasurementStats) {
+	for name, v := range other {
+		s[name] -= v
+	}
+}
+
+// ReadFrom reads stats from r in a binary format. Reader must also be an io.ByteReader.
+func (s MeasurementStats) ReadFrom(r io.Reader) (n int64, err error) {
+	br, ok := r.(io.ByteReader)
+	if !ok {
+		return 0, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: ByteReader required")
+	}
+
+	// Read & verify magic.
+	magic := make([]byte, 4)
+	nn, err := io.ReadFull(r, magic)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: cannot read stats magic: %s", err)
+	} else if string(magic) != MeasurementStatsMagicNumber {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: invalid tsm1 stats file")
+	}
+
+	// Read & verify version.
+	version := make([]byte, 1)
+	nn, err = io.ReadFull(r, version)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: cannot read stats version: %s", err)
+	} else if version[0] != MeasurementStatsVersion {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: incompatible tsm1 stats version: %d", version[0])
+	}
+
+	// Read checksum.
+	checksum := make([]byte, 4)
+	nn, err = io.ReadFull(r, checksum)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: cannot read checksum: %s", err)
+	}
+
+	// Read measurement count.
+	measurementN, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: cannot read stats measurement count: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(measurementN))
+
+	// Read measurements.
+	for i := int64(0); i < measurementN; i++ {
+		nn64, err := s.readMeasurementFrom(r)
+		if n += nn64; err != nil {
+			return n, err
+		}
+	}
+
+	// Expect end-of-file.
+	buf := make([]byte, 1)
+	if _, err := r.Read(buf); err != io.EOF {
+		return n, fmt.Errorf("tsm1.MeasurementStats.ReadFrom: file too large, expected EOF")
+	}
+
+	return n, nil
+}
+
+// readMeasurementFrom reads a measurement stat from r in a binary format.
+func (s MeasurementStats) readMeasurementFrom(r io.Reader) (n int64, err error) {
+	br, ok := r.(io.ByteReader)
+	if !ok {
+		return 0, fmt.Errorf("tsm1.MeasurementStats.readMeasurementFrom: ByteReader required")
+	}
+
+	// Read measurement name length.
+	nameLen, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.readMeasurementFrom: cannot read stats measurement name length: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(nameLen))
+
+	// Read measurement name. Use large capacity so it can usually be stack allocated.
+	// Go allocates unescaped variables smaller than 64KB on the stack.
+	name := make([]byte, nameLen)
+	nn, err := io.ReadFull(r, name)
+	if n += int64(nn); err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.readMeasurementFrom: cannot read stats measurement name: %s", err)
+	}
+
+	// Read size.
+	sz, err := binary.ReadVarint(br)
+	if err != nil {
+		return n, fmt.Errorf("tsm1.MeasurementStats.readMeasurementFrom: cannot read stats measurement size: %s", err)
+	}
+	n += int64(binaryutil.VarintSize(sz))
+
+	// Insert into map.
+	s[string(name)] = int(sz)
+
+	return n, nil
+}
+
+// WriteTo writes stats to w in a binary format.
+func (s MeasurementStats) WriteTo(w io.Writer) (n int64, err error) {
+	// Write magic & version.
+	nn, err := io.WriteString(w, MeasurementStatsMagicNumber)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+	nn, err = w.Write([]byte{MeasurementStatsVersion})
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write measurement count.
+	var buf bytes.Buffer
+	b := make([]byte, binary.MaxVarintLen64)
+	if _, err = buf.Write(b[:binary.PutVarint(b, int64(len(s)))]); err != nil {
+		return n, err
+	}
+
+	// Write all measurements in sorted order.
+	for _, name := range s.MeasurementNames() {
+		if _, err := s.writeMeasurementTo(&buf, name, s[name]); err != nil {
+			return n, err
+		}
+	}
+	data := buf.Bytes()
+
+	// Compute & write checksum.
+	if err := binary.Write(w, binary.BigEndian, crc32.ChecksumIEEE(data)); err != nil {
+		return n, err
+	}
+	n += 4
+
+	// Write buffer.
+	nn, err = w.Write(data)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	return n, err
+}
+
+func (s MeasurementStats) writeMeasurementTo(w io.Writer, name string, sz int) (n int64, err error) {
+	// Write measurement name length.
+	buf := make([]byte, binary.MaxVarintLen64)
+	nn, err := w.Write(buf[:binary.PutVarint(buf, int64(len(name)))])
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write measurement name.
+	nn, err = io.WriteString(w, name)
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	// Write size.
+	nn, err = w.Write(buf[:binary.PutVarint(buf, int64(sz))])
+	if n += int64(nn); err != nil {
+		return n, err
+	}
+
+	return n, err
+}
+
+// StatsFilename returns the path to the stats file for a given TSM file path.
+func StatsFilename(tsmPath string) string {
+	if strings.HasSuffix(tsmPath, "."+TmpTSMFileExtension) {
+		tsmPath = strings.TrimSuffix(tsmPath, "."+TmpTSMFileExtension)
+	}
+	if strings.HasSuffix(tsmPath, "."+TSMFileExtension) {
+		tsmPath = strings.TrimSuffix(tsmPath, "."+TSMFileExtension)
+	}
+	return tsmPath + "." + tssFileExtension
+}

--- a/tsdb/engine/tsm1/stats_test.go
+++ b/tsdb/engine/tsm1/stats_test.go
@@ -1,0 +1,41 @@
+package tsm1
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMeasurementStats_WriteTo(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		stats, other := NewMeasurementStats(), NewMeasurementStats()
+		var buf bytes.Buffer
+		if wn, err := stats.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		} else if rn, err := other.ReadFrom(&buf); err != nil {
+			t.Fatal(err)
+		} else if wn != rn {
+			t.Fatalf("byte count mismatch: w=%d r=%d", wn, rn)
+		} else if diff := cmp.Diff(stats, other); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("WithData", func(t *testing.T) {
+		stats, other := NewMeasurementStats(), NewMeasurementStats()
+		stats["cpu"] = 100
+		stats["mem"] = 2000
+
+		var buf bytes.Buffer
+		if wn, err := stats.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		} else if rn, err := other.ReadFrom(&buf); err != nil {
+			t.Fatal(err)
+		} else if wn != rn {
+			t.Fatalf("byte count mismatch: w=%d r=%d", wn, rn)
+		} else if diff := cmp.Diff(stats, other); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -159,7 +159,9 @@ func TestIndexSet_DedupeInmemIndexes(t *testing.T) {
 
 			var indexes []tsdb.Index
 			for i := 0; i < testCase.tsiN; i++ {
-				indexes = append(indexes, MustOpenNewIndex(tsi1.IndexName))
+				newIdx := MustOpenNewIndex(tsi1.IndexName)
+				indexes = append(indexes, newIdx)
+				defer newIdx.Close()
 			}
 			if testCase.inmem1N > 0 {
 				sfile := MustOpenSeriesFile()
@@ -431,8 +433,7 @@ func (i *Index) Close() error {
 	if err := i.sfile.Close(); err != nil {
 		return err
 	}
-	//return os.RemoveAll(i.rootPath)
-	return nil
+	return os.RemoveAll(i.rootPath)
 }
 
 // This benchmark compares the TagSets implementation across index types.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -490,6 +490,19 @@ func (s *Shard) DiskSize() (int64, error) {
 	return size, nil
 }
 
+// MeasurementStats returns the stats for the shard broken down by measurement
+// (currently the only stat is disk size).
+func (s *Shard) MeasurementStats() (MeasurementStats, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	// We don't use engine() because we still want to report the shard's stats
+	// (disk usage by measurement) even if the shard has been disabled.
+	if s._engine == nil {
+		return MeasurementStats{}, ErrEngineClosed
+	}
+	return s._engine.MeasurementStats()
+}
+
 // FieldCreate holds information for a field to create on a measurement.
 type FieldCreate struct {
 	Measurement []byte

--- a/tsdb/usage_stats.go
+++ b/tsdb/usage_stats.go
@@ -1,0 +1,55 @@
+package tsdb
+
+import (
+	"github.com/influxdata/influxdb/models"
+	"sync"
+)
+
+// Thread-safe (synchronized) container for measurement-level information
+// (currently only for disk size)
+type usageStats struct {
+	// fillStats is the next set of stats, it can be filled but not queried.
+	// FinishStats moves fillStats to showStats
+	fillStats map[string]map[string]float64
+	// showStats is the current set of stats available by calling Statistics .
+	showStats map[string]map[string]float64
+	mu        sync.Mutex
+}
+
+func (s *usageStats) AddDiskSize(database, measurement string, stat float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fillStats == nil {
+		s.fillStats = make(map[string]map[string]float64)
+	}
+	if _, ok := s.fillStats[database]; !ok {
+		s.fillStats[database] = make(map[string]float64)
+	}
+	s.fillStats[database][measurement] += stat
+}
+
+func (s *usageStats) FinishedAdding() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.showStats = s.fillStats
+	s.fillStats = nil
+}
+
+func (s *usageStats) Statistics(tags map[string]string) []models.Statistic {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Add all the series and measurements cardinality estimations.
+	statistics := make([]models.Statistic, 0)
+	for database, measures := range s.showStats {
+		for measure, val := range measures {
+			statistics = append(statistics, models.Statistic{
+				Name: "usage",
+				Tags: models.StatisticTags{"database": database, "measurement": measure}.Merge(tags),
+				Values: map[string]interface{}{
+					"disksize": val,
+				},
+			})
+		}
+	}
+	return statistics
+}

--- a/tsdb/usage_stats_test.go
+++ b/tsdb/usage_stats_test.go
@@ -1,0 +1,55 @@
+package tsdb
+
+import (
+	"github.com/influxdata/influxdb/models"
+	tassert "github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+)
+
+func Test_usageStats(t *testing.T) {
+	assert := tassert.New(t)
+	var testStats usageStats
+	tags := map[string]string{
+		"host": "host-1",
+	}
+
+	// Len and Statistics are safe for uninitialized variables
+	assert.Equal([]models.Statistic{}, testStats.Statistics(tags))
+
+	// Statistics are available after some AddDiskSize calls
+	testStats.AddDiskSize("telegraf", "cpu", 10)
+	testStats.AddDiskSize("telegraf", "diskio", 9.3)
+	testStats.AddDiskSize("telegraf", "cpu", 8)
+	testStats.AddDiskSize("fitbit", "heartrate", 7)
+	testStats.FinishedAdding()
+	stats := testStats.Statistics(tags)
+	// Sort slices for comparison - no defined sort order
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].Tags["database"] != stats[j].Tags["database"] {
+			return stats[i].Tags["database"] < stats[j].Tags["database"]
+		}
+		return stats[i].Tags["measurement"] < stats[j].Tags["measurement"]
+	})
+	assert.Equal([]models.Statistic{
+		models.Statistic{
+			Name:   "usage",
+			Tags:   map[string]string{"database": "fitbit", "measurement": "heartrate", "host": "host-1"},
+			Values: map[string]interface{}{"disksize": 7.0},
+		},
+		models.Statistic{
+			Name:   "usage",
+			Tags:   map[string]string{"database": "telegraf", "measurement": "cpu", "host": "host-1"},
+			Values: map[string]interface{}{"disksize": 18.0},
+		},
+		models.Statistic{
+			Name:   "usage",
+			Tags:   map[string]string{"database": "telegraf", "measurement": "diskio", "host": "host-1"},
+			Values: map[string]interface{}{"disksize": 9.3},
+		},
+	}, stats)
+
+	// Flip to the next set of statistics - it's empty
+	testStats.FinishedAdding()
+	assert.Equal([]models.Statistic{}, testStats.Statistics(tags))
+}


### PR DESCRIPTION
Most of the logic for new files is taking from cloud 2.0.

Backfilling of old files + the ability to turn off statistics completely
via configuration is added.

Closes #20635

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
