### PR TITLE
fix: storage read service should not return a nil cursor (#17359)

### DIFF
--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -207,8 +207,8 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 	if err != nil {
 		return nil, err
 	}
-	if len(shardIDs) == 0 { // TODO(jeff): this was a typed nil
-		return nil, nil
+	if len(shardIDs) == 0 {
+		return cursors.NewStringSliceIterator(nil), nil
 	}
 
 	var expr influxql.Expr
@@ -282,8 +282,8 @@ func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if len(shardIDs) == 0 { // TODO(jeff): this was a typed nil
-		return nil, nil
+	if len(shardIDs) == 0 {
+		return cursors.NewStringSliceIterator(nil), nil
 	}
 
 	var expr influxql.Expr


### PR DESCRIPTION
The storage read service would return a nil cursor if there was no data
and no shards to read from. This modifies it to return an empty cursor
instead.

(cherry picked from commit 2852bf0399c279d2f665fd6484d8bd75ccae1430)

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
