### PR TITLE
feat: enable script editor cursor at eof flag

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -141,7 +141,7 @@
 - name: Default Monaco Selection to EOF
   description: Positions the cursor at the end of the line(s) when using the monaco editor
   key: cursorAtEOF
-  default: false
+  default: true
   contact: Monitoring Team
   expose: true
   lifetime: temporary

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -244,7 +244,7 @@ var cursorAtEOF = MakeBoolFlag(
 	"Default Monaco Selection to EOF",
 	"cursorAtEOF",
 	"Monitoring Team",
-	false,
+	true,
 	Temporary,
 	true,
 )


### PR DESCRIPTION
Closes #21164

Turns on the final feature flag from #21164, which is to have the cursor appear at the end of the editor file when using the monaco script editor.