### PR TITLE
fix: Anti-Entropy loops endlessly with empty shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ v1.9.0 [unreleased]
 -	[#21168](https://github.com/influxdata/influxdb/pull/21168): fix(storage): Detect need for descending cursor in WindowAggregate
 -	[#21285](https://github.com/influxdata/influxdb/pull/21285): fix(storage): Detect need for descending cursor in GroupAggregate
 -	[#21308](https://github.com/influxdata/influxdb/pull/21308): fix(models): grow tag index buffer if needed
+-	[#21310](https://github.com/influxdata/influxdb/pull/21310): fix: Anti-Entropy loops endlessly with empty shard
 
 v1.8.5 [unreleased]
 -------------------


### PR DESCRIPTION
The anti-entropy service will loop trying to copy an empty shard to a
data node missing that shard.  This fix is one of two changes that
correctly create an empty shard on a new node. This fix will set the
LastModified date of an empty shard directory to the modification time
of that directory, instead of to the Unix epoch.

Fixes: https://github.com/influxdata/influxdb/issues/21273
(cherry picked from commit 7f300dc248d767ee1a96642480dfa1daa28f18ba)

Closes #https://github.com/influxdata/influxdb/issues/21287

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
