### PR TITLE
refactor: reorganize inspect subcommands for better package hierarchy

### DIFF
--- a/cmd/influxd/inspect/export_index/export_index.go
+++ b/cmd/influxd/inspect/export_index/export_index.go
@@ -1,4 +1,4 @@
-package inspect
+package export_index
 
 import (
 	"bufio"

--- a/cmd/influxd/inspect/export_lp/export_lp.go
+++ b/cmd/influxd/inspect/export_lp/export_lp.go
@@ -1,4 +1,4 @@
-package inspect
+package export_lp
 
 import (
 	"bufio"

--- a/cmd/influxd/inspect/export_lp/export_lp_test.go
+++ b/cmd/influxd/inspect/export_lp/export_lp_test.go
@@ -1,4 +1,4 @@
-package inspect
+package export_lp
 
 import (
 	"bytes"

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -1,6 +1,11 @@
 package inspect
 
 import (
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/export_index"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/export_lp"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_seriesfile"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_tombstone"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_tsm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -16,17 +21,15 @@ func NewCommand(v *viper.Viper) (*cobra.Command, error) {
 		},
 	}
 
-	exportLp, err := NewExportLineProtocolCommand(v)
+	exportLp, err := export_lp.NewExportLineProtocolCommand(v)
 	if err != nil {
 		return nil, err
 	}
 	base.AddCommand(exportLp)
-	base.AddCommand(NewExportIndexCommand())
-	base.AddCommand(NewTSMVerifyCommand())
-
-	base.AddCommand(NewVerifySeriesfileCommand())
-
-	base.AddCommand(NewVerifyTombstoneCommand())
+	base.AddCommand(export_index.NewExportIndexCommand())
+	base.AddCommand(verify_tsm.NewTSMVerifyCommand())
+	base.AddCommand(verify_seriesfile.NewVerifySeriesfileCommand())
+	base.AddCommand(verify_tombstone.NewVerifyTombstoneCommand())
 
 	return base, nil
 }

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -1,4 +1,4 @@
-package inspect
+package verify_seriesfile
 
 import (
 	"fmt"
@@ -28,10 +28,10 @@ func TestVerifies_Valid(t *testing.T) {
 	test := NewTest(t)
 	defer os.RemoveAll(test.Path)
 
-	verify := NewVerify()
+	verify := newVerify()
 	verify.Logger = zaptest.NewLogger(t)
 
-	passed, err := verify.VerifySeriesFile(test.Path)
+	passed, err := verify.verifySeriesFile(test.Path)
 	require.NoError(t, err)
 	require.True(t, passed)
 }
@@ -58,10 +58,10 @@ func TestVerifies_Invalid(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, fh.Close())
 
-		verify := NewVerify()
+		verify := newVerify()
 		verify.Logger = zaptest.NewLogger(t)
 
-		passed, err := verify.VerifySeriesFile(test.Path)
+		passed, err := verify.verifySeriesFile(test.Path)
 		require.NoError(t, err)
 		require.False(t, passed)
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -1,4 +1,4 @@
-package inspect
+package verify_tombstone
 
 import (
 	"bytes"

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
@@ -1,4 +1,4 @@
-package inspect
+package verify_tsm
 
 import (
 	"bytes"


### PR DESCRIPTION
Refactors the `cmd/influxd/inspect` directory to keep subcommands all separate, and to avoid issues with namespace pollution that we were experiencing as more commands were being ported over. I also made most internal implementation detail methods private within these new packages, exposing only the `NewXXXXXCommand()` method call for the subcommands to be registered by.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
