### PR TITLE
feat: add support for gzip request bodies in restore API

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -147,6 +147,7 @@ var blacklistEndpoints = map[string]isValidMethodFn{
 	prefixNotificationEndpoints:      ignoreMethod("POST"),
 	notificationEndpointsIDPath:      ignoreMethod("PUT"),
 	restoreKVPath:                    ignoreMethod(),
+	restoreSqlPath:                   ignoreMethod(),
 	restoreBucketPath:                ignoreMethod(),
 	restoreShardPath:                 ignoreMethod(),
 }

--- a/http/restore_service.go
+++ b/http/restore_service.go
@@ -81,7 +81,6 @@ func (h *RestoreHandler) handleRestoreKVStore(w http.ResponseWriter, r *http.Req
 	defer span.Finish()
 
 	ctx := r.Context()
-	defer r.Body.Close()
 
 	var kvBytes io.Reader = r.Body
 	if r.Header.Get("Content-Encoding") == "gzip" {
@@ -109,7 +108,6 @@ func (h *RestoreHandler) handleRestoreSqlStore(w http.ResponseWriter, r *http.Re
 	defer span.Finish()
 
 	ctx := r.Context()
-	defer r.Body.Close()
 
 	var sqlBytes io.Reader = r.Body
 	if r.Header.Get("Content-Encoding") == "gzip" {
@@ -137,7 +135,6 @@ func (h *RestoreHandler) handleRestoreBucket(w http.ResponseWriter, r *http.Requ
 	defer span.Finish()
 
 	ctx := r.Context()
-	defer r.Body.Close()
 
 	// Read bucket ID.
 	bucketID, err := decodeIDFromCtx(r.Context(), "bucketID")
@@ -170,7 +167,6 @@ func (h *RestoreHandler) handleRestoreShard(w http.ResponseWriter, r *http.Reque
 	defer span.Finish()
 
 	ctx := r.Context()
-	defer r.Body.Close()
 
 	params := httprouter.ParamsFromContext(ctx)
 	shardID, err := strconv.ParseUint(params.ByName("shardID"), 10, 64)


### PR DESCRIPTION
Closes #21669 
Closes #21670 
Closes #21671 

For the 3 APIs that expect the request-body to be a file, check if `Content-Encoding: gzip` is set and wrap a gzip reader around the body stream if so. Tested manually with the new CLI.