### PR TITLE
feat: make flux controller limits configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v1.9.0 [unreleased]
 -	[#21015](https://github.com/influxdata/influxdb/pull/21015): build: upgrade to go 1.15.10
 -	[#21074](https://github.com/influxdata/influxdb/pull/21074): feat: upgrade to flux 0.111.0
 -	[#21100](https://github.com/influxdata/influxdb/pull/21100): feat: add memory and concurrency limits in flux controller
+-	[#21108](https://github.com/influxdata/influxdb/pull/21108): feat: make flux controller limits configurable
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/pkg/tlsconfig"
+	"github.com/influxdata/influxdb/query/control"
 	"github.com/influxdata/influxdb/services/collectd"
 	"github.com/influxdata/influxdb/services/continuous_querier"
 	"github.com/influxdata/influxdb/services/graphite"
@@ -39,11 +40,12 @@ const (
 
 // Config represents the configuration format for the influxd binary.
 type Config struct {
-	Meta        *meta.Config       `toml:"meta"`
-	Data        tsdb.Config        `toml:"data"`
-	Coordinator coordinator.Config `toml:"coordinator"`
-	Retention   retention.Config   `toml:"retention"`
-	Precreator  precreator.Config  `toml:"shard-precreation"`
+	Meta           *meta.Config       `toml:"meta"`
+	Data           tsdb.Config        `toml:"data"`
+	Coordinator    coordinator.Config `toml:"coordinator"`
+	FluxController control.Config     `toml:"flux-controller"`
+	Retention      retention.Config   `toml:"retention"`
+	Precreator     precreator.Config  `toml:"shard-precreation"`
 
 	Monitor        monitor.Config    `toml:"monitor"`
 	Subscriber     subscriber.Config `toml:"subscriber"`
@@ -72,6 +74,7 @@ func NewConfig() *Config {
 	c.Meta = meta.NewConfig()
 	c.Data = tsdb.NewConfig()
 	c.Coordinator = coordinator.NewConfig()
+	c.FluxController = control.NewConfig()
 	c.Precreator = precreator.NewConfig()
 
 	c.Monitor = monitor.NewConfig()

--- a/prometheus/converters_test.go
+++ b/prometheus/converters_test.go
@@ -1,0 +1,87 @@
+package prometheus
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/influxdata/influxdb/models"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validMetrics = `# HELP cadvisor_version_info A metric with a constant '1' value labeled by kernel version, OS version, docker version, cadvisor version & cadvisor revision.
+# TYPE cadvisor_version_info gauge
+cadvisor_version_info{cadvisorRevision="",cadvisorVersion="",dockerVersion="1.8.2",kernelVersion="3.10.0-229.20.1.el7.x86_64",osVersion="CentOS Linux 7 (Core)"} 1
+# HELP get_token_fail_count Counter of failed Token() requests to the alternate token source
+# TYPE get_token_fail_count counter
+get_token_fail_count 0
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 552048.506
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} 5.876804288e+06
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} 5.876804288e+06
+http_request_duration_microseconds_sum{handler="prometheus"} 1.8909097205e+07
+http_request_duration_microseconds_count{handler="prometheus"} 9
+# HELP apiserver_request_latencies Response latency distribution in microseconds for each verb, resource and client.
+# TYPE apiserver_request_latencies histogram
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="125000"} 1994
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="250000"} 1997
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="500000"} 2000
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="1e+06"} 2005
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="2e+06"} 2012
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="4e+06"} 2017
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="8e+06"} 2024
+apiserver_request_latencies_bucket{resource="bindings",verb="POST",le="+Inf"} 2025
+apiserver_request_latencies_sum{resource="bindings",verb="POST"} 1.02726334e+08
+apiserver_request_latencies_count{resource="bindings",verb="POST"} 2025
+`
+
+func TestParseValidPrometheus(t *testing.T) {
+
+	// Build a sorted list of metric families
+	var parser expfmt.TextParser
+	metricFamiliesMap, err := parser.TextToMetricFamilies(bytes.NewBufferString(validMetrics))
+	metricFamilies := make([]*io_prometheus_client.MetricFamily, 0, len(metricFamiliesMap))
+	require.NoError(t, err)
+	metricFamiliesNames := make([]string, 0, len(metricFamiliesMap))
+	for k, _ := range metricFamiliesMap {
+		metricFamiliesNames = append(metricFamiliesNames, k)
+	}
+	sort.Strings(metricFamiliesNames)
+	for _, name := range metricFamiliesNames {
+		metricFamilies = append(metricFamilies, metricFamiliesMap[name])
+		i := len(metricFamilies) - 1
+		assert.NotNil(t, metricFamilies[i])
+		newName := name
+		metricFamilies[i].Name = &newName
+	}
+
+	// Actual test - parse the list into statistics
+	statistics := PrometheusToStatistics(metricFamilies, map[string]string{"testtag": "test_value"})
+	expected := []models.Statistic{
+		{
+			Name:   "apiserver_request_latencies",
+			Tags:   map[string]string{"testtag": "test_value"},
+			Values: map[string]interface{}{"+Inf": 2025., "125000": 1994., "1e+06": 2005., "250000": 1997., "2e+06": 2012., "4e+06": 2017., "500000": 2000., "8e+06": 2024., "count": 2025., "sum": 1.02726334e+08},
+		},
+		{
+			Name:   "cadvisor_version_info",
+			Tags:   map[string]string{"testtag": "test_value"},
+			Values: map[string]interface{}{"gauge": 1.},
+		},
+		{
+			Name:   "get_token_fail_count",
+			Tags:   map[string]string{"testtag": "test_value"},
+			Values: map[string]interface{}{"counter": 0.},
+		},
+		{
+			Name:   "http_request_duration_microseconds",
+			Tags:   map[string]string{"testtag": "test_value"},
+			Values: map[string]interface{}{"0.5": 552048.506, "0.9": 5.876804288e+06, "0.99": 5.876804288e+06, "count": 9., "sum": 1.8909097205e+07},
+		},
+	}
+	assert.Equal(t, expected, statistics)
+}

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -20,6 +20,7 @@ package control
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -72,18 +73,18 @@ type Config struct {
 	// This value is limited to an int32 because it's used to set the initial delta on the
 	// controller's WaitGroup, and WG deltas have an effective limit of math.MaxInt32.
 	// See: https://github.com/golang/go/issues/20687
-	ConcurrencyQuota int32
+	ConcurrencyQuota int32 `toml:"query-concurrency"`
 
 	// InitialMemoryBytesQuotaPerQuery is the initial number of bytes allocated for a query
 	// when it is started. If this is unset, then the MemoryBytesQuotaPerQuery will be used.
-	InitialMemoryBytesQuotaPerQuery int64
+	InitialMemoryBytesQuotaPerQuery int64 `toml:"query-initial-memory-bytes"`
 
 	// MemoryBytesQuotaPerQuery is the maximum number of bytes (in table memory) a query is allowed to use at
 	// any given time.
 	//
 	// A query may not be able to use its entire quota of memory if requesting more memory would conflict
 	// with the maximum amount of memory that the controller can request.
-	MemoryBytesQuotaPerQuery int64
+	MemoryBytesQuotaPerQuery int64 `toml:"query-max-memory-bytes"`
 
 	// MaxMemoryBytes is the maximum amount of memory the controller is allowed to
 	// allocated to queries.
@@ -91,7 +92,7 @@ type Config struct {
 	// If this is unset, then this number is ConcurrencyQuota * MemoryBytesQuotaPerQuery.
 	// This number must be greater than or equal to the ConcurrencyQuota * InitialMemoryBytesQuotaPerQuery.
 	// This number may be less than the ConcurrencyQuota * MemoryBytesQuotaPerQuery.
-	MaxMemoryBytes int64
+	MaxMemoryBytes int64 `toml:"total-max-memory-bytes"`
 
 	// QueueSize is the number of queries that are allowed to be awaiting execution before new queries are rejected.
 	//
@@ -104,21 +105,21 @@ type Config struct {
 	// Less-scientifically, this was the only Config parameter other than ConcurrencyQuota to be typed as an int
 	// instead of an explicit int64. When ConcurrencyQuota changed to an int32, it felt like a decent idea for
 	// this to follow suit.
-	QueueSize int32
+	QueueSize int32 `toml:"query-queue-size"`
+}
 
-	Logger *zap.Logger
-	// MetricLabelKeys is a list of labels to add to the metrics produced by the controller.
-	// The value for a given key will be read off the context.
-	// The context value must be a string or an implementation of the Stringer interface.
-	MetricLabelKeys []string
-
-	ExecutorDependencies []flux.Dependency
+func NewConfig() Config {
+	return Config{}
 }
 
 // complete will fill in the defaults, validate the configuration, and
 // return the new Config.
 func (c *Config) complete() (Config, error) {
 	config := *c
+	if config.MemoryBytesQuotaPerQuery == 0 {
+		// 0 means unlimited
+		config.MemoryBytesQuotaPerQuery = math.MaxInt64
+	}
 	if config.InitialMemoryBytesQuotaPerQuery == 0 {
 		config.InitialMemoryBytesQuotaPerQuery = config.MemoryBytesQuotaPerQuery
 	}
@@ -130,10 +131,23 @@ func (c *Config) complete() (Config, error) {
 }
 
 func (c *Config) validate(isComplete bool) error {
-	if c.ConcurrencyQuota <= 0 {
-		return errors.New("ConcurrencyQuota must be positive")
+	if c.ConcurrencyQuota < 0 {
+		return errors.New("ConcurrencyQuota must not be negative")
+	} else if c.ConcurrencyQuota == 0 {
+		if c.QueueSize != 0 {
+			return errors.New("QueueSize must be unlimited when ConcurrencyQuota is unlimited")
+		}
+		if c.MaxMemoryBytes != 0 {
+			// This is because we have to account for the per-query reserved memory and remove it from
+			// the max total memory. If there is not a maximum number of queries this is not possible.
+			return errors.New("Cannot limit max memory when ConcurrencyQuota is unlimited")
+		}
+	} else {
+		if c.QueueSize <= 0 {
+			return errors.New("QueueSize must be positive when ConcurrencyQuota is limited")
+		}
 	}
-	if c.MemoryBytesQuotaPerQuery <= 0 {
+	if c.MemoryBytesQuotaPerQuery < 0 || (isComplete && c.MemoryBytesQuotaPerQuery == 0) {
 		return errors.New("MemoryBytesQuotaPerQuery must be positive")
 	}
 	if c.InitialMemoryBytesQuotaPerQuery < 0 || (isComplete && c.InitialMemoryBytesQuotaPerQuery == 0) {
@@ -147,9 +161,6 @@ func (c *Config) validate(isComplete bool) error {
 			return fmt.Errorf("MaxMemoryBytes must be greater than or equal to the ConcurrencyQuota * InitialMemoryBytesQuotaPerQuery: %d < %d (%d * %d)", c.MaxMemoryBytes, minMemory, c.ConcurrencyQuota, c.InitialMemoryBytesQuotaPerQuery)
 		}
 	}
-	if c.QueueSize <= 0 {
-		return errors.New("QueueSize must be positive")
-	}
 	return nil
 }
 
@@ -160,13 +171,12 @@ func (c *Config) Validate() error {
 
 type QueryID uint64
 
-func New(config Config) (*Controller, error) {
+func New(config Config, logger *zap.Logger, deps []flux.Dependency) (*Controller, error) {
 	c, err := config.complete()
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid controller config")
 	}
-	c.MetricLabelKeys = append(c.MetricLabelKeys, orgLabel)
-	logger := c.Logger
+	metricLabelKeys := []string{orgLabel}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -186,25 +196,31 @@ func New(config Config) (*Controller, error) {
 	} else {
 		mm.unlimited = true
 	}
+	queryQueue := make(chan *Query, c.QueueSize)
+	if c.ConcurrencyQuota == 0 {
+		queryQueue = nil
+	}
 	ctrl := &Controller{
 		config:       c,
 		queries:      make(map[QueryID]*Query),
-		queryQueue:   make(chan *Query, c.QueueSize),
+		queryQueue:   queryQueue,
 		done:         make(chan struct{}),
 		abort:        make(chan struct{}),
 		memory:       mm,
 		log:          logger,
-		metrics:      newControllerMetrics(c.MetricLabelKeys),
-		labelKeys:    c.MetricLabelKeys,
-		dependencies: c.ExecutorDependencies,
+		metrics:      newControllerMetrics(metricLabelKeys),
+		labelKeys:    metricLabelKeys,
+		dependencies: deps,
 	}
-	quota := int(c.ConcurrencyQuota)
-	ctrl.wg.Add(quota)
-	for i := 0; i < quota; i++ {
-		go func() {
-			defer ctrl.wg.Done()
-			ctrl.processQueryQueue()
-		}()
+	if c.ConcurrencyQuota != 0 {
+		quota := int(c.ConcurrencyQuota)
+		ctrl.wg.Add(quota)
+		for i := 0; i < quota; i++ {
+			go func() {
+				defer ctrl.wg.Done()
+				ctrl.processQueryQueue()
+			}()
+		}
 	}
 	return ctrl, nil
 }
@@ -373,12 +389,33 @@ func (c *Controller) enqueueQuery(q *Query) error {
 		}
 	}
 
-	select {
-	case c.queryQueue <- q:
-	default:
-		return &flux.Error{
-			Code: codes.ResourceExhausted,
-			Msg:  "queue length exceeded",
+	if c.queryQueue == nil {
+		// unlimited queries case
+
+		c.queriesMu.RLock()
+		defer c.queriesMu.RUnlock()
+		if c.shutdown {
+			return &flux.Error{
+				Code: codes.Internal,
+				Msg:  "controller is shutting down, query not runnable",
+			}
+		}
+		// we can't start shutting down until unlock, so it is safe to add to the waitgroup
+		c.wg.Add(1)
+
+		// unlimited queries, so start a goroutine for every query
+		go func() {
+			defer c.wg.Done()
+			c.executeQuery(q)
+		}()
+	} else {
+		select {
+		case c.queryQueue <- q:
+		default:
+			return &flux.Error{
+				Code: codes.ResourceExhausted,
+				Msg:  "queue length exceeded",
+			}
 		}
 	}
 

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -45,6 +45,12 @@ var (
 	config = control.Config{
 		MemoryBytesQuotaPerQuery: math.MaxInt64,
 	}
+	limitedConfig = control.Config{
+		MemoryBytesQuotaPerQuery: math.MaxInt64,
+		ConcurrencyQuota:         1,
+		QueueSize:                1,
+	}
+	bothConfigs          = map[string]control.Config{"unlimited": config, "limited": limitedConfig}
 	executorDependencies = []flux.Dependency{
 		influxdb.Dependencies{
 			FluxDeps: executetest.NewTestExecuteDependencies(),
@@ -116,115 +122,127 @@ func validateUnusedMemory(t testing.TB, reg *prometheus.Registry, c control.Conf
 }
 
 func TestController_QuerySuccess(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-	reg := setupPromRegistry(ctrl)
+			reg := setupPromRegistry(ctrl)
 
-	q, err := ctrl.Query(context.Background(), mockCompiler)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+			q, err := ctrl.Query(context.Background(), mockCompiler)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 
-	for range q.Results() {
-		// discard the results as we do not care.
-	}
-	q.Done()
+			for range q.Results() {
+				// discard the results as we do not care.
+			}
+			q.Done()
 
-	if err := q.Err(); err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
+			if err := q.Err(); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
 
-	stats := q.Statistics()
-	if stats.CompileDuration == 0 {
-		t.Error("expected compile duration to be above zero")
+			stats := q.Statistics()
+			if stats.CompileDuration == 0 {
+				t.Error("expected compile duration to be above zero")
+			}
+			if stats.QueueDuration == 0 {
+				t.Error("expected queue duration to be above zero")
+			}
+			if stats.ExecuteDuration == 0 {
+				t.Error("expected execute duration to be above zero")
+			}
+			if stats.TotalDuration == 0 {
+				t.Error("expected total duration to be above zero")
+			}
+			validateRequestTotals(t, reg, 1, 0, 0, 0)
+		})
 	}
-	if stats.QueueDuration == 0 {
-		t.Error("expected queue duration to be above zero")
-	}
-	if stats.ExecuteDuration == 0 {
-		t.Error("expected execute duration to be above zero")
-	}
-	if stats.TotalDuration == 0 {
-		t.Error("expected total duration to be above zero")
-	}
-	validateRequestTotals(t, reg, 1, 0, 0, 0)
 }
 
 func TestController_QueryCompileError(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
+
+			reg := setupPromRegistry(ctrl)
+
+			q, err := ctrl.Query(context.Background(), &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return nil, errors.New("compile error")
+				},
+			})
+			if err == nil {
+				t.Error("expected compiler error")
+			}
+
+			if q != nil {
+				t.Errorf("unexpected query value: %v", q)
+				defer q.Done()
+			}
+
+			validateRequestTotals(t, reg, 0, 1, 0, 0)
+		})
 	}
-	defer shutdown(t, ctrl)
-
-	reg := setupPromRegistry(ctrl)
-
-	q, err := ctrl.Query(context.Background(), &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return nil, errors.New("compile error")
-		},
-	})
-	if err == nil {
-		t.Error("expected compiler error")
-	}
-
-	if q != nil {
-		t.Errorf("unexpected query value: %v", q)
-		defer q.Done()
-	}
-
-	validateRequestTotals(t, reg, 0, 1, 0, 0)
 }
 
 func TestController_QueryRuntimeError(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-	reg := setupPromRegistry(ctrl)
+			reg := setupPromRegistry(ctrl)
 
-	q, err := ctrl.Query(context.Background(), &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
-					q.SetErr(errors.New("runtime error"))
+			q, err := ctrl.Query(context.Background(), &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+							q.SetErr(errors.New("runtime error"))
+						},
+					}, nil
 				},
-			}, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 
-	for range q.Results() {
-		// discard the results as we do not care.
-	}
-	q.Done()
+			for range q.Results() {
+				// discard the results as we do not care.
+			}
+			q.Done()
 
-	if q.Err() == nil {
-		t.Error("expected runtime error")
-	}
+			if q.Err() == nil {
+				t.Error("expected runtime error")
+			}
 
-	stats := q.Statistics()
-	if stats.CompileDuration == 0 {
-		t.Error("expected compile duration to be above zero")
+			stats := q.Statistics()
+			if stats.CompileDuration == 0 {
+				t.Error("expected compile duration to be above zero")
+			}
+			if stats.QueueDuration == 0 {
+				t.Error("expected queue duration to be above zero")
+			}
+			if stats.ExecuteDuration == 0 {
+				t.Error("expected execute duration to be above zero")
+			}
+			if stats.TotalDuration == 0 {
+				t.Error("expected total duration to be above zero")
+			}
+			validateRequestTotals(t, reg, 0, 0, 1, 0)
+		})
 	}
-	if stats.QueueDuration == 0 {
-		t.Error("expected queue duration to be above zero")
-	}
-	if stats.ExecuteDuration == 0 {
-		t.Error("expected execute duration to be above zero")
-	}
-	if stats.TotalDuration == 0 {
-		t.Error("expected total duration to be above zero")
-	}
-	validateRequestTotals(t, reg, 0, 0, 1, 0)
 }
 
 func TestController_QueryQueueError(t *testing.T) {
@@ -334,84 +352,99 @@ func findMetric(mfs []*dto.MetricFamily, name string, labels map[string]string) 
 }
 
 func TestController_AfterShutdown(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	shutdown(t, ctrl)
 
-	// No point in continuing. The shutdown didn't work
-	// even though there are no queries.
-	if t.Failed() {
-		return
-	}
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			shutdown(t, ctrl)
 
-	if _, err := ctrl.Query(context.Background(), mockCompiler); err == nil {
-		t.Error("expected error")
-	} else if got, want := err.Error(), "query controller shutdown"; got != want {
-		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			// No point in continuing. The shutdown didn't work
+			// even though there are no queries.
+			if t.Failed() {
+				return
+			}
+
+			if _, err := ctrl.Query(context.Background(), mockCompiler); err == nil {
+				t.Error("expected error")
+			} else if got, want := err.Error(), "query controller shutdown"; got != want {
+				t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			}
+		})
 	}
 }
 
 func TestController_CompileError(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return nil, &flux.Error{
-				Code: codes.Invalid,
-				Msg:  "expected error",
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
 			}
-		},
-	}
-	if _, err := ctrl.Query(context.Background(), compiler); err == nil {
-		t.Error("expected error")
-	} else if got, want := err.Error(), "compilation failed: expected error"; got != want {
-		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			defer shutdown(t, ctrl)
+
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return nil, &flux.Error{
+						Code: codes.Invalid,
+						Msg:  "expected error",
+					}
+				},
+			}
+			if _, err := ctrl.Query(context.Background(), compiler); err == nil {
+				t.Error("expected error")
+			} else if got, want := err.Error(), "compilation failed: expected error"; got != want {
+				t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			}
+		})
 	}
 }
 
 func TestController_ExecuteError(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {
-					return nil, errors.New("expected error")
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
+
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {
+							return nil, errors.New("expected error")
+						},
+					}, nil
 				},
-			}, nil
-		},
-	}
+			}
 
-	q, err := ctrl.Query(context.Background(), compiler)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+			q, err := ctrl.Query(context.Background(), compiler)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 
-	// There should be no results.
-	numResults := 0
-	for range q.Results() {
-		numResults++
-	}
+			// There should be no results.
+			numResults := 0
+			for range q.Results() {
+				numResults++
+			}
 
-	if numResults != 0 {
-		t.Errorf("no results should have been returned, but %d were", numResults)
-	}
-	q.Done()
+			if numResults != 0 {
+				t.Errorf("no results should have been returned, but %d were", numResults)
+			}
+			q.Done()
 
-	if err := q.Err(); err == nil {
-		t.Error("expected error")
-	} else if got, want := err.Error(), "expected error"; got != want {
-		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			if err := q.Err(); err == nil {
+				t.Error("expected error")
+			} else if got, want := err.Error(), "expected error"; got != want {
+				t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			}
+		})
 	}
 }
 
@@ -490,194 +523,218 @@ func TestController_LimitExceededError(t *testing.T) {
 }
 
 func TestController_CompilePanic(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			panic("panic during compile step")
-		},
-	}
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-	_, err = ctrl.Query(context.Background(), compiler)
-	if err == nil {
-		t.Fatalf("expected error when query was compiled")
-	} else if !strings.Contains(err.Error(), "panic during compile step") {
-		t.Fatalf(`expected error to contain "panic during compile step" instead it contains "%v"`, err.Error())
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					panic("panic during compile step")
+				},
+			}
+
+			_, err = ctrl.Query(context.Background(), compiler)
+			if err == nil {
+				t.Fatalf("expected error when query was compiled")
+			} else if !strings.Contains(err.Error(), "panic during compile step") {
+				t.Fatalf(`expected error to contain "panic during compile step" instead it contains "%v"`, err.Error())
+			}
+		})
 	}
 }
 
 func TestController_StartPanic(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				StartFn: func(ctx context.Context, alloc *memory.Allocator) (i *mock.Query, e error) {
-					panic("panic during start step")
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
+
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						StartFn: func(ctx context.Context, alloc *memory.Allocator) (i *mock.Query, e error) {
+							panic("panic during start step")
+						},
+					}, nil
 				},
-			}, nil
-		},
-	}
+			}
 
-	q, err := ctrl.Query(context.Background(), compiler)
-	if err != nil {
-		t.Fatalf("unexpected error when query was compiled")
-	}
+			q, err := ctrl.Query(context.Background(), compiler)
+			if err != nil {
+				t.Fatalf("unexpected error when query was compiled")
+			}
 
-	for range q.Results() {
-	}
-	q.Done()
+			for range q.Results() {
+			}
+			q.Done()
 
-	if err = q.Err(); err == nil {
-		t.Fatalf("expected error after query started")
-	} else if !strings.Contains(err.Error(), "panic during start step") {
-		t.Fatalf(`expected error to contain "panic during start step" instead it contains "%v"`, err.Error())
+			if err = q.Err(); err == nil {
+				t.Fatalf("expected error after query started")
+			} else if !strings.Contains(err.Error(), "panic during start step") {
+				t.Fatalf(`expected error to contain "panic during start step" instead it contains "%v"`, err.Error())
+			}
+		})
 	}
 }
 
 func TestController_ShutdownWithRunningQuery(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	executing := make(chan struct{})
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
-					close(executing)
-					<-ctx.Done()
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-					// This should still be read even if we have been canceled.
-					q.ResultsCh <- &executetest.Result{}
+			executing := make(chan struct{})
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+							close(executing)
+							<-ctx.Done()
+
+							// This should still be read even if we have been canceled.
+							q.ResultsCh <- &executetest.Result{}
+						},
+					}, nil
 				},
-			}, nil
-		},
+			}
+
+			q, err := ctrl.Query(context.Background(), compiler)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range q.Results() {
+					// discard the results
+				}
+				q.Done()
+			}()
+
+			// Wait until execution has started.
+			<-executing
+
+			// Shutdown should succeed and not timeout. The above blocked
+			// query should be canceled and then shutdown should return.
+			shutdown(t, ctrl)
+			wg.Wait()
+		})
 	}
-
-	q, err := ctrl.Query(context.Background(), compiler)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for range q.Results() {
-			// discard the results
-		}
-		q.Done()
-	}()
-
-	// Wait until execution has started.
-	<-executing
-
-	// Shutdown should succeed and not timeout. The above blocked
-	// query should be canceled and then shutdown should return.
-	shutdown(t, ctrl)
-	wg.Wait()
 }
 
 func TestController_ShutdownWithTimeout(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-	// This channel blocks program execution until we are done
-	// with running the test.
-	done := make(chan struct{})
-	defer close(done)
+			// This channel blocks program execution until we are done
+			// with running the test.
+			done := make(chan struct{})
+			defer close(done)
 
-	executing := make(chan struct{})
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
-					// This should just block until the end of the test
-					// when we perform cleanup.
-					close(executing)
-					<-done
+			executing := make(chan struct{})
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+							// This should just block until the end of the test
+							// when we perform cleanup.
+							close(executing)
+							<-done
+						},
+					}, nil
 				},
-			}, nil
-		},
+			}
+
+			q, err := ctrl.Query(context.Background(), compiler)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			go func() {
+				for range q.Results() {
+					// discard the results
+				}
+				q.Done()
+			}()
+
+			// Wait until execution has started.
+			<-executing
+
+			// The shutdown should not succeed.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			if err := ctrl.Shutdown(ctx); err == nil {
+				t.Error("expected error")
+			} else if got, want := err.Error(), context.DeadlineExceeded.Error(); got != want {
+				t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+			}
+			cancel()
+		})
 	}
-
-	q, err := ctrl.Query(context.Background(), compiler)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
-
-	go func() {
-		for range q.Results() {
-			// discard the results
-		}
-		q.Done()
-	}()
-
-	// Wait until execution has started.
-	<-executing
-
-	// The shutdown should not succeed.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	if err := ctrl.Shutdown(ctx); err == nil {
-		t.Error("expected error")
-	} else if got, want := err.Error(), context.DeadlineExceeded.Error(); got != want {
-		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
-	}
-	cancel()
 }
 
 func TestController_PerQueryMemoryLimit(t *testing.T) {
-	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer shutdown(t, ctrl)
 
-	compiler := &mock.Compiler{
-		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return &mock.Program{
-				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
-					defer func() {
-						if err, ok := recover().(error); ok && err != nil {
-							q.SetErr(err)
-						}
-					}()
+	for name, config := range bothConfigs {
+		t.Run(name, func(t *testing.T) {
+			ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shutdown(t, ctrl)
 
-					// This is emulating the behavior of exceeding the memory limit at runtime
-					mem := arrow.NewAllocator(alloc)
-					b := mem.Allocate(int(config.MemoryBytesQuotaPerQuery + 1))
-					mem.Free(b)
+			compiler := &mock.Compiler{
+				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					return &mock.Program{
+						ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+							defer func() {
+								if err, ok := recover().(error); ok && err != nil {
+									q.SetErr(err)
+								}
+							}()
+
+							// This is emulating the behavior of exceeding the memory limit at runtime
+							mem := arrow.NewAllocator(alloc)
+							b := mem.Allocate(int(config.MemoryBytesQuotaPerQuery + 1))
+							mem.Free(b)
+						},
+					}, nil
 				},
-			}, nil
-		},
-	}
+			}
 
-	q, err := ctrl.Query(context.Background(), compiler)
-	if err != nil {
-		t.Fatal(err)
-	}
+			q, err := ctrl.Query(context.Background(), compiler)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	for range q.Results() {
-		// discard the results
-	}
-	q.Done()
+			for range q.Results() {
+				// discard the results
+			}
+			q.Done()
 
-	if q.Err() == nil {
-		t.Fatal("expected error about memory limit exceeded")
+			if q.Err() == nil {
+				t.Fatal("expected error about memory limit exceeded")
+			}
+		})
 	}
 }
 

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -72,7 +72,7 @@ func validateRequestTotals(t testing.TB, reg *prometheus.Registry, success, comp
 	validate := func(name string, want int) {
 		m := FindMetric(
 			metrics,
-			"query_control_requests_total",
+			"qc_requests_total",
 			map[string]string{
 				"result": name,
 				"org":    "",
@@ -100,7 +100,7 @@ func validateUnusedMemory(t testing.TB, reg *prometheus.Registry, c control.Conf
 	}
 	m := FindMetric(
 		metrics,
-		"query_control_memory_unused_bytes",
+		"qc_memory_unused_bytes",
 		map[string]string{
 			"org": "",
 		},
@@ -116,7 +116,7 @@ func validateUnusedMemory(t testing.TB, reg *prometheus.Registry, c control.Conf
 }
 
 func TestController_QuerySuccess(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestController_QuerySuccess(t *testing.T) {
 }
 
 func TestController_QueryCompileError(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestController_QueryCompileError(t *testing.T) {
 }
 
 func TestController_QueryRuntimeError(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestController_QueryRuntimeError(t *testing.T) {
 func TestController_QueryQueueError(t *testing.T) {
 	t.Skip("This test exposed several race conditions, its not clear if the races are specific to the test case")
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +334,7 @@ func findMetric(mfs []*dto.MetricFamily, name string, labels map[string]string) 
 }
 
 func TestController_AfterShutdown(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +354,7 @@ func TestController_AfterShutdown(t *testing.T) {
 }
 
 func TestController_CompileError(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestController_CompileError(t *testing.T) {
 }
 
 func TestController_ExecuteError(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,7 +419,7 @@ func TestController_LimitExceededError(t *testing.T) {
 	const memoryBytesQuotaPerQuery = 64
 	config := config
 	config.MemoryBytesQuotaPerQuery = memoryBytesQuotaPerQuery
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,7 +490,7 @@ func TestController_LimitExceededError(t *testing.T) {
 }
 
 func TestController_CompilePanic(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +511,7 @@ func TestController_CompilePanic(t *testing.T) {
 }
 
 func TestController_StartPanic(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func TestController_StartPanic(t *testing.T) {
 }
 
 func TestController_ShutdownWithRunningQuery(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +590,7 @@ func TestController_ShutdownWithRunningQuery(t *testing.T) {
 }
 
 func TestController_ShutdownWithTimeout(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +641,7 @@ func TestController_ShutdownWithTimeout(t *testing.T) {
 }
 
 func TestController_PerQueryMemoryLimit(t *testing.T) {
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -690,7 +690,7 @@ func TestController_ConcurrencyQuota(t *testing.T) {
 	config := config
 	config.ConcurrencyQuota = concurrencyQuota
 	config.QueueSize = numQueries
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -756,7 +756,7 @@ func TestController_QueueSize(t *testing.T) {
 	config := config
 	config.ConcurrencyQuota = concurrencyQuota
 	config.QueueSize = queueSize
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -822,7 +822,7 @@ func TestController_QueueSize(t *testing.T) {
 func TestController_CancelDone_Unlimited(t *testing.T) {
 	config := config
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -867,7 +867,7 @@ func TestController_CancelDone_Unlimited(t *testing.T) {
 func TestController_DoneWithoutRead_Unlimited(t *testing.T) {
 	config := config
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -919,7 +919,7 @@ func TestController_CancelDone(t *testing.T) {
 	config.ConcurrencyQuota = 10
 	config.QueueSize = 200
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -966,7 +966,7 @@ func TestController_DoneWithoutRead(t *testing.T) {
 	config.ConcurrencyQuota = 10
 	config.QueueSize = 200
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1021,7 +1021,7 @@ func TestController_Error_MaxMemory(t *testing.T) {
 	config.QueueSize = 1
 	config.ConcurrencyQuota = 1
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1079,7 +1079,7 @@ func TestController_NoisyNeighbor(t *testing.T) {
 	// Set the queue length to something that can accommodate the input.
 	config.QueueSize = 1000
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1185,7 +1185,7 @@ func TestController_Error_NoRemainingMemory(t *testing.T) {
 	config.ConcurrencyQuota = 1
 	config.QueueSize = 1
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1231,7 +1231,7 @@ func TestController_MemoryRelease(t *testing.T) {
 	config.QueueSize = 1
 	config.ConcurrencyQuota = 1
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1280,7 +1280,7 @@ func TestController_IrregularMemoryQuota(t *testing.T) {
 	config.QueueSize = 1
 	config.ConcurrencyQuota = 1
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1339,7 +1339,7 @@ func TestController_ReserveMemoryWithoutExceedingMax(t *testing.T) {
 	// Set the queue length to something that can accommodate the input.
 	config.QueueSize = 1000
 
-	ctrl, err := control.New(config, nil, executorDependencies)
+	ctrl, err := control.New(config, zaptest.NewLogger(t), executorDependencies)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/query/control/metrics.go
+++ b/query/control/metrics.go
@@ -31,62 +31,62 @@ const (
 func newControllerMetrics(labels []string) *controllerMetrics {
 	return &controllerMetrics{
 		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name:      "qc_requests_total",
-			Help:      "Count of the query requests",
+			Name: "qc_requests_total",
+			Help: "Count of the query requests",
 		}, append(labels, "result")),
 
 		functions: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name:      "qc_functions_total",
-			Help:      "Count of functions in queries",
+			Name: "qc_functions_total",
+			Help: "Count of functions in queries",
 		}, append(labels, "function")),
 
 		all: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:      "qc_all_active",
-			Help:      "Number of queries in all states",
+			Name: "qc_all_active",
+			Help: "Number of queries in all states",
 		}, labels),
 
 		compiling: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:      "qc_compiling_active",
-			Help:      "Number of queries actively compiling",
+			Name: "qc_compiling_active",
+			Help: "Number of queries actively compiling",
 		}, append(labels, "compiler_type")),
 
 		queueing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:      "qc_queueing_active",
-			Help:      "Number of queries actively queueing",
+			Name: "qc_queueing_active",
+			Help: "Number of queries actively queueing",
 		}, labels),
 
 		executing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:      "qc_executing_active",
-			Help:      "Number of queries actively executing",
+			Name: "qc_executing_active",
+			Help: "Number of queries actively executing",
 		}, labels),
 
 		memoryUnused: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name:      "qc_memory_unused_bytes",
-			Help:      "The free memory as seen by the internal memory manager",
+			Name: "qc_memory_unused_bytes",
+			Help: "The free memory as seen by the internal memory manager",
 		}, labels),
 
 		allDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:      "qc_all_duration_seconds",
-			Help:      "Histogram of total times spent in all query states",
-			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+			Name:    "qc_all_duration_seconds",
+			Help:    "Histogram of total times spent in all query states",
+			Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),
 
 		compilingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:      "qc_compiling_duration_seconds",
-			Help:      "Histogram of times spent compiling queries",
-			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+			Name:    "qc_compiling_duration_seconds",
+			Help:    "Histogram of times spent compiling queries",
+			Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, append(labels, "compiler_type")),
 
 		queueingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:      "qc_queueing_duration_seconds",
-			Help:      "Histogram of times spent queueing queries",
-			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+			Name:    "qc_queueing_duration_seconds",
+			Help:    "Histogram of times spent queueing queries",
+			Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),
 
 		executingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:      "qc_executing_duration_seconds",
-			Help:      "Histogram of times spent executing queries",
-			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+			Name:    "qc_executing_duration_seconds",
+			Help:    "Histogram of times spent executing queries",
+			Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),
 	}
 }

--- a/query/control/metrics.go
+++ b/query/control/metrics.go
@@ -29,89 +29,62 @@ const (
 )
 
 func newControllerMetrics(labels []string) *controllerMetrics {
-	const (
-		namespace = "query"
-		subsystem = "control"
-	)
-
 	return &controllerMetrics{
 		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "requests_total",
+			Name:      "qc_requests_total",
 			Help:      "Count of the query requests",
 		}, append(labels, "result")),
 
 		functions: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "functions_total",
+			Name:      "qc_functions_total",
 			Help:      "Count of functions in queries",
 		}, append(labels, "function")),
 
 		all: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "all_active",
+			Name:      "qc_all_active",
 			Help:      "Number of queries in all states",
 		}, labels),
 
 		compiling: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "compiling_active",
+			Name:      "qc_compiling_active",
 			Help:      "Number of queries actively compiling",
 		}, append(labels, "compiler_type")),
 
 		queueing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "queueing_active",
+			Name:      "qc_queueing_active",
 			Help:      "Number of queries actively queueing",
 		}, labels),
 
 		executing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "executing_active",
+			Name:      "qc_executing_active",
 			Help:      "Number of queries actively executing",
 		}, labels),
 
 		memoryUnused: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "memory_unused_bytes",
+			Name:      "qc_memory_unused_bytes",
 			Help:      "The free memory as seen by the internal memory manager",
 		}, labels),
 
 		allDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "all_duration_seconds",
+			Name:      "qc_all_duration_seconds",
 			Help:      "Histogram of total times spent in all query states",
 			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),
 
 		compilingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "compiling_duration_seconds",
+			Name:      "qc_compiling_duration_seconds",
 			Help:      "Histogram of times spent compiling queries",
 			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, append(labels, "compiler_type")),
 
 		queueingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "queueing_duration_seconds",
+			Name:      "qc_queueing_duration_seconds",
 			Help:      "Histogram of times spent queueing queries",
 			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),
 
 		executingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "executing_duration_seconds",
+			Name:      "qc_executing_duration_seconds",
 			Help:      "Histogram of times spent executing queries",
 			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
 		}, labels),


### PR DESCRIPTION

Closes #17212

A sample of the new config:

```
[flux-controller]
  query-concurrency = 0
  query-initial-memory-bytes = 0
  query-max-memory-bytes = 0
  total-max-memory-bytes = 0
  query-queue-size = 0
