### PR TITLE
fix: prevent time field names from being formatted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ or `/query` HTTP endpoints.
 1. [20827](https://github.com/influxdata/influxdb/pull/20827): Remove unauthenticated, unsupported `/debug/vars` HTTP endpoint.
 1. [20856](https://github.com/influxdata/influxdb/pull/20856): Respect 24 hour clock formats in the UI and allow more choices
 1. [20875](https://github.com/influxdata/influxdb/pull/20875): Prevent "do not have an execution context" error when parsing Flux options in tasks.
+1. [20932](https://github.com/influxdata/influxdb/pull/20932): Prevent time field names from being formatted in the Table visualization
 
 ## v2.0.4 [2021-02-08]
 

--- a/ui/src/shared/components/tables/TableCell.tsx
+++ b/ui/src/shared/components/tables/TableCell.tsx
@@ -250,7 +250,7 @@ class TableCell extends PureComponent<Props> {
     const {properties, data, dataType, timeFormatter} = this.props
     const {decimalPlaces} = properties
 
-    if (data && dataType.includes('dateTime')) {
+    if (data && dataType.includes('dateTime') && !this.isFieldName) {
       return timeFormatter(data)
     }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/815

Follow-up to https://github.com/influxdata/influxdb/pull/20856 - don't format the time column headers
Matching pull request in UI: https://github.com/influxdata/ui/pull/833

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

<img width="1680" alt="Screen Shot 2021-03-12 at 11 11 15 AM" src="https://user-images.githubusercontent.com/10736577/110988925-02913a00-8326-11eb-897d-0f3b39471c0d.png">
