### PR TITLE
feat(flux): implement rewrite rules for window and bare aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ v1.9.0 [unreleased]
 -	[#21074](https://github.com/influxdata/influxdb/pull/21074): feat: upgrade to flux 0.111.0
 -	[#21100](https://github.com/influxdata/influxdb/pull/21100): feat: add memory and concurrency limits in flux controller
 -	[#21108](https://github.com/influxdata/influxdb/pull/21108): feat: make flux controller limits configurable
+-	[#21168](https://github.com/influxdata/influxdb/pull/21168): feat: implement rewrite rules for window and bare aggregates
 
 ### Bugfixes
 
@@ -42,6 +43,7 @@ v1.9.0 [unreleased]
 -	[#17685](https://github.com/influxdata/influxdb/pull/17685): fix(tsm1): Fix temp directory search bug
 -	[#17495](https://github.com/influxdata/influxdb/pull/17495): fix(snapshotter): properly read payload
 -	[#21139](https://github.com/influxdata/influxdb/pull/21139): fix(tsdb): exclude stop time from array cursors
+-	[#21168](https://github.com/influxdata/influxdb/pull/21168): fix(storage): Detect need for descending cursor in WindowAggregate
 
 v1.8.5 [unreleased]
 -------------------

--- a/flux/stdlib/influxdata/influxdb/rules_test.go
+++ b/flux/stdlib/influxdata/influxdb/rules_test.go
@@ -2,6 +2,7 @@ package influxdb_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -13,8 +14,8 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/semantic"
-	fluxinfluxdb "github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 )
@@ -48,6 +49,7 @@ func TestPushDownRangeRule(t *testing.T) {
 			Name: "simple",
 			// from -> range  =>  ReadRange
 			Rules: []plan.Rule{
+				influxdb.FromStorageRule{},
 				influxdb.PushDownRangeRule{},
 			},
 			Before: &plantest.PlanSpec{
@@ -67,6 +69,7 @@ func TestPushDownRangeRule(t *testing.T) {
 			Name: "with successor",
 			// from -> range -> count  =>  ReadRange -> count
 			Rules: []plan.Rule{
+				influxdb.FromStorageRule{},
 				influxdb.PushDownRangeRule{},
 			},
 			Before: &plantest.PlanSpec{
@@ -96,6 +99,7 @@ func TestPushDownRangeRule(t *testing.T) {
 			//        |                ReadRange
 			//       from
 			Rules: []plan.Rule{
+				influxdb.FromStorageRule{},
 				influxdb.PushDownRangeRule{},
 			},
 			Before: &plantest.PlanSpec{
@@ -141,78 +145,30 @@ func TestPushDownFilterRule(t *testing.T) {
 			Stop:  fluxTime(10),
 		}
 
-		pushableExpr1 = &semantic.BinaryExpression{
-			Operator: ast.EqualOperator,
-			Left: &semantic.MemberExpression{
-				Object:   &semantic.IdentifierExpression{Name: "r"},
-				Property: "_measurement",
-			},
-			Right: &semantic.StringLiteral{Value: "cpu"}}
-
-		pushableExpr2 = &semantic.BinaryExpression{
-			Operator: ast.EqualOperator,
-			Left: &semantic.MemberExpression{
-				Object:   &semantic.IdentifierExpression{Name: "r"},
-				Property: "_field",
-			},
-			Right: &semantic.StringLiteral{Value: "cpu"}}
-
-		unpushableExpr = &semantic.BinaryExpression{
-			Operator: ast.LessThanOperator,
-			Left:     &semantic.FloatLiteral{Value: 0.5},
-			Right: &semantic.MemberExpression{
-				Object:   &semantic.IdentifierExpression{Name: "r"},
-				Property: "_value"},
-		}
-
-		statementFn = interpreter.ResolvedFunction{
-			Scope: nil,
-			Fn: &semantic.FunctionExpression{
-				Parameters: &semantic.FunctionParameters{
-					List: []*semantic.FunctionParameter{
-						{Key: &semantic.Identifier{Name: "r"}},
-					},
-				},
-				Block: &semantic.Block{
-					Body: []semantic.Statement{
-						&semantic.ReturnStatement{
-							Argument: &semantic.BooleanLiteral{Value: true},
-						},
-					},
-				},
-			},
-		}
+		pushableFn1             = executetest.FunctionExpression(t, `(r) => r._measurement == "cpu"`)
+		pushableFn2             = executetest.FunctionExpression(t, `(r) => r._field == "cpu"`)
+		pushableFn1and2         = executetest.FunctionExpression(t, `(r) => r._measurement == "cpu" and r._field == "cpu"`)
+		unpushableFn            = executetest.FunctionExpression(t, `(r) => 0.5 < r._value`)
+		pushableAndUnpushableFn = executetest.FunctionExpression(t, `(r) => r._measurement == "cpu" and 0.5 < r._value`)
 	)
 
-	makeFilterFn := func(exprs ...semantic.Expression) *semantic.FunctionExpression {
-		body := semantic.ExprsToConjunction(exprs...)
-		return &semantic.FunctionExpression{
-			Parameters: &semantic.FunctionParameters{
-				List: []*semantic.FunctionParameter{
-					{Key: &semantic.Identifier{Name: "r"}},
-				},
-			},
-			Block: &semantic.Block{
-				Body: []semantic.Statement{
-					&semantic.ReturnStatement{
-						Argument: body,
-					},
-				},
-			},
-		}
-	}
-	makeResolvedFilterFn := func(exprs ...semantic.Expression) interpreter.ResolvedFunction {
+	makeResolvedFilterFn := func(expr *semantic.FunctionExpression) interpreter.ResolvedFunction {
 		return interpreter.ResolvedFunction{
-			Scope: nil,
-			Fn:    makeFilterFn(exprs...),
+			Fn: expr,
 		}
 	}
-	mustStoragePredicate := func(expression semantic.Expression, objectName string) *datatypes.Predicate {
-		pred, err := influxdb.ToStoragePredicate(expression, objectName)
-		if err != nil {
-			t.Fatalf("Error while converting to storage predicate: %v", err)
+
+	toStoragePredicate := func(fn *semantic.FunctionExpression) *datatypes.Predicate {
+		body, ok := fn.GetFunctionBodyExpression()
+		if !ok {
+			panic("more than one statement in function body")
 		}
-		return pred
+
+		predicate, err := influxdb.ToStoragePredicate(body, "r")
+		if err != nil {
+			panic(err)
+		}
+		return predicate
 	}
 
 	tests := []plantest.RuleTestCase{
@@ -226,7 +182,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(pushableExpr1),
+						Fn: makeResolvedFilterFn(pushableFn1),
 					}),
 				},
 				Edges: [][2]int{
@@ -237,7 +193,7 @@ func TestPushDownFilterRule(t *testing.T) {
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
 						Bounds:    bounds,
-						Predicate: mustStoragePredicate(pushableExpr1, "r"),
+						Predicate: toStoragePredicate(pushableFn1),
 					}),
 				},
 			},
@@ -252,10 +208,10 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter1", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(pushableExpr1),
+						Fn: makeResolvedFilterFn(pushableFn1),
 					}),
 					plan.CreatePhysicalNode("filter2", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(pushableExpr2),
+						Fn: makeResolvedFilterFn(pushableFn2),
 					}),
 				},
 				Edges: [][2]int{
@@ -266,12 +222,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter1_filter2", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.LogicalExpression{
-							Operator: ast.AndOperator,
-							Left:     pushableExpr1,
-							Right:    pushableExpr2,
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(pushableFn1and2),
 					}),
 				},
 			},
@@ -286,7 +238,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(pushableExpr1, unpushableExpr),
+						Fn: makeResolvedFilterFn(pushableAndUnpushableFn),
 					}),
 				},
 				Edges: [][2]int{
@@ -297,10 +249,10 @@ func TestPushDownFilterRule(t *testing.T) {
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
 						Bounds:    bounds,
-						Predicate: mustStoragePredicate(pushableExpr1, "r"),
+						Predicate: toStoragePredicate(pushableFn1),
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(unpushableExpr),
+						Fn: makeResolvedFilterFn(unpushableFn),
 					}),
 				},
 				Edges: [][2]int{
@@ -312,6 +264,7 @@ func TestPushDownFilterRule(t *testing.T) {
 			Name: "from range filter",
 			// from -> range -> filter  =>  ReadRange
 			Rules: []plan.Rule{
+				influxdb.FromStorageRule{},
 				influxdb.PushDownRangeRule{},
 				influxdb.PushDownFilterRule{},
 			},
@@ -322,7 +275,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(pushableExpr1)},
+						Fn: makeResolvedFilterFn(pushableFn1)},
 					),
 				},
 				Edges: [][2]int{
@@ -334,7 +287,7 @@ func TestPushDownFilterRule(t *testing.T) {
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
 						Bounds:    bounds,
-						Predicate: mustStoragePredicate(pushableExpr1, "r"),
+						Predicate: toStoragePredicate(pushableFn1),
 					}),
 				},
 			},
