### PR TITLE
feat: Log query text for POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ v1.8.5 [unreleased]
 -	[#20118](https://github.com/influxdata/influxdb/pull/20118): feat: Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
 -	[#20910](https://github.com/influxdata/influxdb/pull/20910): feat: Make meta queries respect QueryTimeout values
 -	[#20977](https://github.com/influxdata/influxdb/pull/20977): feat: influx_inspect export to standard out
+-	[#20993](https://github.com/influxdata/influxdb/pull/20993): feat: Log query text for POST requests
 
 ### Bugfixes
 

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -101,21 +101,46 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 
 	userAgent := r.UserAgent()
 
-	return fmt.Sprintf(`%s - %s [%s] "%s %s %s" %s %s "%s" "%s" %s %d`,
-		host,
-		detect(username, "-"),
-		start.Format("02/Jan/2006:15:04:05 -0700"),
-		r.Method,
-		uri,
-		r.Proto,
-		detect(strconv.Itoa(l.Status()), "-"),
-		strconv.Itoa(l.Size()),
-		detect(referer, "-"),
-		detect(userAgent, "-"),
-		r.Header.Get("Request-Id"),
-		// response time, report in microseconds because this is consistent
-		// with apache's %D parameter in mod_log_config
-		int64(time.Since(start)/time.Microsecond))
+	if r.Method == "POST" {
+		vk := make([]string, 0, len(r.PostForm))
+		for k, v := range r.PostForm {
+			vk = append(vk, fmt.Sprintf("\"%s\": \"%s\"", k, v))
+		}
+		pv := strings.Join(vk, ", ")
+		return fmt.Sprintf(`%s - %s [%s] "%s %s %s" {%s} %s %s "%s" "%s" %s %d`,
+			host,
+			detect(username, "-"),
+			start.Format("02/Jan/2006:15:04:05 -0700"),
+			r.Method,
+			uri,
+			r.Proto,
+			pv,
+			detect(strconv.Itoa(l.Status()), "-"),
+			strconv.Itoa(l.Size()),
+			detect(referer, "-"),
+			detect(userAgent, "-"),
+			r.Header.Get("Request-Id"),
+			// response time, report in microseconds because this is consistent
+			// with apache's %D parameter in mod_log_config
+			int64(time.Since(start)/time.Microsecond))
+
+	} else {
+		return fmt.Sprintf(`%s - %s [%s] "%s %s %s" %s %s "%s" "%s" %s %d`,
+			host,
+			detect(username, "-"),
+			start.Format("02/Jan/2006:15:04:05 -0700"),
+			r.Method,
+			uri,
+			r.Proto,
+			detect(strconv.Itoa(l.Status()), "-"),
+			strconv.Itoa(l.Size()),
+			detect(referer, "-"),
+			detect(userAgent, "-"),
+			r.Header.Get("Request-Id"),
+			// response time, report in microseconds because this is consistent
+			// with apache's %D parameter in mod_log_config
+			int64(time.Since(start)/time.Microsecond))
+	}
 }
 
 // detect detects the first presence of a non blank string and returns it

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -111,13 +111,13 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 			}
 			valuesSlice := make([]string, 0, len(values))
 			for _, v := range values {
-				valuesSlice = append(valuesSlice, fmt.Sprintf("\"%s\"", v))
+				valuesSlice = append(valuesSlice, fmt.Sprintf("'%s'", v))
 			}
 			joined := strings.Join(valuesSlice, ", ")
-			allKeyValues = append(allKeyValues, fmt.Sprintf("{\"%s\": %s}", k, joined))
+			allKeyValues = append(allKeyValues, fmt.Sprintf("{'%s': %s}", k, joined))
 		}
 
-		return fmt.Sprintf(`%s - %s %s "%s %s %s" %s %s %s "%s" "%s" %s %d`,
+		return fmt.Sprintf(`%s - %s [%s] "%s %s %s %s" %s %s "%s" "%s" %s %d`,
 			host,
 			detect(username, "-"),
 			start.Format("02/Jan/2006:15:04:05 -0700"),


### PR DESCRIPTION
The HTTP handler logs URLs, but not body values for POST requests.
This means that queries sent by GET are logged, because the query
is in the URL, but queries sent by POST have no query text in the
log.  This feature prints all the key-value pairs in the post body,
which includes the query text

Closes https://github.com/influxdata/influxdb/issues/20653

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass