### PR TITLE
fix(models): grow tag index buffer if needed (#20137) (#21303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ v1.9.0 [unreleased]
 -	[#17685](https://github.com/influxdata/influxdb/pull/17685): fix(tsm1): Fix temp directory search bug
 -	[#17495](https://github.com/influxdata/influxdb/pull/17495): fix(snapshotter): properly read payload
 -	[#21139](https://github.com/influxdata/influxdb/pull/21139): fix(tsdb): exclude stop time from array cursors
+-	[#21036](https://github.com/influxdata/influxdb/pull/21306): fix(models): grow tag index buffer if needed
 
 v1.8.5 [unreleased]
 -------------------

--- a/models/points.go
+++ b/models/points.go
@@ -652,6 +652,15 @@ func scanTags(buf []byte, i int, indices []int) (int, int, []int, error) {
 		case tagValueState:
 			state, i, err = scanTagsValue(buf, i)
 		case fieldsState:
+			// Grow our indices slice if we had exactly enough tags to fill it
+			if commas >= len(indices) {
+				// The parser is in `fieldsState`, so there are no more
+				// tags. We only need 1 more entry in the slice to store
+				// the final entry.
+				newIndics := make([]int, cap(indices)+1)
+				copy(newIndics, indices)
+				indices = newIndics
+			}
 			indices[commas] = i + 1
 			return i, commas, indices, nil
 		}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1243,6 +1243,17 @@ func TestParsePointWithDuplicateTags(t *testing.T) {
 	}
 }
 
+func TestParsePointWithVariousTags(t *testing.T) {
+	line := "m"
+	for i := 0; i < 1000; i++ {
+		line += fmt.Sprintf(",t%d=x", i+1)
+		_, err := models.ParsePointsString(line + " v=0")
+		if err != nil {
+			t.Errorf(`ParsePoints("%s") failed`, line)
+		}
+	}
+}
+
 func TestParsePointWithStringField(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo",str2="bar" 1000000000`,
 		NewTestPoint("cpu",


### PR DESCRIPTION
(cherry picked from commit cae14176aa4d2f953f1330bc48051641b8c7fc78)

Closes https://github.com/influxdata/influxdb/issues/21303