### PR TITLE
fix(cmd/influx): allow for creating users without initial passwords in `influx user create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20578](https://github.com/influxdata/influxdb/pull/20578): Respect the --skip-verify flag when running `influx query`.
 1. [20495](https://github.com/influxdata/influxdb/pull/20495): Update Flux functions list in UI to reflect that `v1` package was renamed to `schema`.
 1. [20669](https://github.com/influxdata/influxdb/pull/20669): Remove blank lines from payloads sent by `influx write`.
-1. [20657](https://github.com/influxdata/influxdb/pull/20657): Decouple setting initial password from initial org membership in `influx user create`.
+1. [20657](https://github.com/influxdata/influxdb/pull/20657): Allow for creating users without initial passwords in `influx user create`.
 
 ## v2.0.3 [2020-12-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Replacement `tsi1` indexes will be automatically generated on startup for shards
 1. [20578](https://github.com/influxdata/influxdb/pull/20578): Respect the --skip-verify flag when running `influx query`.
 1. [20495](https://github.com/influxdata/influxdb/pull/20495): Update Flux functions list in UI to reflect that `v1` package was renamed to `schema`.
 1. [20669](https://github.com/influxdata/influxdb/pull/20669): Remove blank lines from payloads sent by `influx write`.
+1. [20657](https://github.com/influxdata/influxdb/pull/20657): Decouple setting initial password from initial org membership in `influx user create`.
 
 ## v2.0.3 [2020-12-14]
 

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -180,7 +180,7 @@ func (b *cmdUserBuilder) cmdCreateRunEFn(*cobra.Command, []string) error {
 
 	conf := &ilogger.Config{
 		Level:  zapcore.WarnLevel,
-		Format: "logfmt",
+		Format: "auto",
 	}
 	if b.json {
 		conf.Format = "json"
@@ -208,21 +208,19 @@ func (b *cmdUserBuilder) cmdCreateRunEFn(*cobra.Command, []string) error {
 	}
 
 	orgID, err := b.org.getID(dep.orgSvc)
-	if orgID != 0 && err == nil {
+	if err == nil {
 		err = dep.urmSVC.CreateUserResourceMapping(context.Background(), &influxdb.UserResourceMapping{
 			UserID:       user.ID,
 			UserType:     influxdb.Member,
 			ResourceType: influxdb.OrgsResourceType,
 			ResourceID:   orgID,
 		})
-	} else {
-		log.Warn("Initial org membership not set for user, use `influx org members add` to set it", zap.String("user", b.name))
 	}
 	if err != nil {
 		if b.password != "" {
 			log.Warn("Hit error before attempting to set password, use `influx user password` to retry", zap.String("user", b.name))
 		}
-		return fmt.Errorf("failed adding user %q to org %q, use `influx org members add` to retry: %w", b.name, orgID, err)
+		return fmt.Errorf("failed setting org membership for user %q, use `influx org members add` to retry: %w", b.name, err)
 	}
 
 	if b.password != "" {


### PR DESCRIPTION
Closes #20645 

I manually tested the case of setting a password without specifying an org, it's tough to unit-test because the org-flag helpers are coded to read a global config file as a fallback when no flags are passed in.