### PR TITLE
feat(annotations): annotations api handlers

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -84,8 +84,8 @@ type AnnotationService interface {
 	CreateOrUpdateStream(ctx context.Context, stream Stream) (*ReadStream, error)
 	// UpdateStream updates the stream by the ID.
 	UpdateStream(ctx context.Context, id platform.ID, stream Stream) (*ReadStream, error)
-	// DeleteStream deletes the stream metadata by name.
-	DeleteStream(ctx context.Context, streamName string) error
+	// DeleteStreams deletes one or more streams by name.
+	DeleteStreams(ctx context.Context, delete BasicStream) error
 	// DeleteStreamByID deletes the stream metadata by id.
 	DeleteStreamByID(ctx context.Context, id platform.ID) error
 }

--- a/annotation.go
+++ b/annotation.go
@@ -70,24 +70,24 @@ type AnnotationService interface {
 	// ListAnnotations lists all annotations matching the filter.
 	ListAnnotations(ctx context.Context, orgID platform.ID, filter AnnotationListFilter) (ReadAnnotations, error)
 	// GetAnnotation gets an annotation by id.
-	GetAnnotation(ctx context.Context, orgID, id platform.ID) (*AnnotationEvent, error)
+	GetAnnotation(ctx context.Context, id platform.ID) (*AnnotationEvent, error)
 	// DeleteAnnotations deletes annotations matching the filter.
 	DeleteAnnotations(ctx context.Context, orgID platform.ID, delete AnnotationDeleteFilter) error
 	// DeleteAnnotation deletes an annotation by id.
-	DeleteAnnotation(ctx context.Context, orgID, id platform.ID) error
+	DeleteAnnotation(ctx context.Context, id platform.ID) error
 	// UpdateAnnotation updates an annotation.
-	UpdateAnnotation(ctx context.Context, orgID, id platform.ID, update AnnotationCreate) (*AnnotationEvent, error)
+	UpdateAnnotation(ctx context.Context, id platform.ID, update AnnotationCreate) (*AnnotationEvent, error)
 
 	// ListStreams lists all streams matching the filter.
 	ListStreams(ctx context.Context, orgID platform.ID, filter StreamListFilter) ([]ReadStream, error)
 	// CreateOrUpdateStream creates or updates the matching stream by name.
-	CreateOrUpdateStream(ctx context.Context, orgID platform.ID, stream Stream) (*ReadStream, error)
+	CreateOrUpdateStream(ctx context.Context, stream Stream) (*ReadStream, error)
 	// UpdateStream updates the stream by the ID.
-	UpdateStream(ctx context.Context, orgID, id platform.ID, stream Stream) (*ReadStream, error)
+	UpdateStream(ctx context.Context, id platform.ID, stream Stream) (*ReadStream, error)
 	// DeleteStream deletes the stream metadata by name.
-	DeleteStream(ctx context.Context, orgID platform.ID, streamName string) error
+	DeleteStream(ctx context.Context, streamName string) error
 	// DeleteStreamByID deletes the stream metadata by id.
-	DeleteStreamByID(ctx context.Context, orgID, id platform.ID) error
+	DeleteStreamByID(ctx context.Context, id platform.ID) error
 }
 
 // AnnotationEvent contains fields for annotating an event.

--- a/annotations/transport/annotations_router.go
+++ b/annotations/transport/annotations_router.go
@@ -41,13 +41,13 @@ func (h *AnnotationHandler) handleCreateAnnotations(w http.ResponseWriter, r *ht
 		return
 	}
 
-	created, err := h.annotationService.CreateAnnotations(ctx, *o, c)
+	l, err := h.annotationService.CreateAnnotations(ctx, *o, c)
 	if err != nil {
 		h.api.Err(w, r, err)
 		return
 	}
 
