### PR TITLE
fix(cmd/influx): log error details when `influxd upgrade` fails to migrate databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20834](https://github.com/influxdata/influxdb/pull/20834): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 1. [20833](https://github.com/influxdata/influxdb/pull/20833): Fix Single Stat graphs with thresholds crashing on negative values.
 1. [20843](https://github.com/influxdata/influxdb/pull/20843): Fix data race in TSM cache. Thanks @StoneYunZhao!
-1. [20929](https://github.com/influxdata/influxdb/pull/20929): Log error details when `influxd upgrade` fails to migrate databases.
+1. [20967](https://github.com/influxdata/influxdb/pull/20967): Log error details when `influxd upgrade` fails to migrate databases.
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ the endpoint has been removed. Use the `/metrics` endpoint to collect system sta
 1. [20834](https://github.com/influxdata/influxdb/pull/20834): Fix InfluxDB port in Flux function UI examples. Thanks @sunjincheng121!
 1. [20833](https://github.com/influxdata/influxdb/pull/20833): Fix Single Stat graphs with thresholds crashing on negative values.
 1. [20843](https://github.com/influxdata/influxdb/pull/20843): Fix data race in TSM cache. Thanks @StoneYunZhao!
+1. [20929](https://github.com/influxdata/influxdb/pull/20929): Log error details when `influxd upgrade` fails to migrate databases.
 
 ## v2.0.4 [2021-02-08]
 ----------------------

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -459,8 +459,8 @@ func runUpgradeE(ctx context.Context, ui *input.UI, options *options, log *zap.L
 
 	db2BucketIds, err := upgradeDatabases(ctx, ui, v1, v2, options, or.Org.ID, log)
 	if err != nil {
-		//remove all files
-		log.Info("Database upgrade error, removing data")
+		// remove all files
+		log.Error("Database upgrade error, removing data", zap.Error(err))
 		if e := os.Remove(options.target.boltPath); e != nil {
 			log.Error("Unable to remove bolt database", zap.Error(e))
 		}


### PR DESCRIPTION
Closes #20959

Backports #20929 