### PR TITLE
fix(query): avoid breaking query config validation when upgrading from older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 ### Bug Fixes
 
-1. [21321](https://github.com/influxdata/influxdb/pull/21321): Ensure query config written by influxd upgrade is valid.
-1. [21324](https://github.com/influxdata/influxdb/pull/21324): Revert to nonzero defaults for `query-concurrency` and `query-queue-size` to avoid validation failures for upgrading users.
-1. [21324](https://github.com/influxdata/influxdb/pull/21324): Don't fail validation when `query-concurrency` is 0 and `query-queue-size` is > 0.
+1. [21325](https://github.com/influxdata/influxdb/pull/21325): Ensure query config written by influxd upgrade is valid.
+1. [21325](https://github.com/influxdata/influxdb/pull/21325): Revert to nonzero defaults for `query-concurrency` and `query-queue-size` to avoid validation failures for upgrading users.
+1. [21325](https://github.com/influxdata/influxdb/pull/21325): Don't fail validation when `query-concurrency` is 0 and `query-queue-size` is > 0.
 
 ## v2.0.5 [2021-04-27]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v2.0.6 [unreleased]
 ----------------------
 
+### Bug Fixes
+
+1. [21321](https://github.com/influxdata/influxdb/pull/21321): Ensure query config written by influxd upgrade is valid.
+
 ## v2.0.5 [2021-04-27]
 ----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Bug Fixes
 
 1. [21321](https://github.com/influxdata/influxdb/pull/21321): Ensure query config written by influxd upgrade is valid.
+1. [21324](https://github.com/influxdata/influxdb/pull/21324): Revert to nonzero defaults for `query-concurrency` and `query-queue-size` to avoid validation failures for upgrading users.
+1. [21324](https://github.com/influxdata/influxdb/pull/21324): Don't fail validation when `query-concurrency` is 0 and `query-queue-size` is > 0.
 
 ## v2.0.5 [2021-04-27]
 ----------------------

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -33,8 +33,8 @@ const (
 // NewInfluxdCommand constructs the root of the influxd CLI, along with a `run` subcommand.
 // The `run` subcommand is set as the default to execute.
 func NewInfluxdCommand(ctx context.Context, v *viper.Viper) (*cobra.Command, error) {
-	o := newOpts(v)
-	cliOpts := o.bindCliOpts()
+	o := NewOpts(v)
+	cliOpts := o.BindCliOpts()
 
 	prog := cli.Program{
 		Name: "influxd",
@@ -168,8 +168,8 @@ type InfluxdOpts struct {
 	Viper *viper.Viper
 }
 
-// newOpts constructs options with default values.
-func newOpts(viper *viper.Viper) *InfluxdOpts {
+// NewOpts constructs options with default values.
+func NewOpts(viper *viper.Viper) *InfluxdOpts {
 	dir, err := fs.InfluxDir()
 	if err != nil {
 		panic(fmt.Errorf("failed to determine influx directory: %v", err))
@@ -216,9 +216,9 @@ func newOpts(viper *viper.Viper) *InfluxdOpts {
 	}
 }
 
-// bindCliOpts returns a list of options which can be added to a cobra command
+// BindCliOpts returns a list of options which can be added to a cobra command
 // in order to set options over the CLI.
-func (o *InfluxdOpts) bindCliOpts() []cli.Opt {
+func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 	return []cli.Opt{
 		{
 			DestP:   &o.LogLevel,

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -205,11 +205,11 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 
 		NoTasks: false,
 
-		ConcurrencyQuota:                0,
+		ConcurrencyQuota:                1024,
 		InitialMemoryBytesQuotaPerQuery: 0,
 		MemoryBytesQuotaPerQuery:        MaxInt,
 		MaxMemoryBytes:                  0,
-		QueueSize:                       0,
+		QueueSize:                       1024,
 
 		Testing:                 false,
 		TestingAlwaysAllowSetup: false,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -666,9 +666,8 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	onboardSvc = tenant.NewOnboardingLogger(onboardingLogger, onboardSvc)                 // with logging
 
 	var (
-		authorizerV1 platform.AuthorizerV1
-		passwordV1   platform.PasswordsService
-		authSvcV1    *authv1.Service
+		passwordV1 platform.PasswordsService
+		authSvcV1  *authv1.Service
 	)
 	{
 		authStore, err := authv1.NewStore(m.kvStore)
@@ -679,13 +678,6 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 
 		authSvcV1 = authv1.NewService(authStore, ts)
 		passwordV1 = authv1.NewCachingPasswordsService(authSvcV1)
-
-		authorizerV1 = &authv1.Authorizer{
-			AuthV1:   authSvcV1,
-			AuthV2:   authSvc,
-			Comparer: passwordV1,
-			User:     ts,
-		}
 	}
 
 	var (
@@ -729,12 +721,19 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			BucketFinder:  ts.BucketService,
 			LogBucketName: platform.MonitoringSystemBucketName,
 		},
-		DeleteService:        deleteService,
-		BackupService:        backupService,
-		RestoreService:       restoreService,
-		AuthorizationService: authSvc,
-		AuthorizerV1:         authorizerV1,
-		AlgoWProxy:           &http.NoopProxyHandler{},
+		DeleteService:          deleteService,
+		BackupService:          backupService,
+		RestoreService:         restoreService,
+		AuthorizationService:   authSvc,
+		AuthorizationV1Service: authSvcV1,
+		PasswordV1Service:      passwordV1,
+		AuthorizerV1: &authv1.Authorizer{
+			AuthV1:   authSvcV1,
+			AuthV2:   authSvc,
+			Comparer: passwordV1,
+			User:     ts,
+		},
+		AlgoWProxy: &http.NoopProxyHandler{},
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   ts.BucketService,
 		SessionService:                  sessionSvc,
@@ -1128,6 +1127,10 @@ func (m *Launcher) UserResourceMappingService() platform.UserResourceMappingServ
 // AuthorizationService returns the internal authorization service.
 func (m *Launcher) AuthorizationService() platform.AuthorizationService {
 	return m.apibackend.AuthorizationService
+}
+
+func (m *Launcher) AuthorizationV1Service() platform.AuthorizationService {
+	return m.apibackend.AuthorizationV1Service
 }
 
 // SecretService returns the internal secret service.

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -117,7 +117,7 @@ func (tl *TestLauncher) RunOrFail(tb testing.TB, ctx context.Context, setters ..
 // Run executes the program with additional arguments to set paths and ports.
 // Passed arguments will overwrite/add to the default ones.
 func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ...OptSetter) error {
-	opts := newOpts(viper.New())
+	opts := NewOpts(viper.New())
 	if !tl.realServer {
 		opts.StoreType = "memory"
 		opts.Testing = true

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -128,6 +128,8 @@ func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ..
 	opts.HttpBindAddress = "127.0.0.1:0"
 	opts.LogLevel = zap.DebugLevel
 	opts.ReportingDisabled = true
+	opts.ConcurrencyQuota = 32
+	opts.QueueSize = 16
 
 	for _, setter := range setters {
 		setter(opts)

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -40,6 +40,11 @@ func TestConfigUpgrade(t *testing.T) {
 			config1x: testConfigV1obsoleteArrays,
 			config2x: testConfigV2obsoleteArrays,
 		},
+		{
+			name:     "query concurrency",
+			config1x: testConfigV1QueryConcurrency,
+			config2x: testConfigV2QueryConcurrency,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -398,6 +403,11 @@ reporting-disabled = true
 var testConfigV1empty = `
 `
 
+var testConfigV1QueryConcurrency = `
+[coordinator]
+  max-concurrent-queries = 128
+`
+
 // 2.x test configs
 
 var testConfigV2minimal = `reporting-disabled = false
@@ -422,7 +432,7 @@ influxql-max-select-buckets = 0
 influxql-max-select-point = 0
 influxql-max-select-series = 0
 log-level = "info"
-query-concurrency = 10
+query-concurrency = 0
 storage-cache-max-memory-size = 1073741824
 storage-cache-snapshot-memory-size = 26214400
 storage-cache-snapshot-write-cold-duration = "10m0s"
@@ -452,4 +462,11 @@ http-bind-address = ":8086"
 var testConfigV2empty = `
 bolt-path = "/db/.influxdbv2/influxd.bolt"
 engine-path = "/db/.influxdbv2/engine"
+`
+
+var testConfigV2QueryConcurrency = `
+bolt-path = "/db/.influxdbv2/influxd.bolt"
+engine-path = "/db/.influxdbv2/engine"
+query-concurrency = 128
+query-queue-size = 128
 `

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -62,6 +62,8 @@ type APIBackend struct {
 	BackupService                   influxdb.BackupService
 	RestoreService                  influxdb.RestoreService
 	AuthorizationService            influxdb.AuthorizationService
+	AuthorizationV1Service          influxdb.AuthorizationService
+	PasswordV1Service               influxdb.PasswordsService
 	AuthorizerV1                    influxdb.AuthorizerV1
 	OnboardingService               influxdb.OnboardingService
 	DBRPService                     influxdb.DBRPMappingServiceV2

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -118,19 +118,23 @@ type Config struct {
 
 // complete will fill in the defaults, validate the configuration, and
 // return the new Config.
-func (c *Config) complete() (Config, error) {
+func (c *Config) complete(log *zap.Logger) (Config, error) {
 	config := *c
 	if config.InitialMemoryBytesQuotaPerQuery == 0 {
 		config.InitialMemoryBytesQuotaPerQuery = config.MemoryBytesQuotaPerQuery
 	}
+	if config.ConcurrencyQuota == 0 && config.QueueSize > 0 {
+		log.Warn("Ignoring query QueueSize > 0 when ConcurrencyQuota is 0")
+		config.QueueSize = 0
+	}
 
-	if err := config.validate(true); err != nil {
+	if err := config.validate(); err != nil {
 		return Config{}, err
 	}
 	return config, nil
 }
 
-func (c *Config) validate(isComplete bool) error {
+func (c *Config) validate() error {
 	if c.ConcurrencyQuota < 0 {
 		return errors.New("ConcurrencyQuota must not be negative")
 	} else if c.ConcurrencyQuota == 0 {
@@ -147,10 +151,10 @@ func (c *Config) validate(isComplete bool) error {
 			return errors.New("QueueSize must be positive when ConcurrencyQuota is limited")
 		}
 	}
-	if c.MemoryBytesQuotaPerQuery < 0 || (isComplete && c.MemoryBytesQuotaPerQuery == 0) {
+	if c.MemoryBytesQuotaPerQuery < 0 {
 		return errors.New("MemoryBytesQuotaPerQuery must be positive")
 	}
-	if c.InitialMemoryBytesQuotaPerQuery < 0 || (isComplete && c.InitialMemoryBytesQuotaPerQuery == 0) {
+	if c.InitialMemoryBytesQuotaPerQuery < 0 {
 		return errors.New("InitialMemoryBytesQuotaPerQuery must be positive")
 	}
 	if c.MaxMemoryBytes < 0 {
@@ -164,15 +168,10 @@ func (c *Config) validate(isComplete bool) error {
 	return nil
 }
 
-// Validate will validate that the controller configuration is valid.
-func (c *Config) Validate() error {
-	return c.validate(false)
-}
-
 type QueryID uint64
 
 func New(config Config, logger *zap.Logger) (*Controller, error) {
-	c, err := config.complete()
+	c, err := config.complete(logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid controller config")
 	}


### PR DESCRIPTION
Closes #21319 

Backports #21321 and #21324

* Ensure query config written by influxd upgrade is valid.
* Revert to nonzero defaults for `query-concurrency` and `query-queue-size` to avoid validation failures for upgrading users.
* Don't fail validation when `query-concurrency` is 0 and `query-queue-size` is > 0.