### PR TITLE
fix: Do not close connection twice in DigestWithOptions (#21659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 -	[#21609](https://github.com/influxdata/influxdb/pull/21609): fix: avoid rewriting fields.idx unnecessarily 
+-	[#21695](https://github.com/influxdata/influxdb/pull/21695): fix: Do not close connection twice in DigestWithOptions
 
 v1.9.2 [unreleased]
 


### PR DESCRIPTION
tsm1.DigestWithOptions closes its network connection
twice. This may cause broken pipe errors on concurrent
invocations of the same procedure, by closing a reused
i/o descriptor. This fix also captures errors from TSM
file closures, which were previously ignored.

Closes https://github.com/influxdata/influxdb/issues/21656

(cherry picked from commit bce6553459e0eadea414696c0c564ad28275116b)

Closes https://github.com/influxdata/influxdb/issues/21657

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass