### PR TITLE
fix(flux): buckets call no longer panics (#17319)

### DIFF
--- a/flux/stdlib/influxdata/influxdb/buckets.go
+++ b/flux/stdlib/influxdata/influxdb/buckets.go
@@ -82,10 +82,9 @@ func (bd *BucketsDecoder) Decode(ctx context.Context) (flux.Table, error) {
 			for _, rp := range db.RetentionPolicies {
 				_ = b.AppendString(0, db.Name+"/"+rp.Name)
 				_ = b.AppendString(1, "")
-				_ = b.AppendString(2, "influxdb")
-				_ = b.AppendString(3, "")
-				_ = b.AppendString(4, rp.Name)
-				_ = b.AppendInt(5, rp.Duration.Nanoseconds())
+				_ = b.AppendString(2, "")
+				_ = b.AppendString(3, rp.Name)
+				_ = b.AppendInt(4, rp.Duration.Nanoseconds())
 			}
 		}
 	}

--- a/patches/flux.patch
+++ b/patches/flux.patch
@@ -124,10 +124,9 @@ index 4fd36f948d..9ecbe49234 100644
 +			for _, rp := range db.RetentionPolicies {
 +				_ = b.AppendString(0, db.Name+"/"+rp.Name)
 +				_ = b.AppendString(1, "")
-+				_ = b.AppendString(2, "influxdb")
-+				_ = b.AppendString(3, "")
-+				_ = b.AppendString(4, rp.Name)
-+				_ = b.AppendInt(5, rp.Duration.Nanoseconds())
++				_ = b.AppendString(2, "")
++				_ = b.AppendString(3, rp.Name)
++				_ = b.AppendInt(4, rp.Duration.Nanoseconds())
 +			}
 +		}
  	}


### PR DESCRIPTION
The buckets call had a column removed and the backport did not remove
that line. This modifies the buckets command to not append a row to a
column that no longer exists.

(cherry picked from commit 637ca24d5e933cd147882c324914f5f5548e09e6)

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
