### PR TITLE
feat: influx_inspect export to standard out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ v1.8.5 [unreleased]
 -	[#20917](https://github.com/influxdata/influxdb/pull/20917): feat(inspect): Add report-disk for disk usage by measurement
 -	[#20118](https://github.com/influxdata/influxdb/pull/20118): feat: Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
 -	[#20910](https://github.com/influxdata/influxdb/pull/20910): feat: Make meta queries respect QueryTimeout values
+-	[#20977](https://github.com/influxdata/influxdb/pull/20977): feat: influx_inspect export to standard out
 
 ### Bugfixes
 

--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -62,7 +62,7 @@ func (cmd *Command) Run(args ...string) error {
 	fs := flag.NewFlagSet("export", flag.ExitOnError)
 	fs.StringVar(&cmd.dataDir, "datadir", os.Getenv("HOME")+"/.influxdb/data", "Data storage path")
 	fs.StringVar(&cmd.walDir, "waldir", os.Getenv("HOME")+"/.influxdb/wal", "WAL storage path")
-	fs.StringVar(&cmd.out, "out", os.Getenv("HOME")+"/.influxdb/export", "Destination file to export to")
+	fs.StringVar(&cmd.out, "out", os.Getenv("HOME")+"/.influxdb/export", "'-' for standard out or the destination file to export to")
 	fs.StringVar(&cmd.database, "database", "", "Optional: the database to export")
 	fs.StringVar(&cmd.retentionPolicy, "retention", "", "Optional: the retention policy to export (requires -database)")
 	fs.StringVar(&start, "start", "", "Optional: the start time to export (RFC3339 format)")
@@ -205,23 +205,29 @@ func (cmd *Command) writeDDL(mw io.Writer, w io.Writer) error {
 
 func (cmd *Command) writeDML(mw io.Writer, w io.Writer) error {
 	fmt.Fprintln(mw, "# DML")
+	var msgOut io.Writer
+	if w == cmd.Stdout {
+		msgOut = cmd.Stderr
+	} else {
+		msgOut = cmd.Stdout
+	}
 	for key := range cmd.manifest {
 		keys := strings.Split(key, string(os.PathSeparator))
 		fmt.Fprintf(mw, "# CONTEXT-DATABASE:%s\n", keys[0])
 		fmt.Fprintf(mw, "# CONTEXT-RETENTION-POLICY:%s\n", keys[1])
 		if files, ok := cmd.tsmFiles[key]; ok {
-			fmt.Fprintf(cmd.Stdout, "writing out tsm file data for %s...", key)
+			fmt.Fprintf(msgOut, "writing out tsm file data for %s...", key)
 			if err := cmd.writeTsmFiles(mw, w, files); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.Stdout, "complete.")
+			fmt.Fprintln(msgOut, "complete.")
 		}
 		if _, ok := cmd.walFiles[key]; ok {
-			fmt.Fprintf(cmd.Stdout, "writing out wal file data for %s...", key)
+			fmt.Fprintf(msgOut, "writing out wal file data for %s...", key)
 			if err := cmd.writeWALFiles(mw, w, cmd.walFiles[key], key); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.Stdout, "complete.")
+			fmt.Fprintln(msgOut, "complete.")
 		}
 	}
 
@@ -254,20 +260,23 @@ func (cmd *Command) writeFull(mw io.Writer, w io.Writer) error {
 }
 
 func (cmd *Command) write() error {
-	// open our output file and create an output buffer
-	f, err := os.Create(cmd.out)
-	if err != nil {
-		return err
+	var w io.Writer
+	if cmd.out == "-" {
+		w = cmd.Stdout
+	} else {
+		// open our output file and create an output buffer
+		f, err := os.Create(cmd.out)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		// Because calling (*os.File).Write is relatively expensive,
+		// and we don't *need* to sync to disk on every written line of export,
+		// use a sized buffered writer so that we only sync the file every megabyte.
+		bw := bufio.NewWriterSize(f, 1024*1024)
+		defer bw.Flush()
+		w = bw
 	}
-	defer f.Close()
-
-	// Because calling (*os.File).Write is relatively expensive,
-	// and we don't *need* to sync to disk on every written line of export,
-	// use a sized buffered writer so that we only sync the file every megabyte.
-	bw := bufio.NewWriterSize(f, 1024*1024)
-	defer bw.Flush()
-
-	var w io.Writer = bw
 
 	if cmd.compress {
 		gzw := gzip.NewWriter(w)


### PR DESCRIPTION
add a special value to the -out flag, a hyphen, to write to stdout.
While writing to stdout, send status messages to stderr instead of
stdout (the current behavior).

Closes https://github.com/influxdata/influxdb/issues/20974

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
