### PR TITLE
fix: convert arm arch names for rpms during builds via docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 v1.8.7 [unreleased]
 -------------------
 
-- [#](https://github.com/influxdata/influxdb/pull/21749): fix: rename arm rpms with yum-compatible names
+- [#21749](https://github.com/influxdata/influxdb/pull/21749): fix: rename arm rpms with yum-compatible names
+- [#21775](https://github.com/influxdata/influxdb/pull/21775): fix: convert arm arch names for rpms during builds via docker
 
 v1.8.6 [2021-05-20]
 -------------------

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -113,6 +113,13 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   if [ "$OS" == "linux" ] ; then
     # Call fpm to build .deb and .rpm packages.
     for typeargs in "-t deb" "-t rpm --depends coreutils --depends shadow-utils"; do
+      ARCH_CONVERTED=$ARCH
+      pkg_t=$(echo $typeargs | cut -d ' ' -f2)
+      if [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "armhf" ]; then
+        ARCH_CONVERTED="armv7hl"
+      elif [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "arm64" ]; then
+        ARCH_CONVERTED="aarch64"
+      fi
       FPM_NAME=$(
       fpm \
         -s dir \
@@ -133,7 +140,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         --config-files /etc/influxdb/influxdb.conf \
         --config-files /etc/logrotate.d/influxdb \
         --name "influxdb" \
-        --architecture "$ARCH" \
+        --architecture "$ARCH_CONVERTED" \
         --version "$VERSION" \
         --iteration 1 \
         -C "$PKG_ROOT" \


### PR DESCRIPTION
Additional changes docker-based build system to address influxdata/build-scripts#6.

Follow-on for #21749.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass