### PR TITLE
feat: synchronize ui folder with ui repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,6 @@ workflows:
       - gotest:
           requires:
             - godeps
-      - jstest:
-          requires:
-            - jsdeps
       - tlstest:
           requires:
             - godeps
@@ -24,9 +21,6 @@ workflows:
       - golint:
           requires:
             - godeps
-      - jslint:
-          requires:
-            - jsdeps
       - build:
           requires:
             - godeps
@@ -81,22 +75,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
-      - jstest:
-          requires:
-            - jsdeps
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
-      - jslint:
-          requires:
-            - jsdeps
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
       - influxql_validation:
           requires:
             - godeps
@@ -125,8 +103,6 @@ workflows:
           requires:
             - gotest
             - golint
-            - jstest
-            - jslint
             - influxql_validation
             - influxql_integration
             - tlstest
@@ -317,7 +293,6 @@ commands:
                 command: goreleaser --debug release -p 1 --rm-dist --skip-validate
 
 jobs:
-
   ####################
   ### UI-only jobs ###
   ####################
@@ -346,62 +321,6 @@ jobs:
             - /home/circleci/go/src/github.com/influxdata/influxdb/ui/node_modules
             - ~/.cache/yarn
             - ~/.cache/Cypress
-
-  jstest:
-    docker:
-      - image: cimg/go:1.15.6-node
-    working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore Yarn Cache
-          keys:
-            - yarn-deps-lock-{{ checksum "ui/yarn.lock" }}
-      - run:
-          name: install dependencies
-          command: |
-            cd ui
-            # This should usually be a no-op (fully contained in the Yarn cache above), but we
-            # include it to be safe since `yarn test` won't auto-install missing modules.
-            yarn install --immutable
-      - run: make ui_client
-      - run:
-          name: run tests
-          command: |
-            cd ui
-            yarn test:circleci
-      - store_test_results:
-          path: ui/coverage
-      - store_artifacts:
-          path: ui/coverage
-          destination: raw-test-output
-
-  jslint:
-    docker:
-      - image: cimg/go:1.15.6-node
-    working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
-    parallelism: 8
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore Yarn Cache
-          keys:
-            - yarn-deps-lock-{{ checksum "ui/yarn.lock" }}
-      - run:
-          name: install dependencies
-          command: |
-            cd ui
-            # This should usually be a no-op (fully contained in the Yarn cache above), but we
-            # include it to be safe since the lint commands won't auto-install missing modules.
-            yarn install --immutable
-      - run: make ui_client
-      - run:
-          name: parallel eslint
-          command: |
-            cd ui
-            TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
-            yarn prettier:circleci ${TESTFILES[@]}
-            yarn eslint:circleci ${TESTFILES[@]}
 
   #########################
   ### Backend-only jobs ###
@@ -700,6 +619,7 @@ jobs:
   e2e:
     docker:
       - image: cimg/go:1.15.6-browsers
+    resource_class: large
     environment:
       GOCACHE: /tmp/go-cache
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## v2.0.5 [unreleased]
-
----
+----------------------
 
 ### Windows Support
 
