### PR TITLE
fix: don't access a field in a nil struct (#21693)

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1769,8 +1769,8 @@ func (fs *MeasurementFieldSet) SetMeasurementFieldSetWriter(queueLength int) {
 func (w *MeasurementFieldSetWriter) Close() {
 	if w != nil {
 		close(w.writeRequests)
+		w.wg.Wait()
 	}
-	w.wg.Wait()
 }
 
 func (fs *MeasurementFieldSet) Save() error {


### PR DESCRIPTION
Move an access to a waitgroup into an `if` that ensures
the containing struct is not nil.

(cherry picked from commit aca69e530f16441e343265d717001c68cd1db115)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass