### PR TITLE
fix: do not panic on cleaning up failed iterators (#21666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-[unreleased]
+v1.9.3 [unreleased]
 
 ### Bugfixes
 
 -	[#21609](https://github.com/influxdata/influxdb/pull/21609): fix: avoid rewriting fields.idx unnecessarily 
 -	[#21695](https://github.com/influxdata/influxdb/pull/21695): fix: Do not close connection twice in DigestWithOptions
+-	[#21697](https://github.com/influxdata/influxdb/pull/21697): fix: do not panic on cleaning up failed iterators
 
 v1.9.2 [unreleased]
 

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -43,11 +43,22 @@ func (a Iterators) Stats() IteratorStats {
 }
 
 // Close closes all iterators.
-func (a Iterators) Close() error {
+// We are seeing an occasional panic in this function
+// which looks like a nil reference from one
+// itr.Close() call, thus we check for nil elements
+// in the slice a.  This is often called as error
+// clean-up, so the state of the iterators may be
+// unhappy.
+func (a Iterators) Close() (err error) {
+	err = nil
 	for _, itr := range a {
-		itr.Close()
+		if itr != nil {
+			if e := itr.Close(); e != nil && err == nil {
+				err = e
+			}
+		}
 	}
-	return nil
+	return err
 }
 
 // filterNonNil returns a slice of iterators that removes all nil iterators.


### PR DESCRIPTION
We have seen occasional panics in Iterators.Close()
when cleaning up after failed iterator creation.
This commit checks for nil on any iterator to be
closed, and now returns any errors generated by
that Close().

Closes https://github.com/influxdata/influxdb/issues/19579
Closes https://github.com/influxdata/influxdb/issues/19476

(cherry picked from commit acc4105b8c48657287ddeaed56c28fd2840dd862)

Closes https://github.com/influxdata/influxdb/issues/21667

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
