### PR TITLE
fix(storage): cursor requests are [start, stop] instead of [start, stop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v2.0.7 [unreleased]
 ----------------------
 
+### Bug Fixes
+
+1. [21348](https://github.com/influxdata/influxdb/pull/21348): Fix off-by-one error in query range calculation over partially compacted data.
+
 ## v2.0.6 [2021-04-29]
 ----------------------
 

--- a/storage/reads/array_cursor.go
+++ b/storage/reads/array_cursor.go
@@ -71,13 +71,19 @@ type multiShardArrayCursors struct {
 	}
 }
 
+// newMultiShardArrayCursors is a factory for creating cursors for each series key.
+// The range of the cursor is [start, end). The start time is the lower absolute time
+// and the end time is the higher absolute time regardless of ascending or descending order.
 func newMultiShardArrayCursors(ctx context.Context, start, end int64, asc bool) *multiShardArrayCursors {
+	// When we construct the CursorRequest, we translate the time range
+	// from [start, stop) to [start, stop]. The cursor readers from storage are
+	// inclusive on both ends and we perform that conversion here.
 	m := &multiShardArrayCursors{
 		ctx: ctx,
 		req: cursors.CursorRequest{
 			Ascending: asc,
 			StartTime: start,
-			EndTime:   end,
+			EndTime:   end - 1,
 		},
 	}
 

--- a/storage/reads/resultset.go
+++ b/storage/reads/resultset.go
@@ -18,6 +18,10 @@ type resultSet struct {
 	arrayCursors multiShardCursors
 }
 
+// TODO(jsternberg): The range is [start, end) for this function which is consistent
+// with the documented interface for datatypes.ReadFilterRequest. This function should
+// be refactored to take in a datatypes.ReadFilterRequest similar to the other
+// ResultSet functions.
 func NewFilteredResultSet(ctx context.Context, start, end int64, seriesCursor SeriesCursor) ResultSet {
 	return &resultSet{
 		ctx:          ctx,

--- a/storage/reads/resultset_test.go
+++ b/storage/reads/resultset_test.go
@@ -1,0 +1,42 @@
+package reads_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2/storage/reads"
+	"github.com/influxdata/influxdb/v2/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/v2/tsdb/cursors"
+)
+
+func TestNewFilteredResultSet_TimeRange(t *testing.T) {
+	newCursor := newMockReadCursor(
+		"clicks click=1 1",
+	)
+	for i := range newCursor.rows {
+		newCursor.rows[0].Query[i] = &mockCursorIterator{
+			newCursorFn: func(req *cursors.CursorRequest) cursors.Cursor {
+				if want, got := int64(0), req.StartTime; want != got {
+					t.Errorf("unexpected start time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				if want, got := int64(29), req.EndTime; want != got {
+					t.Errorf("unexpected end time -want/+got:\n\t- %d\n\t+ %d", want, got)
+				}
+				return &mockIntegerArrayCursor{}
+			},
+		}
+	}
+
+	ctx := context.Background()
+	req := datatypes.ReadFilterRequest{
+		Range: datatypes.TimestampRange{
+			Start: 0,
+			End:   30,
+		},
+	}
+
+	resultSet := reads.NewFilteredResultSet(ctx, req.Range.Start, req.Range.End, &newCursor)
+	if !resultSet.Next() {
+		t.Fatal("expected result")
+	}
+}

--- a/tsdb/cursors/cursor.go
+++ b/tsdb/cursors/cursor.go
@@ -39,13 +39,32 @@ type BooleanArrayCursor interface {
 	Next() *BooleanArray
 }
 
+// CursorRequest is a request to the storage engine for a cursor to be
+// created with the given name, tags, and field for a given direction
+// and time range.
 type CursorRequest struct {
-	Name      []byte
-	Tags      models.Tags
-	Field     string
+	// Name is the measurement name a cursor is requested for.
+	Name []byte
+
+	// Tags is the set of series tags a cursor is requested for.
+	Tags models.Tags
+
+	// Field is the selected field for the cursor that is requested.
+	Field string
+
+	// Ascending is whether the cursor should move in an ascending
+	// or descending time order.
 	Ascending bool
+
+	// StartTime is the start time of the cursor. It is the lower
+	// absolute time regardless of the Ascending flag. This value
+	// is an inclusive bound.
 	StartTime int64
-	EndTime   int64
+
+	// EndTime is the end time of the cursor. It is the higher
+	// absolute time regardless of the Ascending flag. This value
+	// is an inclusive bound.
+	EndTime int64
 }
 
 type CursorIterator interface {

--- a/tsdb/engine/tsm1/array_cursor.gen.go
+++ b/tsdb/engine/tsm1/array_cursor.gen.go
@@ -135,9 +135,10 @@ func (c *floatArrayAscendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -182,17 +183,20 @@ func newFloatArrayDescendingCursor() *floatArrayDescendingCursor {
 }
 
 func (c *floatArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -270,6 +274,7 @@ func (c *floatArrayDescendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {
@@ -412,9 +417,10 @@ func (c *integerArrayAscendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -459,17 +465,20 @@ func newIntegerArrayDescendingCursor() *integerArrayDescendingCursor {
 }
 
 func (c *integerArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -547,6 +556,7 @@ func (c *integerArrayDescendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {
@@ -689,9 +699,10 @@ func (c *unsignedArrayAscendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -736,17 +747,20 @@ func newUnsignedArrayDescendingCursor() *unsignedArrayDescendingCursor {
 }
 
 func (c *unsignedArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -824,6 +838,7 @@ func (c *unsignedArrayDescendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {
@@ -966,9 +981,10 @@ func (c *stringArrayAscendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -1013,17 +1029,20 @@ func newStringArrayDescendingCursor() *stringArrayDescendingCursor {
 }
 
 func (c *stringArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -1101,6 +1120,7 @@ func (c *stringArrayDescendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {
@@ -1243,9 +1263,10 @@ func (c *booleanArrayAscendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -1290,17 +1311,20 @@ func newBooleanArrayDescendingCursor() *booleanArrayDescendingCursor {
 }
 
 func (c *booleanArrayDescendingCursor) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -1378,6 +1402,7 @@ func (c *booleanArrayDescendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {

--- a/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
+++ b/tsdb/engine/tsm1/array_cursor.gen.go.tmpl
@@ -134,9 +134,10 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
+	// Strip timestamps from after the end time.
+	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
+		for pos >= 0 && c.res.Timestamps[pos] > c.end {
 			pos--
 		}
 		pos++
@@ -184,17 +185,20 @@ func new{{$Type}}() *{{$type}} {
 }
 
 func (c *{{$type}}) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
+	// Search for the time value greater than the seek time (not included)
+	// and then move our position back one which will include the values in
+	// our time range.
 	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
+		return c.cache.values[i].UnixNano() > seek
 	})
 	c.cache.pos--
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}ArrayBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(c.tsm.values.Len(), func(i int) bool {
-		return c.tsm.values.Timestamps[i] >= seek
+		return c.tsm.values.Timestamps[i] > seek
 	})
 	c.tsm.pos--
 }
@@ -272,6 +276,7 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
+	// Strip timestamps from before the end time.
 	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
 		pos -= 2
 		for pos >= 0 && c.res.Timestamps[pos] < c.end {

--- a/tsdb/engine/tsm1/array_cursor_iterator.go
+++ b/tsdb/engine/tsm1/array_cursor_iterator.go
@@ -57,7 +57,7 @@ func (q *arrayCursorIterator) Next(ctx context.Context, r *tsdb.CursorRequest) (
 	var opt query.IteratorOptions
 	opt.Ascending = r.Ascending
 	opt.StartTime = r.StartTime
-	opt.EndTime = r.EndTime
+	opt.EndTime = r.EndTime // inclusive
 
 	// Return appropriate cursor based on type.
 	switch f.Type {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1944,7 +1944,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 				Field:     "value",
 				Ascending: true,
 				StartTime: 2,
-				EndTime:   12,
+				EndTime:   11,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -2004,7 +2004,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 				Field:     "value",
 				Ascending: false,
 				StartTime: 1,
-				EndTime:   11,
+				EndTime:   10,
 			})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Backports #21318

Original description: 
> The cursors were previously [start, stop) to be consistent with how flux requests data, but the underlying storage file store was [start, stop] because that's how influxql read data. This reverts back the cursor behavior so that it is now [start, stop] everywhere and the conversion from [start, stop) to [start, stop] is performed when doing the cursor request to get the next cursor.