### PR TITLE
fix: rename arm rpms with yum-compatible names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,8 @@ nfpms:
       rpm:
         replacements:
           amd64: x86_64
+          arm64: aarch64
+          armhf: armv7hl
         file_name_template: "influxdb2-{{ .Version }}.{{ .Arch }}"
       deb:
         file_name_template: "influxdb2-{{ .Version }}-{{ .Arch }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1. [21524](https://github.com/influxdata/influxdb/pull/21524): Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files.
 1. [21549](https://github.com/influxdata/influxdb/pull/21549): Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows.
 1. [21548](https://github.com/influxdata/influxdb/pull/21548): Make InfluxQL meta queries respect query timeouts.
+1. [21748](https://github.com/influxdata/influxdb/pull/21748): rename arm rpms with yum-compatible names
 
 ## v2.0.6 [2021-04-29]
 ----------------------


### PR DESCRIPTION
Addresses influxdata/build-scripts#6 in `2.0`.

Yum expects armhf and arm64 architectures to be called armv7hl and aarch64, respectively. New builds of our packages should reflect this requirement.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
