### PR TITLE
feat(cmd/inflxud): add support for writing to stdout in `export-lp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ or `/query` HTTP endpoints.
 1. [20971](https://github.com/influxdata/influxdb/pull/20971): Set a default `--http-idle-timeout` of 3m in `influxd`.
 1. [20861](https://github.com/influxdata/influxdb/pull/20861): Update Telegraf plugins in UI to include additions and changes in 1.18 release.
 1. [20894](https://github.com/influxdata/influxdb/pull/20894): Display task IDs in the UI.
+1. [21046](https://github.com/influxdata/influxdb/pull/21046): Write to standard out when `--output-path -` is passed to `influxd inspect export-lp`.
 
 ### Bug Fixes
 


### PR DESCRIPTION
Closes #20975

Forward-ports the relevant piece of #20977. The 2.x command doesn't write out DML, and was already configured to log to stderr by default.