### PR TITLE
docs: remove broken reference to old DEVELOPMENT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,6 @@ We really like to receive feature requests as it helps us prioritize our work.
 Please be clear about your requirements and goals, help us to understand what you would like to see added to InfluxD with examples and the reasons why it is important to you.
 If you find your feature request already exists as a Github issue please indicate your support for that feature by using the "thumbs up" reaction.
 
-## Contributing to the source code
-
-You should read our [coding guide](https://github.com/influxdata/influxdb/blob/master/DEVELOPMENT.md), to understand better how to write code for InfluxDB.
-
 ## Submitting a pull request
 To submit a pull request you should fork the InfluxDB repository, and make your change on a feature branch of your fork.
 Then generate a pull request from your branch against *master* of the InfluxDB repository.


### PR DESCRIPTION
#20747 deleted `DEVELOPMENT.md` as it was mostly outdated. I missed a reference to it in `CONTRIBUTING.md`