### PR TITLE
fix(httpd): abort processing write request when encountering a precision error.

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -805,7 +805,7 @@ func (h *Handler) async(q *influxql.Query, results <-chan *query.Result) {
 // bucket2drbp extracts a bucket and retention policy from a properly formatted
 // string.
 //
-// The 2.x compatible endpoints encode the databse and retention policy names
+// The 2.x compatible endpoints encode the database and retention policy names
 // in the database URL query value.  It is encoded using a forward slash like
 // "database/retentionpolicy" and we should be able to simply split that string
 // on the forward slash.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -849,6 +849,7 @@ func (h *Handler) serveWriteV2(w http.ResponseWriter, r *http.Request, user meta
 	default:
 		err := fmt.Sprintf("invalid precision %q (use ns, us, ms or s)", precision)
 		h.httpError(w, err, http.StatusBadRequest)
+		return
 	}
 
 	db, rp, err := bucket2dbrp(r.URL.Query().Get("bucket"))
@@ -868,6 +869,7 @@ func (h *Handler) serveWriteV1(w http.ResponseWriter, r *http.Request, user meta
 	default:
 		err := fmt.Sprintf("invalid precision %q (use n, u, ms, s, m or h)", precision)
 		h.httpError(w, err, http.StatusBadRequest)
+		return
 	}
 
 	db := r.URL.Query().Get("db")


### PR DESCRIPTION
abort processing write request when encountering a precision error.

Reproducing: 

```bash
curl -X POST http://localhost:8086/write?db=1&rp=2&precision=aa
```

Expect: 
```json
{"error":"invalid precision \"aa\" (use n, u, ms, s, m or h)"}
```

Got: 
```json
{"error":"invalid precision \"aa\" (use n, u, ms, s, m or h)"}
{"error":"database not found: \"1\""}
```



Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
