### PR TITLE
bugfix: fix nil pointer dereference in shard_mapper

### DIFF
--- a/coordinator/shard_mapper.go
+++ b/coordinator/shard_mapper.go
@@ -195,7 +195,9 @@ func (a *LocalShardMapping) CreateIterator(ctx context.Context, m *influxql.Meas
 				if err != nil {
 					return err
 				}
-				inputs = append(inputs, input)
+				if input != nil {
+					inputs = append(inputs, input)
+				}
 			}
 			return nil
 		}(); err != nil {


### PR DESCRIPTION
Closes #21065

Describe your proposed changes here.

If there is an error in creating an `Iterator`,  the `input` return by `sg.CreateIterator(ctx, mm, opt)` will be nil.

however, when close the `Iterator`, There is no operation to check the status, so there is a panic for `close()`

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ x ] Rebased/mergable
- [ x ] Tests pass
- [ x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)