### PR TITLE
chore: remove unused feature flags: communityTemplates, backendExample, frontendExample

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,7 +637,7 @@ jobs:
             - yarn-deps-lock-{{ checksum "ui/yarn.lock" }}
       - run: sudo apt-get update && sudo apt-get install netcat-openbsd
       - run:
-          command: ./bin/linux/influxd --store=memory --e2e-testing=true --feature-flags=communityTemplates=true
+          command: ./bin/linux/influxd --store=memory --e2e-testing=true
           background: true
       - run: make e2e
       - store_test_results:

--- a/flags.yml
+++ b/flags.yml
@@ -28,14 +28,6 @@
   contact: Gavin Cabbage
   lifetime: permanent
 
-- name: Community Templates
-  description: Replace current template uploading functionality with community driven templates
-  key: communityTemplates
-  default: true
-  expose: true
-  contact: Bucky
-  lifetime: permanent
-
 - name: Frontend Example
   description: A temporary frontend example integer flag
   key: frontendExample

--- a/flags.yml
+++ b/flags.yml
@@ -21,20 +21,6 @@
   contact: Bucky, Monitoring Team
   lifetime: permanent
 
-- name: Backend Example
-  description: A permanent backend example boolean flag
-  key: backendExample
-  default: false
-  contact: Gavin Cabbage
-  lifetime: permanent
-
-- name: Frontend Example
-  description: A temporary frontend example integer flag
-  key: frontendExample
-  default: 42
-  contact: Gavin Cabbage
-  expose: true
-
 - name: Group Window Aggregate Transpose
   description: Enables the GroupWindowAggregateTransposeRule for all enabled window aggregates
   key: groupWindowAggregateTranspose

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -16,34 +16,6 @@ func AppMetrics() BoolFlag {
 	return appMetrics
 }
 
-var backendExample = MakeBoolFlag(
-	"Backend Example",
-	"backendExample",
-	"Gavin Cabbage",
-	false,
-	Permanent,
-	false,
-)
-
-// BackendExample - A permanent backend example boolean flag
-func BackendExample() BoolFlag {
-	return backendExample
-}
-
-var frontendExample = MakeIntFlag(
-	"Frontend Example",
-	"frontendExample",
-	"Gavin Cabbage",
-	42,
-	Temporary,
-	true,
-)
-
-// FrontendExample - A temporary frontend example integer flag
-func FrontendExample() IntFlag {
-	return frontendExample
-}
-
 var groupWindowAggregateTranspose = MakeBoolFlag(
 	"Group Window Aggregate Transpose",
 	"groupWindowAggregateTranspose",
@@ -298,8 +270,6 @@ func TypeAheadDropdownsForVariables() BoolFlag {
 
 var all = []Flag{
 	appMetrics,
-	backendExample,
-	frontendExample,
 	groupWindowAggregateTranspose,
 	newLabels,
 	memoryOptimizedFill,
@@ -322,8 +292,6 @@ var all = []Flag{
 
 var byKey = map[string]Flag{
 	"appMetrics":                    appMetrics,
-	"backendExample":                backendExample,
-	"frontendExample":               frontendExample,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
 	"newLabels":                     newLabels,
 	"memoryOptimizedFill":           memoryOptimizedFill,

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -30,20 +30,6 @@ func BackendExample() BoolFlag {
 	return backendExample
 }
 
-var communityTemplates = MakeBoolFlag(
-	"Community Templates",
-	"communityTemplates",
-	"Bucky",
-	true,
-	Permanent,
-	true,
-)
-
-// CommunityTemplates - Replace current template uploading functionality with community driven templates
-func CommunityTemplates() BoolFlag {
-	return communityTemplates
-}
-
 var frontendExample = MakeIntFlag(
 	"Frontend Example",
 	"frontendExample",
@@ -313,7 +299,6 @@ func TypeAheadDropdownsForVariables() BoolFlag {
 var all = []Flag{
 	appMetrics,
 	backendExample,
-	communityTemplates,
 	frontendExample,
 	groupWindowAggregateTranspose,
 	newLabels,
@@ -338,7 +323,6 @@ var all = []Flag{
 var byKey = map[string]Flag{
 	"appMetrics":                    appMetrics,
 	"backendExample":                backendExample,
-	"communityTemplates":            communityTemplates,
 	"frontendExample":               frontendExample,
 	"groupWindowAggregateTranspose": groupWindowAggregateTranspose,
 	"newLabels":                     newLabels,


### PR DESCRIPTION
Closes influxdata/ui#942

Removes unused `communityTemplate` flag

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass