### PR TITLE
fix: summation should be in native type for new meancount iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ v1.9.0 [unreleased]
 -	[#21139](https://github.com/influxdata/influxdb/pull/21139): fix(tsdb): exclude stop time from array cursors
 -	[#21036](https://github.com/influxdata/influxdb/pull/21306): fix(models): grow tag index buffer if needed
 -	[#21275](https://github.com/influxdata/influxdb/pull/21275): fix: Anti-Entropy loops endlessly with empty shard
+-	[#21334](https://github.com/influxdata/influxdb/pull/21334): fix: summation should be in native type for new meancount iterator
 
 v1.8.5 [unreleased]
 -------------------

--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -2135,7 +2135,7 @@ func (c *integerWindowMeanCountArrayCursor) Next() *cursors.MeanCountArray {
 	}
 
 	rowIdx := 0
-	var sum float64
+	var sum int64
 	var count int64
 
 	var windowEnd int64
@@ -2156,7 +2156,7 @@ WINDOWS:
 				// do not generate a point for empty windows
 				if windowHasPoints {
 					c.res.Timestamps[pos] = windowEnd
-					c.res.Values0[pos] = sum / float64(count)
+					c.res.Values0[pos] = float64(sum) / float64(count)
 					c.res.Values1[pos] = count
 					pos++
 					if pos >= MaxPointsPerBlock {
@@ -2177,7 +2177,7 @@ WINDOWS:
 
 				continue WINDOWS
 			} else {
-				sum += float64(a.Values[rowIdx])
+				sum += a.Values[rowIdx]
 				count++
 				windowHasPoints = true
 			}
@@ -2194,7 +2194,7 @@ WINDOWS:
 			// do not generate a point for empty windows
 			if windowHasPoints {
 				c.res.Timestamps[pos] = windowEnd
-				c.res.Values0[pos] = sum / float64(count)
+				c.res.Values0[pos] = float64(sum) / float64(count)
 				c.res.Values1[pos] = count
 				pos++
 			}
@@ -3138,7 +3138,7 @@ func (c *unsignedWindowMeanCountArrayCursor) Next() *cursors.MeanCountArray {
 	}
 
 	rowIdx := 0
-	var sum float64
+	var sum uint64
 	var count int64
 
 	var windowEnd int64
@@ -3159,7 +3159,7 @@ WINDOWS:
 				// do not generate a point for empty windows
 				if windowHasPoints {
 					c.res.Timestamps[pos] = windowEnd
-					c.res.Values0[pos] = sum / float64(count)
+					c.res.Values0[pos] = float64(sum) / float64(count)
 					c.res.Values1[pos] = count
 					pos++
 					if pos >= MaxPointsPerBlock {
@@ -3180,7 +3180,7 @@ WINDOWS:
 
 				continue WINDOWS
 			} else {
-				sum += float64(a.Values[rowIdx])
+				sum += a.Values[rowIdx]
 				count++
 				windowHasPoints = true
 			}
@@ -3197,7 +3197,7 @@ WINDOWS:
 			// do not generate a point for empty windows
 			if windowHasPoints {
 				c.res.Timestamps[pos] = windowEnd
-				c.res.Values0[pos] = sum / float64(count)
+				c.res.Values0[pos] = float64(sum) / float64(count)
 				c.res.Values1[pos] = count
 				pos++
 			}

--- a/storage/reads/array_cursor.gen.go.tmpldata
+++ b/storage/reads/array_cursor.gen.go.tmpldata
@@ -102,9 +102,9 @@
 			{
 				"Name":"MeanCount",
 				"OutputTypeName":"MeanCount",
-				"AccDecls":"var sum float64; var count int64",
-				"Accumulate":"sum += float64(a.Values[rowIdx]); count++",
-				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values0[pos] = sum / float64(count); c.res.Values1[pos] = count",
+				"AccDecls":"var sum int64; var count int64",
+				"Accumulate":"sum += a.Values[rowIdx]; count++",
+				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values0[pos] = float64(sum) / float64(count); c.res.Values1[pos] = count",
 				"AccReset":"sum = 0; count = 0"
 			}
 		]
@@ -157,9 +157,9 @@
 			{
 				"Name":"MeanCount",
 				"OutputTypeName":"MeanCount",
-				"AccDecls":"var sum float64; var count int64",
-				"Accumulate":"sum += float64(a.Values[rowIdx]); count++",
-				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values0[pos] = sum / float64(count); c.res.Values1[pos] = count",
+				"AccDecls":"var sum uint64; var count int64",
+				"Accumulate":"sum += a.Values[rowIdx]; count++",
+				"AccEmit":"c.res.Timestamps[pos] = windowEnd; c.res.Values0[pos] = float64(sum) / float64(count); c.res.Values1[pos] = count",
 				"AccReset":"sum = 0; count = 0"
 			}
 		]


### PR DESCRIPTION
Small follow-up to https://github.com/influxdata/influxdb/pull/21291

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
