### PR TITLE
fix(query): make config validation for query controller less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Bug Fixes
 
 1. [21321](https://github.com/influxdata/influxdb/pull/21321): Ensure query config written by influxd upgrade is valid.
+1. [21324](https://github.com/influxdata/influxdb/pull/21324): Revert to nonzero defaults for `query-concurrency` and `query-queue-size` to avoid validation failures for upgrading users.
+1. [21324](https://github.com/influxdata/influxdb/pull/21324): Don't fail validation when `query-concurrency` is 0 and `query-queue-size` is > 0.
 
 ## v2.0.5 [2021-04-27]
 

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -205,11 +205,11 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 
 		NoTasks: false,
 
-		ConcurrencyQuota:                0,
+		ConcurrencyQuota:                1024,
 		InitialMemoryBytesQuotaPerQuery: 0,
 		MemoryBytesQuotaPerQuery:        MaxInt,
 		MaxMemoryBytes:                  0,
-		QueueSize:                       0,
+		QueueSize:                       1024,
 
 		Testing:                 false,
 		TestingAlwaysAllowSetup: false,

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -129,6 +129,8 @@ func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ..
 	opts.HttpBindAddress = "127.0.0.1:0"
 	opts.LogLevel = zap.DebugLevel
 	opts.ReportingDisabled = true
+	opts.ConcurrencyQuota = 32
+	opts.QueueSize = 16
 
 	for _, setter := range setters {
 		setter(opts)


### PR DESCRIPTION
Related to #21321

In 2.0.4:
* `query-concurrency: 0` was not allowed
* The default values of `query-concurrency` and `query-queue-size` were both 10

In practice, we found that users quickly hit the default threshold. See #17912.

In 2.0.5:
* `query-concurrency: 0` was enabled as a short-hand for infinite concurrency
* Validation was added to assert that:
   * `query-queue-size` is 0 when `query-concurrency` is 0
   * `query-queue-size` is > 0 when `query-concurrency` is > 0
* The default values of `query-concurrency` and `query-queue-size` were both updated to be 0

This is guaranteed to be a breaking change for any users that had updated their deployments to override the config value for `query-concurrency` without also updating `query-queue-size`, because concurrency must have been > 0 and queue-size would now be 0 by default.

This PR:
* Changes the default values for `query-concurrency` and `query-queue-size` to 1024
* Loosens our config validation to allow `query-queue-size` > 0 when `query-concurrency` is 0

The new non-zero defaults should prevent the guaranteed breaking change from 2.0.5, but still give more breathing room to users that have been fighting the concurrency limits in older versions. The validation change should make it smoother for users who want to make use of the new infinite-concurrency feature.