### PR TITLE
fix: updated the onboarding e2e test

### DIFF
--- a/ui/cypress/e2e/onboarding.test.ts
+++ b/ui/cypress/e2e/onboarding.test.ts
@@ -37,7 +37,7 @@ describe('Onboarding', () => {
     cy.route('POST', 'api/v2/setup').as('orgSetup')
 
     //Check and visit splash page
-    cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB 2.0')
+    cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB')
     cy.getByTestID('credits').contains('Powered by')
     cy.getByTestID('credits').contains('InfluxData')
 


### PR DESCRIPTION
Closes #21271

Updated the e2e test to look for "Welcome to InfluxDB" as the splash page text to be consistent with the latest UI from the `ui` repo.