### PR TITLE
refactor(cmd/influx): clean up existing tests for `influx write`

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -541,7 +541,7 @@ func (o *organization) getID(orgSVC influxdb.OrganizationService) (influxdb.ID, 
 
 func (o *organization) validOrgFlags(f *globalFlags) error {
 	if o.id == "" && o.name == "" && f != nil {
-		o.name = flags.config().Org
+		o.name = f.config().Org
 	}
 
 	if o.id == "" && o.name == "" {

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -28,7 +28,14 @@ const (
 	inputFormatLineProtocol = "lp"
 )
 
-type writeFlagsType struct {
+type buildWriteSvcFn func(builder *writeFlagsBuilder) platform.WriteService
+
+type writeFlagsBuilder struct {
+	genericCLIOpts
+	*globalFlags
+
+	svcFn buildWriteSvcFn
+
 	org                        organization
 	BucketID                   string
 	Bucket                     string
@@ -47,25 +54,49 @@ type writeFlagsType struct {
 	RateLimit                  string
 }
 
-var writeFlags writeFlagsType
+func newWriteFlagsBuilder(svcFn buildWriteSvcFn, f *globalFlags, opt genericCLIOpts) *writeFlagsBuilder {
+	return &writeFlagsBuilder{
+		genericCLIOpts: opt,
+		globalFlags:    f,
+		svcFn:          svcFn,
+	}
+}
 
 func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
-	cmd := opt.newCmd("write", fluxWriteF, true)
+	builder := newWriteFlagsBuilder(newBatchingWriteService, f, opt)
+	return builder.cmd()
+}
+
+func newBatchingWriteService(b *writeFlagsBuilder) platform.WriteService {
+	ac := b.config()
+	return &write.Batcher{
+		Service: &ihttp.WriteService{
+			Addr:               ac.Host,
+			Token:              ac.Token,
+			Precision:          b.Precision,
+			InsecureSkipVerify: b.skipVerify,
+		},
+		MaxLineLength: b.MaxLineLength,
+	}
+}
+
+func (b *writeFlagsBuilder) cmd() *cobra.Command {
+	cmd := b.newCmd("write", b.writeRunE, true)
 	cmd.Args = cobra.MaximumNArgs(1)
 	cmd.Short = "Write points to InfluxDB"
 	cmd.Long = `Write data to InfluxDB via stdin, or add an entire file specified with the -f flag`
 
-	f.registerFlags(opt.viper, cmd)
-	writeFlags.org.register(opt.viper, cmd, true)
+	b.registerFlags(b.viper, cmd)
+	b.org.register(b.viper, cmd, true)
 	opts := flagOpts{
 		{
-			DestP:      &writeFlags.BucketID,
+			DestP:      &b.BucketID,
 			Flag:       "bucket-id",
 			Desc:       "The ID of destination bucket",
 			Persistent: true,
 		},
 		{
-			DestP:      &writeFlags.Bucket,
+			DestP:      &b.Bucket,
 			Flag:       "bucket",
 			Short:      'b',
 			EnvVar:     "BUCKET_NAME",
@@ -73,7 +104,7 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 			Persistent: true,
 		},
 		{
-			DestP:      &writeFlags.Precision,
+			DestP:      &b.Precision,
 			Flag:       "precision",
 			Short:      'p',
 			Default:    "ns",
@@ -81,67 +112,67 @@ func cmdWrite(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 			Persistent: true,
 		},
 	}
-	opts.mustRegister(opt.viper, cmd)
-	cmd.PersistentFlags().StringVar(&writeFlags.Format, "format", "", "Input format, either lp (Line Protocol) or csv (Comma Separated Values). Defaults to lp unless '.csv' extension")
-	cmd.PersistentFlags().StringArrayVar(&writeFlags.Headers, "header", []string{}, "Header prepends lines to input data; Example --header HEADER1 --header HEADER2")
-	cmd.PersistentFlags().StringArrayVarP(&writeFlags.Files, "file", "f", []string{}, "The path to the file to import")
-	cmd.PersistentFlags().StringArrayVarP(&writeFlags.URLs, "url", "u", []string{}, "The URL to import data from")
-	cmd.PersistentFlags().BoolVar(&writeFlags.Debug, "debug", false, "Log CSV columns to stderr before reading data rows")
-	cmd.PersistentFlags().BoolVar(&writeFlags.SkipRowOnError, "skipRowOnError", false, "Log CSV data errors to stderr and continue with CSV processing")
-	cmd.PersistentFlags().IntVar(&writeFlags.SkipHeader, "skipHeader", 0, "Skip the first <n> rows from input data")
-	cmd.PersistentFlags().IntVar(&writeFlags.MaxLineLength, "max-line-length", 16_000_000, "Specifies the maximum number of bytes that can be read for a single line")
+	opts.mustRegister(b.viper, cmd)
+	cmd.PersistentFlags().StringVar(&b.Format, "format", "", "Input format, either lp (Line Protocol) or csv (Comma Separated Values). Defaults to lp unless '.csv' extension")
+	cmd.PersistentFlags().StringArrayVar(&b.Headers, "header", []string{}, "Header prepends lines to input data; Example --header HEADER1 --header HEADER2")
+	cmd.PersistentFlags().StringArrayVarP(&b.Files, "file", "f", []string{}, "The path to the file to import")
+	cmd.PersistentFlags().StringArrayVarP(&b.URLs, "url", "u", []string{}, "The URL to import data from")
+	cmd.PersistentFlags().BoolVar(&b.Debug, "debug", false, "Log CSV columns to stderr before reading data rows")
+	cmd.PersistentFlags().BoolVar(&b.SkipRowOnError, "skipRowOnError", false, "Log CSV data errors to stderr and continue with CSV processing")
+	cmd.PersistentFlags().IntVar(&b.SkipHeader, "skipHeader", 0, "Skip the first <n> rows from input data")
+	cmd.PersistentFlags().IntVar(&b.MaxLineLength, "max-line-length", 16_000_000, "Specifies the maximum number of bytes that can be read for a single line")
 	cmd.Flag("skipHeader").NoOptDefVal = "1" // skipHeader flag value is optional, skip the first header when unspecified
-	cmd.PersistentFlags().BoolVar(&writeFlags.IgnoreDataTypeInColumnName, "xIgnoreDataTypeInColumnName", false, "Ignores dataType which could be specified after ':' in column name")
+	cmd.PersistentFlags().BoolVar(&b.IgnoreDataTypeInColumnName, "xIgnoreDataTypeInColumnName", false, "Ignores dataType which could be specified after ':' in column name")
 	cmd.PersistentFlags().MarkHidden("xIgnoreDataTypeInColumnName") // should be used only upon explicit advice
-	cmd.PersistentFlags().StringVar(&writeFlags.Encoding, "encoding", "UTF-8", "Character encoding of input files or stdin")
-	cmd.PersistentFlags().StringVar(&writeFlags.ErrorsFile, "errors-file", "", "The path to the file to write rejected rows to")
-	cmd.PersistentFlags().StringVar(&writeFlags.RateLimit, "rate-limit", "", "Throttles write, examples: \"5 MB / 5 min\" , \"17kBs\". \"\" (default) disables throttling.")
+	cmd.PersistentFlags().StringVar(&b.Encoding, "encoding", "UTF-8", "Character encoding of input files or stdin")
+	cmd.PersistentFlags().StringVar(&b.ErrorsFile, "errors-file", "", "The path to the file to write rejected rows to")
+	cmd.PersistentFlags().StringVar(&b.RateLimit, "rate-limit", "", "Throttles write, examples: \"5 MB / 5 min\" , \"17kBs\". \"\" (default) disables throttling.")
 
-	cmdDryRun := opt.newCmd("dryrun", fluxWriteDryrunF, false)
+	cmdDryRun := b.newCmd("dryrun", b.writeDryrunE, false)
 	cmdDryRun.Args = cobra.MaximumNArgs(1)
 	cmdDryRun.Short = "Write to stdout instead of InfluxDB"
 	cmdDryRun.Long = `Write protocol lines to stdout instead of InfluxDB. Troubleshoot conversion from CSV to line protocol.`
-	f.registerFlags(opt.viper, cmdDryRun)
+	b.registerFlags(b.viper, cmdDryRun)
 	cmd.AddCommand(cmdDryRun)
 	return cmd
 }
 
-func (writeFlags *writeFlagsType) dump(args []string) {
-	if writeFlags.Debug {
-		log.Printf("WriteFlags%+v args:%v", *writeFlags, args)
+func (b *writeFlagsBuilder) dump(args []string) {
+	if b.Debug {
+		log.Printf("WriteFlags%+v args:%v", *b, args)
 	}
 }
 
 // createLineReader uses writeFlags and cli arguments to create a reader that produces line protocol
-func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cobra.Command, args []string) (io.Reader, io.Closer, error) {
-	files := writeFlags.Files
+func (b *writeFlagsBuilder) createLineReader(ctx context.Context, cmd *cobra.Command, args []string) (io.Reader, io.Closer, error) {
+	files := b.Files
 	if len(args) > 0 && len(args[0]) > 1 && args[0][0] == '@' {
 		// backward compatibility: @ in arg denotes a file
 		files = append(files, args[0][1:])
 		args = args[:0]
 	}
 
-	readers := make([]io.Reader, 0, 2*len(writeFlags.Headers)+2*len(files)+2*len(writeFlags.URLs)+1)
-	closers := make([]io.Closer, 0, len(files)+len(writeFlags.URLs))
+	readers := make([]io.Reader, 0, 2*len(b.Headers)+2*len(files)+2*len(b.URLs)+1)
+	closers := make([]io.Closer, 0, len(files)+len(b.URLs))
 
 	// validate input format
-	if len(writeFlags.Format) > 0 && writeFlags.Format != inputFormatLineProtocol && writeFlags.Format != inputFormatCsv {
-		return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("unsupported input format: %s", writeFlags.Format)
+	if len(b.Format) > 0 && b.Format != inputFormatLineProtocol && b.Format != inputFormatCsv {
+		return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("unsupported input format: %s", b.Format)
 	}
 
 	// validate and setup decoding of files/stdin if encoding is supplied
-	decode, err := csv2lp.CreateDecoder(writeFlags.Encoding)
+	decode, err := csv2lp.CreateDecoder(b.Encoding)
 	if err != nil {
 		return nil, csv2lp.MultiCloser(closers...), err
 	}
 
 	// prepend header lines
-	if len(writeFlags.Headers) > 0 {
-		for _, header := range writeFlags.Headers {
+	if len(b.Headers) > 0 {
+		for _, header := range b.Headers {
 			readers = append(readers, strings.NewReader(header), strings.NewReader("\n"))
 		}
-		if len(writeFlags.Format) == 0 {
-			writeFlags.Format = inputFormatCsv
+		if len(b.Format) == 0 {
+			b.Format = inputFormatCsv
 		}
 	}
 
@@ -154,16 +185,16 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 			}
 			closers = append(closers, f)
 			readers = append(readers, decode(f), strings.NewReader("\n"))
-			if len(writeFlags.Format) == 0 && strings.HasSuffix(file, ".csv") {
-				writeFlags.Format = inputFormatCsv
+			if len(b.Format) == 0 && strings.HasSuffix(file, ".csv") {
+				b.Format = inputFormatCsv
 			}
 		}
 	}
 
 	// #18349 allow URL data sources, a simple alternative to `curl -f -s http://... | influx write ...`
-	if len(writeFlags.URLs) > 0 {
+	if len(b.URLs) > 0 {
 		client := http.DefaultClient
-		for _, addr := range writeFlags.URLs {
+		for _, addr := range b.URLs {
 			u, err := url.Parse(addr)
 			if err != nil {
 				return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to open %q: %v", addr, err)
@@ -181,9 +212,9 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 				return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to open %q: response status_code=%d", addr, resp.StatusCode)
 			}
 			readers = append(readers, decode(resp.Body), strings.NewReader("\n"))
-			if len(writeFlags.Format) == 0 &&
+			if len(b.Format) == 0 &&
 				(strings.HasSuffix(u.Path, ".csv") || strings.HasPrefix(resp.Header.Get("Content-Type"), "text/csv")) {
-				writeFlags.Format = inputFormatCsv
+				b.Format = inputFormatCsv
 			}
 		}
 	}
@@ -203,12 +234,12 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 	}
 
 	// skipHeader lines when set
-	if writeFlags.SkipHeader != 0 {
+	if b.SkipHeader != 0 {
 		// find the last non-string reader (stdin or file)
 		for i := len(readers) - 1; i >= 0; i-- {
 			_, stringReader := readers[i].(*strings.Reader)
 			if !stringReader { // ignore headers and new lines
-				readers[i] = csv2lp.SkipHeaderLinesReader(writeFlags.SkipHeader, readers[i])
+				readers[i] = csv2lp.SkipHeaderLinesReader(b.SkipHeader, readers[i])
 				break
 			}
 		}
@@ -217,10 +248,10 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 	// create writer for errors-file, if supplied
 	var errorsFile *csv.Writer
 	var rowSkippedListener func(*csv2lp.CsvToLineReader, error, []string)
-	if writeFlags.ErrorsFile != "" {
-		writer, err := os.Create(writeFlags.ErrorsFile)
+	if b.ErrorsFile != "" {
+		writer, err := os.Create(b.ErrorsFile)
 		if err != nil {
-			return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to create %q: %v", writeFlags.ErrorsFile, err)
+			return nil, csv2lp.MultiCloser(closers...), fmt.Errorf("failed to create %q: %v", b.ErrorsFile, err)
 		}
 		closers = append(closers, writer)
 		errorsFile = csv.NewWriter(writer)
@@ -237,18 +268,18 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 
 	// concatenate readers
 	r := io.MultiReader(readers...)
-	if writeFlags.Format == inputFormatCsv {
+	if b.Format == inputFormatCsv {
 		csvReader := csv2lp.CsvToLineProtocol(r)
-		csvReader.LogTableColumns(writeFlags.Debug)
-		csvReader.SkipRowOnError(writeFlags.SkipRowOnError)
-		csvReader.Table.IgnoreDataTypeInColumnName(writeFlags.IgnoreDataTypeInColumnName)
+		csvReader.LogTableColumns(b.Debug)
+		csvReader.SkipRowOnError(b.SkipRowOnError)
+		csvReader.Table.IgnoreDataTypeInColumnName(b.IgnoreDataTypeInColumnName)
 		// change LineNumber to report file/stdin line numbers properly
-		csvReader.LineNumber = writeFlags.SkipHeader - len(writeFlags.Headers)
+		csvReader.LineNumber = b.SkipHeader - len(b.Headers)
 		csvReader.RowSkipped = rowSkippedListener
 		r = csvReader
 	}
 	// throttle reader if requested
-	rateLimit, err := ToBytesPerSecond(writeFlags.RateLimit)
+	rateLimit, err := ToBytesPerSecond(b.RateLimit)
 	if err != nil {
 		return nil, csv2lp.MultiCloser(closers...), err
 	}
@@ -264,18 +295,18 @@ func (writeFlags *writeFlagsType) createLineReader(ctx context.Context, cmd *cob
 	return r, csv2lp.MultiCloser(closers...), nil
 }
 
-func fluxWriteF(cmd *cobra.Command, args []string) error {
-	writeFlags.dump(args) // print flags when in Debug mode
+func (b *writeFlagsBuilder) writeRunE(cmd *cobra.Command, args []string) error {
+	b.dump(args) // print flags when in Debug mode
 	// validate InfluxDB flags
-	if err := writeFlags.org.validOrgFlags(&flags); err != nil {
+	if err := b.org.validOrgFlags(b.globalFlags); err != nil {
 		return err
 	}
 
-	if writeFlags.Bucket != "" && writeFlags.BucketID != "" {
+	if b.Bucket != "" && b.BucketID != "" {
 		return fmt.Errorf("please specify one of bucket or bucket-id")
 	}
 
-	if !models.ValidPrecision(writeFlags.Precision) {
+	if !models.ValidPrecision(b.Precision) {
 		return fmt.Errorf("invalid precision")
 	}
 
@@ -284,30 +315,30 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 		err    error
 	)
 
-	if writeFlags.BucketID != "" {
-		filter.ID, err = platform.IDFromString(writeFlags.BucketID)
+	if b.BucketID != "" {
+		filter.ID, err = platform.IDFromString(b.BucketID)
 		if err != nil {
 			return fmt.Errorf("failed to decode bucket-id: %v", err)
 		}
 	}
-	if writeFlags.Bucket != "" {
-		filter.Name = &writeFlags.Bucket
+	if b.Bucket != "" {
+		filter.Name = &b.Bucket
 	}
 
-	if writeFlags.org.id != "" {
-		filter.OrganizationID, err = platform.IDFromString(writeFlags.org.id)
+	if b.org.id != "" {
+		filter.OrganizationID, err = platform.IDFromString(b.org.id)
 		if err != nil {
 			return fmt.Errorf("failed to decode org-id id: %v", err)
 		}
 	}
-	if writeFlags.org.name != "" {
-		filter.Org = &writeFlags.org.name
+	if b.org.name != "" {
+		filter.Org = &b.org.name
 	}
 
 	ctx := signals.WithStandardSignals(context.Background())
 
 	// create line reader
-	r, closer, err := writeFlags.createLineReader(ctx, cmd, args)
+	r, closer, err := b.createLineReader(ctx, cmd, args)
 	if closer != nil {
 		defer closer.Close()
 	}
@@ -315,17 +346,7 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ac := flags.config()
-	// write to InfluxDB
-	s := write.Batcher{
-		Service: &ihttp.WriteService{
-			Addr:               ac.Host,
-			Token:              ac.Token,
-			Precision:          writeFlags.Precision,
-			InsecureSkipVerify: flags.skipVerify,
-		},
-		MaxLineLength: writeFlags.MaxLineLength,
-	}
+	s := b.svcFn(b)
 	if err := s.WriteTo(ctx, filter, r); err != nil && err != context.Canceled {
 		return fmt.Errorf("failed to write data: %v", err)
 	}
@@ -333,11 +354,11 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func fluxWriteDryrunF(cmd *cobra.Command, args []string) error {
-	writeFlags.dump(args) // print flags when in Debug mode
+func (b *writeFlagsBuilder) writeDryrunE(cmd *cobra.Command, args []string) error {
+	b.dump(args) // print flags when in Debug mode
 	// create line reader
 	ctx := signals.WithStandardSignals(context.Background())
-	r, closer, err := writeFlags.createLineReader(ctx, cmd, args)
+	r, closer, err := b.createLineReader(ctx, cmd, args)
 	if closer != nil {
 		defer closer.Close()
 	}


### PR DESCRIPTION
Before we start adding new functionality to `influx write`, I wanted to give the existing tests a facelift.