### PR TITLE
correct the default port desc to 8086

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 1. [20773](https://github.com/influxdata/influxdb/pull/20773): Fix data race in TSM engine when inspecting tombstone stats.
 1. [20797](https://github.com/influxdata/influxdb/pull/20797): Fix data race in TSM cache. Thanks @StoneYunZhao!
 1. [20798](https://github.com/influxdata/influxdb/pull/20798): Deprecate misleading `retentionPeriodHrs` key in onboarding API.
+1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples.
 
 ## v2.0.4 [2021-02-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 1. [20773](https://github.com/influxdata/influxdb/pull/20773): Fix data race in TSM engine when inspecting tombstone stats.
 1. [20797](https://github.com/influxdata/influxdb/pull/20797): Fix data race in TSM cache. Thanks @StoneYunZhao!
 1. [20798](https://github.com/influxdata/influxdb/pull/20798): Deprecate misleading `retentionPeriodHrs` key in onboarding API.
-1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples.
+1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 
 ## v2.0.4 [2021-02-08]
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Once setup is complete, a configuration profile is created to allow you to inter
 ```bash
 $ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx config
 Active	Name	URL			            Org
-*	    default	http://localhost:9999	InfluxData
+*	    default	http://localhost:8086	InfluxData
 ```
 
 ## Writing Data

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -2063,7 +2063,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     desc:
       'Submits an HTTP POST request to the specified URL with headers and data and returns the HTTP status code.',
     example:
-      'http.post(url: "http://localhost:9999/", headers: {x:"a", y:"b"}, data: bytes(v: "body"))',
+      'http.post(url: "http://localhost:8086/", headers: {x:"a", y:"b"}, data: bytes(v: "body"))',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/latest/reference/flux/stdlib/http/post/',
@@ -3804,7 +3804,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'experimental/prometheus',
     desc: 'Retrieves Prometheus-formatted metrics from a specified URL.',
-    example: 'prometheus.scrape(url: "http://localhost:9999/metrics")',
+    example: 'prometheus.scrape(url: "http://localhost:8086/metrics")',
     category: 'Inputs',
     link:
       'https://docs.influxdata.com/influxdb/latest/reference/flux/stdlib/experimental/prometheus/scrape/',


### PR DESCRIPTION
Correct the default port desc to 8086. as the default port has been changed.[1]

[1] https://github.com/influxdata/influxdb/pull/19494

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
- [-] Tests pass
