### PR TITLE
chore(ui): bump UI version in prep for 2.0.5 release

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "influxdb-ui",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": false,
   "license": "MIT",
   "description": "",


### PR DESCRIPTION
Works around #20007
Closes #20715

The UI build process hard-codes the `version` value from `package.json` into its output, to set the value displayed on the login page.