### PR TITLE
fix(onboarding): rename `retentionPeriodHrs` in onboarding for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [19936](https://github.com/influxdata/influxdb/pull/19936): Fix use-after-free bug in series ID iterator. Thanks @foobar!
 1. [20585](https://github.com/influxdata/influxdb/pull/20585): Fix TSM WAL segement size check. Thanks @foobar!
 1. [20754](https://github.com/influxdata/influxdb/pull/20754): Update references to docs site to use current URLs.
+1. [20774](https://github.com/influxdata/influxdb/pull/20774): Rename `retentionPeriodHrs` in onboarding API for clarify. The old key name is still accepted, but deprecated.
 
 ## v2.0.4 [2021-02-08]
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -11143,8 +11143,15 @@ components:
           type: string
         bucket:
           type: string
+        retentionPeriod:
+          type: integer
+          description: Retention period in nanoseconds for the new bucket
         retentionPeriodHrs:
           type: integer
+          description: >
+            Retention period *in nanoseconds* for the new bucket. This key's name has been misleading since OSS 2.0 GA,
+            please transition to use `retentionPeriod`
+          deprecated: true
       required:
         - username
         - org

--- a/onboarding.go
+++ b/onboarding.go
@@ -28,12 +28,13 @@ type OnboardingResults struct {
 // OnboardingRequest is the request
 // to setup defaults.
 type OnboardingRequest struct {
-	User            string        `json:"username"`
-	Password        string        `json:"password"`
-	Org             string        `json:"org"`
-	Bucket          string        `json:"bucket"`
-	RetentionPeriod time.Duration `json:"retentionPeriodHrs,omitempty"`
-	Token           string        `json:"token,omitempty"`
+	User                 string        `json:"username"`
+	Password             string        `json:"password"`
+	Org                  string        `json:"org"`
+	Bucket               string        `json:"bucket"`
+	RetentionPeriod      time.Duration `json:"retentionPeriod,omitempty"`
+	RetentionPeriodHours time.Duration `json:"retentionPeriodHrs,omitempty"`
+	Token                string        `json:"token,omitempty"`
 }
 
 func (r *OnboardingRequest) Valid() error {

--- a/tenant/service_onboarding.go
+++ b/tenant/service_onboarding.go
@@ -136,12 +136,17 @@ func (s *OnboardService) onboardUser(ctx context.Context, req *influxdb.Onboardi
 		return nil, err
 	}
 
+	rp := req.RetentionPeriod
+	if rp == 0 {
+		rp = req.RetentionPeriodHours
+	}
+
 	// create orgs buckets
 	ub := &influxdb.Bucket{
 		OrgID:           org.ID,
 		Name:            req.Bucket,
 		Type:            influxdb.BucketTypeUser,
-		RetentionPeriod: req.RetentionPeriod,
+		RetentionPeriod: rp,
 	}
 
 	if err := s.service.CreateBucket(ctx, ub); err != nil {


### PR DESCRIPTION
Closes #20452 

This API is used by Quartz (not the `influx` CLI) on the Cloud side of things, so we should be able to merge this independently.