### PR TITLE
feat: upgrade UI to v2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Upgrade Flux to v0.117.0
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Optimize `table.fill()` execution within Flux aggregate windows.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Upgrade UI to v2.0.7
+1. [21564](https://github.com/influxdata/influxdb/pull/21564): Upgrade UI to v2.0.7
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Upgrade Flux to v0.117.0
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Optimize `table.fill()` execution within Flux aggregate windows.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Upgrade UI to v2.0.7
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Upgrade Flux to v0.117.0
 1. [21519](https://github.com/influxdata/influxdb/pull/21519): Optimize `table.fill()` execution within Flux aggregate windows.
-1. [21564](https://github.com/influxdata/influxdb/pull/21564): Upgrade UI to v2.0.7
+1. [21564](https://github.com/influxdata/influxdb/pull/21564): Upgrade UI to [v2.0.7](https://github.com/influxdata/ui/releases/tag/OSS-v2.0.7)
 
 ### Bug Fixes
 

--- a/ui/fetch_ui_assets.sh
+++ b/ui/fetch_ui_assets.sh
@@ -12,6 +12,6 @@
 # respective releases in "influxdata/ui" (OSS-2.0, OSS-2.1, etc). Those releases
 # are updated only when a bug fix needs included for the UI of that OSS release.
 
-curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.5/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.7/build.tar.gz --output build.tar.gz
 tar -xzf build.tar.gz
 rm build.tar.gz


### PR DESCRIPTION
Closes #21562

Also:
Closes #21447
Closes #21354
Closes [influxdata-docker#484](https://github.com/influxdata/influxdata-docker/issues/484)

Updates the build script to include the built assets from https://github.com/influxdata/ui/releases/tag/OSS-v2.0.7.