```

Also use the prometheus metrics in debug/vars, here is a sample:

```
"query_control_all_active": {"name":"query_control_all_active","tags":null,"values":{"gauge":0}},
"query_control_all_duration_seconds": {"name":"query_control_all_duration_seconds","tags":null,"values":{"0.001":0,"0.005":0,"0.025":0,"0.125":0,"0.625":0,"15.625":2,"3.125":2,"count":2,"sum":2.9953034240000003}},
"query_control_compiling_active": {"name":"query_control_compiling_active","tags":null,"values":{"gauge":0}},
"query_control_compiling_duration_seconds": {"name":"query_control_compiling_duration_seconds","tags":null,"values":{"0.001":2,"0.005":2,"0.025":2,"0.125":2,"0.625":2,"15.625":2,"3.125":2,"count":2,"sum":0.0010411650000000001}},
"query_control_executing_active": {"name":"query_control_executing_active","tags":null,"values":{"gauge":0}},
"query_control_executing_duration_seconds": {"name":"query_control_executing_duration_seconds","tags":null,"values":{"0.001":0,"0.005":0,"0.025":0,"0.125":0,"0.625":0,"15.625":2,"3.125":2,"count":2,"sum":2.994032791}},
"query_control_memory_unused_bytes": {"name":"query_control_memory_unused_bytes","tags":null,"values":{"gauge":0}},
"query_control_queueing_active": {"name":"query_control_queueing_active","tags":null,"values":{"gauge":0}},
"query_control_queueing_duration_seconds": {"name":"query_control_queueing_duration_seconds","tags":null,"values":{"0.001":2,"0.005":2,"0.025":2,"0.125":2,"0.625":2,"15.625":2,"3.125":2,"count":2,"sum":0.000087963}},
"query_control_requests_total": {"name":"query_control_requests_total","tags":null,"values":{"counter":1}},
"query_control_requests_total:1": {"name":"query_control_requests_total","tags":null,"values":{"counter":1}}
```


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