@@ -349,26 +302,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(unpushableExpr),
-					}),
-				},
-				Edges: [][2]int{
-					{0, 1},
-				},
-			},
-			NoChange: true,
-		},
-		{
-			Name: "statement filter",
-			// ReadRange -> filter(with statement function)  =>  ReadRange -> filter(with statement function)  (no change)
-			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
-			Before: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-					}),
-					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: statementFn,
+						Fn: makeResolvedFilterFn(unpushableFn),
 					}),
 				},
 				Edges: [][2]int{
@@ -386,13 +320,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.UnaryExpression{
-							Operator: ast.ExistsOperator,
-							Argument: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => exists r.host`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -402,17 +330,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.BinaryExpression{
-							Operator: ast.NotEqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-							Right: &semantic.StringLiteral{
-								Value: "",
-							},
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(executetest.FunctionExpression(t, `(r) => r.host != ""`)),
 					}),
 				},
 			},
@@ -426,16 +345,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.UnaryExpression{
-							Operator: ast.NotOperator,
-							Argument: &semantic.UnaryExpression{
-								Operator: ast.ExistsOperator,
-								Argument: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-							},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => not exists r.host`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -445,17 +355,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.BinaryExpression{
-							Operator: ast.EqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-							Right: &semantic.StringLiteral{
-								Value: "",
-							},
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(executetest.FunctionExpression(t, `(r) => r.host == ""`)),
 					}),
 				},
 			},
@@ -469,14 +370,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.BinaryExpression{
-							Operator: ast.EqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-							Right: &semantic.StringLiteral{Value: ""},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => r.host == ""`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -494,14 +388,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.BinaryExpression{
-							Operator: ast.NotEqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-							Right: &semantic.StringLiteral{Value: ""},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => r.host != ""`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -511,17 +398,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.BinaryExpression{
-							Operator: ast.NotEqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "host",
-							},
-							Right: &semantic.StringLiteral{
-								Value: "",
-							},
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(executetest.FunctionExpression(t, `(r) => r.host != ""`)),
 					}),
 				},
 			},
@@ -535,14 +413,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.BinaryExpression{
-							Operator: ast.EqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "_value",
-							},
-							Right: &semantic.StringLiteral{Value: ""},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => r._value == ""`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -552,15 +423,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.BinaryExpression{
-							Operator: ast.EqualOperator,
-							Left: &semantic.MemberExpression{
-								Object:   &semantic.IdentifierExpression{Name: "r"},
-								Property: "_value",
-							},
-							Right: &semantic.StringLiteral{Value: ""},
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(executetest.FunctionExpression(t, `(r) => r._value == ""`)),
 					}),
 				},
 			},
@@ -575,17 +439,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.UnaryExpression{
-							Operator: ast.NotOperator,
-							Argument: &semantic.BinaryExpression{
-								Operator: ast.EqualOperator,
-								Left: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-								Right: &semantic.StringLiteral{Value: "server01"},
-							},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => not r.host == "server01"`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -603,26 +457,7 @@ func TestPushDownFilterRule(t *testing.T) {
 						Bounds: bounds,
 					}),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: makeResolvedFilterFn(&semantic.LogicalExpression{
-							Operator: ast.AndOperator,
-							Left: &semantic.BinaryExpression{
-								Operator: ast.EqualOperator,
-								Left: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-								Right: &semantic.StringLiteral{
-									Value: "cpu",
-								},
-							},
-							Right: &semantic.UnaryExpression{
-								Operator: ast.ExistsOperator,
-								Argument: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-							},
-						}),
+						Fn: makeResolvedFilterFn(executetest.FunctionExpression(t, `(r) => r.host == "cpu" and exists r.host`)),
 					}),
 				},
 				Edges: [][2]int{
@@ -632,30 +467,8 @@ func TestPushDownFilterRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
-						Bounds: bounds,
-						Predicate: mustStoragePredicate(&semantic.LogicalExpression{
-							Operator: ast.AndOperator,
-							Left: &semantic.BinaryExpression{
-								Operator: ast.EqualOperator,
-								Left: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-								Right: &semantic.StringLiteral{
-									Value: "cpu",
-								},
-							},
-							Right: &semantic.BinaryExpression{
-								Operator: ast.NotEqualOperator,
-								Left: &semantic.MemberExpression{
-									Object:   &semantic.IdentifierExpression{Name: "r"},
-									Property: "host",
-								},
-								Right: &semantic.StringLiteral{
-									Value: "",
-								},
-							},
-						}, "r"),
+						Bounds:    bounds,
+						Predicate: toStoragePredicate(executetest.FunctionExpression(t, `(r) => r.host == "cpu" and r.host != ""`)),
 					}),
 				},
 			},
