### PR TITLE
build: update circle config to exit from forks on build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ workflows:
           requires:
             - godeps
       - e2e-monitor-ci:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
           requires:
             - build
       - grace_daily:
@@ -611,8 +614,6 @@ jobs:
     docker:
       - image: cimg/go:1.15.6
     steps:
-      # if we are running from a fork, exit with a fail status.
-      - bail_if_forked
       - checkout
       - run:
           name: Run the tests


### PR DESCRIPTION
Closes #21455

Fixed the config logic to exit gracefully from a job if running on a fork.

I tested that this works as expected by forking `influxdb` and opening a PR against this branch. The `build` step works as expected - exiting the job with a success status prior to trying to build & push the docker candidate image. It then fails the `e2e-monitor-ci` step as expected.