-	h.api.Respond(w, r, http.StatusOK, created)
+	h.api.Respond(w, r, http.StatusOK, l)
 }
 
 func (h *AnnotationHandler) handleGetAnnotations(w http.ResponseWriter, r *http.Request) {
@@ -157,18 +157,18 @@ func (h *AnnotationHandler) handleUpdateAnnotation(w http.ResponseWriter, r *htt
 }
 
 func decodeCreateAnnotationsRequest(r *http.Request) ([]influxdb.AnnotationCreate, error) {
-	creates := []influxdb.AnnotationCreate{}
-	if err := json.NewDecoder(r.Body).Decode(&creates); err != nil {
+	cs := []influxdb.AnnotationCreate{}
+	if err := json.NewDecoder(r.Body).Decode(&cs); err != nil {
 		return nil, err
 	}
 
-	for _, c := range creates {
+	for _, c := range cs {
 		if err := c.Validate(time.Now); err != nil {
 			return nil, err
 		}
 	}
 
-	return creates, nil
+	return cs, nil
 }
 
 func decodeListAnnotationsRequest(r *http.Request) (*influxdb.AnnotationListFilter, error) {

--- a/annotations/transport/annotations_router.go
+++ b/annotations/transport/annotations_router.go
@@ -1,0 +1,236 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+)
+
+func (h *AnnotationHandler) annotationsRouter() http.Handler {
+	r := chi.NewRouter()
+
+	r.Post("/", h.handleCreateAnnotations)
+	r.Get("/", h.handleGetAnnotations)
+	r.Delete("/", h.handleDeleteAnnotations)
+
+	r.Route("/{id}", func(r chi.Router) {
+		r.Get("/", h.handleGetAnnotation)
+		r.Delete("/", h.handleDeleteAnnotation)
+		r.Put("/", h.handleUpdateAnnotation)
+	})
+
+	return r
+}
+
+func (h *AnnotationHandler) handleCreateAnnotations(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	o, err := platform.IDFromString(r.URL.Query().Get("orgID"))
+	if err != nil {
+		h.api.Err(w, r, errBadOrg)
+		return
+	}
+
+	c, err := decodeCreateAnnotationsRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	created, err := h.annotationService.CreateAnnotations(ctx, *o, c)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, created)
+}
+
+func (h *AnnotationHandler) handleGetAnnotations(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	o, err := platform.IDFromString(r.URL.Query().Get("orgID"))
+	if err != nil {
+		h.api.Err(w, r, errBadOrg)
+		return
+	}
+
+	f, err := decodeListAnnotationsRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	l, err := h.annotationService.ListAnnotations(ctx, *o, *f)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, l)
+}
+
+func (h *AnnotationHandler) handleDeleteAnnotations(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	o, err := platform.IDFromString(r.URL.Query().Get("orgID"))
+	if err != nil {
+		h.api.Err(w, r, errBadOrg)
+		return
+	}
+
+	f, err := decodeDeleteAnnotationsRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	if err = h.annotationService.DeleteAnnotations(ctx, *o, *f); err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusNoContent, nil)
+}
+
+func (h *AnnotationHandler) handleGetAnnotation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := platform.IDFromString(chi.URLParam(r, "id"))
+	if err != nil {
+		h.api.Err(w, r, errBadAnnotationId)
+		return
+	}
+
+	a, err := h.annotationService.GetAnnotation(ctx, *id)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, a)
+}
+
+func (h *AnnotationHandler) handleDeleteAnnotation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := platform.IDFromString(chi.URLParam(r, "id"))
+	if err != nil {
+		h.api.Err(w, r, errBadAnnotationId)
+		return
+	}
+
+	if err := h.annotationService.DeleteAnnotation(ctx, *id); err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusNoContent, nil)
+}
+
+func (h *AnnotationHandler) handleUpdateAnnotation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	id, err := platform.IDFromString(chi.URLParam(r, "id"))
+	if err != nil {
+		h.api.Err(w, r, errBadAnnotationId)
+		return
+	}
+
+	u, err := decodeUpdateAnnotationRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	a, err := h.annotationService.UpdateAnnotation(ctx, *id, *u)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, a)
+}
+
+func decodeCreateAnnotationsRequest(r *http.Request) ([]influxdb.AnnotationCreate, error) {
+	creates := []influxdb.AnnotationCreate{}
+	if err := json.NewDecoder(r.Body).Decode(&creates); err != nil {
+		return nil, err
+	}
+
+	for _, c := range creates {
+		if err := c.Validate(time.Now); err != nil {
+			return nil, err
+		}
+	}
+
+	return creates, nil
+}
+
+func decodeListAnnotationsRequest(r *http.Request) (*influxdb.AnnotationListFilter, error) {
+	startTime, endTime, err := tFromReq(r)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &influxdb.AnnotationListFilter{
+		StreamIncludes: r.URL.Query()["streamIncludes"],
+		BasicFilter: influxdb.BasicFilter{
+			EndTime:   endTime,
+			StartTime: startTime,
+		},
+	}
+	f.SetStickerIncludes(r.URL.Query())
+	if err := f.Validate(time.Now); err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func decodeDeleteAnnotationsRequest(r *http.Request) (*influxdb.AnnotationDeleteFilter, error) {
+	// Try to get a stream ID from the query params. The stream ID is not required,
+	// so if one is not set we can leave streamID as the zero value.
+	var streamID platform.ID
+	if qid := chi.URLParam(r, "streamID"); qid != "" {
+		id, err := platform.IDFromString(qid)
+		// if a streamID parameter was provided but is not valid, return an error
+		if err != nil {
+			return nil, errBadStreamId
+		}
+		streamID = *id
+	}
+
+	startTime, endTime, err := tFromReq(r)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &influxdb.AnnotationDeleteFilter{
+		StreamTag: r.URL.Query().Get("stream"),
+		StreamID:  streamID,
+		EndTime:   endTime,
+		StartTime: startTime,
+	}
+	f.SetStickers(r.URL.Query())
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func decodeUpdateAnnotationRequest(r *http.Request) (*influxdb.AnnotationCreate, error) {
+	u := &influxdb.AnnotationCreate{}
+	if err := json.NewDecoder(r.Body).Decode(u); err != nil {
+		return nil, err
+	} else if err := u.Validate(time.Now); err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}

--- a/annotations/transport/annotations_test.go
+++ b/annotations/transport/annotations_test.go
@@ -1,0 +1,229 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	orgStr   = "1234123412341234"
+	orgID, _ = platform.IDFromString(orgStr)
+	idStr    = "4321432143214321"
+	id, _    = platform.IDFromString(idStr)
+	now      = time.Now().UTC().Truncate(time.Second)
+	later    = now.Add(5 * time.Minute)
+
+	testCreate = influxdb.AnnotationCreate{
+		StreamTag: "sometag",
+		Summary:   "testing the api",
+		EndTime:   &now,
+		StartTime: &now,
+	}
+
+	testEvent = influxdb.AnnotationEvent{
+		ID:               *id,
+		AnnotationCreate: testCreate,
+	}
+
+	testRead1 = influxdb.ReadAnnotation{
+		ID: *influxdbtesting.IDPtr(1),
+	}
+
+	testRead2 = influxdb.ReadAnnotation{
+		ID: *influxdbtesting.IDPtr(2),
+	}
+)
+
+func TestAnnotationHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get annotations happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		now := time.Now().UTC().Truncate(time.Second)
+
+		req := newTestRequest(t, "GET", ts.URL+"/annotations", nil)
+
+		q := req.URL.Query()
+		q.Add("orgID", orgStr)
+		q.Add("endTime", now.Format(time.RFC3339))
+		// the remaining query params are not necessary for this test, but intended as a reference for usage
+		q.Add("stickerIncludes[product]", "oss")
+		q.Add("stickerIncludes[env]", "dev")
+		q.Add("streamIncludes", "stream1")
+		q.Add("streamIncludes", "stream2")
+		req.URL.RawQuery = q.Encode()
+
+		want := []influxdb.AnnotationList{
+			{
+				StreamTag:   "stream1",
+				Annotations: []influxdb.ReadAnnotation{testRead1},
+			},
+			{
+				StreamTag:   "stream2",
+				Annotations: []influxdb.ReadAnnotation{testRead2},
+			},
+		}
+
+		svc.EXPECT().
+			ListAnnotations(gomock.Any(), *orgID, influxdb.AnnotationListFilter{
+				StickerIncludes: map[string]string{"product": "oss", "env": "dev"},
+				StreamIncludes:  []string{"stream1", "stream2"},
+				BasicFilter: influxdb.BasicFilter{
+					StartTime: &time.Time{},
+					EndTime:   &now,
+				},
+			}).
+			Return(influxdb.ReadAnnotations{
+				"stream1": []influxdb.ReadAnnotation{testRead1},
+				"stream2": []influxdb.ReadAnnotation{testRead2},
+			}, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := []influxdb.AnnotationList{}
+		err := json.NewDecoder(res.Body).Decode(&got)
+		require.NoError(t, err)
+		require.ElementsMatch(t, want, got)
+	})
+
+	t.Run("create annotations happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		createAnnotations := []influxdb.AnnotationCreate{testCreate}
+
+		req := newTestRequest(t, "POST", ts.URL+"/annotations", createAnnotations)
+
+		q := req.URL.Query()
+		q.Add("orgID", orgStr)
+		req.URL.RawQuery = q.Encode()
+
+		want := []influxdb.AnnotationEvent{testEvent}
+
+		svc.EXPECT().
+			CreateAnnotations(gomock.Any(), *orgID, createAnnotations).
+			Return(want, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := []influxdb.AnnotationEvent{}
+		err := json.NewDecoder(res.Body).Decode(&got)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("delete annotations happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "DELETE", ts.URL+"/annotations", nil)
+		q := req.URL.Query()
+		q.Add("orgID", orgStr)
+		q.Add("stream", "someTag")
+		q.Add("startTime", now.Format(time.RFC3339))
+		q.Add("endTime", later.Format(time.RFC3339))
+		req.URL.RawQuery = q.Encode()
+
+		svc.EXPECT().
+			DeleteAnnotations(gomock.Any(), *orgID, influxdb.AnnotationDeleteFilter{
+				StreamTag: "someTag",
+				StartTime: &now,
+				EndTime:   &later,
+				Stickers:  map[string]string{},
+			}).
+			Return(nil)
+
+		doTestRequest(t, req, http.StatusNoContent, false)
+	})
+
+	t.Run("get annotation happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "GET", ts.URL+"/annotations/"+idStr, nil)
+
+		svc.EXPECT().
+			GetAnnotation(gomock.Any(), *id).
+			Return(&testEvent, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := &influxdb.AnnotationEvent{}
+		err := json.NewDecoder(res.Body).Decode(got)
+		require.NoError(t, err)
+		require.Equal(t, &testEvent, got)
+	})
+
+	t.Run("delete annotation happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "DELETE", ts.URL+"/annotations/"+idStr, nil)
+
+		svc.EXPECT().
+			DeleteAnnotation(gomock.Any(), *id).
+			Return(nil)
+
+		doTestRequest(t, req, http.StatusNoContent, false)
+	})
+
+	t.Run("update annotation happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "PUT", ts.URL+"/annotations/"+idStr, testCreate)
+
+		svc.EXPECT().
+			UpdateAnnotation(gomock.Any(), *id, testCreate).
+			Return(&testEvent, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := &influxdb.AnnotationEvent{}
+		err := json.NewDecoder(res.Body).Decode(got)
+		require.NoError(t, err)
+		require.Equal(t, &testEvent, got)
+	})
+
+	t.Run("invalid org ids return 400 when required", func(t *testing.T) {
+		methods := []string{"POST", "GET", "DELETE"}
+
+		for _, m := range methods {
+			t.Run(m, func(t *testing.T) {
+				ts, _ := newTestServer(t)
+				defer ts.Close()
+
+				req := newTestRequest(t, m, ts.URL+"/annotations", nil)
+				q := req.URL.Query()
+				q.Add("orgID", "badid")
+				req.URL.RawQuery = q.Encode()
+
+				doTestRequest(t, req, http.StatusBadRequest, false)
+			})
+		}
+	})
+
+	t.Run("invalid annotation ids return 400 when required", func(t *testing.T) {
+		methods := []string{"GET", "DELETE", "PUT"}
+
+		for _, m := range methods {
+			t.Run(m, func(t *testing.T) {
+				ts, _ := newTestServer(t)
+				defer ts.Close()
+
+				req := newTestRequest(t, m, ts.URL+"/annotations/badID", nil)
+				doTestRequest(t, req, http.StatusBadRequest, false)
+			})
+		}
+	})
+}

