### PR TITLE
fix: add telemetry slug for additional file exts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [21477](https://github.com/influxdata/influxdb/pull/21477): Print error instead of panicking when `influx restore` fails to find backup manifests.
 1. [21481](https://github.com/influxdata/influxdb/pull/21481): Set last-modified time of empty shard directory to the directory's mod time instead of Unix epoch.
 1. [21486](https://github.com/influxdata/influxdb/pull/21486): chore: remove erroneous dependency on istio
+1. [21522](https://github.com/influxdata/influxdb/pull/21522): Replace telemetry file name with slug `ttf`, `woff`, and `eot` files.
 
 ## v2.0.6 [2021-04-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 1. [21477](https://github.com/influxdata/influxdb/pull/21477): Print error instead of panicking when `influx restore` fails to find backup manifests.
 1. [21481](https://github.com/influxdata/influxdb/pull/21481): Set last-modified time of empty shard directory to the directory's mod time instead of Unix epoch.
 1. [21486](https://github.com/influxdata/influxdb/pull/21486): chore: remove erroneous dependency on istio
-1. [21522](https://github.com/influxdata/influxdb/pull/21522): Replace telemetry file name with slug `ttf`, `woff`, and `eot` files.
+1. [21522](https://github.com/influxdata/influxdb/pull/21522): Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files.
 
 ## v2.0.6 [2021-04-29]
 

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -164,6 +164,9 @@ func normalizeAssetFile(f string) string {
 		".wasm",
 		".map",
 		".LICENSE",
+		".ttf",
+		".woff",
+		".eot",
 	}
 
 	for _, ext := range exts {

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -67,6 +67,21 @@ func Test_normalizePath(t *testing.T) {
 			path:     "/api/v2/backup/shards/1005/extra",
 			expected: path.Join("/api/v2/backup/shards/", shardSlug, "extra"),
 		},
+		{
+			name:     "11",
+			path:     "/35bb8d560d.ttf",
+			expected: "/" + fileSlug + ".ttf",
+		},
+		{
+			name:     "12",
+			path:     "/35bb8d560d.woff",
+			expected: "/" + fileSlug + ".woff",
+		},
+		{
+			name:     "13",
+			path:     "/35bb8d560d.eot",
+			expected: "/" + fileSlug + ".eot",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #21517

This will cause requests for `ttf`, `woff`, and `eot` files to have the file name also replaced by a slug for telemetry reporting purposes to manage cardinality. For example: requests for `/35bb8d560d.ttf` or `/anythingelse.ttf` will both be reported as `/:file_name.ttf`.

Behavior for most files of this nature was already handled by #21158, but `ttf` files were missed in that implementation, so this PR is merely adding that file extension to the list. `woff` and `eot` files may not be accessed often (if ever), but I added those to the list as well since they are given hashed-based names by UI builds.