### PR TITLE
build: update naming conventions for nightly builds to prefer hyphens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,8 +629,15 @@ jobs:
       - install_core_deps
       - run_goreleaser:
           publish_release: false
+      - run:
+          name: Clean up artifacts
+          command: |
+            # goreleaser generates some temp files in the dist/
+            # directory alongside the artifacts we want to save.
+            mkdir artifacts
+            mv dist/influx* artifacts/
       - store_artifacts:
-          path: dist
+          path: artifacts
       - save_cache:
           name: Save GOCACHE
           key: influxdb-cross-build-{{ .Branch }}-{{ .Revision }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ nfpms:
           amd64: x86_64
         file_name_template: "influxdb2-nightly.{{ .Arch }}"
       deb:
-        file_name_template: "influxdb2_nightly_{{ .Arch }}"
+        file_name_template: "influxdb2-nightly-{{ .Arch }}"
     vendor: InfluxData
     homepage: https://influxdata.com
     maintainer: support@influxdb.com
@@ -88,14 +88,14 @@ archives:
     builds: ["influx"]
     format: tar.gz
     wrap_in_directory: true
-    name_template: "influxdb2_client_nightly_{{ .Os }}_{{ .Arch }}"
+    name_template: "influxdb2-client-nightly-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
   - id: influx_and_influxd
     format: tar.gz
     wrap_in_directory: true
-    name_template: "influxdb2_nightly_{{ .Os }}_{{ .Arch }}"
+    name_template: "influxdb2-nightly-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -107,7 +107,7 @@ blobs:
     folder: "platform/nightlies/"
 
 checksum:
-  name_template: "influxdb2_nightly.sha256"
+  name_template: "influxdb2-nightly.sha256"
   algorithm: sha256
 
 dockers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ This release fully removes the `inmem` indexing option, along with the associate
 
 Replacement `tsi1` indexes will be automatically generated on startup for shards that need it.
 
+#### Artifact naming conventions
+
+The names of artifacts produced by our nightly & release builds have been updated according to the
+[Google developer guidelines](https://developers.google.com/style/filenames). Underscores (`_`) have
+been replaced by hyphens (`-`) in nearly all cases; the one exception is the use of `x86_64` in our
+RPM packages, which has been left unchanged.
+
 ### Features
 
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.


### PR DESCRIPTION
Closes #20697 

Update our binaries to match [Google naming conventions](https://developers.google.com/style/filenames).