--- a/annotations/transport/helpers_test.go
+++ b/annotations/transport/helpers_test.go
@@ -1,0 +1,43 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func newTestServer(t *testing.T) (*httptest.Server, *mock.MockAnnotationService) {
+	ctrlr := gomock.NewController(t)
+	svc := mock.NewMockAnnotationService(ctrlr)
+	server := NewAnnotationHandler(zaptest.NewLogger(t), svc)
+	return httptest.NewServer(server), svc
+}
+
+func newTestRequest(t *testing.T, method, path string, body interface{}) *http.Request {
+	dat, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(method, path, bytes.NewBuffer(dat))
+	require.NoError(t, err)
+
+	req.Header.Add("Content-Type", "application/json")
+
+	return req
+}
+
+func doTestRequest(t *testing.T, req *http.Request, wantCode int, needJSON bool) *http.Response {
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, wantCode, res.StatusCode)
+	if needJSON {
+		require.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
+	}
+	return res
+}

--- a/annotations/transport/helpers_test.go
+++ b/annotations/transport/helpers_test.go
@@ -6,11 +6,22 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+)
+
+var (
+	orgStr   = "1234123412341234"
+	orgID, _ = platform.IDFromString(orgStr)
+	idStr    = "4321432143214321"
+	id, _    = platform.IDFromString(idStr)
+	now      = time.Now().UTC().Truncate(time.Second)
+	later    = now.Add(5 * time.Minute)
 )
 
 func newTestServer(t *testing.T) (*httptest.Server, *mock.MockAnnotationService) {

--- a/annotations/transport/http.go
+++ b/annotations/transport/http.go
@@ -33,6 +33,11 @@ var (
 		Code: errors.EInvalid,
 		Msg:  "stream id is invalid",
 	}
+
+	errBadStreamName = &errors.Error{
+		Code: errors.EInvalid,
+		Msg:  "invalid stream name",
+	}
 )
 
 // AnnotationsHandler is the handler for the annotation service

