### PR TITLE
chore: Prepare circle config for backports to 1.x release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,15 @@
-version: 2
+version: 2.1
+orbs:
+  aws-s3: circleci/aws-s3@2.0.0
+
+commands:
+  source-vars:
+    description: source the environment variables from the temp workspace
+    steps:
+      - run: |
+          set -x
+          cat /tmp/workspace/env_vars.sh >> $BASH_ENV
+          source $BASH_ENV
 
 workflows:
   version: 2
@@ -8,7 +19,127 @@ workflows:
       - fluxtest
 
 jobs:
-  build:
+  export_vars:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Export environment variables to bash environment
+          command: |
+            set -x
+            go_ver=$(grep -r '^go ' go.mod | cut -d ' ' -f2)
+            test -n "$go_ver"
+            working_dir=/home/circleci/project
+            touch env_vars.sh
+            echo "export WORKING_DIR=$working_dir" >> env_vars.sh
+            echo "export GO_VERSION=$go_ver" >> env_vars.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+            - env_vars.sh
+  build_binaries:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - source-vars
+      - checkout
+      - run:
+          name: Build source tarballs
+          command: |
+            set -x
+            mkdir -p ${WORKING_DIR}/tarball
+            "${WORKING_DIR}/releng/source-tarball/build.bash" \
+              -p "${WORKING_DIR}/.git" \
+              -s "${CIRCLE_SHA1}" \
+              -b "${CIRCLE_BRANCH}" \
+              -v "${CIRCLE_BRANCH}-${CIRCLE_SHA1}" \
+              -o "${WORKING_DIR}/tarball"
+      - store_artifacts:
+          path: tarball/
+      - run:
+          name: Build binaries
+          command: |
+            OUTDIR=${WORKING_DIR}/bins
+            mkdir -p ${OUTDIR}
+            GOOS=linux GOARCH=amd64 "${WORKING_DIR}/releng/raw-binaries/build.bash" \
+              -i "${WORKING_DIR}/tarball/influxdb-src-${CIRCLE_SHA1}.tar.gz" \
+              -o "$OUTDIR"
+      - store_artifacts:
+          path: bins/
+      - run:
+          name: Build packages
+          command: |
+            OUTDIR=${WORKING_DIR}/oss-packages
+            BINDIR=${WORKING_DIR}/bins
+            mkdir -p ${OUTDIR}
+            mkdir -p ${BINDIR}
+            "${WORKING_DIR}/releng/packages/build.bash" \
+              -s "${WORKING_DIR}/tarball/influxdb-src-${CIRCLE_SHA1}.tar.gz" \
+              -b "${BINDIR}/influxdb_bin_linux_amd64-${CIRCLE_SHA1}.tar.gz" \
+              -O linux -A amd64 \
+              -o "$OUTDIR"
+      - store_artifacts:
+          path: oss-packages/
+      - when:
+          condition:
+            and:
+              - equal: [ master-1.x, << pipeline.git.branch >> ]
+              - << pipeline.git.tag >>
+          steps:
+            - aws-s3/copy:
+                arguments: |
+                  --aws-region us-east-1
+                from: 'tarball'
+                to: 's3://dl.influxdata.com/influxdb/releases'
+            - aws-s3/copy:
+                arguments: |
+                  --aws-region us-east-1
+                from: 'bins'
+                to: 's3://dl.influxdata.com/influxdb/releases'
+            - aws-s3/copy:
+                arguments: |
+                  --aws-region us-east-1
+                from: 'oss-packages'
+                to: 's3://dl.influxdata.com/influxdb/releases'
+  changelog:
+    docker:
+      - image: jsternberg/changelog:latest
+    steps:
+      - checkout
+      - run:
+          name: changelog-magic
+          command: |
+            set -ex
+            if [ -n << pipeline.git.base_revision >> ]; then
+              sh "git changelog << pipeline.git.base_revision >>"
+            else
+              sh "git changelog"
+            fi
+
+            if ! git diff --quiet; then
+              git config remote.origin.pushurl git@github.com:influxdata/influxdb.git
+              git commit -am 'Update changelog'
+              git push origin HEAD:${CIRCLE_BRANCH}
+            fi
+  oss_release_candidate:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    #parallelism: 3 # How many CircleCI test containers
+    steps:
+      - checkout
+      - run:
+          name: Check OSS release candidacy
+          command: |
+            echo "TODO: Run checks to determine if this build is a release candidate"
+            ls ./
+          no_output_timeout: 1500s
+  test:
     machine:
       enabled: true
       docker_layer_caching: true
@@ -16,6 +147,9 @@ jobs:
       - PARALLELISM: 4 # Amount of parallelism within each test (not the number of tests)
     parallelism: 3 # How many CircleCI test containers
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - source-vars
       - checkout
       - run:
           name: Ensure CircleCI parallelism matches "./test.sh count"
@@ -34,3 +168,49 @@ jobs:
           name: Execute test
           command: ./test.sh flux
           no_output_timeout: 1500s
+
+workflows:
+  version: 2.1
+  on_push:
+    jobs:
+      - export_vars
+      - changelog:
+          filters:
+            branches:
+              only: /^1(.\d+)*$/
+      - test:
+          requires:
+            - export_vars
+      - fluxtest:
+          requires:
+            - export_vars
+  daily:
+    triggers:
+      - schedule:
+          # run weekdays at 4am -- note: use spaces, not tabs
+          cron: "0 4 * * 1-5"
+          filters:
+            branches:
+              only:
+                - "master-1.x"
+                - "1.8"
+                - "1.7"
+    jobs:
+      - export_vars
+      - changelog:
+          filters:
+            branches:
+              only: /^1(.\d+)*$/
+      - test:
+          requires:
+            - export_vars
+      - fluxtest:
+          requires:
+            - export_vars
+      - build_binaries:
+          requires:
+            - test
+      - oss_release_candidate:
+          requires:
+            - build_binaries
+>>>>>>> 896c7f5004... chore: Add workflow structure and pre-release actions to circle config

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -13,6 +13,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     python \
     python3-pip \
+    python3 \
+    python3-boto \
+    python3-software-properties \
     rpm \
     ruby \
     ruby-dev \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -1,0 +1,44 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3-software-properties \
+    software-properties-common \
+    wget \
+    git \
+    mercurial \
+    make \
+    ruby \
+    ruby-dev \
+    build-essential \
+    rpm \
+    zip \
+    python3 \
+    python3-boto
+
+RUN gem install fpm
+
+# Setup env
+ENV GOPATH /root/go
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/influxdb
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
+
+
+# Install go
+ENV GO_VERSION 1.13
+ENV GO_ARCH amd64
+RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+   tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+   rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+
+# Clone Go tip for compilation
+ENV GOROOT_BOOTSTRAP /usr/local/go
+RUN git clone https://go.googlesource.com/go
+ENV PATH /go/bin:$PATH
+
+# Add script for compiling go
+ENV GO_CHECKOUT master
+ADD ./gobuild.sh /gobuild.sh
+ENTRYPOINT [ "/gobuild.sh" ]


### PR DESCRIPTION
Improve circleCI config structure in prep for moving automation out of jenkins (influxdata/edge#44).

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable

