### PR TITLE
feat(annotations): add feature flag for annotations

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -153,3 +153,12 @@
   contact: Monitoring Team
   expose: true
   lifetime: temporary
+
+- name: Annotations UI
+  description: Management, display, and manual addition of Annotations from the UI
+  key: annotations
+  default: false
+  contact: Monitoring Team
+  lifetime: temporary
+  expose: true
+  

--- a/flags.yml
+++ b/flags.yml
@@ -161,4 +161,3 @@
   contact: Monitoring Team
   lifetime: temporary
   expose: true
-  

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -268,6 +268,20 @@ func TypeAheadDropdownsForVariables() BoolFlag {
 	return typeAheadVariableDropdown
 }
 
+var annotations = MakeBoolFlag(
+	"Annotations UI",
+	"annotations",
+	"Monitoring Team",
+	false,
+	Temporary,
+	true,
+)
+
+// AnnotationsUi - Management, display, and manual addition of Annotations from the UI
+func AnnotationsUi() BoolFlag {
+	return annotations
+}
+
 var all = []Flag{
 	appMetrics,
 	groupWindowAggregateTranspose,
@@ -288,6 +302,7 @@ var all = []Flag{
 	cursorAtEOF,
 	refreshSingleCell,
 	typeAheadVariableDropdown,
+	annotations,
 }
 
 var byKey = map[string]Flag{
@@ -310,4 +325,5 @@ var byKey = map[string]Flag{
 	"cursorAtEOF":                   cursorAtEOF,
 	"refreshSingleCell":             refreshSingleCell,
 	"typeAheadVariableDropdown":     typeAheadVariableDropdown,
+	"annotations":                   annotations,
 }


### PR DESCRIPTION
Closes #21204

Adds a feature flag for annotations to allow the feature to be "off" by default while it is being developed for OSS. `influxd` can be started with the flag set to `true` by passing the command-line flag `--feature-flags=annotations=true`.