### PR TITLE
fix(tsm): use configured value instead of default when checking WAL segment size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20886](https://github.com/influxdata/influxdb/pull/20886): Prevent "do not have an execution context" error when parsing Flux options in tasks.
 1. [20872](https://github.com/influxdata/influxdb/pull/20872): Respect 24 hour clock formats in the UI and allow more choices
 1. [20860](https://github.com/influxdata/influxdb/pull/20860): Remove unauthenticated, unsupported `/debug/vars` HTTP endpoint.
+1. [20585](https://github.com/influxdata/influxdb/pull/20585): Fix TSM WAL segement size check. Thanks @foobar!
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20886](https://github.com/influxdata/influxdb/pull/20886): Prevent "do not have an execution context" error when parsing Flux options in tasks.
 1. [20872](https://github.com/influxdata/influxdb/pull/20872): Respect 24 hour clock formats in the UI and allow more choices
 1. [20860](https://github.com/influxdata/influxdb/pull/20860): Remove unauthenticated, unsupported `/debug/vars` HTTP endpoint.
-1. [20585](https://github.com/influxdata/influxdb/pull/20585): Fix TSM WAL segement size check. Thanks @foobar!
+1. [20839](https://github.com/influxdata/influxdb/pull/20839): Fix TSM WAL segment size check. Thanks @foobar!
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -464,7 +464,7 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 // rollSegment checks if the current segment is due to roll over to a new segment;
 // and if so, opens a new segment file for future writes.
 func (l *WAL) rollSegment() error {
-	if l.currentSegmentWriter == nil || l.currentSegmentWriter.size > DefaultSegmentSize {
+	if l.currentSegmentWriter == nil || l.currentSegmentWriter.size > l.SegmentSize {
 		if err := l.newSegmentFile(); err != nil {
 			// A drop database or RP call could trigger this error if writes were in-flight
 			// when the drop statement executes.


### PR DESCRIPTION
Closes #20742

Backports #20585 