@@ -665,7 +478,6 @@ func TestPushDownFilterRule(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 			plantest.PhysicalRuleTestHelper(t, &tc)
 		})
 	}
@@ -933,15 +745,8 @@ func TestReadTagKeysRule(t *testing.T) {
 			},
 		}
 		if filter {
-			body, ok := filterSpec.Fn.Fn.GetFunctionBodyExpression()
-			if !ok {
-				t.Fatal("could not get function bodyexpression for filter")
-			}
-			pred, err := influxdb.ToStoragePredicate(body, "r")
-			if err != nil {
-				t.Fatalf("Error while creating storage predicate: %v", err)
-			}
-			s.Predicate = pred
+			bodyExpr, _ := filterSpec.Fn.Fn.GetFunctionBodyExpression()
+			s.Predicate, _ = influxdb.ToStoragePredicate(bodyExpr, "r")
 		}
 		return &s
 	}
@@ -1161,15 +966,8 @@ func TestReadTagValuesRule(t *testing.T) {
 			TagKey: "host",
 		}
 		if filter {
-			body, ok := filterSpec.Fn.Fn.GetFunctionBodyExpression()
-			if !ok {
-				t.Fatal("could not get function bodyexpression for filter")
-			}
-			pred, err := influxdb.ToStoragePredicate(body, "r")
-			if err != nil {
-				t.Fatalf("Error while creating storage predicate: %v", err)
-			}
-			s.Predicate = pred
+			bodyExpr, _ := filterSpec.Fn.Fn.GetFunctionBodyExpression()
+			s.Predicate, _ = influxdb.ToStoragePredicate(bodyExpr, "r")
 		}
 		return &s
 	}
@@ -1319,76 +1117,933 @@ func TestReadTagValuesRule(t *testing.T) {
 	}
 }
 
-func TestMergeFilterRule(t *testing.T) {
-	from := &fluxinfluxdb.FromProcedureSpec{}
-	filter0 := func() *universe.FilterProcedureSpec {
-		return &universe.FilterProcedureSpec{
-			Fn: interpreter.ResolvedFunction{
-				Fn: executetest.FunctionExpression(t, `(r) => r._field == "usage_idle"`),
+func minProcedureSpec() *universe.MinProcedureSpec {
+	return &universe.MinProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: execute.DefaultValueColLabel},
+	}
+}
+func maxProcedureSpec() *universe.MaxProcedureSpec {
+	return &universe.MaxProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: execute.DefaultValueColLabel},
+	}
+}
+func countProcedureSpec() *universe.CountProcedureSpec {
+	return &universe.CountProcedureSpec{
+		AggregateConfig: execute.AggregateConfig{Columns: []string{execute.DefaultValueColLabel}},
+	}
+}
+func sumProcedureSpec() *universe.SumProcedureSpec {
+	return &universe.SumProcedureSpec{
+		AggregateConfig: execute.AggregateConfig{Columns: []string{execute.DefaultValueColLabel}},
+	}
+}
+func firstProcedureSpec() *universe.FirstProcedureSpec {
+	return &universe.FirstProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: execute.DefaultValueColLabel},
+	}
+}
+func lastProcedureSpec() *universe.LastProcedureSpec {
+	return &universe.LastProcedureSpec{
+		SelectorConfig: execute.SelectorConfig{Column: execute.DefaultValueColLabel},
+	}
+}
+func meanProcedureSpec() *universe.MeanProcedureSpec {
+	return &universe.MeanProcedureSpec{
+		AggregateConfig: execute.AggregateConfig{Columns: []string{execute.DefaultValueColLabel}},
+	}
+}
+
+//
+// Window Aggregate Testing
+//
+func TestPushDownWindowAggregateRule(t *testing.T) {
+	readRange := influxdb.ReadRangePhysSpec{
+		Bucket: "my-bucket",
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+
+	dur1m := values.ConvertDurationNsecs(60 * time.Second)
+	dur2m := values.ConvertDurationNsecs(120 * time.Second)
+	dur0 := values.ConvertDurationNsecs(0)
+	durNeg, _ := values.ParseDuration("-60s")
+	dur1mo, _ := values.ParseDuration("1mo")
+	dur1y, _ := values.ParseDuration("1y")
+	durInf := values.ConvertDurationNsecs(math.MaxInt64)
+	durMixed, _ := values.ParseDuration("1mo5m")
+
+	window := func(dur values.Duration) universe.WindowProcedureSpec {
+		return universe.WindowProcedureSpec{
+			Window: plan.WindowSpec{
+				Every:  dur,
+				Period: dur,
+				Offset: dur0,
+			},
+			TimeColumn:  "_time",
+			StartColumn: "_start",
+			StopColumn:  "_stop",
+			CreateEmpty: false,
+		}
+	}
+
+	window1m := window(dur1m)
+	window2m := window(dur2m)
+	windowNeg := window(durNeg)
+	window1y := window(dur1y)
+	window1mo := window(dur1mo)
+	windowInf := window(durInf)
+	windowInfCreateEmpty := windowInf
+	windowInfCreateEmpty.CreateEmpty = true
+
+	tests := make([]plantest.RuleTestCase, 0)
+
+	// construct a simple plan with a specific window and aggregate function
+	simplePlanWithWindowAgg := func(window universe.WindowProcedureSpec, agg plan.NodeID, spec plan.ProcedureSpec) *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window),
+				plan.CreateLogicalNode(agg, spec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
 			},
 		}
 	}