@@ -38,7 +37,7 @@ or `/query` HTTP endpoints.
 1. [21049](https://github.com/influxdata/influxdb/pull/21049): Write to standard out when `--output-path -` is passed to `influxd inspect export-lp`.
 1. [21050](https://github.com/influxdata/influxdb/pull/21050): Add `-p, --profilers` flag to `influx query` command.
 1. [21119](https://github.com/influxdata/influxdb/pull/21119): Upgrade Flux to v0.111.0.
-1. [21090](https://github.com/influxdata/influxdb/pull/21090): Update UI to match InfluxDB Cloud.
+1. [21126](https://github.com/influxdata/influxdb/pull/21090): Update UI to match InfluxDB Cloud.
 
 ### Bug Fixes
 
@@ -62,17 +61,14 @@ or `/query` HTTP endpoints.
 1. [21048](https://github.com/influxdata/influxdb/pull/21048): Prevent concurrent access panic when gathering bolt metrics.
 
 ## v2.0.4 [2021-02-08]
-
----
+----------------------
 
 ### Docker
 
 #### ARM64
-
 This release extends the Docker builds hosted in `quay.io` to support the `linux/arm64` platform.
 
 #### 2.x nightly images
-
 Prior to this release, competing nightly builds caused the `nightly` Docker tag to contain outdated
 binaries. This conflict has been fixed, and the image tagged with `nightly` will now contain `2.x`
 binaries built from the `HEAD` of the `master` branch.
@@ -80,11 +76,9 @@ binaries built from the `HEAD` of the `master` branch.
 ### Breaking Changes
 
 #### inmem index option removed
-
 This release fully removes the `inmem` indexing option, along with the associated config options:
-
-- `max-series-per-database`
-- `max-values-per-tag`
+* `max-series-per-database`
+* `max-values-per-tag`
 
 Replacement `tsi1` indexes will be automatically generated on startup for shards that need it.
 
@@ -142,8 +136,7 @@ RPM packages, which has been left unchanged.
 1. [20708](https://github.com/influxdata/influxdb/pull/20708): Update API spec to document Flux dictionary features.
 
 ## v2.0.3 [2020-12-14]
-
----
+----------------------
 
 ### ARM Support
 
@@ -152,12 +145,10 @@ This release includes our initial ARM64 "preview" build.
 ### Breaking Changes
 
 #### influxd upgrade
-
 Previously, `influxd upgrade` would attempt to write upgraded `config.toml` files into the same directory as the source
 `influxdb.conf` file. If this failed, a warning would be logged and `config.toml` would be written into the `HOME` directory.
 
 This release breaks this behavior in two ways:
-
 1. By default, `config.toml` is now written into the same directory as the Bolt DB and engine files (`~/.influxdbv2/`)
 2. If writing upgraded config fails, the `upgrade` process exits with an error instead of falling back to the `HOME` directory
 
@@ -165,8 +156,7 @@ Users can use the new `--v2-config-path` option to override the output path for 
 want to use the default.
 
 #### v2 packaging
-
-Based on community feedback, the v2 deb and rpm packaging has been improved to avoid confusion between versions. The package
+Based on community feedback, the v2 deb and rpm packaging has been improved to avoid confusion between versions.  The package
 name is now influxdb2 and conflicts with any previous influxdb package (including initial 2.0.0, 2.0.1, and 2.0.2 packages).
 Additionally, v2 specific path defaults are now defined and helper scripts are provided for `influxd upgrade` and cleanup cases.
 
@@ -195,8 +185,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20329](https://github.com/influxdata/influxdb/pull/20329): Set v2 default paths and provide upgrade helper scripts in release packages.
 
 ## v2.0.2 [2020-11-18]
-
----
+----------------------
 
 ### Features
 
@@ -211,7 +200,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 
 1. [19992](https://github.com/influxdata/influxdb/pull/19992): Fix various typos. Thanks @kumakichi!
 1. [19999](https://github.com/influxdata/influxdb/pull/19999): Use --skip-verify flag for backup/restore CLI command.
-1. [19999](https://github.com/influxdata/influxdb/pull/19999): Suggest running with -h on error instead of printing usage when launching `influxd`.
+1. [19999](https://github.com/influxdata/influxdb/pull/19999): Suggest running with -h on error instead of printing usage when launching `influxd`. 
 1. [20047](https://github.com/influxdata/influxdb/pull/20072): Allow self signed certificates for scraper targets. Thanks @cmackenzie1!
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Add locking during TSI iterator creation.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Do not use global viper APIs, which breaks testing.
@@ -222,7 +211,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Reinstate minimal read-only document store for dashboard template.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): UI: Skip dashboard index CRUD case.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed logic checking time filter exists.
-1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed error message semantic.
+1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed error message semantic. 
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Track seen databases in map and skip duplicates.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Build: Remove lint-feature-flag job from OSS.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): CLI: Don't validate unused paths in `upgrade`.
@@ -233,12 +222,11 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): UI: UX improvements and bug fixes to dbrp commands.
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): API: Make the dbrp api match the swagger spec.
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): Revert changes to API page-sizes.
-1. [20089](https://github.com/influxdata/influxdb/pull/20089): Exclude pkger_test.go from linting
+1. [20089](https://github.com/influxdata/influxdb/pull/20089): Exclude pkger\_test.go from linting 
 1. [20091](https://github.com/influxdata/influxdb/pull/20091): Make the DBRP http API match the swagger spec.
 
 ## v2.0.1 [2020-11-10]
-
----
+----------------------
 
 ### Bug Fixes
 
@@ -250,8 +238,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [19980](https://github.com/influxdata/influxdb/pull/19980): check write permission in legacy write path
 
 ## v2.0.0 [2020-11-09]
-
----
+----------------------
 
 ### Features
 
@@ -446,7 +433,6 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19317](https://github.com/influxdata/influxdb/pull/19317): Add validation to Variable name creation for valid Flux identifiers.
 
 ### UI Improvements
-
 1. [19231](https://github.com/influxdata/influxdb/pull/19231): Alerts page filter inputs now have tab indices for keyboard navigation
 1. [19364](https://github.com/influxdata/influxdb/pull/19364): Errors in OSS are now properly printed to the console
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v2.0.5 [unreleased]
-----------------------
+
+---
 
 ### Windows Support
 
@@ -37,6 +38,7 @@ or `/query` HTTP endpoints.
 1. [21049](https://github.com/influxdata/influxdb/pull/21049): Write to standard out when `--output-path -` is passed to `influxd inspect export-lp`.
 1. [21050](https://github.com/influxdata/influxdb/pull/21050): Add `-p, --profilers` flag to `influx query` command.
 1. [21119](https://github.com/influxdata/influxdb/pull/21119): Upgrade Flux to v0.111.0.
+1. [21090](https://github.com/influxdata/influxdb/pull/21090): Update UI to match InfluxDB Cloud.
 
 ### Bug Fixes
 
@@ -60,14 +62,17 @@ or `/query` HTTP endpoints.
 1. [21048](https://github.com/influxdata/influxdb/pull/21048): Prevent concurrent access panic when gathering bolt metrics.
 
 ## v2.0.4 [2021-02-08]
-----------------------
+
+---
 
 ### Docker
 
 #### ARM64
+
 This release extends the Docker builds hosted in `quay.io` to support the `linux/arm64` platform.
 
 #### 2.x nightly images
+
 Prior to this release, competing nightly builds caused the `nightly` Docker tag to contain outdated
 binaries. This conflict has been fixed, and the image tagged with `nightly` will now contain `2.x`
 binaries built from the `HEAD` of the `master` branch.
@@ -75,9 +80,11 @@ binaries built from the `HEAD` of the `master` branch.
 ### Breaking Changes
 
 #### inmem index option removed
+
 This release fully removes the `inmem` indexing option, along with the associated config options:
-* `max-series-per-database`
-* `max-values-per-tag`
+
+- `max-series-per-database`
+- `max-values-per-tag`
 
 Replacement `tsi1` indexes will be automatically generated on startup for shards that need it.
 
@@ -135,7 +142,8 @@ RPM packages, which has been left unchanged.
 1. [20708](https://github.com/influxdata/influxdb/pull/20708): Update API spec to document Flux dictionary features.
 
 ## v2.0.3 [2020-12-14]
-----------------------
+
+---
 
 ### ARM Support
 
@@ -144,10 +152,12 @@ This release includes our initial ARM64 "preview" build.
 ### Breaking Changes
 
 #### influxd upgrade
+
 Previously, `influxd upgrade` would attempt to write upgraded `config.toml` files into the same directory as the source
 `influxdb.conf` file. If this failed, a warning would be logged and `config.toml` would be written into the `HOME` directory.
 
 This release breaks this behavior in two ways:
+
 1. By default, `config.toml` is now written into the same directory as the Bolt DB and engine files (`~/.influxdbv2/`)
 2. If writing upgraded config fails, the `upgrade` process exits with an error instead of falling back to the `HOME` directory
 
@@ -155,7 +165,8 @@ Users can use the new `--v2-config-path` option to override the output path for 
 want to use the default.
 
 #### v2 packaging
-Based on community feedback, the v2 deb and rpm packaging has been improved to avoid confusion between versions.  The package
+
+Based on community feedback, the v2 deb and rpm packaging has been improved to avoid confusion between versions. The package
 name is now influxdb2 and conflicts with any previous influxdb package (including initial 2.0.0, 2.0.1, and 2.0.2 packages).
 Additionally, v2 specific path defaults are now defined and helper scripts are provided for `influxd upgrade` and cleanup cases.
 
@@ -184,7 +195,8 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20329](https://github.com/influxdata/influxdb/pull/20329): Set v2 default paths and provide upgrade helper scripts in release packages.
 
 ## v2.0.2 [2020-11-18]
-----------------------
+
+---
 
 ### Features
 
@@ -199,7 +211,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 
 1. [19992](https://github.com/influxdata/influxdb/pull/19992): Fix various typos. Thanks @kumakichi!
 1. [19999](https://github.com/influxdata/influxdb/pull/19999): Use --skip-verify flag for backup/restore CLI command.
-1. [19999](https://github.com/influxdata/influxdb/pull/19999): Suggest running with -h on error instead of printing usage when launching `influxd`. 
+1. [19999](https://github.com/influxdata/influxdb/pull/19999): Suggest running with -h on error instead of printing usage when launching `influxd`.
 1. [20047](https://github.com/influxdata/influxdb/pull/20072): Allow self signed certificates for scraper targets. Thanks @cmackenzie1!
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Add locking during TSI iterator creation.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Do not use global viper APIs, which breaks testing.
@@ -210,7 +222,7 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Reinstate minimal read-only document store for dashboard template.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): UI: Skip dashboard index CRUD case.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed logic checking time filter exists.
-1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed error message semantic. 
+1. [20072](https://github.com/influxdata/influxdb/pull/20072): Task: Fixed error message semantic.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Track seen databases in map and skip duplicates.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): Build: Remove lint-feature-flag job from OSS.
 1. [20072](https://github.com/influxdata/influxdb/pull/20072): CLI: Don't validate unused paths in `upgrade`.
@@ -221,11 +233,12 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): UI: UX improvements and bug fixes to dbrp commands.
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): API: Make the dbrp api match the swagger spec.
 1. [20089](https://github.com/influxdata/influxdb/pull/20089): Revert changes to API page-sizes.
-1. [20089](https://github.com/influxdata/influxdb/pull/20089): Exclude pkger\_test.go from linting 
+1. [20089](https://github.com/influxdata/influxdb/pull/20089): Exclude pkger_test.go from linting
 1. [20091](https://github.com/influxdata/influxdb/pull/20091): Make the DBRP http API match the swagger spec.
 
 ## v2.0.1 [2020-11-10]
-----------------------
+
+---
 
 ### Bug Fixes
 
@@ -237,7 +250,8 @@ Additionally, v2 specific path defaults are now defined and helper scripts are p
 1. [19980](https://github.com/influxdata/influxdb/pull/19980): check write permission in legacy write path
 
 ## v2.0.0 [2020-11-09]
-----------------------
+
+---
 
 ### Features
 
@@ -432,6 +446,7 @@ need to update any InfluxDB CLI config profiles with the new port number.
 1. [19317](https://github.com/influxdata/influxdb/pull/19317): Add validation to Variable name creation for valid Flux identifiers.
 
 ### UI Improvements
+
 1. [19231](https://github.com/influxdata/influxdb/pull/19231): Alerts page filter inputs now have tab indices for keyboard navigation
 1. [19364](https://github.com/influxdata/influxdb/pull/19364): Errors in OSS are now properly printed to the console
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -12,8 +12,8 @@ e2e: node_modules
 	yarn generate
 	yarn test:e2e
 
-build: node_modules $(UISOURCES)
-	yarn build
+build:
+	./fetch_ui_assets.sh
 
 lint: node_modules $(UISOURCES)
 	yarn generate

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,55 +1,55 @@
-## Packages
+## InfluxDB UI
 
-### Adding new packages
+UI assets for InfluxDB are automatically downloaded and embedded in the `influxd` binary
+when using the top-level `Makefile`. The UI assets are built and made available from
+the [`influxdata/ui` repository](https://github.com/influxdata/ui). Currently, this `ui`
+folder and its contents are being kept to preserve the ability to run end-to-end tests via Cypress in this repository against the built UI when changes are made to `influxdb`.
 
-To add a new package, run
+### Starting a Local Development Environment
 
-```sh
-yarn add packageName
+It is possible to run a frontend development server with hot reloading using the UI from
+[`influxdata/ui`](https://github.com/influxdata/ui) in front of the InfluxDB backend:
+
+Start `influxd` listening on the default port (`8086`):
+
+`$ ./bin/darwin/influxd`
+
+Clone (if needed) & start the UI development server from the `ui` repository:
+
+```
+$ git clone https://github.com/influxdata/ui.git
+$ cd ui
+$ yarn start
 ```
 
-### Adding devDependency
+The UI development server runs at [`http://localhost:8080`](http://localhost:8080/)
 
-```sh
-yarn add packageName --dev
+### Running InfluxDB with Local UI Assets
+
+To run InfluxDB with local UI assets, first build the assets:
+
+```
+$ git clone https://github.com/influxdata/ui.git
+$ cd ui
+$ yarn build
 ```
 
-### Updating a package
+Start `influxd` using the local UI assets via the `--assets-path` flag. For example,
+if the `ui` folder containing built assets is at the same level as the `influxdb` folder
+and the `influxd` binary is at `influxdb/bin/darwin/influxd`:
 
-First, run the command
+`$ ./bin/darwin/influxd --assets-path=../ui/build`
 
-```sh
-yarn outdated
-```
+### Cypress Testing
 
-... to determine which packages may need upgrading.
+For the end to end tests to run properly, the server needs to be running in the e2e testing mode with the in-memory data store. From the `influxdb` directory:
 
-We _really_ should not upgrade all packages at once, but, one at a time and make darn sure
-to test.
+`$ ./bin/darwin/influxd --e2e-testing --store=memory`
 
-To upgrade a single package named `packageName`:
+From the ui directory, install the packages necessary for testing:
 
-```sh
-yarn upgrade packageName
-```
+`$ yarn install`
 
-## Testing
+ To run Cypress locally:
 
-Tests can be run via command line with `yarn test`, from within the `/ui` directory. For more detailed reporting, use `yarn test -- --reporters=verbose`.
-
-
-## Cypress Testing
-
-e2e tests:
-For the end to end tests to run properly, the server needs to be running in the e2e testing mode with the in memory data store.
-From the influxdb directory
-`$ ./bin/darwin/influxd --assets-path=ui/build --e2e-testing --store=memory`
-
-From the ui directory. Build the javascript with
-`$ yarn start`
- To run Cypress locally
-`$ yarn cy:dev`
-
-## Starting Dev Server
-
-The assets are built by running `yarn start` from withing the `/ui` directory. The dev server with hot reloading runs at `localhost:8080`.
+`$ yarn cy`

--- a/ui/cypress.json
+++ b/ui/cypress.json
@@ -1,4 +1,4 @@
 {
   "integrationFolder": "cypress/e2e",
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 30000
 }

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -80,7 +80,7 @@ describe('Checks', () => {
       cy.getByTestID('save-cell--button').should('be.disabled')
       cy.getByTestID('checkeo--header alerting-tab').click()
       cy.getByTestID('add-threshold-condition-WARN').click()
-      cy.getByTestID('input-field')
+      cy.getByTestID('input-field-WARN')
         .clear()
         .type('0')
       cy.getByTestID('save-cell--button').click()
@@ -113,7 +113,7 @@ describe('Checks', () => {
       cy.getByTestID('check-card--name').should('have.length', 1)
       cy.getByTestID('check-card--name').click()
       // ensures that the check WARN value is set to 0
-      cy.getByTestID('input-field')
+      cy.getByTestID('input-field-WARN')
         .should('have.value', '0')
         .clear()
         .type('7')
@@ -173,7 +173,7 @@ describe('Checks', () => {
       cy.getByTestID('save-cell--button').should('be.disabled')
       cy.getByTestID('checkeo--header alerting-tab').click()
       cy.getByTestID('add-threshold-condition-CRIT').click()
-      cy.getByTestID('input-field')
+      cy.getByTestID('input-field-CRIT')
         .clear()
         .type('0')
       cy.getByTestID('add-threshold-condition-WARN').click()
@@ -211,7 +211,6 @@ describe('Checks', () => {
       cy.getByTestID('filter--input checks').should('have.focus')
 
       cy.focused()
-        .tab()
         .tab()
       cy.getByTestID('filter--input endpoints').should('have.focus')
 

--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -358,6 +358,8 @@ describe('Dashboards', () => {
 
         cy.getByTestID('inline-labels--popover-field').type(label)
         cy.getByTestID('inline-labels--create-new').click()
+        // Wait for animation to complete
+        cy.wait(500)
 
         cy.getByTestID('overlay--container').within(() => {
           cy.getByTestID('create-label-form--name').should('have.value', label)

--- a/ui/cypress/e2e/dashboardsView.test.ts
+++ b/ui/cypress/e2e/dashboardsView.test.ts
@@ -100,7 +100,10 @@ describe('Dashboard', () => {
 
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').within(() => {
-      cy.get('.CodeMirror').type(`${headerPrefix} ${noteText}`)
+      cy.getByTestID('markdown-editor').within(() => {
+        cy.get('textarea').type(`${headerPrefix} ${noteText}`, {force: true})
+      })
+
       cy.getByTestID('note-editor--preview').contains(noteText)
       cy.getByTestID('note-editor--preview').should('not.contain', headerPrefix)
 
@@ -298,7 +301,7 @@ describe('Dashboard', () => {
 
             // TESTING CSV VARIABLE
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown')
+            cy.getByTestID('variable-dropdown--button')
               .eq(0)
               .should('contain', bucketOne)
             cy.window()
@@ -306,13 +309,13 @@ describe('Dashboard', () => {
               .should('equal', bucketOne)
 
             //testing variable controls
-            cy.getByTestID('variable-dropdown')
+            cy.getByTestID('variable-dropdown--button')
               .eq(0)
               .should('contain', bucketOne)
             cy.getByTestID('variables--button').click()
-            cy.getByTestID('variable-dropdown').should('not.exist')
+            cy.getByTestID('variable-dropdown--button').should('not.exist')
             cy.getByTestID('variables--button').click()
-            cy.getByTestID('variable-dropdown').should('exist')
+            cy.getByTestID('variable-dropdown--button').should('exist')
 
             // sanity check on the url before beginning
             cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
@@ -324,7 +327,7 @@ describe('Dashboard', () => {
             cy.get(`#${bucketThree}`).click()
 
             // selected value in dashboard is 3rd value
-            cy.getByTestID('variable-dropdown')
+            cy.getByTestID('variable-dropdown--button')
               .eq(0)
               .should('contain', bucketThree)
             cy.window()
@@ -379,14 +382,14 @@ describe('Dashboard', () => {
               .should('equal', bucketOne)
 
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown').should('contain', bucketOne)
+            cy.getByTestID('variable-dropdown--button').should('contain', bucketOne)
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 0))
               .should('equal', bucketOne)
 
             // TESTING MAP VARIABLE
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown')
+            cy.getByTestID('variable-dropdown--button')
               .eq(1)
               .should('contain', 'k1')
             cy.window()
@@ -400,7 +403,7 @@ describe('Dashboard', () => {
             cy.get(`#k2`).click()
 
             // selected value in dashboard is 2nd value
-            cy.getByTestID('variable-dropdown')
+            cy.getByTestID('variable-dropdown--button')
               .eq(1)
               .should('contain', 'k2')
             cy.window()
@@ -438,7 +441,7 @@ describe('Dashboard', () => {
               .should('equal', 'v1')
 
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown').should('contain', 'k1')
+            cy.getByTestID('variable-dropdown--button').should('contain', 'k1')
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 2))
               .should('equal', 'v1')
@@ -535,13 +538,13 @@ describe('Dashboard', () => {
 
         // the default bucket selection should have no results and load all three variables
         // even though only two variables are being used (because 1 is dependent upon another)
-        cy.getByTestID('variable-dropdown')
+        cy.getByTestID('variable-dropdown--button')
           .should('have.length', 3)
           .eq(0)
           .should('contain', 'beans')
 
         // and cause the rest to exist in loading states
-        cy.getByTestID('variable-dropdown')
+        cy.getByTestID('variable-dropdown--button')
           .eq(1)
           .should('contain', 'Loading')
 
@@ -554,7 +557,7 @@ describe('Dashboard', () => {
         cy.get(`#defbuck`).click()
 
         // default select the first result
-        cy.getByTestID('variable-dropdown')
+        cy.getByTestID('variable-dropdown--button')
           .eq(1)
           .should('contain', 'beans')
 
@@ -566,7 +569,7 @@ describe('Dashboard', () => {
         cy.get(`#cool`).click()
 
         // and also load the second result
-        cy.getByTestID('variable-dropdown')
+        cy.getByTestID('variable-dropdown--button')
           .eq(1)
           .should('contain', 'cool')
 
@@ -575,7 +578,7 @@ describe('Dashboard', () => {
           .eq(2)
           .click()
         cy.get(`#beans`).click()
-        cy.getByTestID('variable-dropdown')
+        cy.getByTestID('variable-dropdown--button')
           .eq(1)
           .should('contain', 'beans')
       })
@@ -657,12 +660,12 @@ describe('Dashboard', () => {
       cy.getByTestID('save-cell--button').click()
 
       // the default bucket selection should have no results
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestID('variable-dropdown--button')
         .eq(0)
         .should('contain', 'beans')
 
       // and cause the rest to exist in loading states
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestID('variable-dropdown--button')
         .eq(1)
         .should('contain', 'Loading')
 
@@ -675,7 +678,7 @@ describe('Dashboard', () => {
       cy.get(`#defbuck`).click()
 
       // default select the first result
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestID('variable-dropdown--button')
         .eq(1)
         .should('contain', 'beans')
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -482,6 +482,7 @@ describe('DataExplorer', () => {
     })
 
     it('imports the appropriate packages to build a query', () => {
+      cy.getByTestID('flux-editor').should('be.visible')
       cy.getByTestID('functions-toolbar-contents--functions').should('exist')
       cy.getByTestID('flux--from--inject').click()
       cy.getByTestID('flux--range--inject').click()
@@ -508,6 +509,7 @@ describe('DataExplorer', () => {
     })
 
     it('can use the function selector to build a query', () => {
+      cy.getByTestID('flux-editor').should('be.visible')
       cy.getByTestID('functions-toolbar-contents--functions').should('exist')
 
       cy.getByTestID('flux--from--inject').click()
@@ -536,7 +538,8 @@ describe('DataExplorer', () => {
     })
 
     it('can filter aggregation functions by name from script editor mode', () => {
-      cy.getByTestID('input-field')
+      cy.getByTestID('flux-editor').should('be.visible')
+      cy.getByTestID('flux-toolbar-search--input')
         .clear() //TODO (zoe) when cypress resolves bug remove clear  https://github.com/cypress-io/cypress/issues/5480
         .type('covariance')
         .should('have.value', 'covariance')
@@ -674,9 +677,10 @@ describe('DataExplorer', () => {
             cy.getByTestID('time-machine-submit-button').click()
             cy.getByTestID('empty-graph--error').should('exist')
           })
-          cy.get('.react-monaco-editor-container')
-            .click()
+          cy.getByTestID('flux-editor')
+            .click({force: true})
             .focused()
+            .clear()
             .type('from(', {force: true, delay: 2})
           cy.getByTestID('time-machine-submit-button').click()
         })
@@ -899,8 +903,10 @@ describe('DataExplorer', () => {
             .trigger('mousedown', {force: true})
             .trigger('mousemove', {clientY: 5000})
             .trigger('mouseup')
+            .then(() => {
+              cy.get(`[title="${numLines}"]`).should('be.visible')
+            })
         })
-        cy.get(`[title="${numLines}"]`).should('be.visible')
       })
     })
   })

--- a/ui/cypress/e2e/notificationRules.test.ts
+++ b/ui/cypress/e2e/notificationRules.test.ts
@@ -61,20 +61,20 @@ describe('NotificationRules', () => {
         cy.getByTestID('add-threshold-condition-CRIT').click()
         cy.getByTestID('builder-conditions').within(() => {
           cy.getByTestID('panel').within(() => {
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('{backspace}{backspace}')
               .invoke('attr', 'type')
               .should('equal', 'text')
-              .getByTestID('input-field--error')
+              .getByTestID('input-field-CRIT--error')
               .should('have.length', 1)
               .and('have.value', '')
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('somerangetext')
               .invoke('val')
               .should('equal', '')
-              .getByTestID('input-field--error')
+              .getByTestID('input-field-CRIT--error')
               .should('have.length', 1)
           })
         })
@@ -85,7 +85,7 @@ describe('NotificationRules', () => {
         cy.getByTestID('add-threshold-condition-CRIT').click()
         cy.getByTestID('builder-conditions').within(() => {
           cy.getByTestID('panel').within(() => {
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('{backspace}{backspace}9')
               .invoke('val')

--- a/ui/cypress/e2e/queryBuilder.test.ts
+++ b/ui/cypress/e2e/queryBuilder.test.ts
@@ -34,6 +34,7 @@ describe('The Query Builder', () => {
     it('creates a query, edits it to add another field, then views its results with pride and satisfaction', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
+        cy.getByTestID('tree-nav')
       })
 
       cy.contains('mem').click('right') // users sometimes click in random spots
@@ -59,16 +60,18 @@ describe('The Query Builder', () => {
       cy.getByTestID('save-as-dashboard-cell--submit').click()
 
       // wait for the notification since it's highly animated
-      // we close the notification since it contains the name of the dashboard and interfers with cy.contains
+      // we close the notification since it contains the name of the dashboard and interferes with cy.contains
       cy.wait(250)
       cy.get('.cf-notification--dismiss').click()
       cy.wait(250)
 
       // force a click on the hidden dashboard nav item (cypress can't do the hover)
       // i assure you i spent a nonzero amount of time trying to do this the way a user would
-      cy.getByTestID('nav-item-dashboards').click()
+      cy.getByTestID('nav-item-dashboards').click({force: true})
 
       cy.contains('Basic Ole Dashboard').click()
+      cy.getByTestID('giraffe-layer-line').should('exist')
+      cy.getByTestID('cell-context--toggle').should('exist')
       cy.getByTestID('cell-context--toggle').click()
       cy.contains('Configure').click()
 
@@ -81,6 +84,8 @@ describe('The Query Builder', () => {
       cy.getByTestID('nav-item-dashboards').click()
 
       cy.contains('Basic Ole Dashboard').click()
+      cy.getByTestID('giraffe-layer-line').should('be.visible')
+      cy.getByTestID('cell-context--toggle').should('be.visible')
       cy.getByTestID('cell-context--toggle').click()
       cy.contains('Configure').click()
 

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -384,7 +384,7 @@ function createFirstTask(
   cy.get<Bucket>('@bucket').then(bucket => {
     cy.getByTestID('flux-editor').within(() => {
       cy.get('textarea.inputarea')
-        .click()
+        .click({force: true})
         .focused()
         .type(flux(bucket), {force: true, delay: 2})
     })

--- a/ui/cypress/e2e/telegrafs.test.ts
+++ b/ui/cypress/e2e/telegrafs.test.ts
@@ -162,8 +162,10 @@ describe('Collectors', () => {
         cy.getByTestID('inline-labels--popover-field').type('zoe')
         cy.getByTestID('inline-labels--create-new').click()
         cy.getByTestID('overlay--container').should('exist')
+        // Wait for animation to complete
+        cy.wait(500)
         cy.getByTestID('create-label-form--submit').click()
-        cy.getByTestID('label--pill zoe').should('exist')
+        cy.getByTestID('label--pill--delete zoe').should('exist')
         cy.getByTestID('label--pill--delete zoe').click({force: true})
 
         cy.getByTestID('inline-labels--empty').should('exist')
@@ -394,7 +396,10 @@ describe('Collectors', () => {
       cy.contains('Your configurations have been saved')
 
       cy.contains('Label 1').click()
-      cy.contains('Telegraf Configuration - Label 1').should('exist')
+
+      cy.getByTestID('telegraf-overlay').within(() => {
+        cy.contains('Label 1').should('exist')
+      })
     })
 
     describe('Label creation and searching', () => {
@@ -411,6 +416,8 @@ describe('Collectors', () => {
         cy.getByTestID('inline-labels--popover-field').type('zoe')
         cy.getByTestID('inline-labels--create-new').click()
         cy.getByTestID('overlay--container').should('exist')
+        // Wait for animation to complete
+        cy.wait(500)
         cy.getByTestID('create-label-form--submit').click()
         cy.getByTestID('label--pill zoe').should('exist')
         // search by label

--- a/ui/cypress/e2e/tokens.test.ts
+++ b/ui/cypress/e2e/tokens.test.ts
@@ -434,9 +434,13 @@ describe('tokens', () => {
         cy.getByTestID('resource-sorter--status-asc').click()
       })
       .then(() => {
-        const sortedtoken = testTokens.sort((a, b) =>
-          a.status > b.status ? 1 : -1
-        )
+        const sortedtoken = testTokens.sort((a, b) => {
+          if (a.status !== b.status) {
+            return a.status > b.status ? 1 : -1
+          } else {
+            return a.description > b.description  ? 1 : -1
+          }
+        })
         cy.get('[data-testid*="token-card"]').each((val, index) => {
           const testID = val.attr('data-testid')
           expect(testID).to.contain(sortedtoken[index].description)
@@ -450,9 +454,13 @@ describe('tokens', () => {
         cy.getByTestID('resource-sorter--status-desc').click()
       })
       .then(() => {
-        const sortedtoken = testTokens
-          .sort((a, b) => (a.status > b.status ? 1 : -1))
-          .reverse()
+        const sortedtoken = testTokens.sort((a, b) => {
+          if (a.status !== b.status) {
+            return a.status > b.status ? -1 : 1
+          } else {
+            return a.description > b.description  ? 1 : -1
+          }
+        })
         cy.get('[data-testid*="token-card"]').each((val, index) => {
           const testID = val.attr('data-testid')
           expect(testID).to.contain(sortedtoken[index].description)

--- a/ui/cypress/e2e/variables.test.ts
+++ b/ui/cypress/e2e/variables.test.ts
@@ -40,7 +40,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown-constant').click()
 
     // Create a CSV variable
-    const variableName = 'a Second Variable'
+    const variableName = 'aSecondVariable'
     cy.getByInputName('name').type(variableName)
 
     cy.get('textarea').type('1,2,3,4,5,6')
@@ -113,7 +113,7 @@ describe('Variables', () => {
     cy.getByTestID('context-delete-menu')
       .first()
       .click({force: true})
-    cy.getByTestID('context-delete-variable')
+    cy.getByTestID(`context-delete-variable ${variableName}`)
       .first()
       .click({force: true})
 
@@ -123,7 +123,7 @@ describe('Variables', () => {
 
     cy.getByTestID('resource-card variable')
       .should('have.length', 1)
-      .contains('Little Variable')
+      .contains('LittleVariable')
 
     // Rename the variable
     cy.getByTestID('context-menu')
@@ -134,14 +134,14 @@ describe('Variables', () => {
 
     cy.getByTestID('danger-confirmation-button').click()
 
-    cy.getByInputName('name').type('-renamed')
+    cy.getByInputName('name').type('_renamed')
 
     cy.getByTestID('rename-variable-submit').click()
 
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.getByTestID(`variable-card--name Little Variable-renamed`).contains(
-      '-renamed'
+    cy.getByTestID(`variable-card--name LittleVariable_renamed`).contains(
+      '_renamed'
     )
 
     // Create a Map variable from scratch
@@ -152,7 +152,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown--button').click()
     cy.getByTestID('variable-type-dropdown-map').click()
 
-    const mapVariableName = 'Map Variable'
+    const mapVariableName = 'MapVariable'
     cy.getByInputName('name').type(mapVariableName)
 
     cy.get('textarea').type(`Astrophel Chaudhary,"bDhZbuVj5RV94NcFXZPm"
@@ -178,7 +178,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown--button').click()
     cy.getByTestID('variable-type-dropdown-map').click()
 
-    const queryVariableName = 'Query Variable'
+    const queryVariableName = 'QueryVariable'
     cy.getByInputName('name').type(queryVariableName)
 
     cy.getByTestID('variable-type-dropdown--button').click()
@@ -250,6 +250,8 @@ describe('Variables', () => {
     const labelName = 'label'
     cy.getByTestID('inline-labels--popover--contents').type(labelName)
     cy.getByTestID('inline-labels--create-new').click()
+    // Wait for animation to complete
+    cy.wait(500)
     cy.getByTestID('create-label-form--submit').click()
 
     cy.getByTestID('overlay--children').should('not.exist')
@@ -264,8 +266,8 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown-constant').click()
 
     // Create a CSV variable
-    const variableName = 'a Second Variable'
-    const defaultVar = 'Little Variable'
+    const variableName = 'aSecondVariable'
+    const defaultVar = 'LittleVariable'
     cy.getByInputName('name').type(variableName)
 
     cy.get('textarea').type('1,2,3,4,5,6')

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -176,7 +176,7 @@ export const createTask = (
 
 export const createQueryVariable = (
   orgID?: string,
-  name: string = 'Little Variable',
+  name: string = 'LittleVariable',
   query?: string
 ): Cypress.Chainable<Cypress.Response> => {
   const argumentsObj = {

--- a/ui/fetch_ui_assets.sh
+++ b/ui/fetch_ui_assets.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This script is used to download built UI assets from the "influxdata/ui"
+# repository. The built UI assets are attached to a release in "influxdata/ui",
+# which is linked here.
+# 
+# The master branch of "influxdata/influxdb" (this repository) downloads from the
+# release tagged as "OSS-Master" in "influxdata/ui". That release is kept up-to-date
+# with the most recent changes in "influxdata/ui". 
+# 
+# Feature branches of "influxdata/influxdb" (2.0, 2.1, etc) download from their
+# respective releases in "influxdata/ui" (OSS-2.0, OSS-2.1, etc). Those releases
+# are updated only when a bug fix needs included for the UI of that OSS release.
+
+curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
+tar -xzf build.tar.gz
+rm build.tar.gz

--- a/ui/fetch_ui_assets.sh
+++ b/ui/fetch_ui_assets.sh
@@ -12,6 +12,6 @@
 # respective releases in "influxdata/ui" (OSS-2.0, OSS-2.1, etc). Those releases
 # are updated only when a bug fix needs included for the UI of that OSS release.
 
-curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-2.0/build.tar.gz --output build.tar.gz
 tar -xzf build.tar.gz
 rm build.tar.gz


### PR DESCRIPTION
Backports #21090

Everything is the same except for a couple of differences:
- The `.circleci/config.yml` file isn't the same between the `master` branch and the `2.0` branch for reasons outside this change. For this backport, I removed everything related to `jslint` and `jstest` from the `2.0` config, as well as bumping the e2e resource class to `large`. This is conceptually identical to the PR on master.
- The URL for the `fetch_ui_assets.sh` script is different since the OSS 2.0 branch will get its assets from a different release in the `ui` repository - one on the `ui` branch `OSS-2.0`.