### PR TITLE
fix: infinite recursion bug (#20862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ v1.8.5 [unreleased]
 -	[#20033](https://github.com/influxdata/influxdb/pull/20033): fix(tsm1): "snapshot in progress" error during backup
 -	[#20909](https://github.com/influxdata/influxdb/pull/20909): fix(tsm1): data race when accessing tombstone stats
 -	[#20912](https://github.com/influxdata/influxdb/pull/20912): fix(tsdb): minimize lock contention when adding new fields or measure
+-	[#20914](https://github.com/influxdata/influxdb/pull/20914): fix: infinite recursion bug (#20862)
 
 v1.8.4 [2021-01-27]
 -------------------


### PR DESCRIPTION
* Revert "fix(error): unsupported value: +Inf" error not handled gracefully (#20250)"

This reverts commit 6ac0bb3fe337ca6ec6a7ad651a2ec533c049dae4.

* fix: No infinite recursion on write error

If there is some error writing to the response writer, we
would previous have infinite recursion.

Re-closes https://github.com/influxdata/influxdb/issues/20249

(cherry picked from commit d6f7716924d40aa55304d2c60e266af173163065

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass