### PR TITLE
feat: add bucket description and retention rules to backup manifest

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -66,15 +66,8 @@ type BucketMetadataManifest struct {
 	BucketID               platform.ID               `json:"bucketID"`
 	BucketName             string                    `json:"bucketName"`
 	Description            *string                   `json:"description,omitempty"`
-	RetentionRules         []RetentionRuleManifest   `json:"retentionRules"`
 	DefaultRetentionPolicy string                    `json:"defaultRetentionPolicy"`
 	RetentionPolicies      []RetentionPolicyManifest `json:"retentionPolicies"`
-}
-
-type RetentionRuleManifest struct {
-	Type                      string `json:"type"`
-	EverySeconds              int64  `json:"everySeconds"`
-	ShardGroupDurationSeconds int64  `json:"shardGroupDurationSeconds"`
 }
 
 type RetentionPolicyManifest struct {

--- a/backup.go
+++ b/backup.go
@@ -65,8 +65,16 @@ type BucketMetadataManifest struct {
 	OrganizationName       string                    `json:"organizationName"`
 	BucketID               platform.ID               `json:"bucketID"`
 	BucketName             string                    `json:"bucketName"`
+	Description            *string                   `json:"description,omitempty"`
+	RetentionRules         []RetentionRuleManifest   `json:"retentionRules"`
 	DefaultRetentionPolicy string                    `json:"defaultRetentionPolicy"`
 	RetentionPolicies      []RetentionPolicyManifest `json:"retentionPolicies"`
+}
+
+type RetentionRuleManifest struct {
+	Type                      string `json:"type"`
+	EverySeconds              int64  `json:"everySeconds"`
+	ShardGroupDurationSeconds int64  `json:"shardGroupDurationSeconds"`
 }
 
 type RetentionPolicyManifest struct {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -52,11 +52,24 @@ func (b BucketManifestWriter) WriteManifest(ctx context.Context, w io.Writer) er
 
 		dbInfo := b.mc.Database(bkt.ID.String())
 
+		var description *string
+		if bkt.Description != "" {
+			description = &bkt.Description
+		}
+
 		l = append(l, influxdb.BucketMetadataManifest{
-			OrganizationID:         bkt.OrgID,
-			OrganizationName:       org.Name,
-			BucketID:               bkt.ID,
-			BucketName:             bkt.Name,
+			OrganizationID:   bkt.OrgID,
+			OrganizationName: org.Name,
+			BucketID:         bkt.ID,
+			BucketName:       bkt.Name,
+			Description:      description,
+			RetentionRules: []influxdb.RetentionRuleManifest{
+				{
+					Type:                      "expire",
+					EverySeconds:              int64(bkt.RetentionPeriod.Round(time.Second).Seconds()),
+					ShardGroupDurationSeconds: int64(bkt.ShardGroupDuration.Round(time.Second).Seconds()),
+				},
+			},
 			DefaultRetentionPolicy: dbInfo.DefaultRetentionPolicy,
 			RetentionPolicies:      retentionPolicyToManifest(dbInfo.RetentionPolicies),
 		})

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -63,13 +63,6 @@ func (b BucketManifestWriter) WriteManifest(ctx context.Context, w io.Writer) er
 			BucketID:         bkt.ID,
 			BucketName:       bkt.Name,
 			Description:      description,
-			RetentionRules: []influxdb.RetentionRuleManifest{
-				{
-					Type:                      "expire",
-					EverySeconds:              int64(bkt.RetentionPeriod.Round(time.Second).Seconds()),
-					ShardGroupDurationSeconds: int64(bkt.ShardGroupDuration.Round(time.Second).Seconds()),
-				},
-			},
 			DefaultRetentionPolicy: dbInfo.DefaultRetentionPolicy,
 			RetentionPolicies:      retentionPolicyToManifest(dbInfo.RetentionPolicies),
 		})

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -58,11 +58,11 @@ func (b BucketManifestWriter) WriteManifest(ctx context.Context, w io.Writer) er
 		}
 
 		l = append(l, influxdb.BucketMetadataManifest{
-			OrganizationID:   bkt.OrgID,
-			OrganizationName: org.Name,
-			BucketID:         bkt.ID,
-			BucketName:       bkt.Name,
-			Description:      description,
+			OrganizationID:         bkt.OrgID,
+			OrganizationName:       org.Name,
+			BucketID:               bkt.ID,
+			BucketName:             bkt.Name,
+			Description:            description,
 			DefaultRetentionPolicy: dbInfo.DefaultRetentionPolicy,
 			RetentionPolicies:      retentionPolicyToManifest(dbInfo.RetentionPolicies),
 		})


### PR DESCRIPTION
Closes #21681

Updates the manifest to match influxdata/openapi#130. Adding these new fields will allow the new `restore/bucket-metadata` API to recreate buckets based solely off the manifest contents.