### PR TITLE
fix(tsm1): fix data race and validation in cache ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20837](https://github.com/influxdata/influxdb/pull/20837): Fix use-after-free bug in series ID iterator. Thanks @foobar!
 1. [20834](https://github.com/influxdata/influxdb/pull/20834): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 1. [20833](https://github.com/influxdata/influxdb/pull/20833): Fix Single Stat graphs with thresholds crashing on negative values.
+1. [20797](https://github.com/influxdata/influxdb/pull/20797): Fix data race in TSM cache. Thanks @StoneYunZhao!
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20837](https://github.com/influxdata/influxdb/pull/20837): Fix use-after-free bug in series ID iterator. Thanks @foobar!
 1. [20834](https://github.com/influxdata/influxdb/pull/20834): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 1. [20833](https://github.com/influxdata/influxdb/pull/20833): Fix Single Stat graphs with thresholds crashing on negative values.
-1. [20797](https://github.com/influxdata/influxdb/pull/20797): Fix data race in TSM cache. Thanks @StoneYunZhao!
+1. [20843](https://github.com/influxdata/influxdb/pull/20843): Fix data race in TSM cache. Thanks @StoneYunZhao!
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -166,7 +166,6 @@ const (
 type storer interface {
 	entry(key []byte) *entry                        // Get an entry by its key.
 	write(key []byte, values Values) (bool, error)  // Write an entry to the store.
-	add(key []byte, entry *entry)                   // Add a new entry to the store.
 	remove(key []byte)                              // Remove an entry from the store.
 	keys(sorted bool) [][]byte                      // Return an optionally sorted slice of entry keys.
 	apply(f func([]byte, *entry) error) error       // Apply f to all entries in the store in parallel.
@@ -833,7 +832,6 @@ type emptyStore struct{}
 
 func (e emptyStore) entry(key []byte) *entry                        { return nil }
 func (e emptyStore) write(key []byte, values Values) (bool, error)  { return false, nil }
-func (e emptyStore) add(key []byte, entry *entry)                   {}
 func (e emptyStore) remove(key []byte)                              {}
 func (e emptyStore) keys(sorted bool) [][]byte                      { return nil }
 func (e emptyStore) apply(f func([]byte, *entry) error) error       { return nil }

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/golang/snappy"
 )
 
+// Convenience method for testing.
+func (c *Cache) Write(key []byte, values []Value) error {
+	return c.WriteMulti(map[string][]Value{string(key): values})
+}
+
 func TestCache_NewCache(t *testing.T) {
 	c := NewCache(100)
 	if c == nil {
@@ -32,51 +37,6 @@ func TestCache_NewCache(t *testing.T) {
 	}
 	if len(c.Keys()) != 0 {
 		t.Fatalf("new cache keys not correct: %v", c.Keys())
-	}
-}
-
-func TestCache_CacheWrite(t *testing.T) {
-	v0 := NewValue(1, 1.0)
-	v1 := NewValue(2, 2.0)
-	v2 := NewValue(3, 3.0)
-	values := Values{v0, v1, v2}
-	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
-
-	c := NewCache(3 * valuesSize)
-
-	if err := c.Write([]byte("foo"), values); err != nil {
-		t.Fatalf("failed to write key foo to cache: %s", err.Error())
-	}
-	if err := c.Write([]byte("bar"), values); err != nil {
-		t.Fatalf("failed to write key foo to cache: %s", err.Error())
-	}
-	if n := c.Size(); n != 2*valuesSize+6 {
-		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
-	}
-
-	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
-		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
-	}
-}
-
-func TestCache_CacheWrite_TypeConflict(t *testing.T) {
-	v0 := NewValue(1, 1.0)
-	v1 := NewValue(2, int(64))
-	values := Values{v0, v1}
-	valuesSize := v0.Size() + v1.Size()
-
-	c := NewCache(uint64(2 * valuesSize))
-
-	if err := c.Write([]byte("foo"), values[:1]); err != nil {
-		t.Fatalf("failed to write key foo to cache: %s", err.Error())
-	}
-
-	if err := c.Write([]byte("foo"), values[1:]); err == nil {
-		t.Fatalf("expected field type conflict")
-	}
-
-	if exp, got := uint64(v0.Size())+3, c.Size(); exp != got {
-		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 }
 

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -873,7 +873,6 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 type TestStore struct {
 	entryf       func(key []byte) *entry
 	writef       func(key []byte, values Values) (bool, error)
-	addf         func(key []byte, entry *entry)
 	removef      func(key []byte)
 	keysf        func(sorted bool) [][]byte
 	applyf       func(f func([]byte, *entry) error) error
@@ -886,7 +885,6 @@ type TestStore struct {
 func NewTestStore() *TestStore                                      { return &TestStore{} }
 func (s *TestStore) entry(key []byte) *entry                        { return s.entryf(key) }
 func (s *TestStore) write(key []byte, values Values) (bool, error)  { return s.writef(key, values) }
-func (s *TestStore) add(key []byte, entry *entry)                   { s.addf(key, entry) }
 func (s *TestStore) remove(key []byte)                              { s.removef(key) }
 func (s *TestStore) keys(sorted bool) [][]byte                      { return s.keysf(sorted) }
 func (s *TestStore) apply(f func([]byte, *entry) error) error       { return s.applyf(f) }

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -3,7 +3,6 @@ package tsm1
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/cespare/xxhash"
 	"github.com/influxdata/influxdb/v2/pkg/bytesutil"
@@ -32,12 +31,6 @@ const partitions = 16
 // key is hashed and the first 8 bits are used as an index to the ring.
 //
 type ring struct {
-	// Number of keys within the ring. This is used to provide a hint for
-	// allocating the return values in keys(). It will not be perfectly accurate
-	// since it doesn't consider adding duplicate keys, or trying to remove non-
-	// existent keys.
-	keysHint int64
-
 	// The unique set of partitions in the ring.
 	// len(partitions) <= len(continuum)
 	partitions []*partition
@@ -81,7 +74,6 @@ func (r *ring) reset() {
 	for _, partition := range r.partitions {
 		partition.reset()
 	}
-	atomic.StoreInt64(&r.keysHint, 0)
 }
 
 // getPartition retrieves the hash ring partition associated with the provided
@@ -103,28 +95,16 @@ func (r *ring) write(key []byte, values Values) (bool, error) {
 	return r.getPartition(key).write(key, values)
 }
 
-// add adds an entry to the ring.
-func (r *ring) add(key []byte, entry *entry) {
-	r.getPartition(key).add(key, entry)
-	atomic.AddInt64(&r.keysHint, 1)
-}
-
 // remove deletes the entry for the given key.
 // remove is safe for use by multiple goroutines.
 func (r *ring) remove(key []byte) {
 	r.getPartition(key).remove(key)
-	for {
-		prev := atomic.LoadInt64(&r.keysHint)
-		if prev <= 0 || atomic.CompareAndSwapInt64(&r.keysHint, prev, prev-1) {
-			break
-		}
-	}
 }
 
 // keys returns all the keys from all partitions in the hash ring. The returned
 // keys will be in order if sorted is true.
 func (r *ring) keys(sorted bool) [][]byte {
-	keys := make([][]byte, 0, atomic.LoadInt64(&r.keysHint))
+	keys := make([][]byte, 0)
 	for _, p := range r.partitions {
 		keys = append(keys, p.keys()...)
 	}
@@ -265,13 +245,6 @@ func (p *partition) write(key []byte, values Values) (bool, error) {
 
 	p.store[string(key)] = e
 	return true, nil
-}
-
-// add adds a new entry for key to the partition.
-func (p *partition) add(key []byte, entry *entry) {
-	p.mu.Lock()
-	p.store[string(key)] = entry
-	p.mu.Unlock()
 }
 
 // remove deletes the entry associated with the provided key.

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRing_newRing(t *testing.T) {
@@ -12,34 +14,35 @@ func TestRing_newRing(t *testing.T) {
 		n         int
 		returnErr bool
 	}{
-		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32, returnErr: true},
-		{n: 0, returnErr: true}, {n: 3, returnErr: true},
+		{n: 1},
+		{n: 2},
+		{n: 4},
+		{n: 8},
+		{n: 16},
+		{n: 32, returnErr: true},
+		{n: 0, returnErr: true},
+		{n: 3, returnErr: true},
 	}
 
-	for i, example := range examples {
-		r, err := newring(example.n)
-		if err != nil {
+	for _, example := range examples {
+		t.Run(fmt.Sprintf("ring n %d", example.n), func(t *testing.T) {
+			r, err := newring(example.n)
 			if example.returnErr {
-				continue // expecting an error.
+				require.Error(t, err)
+				return
 			}
-			t.Fatal(err)
-		}
+			require.NoError(t, err)
+			require.Equal(t, example.n, len(r.partitions))
 
-		if got, exp := len(r.partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
-
-		// Check partitions distributed correctly
-		partitions := make([]*partition, 0)
-		for i, partition := range r.partitions {
-			if i == 0 || partition != partitions[len(partitions)-1] {
-				partitions = append(partitions, partition)
+			// Check partitions distributed correctly
+			partitions := make([]*partition, 0)
+			for i, partition := range r.partitions {
+				if i == 0 || partition != partitions[len(partitions)-1] {
+					partitions = append(partitions, partition)
+				}
 			}
-		}
-
-		if got, exp := len(partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
+			require.Equal(t, example.n, len(partitions))
+		})
 	}
 }
 
@@ -48,7 +51,7 @@ var strSliceRes [][]byte
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), nil)
+		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), &entry{})
 	}
 
 	b.ReportAllocs()
@@ -58,10 +61,10 @@ func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(256), 100) }
-func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
-func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
-func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(16), 100) }
+func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(16), 1000) }
+func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(16), 10000) }
+func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(16), 100000) }
 
 func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	vals := make([][]byte, keys)
