### PR TITLE
feat(http): allow for disabling pprof

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,9 +49,8 @@ Generate profiles with the following commands for bugs related to performance, l
 
 ```sh
 # Commands should be run when the bug is actively happening.
-# Note: This command will run for at least 30 seconds.
-curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all?cpu=true"
-curl -o vars.txt "http://localhost:8086/debug/vars"
+# Note: This command will run for ~30 seconds.
+curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all?cpu=30s"
 iostat -xd 1 30 > iostat.txt
-# Attach the `profiles.tar.gz`, `vars.txt`, and `iostat.txt` output files.
+# Attach the `profiles.tar.gz` and `iostat.txt` output files.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20307](https://github.com/influxdata/influxdb/pull/20307): Add `influx task retry-failed` command to rerun failed runs.
 1. [20759](https://github.com/influxdata/influxdb/pull/20759): Add additional properties for Mosaic Graph.
 1. [20763](https://github.com/influxdata/influxdb/pull/20763): Add `--compression` option to `influx write` to support GZIP inputs.
-1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `--pprof-disabled` option to `influxd` to expose profiling information over HTTP.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `--pprof-disabled` option to `influxd` to disable exposing profiling information over HTTP.
 1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `/debug/pprof/all` HTTP endpoint to gather all profiles at once.
 1. [20827](https://github.com/influxdata/influxdb/pull/20827): Upgrade `http.pprof-enabled` config in `influxd upgrade`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,11 @@
 
 ### Breaking Changes
 
-#### /debug/pprof disabled by default
-
-Prior to this release, the `influxd` server would always expose profiling information over `/debug/pprof`.
-This endpoint is currently unauthenticated. For security, the endpoint has been disabled by default, and a
-new config/CLI option has been added to support re-enabling it.
-
 #### /debug/vars removed
 
 Prior to this release, the `influxd` server would always expose profiling information over `/debug/vars`.
-This endpoint was unauthenticated. For security, the endpoint has been removed. Use the `/metrics` endpoint
-to collect system statistics.
+This endpoint was unauthenticated, and not used by InfluxDB systems to report diagnostics. For security and clarity,
+the endpoint has been removed. Use the `/metrics` endpoint to collect system statistics.
 
 ### Features
 
@@ -21,7 +15,8 @@ to collect system statistics.
 1. [20307](https://github.com/influxdata/influxdb/pull/20307): Add `influx task retry-failed` command to rerun failed runs.
 1. [20759](https://github.com/influxdata/influxdb/pull/20759): Add additional properties for Mosaic Graph.
 1. [20763](https://github.com/influxdata/influxdb/pull/20763): Add `--compression` option to `influx write` to support GZIP inputs.
-1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `--pprof-enabled` option to `influxd` to expose profiling information over HTTP.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `--pprof-disabled` option to `influxd` to expose profiling information over HTTP.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `/debug/pprof/all` HTTP endpoint to gather all profiles at once.
 1. [20827](https://github.com/influxdata/influxdb/pull/20827): Upgrade `http.pprof-enabled` config in `influxd upgrade`.
 
 ### Bug Fixes
@@ -36,8 +31,7 @@ to collect system statistics.
 1. [20798](https://github.com/influxdata/influxdb/pull/20798): Deprecate misleading `retentionPeriodHrs` key in onboarding API.
 1. [20819](https://github.com/influxdata/influxdb/pull/20819): Fix Single Stat graphs with thresholds crashing on negative values.
 1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
-1. [20827](https://github.com/influxdata/influxdb/pull/20827): Disable unauthenticated `/debug/pprof` endpoint by default.
-1. [20827](https://github.com/influxdata/influxdb/pull/20827): Remove unauthenticated `/debug/vars` endpoint.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Remove unauthenticated, unsupported `/debug/vars` HTTP endpoint.
 
 ## v2.0.4 [2021-02-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## unreleased
 
+### Breaking Changes
+
+#### /debug/pprof disabled by default
+
+Prior to this release, the `influxd` server would always expose profiling information over `/debug/pprof`.
+This endpoint is currently unauthenticated. For security, the endpoint has been disabled by default, and a
+new config/CLI option has been added to support re-enabling it.
+
+#### /debug/vars removed
+
+Prior to this release, the `influxd` server would always expose profiling information over `/debug/vars`.
+This endpoint was unauthenticated. For security, the endpoint has been removed. Use the `/metrics` endpoint
+to collect system statistics.
+
 ### Features
 
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
@@ -7,6 +21,8 @@
 1. [20307](https://github.com/influxdata/influxdb/pull/20307): Add `influx task retry-failed` command to rerun failed runs.
 1. [20759](https://github.com/influxdata/influxdb/pull/20759): Add additional properties for Mosaic Graph.
 1. [20763](https://github.com/influxdata/influxdb/pull/20763): Add `--compression` option to `influx write` to support GZIP inputs.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Add `--pprof-enabled` option to `influxd` to expose profiling information over HTTP.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Upgrade `http.pprof-enabled` config in `influxd upgrade`.
 
 ### Bug Fixes
 
@@ -20,6 +36,8 @@
 1. [20798](https://github.com/influxdata/influxdb/pull/20798): Deprecate misleading `retentionPeriodHrs` key in onboarding API.
 1. [20819](https://github.com/influxdata/influxdb/pull/20819): Fix Single Stat graphs with thresholds crashing on negative values.
 1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Disable unauthenticated `/debug/pprof` endpoint by default.
+1. [20827](https://github.com/influxdata/influxdb/pull/20827): Remove unauthenticated `/debug/vars` endpoint.
 
 ## v2.0.4 [2021-02-08]
 

--- a/chronograf/server/mux.go
+++ b/chronograf/server/mux.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	_ "net/http/pprof"
-
 	"github.com/NYTimes/gziphandler"
 	"github.com/bouk/httprouter"
 	jhttprouter "github.com/influxdata/httprouter"
@@ -33,7 +31,6 @@ type MuxOpts struct {
 	ProviderFuncs []func(func(oauth2.Provider, oauth2.Mux))
 	StatusFeedURL string            // JSON Feed URL for the client Status page News Feed
 	CustomLinks   map[string]string // Any custom external links for client's User menu
-	PprofEnabled  bool              // Mount pprof routes for profiling
 }
 
 // NewMux attaches all the route handlers; handler returned servers chronograf.
@@ -129,11 +126,6 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 			opts.Logger,
 			next,
 		)
-	}
-
-	if opts.PprofEnabled {
-		// add profiling routes
-		router.GET("/debug/pprof/:thing", http.DefaultServeMux.ServeHTTP)
 	}
 
 	/* Documentation */

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -76,7 +76,7 @@ func setCmdDescriptions(cmd *cobra.Command) {
 func cmdRunE(ctx context.Context, o *InfluxdOpts) func() error {
 	return func() error {
 		// Set this as early as possible, since it affects global profiling rates.
-		pprof.SetGlobalProfiling(o.ProfilingEnabled)
+		pprof.SetGlobalProfiling(!o.ProfilingDisabled)
 
 		fluxinit.FluxInit()
 
@@ -133,7 +133,7 @@ type InfluxdOpts struct {
 	SessionLength        int // in minutes
 	SessionRenewDisabled bool
 
-	ProfilingEnabled bool
+	ProfilingDisabled bool
 
 	NatsPort            int
 	NatsMaxPayloadBytes int
@@ -179,7 +179,7 @@ func newOpts(viper *viper.Viper) *InfluxdOpts {
 		SessionLength:        60, // 60 minutes
 		SessionRenewDisabled: false,
 
-		ProfilingEnabled: false,
+		ProfilingDisabled: false,
 
 		StoreType:   BoltStore,
 		SecretStore: BoltStore,
@@ -505,10 +505,10 @@ func (o *InfluxdOpts) bindCliOpts() []cli.Opt {
 
 		// Pprof config
 		{
-			DestP:   &o.ProfilingEnabled,
-			Flag:    "pprof-enabled",
-			Desc:    "If true, expose debugging information over HTTP at /debug/pprof",
-			Default: o.ProfilingEnabled,
+			DestP:   &o.ProfilingDisabled,
+			Flag:    "pprof-disabled",
+			Desc:    "Don't expose debugging information over HTTP at /debug/pprof",
+			Default: o.ProfilingDisabled,
 		},
 	}
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -920,7 +920,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			m.reg,
 			http.WithLog(httpLogger),
 			http.WithAPIHandler(platformHandler),
-			http.WithPprofEnabled(opts.ProfilingEnabled),
+			http.WithPprofEnabled(!opts.ProfilingDisabled),
 		)
 
 		if opts.LogLevel == zap.DebugLevel {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	nethttp "net/http"
-	_ "net/http/pprof" // needed to add pprof to our binary.
 	"os"
 	"path/filepath"
 	"strings"
@@ -921,6 +920,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			m.reg,
 			http.WithLog(httpLogger),
 			http.WithAPIHandler(platformHandler),
+			http.WithPprofEnabled(opts.ProfilingEnabled),
 		)
 
 		if opts.LogLevel == zap.DebugLevel {

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -116,7 +116,6 @@ func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ..
 	opts.HttpBindAddress = "127.0.0.1:0"
 	opts.LogLevel = zap.DebugLevel
 	opts.ReportingDisabled = true
-	opts.ProfilingEnabled = true
 
 	for _, setter := range setters {
 		setter(opts)

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -116,6 +116,7 @@ func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ..
 	opts.HttpBindAddress = "127.0.0.1:0"
 	opts.LogLevel = zap.DebugLevel
 	opts.ReportingDisabled = true
+	opts.ProfilingEnabled = true
 
 	for _, setter := range setters {
 		setter(opts)

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	_ "net/http/pprof"
 	"os"
 	"time"
 

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -43,7 +43,7 @@ var configMapRules = map[string]string{
 	"http.bind-address":                                    "http-bind-address",
 	"http.https-certificate":                               "tls-cert",
 	"http.https-private-key":                               "tls-key",
-	"http.pprof-enabled":                                   "pprof-enabled",
+	"http.pprof-enabled":                                   "pprof-disabled",
 }
 
 // configValueTransforms is a map from 2.x config keys to transformation functions
@@ -57,6 +57,14 @@ var configValueTransforms = map[string]func(interface{}) interface{}{
 		ret := v
 		if i, ok := v.(int64); ok && i == 0 {
 			ret = 10
+		}
+		return ret
+	},
+	// Flip the boolean (1.x tracked 'enabled', 2.x tracks 'disabled').
+	"pprof-disabled": func(v interface{}) interface{} {
+		ret := v
+		if b, ok := v.(bool); ok {
+			ret = !b
 		}
 		return ret
 	},

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -43,6 +43,7 @@ var configMapRules = map[string]string{
 	"http.bind-address":                                    "http-bind-address",
 	"http.https-certificate":                               "tls-cert",
 	"http.https-private-key":                               "tls-key",
+	"http.pprof-enabled":                                   "pprof-enabled",
 }
 
 // configValueTransforms is a map from 2.x config keys to transformation functions

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -438,6 +438,7 @@ storage-validate-keys = false
 storage-wal-fsync-delay = "0s"
 tls-cert = "/etc/ssl/influxdb.pem"
 tls-key = ""
+pprof-enabled = true
 `
 
 var testConfigV2obsoleteArrays = `reporting-disabled = true

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -181,6 +181,7 @@ bind-address = "127.0.0.1:8088"
   bind-address = ":8086"
   https-certificate = "/etc/ssl/influxdb.pem"
   https-private-key = "/etc/ssl/influxdb-key.pem"
+  pprof-enabled = false
 
 [logging]
   level = "debug"
@@ -410,6 +411,7 @@ storage-shard-precreator-check-interval = "5m"
 storage-wal-fsync-delay = "100s"
 tls-cert = "/etc/ssl/influxdb.pem"
 tls-key = "/etc/ssl/influxdb-key.pem"
+pprof-disabled = true
 `
 
 var testConfigV2default = `reporting-disabled = false
@@ -438,7 +440,7 @@ storage-validate-keys = false
 storage-wal-fsync-delay = "0s"
 tls-cert = "/etc/ssl/influxdb.pem"
 tls-key = ""
-pprof-enabled = true
+pprof-disabled = false
 `
 
 var testConfigV2obsoleteArrays = `reporting-disabled = true

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -38,7 +38,7 @@ func NewAuthenticationHandler(log *zap.Logger, h platform.HTTPErrorHandler) *Aut
 	return &AuthenticationHandler{
 		log:              log,
 		HTTPErrorHandler: h,
-		Handler:          http.DefaultServeMux,
+		Handler:          http.NotFoundHandler(),
 		TokenParser:      jsonweb.NewTokenParser(jsonweb.EmptyKeyStore),
 		noAuthRouter:     httprouter.New(),
 	}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -3,7 +3,6 @@ package http
 import (
 	"net/http"
 	"net/http/httptest"
-	_ "net/http/pprof"
 	"testing"
 
 	"github.com/influxdata/influxdb/v2/kit/prom"

--- a/pprof/http_server.go
+++ b/pprof/http_server.go
@@ -1,0 +1,188 @@
+package pprof
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	httppprof "net/http/pprof"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/influxdata/influxdb/v2"
+	ihttp "github.com/influxdata/influxdb/v2/kit/transport/http"
+)
+
+type Handler struct {
+	chi.Router
+}
+
+func NewHTTPHandler(profilingEnabled bool) *Handler {
+	r := chi.NewRouter()
+	r.Route("/pprof", func(r chi.Router) {
+		if !profilingEnabled {
+			r.NotFound(profilingDisabledHandler)
+			return
+		}
+		r.Get("/cmdline", httppprof.Cmdline)
+		r.Get("/profile", httppprof.Profile)
+		r.Get("/symbol", httppprof.Symbol)
+		r.Get("/trace", httppprof.Trace)
+		r.Get("/all", archiveProfilesHandler)
+		r.Mount("/", http.HandlerFunc(httppprof.Index))
+	})
+
+	return &Handler{r}
+}
+
+func errResponse(ctx context.Context, w http.ResponseWriter, code string, message string) {
+	w.Header().Set(ihttp.PlatformErrorCodeHeader, code)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(ihttp.ErrorCodeToStatusCode(ctx, code))
+	e := struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{
+		Code:    code,
+		Message: message,
+	}
+	b, _ := json.Marshal(e)
+	_, _ = w.Write(b)
+}
+
+func profilingDisabledHandler(w http.ResponseWriter, r *http.Request) {
+	errResponse(r.Context(), w, influxdb.EForbidden, "profiling disabled")
+}
+
+func archiveProfilesHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// We parse the form here so that we can use the http.Request.Form map.
+	//
+	// Otherwise we'd have to use r.FormValue() which makes it impossible to
+	// distinguish between a form value that exists and has no value and one that
+	// does not exist at all.
+	if err := r.ParseForm(); err != nil {
+		errResponse(ctx, w, influxdb.EInternal, err.Error())
+		return
+	}
+
+	// In the following two blocks, we check if the request should include cpu
+	// profiles and a trace log.
+	//
+	// Since the submitted form can contain multiple version of a variable like:
+	//
+	//   http://localhost:8086?cpu=1s&cpu=30s&trace=3s&cpu=5s
+	//
+	// the question arises: which value should we use?  We choose to use the LAST
+	// value supplied.
+	//
+	// This is an edge case but if for some reason, for example, a url is
+	// programmatically built and multiple values are supplied, this will do what
+	// is expected.
+	//
+	var traceDuration, cpuDuration time.Duration
+
+	// last() returns either the last item from a slice of strings or an empty
+	// string if the supplied slice is empty or nil.
+	last := func(s []string) string {
+		if len(s) == 0 {
+			return ""
+		}
+		return s[len(s)-1]
+	}
+
+	// If trace exists as a form value, add it to the profiles slice with the
+	// decoded duration.
+	//
+	// Requests for a trace should look like:
+	//
+	//  ?trace=10s
+	//
+	if vals, exists := r.Form["trace"]; exists {
+		// parse the duration encoded in the last "trace" value supplied.
+		val := last(vals)
+		duration, err := time.ParseDuration(val)
+
+		// If we can't parse the duration or if the user supplies a negative
+		// number, return an appropriate error status and message.
+		//
+		// In this case it is a StatusBadRequest (400) since the problem is in the
+		// supplied form data.
+		if duration < 0 {
+			errResponse(ctx, w, influxdb.EInvalid, "negative trace durations not allowed")
+			return
+		}
+
+		if err != nil {
+			errResponse(ctx, w, influxdb.EInvalid, fmt.Sprintf("could not parse supplied duration for trace %q", val))
+			return
+		}
+
+		// Trace files can get big. Lets clamp the maximum trace duration to 45s.
+		if duration > 45*time.Second {
+			errResponse(ctx, w, influxdb.EInvalid, "cannot trace for longer than 45s")
+			return
+		}
+
+		traceDuration = duration
+	}
+
+	// Capturing CPU profiles is a little trickier. The preferred way to send the
+	// the cpu profile duration is via the supplied "cpu" variable's value.
+	//
+	// The duration should be encoded as a Go duration that can be parsed by
+	// time.ParseDuration().
+	//
+	// In the past users were encouraged to assign any value to cpu and provide
+	// the duration in a separate "seconds" value.
+	//
+	// The code below handles both -- first it attempts to use the old method
+	// which would look like:
+	//
+	//    ?cpu=foobar&seconds=10
+	//
+	// Then it attempts to ascertain the duration provided with:
+	//
+	//    ?cpu=10s
+	//
+	// This preserves backwards compatibility with any tools that have been
+	// written to gather profiles.
+	//
+	if vals, exists := r.Form["cpu"]; exists {
+		duration := time.Second * 30
+		val := last(vals)
+
+		// getDuration is a small function literal that encapsulates the logic
+		// for getting the duration from either the "seconds" form value or from
+		// the value assigned to "cpu".
+		getDuration := func() (time.Duration, error) {
+			if seconds, exists := r.Form["seconds"]; exists {
+				s, err := strconv.ParseInt(last(seconds), 10, 64)
+				if err != nil {
+					return 0, err
+				}
+				return time.Second * time.Duration(s), nil
+			}
+			// see if the value of cpu is a duration like:  cpu=10s
+			return time.ParseDuration(val)
+		}
+
+		duration, err := getDuration()
+		if err != nil {
+			errResponse(ctx, w, influxdb.EInvalid, fmt.Sprintf("could not parse supplied duration for cpu profile %q", val))
+			return
+		}
+
+		cpuDuration = duration
+	}
+
+	tarstream, err := collectAllProfiles(ctx, traceDuration, cpuDuration)
+	if err != nil {
+		errResponse(ctx, w, influxdb.EInternal, err.Error())
+		return
+	}
+	_, _ = io.Copy(w, tarstream)
+}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -31,8 +31,8 @@ func SetGlobalProfiling(enabled bool) {
 //	- blocking profile
 //	- mutex profile
 //	- heap profile
-//  - allocations profile
-//  - (optionally) trace profile
+//	- allocations profile
+//	- (optionally) trace profile
 //	- (optionally) CPU profile
 //
 // All information is added to a tar archive and then compressed, before being

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,0 +1,129 @@
+package pprof
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"time"
+)
+
+func SetGlobalProfiling(enabled bool) {
+	if enabled {
+		// Copy the rates used in 1.x.
+		runtime.MemProfileRate = 4096
+		runtime.SetBlockProfileRate(int(1 * time.Second))
+		runtime.SetMutexProfileFraction(1)
+	} else {
+		runtime.MemProfileRate = 0
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(0)
+	}
+}
+
+// collectAllProfiles generates a tarball containing:
+//	- goroutine profile
+//	- blocking profile
+//	- mutex profile
+//	- heap profile
+//  - allocations profile
+//  - (optionally) trace profile
+//	- (optionally) CPU profile
+//
+// All information is added to a tar archive and then compressed, before being
+// returned to the requester as an archive file. Where profiles support debug
+// parameters, the profile is collected with debug=1.
+func collectAllProfiles(ctx context.Context, traceDuration time.Duration, cpuDuration time.Duration) (io.Reader, error) {
+	// prof describes a profile name and a debug value, or in the case of a CPU
+	// profile, the number of seconds to collect the profile for.
+	type prof struct {
+		Name     string        // name of profile
+		Duration time.Duration // duration of profile if applicable. currently only used by cpu and trace
+	}
+
+	var profiles = []prof{
+		{Name: "goroutine"},
+		{Name: "block"},
+		{Name: "mutex"},
+		{Name: "heap"},
+		{Name: "allocs"},
+		{Name: "threadcreate"},
+	}
+	if traceDuration > 0 {
+		profiles = append(profiles, prof{"trace", traceDuration})
+	}
+	if cpuDuration > 0 {
+		// We want to gather CPU profiles first, if enabled.
+		profiles = append([]prof{{"cpu", cpuDuration}}, profiles...)
+	}
+
+	tarball := &bytes.Buffer{}
+	buf := &bytes.Buffer{} // Temporary buffer for each profile/query result.
+
+	tw := tar.NewWriter(tarball)
+	// Collect and write out profiles.
+	for _, profile := range profiles {
+		switch profile.Name {
+		case "cpu":
+			if err := pprof.StartCPUProfile(buf); err != nil {
+				return nil, err
+			}
+			sleep(ctx, profile.Duration)
+			pprof.StopCPUProfile()
+
+		case "trace":
+			if err := trace.Start(buf); err != nil {
+				return nil, err
+			}
+			sleep(ctx, profile.Duration)
+			trace.Stop()
+
+		default:
+			prof := pprof.Lookup(profile.Name)
+			if prof == nil {
+				return nil, fmt.Errorf("unable to find profile %q", profile.Name)
+			}
+
+			if err := prof.WriteTo(buf, 0); err != nil {
+				return nil, err
+			}
+		}
+
+		// Write the profile file's header.
+		if err := tw.WriteHeader(&tar.Header{
+			Name: path.Join("profiles", profile.Name+".pb.gz"),
+			Mode: 0600,
+			Size: int64(buf.Len()),
+		}); err != nil {
+			return nil, err
+		}
+
+		// Write the profile file's data.
+		if _, err := tw.Write(buf.Bytes()); err != nil {
+			return nil, err
+		}
+
+		// Reset the buffer for the next profile.
+		buf.Reset()
+	}
+
+	// Close the tar writer.
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return tarball, nil
+}
+
+// Adapted from net/http/pprof/pprof.go
+func sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}


### PR DESCRIPTION
Closes #20764

The big chunks of new logic are the `/all` profile, ported from 1.x. I didn't port the pieces of that code that gathered InfluxQL statistics, since we have other endpoints & tooling for scraping that info.

As a side-effect of switching away from using the default Mux, the `/debug/vars` endpoint is no longer exposed. Those vars were mostly empty in 2.x since we turned off the internal diagnostics service. The `/metrics` endpoint is the intended replacement.