### PR TITLE
fix(pingEndpoint): change build type to 'oss2', use correct version

### DIFF
--- a/http/legacy/backend.go
+++ b/http/legacy/backend.go
@@ -13,6 +13,8 @@ import (
 	"github.com/influxdata/influxdb/v2/storage"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+
+	platform "github.com/influxdata/influxdb/v2"
 )
 
 // Handler is a collection of all the service handlers.
@@ -45,7 +47,7 @@ type HandlerConfig struct {
 }
 
 func NewHandlerConfig() *HandlerConfig {
-	return &HandlerConfig{}
+	return &HandlerConfig{Version: platform.GetBuildInfo().Version}
 }
 
 // Opts returns the CLI options for use with kit/cli.

--- a/http/legacy/backend.go
+++ b/http/legacy/backend.go
@@ -13,8 +13,6 @@ import (
 	"github.com/influxdata/influxdb/v2/storage"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-
-	platform "github.com/influxdata/influxdb/v2"
 )
 
 // Handler is a collection of all the service handlers.
@@ -47,7 +45,7 @@ type HandlerConfig struct {
 }
 
 func NewHandlerConfig() *HandlerConfig {
-	return &HandlerConfig{Version: platform.GetBuildInfo().Version}
+	return &HandlerConfig{Version: influxdb.GetBuildInfo().Version}
 }
 
 // Opts returns the CLI options for use with kit/cli.

--- a/http/legacy/influxqld_handler_test.go
+++ b/http/legacy/influxqld_handler_test.go
@@ -233,7 +233,7 @@ func TestInfluxQLdHandler_HandleQuery(t *testing.T) {
 				InfluxqldQueryService: tt.fields.ProxyQueryService,
 			}
 
-			h := NewInfluxQLHandler(b, HandlerConfig{})
+			h := NewInfluxQLHandler(b, *NewHandlerConfig())
 			h.Logger = zaptest.NewLogger(t)
 
 			if tt.context != nil {

--- a/http/legacy/ping_handle_test.go
+++ b/http/legacy/ping_handle_test.go
@@ -1,0 +1,60 @@
+package legacy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPingHandler(t *testing.T) {
+	type wants struct {
+		statusCode int
+		version    string
+		build      string
+	}
+	tests := []struct {
+		name  string
+		w     *httptest.ResponseRecorder
+		r     *http.Request
+		wants wants
+	}{
+		{
+			name: "GET request",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest(http.MethodGet, "/ping", nil),
+			wants: wants{
+				statusCode: http.StatusNoContent,
+				version:    "2.0.0",
+				build:      "oss",
+			},
+		},
+		{
+			name: "HEAD request",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest(http.MethodHead, "/ping", nil),
+			wants: wants{
+				statusCode: http.StatusNoContent,
+				version:    "2.0.0",
+				build:      "oss",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			NewPingHandler("2.0.0").pingHandler(tt.w, tt.r)
+			res := tt.w.Result()
+			build := res.Header.Get("X-Influxdb-Build")
+			version := res.Header.Get("X-Influxdb-Version")
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. PingHandler() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if build != tt.wants.build {
+				t.Errorf("%q. PingHandler() = %v, want %v", tt.name, build, tt.wants.build)
+			}
+			if version != tt.wants.version {
+				t.Errorf("%q. PingHandler() = %v, want %v", tt.name, version, tt.wants.version)
+			}
+		})
+	}
+}

--- a/http/legacy/ping_handle_test.go
+++ b/http/legacy/ping_handle_test.go
@@ -25,7 +25,7 @@ func TestPingHandler(t *testing.T) {
 			wants: wants{
 				statusCode: http.StatusNoContent,
 				version:    "2.0.0",
-				build:      "oss",
+				build:      "oss2",
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestPingHandler(t *testing.T) {
 			wants: wants{
 				statusCode: http.StatusNoContent,
 				version:    "2.0.0",
-				build:      "oss",
+				build:      "oss2",
 			},
 		},
 	}

--- a/http/legacy/ping_handler.go
+++ b/http/legacy/ping_handler.go
@@ -24,7 +24,7 @@ func NewPingHandler(version string) *PingHandler {
 
 // handlePostLegacyWrite is the HTTP handler for the POST /write route.
 func (h *PingHandler) pingHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("X-Influxdb-Build", "cloud2")
+	w.Header().Add("X-Influxdb-Build", "oss")
 	w.Header().Add("X-Influxdb-Version", h.InfluxDBVersion)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/http/legacy/ping_handler.go
+++ b/http/legacy/ping_handler.go
@@ -24,7 +24,7 @@ func NewPingHandler(version string) *PingHandler {
 
 // handlePostLegacyWrite is the HTTP handler for the POST /write route.
 func (h *PingHandler) pingHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("X-Influxdb-Build", "oss")
+	w.Header().Add("X-Influxdb-Build", "oss2")
 	w.Header().Add("X-Influxdb-Version", h.InfluxDBVersion)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -40,7 +40,7 @@ func NewPlatformHandler(b *APIBackend, opts ...APIHandlerOptFn) *PlatformHandler
 	wrappedHandler = kithttp.SkipOptions(wrappedHandler)
 
 	legacyBackend := newLegacyBackend(b)
-	lh := newLegacyHandler(legacyBackend, legacy.HandlerConfig{})
+	lh := newLegacyHandler(legacyBackend, *legacy.NewHandlerConfig())
 
 	return &PlatformHandler{
 		AssetHandler:  assetHandler,


### PR DESCRIPTION
This PR fix the `/ping` endpoint:

- change build type from `cloud2` to `oss2`
- use correct version for `X-Influxdb-Version` header

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