-	filter1 := func() *universe.FilterProcedureSpec {
-		return &universe.FilterProcedureSpec{
-			Fn: interpreter.ResolvedFunction{
-				Fn: executetest.FunctionExpression(t, `(r) => r._measurement == "cpu"`),
+
+	// construct a simple result
+	simpleResult := func(proc plan.ProcedureKind, createEmpty bool, successors ...plan.Node) *plantest.PlanSpec {
+		spec := &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{proc},
+					WindowEvery:       flux.ConvertDuration(60000000000 * time.Nanosecond),
+					CreateEmpty:       createEmpty,
+				}),
+			},
+		}
+		for i, successor := range successors {
+			spec.Nodes = append(spec.Nodes, successor)
+			spec.Edges = append(spec.Edges, [2]int{i, i + 1})
+		}
+		return spec
+	}
+
+	// ReadRange -> window -> min => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassMin",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.MinKind, minProcedureSpec()),
+		After:   simpleResult(universe.MinKind, false),
+	})
+
+	// ReadRange -> window -> max => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassMax",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.MaxKind, maxProcedureSpec()),
+		After:   simpleResult(universe.MaxKind, false),
+	})
+
+	// ReadRange -> window -> mean => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassMean",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.MeanKind, meanProcedureSpec()),
+		After:   simpleResult(universe.MeanKind, false),
+	})
+
+	// ReadRange -> window -> count => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassCount",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.CountKind, countProcedureSpec()),
+		After:   simpleResult(universe.CountKind, false),
+	})
+
+	// ReadRange -> window -> sum => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassSum",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.SumKind, sumProcedureSpec()),
+		After:   simpleResult(universe.SumKind, false),
+	})
+
+	// ReadRange -> window -> first => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassFirst",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.FirstKind, firstProcedureSpec()),
+		After:   simpleResult(universe.FirstKind, false),
+	})
+
+	// ReadRange -> window -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "SimplePassLast",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1m, universe.LastKind, lastProcedureSpec()),
+		After:   simpleResult(universe.LastKind, false),
+	})
+
+	// Rewrite with successors
+	// ReadRange -> window -> min -> count {2} => ReadWindowAggregate -> count {2}
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WithSuccessor",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{2, 4},
+			},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{"min"},
+					WindowEvery:       flux.ConvertDuration(60000000000 * time.Nanosecond),
+				}),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{0, 2},
+			},
+		},
+	})
+
+	// ReadRange -> window(offset: ...) -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WindowPositiveOffset",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(universe.WindowProcedureSpec{
+			Window: plan.WindowSpec{
+				Every:  dur2m,
+				Period: dur2m,
+				Offset: dur1m,
+			},
+			TimeColumn:  "_time",
+			StartColumn: "_start",
+			StopColumn:  "_stop",
+		}, universe.LastKind, lastProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{universe.LastKind},
+					WindowEvery:       flux.ConvertDuration(120000000000 * time.Nanosecond),
+					Offset:            flux.ConvertDuration(60000000000 * time.Nanosecond),
+				}),
+			},
+		},
+	})
+
+	// ReadRange -> window(every: 1mo) -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WindowByMonth",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1mo, universe.LastKind, lastProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{universe.LastKind},
+					WindowEvery:       dur1mo,
+				}),
+			},
+		},
+	})
+
+	// ReadRange -> window(every: 1y) -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WindowByYear",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(window1y, universe.LastKind, lastProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{universe.LastKind},
+					WindowEvery:       dur1y,
+				}),
+			},
+		},
+	})
+
+	// ReadRange -> window(every: 1y, offset: 1mo) -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WindowMonthlyOffset",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(func() universe.WindowProcedureSpec {
+			spec := window1y
+			spec.Window.Offset = dur1mo
+			return spec
+		}(), universe.LastKind, lastProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{universe.LastKind},
+					WindowEvery:       dur1y,
+					Offset:            dur1mo,
+				}),
+			},
+		},
+	})
+
+	// ReadRange -> window(every: 1y, offset: 1mo5m) -> last => ReadWindowAggregate
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "WindowMixedOffset",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(func() universe.WindowProcedureSpec {
+			spec := window1y
+			spec.Window.Offset = durMixed
+			return spec
+		}(), universe.LastKind, lastProcedureSpec()),
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregate", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{universe.LastKind},
+					WindowEvery:       dur1y,
+					Offset:            durMixed,
+				}),
+			},
+		},
+	})
+
+	// Helper that adds a test with a simple plan that does not pass due to a
+	// specified bad window
+	simpleMinUnchanged := func(name string, window universe.WindowProcedureSpec) {
+		// Note: NoChange is not working correctly for these tests. It is
+		// expecting empty time, start, and stop column fields.
+		tests = append(tests, plantest.RuleTestCase{
+			Name:     name,
+			Context:  context.Background(),
+			Rules:    []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+			Before:   simplePlanWithWindowAgg(window, "min", countProcedureSpec()),
+			NoChange: true,
+		})
+	}
+
+	// Condition not met: period not equal to every
+	badWindow1 := window1m
+	badWindow1.Window.Period = dur2m
+	simpleMinUnchanged("BadPeriod", badWindow1)
+
+	// Condition not met: negative offset
+	badWindow2 := window1m
+	badWindow2.Window.Offset = durNeg
+	simpleMinUnchanged("NegOffset", badWindow2)
+
+	// Condition not met: non-standard _time column
+	badWindow3 := window1m
+	badWindow3.TimeColumn = "_timmy"
+	simpleMinUnchanged("BadTime", badWindow3)
+
+	// Condition not met: non-standard start column
+	badWindow4 := window1m
+	badWindow4.StartColumn = "_stooort"
+	simpleMinUnchanged("BadStart", badWindow4)
+
+	// Condition not met: non-standard stop column
+	badWindow5 := window1m
+	badWindow5.StopColumn = "_stappp"
+	simpleMinUnchanged("BadStop", badWindow5)
+
+	// Condition met: createEmpty is true.
+	windowCreateEmpty1m := window1m
+	windowCreateEmpty1m.CreateEmpty = true
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "CreateEmptyPassMin",
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:  simplePlanWithWindowAgg(windowCreateEmpty1m, "min", minProcedureSpec()),
+		After:   simpleResult("min", true),
+	})
+
+	// Condition not met: neg duration.
+	simpleMinUnchanged("WindowNeg", windowNeg)
+
+	// Bad min column
+	// ReadRange -> window -> min => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMinCol",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(window1m, "min", &universe.MinProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column: "_valmoo"},
+		}),
+		NoChange: true,
+	})
+
+	// Bad max column
+	// ReadRange -> window -> max => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMaxCol",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(window1m, "max", &universe.MaxProcedureSpec{
+			SelectorConfig: execute.SelectorConfig{Column: "_valmoo"},
+		}),
+		NoChange: true,
+	})
+
+	// Bad mean columns
+	// ReadRange -> window -> mean => NO-CHANGE
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMeanCol1",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(window1m, "mean", &universe.MeanProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_valmoo"}},
+		}),
+		NoChange: true,
+	})
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "BadMeanCol2",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: simplePlanWithWindowAgg(window1m, "mean", &universe.MeanProcedureSpec{
+			AggregateConfig: execute.AggregateConfig{Columns: []string{"_value", "_valmoo"}},
+		}),
+		NoChange: true,
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> window -> min
+	//                    \-> min
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "CollapsedWithSuccessor1",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{1, 3},
+			},
+		},
+		NoChange: true,
+	})
+
+	// No match due to a collapsed node having a successor
+	// ReadRange -> window -> min
+	//          \-> window
+	tests = append(tests, plantest.RuleTestCase{
+		Name:    "CollapsedWithSuccessor2",
+		Context: context.Background(),
+		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+				plan.CreateLogicalNode("window", &window2m),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{0, 3},
+			},
+		},
+		NoChange: true,
+	})
+
+	// No pattern match
+	// ReadRange -> filter -> window -> min -> NO-CHANGE
+	pushableFn1 := executetest.FunctionExpression(t, `(r) => true`)
+
+	makeResolvedFilterFn := func(expr *semantic.FunctionExpression) interpreter.ResolvedFunction {
+		return interpreter.ResolvedFunction{
+			Scope: nil,
+			Fn:    expr,
+		}
+	}
+	noPatternMatch1 := func() *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+					Fn: makeResolvedFilterFn(pushableFn1),
+				}),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
 			},
 		}
 	}
-	filterMerge := func() *universe.FilterProcedureSpec {
-		return &universe.FilterProcedureSpec{
-			Fn: interpreter.ResolvedFunction{
-				Fn: executetest.FunctionExpression(t, `(r) => r._measurement == "cpu" and r._field == "usage_idle"`),
+	tests = append(tests, plantest.RuleTestCase{
+		Name:     "NoPatternMatch1",
+		Context:  context.Background(),
+		Rules:    []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:   noPatternMatch1(),
+		NoChange: true,
+	})
+
+	// No pattern match 2
+	// ReadRange -> window -> filter -> min -> NO-CHANGE
+	noPatternMatch2 := func() *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window", &window1m),
+				plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+					Fn: makeResolvedFilterFn(pushableFn1),
+				}),
+				plan.CreateLogicalNode("min", minProcedureSpec()),
 			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+			},
+		}
+	}
+	tests = append(tests, plantest.RuleTestCase{
+		Name:     "NoPatternMatch2",
+		Context:  context.Background(),
+		Rules:    []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
+		Before:   noPatternMatch2(),
+		NoChange: true,
+	})
+
+	duplicate := func(column, as string) *universe.SchemaMutationProcedureSpec {
+		return &universe.SchemaMutationProcedureSpec{
+			Mutations: []universe.SchemaMutation{
+				&universe.DuplicateOpSpec{
+					Column: column,
+					As:     as,
+				},
+			},
+		}
+	}
+
+	aggregateWindowPlan := func(window universe.WindowProcedureSpec, agg plan.NodeID, spec plan.ProcedureSpec, timeColumn string) *plantest.PlanSpec {
+		return &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window),
+				plan.CreateLogicalNode(agg, spec),
+				plan.CreateLogicalNode("duplicate", duplicate(timeColumn, "_time")),
+				plan.CreateLogicalNode("window2", &windowInf),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		}
+	}
+
+	aggregateWindowResult := func(proc plan.ProcedureKind, createEmpty bool, timeColumn string, successors ...plan.Node) *plantest.PlanSpec {
+		spec := &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("ReadWindowAggregateByTime", &influxdb.ReadWindowAggregatePhysSpec{
+					ReadRangePhysSpec: readRange,
+					Aggregates:        []plan.ProcedureKind{proc},
+					WindowEvery:       flux.ConvertDuration(60000000000 * time.Nanosecond),
+					CreateEmpty:       createEmpty,
+					TimeColumn:        timeColumn,
+				}),
+			},
+		}
+		for i, successor := range successors {
+			spec.Nodes = append(spec.Nodes, successor)
+			spec.Edges = append(spec.Edges, [2]int{i, i + 1})
+		}
+		return spec
+	}
+
+	// Push down the duplicate |> window(every: inf)
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCount",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: aggregateWindowPlan(window1m, "count", countProcedureSpec(), "_stop"),
+		After:  aggregateWindowResult("count", false, "_stop"),
+	})
+
+	// Push down the duplicate |> window(every: inf) using _start column
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCount",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: aggregateWindowPlan(window1m, "count", countProcedureSpec(), "_start"),
+		After:  aggregateWindowResult("count", false, "_start"),
+	})
+
+	// Push down duplicate |> window(every: inf) with create empty.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountCreateEmpty",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: aggregateWindowPlan(windowCreateEmpty1m, "count", countProcedureSpec(), "_stop"),
+		After:  aggregateWindowResult("count", true, "_stop"),
+	})
+
+	// Invalid duplicate column.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountInvalidDuplicateColumn",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: aggregateWindowPlan(window1m, "count", countProcedureSpec(), "_value"),
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("duplicate", duplicate("_value", "_time")),
+			plan.CreatePhysicalNode("window2", &windowInf),
+		),
+	})
+
+	// Invalid duplicate as.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountInvalidDuplicateAs",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("duplicate", duplicate("_stop", "time")),
+				plan.CreateLogicalNode("window2", &windowInf),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		},
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("duplicate", duplicate("_stop", "time")),
+			plan.CreatePhysicalNode("window2", &windowInf),
+		),
+	})
+
+	// Invalid closing window.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountInvalidClosingWindow",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("duplicate", duplicate("_stop", "_time")),
+				plan.CreateLogicalNode("window2", &window1m),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		},
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("duplicate", duplicate("_stop", "_time")),
+			plan.CreatePhysicalNode("window2", &window1m),
+		),
+	})
+
+	// Invalid closing window with multiple problems.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountInvalidClosingWindowMultiple",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("duplicate", duplicate("_stop", "_time")),
+				plan.CreateLogicalNode("window2", &badWindow3),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		},
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("duplicate", duplicate("_stop", "_time")),
+			plan.CreatePhysicalNode("window2", &badWindow3),
+		),
+	})
+
+	// Invalid closing window with multiple problems.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountInvalidClosingWindowCreateEmpty",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("duplicate", duplicate("_stop", "_time")),
+				plan.CreateLogicalNode("window2", &windowInfCreateEmpty),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		},
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("duplicate", duplicate("_stop", "_time")),
+			plan.CreatePhysicalNode("window2", &windowInfCreateEmpty),
+		),
+	})
+
+	// Multiple matching patterns.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountMultipleMatches",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("duplicate", duplicate("_stop", "_time")),
+				plan.CreateLogicalNode("window2", &windowInf),
+				plan.CreateLogicalNode("duplicate2", duplicate("_stop", "_time")),
+				plan.CreateLogicalNode("window3", &windowInf),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+				{4, 5},
+				{5, 6},
+			},
+		},
+		After: aggregateWindowResult("count", false, "_stop",
+			plan.CreatePhysicalNode("duplicate2", duplicate("_stop", "_time")),
+			plan.CreatePhysicalNode("window3", &windowInf),
+		),
+	})
+
+	rename := universe.SchemaMutationProcedureSpec{
+		Mutations: []universe.SchemaMutation{
+			&universe.RenameOpSpec{
+				Columns: map[string]string{"_time": "time"},
+			},
+		},
+	}
+
+	// Wrong schema mutator.
+	tests = append(tests, plantest.RuleTestCase{
+		Context: context.Background(),
+		Name:    "AggregateWindowCountWrongSchemaMutator",
+		Rules: []plan.Rule{
+			influxdb.PushDownWindowAggregateRule{},
+			influxdb.PushDownWindowAggregateByTimeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("ReadRange", &readRange),
+				plan.CreateLogicalNode("window1", &window1m),
+				plan.CreateLogicalNode("count", countProcedureSpec()),
+				plan.CreateLogicalNode("rename", &rename),
+				plan.CreateLogicalNode("window2", &windowInf),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+				{2, 3},
+				{3, 4},
+			},
+		},
+		After: simpleResult("count", false,
+			plan.CreatePhysicalNode("rename", &rename),
+			plan.CreatePhysicalNode("window2", &windowInf),
+		),
+	})
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestPushDownBareAggregateRule(t *testing.T) {
+	readRange := &influxdb.ReadRangePhysSpec{
+		Bucket: "my-bucket",
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+
+	readWindowAggregate := func(proc plan.ProcedureKind) *influxdb.ReadWindowAggregatePhysSpec {
+		return &influxdb.ReadWindowAggregatePhysSpec{
+			ReadRangePhysSpec: *(readRange.Copy().(*influxdb.ReadRangePhysSpec)),
+			WindowEvery:       flux.ConvertDuration(math.MaxInt64 * time.Nanosecond),
+			Aggregates:        []plan.ProcedureKind{proc},
 		}
 	}
 
 	testcases := []plantest.RuleTestCase{
 		{
+			// ReadRange -> count => ReadWindowAggregate
 			Context: context.Background(),
-			Name:    "merge filter on",
-			Rules:   []plan.Rule{universe.MergeFiltersRule{}},
+			Name:    "push down count",
+			Rules:   []plan.Rule{influxdb.PushDownBareAggregateRule{}},
 			Before: &plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreatePhysicalNode("from", from),
-					plan.CreatePhysicalNode("filter0", filter0()),
-					plan.CreatePhysicalNode("filter1", filter1()),
+					plan.CreatePhysicalNode("ReadRange", readRange),
+					plan.CreatePhysicalNode("count", countProcedureSpec()),
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 			},
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreatePhysicalNode("from", from),
-					plan.CreatePhysicalNode("filter0", filterMerge()),
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate(universe.CountKind)),
 				},
-				Edges: [][2]int{{0, 1}},
 			},
 		},
 		{
+			// ReadRange -> sum => ReadWindowAggregate
 			Context: context.Background(),
-			Name:    "merge filter off",
+			Name:    "push down sum",
+			Rules:   []plan.Rule{influxdb.PushDownBareAggregateRule{}},
 			Before: &plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreatePhysicalNode("from", from),
-					plan.CreatePhysicalNode("filter0", filter0()),
-					plan.CreatePhysicalNode("filter1", filter1()),
+					plan.CreatePhysicalNode("ReadRange", readRange),
+					plan.CreatePhysicalNode("sum", sumProcedureSpec()),
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 			},
-			NoChange: true,
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate(universe.SumKind)),
+				},
+			},
+		},
+		{
+			// ReadRange -> first => ReadWindowAggregate
+			Context: context.Background(),
+			Name:    "push down first",
+			Rules:   []plan.Rule{influxdb.PushDownBareAggregateRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", readRange),
+					plan.CreatePhysicalNode("first", firstProcedureSpec()),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate(universe.FirstKind)),
+				},
+			},
+		},
+		{
+			// ReadRange -> last => ReadWindowAggregate
+			Context: context.Background(),
+			Name:    "push down last",
+			Rules:   []plan.Rule{influxdb.PushDownBareAggregateRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", readRange),
+					plan.CreatePhysicalNode("last", lastProcedureSpec()),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadWindowAggregate", readWindowAggregate(universe.LastKind)),
+				},
+			},
 		},
 	}
