### PR TITLE
feat(ui): enabling feature flags for various UI features

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -171,7 +171,7 @@
 - name: Type Ahead Dropdowns for Variables
   description: Enables type ahead dropdowns for variables
   key: typeAheadVariableDropdown
-  default: true
+  default: false
   contact: Monitoring Team
   expose: true
   lifetime: temporary

--- a/flags.yml
+++ b/flags.yml
@@ -80,7 +80,7 @@
 - name: Band Plot Type
   description: Enables the creation of a band plot in Dashboards
   key: bandPlotType
-  default: false
+  default: true
   contact: Monitoring Team
   expose: true
   lifetime: temporary
@@ -88,7 +88,7 @@
 - name: Mosaic Graph Type
   description: Enables the creation of a mosaic graph in Dashboards
   key: mosaicGraphType
-  default: false
+  default: true
   contact: Monitoring Team
   expose: true
   lifetime: temporary
@@ -119,3 +119,59 @@
   contact: Compute Team
   default: false
   expose: true
+
+- name: Axis Tick Generator
+  description: Allows for controlling how many axis ticks there are on a graph
+  key: axisTicksGenerator
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: UI CSV Uploader
+  description: Adds the ability to upload data from a CSV file to a bucket
+  key: csvUploader
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: Editable Telegraf Configurations
+  description: Edit telegraf configurations from the UI
+  key: editTelegrafs
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: Legend Orientation in the UI
+  description: Change the appearance of the legend
+  key: legendOrientation
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: Default Monaco Selection to EOF
+  description: Positions the cursor at the end of the line(s) when using the monaco editor
+  key: cursorAtEOF
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: Refresh Single Cell
+  description: Refresh a single cell on the dashboard rather than the entire dashboard
+  key: refreshSingleCell
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary
+
+- name: Type Ahead Dropdowns for Variables
+  description: Enables type ahead dropdowns for variables
+  key: typeAheadVariableDropdown
+  default: true
+  contact: Monitoring Team
+  expose: true
+  lifetime: temporary

--- a/flags.yml
+++ b/flags.yml
@@ -155,7 +155,7 @@
 - name: Default Monaco Selection to EOF
   description: Positions the cursor at the end of the line(s) when using the monaco editor
   key: cursorAtEOF
-  default: true
+  default: false
   contact: Monitoring Team
   expose: true
   lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -30,20 +30,6 @@ func BackendExample() BoolFlag {
 	return backendExample
 }
 
