### PR TITLE
fix: convert arm arch names for rpms during builds via docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v1.9.3 [unreleased]
 -	[#21697](https://github.com/influxdata/influxdb/pull/21697): fix: do not panic on cleaning up failed iterators
 -	[#21751](https://github.com/influxdata/influxdb/pull/21751): fix: rename arm rpms with yum-compatible names
 -	[#21764](https://github.com/influxdata/influxdb/pull/21764): fix: do not send non-UTF-8 characters to subscriptions
+-	[#21776](https://github.com/influxdata/influxdb/pull/21776): fix: convert arm arch names for rpms during builds via docker
 
 v1.9.2 [unreleased]
 

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -114,6 +114,13 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   if [ "$OS" == "linux" ] ; then
     # Call fpm to build .deb and .rpm packages.
     for typeargs in "-t deb" "-t rpm --depends coreutils --depends shadow-utils"; do
+      ARCH_CONVERTED=$ARCH
+      pkg_t=$(echo $typeargs | cut -d ' ' -f2)
+      if [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "armhf" ]; then
+        ARCH_CONVERTED="armv7hl"
+      elif [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "arm64" ]; then
+        ARCH_CONVERTED="aarch64"
+      fi
       FPM_NAME=$(
       fpm \
         -s dir \
@@ -134,7 +141,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         --config-files /etc/influxdb/influxdb.conf \
         --config-files /etc/logrotate.d/influxdb \
         --name "influxdb" \
-        --architecture "$ARCH" \
+        --architecture "$ARCH_CONVERTED" \
         --version "$VERSION" \
         --iteration 1 \
         -C "$PKG_ROOT" \


### PR DESCRIPTION
Further adjustments to docker-based build system to produce correctly-named arm rpm packages, to address influxdata/build-scripts#6.

This is a follow-on to #21751.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass