### PR TITLE
fix: avoid rewriting fields.idx unnecessarily

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1826,12 +1826,10 @@ func (fs *MeasurementFieldSet) Save() (err error) {
 					rvw.wg.Wait()
 					err = *rvw.err
 					fmt.Printf("Done with  %d in %d returning %v\n", curMV, v, err)
-					return
+					return true, err
 				}
 			}
-			waitForResults = false
-			err = nil
-			return
+			return false, nil
 		}
 
 		if _, err = fd.Write(fieldsIndexMagicNumber); err != nil {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1772,15 +1772,15 @@ func (fs *MeasurementFieldSet) Save() (err error) {
 		fs.valueWaiters[v] = &valueWaiter
 		// If no fields left, remove the fields index file
 		if len(fs.fields) == 0 {
-			if e := os.RemoveAll(fs.path); err != nil {
-				return true, nil, e
+			if err := os.RemoveAll(fs.path); err != nil {
+				return true, nil, err
 			} else {
 				atomic.StoreUint64(&fs.writtenVersion, v)
-				return false, nil, nil
+				return true, nil, nil
 			}
 		}
-		b, e := fs.marshalMeasurementFieldSetNoLock()
-		return false, b, e
+		b, err := fs.marshalMeasurementFieldSetNoLock()
+		return false, b, err
 	}()
 
 	if err != nil {


### PR DESCRIPTION
Under heavy write load creating new fields and measurements
the rewrite of the fields.idx file is a bottleneck. This enhancement
does the following:

- Marshal the in-memory copy of the MeasurementFieldSet 
- Open a temp file and write the magic number
- If a subsequent call to this procedure has begun, halt work
- Use the later call's return value, because it includes all data

Closes https://github.com/influxdata/influxdb/issues/21577

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