-var communityTemplates = MakeBoolFlag(
-	"Community Templates",
-	"communityTemplates",
-	"Bucky",
-	true,
-	Permanent,
-	true,
-)
-
-// CommunityTemplates - Replace current template uploading functionality with community driven templates
-func CommunityTemplates() BoolFlag {
-	return communityTemplates
-}
-
 var frontendExample = MakeIntFlag(
 	"Frontend Example",
 	"frontendExample",
@@ -132,7 +118,7 @@ var bandPlotType = MakeBoolFlag(
 	"Band Plot Type",
 	"bandPlotType",
 	"Monitoring Team",
-	false,
+	true,
 	Temporary,
 	true,
 )
@@ -146,7 +132,7 @@ var mosaicGraphType = MakeBoolFlag(
 	"Mosaic Graph Type",
 	"mosaicGraphType",
 	"Monitoring Team",
-	false,
+	true,
 	Temporary,
 	true,
 )
@@ -212,10 +198,107 @@ func TimeFilterFlags() BoolFlag {
 	return timeFilterFlags
 }
 
+var axisTicksGenerator = MakeBoolFlag(
+	"Axis Tick Generator",
+	"axisTicksGenerator",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// AxisTickGenerator - Allows for controlling how many axis ticks there are on a graph
+func AxisTickGenerator() BoolFlag {
+	return axisTicksGenerator
+}
+
+var csvUploader = MakeBoolFlag(
+	"UI CSV Uploader",
+	"csvUploader",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// UiCsvUploader - Adds the ability to upload data from a CSV file to a bucket
+func UiCsvUploader() BoolFlag {
+	return csvUploader
+}
+
+var editTelegrafs = MakeBoolFlag(
+	"Editable Telegraf Configurations",
+	"editTelegrafs",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// EditableTelegrafConfigurations - Edit telegraf configurations from the UI
+func EditableTelegrafConfigurations() BoolFlag {
+	return editTelegrafs
+}
+
+var legendOrientation = MakeBoolFlag(
+	"Legend Orientation in the UI",
+	"legendOrientation",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// LegendOrientationInTheUi - Change the appearance of the legend
+func LegendOrientationInTheUi() BoolFlag {
+	return legendOrientation
+}
+
+var cursorAtEOF = MakeBoolFlag(
+	"Default Monaco Selection to EOF",
+	"cursorAtEOF",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// DefaultMonacoSelectionToEof - Positions the cursor at the end of the line(s) when using the monaco editor
+func DefaultMonacoSelectionToEof() BoolFlag {
+	return cursorAtEOF
+}
+
+var refreshSingleCell = MakeBoolFlag(
+	"Refresh Single Cell",
+	"refreshSingleCell",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// RefreshSingleCell - Refresh a single cell on the dashboard rather than the entire dashboard
+func RefreshSingleCell() BoolFlag {
+	return refreshSingleCell
+}
+
+var typeAheadVariableDropdown = MakeBoolFlag(
+	"Type Ahead Dropdowns for Variables",
+	"typeAheadVariableDropdown",
+	"Monitoring Team",
+	true,
+	Temporary,
+	true,
+)
+
+// TypeAheadDropdownsForVariables - Enables type ahead dropdowns for variables
+func TypeAheadDropdownsForVariables() BoolFlag {
+	return typeAheadVariableDropdown
+}
+
 var all = []Flag{
 	appMetrics,
 	backendExample,
-	communityTemplates,
 	frontendExample,
 	groupWindowAggregateTranspose,
 	newLabels,
@@ -228,12 +311,18 @@ var all = []Flag{
 	injectLatestSuccessTime,
 	enforceOrgDashboardLimits,
 	timeFilterFlags,
+	axisTicksGenerator,
+	csvUploader,
+	editTelegrafs,
+	legendOrientation,
+	cursorAtEOF,
+	refreshSingleCell,
+	typeAheadVariableDropdown,
 }
 
 var byKey = map[string]Flag{
 	"appMetrics":                    appMetrics,
 	"backendExample":                backendExample,
-	"communityTemplates":            communityTemplates,
 	"frontendExample":               frontendExample,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
 	"newLabels":                     newLabels,
@@ -246,4 +335,11 @@ var byKey = map[string]Flag{
 	"injectLatestSuccessTime":       injectLatestSuccessTime,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
 	"timeFilterFlags":               timeFilterFlags,
+	"axisTicksGenerator":            axisTicksGenerator,
+	"csvUploader":                   csvUploader,
+	"editTelegrafs":                 editTelegrafs,
+	"legendOrientation":             legendOrientation,
+	"cursorAtEOF":                   cursorAtEOF,
+	"refreshSingleCell":             refreshSingleCell,
+	"typeAheadVariableDropdown":     typeAheadVariableDropdown,
 }

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -30,6 +30,20 @@ func BackendExample() BoolFlag {
 	return backendExample
 }
 
+var communityTemplates = MakeBoolFlag(
+	"Community Templates",
+	"communityTemplates",
+	"Bucky",
+	true,
+	Permanent,
+	true,
+)
+
+// CommunityTemplates - Replace current template uploading functionality with community driven templates
+func CommunityTemplates() BoolFlag {
+	return communityTemplates
+}
+
 var frontendExample = MakeIntFlag(
 	"Frontend Example",
 	"frontendExample",
@@ -299,6 +313,7 @@ func TypeAheadDropdownsForVariables() BoolFlag {
 var all = []Flag{
 	appMetrics,
 	backendExample,
+	communityTemplates,
 	frontendExample,
 	groupWindowAggregateTranspose,
 	newLabels,
@@ -323,6 +338,7 @@ var all = []Flag{
 var byKey = map[string]Flag{
 	"appMetrics":                    appMetrics,
 	"backendExample":                backendExample,
+	"communityTemplates":            communityTemplates,
 	"frontendExample":               frontendExample,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
 	"newLabels":                     newLabels,

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -300,7 +300,7 @@ var typeAheadVariableDropdown = MakeBoolFlag(
 	"Type Ahead Dropdowns for Variables",
 	"typeAheadVariableDropdown",
 	"Monitoring Team",
-	true,
+	false,
 	Temporary,
 	true,
 )

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -272,7 +272,7 @@ var cursorAtEOF = MakeBoolFlag(
 	"Default Monaco Selection to EOF",
 	"cursorAtEOF",
 	"Monitoring Team",
-	true,
+	false,
 	Temporary,
 	true,
 )

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -735,7 +735,7 @@ describe('DataExplorer', () => {
         cy.getByTestID('time-machine-submit-button').click()
         cy.getByTestID('cog-cell--button').click()
         cy.getByTestID('select-group--option')
-          .contains('Custom')
+          .last()
           .click()
         cy.getByTestID('auto-domain--min')
           .type('-100')


### PR DESCRIPTION
Partially closes #21164

This PR turns "on" the feature flags for various UI features, including:
- Axis Ticks Generator (for controlling the number of axis ticks on plots)
- Band Plot Type
- Mosaic Plot Type
- UI CSV Uploader (upload annotated CSVs to a bucket)
- Editable Telegraf Configurations (edit telegraf configs from the UI)
- Legend Orientation in the UI (customize the appearance of the legend)
- Refresh Single Cell (instead of refreshing the entire dashboard's cells)

The two that aren't being turned on with this PR are listed below. To turn these on, we will need to move on from using our "legacy" e2e tests in `influxdb/ui/cypress` and be able to use the latest and greatest e2e tests from the `ui` repo, the implementation of which is described in [influxdata/ui#1007](https://github.com/influxdata/ui/issues/1007).
- Default Monaco Selection to EOF (puts the cursor at the end of the line when editing scripts)
- Type Ahead Dropdowns for Variables