### PR TITLE
fix(upgrade): ensure query config written by `influxd upgrade` is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots.
 
+### Bug Fixes
+
+1. [21321](https://github.com/influxdata/influxdb/pull/21321): Ensure query config written by influxd upgrade is valid.
+
 ## v2.0.5 [2021-04-27]
 
 ### Windows Support

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -33,8 +33,8 @@ const (
 // NewInfluxdCommand constructs the root of the influxd CLI, along with a `run` subcommand.
 // The `run` subcommand is set as the default to execute.
 func NewInfluxdCommand(ctx context.Context, v *viper.Viper) (*cobra.Command, error) {
-	o := newOpts(v)
-	cliOpts := o.bindCliOpts()
+	o := NewOpts(v)
+	cliOpts := o.BindCliOpts()
 
 	prog := cli.Program{
 		Name: "influxd",
@@ -168,8 +168,8 @@ type InfluxdOpts struct {
 	Viper *viper.Viper
 }
 
-// newOpts constructs options with default values.
-func newOpts(viper *viper.Viper) *InfluxdOpts {
+// NewOpts constructs options with default values.
+func NewOpts(viper *viper.Viper) *InfluxdOpts {
 	dir, err := fs.InfluxDir()
 	if err != nil {
 		panic(fmt.Errorf("failed to determine influx directory: %v", err))
@@ -216,9 +216,9 @@ func newOpts(viper *viper.Viper) *InfluxdOpts {
 	}
 }
 
-// bindCliOpts returns a list of options which can be added to a cobra command
+// BindCliOpts returns a list of options which can be added to a cobra command
 // in order to set options over the CLI.
-func (o *InfluxdOpts) bindCliOpts() []cli.Opt {
+func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 	return []cli.Opt{
 		{
 			DestP:   &o.LogLevel,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -672,9 +672,8 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	onboardSvc = tenant.NewOnboardingLogger(onboardingLogger, onboardSvc)                 // with logging
 
 	var (
-		authorizerV1 platform.AuthorizerV1
-		passwordV1   platform.PasswordsService
-		authSvcV1    *authv1.Service
+		passwordV1 platform.PasswordsService
+		authSvcV1  *authv1.Service
 	)
 	{
 		authStore, err := authv1.NewStore(m.kvStore)
@@ -685,13 +684,6 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 
 		authSvcV1 = authv1.NewService(authStore, ts)
 		passwordV1 = authv1.NewCachingPasswordsService(authSvcV1)
-
-		authorizerV1 = &authv1.Authorizer{
-			AuthV1:   authSvcV1,
-			AuthV2:   authSvc,
-			Comparer: passwordV1,
-			User:     ts,
-		}
 	}
 
 	var (
@@ -735,12 +727,19 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			BucketFinder:  ts.BucketService,
 			LogBucketName: platform.MonitoringSystemBucketName,
 		},
-		DeleteService:        deleteService,
-		BackupService:        backupService,
-		RestoreService:       restoreService,
-		AuthorizationService: authSvc,
-		AuthorizerV1:         authorizerV1,
-		AlgoWProxy:           &http.NoopProxyHandler{},
+		DeleteService:          deleteService,
+		BackupService:          backupService,
+		RestoreService:         restoreService,
+		AuthorizationService:   authSvc,
+		AuthorizationV1Service: authSvcV1,
+		PasswordV1Service:      passwordV1,
+		AuthorizerV1: &authv1.Authorizer{
+			AuthV1:   authSvcV1,
+			AuthV2:   authSvc,
+			Comparer: passwordV1,
+			User:     ts,
+		},
+		AlgoWProxy: &http.NoopProxyHandler{},
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   ts.BucketService,
 		SessionService:                  sessionSvc,
@@ -1134,6 +1133,10 @@ func (m *Launcher) UserResourceMappingService() platform.UserResourceMappingServ
 // AuthorizationService returns the internal authorization service.
 func (m *Launcher) AuthorizationService() platform.AuthorizationService {
 	return m.apibackend.AuthorizationService
+}
+
+func (m *Launcher) AuthorizationV1Service() platform.AuthorizationService {
+	return m.apibackend.AuthorizationV1Service
 }
 
 // SecretService returns the internal secret service.

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -118,7 +118,7 @@ func (tl *TestLauncher) RunOrFail(tb testing.TB, ctx context.Context, setters ..
 // Run executes the program with additional arguments to set paths and ports.
 // Passed arguments will overwrite/add to the default ones.
 func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ...OptSetter) error {
-	opts := newOpts(viper.New())
+	opts := NewOpts(viper.New())
 	if !tl.realServer {
 		opts.StoreType = "memory"
 		opts.Testing = true

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -41,7 +41,7 @@ func TestConfigUpgrade(t *testing.T) {
 			config2x: testConfigV2obsoleteArrays,
 		},
 		{
-			name: "query concurrency",
+			name:     "query concurrency",
 			config1x: testConfigV1QueryConcurrency,
 			config2x: testConfigV2QueryConcurrency,
 		},

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -40,6 +40,11 @@ func TestConfigUpgrade(t *testing.T) {
 			config1x: testConfigV1obsoleteArrays,
 			config2x: testConfigV2obsoleteArrays,
 		},
+		{
+			name: "query concurrency",
+			config1x: testConfigV1QueryConcurrency,
+			config2x: testConfigV2QueryConcurrency,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -398,6 +403,11 @@ reporting-disabled = true
 var testConfigV1empty = `
 `
 
+var testConfigV1QueryConcurrency = `
+[coordinator]
+  max-concurrent-queries = 128
+`
+
 // 2.x test configs
 
 var testConfigV2minimal = `reporting-disabled = false
@@ -422,7 +432,7 @@ influxql-max-select-buckets = 0
 influxql-max-select-point = 0
 influxql-max-select-series = 0
 log-level = "info"
-query-concurrency = 10
+query-concurrency = 0
 storage-cache-max-memory-size = 1073741824
 storage-cache-snapshot-memory-size = 26214400
 storage-cache-snapshot-write-cold-duration = "10m0s"
@@ -452,4 +462,11 @@ http-bind-address = ":8086"
 var testConfigV2empty = `
 bolt-path = "/db/.influxdbv2/influxd.bolt"
 engine-path = "/db/.influxdbv2/engine"
+`
+
+var testConfigV2QueryConcurrency = `
+bolt-path = "/db/.influxdbv2/influxd.bolt"
+engine-path = "/db/.influxdbv2/engine"
+query-concurrency = 128
+query-queue-size = 128
 `

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -66,6 +66,8 @@ type APIBackend struct {
 	BackupService                   influxdb.BackupService
 	RestoreService                  influxdb.RestoreService
 	AuthorizationService            influxdb.AuthorizationService
+	AuthorizationV1Service          influxdb.AuthorizationService
+	PasswordV1Service               influxdb.PasswordsService
 	AuthorizerV1                    influxdb.AuthorizerV1
 	OnboardingService               influxdb.OnboardingService
 	DBRPService                     influxdb.DBRPMappingServiceV2


### PR DESCRIPTION
Closes #21315 

1. Stop rewriting `0` to `10` when upgrading `query-concurrency` config, now that 0 is a valid value
2. If writing a value > 0 for `query-concurrency`, ensure we also write a > 0 value for `query-queue-size`

I had to refactor a bunch of things to make our upgrade-real-DB regression test actually test loading upgraded config. I confirmed that the 1st commit fails with the error seen in #21315, and the 2nd commit gets things to pass again.