### PR TITLE
fix: Anti-Entropy loops endlessly with empty shard (#21275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 v1.8.6 [unreleased]
 -------------------
 
--	[21290](https://github.com/influxdata/influxdb/pull/21290): fix: Anti-Entropy loops endlessly with empty shard
+-	[#21290](https://github.com/influxdata/influxdb/pull/21290): fix: Anti-Entropy loops endlessly with empty shard
 
 v1.8.5 [2021-04-19]
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 v1.8.6 [unreleased]
 -------------------
 
+-	[21290](https://github.com/influxdata/influxdb/pull/21290): fix: Anti-Entropy loops endlessly with empty shard
+
 v1.8.5 [2021-04-19]
 -------------------
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -566,6 +566,7 @@ func (f *FileStore) Open() error {
 	}
 
 	var lm int64
+	isEmpty := true
 	for range files {
 		res := <-readerC
 		if res.err != nil {
@@ -585,9 +586,18 @@ func (f *FileStore) Open() error {
 		if res.r.LastModified() > lm {
 			lm = res.r.LastModified()
 		}
-
+		isEmpty = false
 	}
-	f.lastModified = time.Unix(0, lm).UTC()
+	if isEmpty {
+		if fi, err := os.Stat(f.dir); err == nil {
+			f.lastModified = fi.ModTime().UTC()
+		} else {
+			close(readerC)
+			return err
+		}
+	} else {
+		f.lastModified = time.Unix(0, lm).UTC()
+	}
 	close(readerC)
 
 	sort.Sort(tsmReaders(f.files))


### PR DESCRIPTION
The anti-entropy service will loop trying to copy an empty shard to a
data node missing that shard.  This fix is one of two changes that
correctly create an empty shard on a new node. This fix will set the
LastModified date of an empty shard directory to the modification time
of that directory, instead of to the Unix epoch.

Fixes: https://github.com/influxdata/influxdb/issues/21273
(cherry picked from commit 7f300dc248d767ee1a96642480dfa1daa28f18ba)

Closes #https://github.com/influxdata/influxdb/issues/21288

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