--- a/annotations/transport/http.go
+++ b/annotations/transport/http.go
@@ -1,0 +1,100 @@
+package transport
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform/errors"
+	kithttp "github.com/influxdata/influxdb/v2/kit/transport/http"
+	"go.uber.org/zap"
+)
+
+const (
+	// this is the base api prefix, since the annotations service mounts handlers at
+	// both the ../annotations and ../streams paths.
+	prefixAnnotations = "/api/v2private"
+)
+
+var (
+	errBadOrg = &errors.Error{
+		Code: errors.EInvalid,
+		Msg:  "invalid or missing org id",
+	}
+
+	errBadAnnotationId = &errors.Error{
+		Code: errors.EInvalid,
+		Msg:  "annotation id is invalid",
+	}
+
+	errBadStreamId = &errors.Error{
+		Code: errors.EInvalid,
+		Msg:  "stream id is invalid",
+	}
+)
+
+// AnnotationsHandler is the handler for the annotation service
+type AnnotationHandler struct {
+	chi.Router
+
+	log *zap.Logger
+	api *kithttp.API
+
+	annotationService influxdb.AnnotationService
+}
+
+func NewAnnotationHandler(
+	log *zap.Logger,
+	annotationService influxdb.AnnotationService,
+) *AnnotationHandler {
+	h := &AnnotationHandler{
+		log:               log,
+		api:               kithttp.NewAPI(kithttp.WithLog(log)),
+		annotationService: annotationService,
+	}
+
+	r := chi.NewRouter()
+	r.Use(
+		middleware.Recoverer,
+		middleware.RequestID,
+		middleware.RealIP,
+	)
+
+	r.Mount("/annotations", h.annotationsRouter())
+	r.Mount("/streams", h.streamsRouter())
+	h.Router = r
+
+	return h
+}
+
+func (h *AnnotationHandler) Prefix() string {
+	return prefixAnnotations
+}
+
+func tFromReq(r *http.Request) (*time.Time, *time.Time, error) {
+	st, err := tStringToPointer(r.URL.Query().Get("startTime"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	et, err := tStringToPointer(r.URL.Query().Get("endTime"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return st, et, nil
+}
+
+func tStringToPointer(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/annotations/transport/http.go
+++ b/annotations/transport/http.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	// this is the base api prefix, since the annotations service mounts handlers at
+	// this is the base api prefix, since the annotations system mounts handlers at
 	// both the ../annotations and ../streams paths.
 	prefixAnnotations = "/api/v2private"
 )
@@ -50,10 +50,7 @@ type AnnotationHandler struct {
 	annotationService influxdb.AnnotationService
 }
 
-func NewAnnotationHandler(
-	log *zap.Logger,
-	annotationService influxdb.AnnotationService,
-) *AnnotationHandler {
+func NewAnnotationHandler(log *zap.Logger, annotationService influxdb.AnnotationService) *AnnotationHandler {
 	h := &AnnotationHandler{
 		log:               log,
 		api:               kithttp.NewAPI(kithttp.WithLog(log)),
@@ -78,6 +75,8 @@ func (h *AnnotationHandler) Prefix() string {
 	return prefixAnnotations
 }
 
+// tFromReq and tStringToPointer are used in handlers to extract time values from query parameters.
+// pointers to time.Time structs are used, since the JSON responses may omit empty (nil pointer) times.
 func tFromReq(r *http.Request) (*time.Time, *time.Time, error) {
 	st, err := tStringToPointer(r.URL.Query().Get("startTime"))
 	if err != nil {

--- a/annotations/transport/streams_router.go
+++ b/annotations/transport/streams_router.go
@@ -1,0 +1,47 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+)
+
+func (h *AnnotationHandler) streamsRouter() http.Handler {
+	r := chi.NewRouter()
+
+	r.Put("/", h.handleCreateOrUpdateStreams)
+	r.Get("/", h.handleGetStreams)
+	r.Delete("/", h.handleDeleteStreams)
+
+	r.Route("/{id}", func(r chi.Router) {
+		r.Delete("/", h.handleDeleteStream)
+		r.Put("/", h.handleUpdateStream)
+	})
+
+	return r
+}
+
+func (h *AnnotationHandler) handleCreateOrUpdateStreams(w http.ResponseWriter, r *http.Request) {
+
+	h.api.Respond(w, r, http.StatusOK, nil)
+}
+
+func (h *AnnotationHandler) handleGetStreams(w http.ResponseWriter, r *http.Request) {
+
+	h.api.Respond(w, r, http.StatusOK, nil)
+}
+
+func (h *AnnotationHandler) handleDeleteStreams(w http.ResponseWriter, r *http.Request) {
+
+	h.api.Respond(w, r, http.StatusOK, nil)
+}
+
+func (h *AnnotationHandler) handleDeleteStream(w http.ResponseWriter, r *http.Request) {
+
+	h.api.Respond(w, r, http.StatusOK, nil)
+}
+
+func (h *AnnotationHandler) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
+
+	h.api.Respond(w, r, http.StatusOK, nil)
+}

--- a/annotations/transport/streams_router.go
+++ b/annotations/transport/streams_router.go
@@ -1,47 +1,178 @@
 package transport
 
 import (
+	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
 )
 
 func (h *AnnotationHandler) streamsRouter() http.Handler {
 	r := chi.NewRouter()
 
-	r.Put("/", h.handleCreateOrUpdateStreams)
+	r.Put("/", h.handleCreateOrUpdateStream)
 	r.Get("/", h.handleGetStreams)
 	r.Delete("/", h.handleDeleteStreams)
 
 	r.Route("/{id}", func(r chi.Router) {
 		r.Delete("/", h.handleDeleteStream)
-		r.Put("/", h.handleUpdateStream)
+		r.Put("/", h.handleUpdateStreamByID)
 	})
 
 	return r
 }
 
-func (h *AnnotationHandler) handleCreateOrUpdateStreams(w http.ResponseWriter, r *http.Request) {
+func (h *AnnotationHandler) handleCreateOrUpdateStream(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-	h.api.Respond(w, r, http.StatusOK, nil)
+	u, err := decodeCreateOrUpdateStreamRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	s, err := h.annotationService.CreateOrUpdateStream(ctx, *u)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, s)
 }
 
 func (h *AnnotationHandler) handleGetStreams(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-	h.api.Respond(w, r, http.StatusOK, nil)
+	o, err := platform.IDFromString(r.URL.Query().Get("orgID"))
+	if err != nil {
+		h.api.Err(w, r, errBadOrg)
+		return
+	}
+
+	f, err := decodeListStreamsRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	l, err := h.annotationService.ListStreams(ctx, *o, *f)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, l)
 }
 
+// Delete stream(s) by name, capable of handling a list of names
 func (h *AnnotationHandler) handleDeleteStreams(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-	h.api.Respond(w, r, http.StatusOK, nil)
+	f, err := decodeDeleteStreamsRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	// delete all of the streams according to the filter. annotations associated with the stream
+	// will be deleted by the ON DELETE CASCADE relationship between streams and annotations.
+	if err = h.annotationService.DeleteStreams(ctx, *f); err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusNoContent, nil)
 }
 
+// Delete a single stream by ID
 func (h *AnnotationHandler) handleDeleteStream(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-	h.api.Respond(w, r, http.StatusOK, nil)
+	id, err := platform.IDFromString(chi.URLParam(r, "id"))
+	if err != nil {
+		h.api.Err(w, r, errBadAnnotationId)
+		return
+	}
+
+	// as in the handleDeleteStreams method above, deleting a stream will delete annotations
+	// associated with it due to the ON DELETE CASCADE relationship between the two
+	if err := h.annotationService.DeleteStreamByID(ctx, *id); err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusNoContent, nil)
 }
 
-func (h *AnnotationHandler) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
+func (h *AnnotationHandler) handleUpdateStreamByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-	h.api.Respond(w, r, http.StatusOK, nil)
+	id, err := platform.IDFromString(chi.URLParam(r, "id"))
+	if err != nil {
+		h.api.Err(w, r, errBadAnnotationId)
+		return
+	}
+
+	u, err := decodeCreateOrUpdateStreamRequest(r)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	s, err := h.annotationService.UpdateStream(ctx, *id, *u)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+
+	h.api.Respond(w, r, http.StatusOK, s)
+}
+
+func decodeCreateOrUpdateStreamRequest(r *http.Request) (*influxdb.Stream, error) {
+	s := influxdb.Stream{}
+
+	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
+		return nil, err
+	}
+
+	if err := s.Validate(false); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+func decodeListStreamsRequest(r *http.Request) (*influxdb.StreamListFilter, error) {
+	startTime, endTime, err := tFromReq(r)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &influxdb.StreamListFilter{
+		StreamIncludes: r.URL.Query()["streamIncludes"],
+		BasicFilter: influxdb.BasicFilter{
+			EndTime:   endTime,
+			StartTime: startTime,
+		},
+	}
+
+	if err := f.Validate(time.Now); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func decodeDeleteStreamsRequest(r *http.Request) (*influxdb.BasicStream, error) {
+	f := &influxdb.BasicStream{
+		Names: r.URL.Query()["stream"],
+	}
+
+	if !f.IsValid() {
+		return nil, errBadStreamName
+	}
+
+	return f, nil
 }

--- a/annotations/transport/streams_router_test.go
+++ b/annotations/transport/streams_router_test.go
@@ -1,0 +1,174 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2"
+	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testCreateStream = influxdb.Stream{
+		Name: "test stream",
+	}
+
+	testReadStream1 = &influxdb.ReadStream{
+		ID:        *influxdbtesting.IDPtr(1),
+		Name:      "test stream 1",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	testReadStream2 = &influxdb.ReadStream{
+		ID:        *influxdbtesting.IDPtr(2),
+		Name:      "test stream 2",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+)
+
+func TestStreamsRouter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create or update stream happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "PUT", ts.URL+"/streams", testCreateStream)
+
+		q := req.URL.Query()
+		q.Add("orgID", orgStr)
+		req.URL.RawQuery = q.Encode()
+
+		svc.EXPECT().
+			CreateOrUpdateStream(gomock.Any(), testCreateStream).
+			Return(testReadStream1, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := &influxdb.ReadStream{}
+		err := json.NewDecoder(res.Body).Decode(got)
+		require.NoError(t, err)
+		require.Equal(t, testReadStream1, got)
+	})
+
+	t.Run("get streams happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "GET", ts.URL+"/streams", nil)
+
+		q := req.URL.Query()
+		q.Add("orgID", orgStr)
+		q.Add("endTime", now.Format(time.RFC3339))
+		q.Add("streamIncludes", "stream1")
+		q.Add("streamIncludes", "stream2")
+		req.URL.RawQuery = q.Encode()
+
+		want := []influxdb.ReadStream{*testReadStream1, *testReadStream2}
+
+		svc.EXPECT().
+			ListStreams(gomock.Any(), *orgID, influxdb.StreamListFilter{
+				StreamIncludes: []string{"stream1", "stream2"},
+				BasicFilter: influxdb.BasicFilter{
+					StartTime: &time.Time{},
+					EndTime:   &now,
+				},
+			}).
+			Return(want, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := []influxdb.ReadStream{}
+		err := json.NewDecoder(res.Body).Decode(&got)
+		require.NoError(t, err)
+		require.ElementsMatch(t, want, got)
+	})
+
+	t.Run("delete streams (by name) happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "DELETE", ts.URL+"/streams", nil)
+		q := req.URL.Query()
+		q.Add("stream", "stream1")
+		q.Add("stream", "stream2")
+		req.URL.RawQuery = q.Encode()
+
+		svc.EXPECT().
+			DeleteStreams(gomock.Any(), influxdb.BasicStream{
+				Names: []string{"stream1", "stream2"},
+			}).
+			Return(nil)
+
+		doTestRequest(t, req, http.StatusNoContent, false)
+	})
+
+	t.Run("delete stream happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "DELETE", ts.URL+"/streams/"+idStr, nil)
+
+		svc.EXPECT().
+			DeleteStreamByID(gomock.Any(), *id).
+			Return(nil)
+
+		doTestRequest(t, req, http.StatusNoContent, false)
+	})
+
+	t.Run("update stream by id happy path", func(t *testing.T) {
+		ts, svc := newTestServer(t)
+		defer ts.Close()
+
+		req := newTestRequest(t, "PUT", ts.URL+"/streams/"+idStr, testCreateStream)
+
+		svc.EXPECT().
+			UpdateStream(gomock.Any(), *id, testCreateStream).
+			Return(testReadStream1, nil)
+
+		res := doTestRequest(t, req, http.StatusOK, true)
+
+		got := &influxdb.ReadStream{}
+		err := json.NewDecoder(res.Body).Decode(got)
+		require.NoError(t, err)
+		require.Equal(t, testReadStream1, got)
+	})
+
+	t.Run("invalid org ids return 400 when required", func(t *testing.T) {
+		methods := []string{"GET"}
+
+		for _, m := range methods {
+			t.Run(m, func(t *testing.T) {
+				ts, _ := newTestServer(t)
+				defer ts.Close()
+
+				req := newTestRequest(t, m, ts.URL+"/streams", nil)
+				q := req.URL.Query()
+				q.Add("orgID", "badid")
+				req.URL.RawQuery = q.Encode()
+
+				doTestRequest(t, req, http.StatusBadRequest, false)
+			})
+		}
+	})
+
+	t.Run("invalid stream ids return 400 when required", func(t *testing.T) {
+		methods := []string{"DELETE", "PUT"}
+
+		for _, m := range methods {
+			t.Run(m, func(t *testing.T) {
+				ts, _ := newTestServer(t)
+				defer ts.Close()
+
+				req := newTestRequest(t, m, ts.URL+"/streams/badID", nil)
+				doTestRequest(t, req, http.StatusBadRequest, false)
+			})
+		}
+	})
+}

