### PR TITLE
chore: add logging to compaction (#21707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 v1.9.3 [unreleased]
 
+### Features
+
+-	[#21710](https://github.com/influxdata/influxdb/pull/21710): chore: add logging to compaction
+
 ### Bugfixes
 
 -	[#21609](https://github.com/influxdata/influxdb/pull/21609): fix: avoid rewriting fields.idx unnecessarily 

--- a/cmd/influx_tools/compact/command.go
+++ b/cmd/influx_tools/compact/command.go
@@ -229,7 +229,7 @@ func (sc *shardCompactor) CompactShard() (err error) {
 	c.FileStore = sc
 	c.Open()
 
-	tsmFiles, err := c.CompactFull(sc.tsm)
+	tsmFiles, err := c.CompactFull(sc.tsm, sc.logger)
 	if err == nil {
 		sc.newTSM, err = sc.replace(tsmFiles)
 	}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"go.uber.org/zap"
 )
 
 //  Tests compacting a Cache snapshot into a single TSM file
@@ -39,7 +40,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 	compactor.Dir = dir
 	compactor.FileStore = &fakeFileStore{}
 
-	files, err := compactor.WriteSnapshot(c)
+	files, err := compactor.WriteSnapshot(c, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 
 	compactor.Open()
 
-	files, err = compactor.WriteSnapshot(c)
+	files, err = compactor.WriteSnapshot(c, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
 	compactor.FileStore = fs
 	compactor.Open()
 
-	files, err := compactor.CompactFull([]string{f1, f2})
+	files, err := compactor.CompactFull([]string{f1, f2}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %#v", err)
 	}
@@ -175,7 +176,7 @@ func TestCompactor_CompactFull(t *testing.T) {
 	compactor.Dir = dir
 	compactor.FileStore = fs
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
@@ -186,7 +187,7 @@ func TestCompactor_CompactFull(t *testing.T) {
 
 	compactor.Open()
 
-	files, err = compactor.CompactFull([]string{f1, f2, f3})
+	files, err = compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -285,7 +286,7 @@ func TestCompactor_DecodeError(t *testing.T) {
 	compactor.Dir = dir
 	compactor.FileStore = fs
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err == nil {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
@@ -296,7 +297,7 @@ func TestCompactor_DecodeError(t *testing.T) {
 
 	compactor.Open()
 
-	if _, err = compactor.CompactFull([]string{f1, f2, f3}); err == nil || !strings.Contains(err.Error(), "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp") {
+	if _, err = compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop()); err == nil || !strings.Contains(err.Error(), "decode error: unable to decompress block type float for key 'cpu,host=A#!~#value': unpackBlock: not enough data for timestamp") {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
 }
@@ -334,7 +335,7 @@ func TestCompactor_Compact_OverlappingBlocks(t *testing.T) {
 
 	compactor.Open()
 
-	files, err := compactor.CompactFast([]string{f1, f3})
+	files, err := compactor.CompactFast([]string{f1, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -414,7 +415,7 @@ func TestCompactor_Compact_OverlappingBlocksMultiple(t *testing.T) {
 
 	compactor.Open()
 
-	files, err := compactor.CompactFast([]string{f1, f2, f3})
+	files, err := compactor.CompactFast([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -482,7 +483,7 @@ func TestCompactor_Compact_UnsortedBlocks(t *testing.T) {
 
 	compactor.Open()
 
-	files, err := compactor.CompactFast([]string{f1, f2})
+	files, err := compactor.CompactFast([]string{f1, f2}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -556,7 +557,7 @@ func TestCompactor_Compact_UnsortedBlocksOverlapping(t *testing.T) {
 
 	compactor.Open()
 
-	files, err := compactor.CompactFast([]string{f1, f2, f3})
+	files, err := compactor.CompactFast([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -627,7 +628,7 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 	compactor.Size = 2
 	compactor.Open()
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -729,7 +730,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 	compactor.Size = 2
 	compactor.Open()
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -832,7 +833,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 	compactor.Size = 2
 	compactor.Open()
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -940,7 +941,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 	compactor.Size = 2
 	compactor.Open()
 
-	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	files, err := compactor.CompactFull([]string{f1, f2, f3}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -1056,7 +1057,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 	compactor.Open()
 
 	// Compact both files, should get 2 files back
-	files, err := compactor.CompactFull([]string{f1Name, f2Name})
+	files, err := compactor.CompactFull([]string{f1Name, f2Name}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -916,8 +916,8 @@ func (e *Engine) IsIdle() (state bool, reason string) {
 
 	if cacheSize := e.Cache.Size(); cacheSize > 0 {
 		return false, "not idle because cache size is nonzero"
-	} else if !e.CompactionPlan.FullyCompacted() {
-		return false, "not idle because shard is not fully compacted"
+	} else if c, r := e.CompactionPlan.FullyCompacted(); !c {
+		return false, r
 	} else {
 		return true, ""
 	}
@@ -1985,7 +1985,7 @@ func (e *Engine) writeSnapshotAndCommit(log *zap.Logger, closedFiles []string, s
 	}()
 
 	// write the new snapshot files
-	newFiles, err := e.Compactor.WriteSnapshot(snapshot)
+	newFiles, err := e.Compactor.WriteSnapshot(snapshot, e.logger)
 	if err != nil {
 		log.Info("Error writing snapshot from compactor", zap.Error(err))
 		return err
@@ -2269,11 +2269,10 @@ func (s *compactionStrategy) compactGroup() {
 		err   error
 		files []string
 	)
-
 	if s.fast {
-		files, err = s.compactor.CompactFast(group)
+		files, err = s.compactor.CompactFast(group, log)
 	} else {
-		files, err = s.compactor.CompactFull(group)
+		files, err = s.compactor.CompactFull(group, log)
 	}
 
 	if err != nil {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2876,7 +2876,7 @@ func (m *mockPlanner) Plan(lastWrite time.Time) []tsm1.CompactionGroup { return 
 func (m *mockPlanner) PlanLevel(level int) []tsm1.CompactionGroup      { return nil }
 func (m *mockPlanner) PlanOptimize() []tsm1.CompactionGroup            { return nil }
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)           {}
-func (m *mockPlanner) FullyCompacted() bool                            { return false }
+func (m *mockPlanner) FullyCompacted() (bool, string)                  { return false, "not compacted" }
 func (m *mockPlanner) ForceFull()                                      {}
 func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore)                 {}
 


### PR DESCRIPTION
Compaction logging will generate intermediate information on
volume of data written and output files created, as well as
improve some of the anti-entropy messages related to compaction.

This will also apply to `influx_tools compact`

Closes https://github.com/influxdata/influxdb/issues/21704

(cherry picked from commit 73bdb2860e303702ef00be3c91bec8be92906589)

Closes https://github.com/influxdata/influxdb/issues/21705

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass