### PR TITLE
fix: rename arm rpms with yum-compatible names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,8 @@ nfpms:
       rpm:
         replacements:
           amd64: x86_64
+          arm64: aarch64
+          armhf: armv7hl
         file_name_template: "influxdb2-nightly.{{ .Arch }}"
       deb:
         file_name_template: "influxdb2-nightly-{{ .Arch }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21648](https://github.com/influxdata/influxdb/pull/21648): Change static legend's `hide` to `show` to let users decide if they want it.
 1. [21662](https://github.com/influxdata/influxdb/pull/21662): Do not close connection twice in DigestWithOptions
 1. [21691](https://github.com/influxdata/influxdb/pull/21691): Remove incorrect optimization for group-by
+1. [21747](https://github.com/influxdata/influxdb/pull/21747): Rename arm rpms with yum-compatible names
 
 ## v2.0.7 [2021-06-04]
 


### PR DESCRIPTION
Addresses influxdata/build-scripts#6 in `master`.

Yum refers to arm64 as aarch64, and our rpms should reflect this requirement to enable correct use with Yum on arm64 machines.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
