### PR TITLE
fix: report error when a flux acceptance test doesn't have a package statement

### DIFF
--- a/internal/cmd/fluxtest-harness-influxdb/test.go
+++ b/internal/cmd/fluxtest-harness-influxdb/test.go
@@ -235,6 +235,7 @@ func main() {
 	c := cmd.TestCommand(NewTestExecutor)
 	c.Use = "fluxtest-harness-influxdb"
 	if err := tryExec(c); err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Closes #21051 

Currently, we do not show error messages if something fails while running influxdb flux acceptance test harness. This patch will help to report an error message that tells the user what the issue is.