+
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			plantest.LogicalRuleTestHelper(t, &tc)
+			plantest.PhysicalRuleTestHelper(t, &tc)
 		})
 	}
 }

--- a/flux/stdlib/influxdata/influxdb/source.go
+++ b/flux/stdlib/influxdata/influxdb/source.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	execute.RegisterSource(ReadRangePhysKind, createReadFilterSource)
 	execute.RegisterSource(ReadGroupPhysKind, createReadGroupSource)
+	execute.RegisterSource(ReadWindowAggregatePhysKind, createReadWindowAggregateSource)
 	execute.RegisterSource(ReadTagKeysPhysKind, createReadTagKeysSource)
 	execute.RegisterSource(ReadTagValuesPhysKind, createReadTagValuesSource)
 }
@@ -234,6 +235,79 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
 			GroupMode:       ToGroupMode(spec.GroupMode),
 			GroupKeys:       spec.GroupKeys,
 			AggregateMethod: spec.AggregateMethod,
+		},
+		a,
+	), nil
+}
+
+type readWindowAggregateSource struct {
+	Source
+	reader   Reader
+	readSpec ReadWindowAggregateSpec
+}
+
+func ReadWindowAggregateSource(id execute.DatasetID, r Reader, readSpec ReadWindowAggregateSpec, a execute.Administration) execute.Source {
+	src := new(readWindowAggregateSource)
+
+	src.id = id
+	src.alloc = a.Allocator()
+
+	src.reader = r
+	src.readSpec = readSpec
+
+	src.runner = src
+	return src
+}
+
+func (s *readWindowAggregateSource) run(ctx context.Context) error {
+	stop := s.readSpec.Bounds.Stop
+	tables, err := s.reader.ReadWindowAggregate(
+		ctx,
+		s.readSpec,
+		s.alloc,
+	)
+	if err != nil {
+		return err
+	}
+	return s.processTables(ctx, tables, stop)
+}
+
+func createReadWindowAggregateSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	spec := s.(*ReadWindowAggregatePhysSpec)
+
+	bounds := a.StreamContext().Bounds()
+	if bounds == nil {
+		return nil, &flux.Error{
+			Code: codes.Internal,
+			Msg:  "nil bounds passed to from",
+		}
+	}
+
+	deps := GetStorageDependencies(a.Context())
+
+	db, rp, err := spec.LookupDatabase(a.Context(), deps, a)
+	if err != nil {
+		return nil, err
+	}
+
+	return ReadWindowAggregateSource(
+		id,
+		deps.Reader,
+		ReadWindowAggregateSpec{
+			ReadFilterSpec: ReadFilterSpec{
+				Database:        db,
+				RetentionPolicy: rp,
+				Bounds:          *bounds,
+				Predicate:       spec.Predicate,
+			},
+			Window: execute.Window{
+				Every:  spec.WindowEvery,
+				Period: spec.WindowEvery,
+				Offset: spec.Offset,
+			},
+			Aggregates:  spec.Aggregates,
+			CreateEmpty: spec.CreateEmpty,
+			TimeColumn:  spec.TimeColumn,
 		},
 		a,
 	), nil

