### PR TITLE
feat: ingress metrics by login

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -645,7 +645,10 @@ func (s *Server) stopProfile() error {
 type monitorPointsWriter coordinator.PointsWriter
 
 func (pw *monitorPointsWriter) WritePoints(database, retentionPolicy string, points models.Points) error {
-	return (*coordinator.PointsWriter)(pw).WritePointsPrivileged(database, retentionPolicy, models.ConsistencyLevelAny, points)
+	writeCtx := tsdb.WriteContext{
+		UserId: tsdb.MonitorUser,
+	}
+	return (*coordinator.PointsWriter)(pw).WritePointsPrivileged(writeCtx, database, retentionPolicy, models.ConsistencyLevelAny, points)
 }
 
 func raftDBExists(dir string) error {

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -57,7 +57,7 @@ type PointsWriter struct {
 
 	TSDBStore interface {
 		CreateShard(database, retentionPolicy string, shardID uint64, enabled bool) error
-		WriteToShard(shardID uint64, points []models.Point) error
+		WriteToShard(ctx tsdb.WriteContext, shardID uint64, points []models.Point) error
 	}
 
 	subPoints []chan<- *WritePointsRequest
@@ -280,15 +280,26 @@ func (l sgList) Append(sgi meta.ShardGroupInfo) sgList {
 // a cluster structure for information. This is to avoid a circular dependency.
 // It is used for 'SELECT INTO' statements
 func (w *PointsWriter) WritePointsInto(p *IntoWriteRequest) error {
-	return w.WritePointsPrivileged(p.Database, p.RetentionPolicy, models.ConsistencyLevelOne, p.Points)
+	// TODO: assign the correct original user for select into statements
+	writeCtx := tsdb.WriteContext{
+		UserId: tsdb.SelectIntoUser,
+	}
+	return w.WritePointsPrivileged(writeCtx, p.Database, p.RetentionPolicy, models.ConsistencyLevelOne, p.Points)
 }
 
 // A wrapper for WritePointsPrivileged() - user is only required for clustering
 func (w *PointsWriter) WritePoints(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, user meta.User, points []models.Point) error {
-	return w.WritePointsPrivileged(database, retentionPolicy, consistencyLevel, points)
+	userID := tsdb.UnknownUser
+	if user != nil {
+		userID = user.ID()
+	}
+	writeCtx := tsdb.WriteContext{
+		UserId: userID,
+	}
+	return w.WritePointsPrivileged(writeCtx, database, retentionPolicy, consistencyLevel, points)
 }
 
-func (w *PointsWriter) WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+func (w *PointsWriter) WritePointsPrivileged(writeCtx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 	atomic.AddInt64(&w.stats.WriteReq, 1)
 	atomic.AddInt64(&w.stats.PointWriteReq, int64(len(points)))
 
@@ -308,13 +319,13 @@ func (w *PointsWriter) WritePointsPrivileged(database, retentionPolicy string, c
 	// Write each shard in it's own goroutine and return as soon as one fails.
 	ch := make(chan error, len(shardMappings.Points))
 	for shardID, points := range shardMappings.Points {
-		go func(shard *meta.ShardInfo, database, retentionPolicy string, points []models.Point) {
-			err := w.writeToShard(shard, database, retentionPolicy, points)
+		go func(writeCtx tsdb.WriteContext, shard *meta.ShardInfo, database, retentionPolicy string, points []models.Point) {
+			err := w.writeToShard(writeCtx, shard, database, retentionPolicy, points)
 			if err == tsdb.ErrShardDeletion {
 				err = tsdb.PartialWriteError{Reason: fmt.Sprintf("shard %d is pending deletion", shard.ID), Dropped: len(points)}
 			}
 			ch <- err
-		}(shardMappings.Shards[shardID], database, retentionPolicy, points)
+		}(writeCtx, shardMappings.Shards[shardID], database, retentionPolicy, points)
 	}
 
 	// Send points to subscriptions if possible.
@@ -364,10 +375,10 @@ func (w *PointsWriter) WritePointsPrivileged(database, retentionPolicy string, c
 }
 
 // writeToShards writes points to a shard.
-func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPolicy string, points []models.Point) error {
+func (w *PointsWriter) writeToShard(writeCtx tsdb.WriteContext, shard *meta.ShardInfo, database, retentionPolicy string, points []models.Point) error {
 	atomic.AddInt64(&w.stats.PointWriteReqLocal, int64(len(points)))
 	// Except tsdb.ErrShardNotFound no error can be handled here
-	if err := w.TSDBStore.WriteToShard(shard.ID, points); err == tsdb.ErrShardNotFound {
+	if err := w.TSDBStore.WriteToShard(writeCtx, shard.ID, points); err == tsdb.ErrShardNotFound {
 		// Shard doesn't exist -- lets create it and try again..
 
 		// If we've written to shard that should exist on the current node, but the
@@ -380,7 +391,7 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 		}
 
 		// Now that we've created the shard, try to write to it again.
-		if err := w.TSDBStore.WriteToShard(shard.ID, points); err != nil {
+		if err := w.TSDBStore.WriteToShard(writeCtx, shard.ID, points); err != nil {
 			w.Logger.Info("Write failed", zap.Uint64("shard", shard.ID), zap.Error(err))
 			atomic.AddInt64(&w.stats.WriteErr, 1)
 			return err

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -319,7 +319,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		var mu sync.Mutex
 
 		store := &fakeStore{
-			WriteFn: func(shardID uint64, points []models.Point) error {
+			WriteFn: func(_ tsdb.WriteContext, shardID uint64, points []models.Point) error {
 				mu.Lock()
 				defer mu.Unlock()
 				return theTest.err[0]
@@ -346,7 +346,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		c.Open()
 		defer c.Close()
 
-		err := c.WritePointsPrivileged(pr.Database, pr.RetentionPolicy, models.ConsistencyLevelOne, pr.Points)
+		err := c.WritePointsPrivileged(tsdb.WriteContext{}, pr.Database, pr.RetentionPolicy, models.ConsistencyLevelOne, pr.Points)
 		if err == nil && test.expErr != nil {
 			t.Errorf("PointsWriter.WritePointsPrivileged(): '%s' error: got %v, exp %v", test.name, err, test.expErr)
 		}
@@ -395,7 +395,7 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 	var mu sync.Mutex
 
 	store := &fakeStore{
-		WriteFn: func(shardID uint64, points []models.Point) error {
+		WriteFn: func(_ tsdb.WriteContext, shardID uint64, points []models.Point) error {
 			mu.Lock()
 			defer mu.Unlock()
 			return nil
@@ -422,7 +422,7 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 	c.Open()
 	defer c.Close()
 
-	err := c.WritePointsPrivileged(pr.Database, pr.RetentionPolicy, models.ConsistencyLevelOne, pr.Points)
+	err := c.WritePointsPrivileged(tsdb.WriteContext{}, pr.Database, pr.RetentionPolicy, models.ConsistencyLevelOne, pr.Points)
 	if _, ok := err.(tsdb.PartialWriteError); !ok {
 		t.Errorf("PointsWriter.WritePoints(): got %v, exp %v", err, tsdb.PartialWriteError{})
 	}
@@ -549,12 +549,12 @@ func TestBufferedPointsWriter(t *testing.T) {
 var shardID uint64
 
 type fakeStore struct {
-	WriteFn       func(shardID uint64, points []models.Point) error
+	WriteFn       func(ctx tsdb.WriteContext, shardID uint64, points []models.Point) error
 	CreateShardfn func(database, retentionPolicy string, shardID uint64, enabled bool) error
 }
 
-func (f *fakeStore) WriteToShard(shardID uint64, points []models.Point) error {
-	return f.WriteFn(shardID, points)
+func (f *fakeStore) WriteToShard(ctx tsdb.WriteContext, shardID uint64, points []models.Point) error {
+	return f.WriteFn(ctx, shardID, points)
 }
 
 func (f *fakeStore) CreateShard(database, retentionPolicy string, shardID uint64, enabled bool) error {

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1363,7 +1363,7 @@ type IntoWriteRequest struct {
 // TSDBStore is an interface for accessing the time series data store.
 type TSDBStore interface {
 	CreateShard(database, policy string, shardID uint64, enabled bool) error
-	WriteToShard(shardID uint64, points []models.Point) error
+	WriteToShard(writeCtx tsdb.WriteContext, shardID uint64, points []models.Point) error
 
 	RestoreShard(id uint64, r io.Reader) error
 	BackupShard(id uint64, since time.Time, w io.Writer) error

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -67,6 +67,12 @@
   # log any sensitive data contained within a query.
   # query-log-enabled = true
 
+  # It is possible to collect statistics of points written per-measurement and/or per-login.
+  # These can be accessed via the monitoring subsystem.
+  # ingress-metric-by-measurement-enabled = false
+  # ingress-metric-by-login-enabled = false
+
+
   # Provides more error checking. For example, SELECT INTO will err out inserting an +/-Inf value
   # rather than silently failing.
   # strict-error-handling = false

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -46,7 +46,7 @@ type TSDBStoreMock struct {
 	TagKeysFn                 func(auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
 	TagValuesFn               func(auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
 	WithLoggerFn              func(log *zap.Logger)
-	WriteToShardFn            func(shardID uint64, points []models.Point) error
+	WriteToShardFn            func(ctx tsdb.WriteContext, shardID uint64, points []models.Point) error
 }
 
 func (s *TSDBStoreMock) BackupShard(id uint64, since time.Time, w io.Writer) error {
@@ -146,6 +146,6 @@ func (s *TSDBStoreMock) TagValues(auth query.Authorizer, shardIDs []uint64, cond
 func (s *TSDBStoreMock) WithLogger(log *zap.Logger) {
 	s.WithLoggerFn(log)
 }
-func (s *TSDBStoreMock) WriteToShard(shardID uint64, points []models.Point) error {
-	return s.WriteToShardFn(shardID, points)
+func (s *TSDBStoreMock) WriteToShard(writeCtx tsdb.WriteContext, shardID uint64, points []models.Point) error {
+	return s.WriteToShardFn(writeCtx, shardID, points)
 }

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -35,7 +35,7 @@ const (
 
 // pointsWriter is an internal interface to make testing easier.
 type pointsWriter interface {
-	WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+	WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 }
 
 // metaClient is an internal interface to make testing easier.
@@ -386,7 +386,10 @@ func (s *Service) writePoints() {
 				continue
 			}
 
-			if err := s.PointsWriter.WritePointsPrivileged(s.Config.Database, s.Config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
+			writeCtx := tsdb.WriteContext{
+				UserId: tsdb.CollectdUser,
+			}
+			if err := s.PointsWriter.WritePointsPrivileged(writeCtx, s.Config.Database, s.Config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
 				atomic.AddInt64(&s.stats.BatchesTransmitted, 1)
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {

--- a/services/collectd/service_test.go
+++ b/services/collectd/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/toml"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestService_OpenClose(t *testing.T) {
@@ -113,7 +114,7 @@ func TestService_CreatesDatabase(t *testing.T) {
 
 	s := NewTestService(1, time.Second, "split")
 
-	s.WritePointsFn = func(string, string, models.ConsistencyLevel, []models.Point) error {
+	s.WritePointsFn = func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error {
 		return nil
 	}
 
@@ -198,7 +199,7 @@ func TestService_BatchSize(t *testing.T) {
 			s := NewTestService(batchSize, time.Second, "split")
 
 			pointCh := make(chan models.Point)
-			s.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+			s.WritePointsFn = func(_ tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 				if len(points) != batchSize {
 					t.Errorf("\n\texp = %d\n\tgot = %d\n", batchSize, len(points))
 				}
@@ -269,7 +270,7 @@ func TestService_ParseMultiValuePlugin(t *testing.T) {
 	s := NewTestService(1, time.Second, "join")
 
 	pointCh := make(chan models.Point, 1000)
-	s.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	s.WritePointsFn = func(_ tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 		for _, p := range points {
 			pointCh <- p
 		}
@@ -331,7 +332,7 @@ func TestService_BatchDuration(t *testing.T) {
 	s := NewTestService(5000, 250*time.Millisecond, "split")
 
 	pointCh := make(chan models.Point, 1000)
-	s.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	s.WritePointsFn = func(_ tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 		for _, p := range points {
 			pointCh <- p
 		}
@@ -390,7 +391,7 @@ type TestService struct {
 	Service       *Service
 	Config        Config
 	MetaClient    *internal.MetaClientMock
-	WritePointsFn func(string, string, models.ConsistencyLevel, []models.Point) error
+	WritePointsFn func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error
 }
 
 func NewTestService(batchSize int, batchDuration time.Duration, parseOpt string) *TestService {
@@ -427,8 +428,8 @@ func NewTestService(batchSize int, batchDuration time.Duration, parseOpt string)
 	return s
 }
 
-func (w *TestService) WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-	return w.WritePointsFn(database, retentionPolicy, consistencyLevel, points)
+func (w *TestService) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	return w.WritePointsFn(ctx, database, retentionPolicy, consistencyLevel, points)
 }
 
 func check(err error) {

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -80,7 +80,7 @@ type Service struct {
 		DeregisterDiagnosticsClient(name string)
 	}
 	PointsWriter interface {
-		WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+		WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 	}
 	MetaClient interface {
 		CreateDatabaseWithRetentionPolicy(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error)
@@ -458,7 +458,11 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 				continue
 			}
 
-			if err := s.PointsWriter.WritePointsPrivileged(s.database, s.retentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
+			writeCtx := tsdb.WriteContext{
+				UserId: tsdb.GraphiteUser,
+			}
+
+			if err := s.PointsWriter.WritePointsPrivileged(writeCtx, s.database, s.retentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
 				atomic.AddInt64(&s.stats.BatchesTransmitted, 1)
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/toml"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func Test_Service_OpenClose(t *testing.T) {
@@ -60,7 +61,7 @@ func TestService_CreatesDatabase(t *testing.T) {
 	t.Parallel()
 
 	s := NewTestService(nil)
-	s.WritePointsFn = func(string, string, models.ConsistencyLevel, []models.Point) error {
+	s.WritePointsFn = func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error {
 		return nil
 	}
 
@@ -148,7 +149,7 @@ func Test_Service_TCP(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	service.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	service.WritePointsFn = func(_ tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 		defer wg.Done()
 
 		pt, _ := models.NewPoint(
@@ -212,7 +213,7 @@ func Test_Service_UDP(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	service.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	service.WritePointsFn = func(_ tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 		defer wg.Done()
 
 		pt, _ := models.NewPoint(
@@ -255,7 +256,7 @@ func Test_Service_UDP(t *testing.T) {
 type TestService struct {
 	Service       *Service
 	MetaClient    *internal.MetaClientMock
-	WritePointsFn func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+	WritePointsFn func(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 }
 
 func NewTestService(c *Config) *TestService {
@@ -301,6 +302,6 @@ func NewTestService(c *Config) *TestService {
 	return service
 }
 
-func (s *TestService) WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-	return s.WritePointsFn(database, retentionPolicy, consistencyLevel, points)
+func (s *TestService) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	return s.WritePointsFn(ctx, database, retentionPolicy, consistencyLevel, points)
 }

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
 	"go.uber.org/zap"
 )
 
@@ -23,7 +24,7 @@ type Handler struct {
 	RetentionPolicy string
 
 	PointsWriter interface {
-		WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+		WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 	}
 
 	Logger *zap.Logger
@@ -124,8 +125,12 @@ func (h *Handler) servePut(w http.ResponseWriter, r *http.Request) {
 		points = append(points, pt)
 	}
 
+	writeCtx := tsdb.WriteContext{
+		UserId: tsdb.OpenTsdbUser,
+	}
+
 	// Write points.
-	if err := h.PointsWriter.WritePointsPrivileged(h.Database, h.RetentionPolicy, models.ConsistencyLevelAny, points); influxdb.IsClientError(err) {
+	if err := h.PointsWriter.WritePointsPrivileged(writeCtx, h.Database, h.RetentionPolicy, models.ConsistencyLevelAny, points); influxdb.IsClientError(err) {
 		h.Logger.Info("Write series error", zap.Error(err))
 		http.Error(w, "write series error: "+err.Error(), http.StatusBadRequest)
 		return

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -61,7 +61,7 @@ type Service struct {
 	RetentionPolicy string
 
 	PointsWriter interface {
-		WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+		WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 	}
 	MetaClient interface {
 		CreateDatabase(name string) (*meta.DatabaseInfo, error)
@@ -476,7 +476,11 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 				continue
 			}
 
-			if err := s.PointsWriter.WritePointsPrivileged(s.Database, s.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
+			writeCtx := tsdb.WriteContext{
+				UserId: tsdb.OpenTsdbUser,
+			}
+
+			if err := s.PointsWriter.WritePointsPrivileged(writeCtx, s.Database, s.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
 				atomic.AddInt64(&s.stats.BatchesTransmitted, 1)
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -49,7 +49,7 @@ type Service struct {
 	config     Config
 
 	PointsWriter interface {
-		WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+		WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 	}
 
 	MetaClient interface {
@@ -166,7 +166,11 @@ func (s *Service) writer() {
 				continue
 			}
 
-			if err := s.PointsWriter.WritePointsPrivileged(s.config.Database, s.config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
+			writeCtx := tsdb.WriteContext{
+				UserId: tsdb.UdpUser,
+			}
+
+			if err := s.PointsWriter.WritePointsPrivileged(writeCtx, s.config.Database, s.config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
 				atomic.AddInt64(&s.stats.BatchesTransmitted, 1)
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {

--- a/services/udp/service_test.go
+++ b/services/udp/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestService_OpenClose(t *testing.T) {
@@ -53,7 +54,7 @@ func TestService_CreatesDatabase(t *testing.T) {
 	t.Parallel()
 
 	s := NewTestService(nil)
-	s.WritePointsFn = func(string, string, models.ConsistencyLevel, []models.Point) error {
+	s.WritePointsFn = func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error {
 		return nil
 	}
 
@@ -128,7 +129,7 @@ type TestService struct {
 	Service       *Service
 	Config        Config
 	MetaClient    *internal.MetaClientMock
-	WritePointsFn func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+	WritePointsFn func(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 }
 
 func NewTestService(c *Config) *TestService {
@@ -152,6 +153,6 @@ func NewTestService(c *Config) *TestService {
 	return service
 }
 
-func (s *TestService) WritePointsPrivileged(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-	return s.WritePointsFn(database, retentionPolicy, consistencyLevel, points)
+func (s *TestService) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	return s.WritePointsFn(ctx, database, retentionPolicy, consistencyLevel, points)
 }

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -109,6 +109,7 @@ type Config struct {
 
 	// Options for ingress metrics
 	IngressMetricByMeasurement bool `toml:"ingress-metric-by-measurement-enabled"`
+	IngressMetricByLogin       bool `toml:"ingress-metric-by-login-enabled"`
 
 	// Limits
 

--- a/tsdb/ingress_metrics.go
+++ b/tsdb/ingress_metrics.go
@@ -10,7 +10,7 @@ type MetricKey struct {
 	measurement string
 	db          string
 	rp          string
-	// TODO: add login
+	login       string
 }
 
 type MetricValue struct {
@@ -23,8 +23,8 @@ type IngressMetrics struct {
 	length int64
 }
 
-func (i *IngressMetrics) AddMetric(measurement, db, rp string, points, values int64) {
-	key := MetricKey{measurement, db, rp}
+func (i *IngressMetrics) AddMetric(measurement, db, rp, login string, points, values int64) {
+	key := MetricKey{measurement, db, rp, login}
 	val, ok := i.m.Load(key)
 	if !ok {
 		var loaded bool
@@ -51,8 +51,10 @@ func (i *IngressMetrics) ForEach(f func(m MetricKey, points, values int64)) {
 		if keys[i].rp != keys[j].rp {
 			return keys[i].rp < keys[j].rp
 		}
-		return keys[i].measurement < keys[j].measurement
-		//TODO: sort based on login
+		if keys[i].measurement != keys[j].measurement {
+			return keys[i].measurement < keys[j].measurement
+		}
+		return keys[i].login < keys[j].login
 	})
 	for _, key := range keys {
 		val, ok := i.m.Load(key)

--- a/tsdb/ingress_metrics_test.go
+++ b/tsdb/ingress_metrics_test.go
@@ -15,14 +15,12 @@ func TestIngressMetrics(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			ingress.AddMetric("cpu", "telegraf", "autogen", 1, 10)
+			ingress.AddMetric("cpu", "telegraf", "autogen", "user1", 1, 10)
 			wg.Done()
 		}()
-	}
-	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			ingress.AddMetric("mem", "telegraf", "autogen", 2, 20)
+			ingress.AddMetric("mem", "telegraf", "autogen", "user1", 2, 20)
 			wg.Done()
 		}()
 	}
@@ -34,6 +32,7 @@ func TestIngressMetrics(t *testing.T) {
 				measurement: "cpu",
 				db:          "telegraf",
 				rp:          "autogen",
+				login:       "user1",
 			}, m)
 			assert.Equal(int64(10), points)
 			assert.Equal(int64(100), values)
@@ -42,6 +41,7 @@ func TestIngressMetrics(t *testing.T) {
 				measurement: "mem",
 				db:          "telegraf",
 				rp:          "autogen",
+				login:       "user1",
 			}, m)
 			assert.Equal(int64(20), points)
 			assert.Equal(int64(200), values)

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1222,7 +1222,7 @@ func TestStore_Cardinality_Limit_On_InMem_Index(t *testing.T) {
 		from := shardID * pointsPerShard
 		to := from + pointsPerShard
 
-		if err := store.Store.WriteToShard(uint64(shardID), points[from:to]); err != nil {
+		if err := store.Store.WriteToShard(tsdb.WriteContext{}, uint64(shardID), points[from:to]); err != nil {
 			if !strings.Contains(err.Error(), "partial write: max-series-per-database limit exceeded:") {
 				t.Fatal(err)
 			}
@@ -2124,7 +2124,7 @@ func BenchmarkStore_SeriesCardinality_100_Shards(b *testing.B) {
 				b.Fatalf("create shard: %s", err)
 			}
 
-			err := store.WriteToShard(uint64(shardID), []models.Point{models.MustNewPoint("cpu", nil, map[string]interface{}{"value": 1.0}, time.Now())})
+			err := store.WriteToShard(tsdb.WriteContext{}, uint64(shardID), []models.Point{models.MustNewPoint("cpu", nil, map[string]interface{}{"value": 1.0}, time.Now())})
 			if err != nil {
 				b.Fatalf("write: %s", err)
 			}
@@ -2394,7 +2394,7 @@ func (s *Store) MustWriteToShardString(shardID int, data ...string) {
 		points = append(points, a...)
 	}
 
-	if err := s.WriteToShard(uint64(shardID), points); err != nil {
+	if err := s.WriteToShard(tsdb.WriteContext{}, uint64(shardID), points); err != nil {
 		panic(err)
 	}
 }
@@ -2414,7 +2414,7 @@ func (s *Store) BatchWrite(shardID int, points []models.Point) error {
 			break
 		}
 
-		if err := s.WriteToShard(uint64(shardID), points[start:end]); err != nil {
+		if err := s.WriteToShard(tsdb.WriteContext{}, uint64(shardID), points[start:end]); err != nil {
 			return err
 		}
 		start = end


### PR DESCRIPTION
After turning on authentication and both forms of ingress metrics:

"ingress": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"cq","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":76}},
"ingress:1": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"database","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":152}},
"ingress:2": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"httpd","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":874}},
"ingress:3": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"ingress","rp":"monitor"},"values":{"pointsWritten":534,"valuesWritten":1068}},
"ingress:4": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"localStore","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":76}},
"ingress:5": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"queryExecutor","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":190}},
"ingress:6": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"runtime","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":570}},
"ingress:7": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"shard","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":836}},
"ingress:8": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"subscriber","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":114}},
"ingress:9": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_cache","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":684}},
"ingress:10": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_engine","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":2204}},
"ingress:11": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_filestore","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":152}},
"ingress:12": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_wal","rp":"monitor"},"values":{"pointsWritten":76,"valuesWritten":304}},
"ingress:13": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"write","rp":"monitor"},"values":{"pointsWritten":38,"valuesWritten":342}},
"ingress:14": {"name":"ingress","tags":{"db":"telegraf","login":"admin","measurement":"cpu","rp":"autogen"},"values":{"pointsWritten":1,"valuesWritten":1}},
"ingress:15": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"cpu","rp":"autogen"},"values":{"pointsWritten":1316,"valuesWritten":13160}},
"ingress:16": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"disk","rp":"autogen"},"values":{"pointsWritten":642,"valuesWritten":4494}},
"ingress:17": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"diskio","rp":"autogen"},"values":{"pointsWritten":214,"valuesWritten":2354}},
"ingress:18": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"mem","rp":"autogen"},"values":{"pointsWritten":107,"valuesWritten":963}},
"ingress:19": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"processes","rp":"autogen"},"values":{"pointsWritten":107,"valuesWritten":856}},
"ingress:20": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"swap","rp":"autogen"},"values":{"pointsWritten":214,"valuesWritten":642}},
"ingress:21": {"name":"ingress","tags":{"db":"telegraf","login":"telegraf","measurement":"system","rp":"autogen"},"values":{"pointsWritten":321,"valuesWritten":749}},

Only by login:

"ingress": {"name":"ingress","tags":{"login":"_systemuser_monitor"},"values":{"pointsWritten":42,"valuesWritten":354}},
"ingress:1": {"name":"ingress","tags":{"login":"admin"},"values":{"pointsWritten":1,"valuesWritten":1}},
"ingress:2": {"name":"ingress","tags":{"login":"telegraf"},"values":{"pointsWritten":3547,"valuesWritten":28246}},

Notice writes by users 'telegraf', '_systemuser_monitor', and 'admin'.

Closes #20612

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
