### PR TITLE
fix(ui): respect 24 hour clock format and allow more choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20819](https://github.com/influxdata/influxdb/pull/20819): Fix Single Stat graphs with thresholds crashing on negative values.
 1. [20809](https://github.com/influxdata/influxdb/pull/20809): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 1. [20827](https://github.com/influxdata/influxdb/pull/20827): Remove unauthenticated, unsupported `/debug/vars` HTTP endpoint.
+1. [20856](https://github.com/influxdata/influxdb/pull/20856): Respect 24 hour clock formats in the UI and allow more choices
 
 ## v2.0.4 [2021-02-08]
 

--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -36,17 +36,26 @@ export const DEFAULT_TABLE_OPTIONS = {
 }
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
-  {text: DEFAULT_TIME_FORMAT},
+  {text: DEFAULT_TIME_FORMAT}, // 'YYYY-MM-DD HH:mm:ss ZZ'
+  {text: 'YYYY-MM-DD hh:mm:ss a ZZ'},
   {text: 'DD/MM/YYYY HH:mm:ss.sss'},
+  {text: 'DD/MM/YYYY hh:mm:ss.sss a'},
   {text: 'MM/DD/YYYY HH:mm:ss.sss'},
+  {text: 'MM/DD/YYYY hh:mm:ss.sss a'},
   {text: 'YYYY/MM/DD HH:mm:ss'},
-  {text: 'hh:mm a'},
+  {text: 'YYYY/MM/DD hh:mm:ss a'},
   {text: 'HH:mm'},
+  {text: 'hh:mm a'},
   {text: 'HH:mm:ss'},
+  {text: 'hh:mm:ss a'},
   {text: 'HH:mm:ss ZZ'},
+  {text: 'hh:mm:ss a ZZ'},
   {text: 'HH:mm:ss.sss'},
+  {text: 'hh:mm:ss.sss a'},
   {text: 'MMMM D, YYYY HH:mm:ss'},
+  {text: 'MMMM D, YYYY hh:mm:ss a'},
   {text: 'dddd, MMMM D, YYYY HH:mm:ss'},
+  {text: 'dddd, MMMM D, YYYY hh:mm:ss a'},
 ]
 
 export type NewDefaultCell = Pick<

--- a/ui/src/shared/components/tables/TableGraphTable.tsx
+++ b/ui/src/shared/components/tables/TableGraphTable.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
-import {timeFormatter} from '@influxdata/giraffe'
 import classnames from 'classnames'
 
 // Components
@@ -11,6 +10,7 @@ import {ColumnSizer, SizedColumnProps, AutoSizer} from 'react-virtualized'
 import {MultiGrid, PropsMultiGrid} from 'src/shared/components/MultiGrid'
 
 // Utils
+import {getFormatter} from 'src/shared/utils/vis'
 import {withHoverTime, InjectedHoverProps} from 'src/dashboards/utils/hoverTime'
 import {
   findHoverTimeIndex,
@@ -351,9 +351,9 @@ class TableGraphTable extends PureComponent<Props, State> {
       properties: {timeFormat},
     } = this.props
 
-    return timeFormatter({
+    return getFormatter('time', {
       timeZone: timeZone === 'Local' ? undefined : timeZone,
-      format: resolveTimeFormat(timeFormat),
+      timeFormat: resolveTimeFormat(timeFormat),
     })
   }
 

--- a/ui/src/shared/utils/vis.ts
+++ b/ui/src/shared/utils/vis.ts
@@ -79,10 +79,14 @@ export const getFormatter = (
   }
 
   if (columnType === 'time') {
-    return timeFormatter({
+    const formatOptions = {
       timeZone: timeZone === 'Local' ? undefined : timeZone,
       format: resolveTimeFormat(timeFormat),
-    })
+    }
+    if (timeFormat?.includes('HH')) {
+      formatOptions['hour12'] = false
+    }
+    return timeFormatter(formatOptions)
   }
 
   return null


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/768

Identical to change made in InfluxDB Cloud UI. See https://github.com/influxdata/ui/pull/772

- 'HH' triggers 24 hour clock format
- Add more choices to allow users to keep 12 hour formats
- Add meridiem to 12 hour formats

![Kapture 2021-03-03 at 16 11 29](https://user-images.githubusercontent.com/10736577/109893111-e9123300-7c3f-11eb-8e0a-fb46a6af2031.gif)



<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

