### PR TITLE
feat: remove ui feature flags for permanent features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells.
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots.
 1. [21367](https://github.com/influxdata/influxdb/pull/21367): List users via the API now supports pagination
+1. [21531](https://github.com/influxdata/influxdb/pull/21531): Remove feature flags for permanent UI features
 
 ### Bug Fixes
 

--- a/flags.yml
+++ b/flags.yml
@@ -55,22 +55,6 @@
   contact: Query Team
   lifetime: permanent
 
-- name: Band Plot Type
-  description: Enables the creation of a band plot in Dashboards
-  key: bandPlotType
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
-- name: Mosaic Graph Type
-  description: Enables the creation of a mosaic graph in Dashboards
-  key: mosaicGraphType
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
 - name: Notebooks
   description: Determine if the notebook feature's route and navbar icon are visible to the user
   key: notebooks
@@ -106,14 +90,6 @@
   default: false
   expose: true
 
-- name: Axis Tick Generator
-  description: Allows for controlling how many axis ticks there are on a graph
-  key: axisTicksGenerator
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
 - name: UI CSV Uploader
   description: Adds the ability to upload data from a CSV file to a bucket
   key: csvUploader
@@ -125,14 +101,6 @@
 - name: Editable Telegraf Configurations
   description: Edit telegraf configurations from the UI
   key: editTelegrafs
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
-- name: Legend Orientation in the UI
-  description: Change the appearance of the legend
-  key: legendOrientation
   default: true
   contact: Monitoring Team
   expose: true

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -86,34 +86,6 @@ func QueryTracing() BoolFlag {
 	return queryTracing
 }
 
-var bandPlotType = MakeBoolFlag(
-	"Band Plot Type",
-	"bandPlotType",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// BandPlotType - Enables the creation of a band plot in Dashboards
-func BandPlotType() BoolFlag {
-	return bandPlotType
-}
-
-var mosaicGraphType = MakeBoolFlag(
-	"Mosaic Graph Type",
-	"mosaicGraphType",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// MosaicGraphType - Enables the creation of a mosaic graph in Dashboards
-func MosaicGraphType() BoolFlag {
-	return mosaicGraphType
-}
-
 var notebooks = MakeBoolFlag(
 	"Notebooks",
 	"notebooks",
@@ -184,20 +156,6 @@ func TimeFilterFlags() BoolFlag {
 	return timeFilterFlags
 }
 
-var axisTicksGenerator = MakeBoolFlag(
-	"Axis Tick Generator",
-	"axisTicksGenerator",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// AxisTickGenerator - Allows for controlling how many axis ticks there are on a graph
-func AxisTickGenerator() BoolFlag {
-	return axisTicksGenerator
-}
-
 var csvUploader = MakeBoolFlag(
 	"UI CSV Uploader",
 	"csvUploader",
@@ -224,20 +182,6 @@ var editTelegrafs = MakeBoolFlag(
 // EditableTelegrafConfigurations - Edit telegraf configurations from the UI
 func EditableTelegrafConfigurations() BoolFlag {
 	return editTelegrafs
-}
-
-var legendOrientation = MakeBoolFlag(
-	"Legend Orientation in the UI",
-	"legendOrientation",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// LegendOrientationInTheUi - Change the appearance of the legend
-func LegendOrientationInTheUi() BoolFlag {
-	return legendOrientation
 }
 
 var cursorAtEOF = MakeBoolFlag(
@@ -289,17 +233,13 @@ var all = []Flag{
 	memoryOptimizedFill,
 	memoryOptimizedSchemaMutation,
 	queryTracing,
-	bandPlotType,
-	mosaicGraphType,
 	notebooks,
 	notebooksApi,
 	injectLatestSuccessTime,
 	enforceOrgDashboardLimits,
 	timeFilterFlags,
-	axisTicksGenerator,
 	csvUploader,
 	editTelegrafs,
-	legendOrientation,
 	cursorAtEOF,
 	refreshSingleCell,
 	annotations,
@@ -312,17 +252,13 @@ var byKey = map[string]Flag{
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,
 	"queryTracing":                  queryTracing,
-	"bandPlotType":                  bandPlotType,
-	"mosaicGraphType":               mosaicGraphType,
 	"notebooks":                     notebooks,
 	"notebooksApi":                  notebooksApi,
 	"injectLatestSuccessTime":       injectLatestSuccessTime,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
 	"timeFilterFlags":               timeFilterFlags,
-	"axisTicksGenerator":            axisTicksGenerator,
 	"csvUploader":                   csvUploader,
 	"editTelegrafs":                 editTelegrafs,
-	"legendOrientation":             legendOrientation,
 	"cursorAtEOF":                   cursorAtEOF,
 	"refreshSingleCell":             refreshSingleCell,
 	"annotations":                   annotations,


### PR DESCRIPTION
Closes idpe 10605

Removes the feature flags `axisTicksGenerator`, `legendOrientation`, `mosaicGraphType`, and `bandPlotType` as they have become permanent UI features.

UI issues:
https://github.com/influxdata/ui/issues/1460  
https://github.com/influxdata/ui/issues/1462  
https://github.com/influxdata/ui/issues/1463  
https://github.com/influxdata/ui/issues/1464  

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
