### PR TITLE
feat(telemetry): replace unique ids for resources with a slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The prefix used for Prometheus metrics from the query controller has changed fro
 1. [21119](https://github.com/influxdata/influxdb/pull/21119): Upgrade Flux to v0.111.0.
 1. [21126](https://github.com/influxdata/influxdb/pull/21126): Update UI to match InfluxDB Cloud.
 1. [21144](https://github.com/influxdata/influxdb/pull/21144): Allow for disabling concurrency-limits in Flux controller.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Replace unique resource IDs (UI assets, backup shards) with slugs to reduce cardinality of telemetry data.
+1. [21166](https://github.com/influxdata/influxdb/pull/21166): Replace unique resource IDs (UI assets, backup shards) with slugs to reduce cardinality of telemetry data.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The prefix used for Prometheus metrics from the query controller has changed fro
 1. [21119](https://github.com/influxdata/influxdb/pull/21119): Upgrade Flux to v0.111.0.
 1. [21126](https://github.com/influxdata/influxdb/pull/21126): Update UI to match InfluxDB Cloud.
 1. [21144](https://github.com/influxdata/influxdb/pull/21144): Allow for disabling concurrency-limits in Flux controller.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Replace unique resource IDs (UI assets, backup shards) with slugs to reduce cardinality of telemetry data.
 
 ### Bug Fixes
 

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -36,6 +36,36 @@ func Test_normalizePath(t *testing.T) {
 			path:     path.Join("/api/v2/organizations", influxdb.ID(2).String(), "users", influxdb.ID(3).String()),
 			expected: "/api/v2/organizations/:id/users/:id",
 		},
+		{
+			name:     "5",
+			path:     "/838442d56d.svg",
+			expected: "/" + fileSlug + ".svg",
+		},
+		{
+			name:     "6",
+			path:     "/838442d56d.svg/extra",
+			expected: "/838442d56d.svg/extra",
+		},
+		{
+			name:     "7",
+			path:     "/api/v2/restore/shards/1001",
+			expected: path.Join("/api/v2/restore/shards/", shardSlug),
+		},
+		{
+			name:     "8",
+			path:     "/api/v2/restore/shards/1001/extra",
+			expected: path.Join("/api/v2/restore/shards/", shardSlug, "extra"),
+		},
+		{
+			name:     "9",
+			path:     "/api/v2/backup/shards/1005",
+			expected: path.Join("/api/v2/backup/shards/", shardSlug),
+		},
+		{
+			name:     "10",
+			path:     "/api/v2/backup/shards/1005/extra",
+			expected: path.Join("/api/v2/backup/shards/", shardSlug, "extra"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #21163

Backports #21158

In `kit/transport/http/middleware.go` the properties and methods associated with ID's have been moved from `influxdb` to `platform` per #21101 on `master`. Since the `2.0` branch continues to use `influxdb` for ID's, this backport uses `influxdb.IDLength` and `influxdb.IDFromString(...)` instead of their respective `platform` equivalents on the `master` branch.