### PR TITLE
fix: do not panic on cleaning up failed iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 v1.9.3 [unreleased]
+
+#### Bugfixes
+
 -	[#21592](https://github.com/influxdata/influxdb/pull/21592): fix: avoid rewriting fields.idx unnecessarily
 -	[#21659](https://github.com/influxdata/influxdb/pull/21659): fix: do not close connection twice in DigestWithOptions
+-	[#21666](https://github.com/influxdata/influxdb/pull/21666): fix: do not panic on cleaning up failed iterators
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -51,17 +51,14 @@ func (a Iterators) Stats() IteratorStats {
 // unhappy.
 func (a Iterators) Close() (err error) {
 	err = nil
-	if a != nil {
-		for _, itr := range a {
-			if itr != nil {
-				if e := itr.Close(); e != nil && err == nil {
-					err = e
-				}
+	for _, itr := range a {
+		if itr != nil {
+			if e := itr.Close(); e != nil && err == nil {
+				err = e
 			}
 		}
-		return err
 	}
-	return nil
+	return err
 }
 
 // filterNonNil returns a slice of iterators that removes all nil iterators.

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -43,9 +43,23 @@ func (a Iterators) Stats() IteratorStats {
 }
 
 // Close closes all iterators.
-func (a Iterators) Close() error {
-	for _, itr := range a {
-		itr.Close()
+// We are seeing an occasional panic in this function
+// which looks like a nil reference from one
+// itr.Close() call, thus we check for nil elements
+// in the slice a.  This is often called as error
+// clean-up, so the state of the iterators may be
+// unhappy.
+func (a Iterators) Close() (err error) {
+	err = nil
+	if a != nil {
+		for _, itr := range a {
+			if itr != nil {
+				if e := itr.Close(); e != nil && err == nil {
+					err = e
+				}
+			}
+		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
We have seen occasional panics in Iterators.Close()
when cleaning up after failed iterator creation.
This commit checks for nil on any iterator to be
closed, and now returns any errors generated by
that Close().

Closes https://github.com/influxdata/influxdb/issues/19579
Closes https://github.com/influxdata/influxdb/issues/19476

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
