### PR TITLE
fix(kit/cli): fix loading config from directories with '.' in the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ RPM packages, which has been left unchanged.
 1. [20669](https://github.com/influxdata/influxdb/pull/20669): Remove blank lines from payloads sent by `influx write`.
 1. [20657](https://github.com/influxdata/influxdb/pull/20657): Allow for creating users without initial passwords in `influx user create`.
 1. [20679](https://github.com/influxdata/influxdb/pull/20679): Fix incorrect "bucket not found" errors when passing `--bucket-id` to `influx write`.
+1. [20702](https://github.com/influxdata/influxdb/pull/20702): Fix loading config when `INFLUXD_CONFIG_PATH` points to a directory with `.` in its name.
+1. [20702](https://github.com/influxdata/influxdb/pull/20702): Raise an error instead of silently failing when `INFLUXD_CONFIG_PATH` points to a nonexistent file.
 
 ## v2.0.3 [2020-12-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ RPM packages, which has been left unchanged.
 1. [20657](https://github.com/influxdata/influxdb/pull/20657): Allow for creating users without initial passwords in `influx user create`.
 1. [20679](https://github.com/influxdata/influxdb/pull/20679): Fix incorrect "bucket not found" errors when passing `--bucket-id` to `influx write`.
 1. [20702](https://github.com/influxdata/influxdb/pull/20702): Fix loading config when `INFLUXD_CONFIG_PATH` points to a directory with `.` in its name.
-1. [20702](https://github.com/influxdata/influxdb/pull/20702): Raise an error instead of silently failing when `INFLUXD_CONFIG_PATH` points to a nonexistent file.
 
 ## v2.0.3 [2020-12-14]
 

--- a/kit/cli/viper.go
+++ b/kit/cli/viper.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -79,17 +80,11 @@ func initializeConfig(v *viper.Viper) error {
 		configPath = "."
 	}
 
-	fi, err := os.Stat(configPath)
-	if err != nil {
-		return err
-	}
-	if fi.IsDir() {
-		// NOTE: if given a directory, viper will look in the dir for a file
-		// with base name `config` and an extension from `viper.SupportedExts`.
-		// Of those extensions, we only document support for .json|.toml|.yaml|.yml
-		v.AddConfigPath(configPath)
-	} else {
+	switch strings.ToLower(path.Ext(configPath)) {
+	case ".json",".toml",".yaml",".yml":
 		v.SetConfigFile(configPath)
+	default:
+		v.AddConfigPath(configPath)
 	}
 
 	if err := v.ReadInConfig(); err != nil && !os.IsNotExist(err) {

--- a/kit/cli/viper.go
+++ b/kit/cli/viper.go
@@ -81,7 +81,7 @@ func initializeConfig(v *viper.Viper) error {
 	}
 
 	switch strings.ToLower(path.Ext(configPath)) {
-	case ".json",".toml",".yaml",".yml":
+	case ".json", ".toml", ".yaml", ".yml":
 		v.SetConfigFile(configPath)
 	default:
 		v.AddConfigPath(configPath)

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -427,21 +427,21 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
-	tests := []struct{
+	tests := []struct {
 		name string
-		dir string
+		dir  string
 	}{
 		{
 			name: "dot at start",
-			dir: ".directory",
+			dir:  ".directory",
 		},
 		{
 			name: "dot in middle",
-			dir: "config.d",
+			dir:  "config.d",
 		},
 		{
 			name: "dot at end",
-			dir: "forgotmyextension.",
+			dir:  "forgotmyextension.",
 		},
 	}
 
@@ -464,7 +464,7 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 				Opts: []Opt{
 					{
 						DestP: &foo,
-						Flag: "foo",
+						Flag:  "foo",
 					},
 				},
 				Run: func() error { return nil },

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -418,5 +419,62 @@ func Test_ConfigPrecedence(t *testing.T) {
 		}
 
 		t.Run(tt.name, fn)
+	}
+}
+
+func Test_ConfigPathDotDirectory(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	tests := []struct{
+		name string
+		dir string
+	}{
+		{
+			name: "dot at start",
+			dir: ".directory",
+		},
+		{
+			name: "dot in middle",
+			dir: "config.d",
+		},
+		{
+			name: "dot at end",
+			dir: "forgotmyextension.",
+		},
+	}
+
+	config := map[string]string{
+		"foo": "bar",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configDir := filepath.Join(testDir, tc.dir)
+			require.NoError(t, os.Mkdir(configDir, 0700))
+
+			_, err = writeTomlConfig(configDir, config)
+			require.NoError(t, err)
+			defer setEnvVar("TEST_CONFIG_PATH", configDir)()
+
+			var foo string
+			program := &Program{
+				Name: "test",
+				Opts: []Opt{
+					{
+						DestP: &foo,
+						Flag: "foo",
+					},
+				},
+				Run: func() error { return nil },
+			}
+
+			cmd := NewCommand(viper.New(), program)
+			cmd.SetArgs([]string{})
+			require.NoError(t, cmd.Execute())
+
+			require.Equal(t, "bar", foo)
+		})
 	}
 }


### PR DESCRIPTION
Closes #20696

Instead of using an extension-check to guess if `INFLUXD_CONFIG_PATH` is pointing to a file vs. a directory, use `os.Stat` + `IsDir()`.

This change introduces a new failure mode when `INFLUXD_CONFIG_PATH` is set in the env, but points to a nonexistent file. I think that's a win, but could be convinced to revert to the previous behavior.