### PR TITLE
fix: rename arm rpms with yum-compatible names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.9.3 [unreleased]
 -	[#21609](https://github.com/influxdata/influxdb/pull/21609): fix: avoid rewriting fields.idx unnecessarily 
 -	[#21695](https://github.com/influxdata/influxdb/pull/21695): fix: Do not close connection twice in DigestWithOptions
 -	[#21697](https://github.com/influxdata/influxdb/pull/21697): fix: do not panic on cleaning up failed iterators
+- [#21751](https://github.com/influxdata/influxdb/pull/21751): fix: rename arm rpms with yum-compatible names
 
 v1.9.2 [unreleased]
 

--- a/build.py
+++ b/build.py
@@ -707,6 +707,11 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                     elif package_type not in ['zip', 'tar'] and static or "static_" in arch:
                         logging.info("Skipping package type '{}' for static builds.".format(package_type))
                     else:
+                        if package_type == "rpm":
+                            if package_arch == "armhf":
+                                package_arch = "armv7hl"
+                            elif package_arch == "arm64":
+                                package_arch = "aarch64"
                         fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} ".format(
                             fpm_common_args,
                             name,


### PR DESCRIPTION
Addresses influxdata/build-scripts#6 in `1.9`

Yum refers to arm64 as aarch64, and our rpms should reflect this requirement to enable correct use with Yum on arm64 machines.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
