### PR TITLE
fix: updated the text for the e2e onboarding test splash page

### DIFF
--- a/ui/cypress/e2e/onboarding.test.ts
+++ b/ui/cypress/e2e/onboarding.test.ts
@@ -50,7 +50,7 @@ describe('Onboarding', () => {
     cy.getByTestID('nav-step--welcome').click()
 
     //Check splash page
-    cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB 2.0')
+    cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB')
     cy.getByTestID('credits').contains('Powered by')
     cy.getByTestID('credits').contains('InfluxData')
 


### PR DESCRIPTION
Closes #21271

Updates an additional test that was missed in #21272. There are actually TWO places in the onboarding tests where the splash text is checked - this PR updates the additional location.
