### PR TITLE
fix: set correct go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go/bigtable v1.2.0 // indirect


### PR DESCRIPTION
This appears to be the only place where influxdata/plutonium#3339 occurs in source