### PR TITLE
feat(notebooks): additional auth filter for listing

### DIFF
--- a/authorizer/authorize_find.go
+++ b/authorizer/authorize_find.go
@@ -128,6 +128,24 @@ func AuthorizeFindStreams(ctx context.Context, rs []influxdb.StoredStream) ([]in
 	return rrs, len(rrs), nil
 }
 
+// AuthorizeFindNotebooks takes the given items and returns only the ones that the user is authorized to read.
+func AuthorizeFindNotebooks(ctx context.Context, rs []*influxdb.Notebook) ([]*influxdb.Notebook, int, error) {
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	rrs := rs[:0]
+	for _, r := range rs {
+		_, _, err := AuthorizeRead(ctx, influxdb.NotebooksResourceType, r.ID, r.OrgID)
+		if err != nil && errors.ErrorCode(err) != errors.EUnauthorized {
+			return nil, 0, err
+		}
+		if errors.ErrorCode(err) == errors.EUnauthorized {
+			continue
+		}
+		rrs = append(rrs, r)
+	}
+	return rrs, len(rrs), nil
+}
+
 // AuthorizeFindOrganizations takes the given items and returns only the ones that the user is authorized to read.
 func AuthorizeFindOrganizations(ctx context.Context, rs []*influxdb.Organization) ([]*influxdb.Organization, int, error) {
 	// This filters without allocating

--- a/authorizer/notebook.go
+++ b/authorizer/notebook.go
@@ -73,5 +73,11 @@ func (s *NotebookService) ListNotebooks(ctx context.Context, filter influxdb.Not
 		return nil, err
 	}
 
-	return s.s.ListNotebooks(ctx, filter)
+	ns, err := s.s.ListNotebooks(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	ns, _, err = AuthorizeFindNotebooks(ctx, ns)
+	return ns, err
 }


### PR DESCRIPTION
Closes #21668

This adds an additional filtering step for the "list all" operation on notebooks to filter the list down to only specific resources that the user has access to. Although it's not currently used, this could be useful in the future if fine-grained authz is implemented, and is consistent with #21668 and the other REST resources of the platform.