### PR TITLE
fix: deprecate PostSetupUser and `influx setup user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots.
 
+### Bug Fixes
+
+1. [21345](https://github.com/influxdata/influxdb/pull/21345): Deprecate the unsupported `PostSetupUser` API.
+
 ## v2.0.6 [2021-04-29]
 
 ### Bug Fixes

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -56,7 +56,12 @@ func cmdSetup(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 	cmd := opt.newCmd("user", nil, true)
 	cmd.RunE = setupUserF
-	cmd.Short = "Setup instance with user, org, bucket"
+	cmd.Short = "Setup instance with user, org, bucket [DEPRECATED]"
+	cmd.Long = `***************************************** WARNING *****************************************
+*** 'setup user' is not intended for public use, and will be removed in InfluxDB 2.1.0. ***
+*** Please migrate to using the 'bucket', 'org', and 'user' commands.                   ***
+*******************************************************************************************`
+	cmd.Hidden = true
 
 	f.registerFlags(opt.viper, cmd, "token")
 	cmd.Flags().StringVarP(&setupFlags.username, "username", "u", "", "primary username")
@@ -73,7 +78,8 @@ func cmdSetupUser(f *globalFlags, opt genericCLIOpts) *cobra.Command {
 }
 
 func setupUserF(cmd *cobra.Command, args []string) error {
-	// check if setup is allowed
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), cmd.Long)
+
 	client, err := newHTTPClient()
 	if err != nil {
 		return err

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -114,11 +114,15 @@ paths:
                 $ref: "#/components/schemas/Error"
   /setup/user:
     post:
+      deprecated: true
       operationId: PostSetupUser
       tags:
         - Setup
       summary: Set up a new user, org and bucket
-      description: Post an onboarding request to set up a new user, org and bucket.
+      description: >
+        Post an onboarding request to set up a new user, org and bucket.
+        NOTE: This API will be removed in InfluxDB 2.1.0. Please migrate to
+        using the dedicated APIs for users, orgs, and buckets.
       parameters:
         - $ref: "#/components/parameters/TraceSpan"
       requestBody:


### PR DESCRIPTION
Closes #21342

* Mark `PostSetupUser` as deprecated in our API docs
* Hide the `influx setup user` command that uses the API
* Add a loud warning to the help-text and output of `influx setup user` for people who are already using it / who find it later