### PR TITLE
fix: remove e2e test for creating a task from a template

### DIFF
--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -41,14 +41,6 @@ from(bucket: "${name}"{rightarrow}
       .should('have.length', 1)
       .and('contain', taskName)
 
-    // Creating a task from a template is no longer an option - 
-    // see https://github.com/influxdata/ui/issues/869
-    // cy.getByTestID('add-resource-dropdown--button').click()
-    // cy.getByTestID('add-resource-dropdown--template').click()
-    // cy.getByTestID('task-import-template--overlay').within(() => {
-    //   cy.get('.cf-overlay--dismiss').click()
-    // })
-
     // TODO: extend to create a template from JSON
     cy.getByTestID('add-resource-dropdown--button').click()
     cy.getByTestID('add-resource-dropdown--import').click()

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -41,12 +41,13 @@ from(bucket: "${name}"{rightarrow}
       .should('have.length', 1)
       .and('contain', taskName)
 
-    // TODO: extend to create from template overlay
-    cy.getByTestID('add-resource-dropdown--button').click()
-    cy.getByTestID('add-resource-dropdown--template').click()
-    cy.getByTestID('task-import-template--overlay').within(() => {
-      cy.get('.cf-overlay--dismiss').click()
-    })
+    // Creating a task from a template is no longer an option - 
+    // see https://github.com/influxdata/ui/issues/869
+    // cy.getByTestID('add-resource-dropdown--button').click()
+    // cy.getByTestID('add-resource-dropdown--template').click()
+    // cy.getByTestID('task-import-template--overlay').within(() => {
+    //   cy.get('.cf-overlay--dismiss').click()
+    // })
 
     // TODO: extend to create a template from JSON
     cy.getByTestID('add-resource-dropdown--button').click()


### PR DESCRIPTION
Closes #21242

Comments out the part of the e2e test for creating a task from a template so that the tests don't break when running against the latest UI.