--- a/mock/annotation_service.go
+++ b/mock/annotation_service.go
@@ -94,20 +94,6 @@ func (mr *MockAnnotationServiceMockRecorder) DeleteAnnotations(ctx, orgID, delet
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAnnotations", reflect.TypeOf((*MockAnnotationService)(nil).DeleteAnnotations), ctx, orgID, delete)
 }
 
-// DeleteStream mocks base method.
-func (m *MockAnnotationService) DeleteStream(ctx context.Context, streamName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteStream", ctx, streamName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteStream indicates an expected call of DeleteStream.
-func (mr *MockAnnotationServiceMockRecorder) DeleteStream(ctx, streamName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStream", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStream), ctx, streamName)
-}
-
 // DeleteStreamByID mocks base method.
 func (m *MockAnnotationService) DeleteStreamByID(ctx context.Context, id platform.ID) error {
 	m.ctrl.T.Helper()
@@ -120,6 +106,20 @@ func (m *MockAnnotationService) DeleteStreamByID(ctx context.Context, id platfor
 func (mr *MockAnnotationServiceMockRecorder) DeleteStreamByID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStreamByID", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStreamByID), ctx, id)
+}
+
+// DeleteStreams mocks base method.
+func (m *MockAnnotationService) DeleteStreams(ctx context.Context, delete influxdb.BasicStream) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteStreams", ctx, delete)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteStreams indicates an expected call of DeleteStreams.
+func (mr *MockAnnotationServiceMockRecorder) DeleteStreams(ctx, delete interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStreams", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStreams), ctx, delete)
 }
 
 // GetAnnotation mocks base method.

--- a/mock/annotation_service.go
+++ b/mock/annotation_service.go
@@ -52,32 +52,32 @@ func (mr *MockAnnotationServiceMockRecorder) CreateAnnotations(ctx, orgID, creat
 }
 
 // CreateOrUpdateStream mocks base method.
-func (m *MockAnnotationService) CreateOrUpdateStream(ctx context.Context, orgID platform.ID, stream influxdb.Stream) (*influxdb.ReadStream, error) {
+func (m *MockAnnotationService) CreateOrUpdateStream(ctx context.Context, stream influxdb.Stream) (*influxdb.ReadStream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateStream", ctx, orgID, stream)
+	ret := m.ctrl.Call(m, "CreateOrUpdateStream", ctx, stream)
 	ret0, _ := ret[0].(*influxdb.ReadStream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateOrUpdateStream indicates an expected call of CreateOrUpdateStream.
-func (mr *MockAnnotationServiceMockRecorder) CreateOrUpdateStream(ctx, orgID, stream interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) CreateOrUpdateStream(ctx, stream interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateStream", reflect.TypeOf((*MockAnnotationService)(nil).CreateOrUpdateStream), ctx, orgID, stream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateStream", reflect.TypeOf((*MockAnnotationService)(nil).CreateOrUpdateStream), ctx, stream)
 }
 
 // DeleteAnnotation mocks base method.
-func (m *MockAnnotationService) DeleteAnnotation(ctx context.Context, orgID, id platform.ID) error {
+func (m *MockAnnotationService) DeleteAnnotation(ctx context.Context, id platform.ID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAnnotation", ctx, orgID, id)
+	ret := m.ctrl.Call(m, "DeleteAnnotation", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAnnotation indicates an expected call of DeleteAnnotation.
-func (mr *MockAnnotationServiceMockRecorder) DeleteAnnotation(ctx, orgID, id interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) DeleteAnnotation(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).DeleteAnnotation), ctx, orgID, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).DeleteAnnotation), ctx, id)
 }
 
 // DeleteAnnotations mocks base method.
@@ -95,46 +95,46 @@ func (mr *MockAnnotationServiceMockRecorder) DeleteAnnotations(ctx, orgID, delet
 }
 
 // DeleteStream mocks base method.
-func (m *MockAnnotationService) DeleteStream(ctx context.Context, orgID platform.ID, streamName string) error {
+func (m *MockAnnotationService) DeleteStream(ctx context.Context, streamName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteStream", ctx, orgID, streamName)
+	ret := m.ctrl.Call(m, "DeleteStream", ctx, streamName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteStream indicates an expected call of DeleteStream.
-func (mr *MockAnnotationServiceMockRecorder) DeleteStream(ctx, orgID, streamName interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) DeleteStream(ctx, streamName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStream", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStream), ctx, orgID, streamName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStream", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStream), ctx, streamName)
 }
 
 // DeleteStreamByID mocks base method.
-func (m *MockAnnotationService) DeleteStreamByID(ctx context.Context, orgID, id platform.ID) error {
+func (m *MockAnnotationService) DeleteStreamByID(ctx context.Context, id platform.ID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteStreamByID", ctx, orgID, id)
+	ret := m.ctrl.Call(m, "DeleteStreamByID", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteStreamByID indicates an expected call of DeleteStreamByID.
-func (mr *MockAnnotationServiceMockRecorder) DeleteStreamByID(ctx, orgID, id interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) DeleteStreamByID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStreamByID", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStreamByID), ctx, orgID, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStreamByID", reflect.TypeOf((*MockAnnotationService)(nil).DeleteStreamByID), ctx, id)
 }
 
 // GetAnnotation mocks base method.
-func (m *MockAnnotationService) GetAnnotation(ctx context.Context, orgID, id platform.ID) (*influxdb.AnnotationEvent, error) {
+func (m *MockAnnotationService) GetAnnotation(ctx context.Context, id platform.ID) (*influxdb.AnnotationEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAnnotation", ctx, orgID, id)
+	ret := m.ctrl.Call(m, "GetAnnotation", ctx, id)
 	ret0, _ := ret[0].(*influxdb.AnnotationEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAnnotation indicates an expected call of GetAnnotation.
-func (mr *MockAnnotationServiceMockRecorder) GetAnnotation(ctx, orgID, id interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) GetAnnotation(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).GetAnnotation), ctx, orgID, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).GetAnnotation), ctx, id)
 }
 
 // ListAnnotations mocks base method.
@@ -168,31 +168,31 @@ func (mr *MockAnnotationServiceMockRecorder) ListStreams(ctx, orgID, filter inte
 }
 
 // UpdateAnnotation mocks base method.
-func (m *MockAnnotationService) UpdateAnnotation(ctx context.Context, orgID, id platform.ID, update influxdb.AnnotationCreate) (*influxdb.AnnotationEvent, error) {
+func (m *MockAnnotationService) UpdateAnnotation(ctx context.Context, id platform.ID, update influxdb.AnnotationCreate) (*influxdb.AnnotationEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAnnotation", ctx, orgID, id, update)
+	ret := m.ctrl.Call(m, "UpdateAnnotation", ctx, id, update)
 	ret0, _ := ret[0].(*influxdb.AnnotationEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateAnnotation indicates an expected call of UpdateAnnotation.
-func (mr *MockAnnotationServiceMockRecorder) UpdateAnnotation(ctx, orgID, id, update interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) UpdateAnnotation(ctx, id, update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).UpdateAnnotation), ctx, orgID, id, update)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockAnnotationService)(nil).UpdateAnnotation), ctx, id, update)
 }
 
 // UpdateStream mocks base method.
