### PR TITLE
feat(users): list users via the API now supports `offset`, `limit` or `after` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots.
-1. [21367](https://github.com/influxdata/influxdb/pull/21367): List users via the API now supports `offset`, `limit` or `after` parameter.
+1. [21367](https://github.com/influxdata/influxdb/pull/21367): List users via the API now supports pagination
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots.
+1. [21367](https://github.com/influxdata/influxdb/pull/21367): List users via the API now supports `offset`, `limit` or `after` parameter.
 
 ### Bug Fixes
 

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -388,7 +388,7 @@ func (h *UserHandler) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	users, _, err := h.UserService.FindUsers(ctx, req.filter)
+	users, _, err := h.UserService.FindUsers(ctx, req.filter, req.opts)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
@@ -404,11 +404,19 @@ func (h *UserHandler) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 
 type getUsersRequest struct {
 	filter influxdb.UserFilter
+	opts   influxdb.FindOptions
 }
 
 func decodeGetUsersRequest(ctx context.Context, r *http.Request) (*getUsersRequest, error) {
+	opts, err := influxdb.DecodeFindOptions(r)
+	if err != nil {
+		return nil, err
+	}
+
 	qp := r.URL.Query()
-	req := &getUsersRequest{}
+	req := &getUsersRequest{
+		opts: *opts,
+	}
 
 	if userID := qp.Get("id"); userID != "" {
 		id, err := platform.IDFromString(userID)

--- a/tenant/http_server_user.go
+++ b/tenant/http_server_user.go
@@ -409,7 +409,7 @@ func (h *UserHandler) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	users, _, err := h.userSvc.FindUsers(ctx, req.filter)
+	users, _, err := h.userSvc.FindUsers(ctx, req.filter, req.opts)
 	if err != nil {
 		h.api.Err(w, r, err)
 		return
@@ -421,11 +421,19 @@ func (h *UserHandler) handleGetUsers(w http.ResponseWriter, r *http.Request) {
 
 type getUsersRequest struct {
 	filter influxdb.UserFilter
+	opts   influxdb.FindOptions
 }
 
 func decodeGetUsersRequest(ctx context.Context, r *http.Request) (*getUsersRequest, error) {
+	opts, err := influxdb.DecodeFindOptions(r)
+	if err != nil {
+		return nil, err
+	}
+
 	qp := r.URL.Query()
-	req := &getUsersRequest{}
+	req := &getUsersRequest{
+		opts: *opts,
+	}
 
 	if userID := qp.Get("id"); userID != "" {
 		id, err := platform.IDFromString(userID)

--- a/tenant/storage_user.go
+++ b/tenant/storage_user.go
@@ -119,7 +119,21 @@ func (s *Store) ListUsers(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOpt
 		return nil, err
 	}
 
-	cursor, err := b.ForwardCursor(nil)
+	var opts []kv.CursorOption
+	if o.Descending {
+		opts = append(opts, kv.WithCursorDirection(kv.CursorDescending))
+	}
+
+	var seek []byte
+	if o.After != nil {
+		after := (*o.After) + 1
+		seek, err = after.Encode()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cursor, err := b.ForwardCursor(seek, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #21402
Related to https://github.com/influxdata/influxdb-client-csharp/issues/190

List users via the API now supports `offset`, `limit` or `after` parameter

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
