### PR TITLE
feat(cmd/influx): support reading GZIP data in `influx write`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [20621](https://github.com/influxdata/influxdb/pull/20621): Add Swift client library to the data loading section of the UI.
 1. [20307](https://github.com/influxdata/influxdb/pull/20307): Add `influx task retry-failed` command to rerun failed runs.
 1. [20759](https://github.com/influxdata/influxdb/pull/20759): Add additional properties for Mosaic Graph.
+1. [20763](https://github.com/influxdata/influxdb/pull/20763): Add `--compression` option to `influx write` to support GZIP inputs.
 
 ### Bug Fixes
 

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -56,7 +56,6 @@ type writeFlagsBuilder struct {
 	ErrorsFile                 string
 	RateLimit                  string
 	Compression                string
-	ErrorThreshold             uint64
 }
 
 func newWriteFlagsBuilder(svcFn buildWriteSvcFn, f *globalFlags, opt genericCLIOpts) *writeFlagsBuilder {

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -130,7 +130,7 @@ func (b *writeFlagsBuilder) cmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&b.Encoding, "encoding", "UTF-8", "Character encoding of input files or stdin")
 	cmd.PersistentFlags().StringVar(&b.ErrorsFile, "errors-file", "", "The path to the file to write rejected rows to")
 	cmd.PersistentFlags().StringVar(&b.RateLimit, "rate-limit", "", "Throttles write, examples: \"5 MB / 5 min\" , \"17kBs\". \"\" (default) disables throttling.")
-	cmd.PersistentFlags().BoolVar(&b.Compressed, "compressed", false, "Indicates that the file is compressed")
+	cmd.PersistentFlags().BoolVar(&b.Compressed, "compressed", false, "Indicates that the input is GZIP-compressed. Defaults to false unless a '.gz' extension")
 
 	cmdDryRun := b.newCmd("dryrun", b.writeDryrunE, false)
 	cmdDryRun.Args = cobra.MaximumNArgs(1)

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -178,7 +178,6 @@ func (b *writeFlagsBuilder) createLineReader(ctx context.Context, cmd *cobra.Com
 	// utility to manage common steps used to decode / decompress input sources,
 	// while tracking resources that must be cleaned-up after reading.
 	addReader := func(r io.Reader, name string, compressed bool) error {
-		r = decode(r)
 		if compressed {
 			rcz, err := gzip.NewReader(r)
 			if err != nil {
@@ -187,7 +186,7 @@ func (b *writeFlagsBuilder) createLineReader(ctx context.Context, cmd *cobra.Com
 			closers = append(closers, rcz)
 			r = rcz
 		}
-		readers = append(readers, r, strings.NewReader("\n"))
+		readers = append(readers, decode(r), strings.NewReader("\n"))
 		return nil
 	}
 

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -209,11 +209,12 @@ func (b *writeFlagsBuilder) createLineReader(ctx context.Context, cmd *cobra.Com
 			}
 			closers = append(closers, f)
 
-			compressed := b.Compression == "gzip" || (len(b.Compression) == 0 && strings.HasSuffix(file, ".gz"))
+			fname := file
+			compressed := b.Compression == "gzip" || (len(b.Compression) == 0 && strings.HasSuffix(fname, ".gz"))
 			if compressed {
-				file = strings.TrimSuffix(file, ".gz")
+				fname = strings.TrimSuffix(fname, ".gz")
 			}
-			if len(b.Format) == 0 && strings.HasSuffix(file, ".csv") {
+			if len(b.Format) == 0 && strings.HasSuffix(fname, ".csv") {
 				b.Format = inputFormatCsv
 			}
 

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -170,8 +170,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed LP data from file",
 			flags: writeFlagsBuilder{
-				Files:      []string{gzipLpFileNoExt},
-				Compressed: true,
+				Files:       []string{gzipLpFileNoExt},
+				Compression: inputCompressionGzip,
 			},
 			firstLineCorrection: 0,
 			lines: []string{
@@ -199,7 +199,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed LP data from stdin",
 			flags: writeFlagsBuilder{
-				Compressed: true,
+				Compression: inputCompressionGzip,
 			},
 			stdIn: stdInLpGzipContents,
 			lines: []string{
@@ -235,8 +235,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed LP data from URL",
 			flags: writeFlagsBuilder{
-				URLs:       []string{fmt.Sprintf("%s/a?data=%s&compress=true", server.URL, url.QueryEscape(lpContents))},
-				Compressed: true,
+				URLs:        []string{fmt.Sprintf("%s/a?data=%s&compress=true", server.URL, url.QueryEscape(lpContents))},
+				Compression: inputCompressionGzip,
 			},
 			lines: []string{
 				lpContents,
@@ -273,8 +273,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from file + transform to line protocol",
 			flags: writeFlagsBuilder{
-				Files:      []string{gzipCsvFileNoExt},
-				Compressed: true,
+				Files:       []string{gzipCsvFileNoExt},
+				Compression: inputCompressionGzip,
 			},
 			firstLineCorrection: 0,
 			lines: []string{
@@ -340,8 +340,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from stdin + transform to line protocol",
 			flags: writeFlagsBuilder{
-				Format:     inputFormatCsv,
-				Compressed: true,
+				Format:      inputFormatCsv,
+				Compression: inputCompressionGzip,
 			},
 			stdIn: stdInCsvGzipContents,
 			lines: []string{
@@ -381,8 +381,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from URL + transform to line protocol",
 			flags: writeFlagsBuilder{
-				URLs:       []string{fmt.Sprintf("%s/a.csv?data=%s&compress=true", server.URL, url.QueryEscape(csvContents))},
-				Compressed: true,
+				URLs:        []string{fmt.Sprintf("%s/a.csv?data=%s&compress=true", server.URL, url.QueryEscape(csvContents))},
+				Compression: inputCompressionGzip,
 			},
 			lines: []string{
 				"f1 b=f2,c=f3,d=f4",

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -226,7 +226,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read LP data from URL",
 			flags: writeFlagsBuilder{
-				URLs: []string{server.URL + "/a?data=" + url.QueryEscape(lpContents)},
+				URLs: []string{fmt.Sprintf("%s/a?data=%s", server.URL, url.QueryEscape(lpContents))},
 			},
 			lines: []string{
 				lpContents,
@@ -372,7 +372,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read data from .csv URL + transform to line protocol",
 			flags: writeFlagsBuilder{
-				URLs: []string{server.URL + "/a.csv?data=" + url.QueryEscape(csvContents)},
+				URLs: []string{fmt.Sprintf("%s/a.csv?data=%s", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
 				"f1 b=f2,c=f3,d=f4",
@@ -409,7 +409,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read data from .csv URL + change header line + transform to line protocol",
 			flags: writeFlagsBuilder{
-				URLs:       []string{server.URL + "/a.csv?data=" + url.QueryEscape(csvContents)},
+				URLs:       []string{fmt.Sprintf("%s/a.csv?data=%s", server.URL, url.QueryEscape(csvContents))},
 				Headers:    []string{"k,j,_measurement,i"},
 				SkipHeader: 1,
 			},
@@ -420,7 +420,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read data from having text/csv URL resource + transform to line protocol",
 			flags: writeFlagsBuilder{
-				URLs: []string{server.URL + "/a?Content-Type=text/csv&data=" + url.QueryEscape(csvContents)},
+				URLs: []string{fmt.Sprintf("%s/a?Content-Type=text/csv&data=%s", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
 				"f1 b=f2,c=f3,d=f4",

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -189,7 +189,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name: "read LP data from stdin",
+			name:  "read LP data from stdin",
 			flags: writeFlagsBuilder{},
 			stdIn: strings.NewReader(stdInLpContents),
 			lines: []string{
@@ -207,8 +207,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name: "read LP data from stdin using '-' argument",
-			flags: writeFlagsBuilder{},
+			name:      "read LP data from stdin using '-' argument",
+			flags:     writeFlagsBuilder{},
 			stdIn:     strings.NewReader(stdInLpContents),
 			arguments: []string{"-"},
 			lines: []string{
@@ -216,8 +216,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name: "read LP data from 1st argument",
-			flags: writeFlagsBuilder{},
+			name:      "read LP data from 1st argument",
+			flags:     writeFlagsBuilder{},
 			arguments: []string{stdInLpContents},
 			lines: []string{
 				stdInLpContents,
@@ -235,7 +235,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed LP data from URL",
 			flags: writeFlagsBuilder{
-				URLs: []string{fmt.Sprintf("%s/a?data=%s&compress=true", server.URL, url.QueryEscape(lpContents))},
+				URLs:       []string{fmt.Sprintf("%s/a?data=%s&compress=true", server.URL, url.QueryEscape(lpContents))},
 				Compressed: true,
 			},
 			lines: []string{
@@ -340,7 +340,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from stdin + transform to line protocol",
 			flags: writeFlagsBuilder{
-				Format: inputFormatCsv,
+				Format:     inputFormatCsv,
 				Compressed: true,
 			},
 			stdIn: stdInCsvGzipContents,
@@ -381,7 +381,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from URL + transform to line protocol",
 			flags: writeFlagsBuilder{
-				URLs: []string{fmt.Sprintf("%s/a.csv?data=%s&compress=true", server.URL, url.QueryEscape(csvContents))},
+				URLs:       []string{fmt.Sprintf("%s/a.csv?data=%s&compress=true", server.URL, url.QueryEscape(csvContents))},
 				Compressed: true,
 			},
 			lines: []string{

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -104,7 +104,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 	lpFile := createTempFile(t, "txt", []byte(lpContents), false)
 	gzipLpFile := createTempFile(t, "txt.gz", []byte(lpContents), true)
 	gzipLpFileNoExt := createTempFile(t, "lp", []byte(lpContents), true)
-	stdInLpContents := "f1 x=1,b=2,c=3"
+	stdInLpContents := "stdin3 i=stdin1,j=stdin2,k=stdin4"
 	stdInLpGzipContents := &bytes.Buffer{}
 	stdInLpGzipWriter := gzip.NewWriter(stdInLpGzipContents)
 	_, err := stdInLpGzipWriter.Write([]byte(stdInLpContents))
@@ -189,6 +189,17 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
+			name: "read compressed an uncompressed LP data from file in the same call",
+			flags: writeFlagsBuilder{
+				Files: []string{gzipLpFile, lpFile},
+			},
+			firstLineCorrection: 0,
+			lines: []string{
+				lpContents,
+				lpContents,
+			},
+		},
+		{
 			name:  "read LP data from stdin",
 			flags: writeFlagsBuilder{},
 			stdIn: strings.NewReader(stdInLpContents),
@@ -267,7 +278,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 			firstLineCorrection: 0, // no changes
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 		{
@@ -334,7 +345,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 			stdIn: strings.NewReader(stdInCsvContents),
 			lines: []string{
-				"stdin3 i=stdin1,j=stdin2,k=stdin4",
+				stdInLpContents,
 			},
 		},
 		{
@@ -345,7 +356,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 			stdIn: stdInCsvGzipContents,
 			lines: []string{
-				"stdin3 i=stdin1,j=stdin2,k=stdin4",
+				stdInLpContents,
 			},
 		},
 		{
@@ -356,7 +367,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			stdIn:     strings.NewReader(stdInCsvContents),
 			arguments: []string{"-"},
 			lines: []string{
-				"stdin3 i=stdin1,j=stdin2,k=stdin4",
+				stdInLpContents,
 			},
 		},
 		{
@@ -366,7 +377,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 			arguments: []string{stdInCsvContents},
 			lines: []string{
-				"stdin3 i=stdin1,j=stdin2,k=stdin4",
+				stdInLpContents,
 			},
 		},
 		{
@@ -375,7 +386,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 				URLs: []string{fmt.Sprintf("%s/a.csv?data=%s", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 		{
@@ -385,7 +396,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 				Compression: inputCompressionGzip,
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 		{
@@ -394,7 +405,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 				URLs: []string{fmt.Sprintf("%s/a.csv.gz?data=%s&compress=true", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 		{
@@ -403,7 +414,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 				URLs: []string{fmt.Sprintf("%s/a.csv?data=%s&compress=true&encoding=gzip", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 		{
@@ -418,12 +429,21 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name: "read data from having text/csv URL resource + transform to line protocol",
+			name: "read data from URL with text/csv Content-Type + transform to line protocol",
 			flags: writeFlagsBuilder{
 				URLs: []string{fmt.Sprintf("%s/a?Content-Type=text/csv&data=%s", server.URL, url.QueryEscape(csvContents))},
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
+			},
+		},
+		{
+			name: "read compressed data from URL with text/csv Content-Type and gzip Content-Encoding + transform to line protocol",
+			flags: writeFlagsBuilder{
+				URLs: []string{fmt.Sprintf("%s/a?Content-Type=text/csv&data=%s&compress=true&encoding=gzip", server.URL, url.QueryEscape(csvContents))},
+			},
+			lines: []string{
+				lpContents,
 			},
 		},
 		{
@@ -433,7 +453,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 				RateLimit: "1MBs",
 			},
 			lines: []string{
-				"f1 b=f2,c=f3,d=f4",
+				lpContents,
 			},
 		},
 	}

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -170,7 +170,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read data from LP file using non-UTF encoding",
 			flags: writeFlagsBuilder{
-				Files: []string{lpFile},
+				Files:    []string{lpFile},
 				Encoding: "ISO_8859-1",
 			},
 			firstLineCorrection: 0,
@@ -192,9 +192,9 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed data from LP file using non-UTF encoding",
 			flags: writeFlagsBuilder{
-				Files: []string{gzipLpFileNoExt},
+				Files:       []string{gzipLpFileNoExt},
 				Compression: inputCompressionGzip,
-				Encoding: "ISO_8859-1",
+				Encoding:    "ISO_8859-1",
 			},
 			firstLineCorrection: 0,
 			lines: []string{
@@ -250,8 +250,8 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name:      "read compressed LP data from stdin using '-' argument",
-			flags:     writeFlagsBuilder{
+			name: "read compressed LP data from stdin using '-' argument",
+			flags: writeFlagsBuilder{
 				Compression: inputCompressionGzip,
 			},
 			stdIn:     stdInLpGzipContents,

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -168,10 +168,33 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
+			name: "read data from LP file using non-UTF encoding",
+			flags: writeFlagsBuilder{
+				Files: []string{lpFile},
+				Encoding: "ISO_8859-1",
+			},
+			firstLineCorrection: 0,
+			lines: []string{
+				lpContents,
+			},
+		},
+		{
 			name: "read compressed LP data from file",
 			flags: writeFlagsBuilder{
 				Files:       []string{gzipLpFileNoExt},
 				Compression: inputCompressionGzip,
+			},
+			firstLineCorrection: 0,
+			lines: []string{
+				lpContents,
+			},
+		},
+		{
+			name: "read compressed data from LP file using non-UTF encoding",
+			flags: writeFlagsBuilder{
+				Files: []string{gzipLpFileNoExt},
+				Compression: inputCompressionGzip,
+				Encoding: "ISO_8859-1",
 			},
 			firstLineCorrection: 0,
 			lines: []string{
@@ -189,7 +212,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			},
 		},
 		{
-			name: "read compressed an uncompressed LP data from file in the same call",
+			name: "read compressed and uncompressed LP data from file in the same call",
 			flags: writeFlagsBuilder{
 				Files: []string{gzipLpFile, lpFile},
 			},
@@ -221,6 +244,17 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 			name:      "read LP data from stdin using '-' argument",
 			flags:     writeFlagsBuilder{},
 			stdIn:     strings.NewReader(stdInLpContents),
+			arguments: []string{"-"},
+			lines: []string{
+				stdInLpContents,
+			},
+		},
+		{
+			name:      "read compressed LP data from stdin using '-' argument",
+			flags:     writeFlagsBuilder{
+				Compression: inputCompressionGzip,
+			},
+			stdIn:     stdInLpGzipContents,
 			arguments: []string{"-"},
 			lines: []string{
 				stdInLpContents,

--- a/cmd/influx/write_test.go
+++ b/cmd/influx/write_test.go
@@ -406,7 +406,7 @@ func Test_writeFlags_createLineReader(t *testing.T) {
 		{
 			name: "read compressed CSV data from stdin using '-' argument + transform to line protocol",
 			flags: writeFlagsBuilder{
-				Format: inputFormatCsv,
+				Format:      inputFormatCsv,
 				Compression: inputCompressionGzip,
 			},
 			stdIn:     gzipStdin(stdInCsvContents),


### PR DESCRIPTION
Closes #20659

This is meant to mirror the implementation of the existing CSV support.
* A new CLI option allows for explicitly specifying compression of all inputs
* If the flag isn't set, the line-reader checks the names of input files & URLs to detect GZIP
   * Files or URLs ending in `.gz` enable decompression
   * URLs that respond with `Content-Encoding: gzip` enable decompression

Unlike the existing CSV impl, gzip-or-not is handled on an input-by-input basis when the CLI option isn't set.