### PR TITLE
feat: series creation ingress metrics

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -426,7 +426,7 @@ func IndexShard(sfile *tsdb.SeriesFile, dataDir, walDir string, maxLogFileSize i
 
 			// Flush batch?
 			if len(keysBatch) == batchSize {
-				if err := tsiIndex.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch); err != nil {
+				if err := tsiIndex.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch, tsdb.NoopStatsTracker()); err != nil {
 					return fmt.Errorf("problem creating series: (%s)", err)
 				}
 				keysBatch = keysBatch[:0]
@@ -437,7 +437,7 @@ func IndexShard(sfile *tsdb.SeriesFile, dataDir, walDir string, maxLogFileSize i
 
 		// Flush any remaining series in the batches
 		if len(keysBatch) > 0 {
-			if err := tsiIndex.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch); err != nil {
+			if err := tsiIndex.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch, tsdb.NoopStatsTracker()); err != nil {
 				return fmt.Errorf("problem creating series: (%s)", err)
 			}
 			keysBatch = nil
@@ -496,7 +496,7 @@ func IndexTSMFile(index *tsi1.Index, path string, batchSize int, log *zap.Logger
 
 		// Flush batch?
 		if len(keysBatch) == batchSize {
-			if err := index.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch[:ti]); err != nil {
+			if err := index.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch[:ti], tsdb.NoopStatsTracker()); err != nil {
 				return fmt.Errorf("problem creating series: (%s)", err)
 			}
 			keysBatch = keysBatch[:0]
@@ -507,7 +507,7 @@ func IndexTSMFile(index *tsi1.Index, path string, batchSize int, log *zap.Logger
 
 	// Flush any remaining series in the batches
 	if len(keysBatch) > 0 {
-		if err := index.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch[:ti]); err != nil {
+		if err := index.CreateSeriesListIfNotExists(keysBatch, namesBatch, tagsBatch[:ti], tsdb.NoopStatsTracker()); err != nil {
 			return fmt.Errorf("problem creating series: (%s)", err)
 		}
 	}

--- a/cmd/influx_inspect/verify/seriesfile/verify_test.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify_test.go
@@ -102,7 +102,7 @@ func NewTest(t *testing.T) *Test {
 			tagsSlice = append(tagsSlice, nil)
 		}
 
-		ids, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice)
+		ids, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice, tsdb.NoopStatsTracker())
 		if err != nil {
 			return err
 		}

--- a/cmd/influx_tools/generate/exec/generator.go
+++ b/cmd/influx_tools/generate/exec/generator.go
@@ -145,7 +145,7 @@ func (g *Generator) writeShard(idx seriesIndex, sg gen.SeriesGenerator, id uint6
 		tags = append(tags, sg.Tags())
 
 		if len(keys) == seriesBatchSize {
-			if err := idx.CreateSeriesListIfNotExists(keys, names, tags); err != nil {
+			if err := idx.CreateSeriesListIfNotExists(keys, names, tags, tsdb.NoopStatsTracker()); err != nil {
 				return err
 			}
 			keys = keys[:0]
@@ -166,7 +166,7 @@ func (g *Generator) writeShard(idx seriesIndex, sg gen.SeriesGenerator, id uint6
 	}
 
 	if len(keys) > seriesBatchSize {
-		if err := idx.CreateSeriesListIfNotExists(keys, names, tags); err != nil {
+		if err := idx.CreateSeriesListIfNotExists(keys, names, tags, tsdb.NoopStatsTracker()); err != nil {
 			return err
 		}
 	}
@@ -174,7 +174,7 @@ func (g *Generator) writeShard(idx seriesIndex, sg gen.SeriesGenerator, id uint6
 }
 
 type seriesIndex interface {
-	CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags) error
+	CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) error
 }
 
 type seriesFileAdapter struct {
@@ -182,7 +182,7 @@ type seriesFileAdapter struct {
 	buf []byte
 }
 
-func (s *seriesFileAdapter) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags) (err error) {
-	_, err = s.sf.CreateSeriesListIfNotExists(names, tagsSlice)
+func (s *seriesFileAdapter) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) (err error) {
+	_, err = s.sf.CreateSeriesListIfNotExists(names, tagsSlice, tracker)
 	return
 }

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -53,8 +53,8 @@ type Engine interface {
 	IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error)
 	WritePoints(points []models.Point, tracker StatsTracker) error
 
-	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
-	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
+	CreateSeriesIfNotExists(key, name []byte, tags models.Tags, tracker StatsTracker) error
+	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags, tracker StatsTracker) error
 	DeleteSeriesRange(itr SeriesIterator, min, max int64) error
 	DeleteSeriesRangeWithPredicate(itr SeriesIterator, predicate func(name []byte, tags models.Tags) (int64, int64, bool)) error
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1264,7 +1264,9 @@ func (e *Engine) addToIndexFromKey(keys [][]byte, fieldTypes []influxql.DataType
 			return err
 		}
 	} else {
-		if err := e.index.CreateSeriesListIfNotExists(keys, names, tags); err != nil {
+		// We don't count series additions in this code, it is (only?) used at startup
+		tracker := tsdb.NoopStatsTracker()
+		if err := e.index.CreateSeriesListIfNotExists(keys, names, tags, tracker); err != nil {
 			return err
 		}
 	}
@@ -1854,12 +1856,12 @@ func (e *Engine) ForEachMeasurementName(fn func(name []byte) error) error {
 	return e.index.ForEachMeasurementName(fn)
 }
 
-func (e *Engine) CreateSeriesListIfNotExists(keys, names [][]byte, tagsSlice []models.Tags) error {
-	return e.index.CreateSeriesListIfNotExists(keys, names, tagsSlice)
+func (e *Engine) CreateSeriesListIfNotExists(keys, names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) error {
+	return e.index.CreateSeriesListIfNotExists(keys, names, tagsSlice, tracker)
 }
 
-func (e *Engine) CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error {
-	return e.index.CreateSeriesIfNotExists(key, name, tags)
+func (e *Engine) CreateSeriesIfNotExists(key, name []byte, tags models.Tags, tracker tsdb.StatsTracker) error {
+	return e.index.CreateSeriesIfNotExists(key, name, tags, tracker)
 }
 
 // WriteTo is not implemented.

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -31,6 +31,8 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 )
 
+var notrack = tsdb.NoopStatsTracker()
+
 // Ensure that deletes only sent to the WAL will clear out the data from the cache on restart
 func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
@@ -82,8 +84,8 @@ func TestEngine_DeleteSeriesAfterCacheSnapshot(t *testing.T) {
 			}
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
-			e.CreateSeriesIfNotExists([]byte("cpu,host=B"), []byte("cpu"), models.NewTags(map[string]string{"host": "B"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
+			e.CreateSeriesIfNotExists([]byte("cpu,host=B"), []byte("cpu"), models.NewTags(map[string]string{"host": "B"}), notrack)
 
 			// Verify series exist.
 			n, err := seriesExist(e, "cpu", []string{"host"})
@@ -755,7 +757,7 @@ func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1000000000`,
@@ -812,7 +814,7 @@ func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1000000000`,
@@ -868,7 +870,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1000000000`,
@@ -926,7 +928,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1000000000`,
@@ -985,7 +987,7 @@ func TestEngine_CreateIterator_Aux(t *testing.T) {
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("F"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1000000000`,
@@ -1046,7 +1048,7 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("X"), influxql.Float)
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("Y"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 			e.SetFieldName([]byte("cpu"), "X")
 			e.SetFieldName([]byte("cpu"), "Y")
 
@@ -1270,7 +1272,7 @@ func TestEngine_DeleteSeriesRange(t *testing.T) {
 			defer e.Close()
 
 			for _, p := range []models.Point{p1, p2, p3, p4, p5, p6, p7, p8} {
-				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 					t.Fatalf("create series index error: %v", err)
 				}
 			}
@@ -1380,7 +1382,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate(t *testing.T) {
 			defer e.Close()
 
 			for _, p := range []models.Point{p1, p2, p3, p4, p5, p6, p7, p8} {
-				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 					t.Fatalf("create series index error: %v", err)
 				}
 			}
@@ -1506,7 +1508,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate_Nil(t *testing.T) {
 			defer e.Close()
 
 			for _, p := range []models.Point{p1, p2, p3, p4, p5, p6, p7, p8} {
-				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 					t.Fatalf("create series index error: %v", err)
 				}
 			}
@@ -1592,7 +1594,7 @@ func TestEngine_DeleteSeriesRangeWithPredicate_FlushBatch(t *testing.T) {
 			defer e.Close()
 
 			for _, p := range []models.Point{p1, p2, p3, p4, p5, p6, p7, p8} {
-				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 					t.Fatalf("create series index error: %v", err)
 				}
 			}
@@ -1711,7 +1713,7 @@ func TestEngine_DeleteSeriesRange_OutsideTime(t *testing.T) {
 			defer e.Close()
 
 			for _, p := range []models.Point{p1} {
-				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+				if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 					t.Fatalf("create series index error: %v", err)
 				}
 			}
@@ -1920,7 +1922,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1`,
@@ -1980,7 +1982,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A value=1.1 1`,
@@ -2040,10 +2042,10 @@ func TestEngine_CreateIterator_SeriesKey(t *testing.T) {
 			defer e.Close()
 
 			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "A", "region": "east"}))
-			e.CreateSeriesIfNotExists([]byte("cpu,host=B,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "B", "region": "east"}))
-			e.CreateSeriesIfNotExists([]byte("cpu,host=C,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "C", "region": "east"}))
-			e.CreateSeriesIfNotExists([]byte("cpu,host=A,region=west"), []byte("cpu"), models.NewTags(map[string]string{"host": "A", "region": "west"}))
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "A", "region": "east"}), notrack)
+			e.CreateSeriesIfNotExists([]byte("cpu,host=B,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "B", "region": "east"}), notrack)
+			e.CreateSeriesIfNotExists([]byte("cpu,host=C,region=east"), []byte("cpu"), models.NewTags(map[string]string{"host": "C", "region": "east"}), notrack)
+			e.CreateSeriesIfNotExists([]byte("cpu,host=A,region=west"), []byte("cpu"), models.NewTags(map[string]string{"host": "A", "region": "west"}), notrack)
 
 			if err := e.WritePointsString(
 				`cpu,host=A,region=east value=1.1 1000000001`,
@@ -2327,7 +2329,7 @@ func TestEngine_Invalid_UTF8(t *testing.T) {
 			}
 			defer e.Close()
 
-			if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags()); err != nil {
+			if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
 				t.Fatalf("create series index error: %v", err)
 			}
 
@@ -2607,7 +2609,7 @@ func MustInitDefaultBenchmarkEngine(name string, pointN int) *benchmarkEngine {
 
 	// Initialize metadata.
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float)
-	e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+	e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}), notrack)
 
 	// Generate time ascending points with jitterred time & value.
 	rand := rand.New(rand.NewSource(0))
@@ -2803,7 +2805,7 @@ func (e *Engine) WritePointsString(ptstr ...string) error {
 func (e *Engine) writePoints(points ...models.Point) error {
 	for _, point := range points {
 		// Write into the index.
-		if err := e.Engine.CreateSeriesIfNotExists(point.Key(), point.Name(), point.Tags()); err != nil {
+		if err := e.Engine.CreateSeriesIfNotExists(point.Key(), point.Name(), point.Tags(), notrack); err != nil {
 			return err
 		}
 	}

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -40,8 +40,8 @@ type Index interface {
 	ForEachMeasurementName(fn func(name []byte) error) error
 
 	InitializeSeries(keys, names [][]byte, tags []models.Tags) error
-	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
-	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
+	CreateSeriesIfNotExists(key, name []byte, tags models.Tags, tracker StatsTracker) error
+	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags, tracker StatsTracker) error
 	DropSeries(seriesID uint64, key []byte, cascade bool) error
 	DropSeriesList(seriesID []uint64, key [][]byte, cascade bool) error
 	DropMeasurementIfSeriesNotExist(name []byte) (bool, error)

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/influxdata/influxdb/tsdb/index/inmem"
 )
 
+var notrack = tsdb.NoopStatsTracker()
+
 func createData(lo, hi int) (keys, names [][]byte, tags []models.Tags) {
 	for i := lo; i < hi; i++ {
 		keys = append(keys, []byte(fmt.Sprintf("m0,tag0=t%d", i)))
@@ -30,13 +32,13 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded(b *testin
 	si := inmem.NewShardIndex(1, tsdb.NewSeriesIDSet(), opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
-	si.CreateSeriesListIfNotExists(keys, names, tags)
+	si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	keys, names, tags = createData(9, 5010)
 	for i := 0; i < b.N; i++ {
-		si.CreateSeriesListIfNotExists(keys, names, tags)
+		si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	}
 }
 
@@ -48,13 +50,13 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded(b *tes
 	si := inmem.NewShardIndex(1, tsdb.NewSeriesIDSet(), opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
-	si.CreateSeriesListIfNotExists(keys, names, tags)
+	si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	keys, names, tags = createData(9, 5010)
 	for i := 0; i < b.N; i++ {
-		si.CreateSeriesListIfNotExists(keys, names, tags)
+		si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	}
 }
 
@@ -65,13 +67,13 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues(b *testing.B) {
 	si := inmem.NewShardIndex(1, tsdb.NewSeriesIDSet(), opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
-	si.CreateSeriesListIfNotExists(keys, names, tags)
+	si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	keys, names, tags = createData(9, 5010)
 	for i := 0; i < b.N; i++ {
-		si.CreateSeriesListIfNotExists(keys, names, tags)
+		si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	}
 }
 
@@ -84,13 +86,13 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded(b *testin
 	si := inmem.NewShardIndex(1, tsdb.NewSeriesIDSet(), opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
-	si.CreateSeriesListIfNotExists(keys, names, tags)
+	si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	keys, names, tags = createData(9, 5010)
 	for i := 0; i < b.N; i++ {
-		si.CreateSeriesListIfNotExists(keys, names, tags)
+		si.CreateSeriesListIfNotExists(keys, names, tags, notrack)
 	}
 }
 
@@ -103,7 +105,7 @@ func TestIndex_Bytes(t *testing.T) {
 	indexBaseBytes := si.Bytes()
 
 	name := []byte("name")
-	err := si.CreateSeriesIfNotExists(name, name, models.Tags{})
+	err := si.CreateSeriesIfNotExists(name, name, models.Tags{}, notrack)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -124,10 +126,10 @@ func TestIndex_MeasurementTracking(t *testing.T) {
 	b := func(s string) []byte { return []byte(s) }
 	mt := func(k, v string) models.Tag { return models.Tag{Key: b(k), Value: b(v)} }
 
-	s1.CreateSeriesIfNotExists(b("m,t=t1"), b("m"), models.Tags{mt("t", "t1")})
-	s1.CreateSeriesIfNotExists(b("m,t=t2"), b("m"), models.Tags{mt("t", "t2")})
-	s2.CreateSeriesIfNotExists(b("m,t=t1"), b("m"), models.Tags{mt("t", "t1")})
-	s2.CreateSeriesIfNotExists(b("m,t=t2"), b("m"), models.Tags{mt("t", "t2")})
+	s1.CreateSeriesIfNotExists(b("m,t=t1"), b("m"), models.Tags{mt("t", "t1")}, notrack)
+	s1.CreateSeriesIfNotExists(b("m,t=t2"), b("m"), models.Tags{mt("t", "t2")}, notrack)
+	s2.CreateSeriesIfNotExists(b("m,t=t1"), b("m"), models.Tags{mt("t", "t1")}, notrack)
+	s2.CreateSeriesIfNotExists(b("m,t=t2"), b("m"), models.Tags{mt("t", "t2")}, notrack)
 	series1, _ := s1.Series(b("m,t=t1"))
 	series2, _ := s1.Series(b("m,t=t2"))
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -631,7 +631,7 @@ func (i *Index) DropMeasurement(name []byte) error {
 }
 
 // CreateSeriesListIfNotExists creates a list of series if they doesn't exist in bulk.
-func (i *Index) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags) error {
+func (i *Index) CreateSeriesListIfNotExists(keys, names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) error {
 	// All slices must be of equal length.
 	if len(names) != len(tagsSlice) {
 		return errors.New("names/tags length mismatch in index")
@@ -664,7 +664,7 @@ func (i *Index) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsS
 					return // No more work.
 				}
 
-				ids, err := i.partitions[idx].createSeriesListIfNotExists(pNames[idx], pTags[idx])
+				ids, err := i.partitions[idx].createSeriesListIfNotExists(pNames[idx], pTags[idx], tracker)
 
 				var updateCache bool
 				for _, id := range ids {
@@ -737,8 +737,8 @@ func (i *Index) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsS
 }
 
 // CreateSeriesIfNotExists creates a series if it doesn't exist or is deleted.
-func (i *Index) CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error {
-	ids, err := i.partition(key).createSeriesListIfNotExists([][]byte{name}, []models.Tags{tags})
+func (i *Index) CreateSeriesIfNotExists(key, name []byte, tags models.Tags, tracker tsdb.StatsTracker) error {
+	ids, err := i.partition(key).createSeriesListIfNotExists([][]byte{name}, []models.Tags{tags}, tracker)
 	if err != nil {
 		return err
 	}

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -511,8 +511,8 @@ func (f *LogFile) DeleteTagValue(name, key, value []byte) error {
 }
 
 // AddSeriesList adds a list of series to the log file in bulk.
-func (f *LogFile) AddSeriesList(seriesSet *tsdb.SeriesIDSet, names [][]byte, tagsSlice []models.Tags) ([]uint64, error) {
-	seriesIDs, err := f.sfile.CreateSeriesListIfNotExists(names, tagsSlice)
+func (f *LogFile) AddSeriesList(seriesSet *tsdb.SeriesIDSet, names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) ([]uint64, error) {
+	seriesIDs, err := f.sfile.CreateSeriesListIfNotExists(names, tagsSlice, tracker)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -38,6 +38,7 @@ func TestLogFile_AddSeriesList(t *testing.T) {
 			models.NewTags(map[string]string{"region": "us-east"}),
 			models.NewTags(map[string]string{"host": "serverA"}),
 		},
+		notrack,
 	)
 
 	if err != nil {
@@ -57,6 +58,7 @@ func TestLogFile_AddSeriesList(t *testing.T) {
 			models.NewTags(map[string]string{"region": "us-west"}),
 			models.NewTags(map[string]string{"host": "serverA"}),
 		},
+		notrack,
 	)
 
 	if err != nil {
@@ -78,6 +80,7 @@ func TestLogFile_AddSeriesList(t *testing.T) {
 			models.NewTags(map[string]string{"region": "us-west"}),
 			models.NewTags(map[string]string{"host": "serverA"}),
 		},
+		notrack,
 	)
 
 	if err != nil {
@@ -135,7 +138,9 @@ func TestLogFile_SeriesStoredInOrder(t *testing.T) {
 		}, []models.Tags{
 			{models.NewTag([]byte("host"), []byte(tv))},
 			{models.NewTag([]byte("host"), []byte(tv))},
-		}); err != nil {
+		},
+			notrack,
+		); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -188,7 +193,7 @@ func TestLogFile_DeleteMeasurement(t *testing.T) {
 		{{Key: []byte("host"), Value: []byte("serverA")}},
 		{{Key: []byte("region"), Value: []byte("us-east")}},
 		{{Key: []byte("region"), Value: []byte("us-west")}},
-	}); err != nil {
+	}, notrack); err != nil {
 		t.Fatal(err)
 	}
 
@@ -219,7 +224,7 @@ func TestLogFile_Open(t *testing.T) {
 		defer f.Close()
 
 		// Add test data & close.
-		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("cpu"), []byte("mem")}, []models.Tags{{{}}, {{}}}); err != nil {
+		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("cpu"), []byte("mem")}, []models.Tags{{{}}, {{}}}, notrack); err != nil {
 			t.Fatal(err)
 		} else if err := f.LogFile.Close(); err != nil {
 			t.Fatal(err)
@@ -247,7 +252,7 @@ func TestLogFile_Open(t *testing.T) {
 		}
 
 		// Add more data & reopen.
-		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("disk")}, []models.Tags{{{}}}); err != nil {
+		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("disk")}, []models.Tags{{{}}}, notrack); err != nil {
 			t.Fatal(err)
 		} else if err := f.Reopen(); err != nil {
 			t.Fatal(err)
@@ -279,7 +284,7 @@ func TestLogFile_Open(t *testing.T) {
 		defer f.Close()
 
 		// Add test data & close.
-		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("cpu"), []byte("mem")}, []models.Tags{{{}}, {{}}}); err != nil {
+		if _, err := f.AddSeriesList(seriesSet, [][]byte{[]byte("cpu"), []byte("mem")}, []models.Tags{{{}}, {{}}}, notrack); err != nil {
 			t.Fatal(err)
 		} else if err := f.LogFile.Close(); err != nil {
 			t.Fatal(err)
@@ -360,7 +365,7 @@ func CreateLogFile(sfile *tsdb.SeriesFile, series []Series) (*LogFile, error) {
 	f := MustOpenLogFile(sfile)
 	seriesSet := tsdb.NewSeriesIDSet()
 	for _, serie := range series {
-		if _, err := f.AddSeriesList(seriesSet, [][]byte{serie.Name}, []models.Tags{serie.Tags}); err != nil {
+		if _, err := f.AddSeriesList(seriesSet, [][]byte{serie.Name}, []models.Tags{serie.Tags}, notrack); err != nil {
 			return nil, err
 		}
 	}
@@ -385,7 +390,7 @@ func GenerateLogFile(sfile *tsdb.SeriesFile, measurementN, tagN, valueN int) (*L
 				value := []byte(fmt.Sprintf("value%d", (j / pow(valueN, k) % valueN)))
 				tags = append(tags, models.NewTag(key, value))
 			}
-			if _, err := f.AddSeriesList(seriesSet, [][]byte{name}, []models.Tags{tags}); err != nil {
+			if _, err := f.AddSeriesList(seriesSet, [][]byte{name}, []models.Tags{tags}, notrack); err != nil {
 				return nil, err
 			}
 		}
@@ -432,7 +437,7 @@ func benchmarkLogFile_AddSeries(b *testing.B, measurementN, seriesKeyN, seriesVa
 
 	for i := 0; i < b.N; i++ {
 		for _, d := range data {
-			if _, err := f.AddSeriesList(seriesSet, [][]byte{d.Name}, []models.Tags{d.Tags}); err != nil {
+			if _, err := f.AddSeriesList(seriesSet, [][]byte{d.Name}, []models.Tags{d.Tags}, notrack); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -470,7 +475,7 @@ func BenchmarkLogFile_WriteTo(b *testing.B) {
 					[]models.Tags{{
 						{Key: []byte("host"), Value: []byte(fmt.Sprintf("server-%d", i))},
 						{Key: []byte("location"), Value: []byte("us-west")},
-					}},
+					}}, notrack,
 				); err != nil {
 					b.Fatal(err)
 				}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -642,7 +642,7 @@ func (p *Partition) DropMeasurement(name []byte) error {
 
 // createSeriesListIfNotExists creates a list of series if they doesn't exist in
 // bulk.
-func (p *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) ([]uint64, error) {
+func (p *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) ([]uint64, error) {
 	// Is there anything to do? The partition may have been sent an empty batch.
 	if len(names) == 0 {
 		return nil, nil
@@ -660,7 +660,7 @@ func (p *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []mode
 	// Ensure fileset cannot change during insert.
 	p.mu.RLock()
 	// Insert series into log file.
-	ids, err := p.activeLogFile.AddSeriesList(p.seriesIDSet, names, tagsSlice)
+	ids, err := p.activeLogFile.AddSeriesList(p.seriesIDSet, names, tagsSlice, tracker)
 	if err != nil {
 		p.mu.RUnlock()
 		return nil, err

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -390,7 +390,7 @@ func (idx *Index) IndexSet() *tsdb.IndexSet {
 func (idx *Index) AddSeries(name string, tags map[string]string) error {
 	t := models.NewTags(tags)
 	key := fmt.Sprintf("%s,%s", name, t.HashKey())
-	return idx.CreateSeriesIfNotExists([]byte(key), []byte(name), t)
+	return idx.CreateSeriesIfNotExists([]byte(key), []byte(name), t, tsdb.NoopStatsTracker())
 }
 
 // Reopen closes and re-opens the underlying index, without removing any data.
@@ -491,7 +491,7 @@ func BenchmarkIndexSet_TagSets(b *testing.B) {
 				k := keys[i : i+batchSize]
 				n := names[i : i+batchSize]
 				t := tags[i : i+batchSize]
-				if err := idx.CreateSeriesListIfNotExists(k, n, t); err != nil {
+				if err := idx.CreateSeriesListIfNotExists(k, n, t, tsdb.NoopStatsTracker()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -647,7 +647,7 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 				k := keys[i : i+batchSize]
 				n := names[i : i+batchSize]
 				t := tags[i : i+batchSize]
-				if err := idx.CreateSeriesListIfNotExists(k, n, t); err != nil {
+				if err := idx.CreateSeriesListIfNotExists(k, n, t, tsdb.NoopStatsTracker()); err != nil {
 					b.Fatal(err)
 				}
 				once.Do(func() { close(begin) })

--- a/tsdb/ingress_metrics_test.go
+++ b/tsdb/ingress_metrics_test.go
@@ -15,18 +15,18 @@ func TestIngressMetrics(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			ingress.AddMetric("cpu", "telegraf", "autogen", "user1", 1, 10)
+			ingress.AddMetric("cpu", "telegraf", "autogen", "user1", 1, 10, 0)
 			wg.Done()
 		}()
 		wg.Add(1)
 		go func() {
-			ingress.AddMetric("mem", "telegraf", "autogen", "user1", 2, 20)
+			ingress.AddMetric("mem", "telegraf", "autogen", "user1", 2, 20, 1)
 			wg.Done()
 		}()
 	}
 	wg.Wait()
 	metric := 0
-	ingress.ForEach(func(m MetricKey, points, values int64) {
+	ingress.ForEach(func(m MetricKey, points, values, series int64) {
 		if metric == 0 {
 			assert.Equal(MetricKey{
 				measurement: "cpu",
@@ -45,6 +45,7 @@ func TestIngressMetrics(t *testing.T) {
 			}, m)
 			assert.Equal(int64(20), points)
 			assert.Equal(int64(200), values)
+			assert.Equal(int64(10), series)
 		}
 		metric++
 	})

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -175,7 +175,7 @@ func (f *SeriesFile) FileSize() (n int64, err error) {
 
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
 // The returned ids slice returns IDs for every name+tags, creating new series IDs as needed.
-func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) ([]uint64, error) {
+func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, tracker StatsTracker) ([]uint64, error) {
 	keys := GenerateSeriesKeys(names, tagsSlice)
 	keyPartitionIDs := f.SeriesKeysPartitionIDs(keys)
 	ids := make([]uint64, len(keys))
@@ -184,7 +184,7 @@ func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []mod
 	for i := range f.partitions {
 		p := f.partitions[i]
 		g.Go(func() error {
-			return p.CreateSeriesListIfNotExists(keys, keyPartitionIDs, ids)
+			return p.CreateSeriesListIfNotExists(keys, keyPartitionIDs, ids, tracker)
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -75,7 +75,7 @@ func TestSeriesFile_Series(t *testing.T) {
 		{Name: []byte("mem"), Tags: models.NewTags(map[string]string{"region": "east"})},
 	}
 	for _, s := range series {
-		if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte(s.Name)}, []models.Tags{s.Tags}); err != nil {
+		if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte(s.Name)}, []models.Tags{s.Tags}, tsdb.NoopStatsTracker()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -114,7 +114,7 @@ func TestSeriesFileCompactor(t *testing.T) {
 		names = append(names, []byte(fmt.Sprintf("m%d", i)))
 		tagsSlice = append(tagsSlice, models.NewTags(map[string]string{"foo": "bar"}))
 	}
-	if _, err := sfile.CreateSeriesListIfNotExists(names, tagsSlice); err != nil {
+	if _, err := sfile.CreateSeriesListIfNotExists(names, tagsSlice, tsdb.NoopStatsTracker()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -144,10 +144,10 @@ func TestSeriesFile_DeleteSeriesID(t *testing.T) {
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 
-	ids0, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m1")}, []models.Tags{nil})
+	ids0, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m1")}, []models.Tags{nil}, tsdb.NoopStatsTracker())
 	if err != nil {
 		t.Fatal(err)
-	} else if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m2")}, []models.Tags{nil}); err != nil {
+	} else if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m2")}, []models.Tags{nil}, tsdb.NoopStatsTracker()); err != nil {
 		t.Fatal(err)
 	} else if err := sfile.ForceCompact(); err != nil {
 		t.Fatal(err)
@@ -156,7 +156,7 @@ func TestSeriesFile_DeleteSeriesID(t *testing.T) {
 	// Delete and ensure deletion.
 	if err := sfile.DeleteSeriesID(ids0[0]); err != nil {
 		t.Fatal(err)
-	} else if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m1")}, []models.Tags{nil}); err != nil {
+	} else if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("m1")}, []models.Tags{nil}, tsdb.NoopStatsTracker()); err != nil {
 		t.Fatal(err)
 	} else if !sfile.IsDeleted(ids0[0]) {
 		t.Fatal("expected deletion before compaction")
@@ -188,7 +188,7 @@ func TestSeriesFile_Compaction(t *testing.T) {
 	}
 
 	// Add all to the series file.
-	ids, err := sfile.CreateSeriesListIfNotExists(mms, tagSets)
+	ids, err := sfile.CreateSeriesListIfNotExists(mms, tagSets, tsdb.NoopStatsTracker())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func BenchmarkSeriesFile_Compaction(b *testing.B) {
 		// Generate a bunch of keys.
 		var ids []uint64
 		for i := 0; i < n; i++ {
-			tmp, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("cpu")}, []models.Tags{models.NewTags(map[string]string{"region": fmt.Sprintf("r%d", i)})})
+			tmp, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte("cpu")}, []models.Tags{models.NewTags(map[string]string{"region": fmt.Sprintf("r%d", i)})}, tsdb.NoopStatsTracker())
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
After turning this on and testing locally, note the 'seriesCreated' metric

"localStore": {"name":"localStore","tags":null,"values":{"pointsWritten":2987,"seriesCreated":58,"valuesWritten":23754}},
"ingress": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"cq","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":4}},
"ingress:1": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"database","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":4}},
"ingress:2": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"httpd","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":46}},
"ingress:3": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"ingress","rp":"monitor"},"values":{"pointsWritten":14,"seriesCreated":14,"valuesWritten":42}},
"ingress:4": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"localStore","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":6}},
"ingress:5": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"queryExecutor","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":10}},
"ingress:6": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"runtime","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":30}},
"ingress:7": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"shard","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":22}},
"ingress:8": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"subscriber","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":6}},
"ingress:9": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_cache","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":18}},
"ingress:10": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_engine","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":58}},
"ingress:11": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_filestore","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":4}},
"ingress:12": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"tsm1_wal","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":2,"valuesWritten":8}},
"ingress:13": {"name":"ingress","tags":{"db":"_internal","login":"_systemuser_monitor","measurement":"write","rp":"monitor"},"values":{"pointsWritten":2,"seriesCreated":1,"valuesWritten":18}},
"ingress:14": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"cpu","rp":"autogen"},"values":{"pointsWritten":1342,"seriesCreated":13,"valuesWritten":13420}},
"ingress:15": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"disk","rp":"autogen"},"values":{"pointsWritten":642,"seriesCreated":6,"valuesWritten":4494}},
"ingress:16": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"diskio","rp":"autogen"},"values":{"pointsWritten":214,"seriesCreated":2,"valuesWritten":2354}},
"ingress:17": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"mem","rp":"autogen"},"values":{"pointsWritten":107,"seriesCreated":1,"valuesWritten":963}},
"ingress:18": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"processes","rp":"autogen"},"values":{"pointsWritten":107,"seriesCreated":1,"valuesWritten":856}},
"ingress:19": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"swap","rp":"autogen"},"values":{"pointsWritten":214,"seriesCreated":1,"valuesWritten":642}},
"ingress:20": {"name":"ingress","tags":{"db":"telegraf","login":"_systemuser_unknown","measurement":"system","rp":"autogen"},"values":{"pointsWritten":321,"seriesCreated":1,"valuesWritten":749}},

https://github.com/influxdata/influxdb/issues/20613

Closes #20613

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
