### PR TITLE
fix(cmd/influxd): Add logging work-around for absolute file paths on Windows

### DIFF
--- a/cmd/influxd/upgrade/logging_unix.go
+++ b/cmd/influxd/upgrade/logging_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package upgrade
+
+// Zap only has problems with Windows paths, so this is a no-op on Unix systems.
+func (o *logOptions) zapSafeLogPath() (string, error) {
+	return o.logPath, nil
+}

--- a/cmd/influxd/upgrade/logging_windows.go
+++ b/cmd/influxd/upgrade/logging_windows.go
@@ -1,0 +1,30 @@
+package upgrade
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+)
+
+// Work around a bug in zap's handling of absolute paths on Windows.
+// See https://github.com/uber-go/zap/issues/621
+
+const FakeWindowsScheme = "winfile"
+
+func init() {
+	newWinFileSink := func(u *url.URL) (zap.Sink, error) {
+		// Remove leading slash left by url.Parse()
+		return os.OpenFile(u.Path[1:], os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	}
+	zap.RegisterSink(FakeWindowsScheme, newWinFileSink)
+}
+
+func (o *logOptions) zapSafeLogPath() (string, error) {
+	logPath, err := filepath.Abs(o.logPath)
+	if err != nil {
+		return "", err
+	}
+	return FakeWindowsScheme + ":///" + logPath, nil
+}

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -331,9 +331,13 @@ func buildLogger(options *logOptions, verbose bool) (*zap.Logger, error) {
 	if verbose {
 		config.Level.SetLevel(zap.DebugLevel)
 	}
+	logPath, err := options.zapSafeLogPath()
+	if err != nil {
+		return nil, err
+	}
 
-	config.OutputPaths = append(config.OutputPaths, options.logPath)
-	config.ErrorOutputPaths = append(config.ErrorOutputPaths, options.logPath)
+	config.OutputPaths = append(config.OutputPaths, logPath)
+	config.ErrorOutputPaths = append(config.ErrorOutputPaths, logPath)
 
 	log, err := config.Build()
 	if err != nil {


### PR DESCRIPTION
Closes #21537

Backports #21540