### PR TITLE
build: verify checksum of built ui assets

### DIFF
--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -20,7 +20,7 @@ set -e
 curl -Ls https://github.com/influxdata/ui/releases/download/OSS-Master/sha256.txt --output sha256.txt
 
 # Download the tar file containing the built UI assets.
-curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.7/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
 
 # Verify the checksums match; exit if they don't.
 echo "$(cat sha256.txt)" | sha256sum --check -- \

--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -12,6 +12,21 @@
 # respective releases in "influxdata/ui" (OSS-2.0, OSS-2.1, etc). Those releases
 # are updated only when a bug fix needs included for the UI of that OSS release.
 
-curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output ui/build.tar.gz
-tar -xzf ui/build.tar.gz -C ui
-rm ui/build.tar.gz
+set -e
+
+# Download the SHA256 checksum attached to the release. To verify the integrity
+# of the download, this checksum will be used to check the download tar file
+# containing the built UI assets.
+curl -Ls https://github.com/influxdata/ui/releases/download/OSS-Master/sha256.txt --output sha256.txt
+
+# Download the tar file containing the built UI assets.
+curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
+
+# Verify the checksums match; exit if they don't.
+echo "$(cat sha256.txt)" | sha256sum --check -- \
+    || { echo "Checksums did not match for downloaded UI assets!"; exit 1; }
+
+# Extract the assets and clean up.
+tar -xzf build.tar.gz -C ui
+rm sha256.txt
+rm build.tar.gz

--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -20,7 +20,7 @@ set -e
 curl -Ls https://github.com/influxdata/ui/releases/download/OSS-Master/sha256.txt --output sha256.txt
 
 # Download the tar file containing the built UI assets.
-curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.7/build.tar.gz --output build.tar.gz
 
 # Verify the checksums match; exit if they don't.
 echo "$(cat sha256.txt)" | sha256sum --check -- \


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/10889

Adds a check to verify the SHA256 checksum of the downloaded `tar` for the UI assets matches the checksum attached to the release for the UI assets. This will ensure the integrity of the download. Also adds some additional comments to the script.

You can see an example of what happens if the check is "bad" here, where I intentionally linked a different `tar` file than what was attached with the respective SHA256: https://app.circleci.com/pipelines/github/influxdata/influxdb/21476/workflows/867eaf25-6615-4d97-972f-ac17d6c8c7ae/jobs/197526