### PR TITLE
fix(cmd/influx): log error details when `influxd upgrade` fails to migrate databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ or `/query` HTTP endpoints.
 1. [20856](https://github.com/influxdata/influxdb/pull/20856): Respect 24 hour clock formats in the UI and allow more choices
 1. [20875](https://github.com/influxdata/influxdb/pull/20875): Prevent "do not have an execution context" error when parsing Flux options in tasks.
 1. [20932](https://github.com/influxdata/influxdb/pull/20932): Prevent time field names from being formatted in the Table visualization
+1. [20929](https://github.com/influxdata/influxdb/pull/20929): Log error details when `influxd upgrade` fails to migrate databases.
 
 ## v2.0.4 [2021-02-08]
 

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -460,7 +460,7 @@ func runUpgradeE(ctx context.Context, ui *input.UI, options *options, log *zap.L
 	db2BucketIds, err := upgradeDatabases(ctx, ui, v1, v2, options, or.Org.ID, log)
 	if err != nil {
 		//remove all files
-		log.Info("Database upgrade error, removing data")
+		log.Info("Database upgrade error, removing data", zap.Error(e))
 		if e := os.Remove(options.target.boltPath); e != nil {
 			log.Error("Unable to remove bolt database", zap.Error(e))
 		}

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -459,8 +459,8 @@ func runUpgradeE(ctx context.Context, ui *input.UI, options *options, log *zap.L
 
 	db2BucketIds, err := upgradeDatabases(ctx, ui, v1, v2, options, or.Org.ID, log)
 	if err != nil {
-		//remove all files
-		log.Info("Database upgrade error, removing data", zap.Error(e))
+		// remove all files
+		log.Error("Database upgrade error, removing data", zap.Error(err))
 		if e := os.Remove(options.target.boltPath); e != nil {
 			log.Error("Unable to remove bolt database", zap.Error(e))
 		}


### PR DESCRIPTION
Make upgrade error in upgrade log more specific.  It isn't very helpful here.

Closes #