### PR TITLE
fix(storage): cursor requests are [start, stop] instead of [start, stop) (#21347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ v1.9.0 [unreleased]
 -	[#21308](https://github.com/influxdata/influxdb/pull/21308): fix(models): grow tag index buffer if needed
 -	[#21310](https://github.com/influxdata/influxdb/pull/21310): fix: Anti-Entropy loops endlessly with empty shard
 -	[#21341](https://github.com/influxdata/influxdb/pull/21341): fix: summation should be in native type for new meancount iterator
+-	[#21348](https://github.com/influxdata/influxdb/pull/21348): fix(storage): cursor requests are [start, stop] instead of [start, stop)
 
 v1.8.5 [unreleased]
 -------------------

--- a/storage/reads/array_cursor.go
+++ b/storage/reads/array_cursor.go
@@ -75,13 +75,19 @@ type multiShardArrayCursors struct {
 	}
 }
 
+// newMultiShardArrayCursors is a factory for creating cursors for each series key.
+// The range of the cursor is [start, end). The start time is the lower absolute time
+// and the end time is the higher absolute time regardless of ascending or descending order.
 func newMultiShardArrayCursors(ctx context.Context, start, end int64, asc bool) *multiShardArrayCursors {
+	// When we construct the CursorRequest, we translate the time range
+	// from [start, stop) to [start, stop]. The cursor readers from storage are
+	// inclusive on both ends and we perform that conversion here.
 	m := &multiShardArrayCursors{
 		ctx: ctx,
 		req: cursors.CursorRequest{
 			Ascending: asc,
 			StartTime: start,
-			EndTime:   end,
+			EndTime:   end - 1,
 		},
 	}
 

--- a/storage/reads/group_resultset_test.go
+++ b/storage/reads/group_resultset_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/data/gen"
 	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
 func TestNewGroupResultSet_Sorting(t *testing.T) {
@@ -461,5 +461,43 @@ func BenchmarkNewGroupResultSet_GroupBy(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupBy, GroupKeys: []string{"tag2"}, Hints: hints}, newCursor)
 		rs.Close()
+	}
+}
+
+func TestNewGroupResultSet_TimeRange(t *testing.T) {
+	newCursor := newMockReadCursor(
+		"clicks click=1 1",
+	)
+	for i := range newCursor.rows {
+		newCursor.rows[0].Query[i] = &mockCursorIterator{
+			newCursorFn: func(req *cursors.CursorRequest) cursors.Cursor {
+				if want, got := int64(0), req.StartTime; want != got {
+					t.Errorf("unexpected start time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				if want, got := int64(29), req.EndTime; want != got {
+					t.Errorf("unexpected end time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				return &mockIntegerArrayCursor{}
+			},
+		}
+	}
+
+	ctx := context.Background()
+	req := datatypes.ReadGroupRequest{
+		Range: datatypes.TimestampRange{
+			Start: 0,
+			End:   30,
+		},
+	}
+
+	resultSet := reads.NewGroupResultSet(ctx, &req, func() (reads.SeriesCursor, error) {
+		return &newCursor, nil
+	})
+	groupByCursor := resultSet.Next()
+	if groupByCursor == nil {
+		t.Fatal("unexpected: groupByCursor was nil")
+	}
+	if groupByCursor.Next() {
+		t.Fatal("unexpected: groupByCursor.Next should not have advanced")
 	}
 }

--- a/storage/reads/resultset.go
+++ b/storage/reads/resultset.go
@@ -18,6 +18,10 @@ type resultSet struct {
 	arrayCursors multiShardCursors
 }
 
+// TODO(jsternberg): The range is [start, end) for this function which is consistent
+// with the documented interface for datatypes.ReadFilterRequest. This function should
+// be refactored to take in a datatypes.ReadFilterRequest similar to the other
+// ResultSet functions.
 func NewFilteredResultSet(ctx context.Context, start, end int64, seriesCursor SeriesCursor) ResultSet {
 	return &resultSet{
 		ctx:          ctx,

--- a/storage/reads/resultset_test.go
+++ b/storage/reads/resultset_test.go
@@ -1,0 +1,42 @@
+package reads_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+func TestNewFilteredResultSet_TimeRange(t *testing.T) {
+	newCursor := newMockReadCursor(
+		"clicks click=1 1",
+	)
+	for i := range newCursor.rows {
+		newCursor.rows[0].Query[i] = &mockCursorIterator{
+			newCursorFn: func(req *cursors.CursorRequest) cursors.Cursor {
+				if want, got := int64(0), req.StartTime; want != got {
+					t.Errorf("unexpected start time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				if want, got := int64(29), req.EndTime; want != got {
+					t.Errorf("unexpected end time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				return &mockIntegerArrayCursor{}
+			},
+		}
+	}
+
+	ctx := context.Background()
+	req := datatypes.ReadFilterRequest{
+		Range: datatypes.TimestampRange{
+			Start: 0,
+			End:   30,
+		},
+	}
+
+	resultSet := reads.NewFilteredResultSet(ctx, req.Range.Start, req.Range.End, &newCursor)
+	if !resultSet.Next() {
+		t.Fatal("expected result")
+	}
+}

--- a/tsdb/cursors/cursor.go
+++ b/tsdb/cursors/cursor.go
@@ -44,13 +44,32 @@ type MeanCountArrayCursor interface {
 	Next() *MeanCountArray
 }
 
+// CursorRequest is a request to the storage engine for a cursor to be
+// created with the given name, tags, and field for a given direction
+// and time range.
 type CursorRequest struct {
-	Name      []byte
-	Tags      models.Tags
-	Field     string
+	// Name is the measurement name a cursor is requested for.
+	Name []byte
+
+	// Tags is the set of series tags a cursor is requested for.
+	Tags models.Tags
+
+	// Field is the selected field for the cursor that is requested.
+	Field string
+
+	// Ascending is whether the cursor should move in an ascending
+	// or descending time order.
 	Ascending bool
+
+	// StartTime is the start time of the cursor. It is the lower
+	// absolute time regardless of the Ascending flag. This value
+	// is an inclusive bound.
 	StartTime int64
-	EndTime   int64
+
+	// EndTime is the end time of the cursor. It is the higher
+	// absolute time regardless of the Ascending flag. This value
+	// is an inclusive bound.
+	EndTime int64
 }
 
 type CursorIterator interface {

--- a/tsdb/engine/tsm1/array_cursor.gen.go
+++ b/tsdb/engine/tsm1/array_cursor.gen.go
@@ -135,9 +135,10 @@ func (c *floatArrayAscendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -182,35 +183,22 @@ func newFloatArrayDescendingCursor() *floatArrayDescendingCursor {
 }
 
 func (c *floatArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *floatArrayDescendingCursor) Err() error { return nil }
@@ -286,9 +274,10 @@ func (c *floatArrayDescendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -428,9 +417,10 @@ func (c *integerArrayAscendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -475,35 +465,22 @@ func newIntegerArrayDescendingCursor() *integerArrayDescendingCursor {
 }
 
 func (c *integerArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *integerArrayDescendingCursor) Err() error { return nil }
@@ -579,9 +556,10 @@ func (c *integerArrayDescendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -721,9 +699,10 @@ func (c *unsignedArrayAscendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -768,35 +747,22 @@ func newUnsignedArrayDescendingCursor() *unsignedArrayDescendingCursor {
 }
 
 func (c *unsignedArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *unsignedArrayDescendingCursor) Err() error { return nil }
@@ -872,9 +838,10 @@ func (c *unsignedArrayDescendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -1014,9 +981,10 @@ func (c *stringArrayAscendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -1061,35 +1029,22 @@ func newStringArrayDescendingCursor() *stringArrayDescendingCursor {
 }
 
 func (c *stringArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *stringArrayDescendingCursor) Err() error { return nil }
@@ -1165,9 +1120,10 @@ func (c *stringArrayDescendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++
@@ -1307,9 +1263,10 @@ func (c *booleanArrayAscendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -1354,35 +1311,22 @@ func newBooleanArrayDescendingCursor() *booleanArrayDescendingCursor {
 }
 
 func (c *booleanArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *booleanArrayDescendingCursor) Err() error { return nil }
@@ -1458,9 +1402,10 @@ func (c *booleanArrayDescendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
+++ b/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
@@ -134,9 +134,10 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -184,35 +185,22 @@ func new{{$Type}}() *{{$type}} {
 }
 
 func (c *{{$type}}) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
-	if len(c.cache.values) > 0 {
-		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-			return c.cache.values[i].UnixNano() >= seek
-		})
-		if c.cache.pos == len(c.cache.values) {
-			c.cache.pos--
-		} else if c.cache.values[c.cache.pos].UnixNano() != seek {
-			c.cache.pos--
-		}
-	} else {
-		c.cache.pos = -1
-	}
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].UnixNano() > seek
+	})
+	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}ArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
-	if c.tsm.values.Len() > 0 {
-		if c.tsm.pos == c.tsm.values.Len() {
-			c.tsm.pos--
-		} else if c.tsm.values.Timestamps[c.tsm.pos] != seek {
-			c.tsm.pos--
-		}
-	} else {
-		c.tsm.pos = -1
-	}
+	c.tsm.pos--
 }
 
 func (c *{{$type}}) Err() error        { return nil }
@@ -288,9 +276,10 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
+	// Strip timestamps from before the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] < c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/engine/tsm1/array_cursor_iterator.go
+++ b/tsdb/engine/tsm1/array_cursor_iterator.go
@@ -57,7 +57,7 @@ func (q *arrayCursorIterator) Next(ctx context.Context, r *tsdb.CursorRequest) (
 	var opt query.IteratorOptions
 	opt.Ascending = r.Ascending
 	opt.StartTime = r.StartTime
-	opt.EndTime = r.EndTime
+	opt.EndTime = r.EndTime // inclusive
 
 	// Return appropriate cursor based on type.
 	switch f.Type {

--- a/tsdb/engine/tsm1/array_cursor_test.go
+++ b/tsdb/engine/tsm1/array_cursor_test.go
@@ -1,0 +1,558 @@
+package tsm1
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb/pkg/file"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/stretchr/testify/assert"
+)
+
+type keyValues struct {
+	key    string
+	values []Value
+}
+
+func MustTempDir() string {
+	dir, err := ioutil.TempDir("", "tsm1-test")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp dir: %v", err))
+	}
+	return dir
+}
+
+func MustTempFile(dir string) *os.File {
+	f, err := ioutil.TempFile(dir, "tsm1test")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp file: %v", err))
+	}
+	return f
+}
+
+func newFiles(dir string, values ...keyValues) ([]string, error) {
+	var files []string
+
+	id := 1
+	for _, v := range values {
+		f := MustTempFile(dir)
+		w, err := NewTSMWriter(f)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := w.Write([]byte(v.key), v.values); err != nil {
+			return nil, err
+		}
+
+		if err := w.WriteIndex(); err != nil {
+			return nil, err
+		}
+
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+
+		newName := filepath.Join(filepath.Dir(f.Name()), DefaultFormatFileName(id, 1)+".tsm")
+		if err := file.RenameFile(f.Name(), newName); err != nil {
+			return nil, err
+		}
+		id++
+
+		files = append(files, newName)
+	}
+	return files, nil
+}
+
+func TestDescendingCursor_SinglePointStartTime(t *testing.T) {
+	t.Run("cache", func(t *testing.T) {
+		dir := MustTempDir()
+		defer os.RemoveAll(dir)
+		fs := NewFileStore(dir)
+
+		const START, END = 10, 1
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newIntegerArrayDescendingCursor()
+		// Include a cached value with timestamp equal to END
+		cur.reset(START, END, Values{NewIntegerValue(1, 1)}, kc)
+
+		var got []int64
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got = append(got, ar.Timestamps...)
+			ar = cur.Next()
+		}
+
+		if exp := []int64{1}; !cmp.Equal(got, exp) {
+			t.Errorf("unexpected values; -got/+exp\n%s", cmp.Diff(got, exp))
+		}
+	})
+	t.Run("tsm", func(t *testing.T) {
+		dir := MustTempDir()
+		defer os.RemoveAll(dir)
+		fs := NewFileStore(dir)
+
+		const START, END = 10, 1
+
+		data := []keyValues{
+			// Write a single data point with timestamp equal to END
+			{"m,_field=v#!~#v", []Value{NewIntegerValue(1, 1)}},
+		}
+
+		files, err := newFiles(dir, data...)
+		if err != nil {
+			t.Fatalf("unexpected error creating files: %v", err)
+		}
+
+		_ = fs.Replace(nil, files)
+
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newIntegerArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		var got []int64
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got = append(got, ar.Timestamps...)
+			ar = cur.Next()
+		}
+
+		if exp := []int64{1}; !cmp.Equal(got, exp) {
+			t.Errorf("unexpected values; -got/+exp\n%s", cmp.Diff(got, exp))
+		}
+	})
+}
+
+func TestFileStore_DuplicatePoints(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := NewFileStore(dir)
+
+	makeVals := func(ts ...int64) []Value {
+		vals := make([]Value, len(ts))
+		for i, t := range ts {
+			vals[i] = NewFloatValue(t, 1.01)
+		}
+		return vals
+	}
+
+	// Setup 3 files
+	data := []keyValues{
+		{"m,_field=v#!~#v", makeVals(21)},
+		{"m,_field=v#!~#v", makeVals(44)},
+		{"m,_field=v#!~#v", makeVals(40, 46)},
+		{"m,_field=v#!~#v", makeVals(46, 51)},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	_ = fs.Replace(nil, files)
+
+	t.Run("ascending", func(t *testing.T) {
+		const START, END = 0, 100
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, true)
+		defer kc.Close()
+		cur := newFloatArrayAscendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		var got []int64
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got = append(got, ar.Timestamps...)
+			ar = cur.Next()
+		}
+
+		if exp := []int64{21, 40, 44, 46, 51}; !cmp.Equal(got, exp) {
+			t.Errorf("unexpected values; -got/+exp\n%s", cmp.Diff(got, exp))
+		}
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		const START, END = 100, 0
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newFloatArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		var got []int64
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got = append(got, ar.Timestamps...)
+			ar = cur.Next()
+		}
+
+		if exp := []int64{51, 46, 44, 40, 21}; !cmp.Equal(got, exp) {
+			t.Errorf("unexpected values; -got/+exp\n%s", cmp.Diff(got, exp))
+		}
+	})
+}
+
+// Int64Slice attaches the methods of Interface to []int64, sorting in increasing order.
+type Int64Slice []int64
+
+func (p Int64Slice) Len() int           { return len(p) }
+func (p Int64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// Verifies the array cursors correctly handle merged blocks from KeyCursor which may exceed the
+// array cursor's local values buffer, which is initialized to MaxPointsPerBlock elements (1000)
+//
+// This test creates two TSM files which have a single block each. The second file
+// has interleaving timestamps with the first file.
+//
+// The first file has a block of 800 timestamps starting at 1000 an increasing by 10ns
+// The second file has a block of 400 timestamps starting at 1005, also increasing by 10ns
+//
+// When calling `nextTSM`, a single block of 1200 timestamps will be returned and the
+// array cursor must chuck the values in the Next call.
+func TestFileStore_MergeBlocksLargerThat1000_SecondEntirelyContained(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := NewFileStore(dir)
+
+	// makeVals creates count points starting at ts and incrementing by step
+	makeVals := func(ts, count, step int64) []Value {
+		vals := make([]Value, count)
+		for i := range vals {
+			vals[i] = NewFloatValue(ts, 1.01)
+			ts += step
+		}
+		return vals
+	}
+
+	makeTs := func(ts, count, step int64) []int64 {
+		vals := make([]int64, count)
+		for i := range vals {
+			vals[i] = ts
+			ts += step
+		}
+		return vals
+	}
+
+	// Setup 2 files with the second containing a single block that is completely within the first
+	data := []keyValues{
+		{"m,_field=v#!~#v", makeVals(1000, 800, 10)},
+		{"m,_field=v#!~#v", makeVals(1005, 400, 10)},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	_ = fs.Replace(nil, files)
+
+	t.Run("ascending", func(t *testing.T) {
+		const START, END = 1000, 10000
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, true)
+		defer kc.Close()
+		cur := newFloatArrayAscendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeTs(1000, 800, 10)
+		exp = append(exp, makeTs(1005, 400, 10)...)
+		sort.Sort(Int64Slice(exp))
+
+		// check first block
+		ar := cur.Next()
+		assert.Len(t, ar.Timestamps, 1000)
+		assert.Equal(t, exp[:1000], ar.Timestamps)
+
+		// check second block
+		exp = exp[1000:]
+		ar = cur.Next()
+		assert.Len(t, ar.Timestamps, 200)
+		assert.Equal(t, exp, ar.Timestamps)
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		const START, END = 10000, 0
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newFloatArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeTs(1000, 800, 10)
+		exp = append(exp, makeTs(1005, 400, 10)...)
+		sort.Sort(sort.Reverse(Int64Slice(exp)))
+
+		// check first block
+		ar := cur.Next()
+		assert.Len(t, ar.Timestamps, 1000)
+		assert.Equal(t, exp[:1000], ar.Timestamps)
+
+		// check second block
+		exp = exp[1000:]
+		ar = cur.Next()
+		assert.Len(t, ar.Timestamps, 200)
+		assert.Equal(t, exp, ar.Timestamps)
+	})
+}
+
+// FloatArray attaches the methods of sort.Interface to *tsdb.FloatArray, sorting in increasing order.
+type FloatArray struct {
+	*cursors.FloatArray
+}
+
+func (a *FloatArray) Less(i, j int) bool { return a.Timestamps[i] < a.Timestamps[j] }
+func (a *FloatArray) Swap(i, j int) {
+	a.Timestamps[i], a.Timestamps[j] = a.Timestamps[j], a.Timestamps[i]
+	a.Values[i], a.Values[j] = a.Values[j], a.Values[i]
+}
+
+// Verifies the array cursors correctly handle merged blocks from KeyCursor which may exceed the
+// array cursor's local values buffer, which is initialized to MaxPointsPerBlock elements (1000)
+//
+// This test creates two TSM files with a significant number of interleaved points in addition
+// to a significant number of points in the second file which replace values in the first.
+// To verify intersecting data from the second file replaces the first, the values differ,
+// so the enumerated results can be compared with the expected output.
+func TestFileStore_MergeBlocksLargerThat1000_MultipleBlocksInEachFile(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := NewFileStore(dir)
+
+	// makeVals creates count points starting at ts and incrementing by step
+	makeVals := func(ts, count, step int64, v float64) []Value {
+		vals := make([]Value, count)
+		for i := range vals {
+			vals[i] = NewFloatValue(ts, v)
+			ts += step
+		}
+		return vals
+	}
+
+	makeArray := func(ts, count, step int64, v float64) *cursors.FloatArray {
+		ar := cursors.NewFloatArrayLen(int(count))
+		for i := range ar.Timestamps {
+			ar.Timestamps[i] = ts
+			ar.Values[i] = v
+			ts += step
+		}
+		return ar
+	}
+
+	// Setup 2 files with partially overlapping blocks and the second file replaces some elements of the first
+	data := []keyValues{
+		{"m,_field=v#!~#v", makeVals(1000, 3500, 10, 1.01)},
+		{"m,_field=v#!~#v", makeVals(4005, 3500, 5, 2.01)},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	_ = fs.Replace(nil, files)
+
+	t.Run("ascending", func(t *testing.T) {
+		const START, END = 1000, 1e9
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, true)
+		defer kc.Close()
+		cur := newFloatArrayAscendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1000, 3500, 10, 1.01)
+		a2 := makeArray(4005, 3500, 5, 2.01)
+		exp.Merge(a2)
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		const START, END = 1e9, 0
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newFloatArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1000, 3500, 10, 1.01)
+		a2 := makeArray(4005, 3500, 5, 2.01)
+		exp.Merge(a2)
+		sort.Sort(sort.Reverse(&FloatArray{exp}))
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+}
+
+func TestFileStore_SeekBoundaries(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := NewFileStore(dir)
+
+	// makeVals creates count points starting at ts and incrementing by step
+	makeVals := func(ts, count, step int64, v float64) []Value {
+		vals := make([]Value, count)
+		for i := range vals {
+			vals[i] = NewFloatValue(ts, v)
+			ts += step
+		}
+		return vals
+	}
+
+	makeArray := func(ts, count, step int64, v float64) *cursors.FloatArray {
+		ar := cursors.NewFloatArrayLen(int(count))
+		for i := range ar.Timestamps {
+			ar.Timestamps[i] = ts
+			ar.Values[i] = v
+			ts += step
+		}
+		return ar
+	}
+
+	// Setup 2 files where the seek time matches the end time.
+	data := []keyValues{
+		{"m,_field=v#!~#v", makeVals(1000, 100, 1, 1.01)},
+		{"m,_field=v#!~#v", makeVals(1100, 100, 1, 2.01)},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %s", err)
+	}
+
+	_ = fs.Replace(nil, files)
+
+	t.Run("ascending full", func(t *testing.T) {
+		const START, END = 1000, 1099
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, true)
+		defer kc.Close()
+		cur := newFloatArrayAscendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1000, 100, 1, 1.01)
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+
+	t.Run("ascending split", func(t *testing.T) {
+		const START, END = 1050, 1149
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, true)
+		defer kc.Close()
+		cur := newFloatArrayAscendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1050, 50, 1, 1.01)
+		a2 := makeArray(1100, 50, 1, 2.01)
+		exp.Merge(a2)
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+
+	t.Run("descending full", func(t *testing.T) {
+		const START, END = 1099, 1000
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newFloatArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1000, 100, 1, 1.01)
+		sort.Sort(sort.Reverse(&FloatArray{exp}))
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+
+	t.Run("descending split", func(t *testing.T) {
+		const START, END = 1149, 1050
+		kc := fs.KeyCursor(context.Background(), []byte("m,_field=v#!~#v"), START, false)
+		defer kc.Close()
+		cur := newFloatArrayDescendingCursor()
+		cur.reset(START, END, nil, kc)
+
+		exp := makeArray(1050, 50, 1, 1.01)
+		a2 := makeArray(1100, 50, 1, 2.01)
+		exp.Merge(a2)
+		sort.Sort(sort.Reverse(&FloatArray{exp}))
+
+		got := cursors.NewFloatArrayLen(exp.Len())
+		got.Timestamps = got.Timestamps[:0]
+		got.Values = got.Values[:0]
+
+		ar := cur.Next()
+		for ar.Len() > 0 {
+			got.Timestamps = append(got.Timestamps, ar.Timestamps...)
+			got.Values = append(got.Values, ar.Values...)
+			ar = cur.Next()
+		}
+
+		assert.Len(t, got.Timestamps, exp.Len())
+		assert.Equal(t, exp.Timestamps, got.Timestamps)
+		assert.Equal(t, exp.Values, got.Values)
+	})
+}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1952,7 +1952,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 				Field:     "value",
 				Ascending: true,
 				StartTime: 2,
-				EndTime:   12,
+				EndTime:   11,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -2012,7 +2012,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 				Field:     "value",
 				Ascending: false,
 				StartTime: 1,
-				EndTime:   11,
+				EndTime:   10,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -2021,11 +2021,11 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 
 			fcur := cur.(tsdb.FloatArrayCursor)
 			a := fcur.Next()
-			if !cmp.Equal([]int64{11, 10, 3, 2}, a.Timestamps) {
-				t.Fatal("unexpect timestamps")
+			if !cmp.Equal([]int64{10, 3, 2, 1}, a.Timestamps) {
+				t.Fatalf("unexpect timestamps %v", a.Timestamps)
 			}
-			if !cmp.Equal([]float64{11.2, 10.1, 1.3, 1.2}, a.Values) {
-				t.Fatal("unexpect timestamps")
+			if !cmp.Equal([]float64{10.1, 1.3, 1.2, 1.1}, a.Values) {
+				t.Fatal("unexpect values")
 			}
 		})
 	}


### PR DESCRIPTION
* fix: backport tsdb fix for window pushdowns

From https://github.com/influxdata/influxdb/pull/19855

* fix(storage): cursor requests are [start, stop] instead of [start, stop)

The cursors were previously [start, stop) to be consistent with how flux
requests data, but the underlying storage file store was [start, stop]
because that's how influxql read data. This reverts back the cursor
behavior so that it is now [start, stop] everywhere and the conversion
from [start, stop) to [start, stop] is performed when doing the cursor
request to get the next cursor.

cherry-pick from #21318

Co-authored-by: Sam Arnold <sarnold@influxdata.com>
(cherry picked from commit 776667279733519972dbc27fe559c1d8ffd5864a)

* chore: fix formatting

Co-authored-by: Jonathan A. Sternberg <jonathan@influxdata.com>
(cherry picked from commit 8edf7a4e2f9b048178338580af15916e15c0afdd)

Partial close of #21337

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
