### PR TITLE
fix(storage): ArrayFilterCursor truncation for multi-block data (#19439)

### DIFF
--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -55,8 +55,6 @@ func (c *floatArrayFilterCursor) Next() *cursors.FloatArray {
 
 	if c.tmp.Len() > 0 {
 		a = c.tmp
-		c.tmp.Timestamps = nil
-		c.tmp.Values = nil
 	} else {
 		a = c.FloatArrayCursor.Next()
 	}
@@ -76,6 +74,10 @@ LOOP:
 				}
 			}
 		}
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
 		a = c.FloatArrayCursor.Next()
 	}
 
@@ -284,8 +286,6 @@ func (c *integerArrayFilterCursor) Next() *cursors.IntegerArray {
 
 	if c.tmp.Len() > 0 {
 		a = c.tmp
-		c.tmp.Timestamps = nil
-		c.tmp.Values = nil
 	} else {
 		a = c.IntegerArrayCursor.Next()
 	}
@@ -305,6 +305,10 @@ LOOP:
 				}
 			}
 		}
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
 		a = c.IntegerArrayCursor.Next()
 	}
 
@@ -513,8 +517,6 @@ func (c *unsignedArrayFilterCursor) Next() *cursors.UnsignedArray {
 
 	if c.tmp.Len() > 0 {
 		a = c.tmp
-		c.tmp.Timestamps = nil
-		c.tmp.Values = nil
 	} else {
 		a = c.UnsignedArrayCursor.Next()
 	}
@@ -534,6 +536,10 @@ LOOP:
 				}
 			}
 		}
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
 		a = c.UnsignedArrayCursor.Next()
 	}
 
@@ -742,8 +748,6 @@ func (c *stringArrayFilterCursor) Next() *cursors.StringArray {
 
 	if c.tmp.Len() > 0 {
 		a = c.tmp
-		c.tmp.Timestamps = nil
-		c.tmp.Values = nil
 	} else {
 		a = c.StringArrayCursor.Next()
 	}
@@ -763,6 +767,10 @@ LOOP:
 				}
 			}
 		}
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
 		a = c.StringArrayCursor.Next()
 	}
 
@@ -931,8 +939,6 @@ func (c *booleanArrayFilterCursor) Next() *cursors.BooleanArray {
 
 	if c.tmp.Len() > 0 {
 		a = c.tmp
-		c.tmp.Timestamps = nil
-		c.tmp.Values = nil
 	} else {
 		a = c.BooleanArrayCursor.Next()
 	}
@@ -952,6 +958,10 @@ LOOP:
 				}
 			}
 		}
+		// Clear buffered timestamps & values if we make it through a cursor.
+		// The break above will skip this if a cursor is partially read.
+		c.tmp.Timestamps = nil
+		c.tmp.Values = nil
 		a = c.BooleanArrayCursor.Next()
 	}
 


### PR DESCRIPTION
Backport https://github.com/influxdata/influxdb/commit/abfe5a54a0b419d0231762574229caddf971bbfd

(cherry picked from commit 77d1a4180b09f83138c59ca5ae9294ee771e1d86)

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
