### PR TITLE
chore(ae): add more logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v1.8.6 [unreleased]
 -------------------
 
 -	[#21290](https://github.com/influxdata/influxdb/pull/21290): fix: Anti-Entropy loops endlessly with empty shard
+-	[#21381](https://github.com/influxdata/influxdb/pull/21381): chore(ae): add more logging
 
 v1.8.5 [2021-04-19]
 -------------------

--- a/flux/control/controller_test.go
+++ b/flux/control/controller_test.go
@@ -24,6 +24,8 @@ func TestController_Query(t *testing.T) {
 		compiler := &mock.Compiler{
 			Type: "mock",
 			CompileFn: func(ctx context.Context) (flux.Program, error) {
+				// On fast machines, compilation can be faster than clock granularity
+				// causing the compile duration test below to fail
 				time.Sleep(time.Second)
 				return &mock.Program{
 					StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {

--- a/flux/control/controller_test.go
+++ b/flux/control/controller_test.go
@@ -24,12 +24,7 @@ func TestController_Query(t *testing.T) {
 		compiler := &mock.Compiler{
 			Type: "mock",
 			CompileFn: func(ctx context.Context) (flux.Program, error) {
-				const pd = "1s"
-				d, err := time.ParseDuration(pd)
-				if err != nil {
-					return nil, err
-				}
-				time.Sleep(d)
+				time.Sleep(time.Second)
 				return &mock.Program{
 					StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {
 						ch := make(chan flux.Result)

--- a/flux/control/controller_test.go
+++ b/flux/control/controller_test.go
@@ -3,6 +3,7 @@ package control_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/memory"
@@ -23,6 +24,12 @@ func TestController_Query(t *testing.T) {
 		compiler := &mock.Compiler{
 			Type: "mock",
 			CompileFn: func(ctx context.Context) (flux.Program, error) {
+				const pd = "1s"
+				d, err := time.ParseDuration(pd)
+				if err != nil {
+					return nil, err
+				}
+				time.Sleep(d)
 				return &mock.Program{
 					StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {
 						ch := make(chan flux.Result)

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -78,7 +78,7 @@ type Engine interface {
 	Statistics(tags map[string]string) []models.Statistic
 	LastModified() time.Time
 	DiskSize() int64
-	IsIdle() bool
+	IsIdle(isLogged bool) bool
 	Free() error
 
 	io.WriterTo

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -78,7 +78,7 @@ type Engine interface {
 	Statistics(tags map[string]string) []models.Statistic
 	LastModified() time.Time
 	DiskSize() int64
-	IsIdle(isLogged bool) bool
+	IsIdle() (bool, string)
 	Free() error
 
 	io.WriterTo

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -886,19 +886,53 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
 	return nil
 }
 
-// IsIdle returns true if the cache is empty, there are no running compactions and the
-// shard is fully compacted.
-func (e *Engine) IsIdle() bool {
+func (e *Engine) IsIdle(isLogged bool) bool {
+	return e.loggedIsIdle(isLogged)
+}
+
+const logMsg = "IsIdle false because nonzero"
+
+// loggedIsIdle returns true if the cache is empty, there are no running compactions and the
+// shard is fully compacted.  If trace logging is enabled, it logs the reasons why an engine
+// is busy
+func (e *Engine) loggedIsIdle(isLogged bool) bool {
+	const cacheCompactions = "Cache Compactions: "
+	const levelZeroCompactions = "Level Zero Compactions: "
+	const levelOneCompactions = "Level One Compactions: "
+	const levelTwoCompactions = "Level Two Compactions: "
+	const fullCompactions = "Full Compactions: "
+	const optimizeCompactions = "TSM Optimization Compactions: "
+	var log *zap.Logger
+
+	if isLogged {
+		log = e.traceLogger.With(zap.Uint64("ShardId", e.id), zap.String("path", e.path))
+	}
+
 	cacheEmpty := e.Cache.Size() == 0
+	if !cacheEmpty && log != nil {
+		log.Info(logMsg, zap.Uint64("Cache size", e.Cache.Size()))
+	}
 
-	runningCompactions := atomic.LoadInt64(&e.stats.CacheCompactionsActive)
-	runningCompactions += atomic.LoadInt64(&e.stats.TSMCompactionsActive[0])
-	runningCompactions += atomic.LoadInt64(&e.stats.TSMCompactionsActive[1])
-	runningCompactions += atomic.LoadInt64(&e.stats.TSMCompactionsActive[2])
-	runningCompactions += atomic.LoadInt64(&e.stats.TSMFullCompactionsActive)
-	runningCompactions += atomic.LoadInt64(&e.stats.TSMOptimizeCompactionsActive)
+	runningCompactions := logCheckForCompactions(log, &e.stats.CacheCompactionsActive, cacheCompactions)
+	runningCompactions += logCheckForCompactions(log, &e.stats.TSMCompactionsActive[0], levelZeroCompactions)
+	runningCompactions += logCheckForCompactions(log, &e.stats.TSMCompactionsActive[1], levelOneCompactions)
+	runningCompactions += logCheckForCompactions(log, &e.stats.TSMCompactionsActive[2], levelTwoCompactions)
+	runningCompactions += logCheckForCompactions(log, &e.stats.TSMFullCompactionsActive, fullCompactions)
+	runningCompactions += logCheckForCompactions(log, &e.stats.TSMOptimizeCompactionsActive, optimizeCompactions)
+	fullyCompacted := e.CompactionPlan.FullyCompacted()
+	if !fullyCompacted && log != nil {
+		log.Info("IsIdle false because", zap.Bool("FullyCompacted", fullyCompacted))
+	}
 
-	return cacheEmpty && runningCompactions == 0 && e.CompactionPlan.FullyCompacted()
+	return cacheEmpty && runningCompactions == 0 && fullyCompacted
+}
+
+func logCheckForCompactions(log *zap.Logger, counter *int64, fieldName string) int64 {
+	count := atomic.LoadInt64(counter)
+	if count > 0 && log != nil {
+		log.Info(logMsg, zap.Int64(fieldName, count))
+	}
+	return count
 }
 
 // Free releases any resources held by the engine to free up memory or CPU.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -452,7 +452,16 @@ func (s *Shard) IsIdle() bool {
 	if err != nil {
 		return true
 	}
-	return engine.IsIdle()
+	return engine.IsIdle(false)
+}
+
+// IsIdle return true if the shard is not receiving writes and is fully compacted.
+func (s *Shard) LoggedIsIdle() bool {
+	engine, err := s.Engine()
+	if err != nil {
+		return true
+	}
+	return engine.IsIdle(true)
 }
 
 func (s *Shard) Free() error {
@@ -1200,7 +1209,7 @@ func (s *Shard) TagKeyCardinality(name, key []byte) int {
 }
 
 // Digest returns a digest of the shard.
-func (s *Shard) Digest() (io.ReadCloser, int64, error) {
+func (s *Shard) Digest(isLogged bool) (io.ReadCloser, int64, error) {
 	engine, err := s.Engine()
 	if err != nil {
 		return nil, 0, err
@@ -1208,7 +1217,7 @@ func (s *Shard) Digest() (io.ReadCloser, int64, error) {
 
 	// Make sure the shard is idle/cold. (No use creating a digest of a
 	// hot shard that is rapidly changing.)
-	if !engine.IsIdle() {
+	if !engine.IsIdle(isLogged) {
 		return nil, 0, ErrShardNotIdle
 	}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1208,7 +1208,7 @@ func (s *Shard) Digest() (io.ReadCloser, int64, error, string) {
 
 	// Make sure the shard is idle/cold. (No use creating a digest of a
 	// hot shard that is rapidly changing.)
-	if state, reason := engine.IsIdle(); !state {
+	if isIdle, reason := engine.IsIdle(); !isIdle {
 		return nil, 0, ErrShardNotIdle, reason
 	}
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -593,7 +593,7 @@ func (s *Store) ShardDigest(id uint64) (io.ReadCloser, int64, error) {
 		return nil, 0, ErrShardNotFound
 	}
 
-	return sh.Digest()
+	return sh.Digest(false)
 }
 
 // CreateShard creates a shard with the given id and retention policy on a database.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -445,7 +445,7 @@ func (s *Store) loadShards() error {
 	// Enable all shards
 	for _, sh := range s.shards {
 		sh.SetEnabled(true)
-		if sh.IsIdle() {
+		if isIdle, _ := sh.IsIdle(); isIdle {
 			if err := sh.Free(); err != nil {
 				return err
 			}
@@ -593,7 +593,8 @@ func (s *Store) ShardDigest(id uint64) (io.ReadCloser, int64, error) {
 		return nil, 0, ErrShardNotFound
 	}
 
-	return sh.Digest(false)
+	readCloser, size, err, _ := sh.Digest()
+	return readCloser, size, err
 }
 
 // CreateShard creates a shard with the given id and retention policy on a database.
@@ -1445,7 +1446,7 @@ func (s *Store) WriteToShardWithContext(ctx context.Context, shardID uint64, poi
 
 	// Ensure snapshot compactions are enabled since the shard might have been cold
 	// and disabled by the monitor.
-	if sh.IsIdle() {
+	if isIdle, _ := sh.IsIdle(); isIdle {
 		sh.SetCompactionsEnabled(true)
 	}
 
@@ -1986,7 +1987,7 @@ func (s *Store) monitorShards() {
 		case <-t.C:
 			s.mu.RLock()
 			for _, sh := range s.shards {
-				if sh.IsIdle() {
+				if isIdle, _ := sh.IsIdle(); isIdle {
 					if err := sh.Free(); err != nil {
 						s.Logger.Warn("Error while freeing cold shard resources",
 							zap.Error(err),


### PR DESCRIPTION
tsdb.Engine.IsIdle and tsdb.Engine.Digest now return a reason string for why the engine & shard are not idle.
Callers can then use this string for logging, if desired.  The returned reason does not allocate memory, so the 
caller may want to add the shard ID and path for more information in the log. This is intended to be used in 
calls from the anti-entropy service in Enterprise.

Closes https://github.com/influxdata/influxdb/issues/21380
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
