### PR TITLE
fix(cmd/influx): accept `--input` flag in `restore` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 1. [21369](https://github.com/influxdata/influxdb/pull/21369): Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages.
 1. [21375](https://github.com/influxdata/influxdb/pull/21375): Add logging to NATS streaming server to help debug startup failures.
 1. [21477](https://github.com/influxdata/influxdb/pull/21477): Accept `--input` instead of a positional arg in `influx restore`.
-1. [21477](https://github.com/influxdata/influxdb/pull/21477): Avoid panic when `influx restore` is passed a nonexistent backup directory.
+1. [21477](https://github.com/influxdata/influxdb/pull/21477): Print error instead of panicking when `influx restore` fails to find backup manifests.
 
 ## v2.0.6 [2021-04-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 1. [21356](https://github.com/influxdata/influxdb/pull/21356): Disable MergeFiltersRule until it is more stable.
 1. [21369](https://github.com/influxdata/influxdb/pull/21369): Add limits to the `/api/v2/delete` endpoint for start and stop times with error messages.
 1. [21375](https://github.com/influxdata/influxdb/pull/21375): Add logging to NATS streaming server to help debug startup failures.
+1. [21477](https://github.com/influxdata/influxdb/pull/21477): Accept `--input` instead of a positional arg in `influx restore`.
+1. [21477](https://github.com/influxdata/influxdb/pull/21477): Avoid panic when `influx restore` is passed a nonexistent backup directory.
 
 ## v2.0.6 [2021-04-29]
 

--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -46,13 +47,22 @@ func (b *cmdRestoreBuilder) cmdRestore() *cobra.Command {
 	cmd.Flags().StringVarP(&b.bucketName, "bucket", "b", "", "The name of the bucket to restore")
 	cmd.Flags().StringVar(&b.newBucketName, "new-bucket", "", "The name of the bucket to restore to")
 	cmd.Flags().StringVar(&b.newOrgName, "new-org", "", "The name of the organization to restore to")
-	cmd.Flags().StringVar(&b.path, "input", "", "Local backup data path (required)")
+	cmd.Flags().StringVar(&b.path, "input", "", "Local backup data path")
+	cmd.Flags().MarkDeprecated("input", "pass backup data path as a positional argument instead")
 	cmd.Use = "restore [flags] path"
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
+		// Legacy: path set by --input flag.
+		if b.path != "" {
+			if len(args) != 0 {
+				return errors.New("cannot specify backup directory using both --input and a positional argument")
+			}
+			return nil
+		}
+
 		if len(args) == 0 {
-			return fmt.Errorf("must specify path to backup directory")
+			return errors.New("must specify path to backup directory")
 		} else if len(args) > 1 {
-			return fmt.Errorf("too many args specified")
+			return errors.New("only one backup directory can be specified at a time")
 		}
 		b.path = args[0]
 		return nil

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -74,6 +74,11 @@ func RunRestore(ctx context.Context, req Request, svcs Services, log *zap.Logger
 	if err := runner.loadManifests(req.Path); err != nil {
 		return err
 	}
+	// Bail out early if no manifests were found.
+	// TODO: Should this be an error?
+	if runner.kvManifest == nil {
+		return nil
+	}
 
 	if req.Full {
 		return runner.fullRestore(ctx, req)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -74,11 +74,6 @@ func RunRestore(ctx context.Context, req Request, svcs Services, log *zap.Logger
 	if err := runner.loadManifests(req.Path); err != nil {
 		return err
 	}
-	// Bail out early if no manifests were found.
-	// TODO: Should this be an error?
-	if runner.kvManifest == nil {
-		return nil
-	}
 
 	if req.Full {
 		return runner.fullRestore(ctx, req)
@@ -92,7 +87,7 @@ func (r *restoreRunner) loadManifests(path string) error {
 	if err != nil {
 		return fmt.Errorf("failed to find backup manifests at %q: %w", path, err)
 	} else if len(manifests) == 0 {
-		return nil
+		return fmt.Errorf("no backup manifests found at %q", path)
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(manifests)))
 


### PR DESCRIPTION
Closes #21475

`--input` has been effectively useless up until now, but all of the examples in our public docs show using it instead of the positional arg.

I chose to deprecate `--input` instead of the arg because `influx backup` uses a positional arg to specify the path where backup data should be stored, and it felt intuitive to have symmetry between the two.