### PR TITLE
chore: enable ingest performance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,21 @@
-version: 2
+version: 2.1
+
+parameters:
+  aws_teardown:
+    default: false
+    type: boolean
+  aws_teardown_branch:
+    default: "n/a"
+    type: string
+  aws_teardown_sha:
+    default: "n/a"
+    type: string
+  aws_teardown_datestring:
+    default: "n/a"
+    type: string
 
 jobs:
-  build:
+  build_and_test:
     machine:
       enabled: true
       docker_layer_caching: true
@@ -9,11 +23,182 @@ jobs:
       - PARALLELISM: 4 # Input to influxdb/build.py
     parallelism: 4 # How many CircleCI test containers
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - run:
           name: Ensure CircleCI parallelism matches "./test.sh count"
           command: "[ `./test.sh count` -eq $CIRCLE_NODE_TOTAL ]"
       - run:
           name: Execute test
-          command: ./test.sh $CIRCLE_NODE_INDEX
+          command: ./test.sh ${CIRCLE_NODE_INDEX}
           no_output_timeout: 1500s
+      - run:
+          name: Rename packages
+          command: |
+            set -x
+            if [ 0 -eq ${CIRCLE_NODE_INDEX} ]; then
+              ls build
+              mv build packages
+            else
+              mkdir -p packages
+              touch packages/${CIRCLE_NODE_INDEX}-dummy.deb  # this is a hack to make persisting to workspace work for all parallel executors, even though some don't produce build output
+            fi
+      - store_artifacts:
+          path: packages/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - packages/*.deb
+  # Note: command-level insertion of AWS environment variables is required to
+  # shadow separate legacy credentials used for dl.influxdata.com s3 bucket in
+  # other CI for this repo
+  # see the following known issue for more info: https://support.circleci.com/hc/en-us/articles/360021415793-Wrong-AWS-credentials-being-used
+  perf_test:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+      - run:
+          name: Run test in AWS instance
+          no_output_timeout: 20m
+          command: |
+            set -x
+
+            # get latest ubuntu 20.04 ami for us-west-2
+            ami_id=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ssm get-parameters --names /aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id --query 'Parameters[0].[Value]' --output text)
+
+            # launch ec2 instance
+            instance_type="m5.large"
+            datestring=$(date +%Y%m%d)
+            instance_info=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 run-instances \
+              --image-id $ami_id \
+              --instance-type $instance_type \
+              --block-device-mappings DeviceName=/dev/sda1,Ebs={VolumeSize=100} \
+              --key-name circleci-oss-test \
+              --security-group-ids sg-03004366a38eccc97 \
+              --subnet-id subnet-0c079d746f27ede5e \
+              --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=oss-perftest-$datestring-${CIRCLE_BRANCH}-${CIRCLE_SHA1}}]")
+
+            # get instance info
+            ec2_instance_id=$(echo $instance_info | jq -r .Instances[].InstanceId)
+            sleep 60
+
+            ec2_ip=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws \
+              --region us-west-2 \
+              ec2 describe-instances \
+                --instance-ids $ec2_instance_id \
+                --query "Reservations[].Instances[].PublicIpAddress" \
+                --output text)
+
+            while [ -z $ec2_ip ]; do
+              sleep 5
+              ec2_ip=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws \
+                --region us-west-2 \
+                ec2 describe-instances \
+                  --instance-ids $ec2_instance_id \
+                  --query "Reservations[].Instances[].PublicIpAddress" \
+                  --output text)
+            done
+
+            # push binary and script to instance
+            debname=$(find /tmp/workspace/packages/influxdb*amd64.deb)
+            base_debname=$(basename $debname)
+
+            scp $debname ubuntu@$ec2_ip:/home/ubuntu/$base_debname
+            scp run_perftest.sh ubuntu@$ec2_ip:/home/ubuntu/run_perftest.sh
+
+            # run scripts
+            ssh ubuntu@$ec2_ip \<< EOF
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes /home/ubuntu/$base_debname
+            sudo systemctl unmask influxdb.service
+            sudo systemctl start influxdb
+            EOF
+
+            ssh ubuntu@$ec2_ip \<< EOF
+            nohup sudo CIRCLE_TEARDOWN=true CIRCLE_TOKEN=${CIRCLE_API_CALLBACK_TOKEN}  CLOUD2_BUCKET=${CLOUD2_PERFTEST_BUCKET} CLOUD2_ORG=${CLOUD2_PERFTEST_ORG} DATA_I_TYPE=m5.large DB_TOKEN=${CLOUD2_PERFTEST_TOKEN} INFLUXDB_VERSION=${CIRCLE_BRANCH} NGINX_HOST=localhost TEST_COMMIT=${CIRCLE_SHA1} CIRCLE_TEARDOWN_DATESTRING=$datestring ./run_perftest.sh > /home/ubuntu/perftest_log.txt 2>&1 &
+            EOF
+  aws_destroy_by_date:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+      - run:
+          name: Destroy AWS instances with datestring more than a day old
+          no_output_timeout: 20m
+          command: |
+            set -x
+            yesterday_date=$(date --date"yesterday" +%Y%md)
+            today=$(date +%Y%m%d)
+            instance_info=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 describe-instances --filters "Name=tag:Name,Values=oss-perftest-*" --query "Reservations[].Instances[].[InstanceId, Tags[?Key==`Name`]]" --output text)
+            for info in $instance_info; do
+              name=$(echo $info | cut -d ' ' -f2)
+              date=$(echo $name | cut -d '-' -f3)
+              if [ $(expr $today - $yesterday_date) -gt 1 ]; then
+                instance_id=$(echo $info | cut -d ' ' -f1)
+                AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 terminate-instances --instance-ids $instance_id
+              fi
+            done
+  aws_destroy_by_name:
+    machine:
+      enabled: true
+      docker_layer_caching: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+      - run:
+          name: Destroy AWS instances by constructing name from arguments
+          no_output_timeout: 20m
+          command: |
+            set -x
+            name=oss-perftest-<< pipeline.parameters.aws_teardown_datestring >>-<< pipeline.parameters.aws_teardown_branch >>-<< pipeline.parameters.aws_teardown_sha >>
+            instance_id=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 describe-instances --filters "Name=tag:Name,Values=$name" --query 'Reservations[].Instances[].InstanceId' --output text)
+            AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 terminate-instances --instance-ids $instance_id
+
+workflows:
+  version: 2
+  on_push:
+    when:
+      not: << pipeline.parameters.aws_teardown >>
+    jobs:
+      - build_and_test
+      - perf_test:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only:
+                - "1.8"
+                - "perftests-1.8"
+  aws_destroy_daily:
+    triggers:
+      - schedule:
+          # run every day at 10pm -- note: use spaces, not tabs
+          cron: "0 22 * * *"
+          filters:
+            branches:
+              only:
+                - "1.8"
+                - master
+    jobs:
+      - aws_destroy_by_date
+  aws_destroy_callback:
+    when: << pipeline.parameters.aws_teardown >>
+    jobs:
+      - aws_destroy_by_name

--- a/run_perftest.sh
+++ b/run_perftest.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/sh -ex
+
+# NOTE: because this script is used as a template file by Terraform, variables
+# cannot be specified using braces, even in comments, as Terraform will
+# interpret these as interpolation strings. Variables must either lack braces,
+# or else use two $ symbols, e.g. $${my_non_template_interpolation_variable},
+# though this is not recommended, as the script will fail to work when run
+# locally
+
+# Install Telegraf
+wget -qO- https://repos.influxdata.com/influxdb.key | apt-key add -
+echo "deb https://repos.influxdata.com/ubuntu focal stable" | tee /etc/apt/sources.list.d/influxdb.list
+
+DEBIAN_FRONTEND=noninteractive apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y git jq telegraf
+
+working_dir=$(mktemp -d)
+mkdir -p /etc/telegraf
+cat << EOF > /etc/telegraf/telegraf.conf
+[[outputs.influxdb_v2]]
+  urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+  token = "${DB_TOKEN}"
+  organization = "${CLOUD2_ORG}"
+  bucket = "${CLOUD2_BUCKET}"
+
+[[inputs.file]]
+  files = ["$working_dir/*.json"]
+  file_tag = "test_name"
+  data_format = "json"
+  json_strict = true
+  json_string_fields = [
+    "branch",
+    "commit",
+    "i_type",
+    "time"
+  ]
+  json_time_key = "time"
+  json_time_format = "unix"
+  tag_keys = [
+    "i_type",
+    "branch"
+  ]
+EOF
+systemctl restart telegraf
+
+cd $working_dir
+
+# install golang latest version
+go_version=$(curl https://golang.org/VERSION?m=text)
+go_endpoint="$go_version.linux-amd64.tar.gz"
+
+wget "https://dl.google.com/go/$go_endpoint" -O "$working_dir/$go_endpoint"
+rm -rf /usr/local/go
+tar -C /usr/local -xzf "$working_dir/$go_endpoint"
+
+# set env variables necessary for go to work during cloud-init
+if [ `whoami` = root ]; then
+  mkdir -p /root/go/bin
+  export HOME=/root
+  export GOPATH=/root/go/bin
+  export PATH=$PATH:/usr/local/go/bin:$GOPATH
+fi
+go version
+
+# clone influxdb comparisons
+git clone https://github.com/influxdata/influxdb-comparisons.git $working_dir/influxdb-comparisons
+cd $working_dir/influxdb-comparisons
+
+# install cmds
+go get \
+  github.com/influxdata/influxdb-comparisons/cmd/bulk_data_gen \
+  github.com/influxdata/influxdb-comparisons/cmd/bulk_load_influx \
+  github.com/influxdata/influxdb-comparisons/cmd/bulk_query_gen \
+  github.com/influxdata/influxdb-comparisons/cmd/query_benchmarker_influxdb
+
+# Run and record tests
+datestring=$(date +%s)
+seed=$datestring
+for scale in 50 100 500; do
+  # generate bulk data
+  scale_string="scalevar-$scale"
+  scale_seed_string="$scale_string-seed-$seed"
+  data_fname="influx-bulk-records-usecase-devops-$scale_seed_string.gz"
+  $GOPATH/bin/bulk_data_gen --seed=$seed --use-case=devops --scale-var=$scale --format=influx-bulk | gzip > $working_dir/$data_fname
+
+  # run ingest tests
+  test_type=ingest
+  for parseme in "5000:2" "5000:20" "15000:2" "15000:20"; do
+    batch=$(echo $parseme | cut -d: -f1)
+    workers=$(echo $parseme | cut -d: -f2)
+    cat $working_dir/$data_fname | gunzip | $GOPATH/bin/bulk_load_influx -batch-size=$batch -workers=$workers -urls=http://${NGINX_HOST}:8086 -do-abort-on-exist=false -do-db-create=true -backoff=1s -backoff-timeout=300m0s | jq ". += {branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\"}" > $working_dir/test-$test_type-$scale_string-batchsize-$batch-workers-$workers.json
+  done
+done
+
+telegraf --once
+
+if [ "${CIRCLE_TEARDOWN}" = "true" ]; then
+  curl --request POST \
+    --url https://circleci.com/api/v2/project/github/influxdata/influxdb/aws_destroy_callback \
+    --header 'Circle-Token: ${CIRCLE_TOKEN}' \
+    --header 'content-type: application/json' \
+    --data '{"parameters":{"aws_teardown": true, "aws_teardown_branch":"${INFLUXDB_VERSION}", "aws_teardown_sha":"${TEST_COMMIT}", "aws_teardown_datestring":"${CIRCLE_TEARDOWN_DATESTRING}"}}'
+fi

--- a/run_perftest.sh
+++ b/run_perftest.sh
@@ -96,8 +96,8 @@ telegraf --once
 
 if [ "${CIRCLE_TEARDOWN}" = "true" ]; then
   curl --request POST \
-    --url https://circleci.com/api/v2/project/github/influxdata/influxdb/aws_destroy_callback \
-    --header 'Circle-Token: ${CIRCLE_TOKEN}' \
+    --url https://circleci.com/api/v2/project/github/influxdata/influxdb/pipeline \
+    --header "Circle-Token: ${CIRCLE_TOKEN}" \
     --header 'content-type: application/json' \
-    --data '{"parameters":{"aws_teardown": true, "aws_teardown_branch":"${INFLUXDB_VERSION}", "aws_teardown_sha":"${TEST_COMMIT}", "aws_teardown_datestring":"${CIRCLE_TEARDOWN_DATESTRING}"}}'
+    --data "{\"branch\":\"${INFLUXDB_VERSION}\", \"parameters\":{\"aws_teardown\": true, \"aws_teardown_branch\":\"${INFLUXDB_VERSION}\", \"aws_teardown_sha\":\"${TEST_COMMIT}\", \"aws_teardown_datestring\":\"${CIRCLE_TEARDOWN_DATESTRING}\"}}"
 fi

--- a/test.sh
+++ b/test.sh
@@ -102,7 +102,7 @@ fi
 case $ENVIRONMENT_INDEX in
     0)
         # 64 bit tests
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit --test --junit-report
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit --test --junit-report --package
         rc=$?
         ;;
     1)


### PR DESCRIPTION
This PR enables the running of ingest (bulk load) performance testing for the `1.8` branch.

The automation logic works by launching an AWS EC2 instance and installing the deb produced from the test build on the VM. Then, using the github.com/influxdata/influxdb-comparisons repo, a dataset is generated on the VM and loaded into the influxdb instance running there.

Results are reported to an influxdata cloud 2 bucket.

AWS instances are destroyed via a callback mechanism, as well as a nightly cleanup which is intended as a backstop for any instances left running by ephemeral api failures.

All api tokens are stored in CircleCI config.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
