### PR TITLE
feat: add total-buffer-bytes config parameter to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 -	[#21707](https://github.com/influxdata/influxdb/pull/21707): chore: add logging to compaction
+-	[#21752](https://github.com/influxdata/influxdb/pull/21752): feat: add total-buffer-bytes config parameter to subscriptions
 
 ### Bugfixes
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -80,6 +80,9 @@ type Client interface {
 	// Write takes a BatchPoints object and writes all Points to InfluxDB.
 	Write(bp BatchPoints) error
 
+	// WriteCtx takes a BatchPoints object and writes all Points to InfluxDB.
+	WriteCtx(ctx context.Context, bp BatchPoints) error
+
 	// Query makes an InfluxDB Query on the database. This will fail if using
 	// the UDP client.
 	Query(q Query) (*Response, error)
@@ -377,6 +380,10 @@ func NewPointFrom(pt models.Point) *Point {
 }
 
 func (c *client) Write(bp BatchPoints) error {
+	return c.WriteCtx(context.Background(), bp)
+}
+
+func (c *client) WriteCtx(ctx context.Context, bp BatchPoints) error {
 	var b bytes.Buffer
 
 	for _, p := range bp.Points() {
@@ -395,7 +402,7 @@ func (c *client) Write(bp BatchPoints) error {
 	u := c.url
 	u.Path = path.Join(u.Path, "write")
 
-	req, err := http.NewRequest("POST", u.String(), &b)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), &b)
 	if err != nil {
 		return err
 	}

--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -61,6 +61,10 @@ type udpclient struct {
 }
 
 func (uc *udpclient) Write(bp BatchPoints) error {
+	return uc.WriteCtx(context.Background(), bp)
+}
+
+func (uc *udpclient) WriteCtx(ctx context.Context, bp BatchPoints) error {
 	var b = make([]byte, 0, uc.payloadSize) // initial buffer size, it will grow as needed
 	var d, _ = time.ParseDuration("1" + bp.Precision())
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -39,14 +39,15 @@ import (
 	reads "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
-	client "github.com/influxdata/usage-client/v1"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 
 	// Initialize the engine package
 	_ "github.com/influxdata/influxdb/tsdb/engine"
+
 	// Initialize the index package
 	_ "github.com/influxdata/influxdb/tsdb/index"
+	client "github.com/influxdata/usage-client/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 )
 
 var startTime time.Time

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -475,6 +475,9 @@ func (s *Server) Open() error {
 		return fmt.Errorf("open tsdb store: %s", err)
 	}
 
+	// Add the subscriber before opening the PointsWriter
+	s.PointsWriter.Subscriber = s.Subscriber
+
 	// Open the subscriber service
 	if err := s.Subscriber.Open(); err != nil {
 		return fmt.Errorf("open subscriber: %s", err)
@@ -484,8 +487,6 @@ func (s *Server) Open() error {
 	if err := s.PointsWriter.Open(); err != nil {
 		return fmt.Errorf("open points writer: %s", err)
 	}
-
-	s.PointsWriter.AddWriteSubscriber(s.Subscriber.Points())
 
 	for _, service := range s.Services {
 		if err := service.Open(); err != nil {

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -340,7 +340,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		c := coordinator.NewPointsWriter()
 		c.MetaClient = ms
 		c.TSDBStore = store
-		c.AddWriteSubscriber(sub.Points())
+		c.Subscriber = sub
 		c.Node = &influxdb.Node{ID: 1}
 
 		c.Open()
@@ -416,7 +416,7 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 	c := coordinator.NewPointsWriter()
 	c.MetaClient = ms
 	c.TSDBStore = store
-	c.AddWriteSubscriber(sub.Points())
+	c.Subscriber = sub
 	c.Node = &influxdb.Node{ID: 1}
 
 	c.Open()

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -333,8 +333,8 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 
 		subPoints := make(chan *coordinator.WritePointsRequest, 1)
 		sub := Subscriber{}
-		sub.PointsFn = func() chan<- *coordinator.WritePointsRequest {
-			return subPoints
+		sub.SendFn = func(wr *coordinator.WritePointsRequest) {
+			subPoints <- wr
 		}
 
 		c := coordinator.NewPointsWriter()
@@ -409,8 +409,8 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 
 	subPoints := make(chan *coordinator.WritePointsRequest, 1)
 	sub := Subscriber{}
-	sub.PointsFn = func() chan<- *coordinator.WritePointsRequest {
-		return subPoints
+	sub.SendFn = func(wr *coordinator.WritePointsRequest) {
+		subPoints <- wr
 	}
 
 	c := coordinator.NewPointsWriter()
@@ -617,11 +617,11 @@ func (m PointsWriterMetaClient) ShardOwner(shardID uint64) (string, string, *met
 }
 
 type Subscriber struct {
-	PointsFn func() chan<- *coordinator.WritePointsRequest
+	SendFn func(*coordinator.WritePointsRequest)
 }
 
-func (s Subscriber) Points() chan<- *coordinator.WritePointsRequest {
-	return s.PointsFn()
+func (s Subscriber) Send(wr *coordinator.WritePointsRequest) {
+	s.SendFn(wr)
 }
 
 func NewRetentionPolicy(name string, duration time.Duration, nodeCount int) *meta.RetentionPolicyInfo {

--- a/models/points.go
+++ b/models/points.go
@@ -2529,6 +2529,7 @@ func appendField(b []byte, k string, v interface{}) []byte {
 
 // ValidKeyToken returns true if the token used for measurement, tag key, or tag
 // value is a valid unicode string and only contains printable, non-replacement characters.
+// Note \n (newline) is not printable.
 func ValidKeyToken(s string) bool {
 	if !utf8.ValidString(s) {
 		return false

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	// The number of in-flight writes buffered in the write channel.
 	WriteBufferSize int `toml:"write-buffer-size"`
 
+	// TotalBufferBytes is the total size in bytes allocated to buffering across all subscriptions.
+	// Each named subscription will receive an even division of the total.
+	TotalBufferBytes int `toml:"total-buffer-bytes"`
+
 	// TLS is a base tls config to use for https clients.
 	TLS *tls.Config `toml:"-"`
 }

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -1,6 +1,7 @@
 package subscriber
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -42,7 +43,7 @@ func NewHTTPS(addr string, timeout time.Duration, unsafeSsl bool, caCerts string
 }
 
 // WritePoints writes points over HTTP transport.
-func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
+func (h *HTTP) WritePointsContext(ctx context.Context, p *coordinator.WritePointsRequest) (err error) {
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:        p.Database,
 		RetentionPolicy: p.RetentionPolicy,
@@ -50,7 +51,7 @@ func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
 	for _, pt := range p.Points {
 		bp.AddPoint(client.NewPointFrom(pt))
 	}
-	err = h.c.Write(bp)
+	err = h.c.WriteCtx(ctx, bp)
 	return
 }
 

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -1,6 +1,7 @@
 package subscriber
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -8,12 +9,11 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/client/v2"
-	"github.com/influxdata/influxdb/coordinator"
 )
 
 // HTTP supports writing points over HTTP using the line protocol.
 type HTTP struct {
-	c client.Client
+	c client.HTTPClient
 }
 
 // NewHTTP returns a new HTTP points writer with default options.
@@ -43,16 +43,12 @@ func NewHTTPS(addr string, timeout time.Duration, unsafeSsl bool, caCerts string
 }
 
 // WritePoints writes points over HTTP transport.
-func (h *HTTP) WritePointsContext(ctx context.Context, p *coordinator.WritePointsRequest) (err error) {
+func (h *HTTP) WritePointsContext(ctx context.Context, request WriteRequest) (err error) {
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
-		Database:        p.Database,
-		RetentionPolicy: p.RetentionPolicy,
+		Database:        request.Database,
+		RetentionPolicy: request.RetentionPolicy,
 	})
-	for _, pt := range p.Points {
-		bp.AddPoint(client.NewPointFrom(pt))
-	}
-	err = h.c.WriteCtx(ctx, bp)
-	return
+	return h.c.WriteRawCtx(ctx, bp, bytes.NewReader(request.lineProtocol))
 }
 
 func createTLSConfig(caCerts string, tlsConfig *tls.Config) (*tls.Config, error) {

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -109,7 +109,7 @@ type Service struct {
 	stats           *Statistics
 	wg              sync.WaitGroup
 	closing         chan struct{}
-	mu              sync.RWMutex
+	mu              sync.Mutex
 	conf            Config
 	subs            map[subEntry]*chanWriter
 
@@ -233,8 +233,8 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 		},
 	}}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, cw := range s.subs {
 		statistics = append(statistics, cw.Statistics(tags)...)
 	}

--- a/services/subscriber/service_test.go
+++ b/services/subscriber/service_test.go
@@ -1,6 +1,7 @@
 package subscriber_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ type Subscription struct {
 	WritePointsFn func(*coordinator.WritePointsRequest) error
 }
 
-func (s Subscription) WritePoints(p *coordinator.WritePointsRequest) error {
+func (s Subscription) WritePointsContext(_ context.Context, p *coordinator.WritePointsRequest) error {
 	return s.WritePointsFn(p)
 }
 

--- a/services/subscriber/service_test.go
+++ b/services/subscriber/service_test.go
@@ -3,8 +3,6 @@ package subscriber_test
 import (
 	"context"
 	"fmt"
-	"github.com/influxdata/influxdb/pkg/testing/assert"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -14,8 +12,10 @@ import (
 
 	"github.com/influxdata/influxdb/coordinator"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/testing/assert"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/services/subscriber"
+	"github.com/stretchr/testify/require"
 )
 
 const testTimeout = 10 * time.Second
@@ -385,7 +385,7 @@ func TestService_Multiple(t *testing.T) {
 		case <-time.After(testTimeout):
 			t.Fatalf("expected points request: got %d exp 2", i)
 		}
-		assert.Equal(t,expPR,pr)
+		assert.Equal(t, expPR, pr)
 	}
 	close(dataChanged)
 }
@@ -469,7 +469,7 @@ func TestService_WaitForDataChanged(t *testing.T) {
 	// Signal that data has changed - two calls to DatabaseInfo implies we already updated once due to channel size
 	currentDatabaseInfo[0].RetentionPolicies[0].Subscriptions[0].Destinations[0] = nonBlockingServer.URL
 	currentDatabaseInfo[0].RetentionPolicies[0].Subscriptions[0].Name = "nonblock"
-	for i := 0 ; i < 2; i ++ {
+	for i := 0; i < 2; i++ {
 		dataChanged <- struct{}{}
 
 		// DatabaseInfo should be called once more after data changed
@@ -490,14 +490,14 @@ func TestService_WaitForDataChanged(t *testing.T) {
 	s.Points() <- &coordinator.WritePointsRequest{
 		Database:        "db0",
 		RetentionPolicy: "rp0",
-		Points:          []models.Point{
-			models.MustNewPoint("m0", nil, models.Fields{"f": 1.0}, time.Date(2020,1,1,0,0,0,0, time.UTC)),
-			models.MustNewPoint("m0", nil, models.Fields{"f": 2.0}, time.Date(2020,1,1,0,0,0,4, time.UTC)),
+		Points: []models.Point{
+			models.MustNewPoint("m0", nil, models.Fields{"f": 1.0}, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
+			models.MustNewPoint("m0", nil, models.Fields{"f": 2.0}, time.Date(2020, 1, 1, 0, 0, 0, 4, time.UTC)),
 		},
 	}
 	select {
 	case receivedStr := <-receivedNonBlocking:
-		assert.Equal(t, receivedStr,"m0 f=1 1577836800000000000\nm0 f=2 1577836800000000004\n")
+		assert.Equal(t, receivedStr, "m0 f=1 1577836800000000000\nm0 f=2 1577836800000000004\n")
 	case <-time.After(testTimeout):
 		t.Fatal("expected call to non blocking server")
 	}

--- a/services/subscriber/udp.go
+++ b/services/subscriber/udp.go
@@ -1,6 +1,7 @@
 package subscriber
 
 import (
+	"context"
 	"net"
 
 	"github.com/influxdata/influxdb/coordinator"
@@ -17,7 +18,7 @@ func NewUDP(addr string) *UDP {
 }
 
 // WritePoints writes points over UDP transport.
-func (u *UDP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
+func (u *UDP) WritePointsContext(_ context.Context, p *coordinator.WritePointsRequest) (err error) {
 	var addr *net.UDPAddr
 	var con *net.UDPConn
 	addr, err = net.ResolveUDPAddr("udp", u.addr)

--- a/services/subscriber/udp.go
+++ b/services/subscriber/udp.go
@@ -36,7 +36,6 @@ func (u *UDP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
 		if err != nil {
 			return
 		}
-
 	}
 	return
 }


### PR DESCRIPTION
Closes #21733

Fixes the concurrency patterns for subscriptions and adds the `total-buffer-bytes` subscription configuration to limit the amount of memory taken by subscriptions.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
