### PR TITLE
fix: do not send non-UTF-8 characters to subscriptions (#21558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ v1.9.3 [unreleased]
 -	[#21609](https://github.com/influxdata/influxdb/pull/21609): fix: avoid rewriting fields.idx unnecessarily 
 -	[#21695](https://github.com/influxdata/influxdb/pull/21695): fix: Do not close connection twice in DigestWithOptions
 -	[#21697](https://github.com/influxdata/influxdb/pull/21697): fix: do not panic on cleaning up failed iterators
-- [#21751](https://github.com/influxdata/influxdb/pull/21751): fix: rename arm rpms with yum-compatible names
+-	[#21751](https://github.com/influxdata/influxdb/pull/21751): fix: rename arm rpms with yum-compatible names
+-	[#21764](https://github.com/influxdata/influxdb/pull/21764): fix: do not send non-UTF-8 characters to subscriptions
 
 v1.9.2 [unreleased]
 

--- a/models/points.go
+++ b/models/points.go
@@ -100,6 +100,9 @@ type Point interface {
 	// HasTag returns true if the tag exists for the point.
 	HasTag(tag []byte) bool
 
+	// ForEachField iterates over each field invoking fn. if fn returns false, iteration stops.
+	ForEachField(fn func(k, v []byte) bool) error
+
 	// Fields returns the fields for the point.
 	Fields() (Fields, error)
 
@@ -1574,6 +1577,10 @@ func walkTags(buf []byte, fn func(key, value []byte) bool) {
 	}
 }
 
+func (p *point) ForEachField(fn func(k, v []byte) bool) error {
+	return walkFields(p.fields, fn)
+}
+
 // walkFields walks each field key and value via fn.  If fn returns false, the iteration
 // is stopped.  The values are the raw byte slices and not the converted types.
 func walkFields(buf []byte, fn func(key, value []byte) bool) error {
@@ -2545,4 +2552,44 @@ func ValidKeyTokens(name string, tags Tags) bool {
 		}
 	}
 	return true
+}
+
+// ValidPointStrings validates the measurement name, tage names and values, and field names in a point
+func ValidPointStrings(p Point) (err error) {
+	if !ValidKeyToken(string(p.Name())) {
+		return fmt.Errorf("invalid or unprintable UTF-8 characters in measurement name: %q", p.Name())
+	}
+
+	validTag := func(k []byte, v []byte) bool {
+		if !ValidKeyToken(string(k)) {
+			err = fmt.Errorf("invalid or unprintable UTF-8 characters in tag key: %q", k)
+			return false
+		} else if !ValidKeyToken(string(v)) {
+			err = fmt.Errorf("invalid or unprintable UTF-8 characters in tag value: %q", v)
+			return false
+		}
+		return true
+	}
+
+	p.ForEachTag(validTag)
+	if err != nil {
+		return err
+	}
+
+	validField := func(k, v []byte) bool {
+		if !ValidKeyToken(string(k)) {
+			err = fmt.Errorf("invalid or unprintable UTF-8 in field name: %q", k)
+			return false
+		} else {
+			return true
+		}
+	}
+
+	if e := p.ForEachField(validField); e != nil {
+		return e
+	} else if err != nil {
+		return err
+	} else {
+		return nil
+	}
 }

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -245,6 +245,8 @@ func (s *Service) run() {
 				s.close(&wg)
 				return
 			}
+
+			p = s.removeBadPoints(p)
 			for se, cw := range s.subs {
 				if p.Database == se.db && p.RetentionPolicy == se.rp {
 					select {
@@ -256,6 +258,44 @@ func (s *Service) run() {
 			}
 		}
 	}
+}
+
+// removeBadPoints - if any non-UTF8 strings are found in the points in the WritePointRequest,
+// make a copy without those points
+func (s *Service) removeBadPoints(p *coordinator.WritePointsRequest) *coordinator.WritePointsRequest {
+	log := s.Logger.With(zap.String("database", p.Database), zap.String("retention_policy", p.RetentionPolicy))
+
+	firstBad, err := func() (int, error) {
+		for i, point := range p.Points {
+			if err := models.ValidPointStrings(point); err != nil {
+				atomic.AddInt64(&s.stats.WriteFailures, 1)
+				log.Debug("discarding point", zap.Error(err))
+				return i, err
+			}
+		}
+		return -1, nil
+	}()
+	if err != nil {
+		wrq := &coordinator.WritePointsRequest{
+			Database:        p.Database,
+			RetentionPolicy: p.RetentionPolicy,
+			Points:          make([]models.Point, 0, len(p.Points)-1),
+		}
+
+		// Copy all the points up to the first bad one.
+		wrq.Points = append(wrq.Points, p.Points[:firstBad]...)
+		for _, point := range p.Points[firstBad+1:] {
+			if err := models.ValidPointStrings(point); err != nil {
+				// Log and omit this point from subscription writes
+				atomic.AddInt64(&s.stats.WriteFailures, 1)
+				log.Debug("discarding point", zap.Error(err))
+			} else {
+				wrq.Points = append(wrq.Points, point)
+			}
+		}
+		p = wrq
+	}
+	return p
 }
 
 // close closes the existing channel writers.


### PR DESCRIPTION
Added a check for valid UTF-8 strings in measurement names,
tags name, tag values, and field names when writing to subscriptions.
Do not send the failing points to subscribers, and log the errors if at
debug level logging

Closes https://github.com/influxdata/influxdb/issues/21557

(cherry picked from commit a08b69098eba5362ffcaeabf748ada57ff009ffa)

Closes https://github.com/influxdata/influxdb/issues/21559

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass