### PR TITLE
fix(tsm1): mark tombstone stats as loaded to enable caching

### DIFF
--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -226,6 +226,7 @@ func (t *Tombstoner) TombstoneStats() TombstoneStat {
 		LastModified:    stat.ModTime().UnixNano(),
 		Size:            uint32(stat.Size()),
 	}
+	t.statsLoaded = true
 	stats := t.tombstoneStats
 	t.mu.Unlock()
 


### PR DESCRIPTION
Fixes up #20773, see https://github.com/influxdata/influxdb/commit/efd766d60febc066f14caf59f87cdcf99a5319f5#r47320007
