### PR TITLE
fix(tsm1): fix data race and validation in cache ring

### DIFF
--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRing_newRing(t *testing.T) {
@@ -12,34 +14,35 @@ func TestRing_newRing(t *testing.T) {
 		n         int
 		returnErr bool
 	}{
-		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32, returnErr: true},
-		{n: 0, returnErr: true}, {n: 3, returnErr: true},
+		{n: 1},
+		{n: 2},
+		{n: 4},
+		{n: 8},
+		{n: 16},
+		{n: 32, returnErr: true},
+		{n: 0, returnErr: true},
+		{n: 3, returnErr: true},
 	}
 
-	for i, example := range examples {
-		r, err := newring(example.n)
-		if err != nil {
+	for _, example := range examples {
+		t.Run(fmt.Sprintf("ring n %d", example.n), func(t *testing.T) {
+			r, err := newring(example.n)
 			if example.returnErr {
-				continue // expecting an error.
+				require.Error(t, err)
+				return
 			}
-			t.Fatal(err)
-		}
+			require.NoError(t, err)
+			require.Equal(t, example.n, len(r.partitions))
 
-		if got, exp := len(r.partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
-
-		// Check partitions distributed correctly
-		partitions := make([]*partition, 0)
-		for i, partition := range r.partitions {
-			if i == 0 || partition != partitions[len(partitions)-1] {
-				partitions = append(partitions, partition)
+			// Check partitions distributed correctly
+			partitions := make([]*partition, 0)
+			for i, partition := range r.partitions {
+				if i == 0 || partition != partitions[len(partitions)-1] {
+					partitions = append(partitions, partition)
+				}
 			}
-		}
-
-		if got, exp := len(partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
+			require.Equal(t, example.n, len(partitions))
+		})
 	}
 }
 
@@ -48,7 +51,7 @@ var strSliceRes [][]byte
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), nil)
+		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), &entry{})
 	}
 
 	b.ReportAllocs()
@@ -58,10 +61,10 @@ func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(256), 100) }
-func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
-func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
-func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(16), 100) }
+func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(16), 1000) }
+func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(16), 10000) }
+func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(16), 100000) }
 
 func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	vals := make([][]byte, keys)
@@ -80,10 +83,10 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 }
 
 func BenchmarkRing_getPartition_100(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 100)
+	benchmarkRingGetPartition(b, MustNewRing(16), 100)
 }
 func BenchmarkRing_getPartition_1000(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 1000)
+	benchmarkRingGetPartition(b, MustNewRing(16), 1000)
 }
 
 func benchmarkRingWrite(b *testing.B, r *ring, n int) {
@@ -116,26 +119,18 @@ func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 	}
 }
 
-func BenchmarkRing_write_1_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(1), 100) }
-func BenchmarkRing_write_1_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 1000) }
-func BenchmarkRing_write_1_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 10000) }
-func BenchmarkRing_write_1_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 100000) }
-func BenchmarkRing_write_4_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(4), 100) }
-func BenchmarkRing_write_4_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 1000) }
-func BenchmarkRing_write_4_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 10000) }
-func BenchmarkRing_write_4_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 100000) }
-func BenchmarkRing_write_32_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(32), 100) }
-func BenchmarkRing_write_32_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(32), 1000) }
-func BenchmarkRing_write_32_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(32), 10000) }
-func BenchmarkRing_write_32_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(32), 100000) }
-func BenchmarkRing_write_128_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(128), 100) }
-func BenchmarkRing_write_128_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(128), 1000) }
-func BenchmarkRing_write_128_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(128), 10000) }
-func BenchmarkRing_write_128_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
-func BenchmarkRing_write_256_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(256), 100) }
-func BenchmarkRing_write_256_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(256), 1000) }
-func BenchmarkRing_write_256_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(256), 10000) }
-func BenchmarkRing_write_256_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
+func BenchmarkRing_write_1_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 100) }
+func BenchmarkRing_write_1_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 1000) }
+func BenchmarkRing_write_1_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 10000) }
+func BenchmarkRing_write_1_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(1), 100000) }
+func BenchmarkRing_write_4_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 100) }
+func BenchmarkRing_write_4_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 1000) }
+func BenchmarkRing_write_4_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 10000) }
+func BenchmarkRing_write_4_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(4), 100000) }
+func BenchmarkRing_write_16_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(16), 100) }
+func BenchmarkRing_write_16_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(16), 1000) }
+func BenchmarkRing_write_16_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(16), 10000) }
+func BenchmarkRing_write_16_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(16), 100000) }
 
 func MustNewRing(n int) *ring {
 	r, err := newring(n)


### PR DESCRIPTION
Backport of #20797 (which was a forward-port++ of #20172)