--- a/flux/stdlib/universe/bare_aggregate_test.flux
+++ b/flux/stdlib/universe/bare_aggregate_test.flux
@@ -1,0 +1,178 @@
+package universe_test
+
+import "testing"
+import "testing/expect"
+import "planner"
+import "csv"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+input = "
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,meter
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-11T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-23T07:00:00Z,64,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-05-22T07:00:00Z,759,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-06-24T07:00:00Z,1234,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-07-24T07:00:00Z,1503,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-08-22T07:00:00Z,1707,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-09-23T07:00:00Z,1874,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-10-23T07:00:00Z,2086,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-11-21T08:00:00Z,2187,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-12-24T08:00:00Z,1851,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-01-24T08:00:00Z,1391,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-02-24T08:00:00Z,1221,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-03-25T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-04-23T07:00:00Z,447,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-05-22T07:00:00Z,868,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-06-23T07:00:00Z,1321,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-07-23T07:00:00Z,1453,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-08-21T07:00:00Z,1332,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-09-23T07:00:00Z,1312,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-10-22T07:00:00Z,1261,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-11-20T08:00:00Z,933,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-12-23T08:00:00Z,233,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2021-01-26T08:00:00Z,-1099,bank,pge_bill,35632393IN
+"
+
+testcase bare_count {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,long
+#group,false,false,false
+#default,_result,,
+,result,table,_value
+,,0,23
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> count()
+        |> keep(columns: ["_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_sum {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,double
+#group,false,false,false
+#default,_result,,
+,result,table,_value
+,,0,23938.0
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> sum()
+        |> keep(columns: ["_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_mean {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,double
+#group,false,false,false
+#default,_result,,
+,result,table,_value
+,,0,1040.782608696
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> mean()
+        |> keep(columns: ["_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_min {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> min()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_max {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-11-21T08:00:00Z,2187,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> max()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_first {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-04-11T07:00:00Z,0,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> first()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase bare_last {
+    expect.planner(rules: ["PushDownBareAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> last()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+
+    testing.diff(want: want, got: result)
+}

--- a/flux/stdlib/universe/window_aggregate_by_time_test.flux
+++ b/flux/stdlib/universe/window_aggregate_by_time_test.flux
@@ -1,0 +1,196 @@
+package universe_test
+
+import "testing"
+import "testing/expect"
+import "planner"
+import "csv"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+input = "
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,meter
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-11T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-23T07:00:00Z,64,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-05-22T07:00:00Z,759,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-06-24T07:00:00Z,1234,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-07-24T07:00:00Z,1503,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-08-22T07:00:00Z,1707,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-09-23T07:00:00Z,1874,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-10-23T07:00:00Z,2086,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-11-21T08:00:00Z,2187,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-12-24T08:00:00Z,1851,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-01-24T08:00:00Z,1391,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-02-24T08:00:00Z,1221,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-03-25T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-04-23T07:00:00Z,447,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-05-22T07:00:00Z,868,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-06-23T07:00:00Z,1321,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-07-23T07:00:00Z,1453,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-08-21T07:00:00Z,1332,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-09-23T07:00:00Z,1312,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-10-22T07:00:00Z,1261,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-11-20T08:00:00Z,933,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-12-23T08:00:00Z,233,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2021-01-26T08:00:00Z,-1099,bank,pge_bill,35632393IN
+"
+
+testcase windowed_by_time_count {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,long
+#group,false,false,false,false
+#default,_result,,,
+,result,table,_time,_value
+,,0,2019-01-01T00:00:00Z,10
+,,0,2020-01-01T00:00:00Z,12
+,,0,2021-01-01T00:00:00Z,1
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: count, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_sum {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,false,false,false
+#default,_result,,,
+,result,table,_time,_value
+,,0,2019-01-01T00:00:00Z,13265.00
+,,0,2020-01-01T00:00:00Z,11772.00
+,,0,2021-01-01T00:00:00Z,-1099.00
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: sum, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_mean {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,false,false,false
+#default,_result,,,
+,result,table,_time,_value
+,,0,2019-01-01T00:00:00Z,1326.50
+,,0,2020-01-01T00:00:00Z,981.00
+,,0,2021-01-01T00:00:00Z,-1099.00
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: mean, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_min {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-01-01T00:00:00Z,0,bank,pge_bill
+,,0,2020-01-01T00:00:00Z,0,bank,pge_bill
+,,0,2021-01-01T00:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: min, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_max {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-01-01T00:00:00Z,2187,bank,pge_bill
+,,0,2020-01-01T00:00:00Z,1453,bank,pge_bill
+,,0,2021-01-01T00:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: max, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_first {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-01-01T00:00:00Z,0,bank,pge_bill
+,,0,2020-01-01T00:00:00Z,1391,bank,pge_bill
+,,0,2021-01-01T00:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: first, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_by_time_last {
+    expect.planner(rules: ["PushDownWindowAggregateByTimeRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-01-01T00:00:00Z,1851.000,bank,pge_bill
+,,0,2020-01-01T00:00:00Z,233.000,bank,pge_bill
+,,0,2021-01-01T00:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> aggregateWindow(every: 1y, fn: last, timeSrc: "_start", createEmpty: false)
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}

--- a/flux/stdlib/universe/window_aggregate_test.flux
+++ b/flux/stdlib/universe/window_aggregate_test.flux
@@ -1,0 +1,203 @@
+package universe_test
+
+import "testing"
+import "testing/expect"
+import "planner"
+import "csv"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+input = "
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,meter
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-11T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-04-23T07:00:00Z,64,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-05-22T07:00:00Z,759,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-06-24T07:00:00Z,1234,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-07-24T07:00:00Z,1503,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-08-22T07:00:00Z,1707,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-09-23T07:00:00Z,1874,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-10-23T07:00:00Z,2086,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-11-21T08:00:00Z,2187,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2019-12-24T08:00:00Z,1851,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-01-24T08:00:00Z,1391,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-02-24T08:00:00Z,1221,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-03-25T07:00:00Z,0,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-04-23T07:00:00Z,447,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-05-22T07:00:00Z,868,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-06-23T07:00:00Z,1321,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-07-23T07:00:00Z,1453,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-08-21T07:00:00Z,1332,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-09-23T07:00:00Z,1312,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-10-22T07:00:00Z,1261,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-11-20T08:00:00Z,933,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2020-12-23T08:00:00Z,233,bank,pge_bill,35632393IN
+,,0,2017-02-16T20:30:31.713576368Z,2021-02-16T20:30:31.713576368Z,2021-01-26T08:00:00Z,-1099,bank,pge_bill,35632393IN
+"
+
+testcase windowed_count {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,long
+#group,false,false,true,false
+#default,_result,,,
+,result,table,_start,_value
+,,0,2019-01-01T00:00:00Z,10
+,,1,2020-01-01T00:00:00Z,12
+,,2,2021-01-01T00:00:00Z,1
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> count()
+        |> keep(columns: ["_start", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_sum {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,false,true,false
+#default,_result,,,
+,result,table,_start,_value
+,,0,2019-01-01T00:00:00Z,13265.00
+,,1,2020-01-01T00:00:00Z,11772.00
+,,2,2021-01-01T00:00:00Z,-1099.00
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> sum()
+        |> keep(columns: ["_start", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_mean {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,false,true,false
+#default,_result,,,
+,result,table,_start,_value
+,,0,2019-01-01T00:00:00Z,1326.50
+,,1,2020-01-01T00:00:00Z,981.00
+,,2,2021-01-01T00:00:00Z,-1099.00
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> mean()
+        |> keep(columns: ["_start", "_value"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_min {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-04-11T07:00:00Z,0,bank,pge_bill
+,,0,2020-03-25T07:00:00Z,0,bank,pge_bill
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> min()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_max {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-11-21T08:00:00Z,2187,bank,pge_bill
+,,0,2020-07-23T07:00:00Z,1453,bank,pge_bill
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> max()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_first {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-04-11T07:00:00Z,0,bank,pge_bill
+,,0,2020-01-24T08:00:00Z,1391,bank,pge_bill
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> first()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}
+
+testcase windowed_last {
+    expect.planner(rules: ["PushDownWindowAggregateRule": 1])
+
+    want = csv.from(
+        csv: "
+#group,false,false,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string
+#default,_result,,,,,
+,result,table,_time,_value,_field,_measurement
+,,0,2019-12-24T08:00:00Z,1851.000,bank,pge_bill
+,,0,2020-12-23T08:00:00Z,233.000,bank,pge_bill
+,,0,2021-01-26T08:00:00Z,-1099,bank,pge_bill
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> window(every: 1y)
+        |> last()
+        |> keep(columns: ["_time", "_value", "_field", "_measurement"])
+        |> sort(columns: ["_time"])
+
+    testing.diff(want: want, got: result)
+}

--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -203,7 +203,11 @@ func (s *Store) WindowAggregate(ctx context.Context, req *datatypes.ReadWindowAg
 		return nil, err
 	}
 
-	shardIDs, err := s.findShardIDs(database, rp, false, start, end)
+	// Due to some optimizations around how flux's `last()` function is implemented with the
+	// storage engine, we need to detect if the read request requires a descending
+	// cursor or not.
+	descending := !reads.IsAscendingWindowAggregate(req)
+	shardIDs, err := s.findShardIDs(database, rp, descending, start, end)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/reads/aggregate_resultset.go
+++ b/storage/reads/aggregate_resultset.go
@@ -22,28 +22,36 @@ type windowAggregateResultSet struct {
 	err          error
 }
 
-func NewWindowAggregateResultSet(ctx context.Context, req *datatypes.ReadWindowAggregateRequest, cursor SeriesCursor) (ResultSet, error) {
-	if nAggs := len(req.Aggregate); nAggs != 1 {
-		return nil, errors.Errorf(errors.InternalError, "attempt to create a windowAggregateResultSet with %v aggregate functions", nAggs)
+// IsAscendingWindowAggregate checks two things: If the request passed in
+// is using the `last` aggregate type, and if it doesn't have a window. If both
+// conditions are met, it returns false, otherwise, it returns true.
+func IsAscendingWindowAggregate(req *datatypes.ReadWindowAggregateRequest) bool {
+	if len(req.Aggregate) != 1 {
+		return false
 	}
-
-	ascending := true
 
 	// The following is an optimization where in the case of a single window,
 	// the selector `last` is implemented as a descending array cursor followed
 	// by a limit array cursor that selects only the first point, i.e the point
 	// with the largest timestamp, from the descending array cursor.
-	//
 	if req.Aggregate[0].Type == datatypes.AggregateTypeLast {
 		if req.Window == nil {
 			if req.WindowEvery == 0 || req.WindowEvery == math.MaxInt64 {
-				ascending = false
+				return false
 			}
 		} else if (req.Window.Every.Nsecs == 0 && req.Window.Every.Months == 0) || req.Window.Every.Nsecs == math.MaxInt64 {
-			ascending = false
+			return false
 		}
 	}
+	return true
+}
 
+func NewWindowAggregateResultSet(ctx context.Context, req *datatypes.ReadWindowAggregateRequest, cursor SeriesCursor) (ResultSet, error) {
+	if nAggs := len(req.Aggregate); nAggs != 1 {
+		return nil, errors.Errorf(errors.InternalError, "attempt to create a windowAggregateResultSet with %v aggregate functions", nAggs)
+	}
+
+	ascending := IsAscendingWindowAggregate(req)
 	results := &windowAggregateResultSet{
 		ctx:          ctx,
 		req:          req,


### PR DESCRIPTION
Backports #21124

This includes:
* The fix for last() within the `WindowAggregate` cursor code
* Rewrite rules for bare & window aggregates
* e2e test cases showing everything works