### PR TITLE
build: speed up CI runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,11 @@ jobs:
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
       - install_core_deps
+      - run:
+          name: Create RAM disk
+          command: |
+            mkdir -p ${TMPDIR}
+            mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
       - run_goreleaser:
           publish_release: false
       - run:
@@ -547,6 +552,11 @@ jobs:
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
       - install_core_deps
+      - run:
+          name: Create RAM disk
+          command: |
+            mkdir -p ${TMPDIR}
+            mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
       - run_goreleaser:
           publish_release: true
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,16 +516,16 @@ jobs:
       TMPDIR: /mnt/ramdisk
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOPATH/pkg/mod
-          keys:
-            - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - install_core_deps
       - run:
           name: Create RAM disk
           command: |
             mkdir -p ${TMPDIR}
             mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
+      - restore_cache:
+          name: Restore GOPATH/pkg/mod
+          keys:
+            - influxdb-gomod-sum-{{ checksum "go.sum" }}
+      - install_core_deps
       - run_goreleaser:
           publish_release: false
       - run:
@@ -547,16 +547,16 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOPATH/pkg/mod
-          keys:
-            - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - install_core_deps
       - run:
           name: Create RAM disk
           command: |
             mkdir -p ${TMPDIR}
             mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
+      - restore_cache:
+          name: Restore GOPATH/pkg/mod
+          keys:
+            - influxdb-gomod-sum-{{ checksum "go.sum" }}
+      - install_core_deps
       - run_goreleaser:
           publish_release: true
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ jobs:
     docker:
       - image: cimg/go:1.15.6
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -320,7 +320,7 @@ jobs:
     docker:
       - image: cimg/go:1.15.6
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -353,17 +353,12 @@ jobs:
       - image: cimg/go:1.15.6
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
       TEST_RESULTS: /tmp/test-results
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     parallelism: 8
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-gotest-{{ .Branch }}-{{ .Revision }}
-            - influxdb-gotest-{{ .Branch }}-
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
@@ -376,11 +371,6 @@ jobs:
             GO_TEST_CMD="gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -p=4"
             TESTFILES=($(go list ./... | circleci tests split --split-by=timings))
             make GO_TEST_CMD="$GO_TEST_CMD" GO_TEST_PATHS="${TESTFILES[*]}" test-go-race
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-gotest-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output
@@ -391,7 +381,7 @@ jobs:
     docker:
       - image: cimg/go:1.15.6
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -405,6 +395,8 @@ jobs:
   tlstest:
     docker:
       - image: cimg/go:1.15.6
+    environment:
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -420,16 +412,11 @@ jobs:
       - image: cimg/go:1.15.6
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
       TEST_RESULTS: /tmp/test-results
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-iqlvalidation-{{ .Branch }}-{{ .Revision }}
-            - influxdb-iqlvalidation-{{ .Branch }}-
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
@@ -437,11 +424,6 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - install_core_deps
       - run: make GO_TEST_CMD="gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml --" test-influxql-validation
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-iqlvalidation-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output
@@ -453,16 +435,11 @@ jobs:
       - image: cimg/go:1.15.6
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
       TEST_RESULTS: /tmp/test-results
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-iqlintegration-{{ .Branch }}-{{ .Revision }}
-            - influxdb-iqlintegration-{{ .Branch }}-
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
@@ -470,11 +447,6 @@ jobs:
       - run: mkdir -p $TEST_RESULTS
       - install_core_deps
       - run: make GO_TEST_CMD="gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml --" test-influxql-integration
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-iqlintegration-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output
@@ -490,7 +462,7 @@ jobs:
       - image: cimg/go:1.15.6
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -498,20 +470,10 @@ jobs:
           name: Restore GOPATH/pkg/mod
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-build-{{ .Branch }}-{{ .Revision }}
-            - influxdb-build-{{ .Branch }}-
       - install_core_deps
       - install_cross_bin_deps
       # Build the static binary for linux
       - run: goreleaser build --snapshot --single-target
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-build-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -551,18 +513,13 @@ jobs:
       image: ubuntu-2004:202010-01
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     steps:
       - checkout
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-cross-build-{{ .Branch }}-{{ .Revision }}
-            - influxdb-cross-build-{{ .Branch }}-
       - install_core_deps
       - run_goreleaser:
           publish_release: false
@@ -575,18 +532,13 @@ jobs:
             mv dist/influx* artifacts/
       - store_artifacts:
           path: artifacts
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-cross-build-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
 
   deploy_nightly:
     machine:
       image: ubuntu-2004:202010-01
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
+      TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -594,19 +546,9 @@ jobs:
           name: Restore GOPATH/pkg/mod
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - restore_cache:
-          name: Restore GOCACHE
-          keys:
-            - influxdb-nightly-{{ .Branch }}-{{ .Revision }}
-            - influxdb-nightly-{{ .Branch }}-
       - install_core_deps
       - run_goreleaser:
           publish_release: true
-      - save_cache:
-          name: Save GOCACHE
-          key: influxdb-nightly-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/go-cache
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,8 +519,8 @@ jobs:
       - run:
           name: Create RAM disk
           command: |
-            mkdir -p ${TMPDIR}
-            mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
+            sudo mkdir -p ${TMPDIR}
+            sudo mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:
@@ -550,8 +550,8 @@ jobs:
       - run:
           name: Create RAM disk
           command: |
-            mkdir -p ${TMPDIR}
-            mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
+            sudo mkdir -p ${TMPDIR}
+            sudo mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
       - restore_cache:
           name: Restore GOPATH/pkg/mod
           keys:


### PR DESCRIPTION
* Stop using `GOCACHE`, it only ever grows in size and the upload/download ends up dominating job runtime
* Use RAMdisks in build/test steps where we expect it'll help runtime

Before:
![Screen Shot 2021-06-04 at 11 03 37 AM](https://user-images.githubusercontent.com/2755881/120822734-b7ea1d00-c524-11eb-847c-05b0b56398d7.png)

After:
![Screen Shot 2021-06-04 at 11 03 43 AM](https://user-images.githubusercontent.com/2755881/120822758-bd476780-c524-11eb-93eb-06e2648ac8b4.png)
