### PR TITLE
refactor: remove panics from influx CLI setup code

### DIFF
--- a/cmd/influx/bucket_test.go
+++ b/cmd/influx/bucket_test.go
@@ -92,7 +92,7 @@ func TestCmdBucket(t *testing.T) {
 			},
 		}
 
-		cmdFn := func(expectedBkt influxdb.Bucket) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(expectedBkt influxdb.Bucket) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := mock.NewBucketService()
 			svc.CreateBucketFn = func(ctx context.Context, bucket *influxdb.Bucket) error {
 				if expectedBkt != *bucket {
@@ -101,7 +101,7 @@ func TestCmdBucket(t *testing.T) {
 				return nil
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				return newCmdBucketBuilder(fakeSVCFn(svc), g, opt).cmd()
 			}
 		}
@@ -114,7 +114,8 @@ func TestCmdBucket(t *testing.T) {
 					in(new(bytes.Buffer)),
 					out(ioutil.Discard),
 				)
-				cmd := builder.cmd(cmdFn(tt.expectedBucket))
+				cmd, err := builder.cmd(cmdFn(tt.expectedBucket))
+				require.NoError(t, err)
 				cmd.SetArgs(append([]string{"bucket", "create"}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
@@ -157,7 +158,7 @@ func TestCmdBucket(t *testing.T) {
 			},
 		}
 
-		cmdFn := func(expectedID influxdb.ID) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(expectedID influxdb.ID) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := mock.NewBucketService()
 			svc.FindBucketByIDFn = func(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
 				return &influxdb.Bucket{ID: id}, nil
@@ -178,7 +179,7 @@ func TestCmdBucket(t *testing.T) {
 				return nil
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				return newCmdBucketBuilder(fakeSVCFn(svc), g, opt).cmd()
 			}
 		}
@@ -198,7 +199,8 @@ func TestCmdBucket(t *testing.T) {
 					out(outBuf),
 				)
 
-				cmd := builder.cmd(cmdFn(tt.expectedID))
+				cmd, err := builder.cmd(cmdFn(tt.expectedID))
+				require.NoError(t, err)
 				cmd.SetArgs(append([]string{"bucket", "delete"}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())
@@ -298,7 +300,7 @@ func TestCmdBucket(t *testing.T) {
 			},
 		}
 
-		cmdFn := func() (func(*globalFlags, genericCLIOpts) *cobra.Command, *called) {
+		cmdFn := func() (func(*globalFlags, genericCLIOpts) (*cobra.Command, error), *called) {
 			calls := new(called)
 
 			svc := mock.NewBucketService()
@@ -318,7 +320,7 @@ func TestCmdBucket(t *testing.T) {
 				return nil, 0, nil
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				return newCmdBucketBuilder(fakeSVCFn(svc), g, opt).cmd()
 			}, calls
 		}
@@ -333,7 +335,8 @@ func TestCmdBucket(t *testing.T) {
 				)
 
 				cmdFn, calls := cmdFn()
-				cmd := builder.cmd(cmdFn)
+				cmd, err := builder.cmd(cmdFn)
+				require.NoError(t, err)
 
 				if tt.command == "" {
 					tt.command = "list"
@@ -410,7 +413,7 @@ func TestCmdBucket(t *testing.T) {
 			},
 		}
 
-		cmdFn := func(expectedUpdate influxdb.BucketUpdate) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(expectedUpdate influxdb.BucketUpdate) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := mock.NewBucketService()
 			svc.UpdateBucketFn = func(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
 				if id != 3 {
@@ -422,7 +425,7 @@ func TestCmdBucket(t *testing.T) {
 				return &influxdb.Bucket{}, nil
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				return newCmdBucketBuilder(fakeSVCFn(svc), g, opt).cmd()
 			}
 		}
@@ -436,7 +439,8 @@ func TestCmdBucket(t *testing.T) {
 					out(ioutil.Discard),
 				)
 
-				cmd := builder.cmd(cmdFn(tt.expected))
+				cmd, err := builder.cmd(cmdFn(tt.expected))
+				require.NoError(t, err)
 
 				cmd.SetArgs(append([]string{"bucket", "update"}, tt.flags...))
 				require.NoError(t, cmd.Execute())

--- a/cmd/influx/config_test.go
+++ b/cmd/influx/config_test.go
@@ -87,8 +87,8 @@ func TestCmdConfig(t *testing.T) {
 					},
 				},
 			}
-			cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) *cobra.Command {
-				return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
+				return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 					builder := cmdConfigBuilder{
 						genericCLIOpts: opt,
 						globalFlags:    g,
@@ -114,7 +114,8 @@ func TestCmdConfig(t *testing.T) {
 						in(new(bytes.Buffer)),
 						out(ioutil.Discard),
 					)
-					cmd := builder.cmd(cmdFn(tt.original, tt.expected))
+					cmd, err := builder.cmd(cmdFn(tt.original, tt.expected))
+					require.NoError(t, err)
 					cmd.SetArgs(append([]string{"config", "create"}, tt.flags...))
 					require.NoError(t, cmd.Execute())
 				}
@@ -132,7 +133,8 @@ func TestCmdConfig(t *testing.T) {
 				in(new(bytes.Buffer)),
 				out(ioutil.Discard),
 			)
-			cmd := builder.cmd(cmdConfig)
+			cmd, err := builder.cmd(cmdConfig)
+			require.NoError(t, err)
 
 			flags := []string{
 				"--configs-path=" + file,
@@ -158,7 +160,7 @@ func TestCmdConfig(t *testing.T) {
 		})
 
 		t.Run("rejects a config option with an invalid host url", func(t *testing.T) {
-			cmdFn := func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			cmdFn := func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				builder := cmdConfigBuilder{
 					genericCLIOpts: opt,
 					globalFlags:    g,
@@ -239,7 +241,7 @@ func TestCmdConfig(t *testing.T) {
 				},
 			},
 		}
-		cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := func(_ string) config.Service {
 				return &mockConfigService{
 					SwitchActiveFn: func(name string) (config.Config, error) {
@@ -264,7 +266,7 @@ func TestCmdConfig(t *testing.T) {
 				}
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				builder := cmdConfigBuilder{
 					genericCLIOpts: opt,
 					globalFlags:    g,
@@ -279,7 +281,8 @@ func TestCmdConfig(t *testing.T) {
 					in(new(bytes.Buffer)),
 					out(ioutil.Discard),
 				)
-				cmd := builder.cmd(cmdFn(tt.original, tt.expected))
+				cmd, err := builder.cmd(cmdFn(tt.original, tt.expected))
+				require.NoError(t, err)
 				cmd.SetArgs([]string{"config", tt.arg})
 				require.NoError(t, cmd.Execute())
 			}
@@ -375,7 +378,7 @@ func TestCmdConfig(t *testing.T) {
 					},
 				},
 			}
-			cmdFn := func(expected config.Config) func(*globalFlags, genericCLIOpts) *cobra.Command {
+			cmdFn := func(expected config.Config) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 				svc := func(_ string) config.Service {
 					return &mockConfigService{
 						UpdateConfigFn: func(cfg config.Config) (config.Config, error) {
@@ -389,7 +392,7 @@ func TestCmdConfig(t *testing.T) {
 					}
 				}
 
-				return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+				return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 					builder := cmdConfigBuilder{
 						genericCLIOpts: opt,
 						globalFlags:    g,
@@ -404,7 +407,8 @@ func TestCmdConfig(t *testing.T) {
 						in(new(bytes.Buffer)),
 						out(ioutil.Discard),
 					)
-					cmd := builder.cmd(cmdFn(tt.expected))
+					cmd, err := builder.cmd(cmdFn(tt.expected))
+					require.NoError(t, err)
 					cmd.SetArgs(append([]string{"config", "set"}, tt.flags...))
 					require.NoError(t, cmd.Execute())
 				}
@@ -413,7 +417,7 @@ func TestCmdConfig(t *testing.T) {
 		})
 
 		t.Run("rejects a config option with an invalid host url", func(t *testing.T) {
-			cmdFn := func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			cmdFn := func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				builder := cmdConfigBuilder{
 					genericCLIOpts: opt,
 					globalFlags:    g,
@@ -484,7 +488,7 @@ func TestCmdConfig(t *testing.T) {
 				},
 			},
 		}
-		cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(original config.Configs, expected config.Config) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := func(_ string) config.Service {
 				return &mockConfigService{
 					DeleteConfigFn: func(name string) (config.Config, error) {
@@ -505,7 +509,7 @@ func TestCmdConfig(t *testing.T) {
 				}
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				builder := cmdConfigBuilder{
 					genericCLIOpts: opt,
 					globalFlags:    g,
@@ -520,7 +524,8 @@ func TestCmdConfig(t *testing.T) {
 					in(new(bytes.Buffer)),
 					out(ioutil.Discard),
 				)
-				cmd := builder.cmd(cmdFn(tt.original, tt.expected))
+				cmd, err := builder.cmd(cmdFn(tt.original, tt.expected))
+				require.NoError(t, err)
 				cmd.SetArgs(append([]string{"config", "delete"}, tt.flags...))
 				require.NoError(t, cmd.Execute())
 			}
@@ -551,7 +556,7 @@ func TestCmdConfig(t *testing.T) {
 				},
 			},
 		}
-		cmdFn := func(expected config.Configs) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(expected config.Configs) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := func(_ string) config.Service {
 				return &mockConfigService{
 					ListConfigsFn: func() (config.Configs, error) {
@@ -560,7 +565,7 @@ func TestCmdConfig(t *testing.T) {
 				}
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				builder := cmdConfigBuilder{
 					genericCLIOpts: opt,
 					globalFlags:    g,
@@ -575,7 +580,8 @@ func TestCmdConfig(t *testing.T) {
 					in(new(bytes.Buffer)),
 					out(ioutil.Discard),
 				)
-				cmd := builder.cmd(cmdFn(tt.expected))
+				cmd, err := builder.cmd(cmdFn(tt.expected))
+				require.NoError(t, err)
 				cmd.SetArgs([]string{"config", "list"})
 				require.NoError(t, cmd.Execute())
 			}
@@ -584,7 +590,7 @@ func TestCmdConfig(t *testing.T) {
 	})
 }
 
-func testConfigInvalidURLs(t *testing.T, cmdName string, cmdFn func(*globalFlags, genericCLIOpts) *cobra.Command) {
+func testConfigInvalidURLs(t *testing.T, cmdName string, cmdFn func(*globalFlags, genericCLIOpts) (*cobra.Command, error)) {
 	tests := []struct {
 		name  string
 		flags []string
@@ -615,7 +621,8 @@ func testConfigInvalidURLs(t *testing.T, cmdName string, cmdFn func(*globalFlags
 				in(new(bytes.Buffer)),
 				out(ioutil.Discard),
 			)
-			cmd := builder.cmd(cmdFn)
+			cmd, err := builder.cmd(cmdFn)
+			require.NoError(t, err)
 			cmd.SetArgs(append([]string{"config", cmdName}, tt.flags...))
 			require.Error(t, cmd.Execute(), "cmd name: influx config "+cmdName)
 		}

--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func cmdDelete(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+func cmdDelete(f *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 	builder := &cmdDeleteBuilder{
 		genericCLIOpts: opt,
 		globalFlags:    f,
@@ -24,8 +24,11 @@ type cmdDeleteBuilder struct {
 	flags http.DeleteRequest
 }
 
-func (b *cmdDeleteBuilder) cmd() *cobra.Command {
-	cmd := b.newCmd("delete", b.fluxDeleteF)
+func (b *cmdDeleteBuilder) cmd() (*cobra.Command, error) {
+	cmd, err := b.newCmd("delete", b.fluxDeleteF)
+	if err != nil {
+		return nil, err
+	}
 	cmd.Short = "Delete points from influxDB"
 	cmd.Long = `Delete points from influxDB, by specify start, end time
 	and a sql like predicate string.`
@@ -58,13 +61,15 @@ func (b *cmdDeleteBuilder) cmd() *cobra.Command {
 			Persistent: true,
 		},
 	}
-	opts.mustRegister(b.viper, cmd)
+	if err := opts.register(b.viper, cmd); err != nil {
+		return nil, err
+	}
 
 	cmd.PersistentFlags().StringVar(&b.flags.Start, "start", "", "the start time in RFC3339Nano format, exp 2009-01-02T23:00:00Z")
 	cmd.PersistentFlags().StringVar(&b.flags.Stop, "stop", "", "the stop time in RFC3339Nano format, exp 2009-01-02T23:00:00Z")
 	cmd.PersistentFlags().StringVarP(&b.flags.Predicate, "predicate", "p", "", "sql like predicate string, exp 'tag1=\"v1\" and (tag2=123)'")
 
-	return cmd
+	return cmd, nil
 }
 
 func (b *cmdDeleteBuilder) fluxDeleteF(cmd *cobra.Command, args []string) error {
@@ -100,8 +105,10 @@ func (b *cmdDeleteBuilder) fluxDeleteF(cmd *cobra.Command, args []string) error 
 	return nil
 }
 
-func (b *cmdDeleteBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) *cobra.Command {
+func (b *cmdDeleteBuilder) newCmd(use string, runE func(*cobra.Command, []string) error) (*cobra.Command, error) {
 	cmd := b.genericCLIOpts.newCmd(use, runE, true)
-	b.globalFlags.registerFlags(b.viper, cmd)
-	return cmd
+	if err := b.globalFlags.registerFlags(b.viper, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+func cmdPing(f *globalFlags, opts genericCLIOpts) (*cobra.Command, error) {
 	runE := func(cmd *cobra.Command, args []string) error {
 		c := http.Client{
 			Timeout: 5 * time.Second,
@@ -46,7 +46,9 @@ func cmdPing(f *globalFlags, opts genericCLIOpts) *cobra.Command {
 	cmd := opts.newCmd("ping", runE, true)
 	cmd.Short = "Check the InfluxDB /health endpoint"
 	cmd.Long = `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`
-	f.registerFlags(opts.viper, cmd, "token")
+	if err := f.registerFlags(opts.viper, cmd, "token"); err != nil {
+		return nil, err
+	}
 
-	return cmd
+	return cmd, nil
 }

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -26,18 +26,22 @@ var queryFlags struct {
 	raw  bool
 }
 
-func cmdQuery(f *globalFlags, opts genericCLIOpts) *cobra.Command {
+func cmdQuery(f *globalFlags, opts genericCLIOpts) (*cobra.Command, error) {
 	cmd := opts.newCmd("query [query literal or -f /path/to/query.flux]", fluxQueryF, true)
 	cmd.Short = "Execute a Flux query"
 	cmd.Long = `Execute a Flux query provided via the first argument or a file or stdin`
 	cmd.Args = cobra.MaximumNArgs(1)
 
-	f.registerFlags(opts.viper, cmd)
-	queryFlags.org.register(opts.viper, cmd, true)
+	if err := f.registerFlags(opts.viper, cmd); err != nil {
+		return nil, err
+	}
+	if err := queryFlags.org.register(opts.viper, cmd, true); err != nil {
+		return nil, err
+	}
 	cmd.Flags().StringVarP(&queryFlags.file, "file", "f", "", "Path to Flux query file")
 	cmd.Flags().BoolVarP(&queryFlags.raw, "raw", "r", false, "Display raw query results")
 
-	return cmd
+	return cmd, nil
 }
 
 // readFluxQuery returns first argument, file contents or stdin

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -31,12 +31,14 @@ var setupFlags struct {
 	username    string
 }
 
-func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+func cmdSetup(f *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 	cmd := opt.newCmd("setup", nil, true)
 	cmd.RunE = setupF
 	cmd.Short = "Setup instance with initial user, org, bucket"
 
-	f.registerFlags(opt.viper, cmd, "token")
+	if err := f.registerFlags(opt.viper, cmd, "token"); err != nil {
+		return nil, err
+	}
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
 	cmd.Flags().StringVarP(&setupFlags.password, "password", "p", "", "password for username")
 	cmd.Flags().StringVarP(&setupFlags.token, "token", "t", "", "token for username, else auto-generated")
@@ -45,20 +47,27 @@ func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Flags().StringVarP(&setupFlags.name, "name", "n", "", "config name, only required if you already have existing configs")
 	cmd.Flags().StringVarP(&setupFlags.retention, "retention", "r", "", "Duration bucket will retain data. 0 is infinite. Default is 0.")
 	cmd.Flags().BoolVarP(&setupFlags.force, "force", "f", false, "skip confirmation prompt")
-	registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json)
+	if err := registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json); err != nil {
+		return nil, err
+	}
 
-	cmd.AddCommand(
-		cmdSetupUser(f, opt),
-	)
-	return cmd
+	subcmd, err := cmdSetupUser(f, opt)
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(subcmd)
+
+	return cmd, nil
 }
 
-func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+func cmdSetupUser(f *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 	cmd := opt.newCmd("user", nil, true)
 	cmd.RunE = setupUserF
 	cmd.Short = "Setup instance with user, org, bucket"
 
-	f.registerFlags(opt.viper, cmd, "token")
+	if err := f.registerFlags(opt.viper, cmd, "token"); err != nil {
+		return nil, err
+	}
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
 	cmd.Flags().StringVarP(&setupFlags.password, "password", "p", "", "password for username")
 	cmd.Flags().StringVarP(&setupFlags.token, "token", "t", "", "token for username, else auto-generated")
@@ -67,9 +76,11 @@ func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd.Flags().StringVarP(&setupFlags.name, "name", "n", "", "config name, only required if you already have existing configs")
 	cmd.Flags().StringVarP(&setupFlags.retention, "retention", "r", "", "Duration bucket will retain data. 0 is infinite. Default is 0.")
 	cmd.Flags().BoolVarP(&setupFlags.force, "force", "f", false, "skip confirmation prompt")
-	registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json)
+	if err := registerPrintOptions(opt.viper, cmd, &setupFlags.hideHeaders, &setupFlags.json); err != nil {
+		return nil, err
+	}
 
-	return cmd
+	return cmd, nil
 }
 
 func setupUserF(cmd *cobra.Command, args []string) error {

--- a/cmd/influx/task_test.go
+++ b/cmd/influx/task_test.go
@@ -50,7 +50,7 @@ func TestCmdTask(t *testing.T) {
 			},
 		}
 
-		cmdFn := func(expectedTsk influxdb.Task) func(*globalFlags, genericCLIOpts) *cobra.Command {
+		cmdFn := func(expectedTsk influxdb.Task) func(*globalFlags, genericCLIOpts) (*cobra.Command, error) {
 			svc := mock.NewTaskService()
 			svc.CreateTaskFn = func(ctx context.Context, task influxdb.TaskCreate) (*influxdb.Task, error) {
 				tmpTsk := influxdb.Task{
@@ -71,7 +71,7 @@ func TestCmdTask(t *testing.T) {
 				}
 			}
 
-			return func(g *globalFlags, opt genericCLIOpts) *cobra.Command {
+			return func(g *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 				return newCmdTaskBuilder(fakeSVCFn(svc), g, opt).cmd()
 			}
 		}
@@ -84,7 +84,8 @@ func TestCmdTask(t *testing.T) {
 					in(new(bytes.Buffer)),
 					out(ioutil.Discard),
 				)
-				cmd := builder.cmd(cmdFn(tt.expectedTask))
+				cmd, err := builder.cmd(cmdFn(tt.expectedTask))
+				require.NoError(t, err)
 				cmd.SetArgs(append([]string{"task", "create"}, tt.flags...))
 
 				require.NoError(t, cmd.Execute())

--- a/cmd/influx/transpile.go
+++ b/cmd/influx/transpile.go
@@ -16,7 +16,7 @@ var transpileFlags struct {
 	Now string
 }
 
-func cmdTranspile(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+func cmdTranspile(f *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 	cmd := opt.newCmd("transpile [InfluxQL query]", transpileF, false)
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.Short = "Transpile an InfluxQL query to Flux source code"
@@ -34,9 +34,11 @@ The transpiled query will be written for absolute time ranges using the provided
 			Desc:  "An RFC3339Nano formatted time to use as the now() time. Defaults to the current time",
 		},
 	}
-	opts.mustRegister(opt.viper, cmd)
+	if err := opts.register(opt.viper, cmd); err != nil {
+		return nil, err
+	}
 
-	return cmd
+	return cmd, nil
 }
 
 func transpileF(cmd *cobra.Command, args []string) error {

--- a/cmd/influx/v1_commands.go
+++ b/cmd/influx/v1_commands.go
@@ -2,15 +2,19 @@ package main
 
 import "github.com/spf13/cobra"
 
-func cmdV1SubCommands(f *globalFlags, opt genericCLIOpts) *cobra.Command {
+func cmdV1SubCommands(f *globalFlags, opt genericCLIOpts) (*cobra.Command, error) {
 	cmd := opt.newCmd("v1", nil, false)
 	cmd.Short = "InfluxDB v1 management commands"
 	cmd.Run = seeHelp
 
-	cmd.AddCommand(
-		cmdV1Auth(f, opt),
-		cmdV1DBRP(f, opt),
-	)
+	builders := []func(*globalFlags, genericCLIOpts) (*cobra.Command, error){cmdV1Auth, cmdV1DBRP}
+	for _, builder := range builders {
+		subcmd, err := builder(f, opt)
+		if err != nil {
+			return nil, err
+		}
+		cmd.AddCommand(subcmd)
+	}
 
-	return cmd
+	return cmd, nil
 }


### PR DESCRIPTION
Closes #20491 

This removes all `panic` calls from `cmd/influx`. The blast radius is extensive, and highlights many other smells in our CLI code.

IMO `cmd/influx` needs to be significantly restructured, to reduce duplicate code and duplicate work (i.e. registering the global flags when setting up _every_ subcommand). I'm not sure if merging this before that change would be useful because it really highlights the duplication problem, or if it just adds more noise and should be held back.

