### PR TITLE
docs: Update build-from-source docs to favor make commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,9 @@ You need a recent stable version of Rust. We recommend using [rustup](https://ru
 
 You also need `clang`, `make`, `pkg-config`, and `protobuf` installed.
 
-- OSX: `brew install make pkg-config protobuf`
+- OSX: `brew install pkg-config protobuf`
     - For OSX, you must have [HomeBrew](https://brew.sh) installed.
+    - You will also need the [Developer Tools](https://webkit.org/build-tools/), which includes `make`.
 - Linux (Arch): `pacman -S clang make pkgconf protobuf`
 - Linux (Ubuntu): `sudo apt install make clang pkg-config protobuf-compiler libprotobuf-dev`
 - Linux (RHEL): See below

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,40 +148,6 @@ Logs to stdout by default:
 $ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influxd
 ```
 
-### Building with the go command
-
-The `Makefile` provides a wrapper around configuring the utilities for building influxdb. For those wanting to use the `go` command directly, one of two things can be done.
-
-First, the `env` script is located in the root of the repository. This script can be used to execute `go` commands with the appropriate environment configuration.
-
-```bash
-$ ./env go build ./cmd/influxd
-```
-
-Another method is to configure the `pkg-config` utility. Follow the instructions [here](https://github.com/influxdata/flux#getting-started) to install and configure `pkg-config` and then the normal go commands will work.
-
-You should have already installed the pkg-config commands when doing the regular 'make' build.
-
-Install the `pkg-config` wrapper utility of the same name to a different path that is earlier in the PATH.
-
-```bash
-# Install the pkg-config wrapper utility
-$ go build -o ~/go/bin/ github.com/influxdata/pkg-config
-# Ensure the GOBIN directory is on your PATH
-$ export PATH=$HOME/go/bin:${PATH}
-$ which -a pkg-config
-/home/user/go/bin/pkg-config
-/usr/bin/pkg-config
-```
-
-Then all `go` build commands should work.
-
-```bash
-$ go build ./cmd/influxd
-$ go test ./...
-```
-
-
 ### Testing
 
 This project is built from various languages. To run test for all langauges and components use:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,7 @@ You need a recent stable version of Rust. We recommend using [rustup](https://ru
 You also need `clang`, `make`, `pkg-config`, and `protobuf` installed.
 
 - OSX: `brew install make pkg-config protobuf`
+    - For OSX, you must have [HomeBrew](https://brew.sh) installed.
 - Linux (Arch): `pacman -S clang make pkgconf protobuf`
 - Linux (Ubuntu): `sudo apt install make clang pkg-config protobuf-compiler libprotobuf-dev`
 - Linux (RHEL): See below


### PR DESCRIPTION
Closes #21589

Updates build from source docs [here](https://github.com/influxdata/influxdb/blob/master/CONTRIBUTING.md#building-with-the-go-command) to remove the section about using the go command to build, in favor of using `make`. Additionally I updated the additional dependencies section [here](https://github.com/influxdata/influxdb/blob/master/CONTRIBUTING.md#additional-dependencies) to be a little clearer for OSX, mentioning that Homebrew is required, as well as stating that `make` is included in the Apple Developer Tools.