@@ -80,10 +83,10 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 }
 
 func BenchmarkRing_getPartition_100(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 100)
+	benchmarkRingGetPartition(b, MustNewRing(16), 100)
 }
 func BenchmarkRing_getPartition_1000(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 1000)
+	benchmarkRingGetPartition(b, MustNewRing(16), 1000)
 }
 
 func benchmarkRingWrite(b *testing.B, r *ring, n int) {
@@ -116,26 +119,18 @@ func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 	}
 }
 
-func BenchmarkRing_write_1_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(1), 100) }
-func BenchmarkRing_write_1_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 1000) }
-func BenchmarkRing_write_1_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 10000) }
-func BenchmarkRing_write_1_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 100000) }
-func BenchmarkRing_write_4_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(4), 100) }
-func BenchmarkRing_write_4_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 1000) }
-func BenchmarkRing_write_4_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 10000) }
-func BenchmarkRing_write_4_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 100000) }
-func BenchmarkRing_write_32_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(32), 100) }
-func BenchmarkRing_write_32_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(32), 1000) }
-func BenchmarkRing_write_32_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(32), 10000) }
-func BenchmarkRing_write_32_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(32), 100000) }
-func BenchmarkRing_write_128_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(128), 100) }
-func BenchmarkRing_write_128_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(128), 1000) }
-func BenchmarkRing_write_128_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(128), 10000) }
-func BenchmarkRing_write_128_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
-func BenchmarkRing_write_256_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(256), 100) }
-func BenchmarkRing_write_256_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(256), 1000) }
-func BenchmarkRing_write_256_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(256), 10000) }
-func BenchmarkRing_write_256_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
+func BenchmarkRing_write_1_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 100) }
+func BenchmarkRing_write_1_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 1000) }
+func BenchmarkRing_write_1_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 10000) }
+func BenchmarkRing_write_1_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(1), 100000) }
+func BenchmarkRing_write_4_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 100) }
+func BenchmarkRing_write_4_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 1000) }
+func BenchmarkRing_write_4_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 10000) }
+func BenchmarkRing_write_4_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(4), 100000) }
+func BenchmarkRing_write_16_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(16), 100) }
+func BenchmarkRing_write_16_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(16), 1000) }
+func BenchmarkRing_write_16_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(16), 10000) }
+func BenchmarkRing_write_16_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(16), 100000) }
 
 func MustNewRing(n int) *ring {
 	r, err := newring(n)

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -51,7 +51,12 @@ var strSliceRes [][]byte
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), &entry{})
+		r.write([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), Values([]Value{
+			IntegerValue{
+				unixnano: 1,
+				value:    int64(i),
+			},
+		}))
 	}
 
 	b.ReportAllocs()
@@ -72,7 +77,12 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
 		vals[i] = []byte(fmt.Sprintf("cpu,host=server-%d field1=value1,field2=value2,field4=value4,field5=value5,field6=value6,field7=value7,field8=value1,field9=value2,field10=value4,field11=value5,field12=value6,field13=value7", i))
-		r.add(vals[i], nil)
+		r.write([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), Values([]Value{
+			IntegerValue{
+				unixnano: 1,
+				value:    int64(i),
+			},
+		}))
 	}
 
 	b.ReportAllocs()


### PR DESCRIPTION
Closes #20801 

Backports #20797, #20803, and #20890