### PR TITLE
feat: Log query text for POST requests (#20993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v1.8.5 [unreleased]
 -	[#20118](https://github.com/influxdata/influxdb/pull/20118): feat: Optimize shard lookups in groups containing only one shard. Thanks @StoneYunZhao!
 -	[#20910](https://github.com/influxdata/influxdb/pull/20910): feat: Make meta queries respect QueryTimeout values
 -	[#20989](https://github.com/influxdata/influxdb/pull/20989): feat: influx_inspect export to standard out
+-	[#21021](https://github.com/influxdata/influxdb/pull/21021): feat: Log query text for POST requests
 
 ### Bugfixes
 


### PR DESCRIPTION
The HTTP handler logs URLs, but not body values for POST requests.
This means that queries sent by GET are logged, because the query
is in the URL, but queries sent by POST have no query text in the
log.  This feature prints all the key-value pairs in the post body,
which includes the query text, except passwords, which are redacted.

Closes https://github.com/influxdata/influxdb/issues/20653

(cherry picked from commit 70755bf42c075f474a49f59d515d84310ef8cace)

Closes https://github.com/influxdata/influxdb/issues/21000

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
