### PR TITLE
fix: empty notebooks list returns empty array

### DIFF
--- a/notebooks/service.go
+++ b/notebooks/service.go
@@ -137,7 +137,7 @@ func (s *Service) DeleteNotebook(ctx context.Context, id platform.ID) error {
 // ListNotebooks lists notebooks matching the provided filter. Currently, only org_id is used in the filter.
 // Future uses may support pagination via this filter as well.
 func (s *Service) ListNotebooks(ctx context.Context, filter influxdb.NotebookListFilter) ([]*influxdb.Notebook, error) {
-	var ns []*influxdb.Notebook
+	ns := []*influxdb.Notebook{}
 
 	query := `
 		SELECT id, org_id, name, spec, created_at, updated_at

--- a/notebooks/service_test.go
+++ b/notebooks/service_test.go
@@ -154,7 +154,7 @@ func TestList(t *testing.T) {
 	// selecting with no matches for org_id should return an empty list and no error
 	got, err := svc.ListNotebooks(ctx, influxdb.NotebookListFilter{OrgID: orgID})
 	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+	require.Equal(t, []*influxdb.Notebook{}, got)
 
 	// create some notebooks to test the list operation with
 	creates := []*influxdb.NotebookReqBody{


### PR DESCRIPTION
Closes #21587

This change will allow the API to respond with `{flows: []}` instead of `{flows: null}` when making a request to list notebooks that includes 0 notebooks.

This is important for cases where all the notebooks are removed external to the UI - by doing a database restore for example - the `{flows: null}` response in this case was not able to be processed by the UI and resulting in the old notebooks to still show up via the browser local storage. With the `{flows: []}` the browser updates the list of notebooks to have 0 notebooks and display correctly.