### PR TITLE
Organization paging enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ or `/query` HTTP endpoints.
 1. [20911](https://github.com/influxdata/influxdb/pull/20911): Add support for explicitly setting shard-group durations on buckets. Thanks @hinst!
 1. [20882](https://github.com/influxdata/influxdb/pull/20882): Rewrite regex conditions in InfluxQL subqueries for performance. Thanks @yujiahaol68!
 1. [20963](https://github.com/influxdata/influxdb/pull/20963): Add `--metrics-disabled` option to `influxd` to disable exposing Prometheus metrics over HTTP.
+1. [20985](https://github.com/influxdata/influxdb/pull/20985): Enable paging for GET /orgs API. Show all organizations in UI -> Organization Switcher.
 
 ### Bug Fixes
 

--- a/organization.go
+++ b/organization.go
@@ -84,3 +84,17 @@ func ErrInternalOrgServiceError(op string, err error) *Error {
 		Err:  err,
 	}
 }
+
+func (f OrganizationFilter) QueryParams() map[string][]string {
+	queryParams := make(map[string][]string)
+	if f.Name != nil {
+		queryParams["org"] = []string{*f.Name}
+	}
+	if f.ID != nil {
+		queryParams["orgID"] = []string{f.ID.String()}
+	}
+	if f.UserID != nil {
+		queryParams["userID"] = []string{f.UserID.String()}
+	}
+	return queryParams
+}

--- a/tenant/http_server_org.go
+++ b/tenant/http_server_org.go
@@ -86,15 +86,13 @@ func newOrgResponse(o influxdb.Organization) orgResponse {
 }
 
 type orgsResponse struct {
-	Links         map[string]string `json:"links"`
-	Organizations []orgResponse     `json:"orgs"`
+	Links         *influxdb.PagingLinks `json:"links"`
+	Organizations []orgResponse         `json:"orgs"`
 }
 
-func newOrgsResponse(orgs []*influxdb.Organization) *orgsResponse {
+func newOrgsResponse(orgs []*influxdb.Organization, opts influxdb.FindOptions, f influxdb.OrganizationFilter) *orgsResponse {
 	res := orgsResponse{
-		Links: map[string]string{
-			"self": "/api/v2/orgs",
-		},
+		Links:         influxdb.NewPagingLinks(prefixOrganizations, opts, f, len(orgs)),
 		Organizations: []orgResponse{},
 	}
 	for _, org := range orgs {
@@ -175,7 +173,7 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 	}
 	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
 
-	h.api.Respond(w, r, http.StatusOK, newOrgsResponse(orgs))
+	h.api.Respond(w, r, http.StatusOK, newOrgsResponse(orgs, *opts, filter))
 }
 
 // handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.

--- a/ui/src/organizations/actions/thunks.ts
+++ b/ui/src/organizations/actions/thunks.ts
@@ -52,17 +52,18 @@ export const getOrganizations = () => async (
     const orgs: api.Organization[] = []
 
     for (let offset = 0, batchSize = 20; ; offset += batchSize) {
-      const resp = await api.getOrgs({query: {
-        offset: offset,
-        limit: batchSize,
-      }})
+      const resp = await api.getOrgs({
+        query: {
+          offset: offset,
+          limit: batchSize,
+        },
+      })
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
       }
       orgs.push(...resp.data.orgs)
       const nextLink = resp.data.links ? resp.data.links.next : null
-      if (nextLink == null)
-        break
+      if (nextLink == null) break
     }
 
     const organizations = normalize<Organization, OrgEntities, string[]>(

--- a/ui/src/organizations/actions/thunks.ts
+++ b/ui/src/organizations/actions/thunks.ts
@@ -49,13 +49,21 @@ export const getOrganizations = () => async (
   try {
     dispatch(setOrgs(RemoteDataState.Loading))
 
-    const resp = await api.getOrgs({})
+    const orgs: api.Organization[] = []
 
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
+    for (let offset = 0, batchSize = 20; ; offset += batchSize) {
+      const resp = await api.getOrgs({query: {
+        offset: offset,
+        limit: batchSize,
+      }})
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+      orgs.push(...resp.data.orgs)
+      const nextLink = resp.data.links ? resp.data.links.next : null
+      if (nextLink == null)
+        break
     }
-
-    const {orgs} = resp.data
 
     const organizations = normalize<Organization, OrgEntities, string[]>(
       orgs,


### PR DESCRIPTION
Closes #19033 

There are two changes:
* API GET `/orgs` now provides links for paging
* UI: `function getOrganizations()` now returns all organizations
    * As a result, all organizations become visible in InfluxDB UI in dialog `Switch Organizations`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
