### PR TITLE
feat: structured logging for HTTP server ErrorLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The prefix used for Prometheus metrics from the query controller has changed fro
 1. [21090](https://github.com/influxdata/influxdb/pull/21090): Update UI to match InfluxDB Cloud.
 1. [21127](https://github.com/influxdata/influxdb/pull/21127): Allow for disabling concurrency-limits in Flux controller.
 1. [21158](https://github.com/influxdata/influxdb/pull/21158): Replace unique resource IDs (UI assets, backup shards) with slugs to reduce cardinality of telemetry data.
+1. [21235](https://github.com/influxdata/influxdb/pull/21235): HTTP server errors output logs following the standard format.
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -934,7 +934,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	if !opts.ReportingDisabled {
 		m.runReporter(ctx)
 	}
-	if err := m.runHTTP(opts, httpHandler); err != nil {
+	if err := m.runHTTP(opts, httpHandler, httpLogger); err != nil {
 		return err
 	}
 
@@ -944,7 +944,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 // runHTTP configures and launches a listener for incoming HTTP(S) requests.
 // The listener is run in a separate goroutine. If it fails to start up, it
 // will cancel the launcher.
-func (m *Launcher) runHTTP(opts *InfluxdOpts, handler nethttp.Handler) error {
+func (m *Launcher) runHTTP(opts *InfluxdOpts, handler nethttp.Handler, httpLogger *zap.Logger) error {
 	log := m.log.With(zap.String("service", "tcp-listener"))
 
 	m.httpServer = &nethttp.Server{
@@ -954,6 +954,7 @@ func (m *Launcher) runHTTP(opts *InfluxdOpts, handler nethttp.Handler) error {
 		ReadTimeout:       opts.HttpReadTimeout,
 		WriteTimeout:      opts.HttpWriteTimeout,
 		IdleTimeout:       opts.HttpIdleTimeout,
+		ErrorLog:          zap.NewStdLog(httpLogger),
 	}
 
 	ln, err := net.Listen("tcp", opts.HttpBindAddress)


### PR DESCRIPTION
Closes #20740

This change makes the `httpLogger` available to the top-level `http.Server` via the `ErrorLog` property to ensure that errors from the server will follow the standard logging format used everywhere else.