### PR TITLE
build: set 'noasm' tag when building ARM64 binaries

### DIFF
--- a/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
+++ b/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
@@ -66,8 +66,11 @@ OUTDIR=$(mktemp -d)
 		export CGO_ENABLED=1
 		echo "env for go build: GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED"
 		# Note that we only do static builds for arm, to be consistent with influxdb 2.x
-		if [[ -n "$STATIC" || "$GOARCH" == arm64 ]] ; then
-			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+		if [[ "$GOARCH" == arm64 ]] ; then
+			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+		elif [[ -n "$STATIC" ]]; then
+		  echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
 			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
 		elif [[ "$GOOS" == windows ]] ; then
 			echo go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd

--- a/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
+++ b/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
@@ -70,7 +70,7 @@ OUTDIR=$(mktemp -d)
 			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
 			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
 		elif [[ -n "$STATIC" ]]; then
-		  echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
 			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
 		elif [[ "$GOOS" == windows ]] ; then
 			echo go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd


### PR DESCRIPTION
Closes #21061

Newer versions of Flux depend on Apache Arrow, which uses c2goasm to optimize some operations (see [their README](https://github.com/apache/arrow/tree/master/go#performance)). The optimized code only works on `amd64` and `s390x`; other architectures will panic.

Setting the `noasm` tag disables the optimizations. We added the tag to the 2.x line across a few PRs:
* #20260
* #20290