### PR TITLE
feat: Port influxd inspect verify-seriesfile

### DIFF
--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -23,5 +23,7 @@ func NewCommand(v *viper.Viper) (*cobra.Command, error) {
 	base.AddCommand(exportLp)
 	base.AddCommand(NewExportIndexCommand())
 
+	base.AddCommand(NewVerifySeriesfileCommand())
+
 	return base, nil
 }

--- a/cmd/influxd/inspect/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile_test.go
@@ -1,4 +1,4 @@
-package seriesfile_test
+package inspect
 
 import (
 	"fmt"
@@ -9,33 +9,41 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb/v2/cmd/influx_inspect/verify/seriesfile"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
+func TestVerifies_BasicCobra(t *testing.T) {
+	test := NewTest(t)
+	defer os.RemoveAll(test.Path)
+
+	verify := NewVerifySeriesfileCommand()
+	verify.SetArgs([]string{"--dir", test.Path})
+	require.NoError(t, verify.Execute())
+}
+
 func TestVerifies_Valid(t *testing.T) {
 	test := NewTest(t)
-	defer test.Close()
+	defer os.RemoveAll(test.Path)
 
-	verify := seriesfile.NewVerify()
+	verify := NewVerify()
 	if testing.Verbose() {
 		verify.Logger, _ = zap.NewDevelopment()
 	}
 	passed, err := verify.VerifySeriesFile(test.Path)
-	test.AssertNoError(err)
-	test.Assert(passed)
+	require.NoError(t, err)
+	require.True(t, passed)
 }
 
 func TestVerifies_Invalid(t *testing.T) {
 	test := NewTest(t)
-	defer test.Close()
+	defer os.RemoveAll(test.Path)
 
-	test.AssertNoError(filepath.Walk(test.Path, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
+	require.NoError(t, filepath.Walk(test.Path, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+
 		if info.IsDir() {
 			return nil
 		}
@@ -44,24 +52,20 @@ func TestVerifies_Invalid(t *testing.T) {
 		defer test.Restore(path)
 
 		fh, err := os.OpenFile(path, os.O_RDWR, 0)
-		test.AssertNoError(err)
+		require.NoError(t, err)
 		defer fh.Close()
 
-		_, err = fh.WriteAt([]byte("BOGUS"), 0)
-		test.AssertNoError(err)
-		test.AssertNoError(fh.Close())
+		_, err = fh.WriteAt([]byte("foobar"), 0)
+		require.NoError(t, err)
+		require.NoError(t, fh.Close())
 
-		passed, err := seriesfile.NewVerify().VerifySeriesFile(test.Path)
-		test.AssertNoError(err)
-		test.Assert(!passed)
+		passed, err := NewVerify().VerifySeriesFile(test.Path)
+		require.NoError(t, err)
+		require.False(t, passed)
 
 		return nil
 	}))
 }
-
-//
-// helpers
-//
 
 type Test struct {
 	*testing.T
@@ -72,9 +76,7 @@ func NewTest(t *testing.T) *Test {
 	t.Helper()
 
 	dir, err := ioutil.TempDir("", "verify-seriesfile-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// create a series file in the directory
 	err = func() error {
@@ -135,39 +137,21 @@ func NewTest(t *testing.T) *Test {
 	}
 }
 
-func (t *Test) Close() {
-	os.RemoveAll(t.Path)
-}
-
-func (t *Test) AssertNoError(err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal("unexpected error:", err)
-	}
-}
-
-func (t *Test) Assert(x bool) {
-	t.Helper()
-	if !x {
-		t.Fatal("unexpected condition")
-	}
-}
-
 // Backup makes a copy of the path for a later Restore.
 func (t *Test) Backup(path string) {
 	in, err := os.Open(path)
-	t.AssertNoError(err)
+	require.NoError(t.T, err)
 	defer in.Close()
 
 	out, err := os.Create(path + ".backup")
-	t.AssertNoError(err)
+	require.NoError(t.T, err)
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
-	t.AssertNoError(err)
+	require.NoError(t.T, err)
 }
 
 // Restore restores the file at the path to the time when Backup was called last.
 func (t *Test) Restore(path string) {
-	t.AssertNoError(os.Rename(path+".backup", path))
+	require.NoError(t.T, os.Rename(path+".backup", path))
 }


### PR DESCRIPTION
Closes #19535

This PR ports the `influxd inspect verify-seriesfile` command from 1.x to 2.x. Similar to #21615, the functional logic needed little to no change, aside from hooking into Cobra. I also added another test case to give some coverage to the Cobra command section of the code.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