-func (m *MockAnnotationService) UpdateStream(ctx context.Context, orgID, id platform.ID, stream influxdb.Stream) (*influxdb.ReadStream, error) {
+func (m *MockAnnotationService) UpdateStream(ctx context.Context, id platform.ID, stream influxdb.Stream) (*influxdb.ReadStream, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStream", ctx, orgID, id, stream)
+	ret := m.ctrl.Call(m, "UpdateStream", ctx, id, stream)
 	ret0, _ := ret[0].(*influxdb.ReadStream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateStream indicates an expected call of UpdateStream.
-func (mr *MockAnnotationServiceMockRecorder) UpdateStream(ctx, orgID, id, stream interface{}) *gomock.Call {
+func (mr *MockAnnotationServiceMockRecorder) UpdateStream(ctx, id, stream interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStream", reflect.TypeOf((*MockAnnotationService)(nil).UpdateStream), ctx, orgID, id, stream)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStream", reflect.TypeOf((*MockAnnotationService)(nil).UpdateStream), ctx, id, stream)
 }


### PR DESCRIPTION
This PR closes several issues on the annotations epic, including:
#21205
#21206
#21207
#21208

There was not as much need to break these up as I had originally thought, and reviewing them as a whole unit should be easier than looking at them individually since they are so similar.

The handler code is mostly straight-forward. There were also a few small tweaks I made to the service definition for OSS-specific things, particularly only requiring the org ID when it's necessary to do the query since that will have to be passed in the query parameters.

