### PR TITLE
docs(readme): update README to reference go 1.15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Please be clear about your requirements and goals, help us to understand what yo
 If you find your feature request already exists as a Github issue please indicate your support for that feature by using the "thumbs up" reaction.
 
 ## Contributing to the source code
-InfluxDB requires Go 1.13 and uses Go modules.
+InfluxDB requires Go 1.15 and uses Go modules.
 
 You should read our [coding guide](https://github.com/influxdata/influxdb/blob/master/DEVELOPMENT.md), to understand better how to write code for InfluxDB.
 
@@ -92,15 +92,15 @@ More details about security vulnerability reporting, including our GPG key, [can
 If you are going to be contributing back to InfluxDB please take a second to sign our CLA, which can be found [on our website](https://influxdata.com/community/cla/).
 
 ## Installing Go
-InfluxDB requires Go 1.13.
+InfluxDB requires Go 1.15.
 
 At InfluxData we find `gvm`, a Go version manager, useful for installing Go.
 For instructions on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
 
 After installing gvm you can install and set the default go version by running the following:
 ```bash
-$ gvm install go1.13
-$ gvm use go1.13 --default
+$ gvm install go1.15
+$ gvm use go1.15 --default
 ```
 
 ## Revision Control Systems

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ Other container runtimes should work, but we've only tested with Docker and Podm
 
 ## Local
 
-Assuming you have Go 1.13, Node LTS, and yarn installed, and some means of ingesting data locally (e.g. telegraf):
+Assuming you have Go 1.15, Node LTS, and yarn installed, and some means of ingesting data locally (e.g. telegraf):
 
 You'll need two terminal tabs to run influxdb from source: one to run the go application server, the other to run the development server that will listen for front-end changes, rebuild the bundle, serve the new bundle, then reload your webpage for you.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We have nightly and versioned Docker images, Debian packages, RPM packages, and 
 
 ## Building From Source
 
-This project requires Go 1.13 and Go module support.
+This project requires Go 1.15 and Go module support.
 
 Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed.
 


### PR DESCRIPTION
Updates the Go version referenced in `README.md` under "Building From Source" to be Go 1.15 instead of Go 1.13. Go 1.15 is required to successfully build from source. This is purely a documentation update.