### PR TITLE
feat: influx_inspect export to standard out (#20977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v1.8.5 [unreleased]
 -	[#20917](https://github.com/influxdata/influxdb/pull/20917): feat(inspect): Add report-disk for disk usage by measurement
 -	[#20118](https://github.com/influxdata/influxdb/pull/20118): feat: Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
 -	[#20910](https://github.com/influxdata/influxdb/pull/20910): feat: Make meta queries respect QueryTimeout values
+-	[#20977](https://github.com/influxdata/influxdb/pull/20977): feat: influx_inspect export to standard out
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ v1.8.5 [unreleased]
 -	[#20917](https://github.com/influxdata/influxdb/pull/20917): feat(inspect): Add report-disk for disk usage by measurement
 -	[#20118](https://github.com/influxdata/influxdb/pull/20118): feat: Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
 -	[#20910](https://github.com/influxdata/influxdb/pull/20910): feat: Make meta queries respect QueryTimeout values
--	[#20977](https://github.com/influxdata/influxdb/pull/20977): feat: influx_inspect export to standard out
+-	[#20989](https://github.com/influxdata/influxdb/pull/20989): feat: influx_inspect export to standard out
 
 ### Bugfixes
 


### PR DESCRIPTION
Add a special value to the -out flag, a hyphen, to write to stdout.
While writing to stdout, send status messages to stderr instead of
stdout (the current behavior).

Closes https://github.com/influxdata/influxdb/issues/20974

(cherry picked from commit 642726e898c895b82b81784f79adfe4b296f2f54)

Closes https://github.com/influxdata/influxdb/issues/20976

Describe your proposed changes here.
- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Documentation updated or issue created (provide link to issue/pr)
https://github.com/influxdata/docs-v2/issues/2308
