### PR TITLE
chore: rename Jenkins creds for 1.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         withDockerContainer(image: "jsternberg/changelog") {
           withCredentials(
             [[$class: "UsernamePasswordMultiBinding",
-              credentialsId: "hercules-username-password",
+              credentialsId: "team-edge-influx-github-username-token",
               usernameVariable: "GITHUB_USER",
               passwordVariable: "GITHUB_TOKEN"]]) {
             script {
@@ -31,7 +31,7 @@ pipeline {
           }
         }
 
-        sshagent(credentials: ['jenkins-hercules-ssh']) {
+        sshagent(credentials: ['team-edge-influx-github-ssh']) {
           sh """
           set -e
           if ! git diff --quiet; then


### PR DESCRIPTION
Follows the rename of credentials in Jenkins.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass