### PR TITLE
fix: convert arm arch names for rpms during builds via docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -	[#21693](https://github.com/influxdata/influxdb/pull/21693): fix: don't access a field in a nil struct
 -	[#21558](https://github.com/influxdata/influxdb/pull/21558): fix: do not send non-UTF-8 characters to subscriptions
 - [#21750](https://github.com/influxdata/influxdb/pull/21750): fix: rename arm rpms with yum-compatible names
+- [#21777](https://github.com/influxdata/influxdb/pull/21777): fix: convert arm arch names for rpms during builds via docker
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -114,6 +114,13 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   if [ "$OS" == "linux" ] ; then
     # Call fpm to build .deb and .rpm packages.
     for typeargs in "-t deb" "-t rpm --depends coreutils --depends shadow-utils"; do
+      ARCH_CONVERTED=$ARCH
+      pkg_t=$(echo $typeargs | cut -d ' ' -f2)
+      if [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "armhf" ]; then
+        ARCH_CONVERTED="armv7hl"
+      elif [ "$pkg_t" == "rpm" ] && [ $"$ARCH" == "arm64" ]; then
+        ARCH_CONVERTED="aarch64"
+      fi
       FPM_NAME=$(
       fpm \
         -s dir \
@@ -134,7 +141,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         --config-files /etc/influxdb/influxdb.conf \
         --config-files /etc/logrotate.d/influxdb \
         --name "influxdb" \
-        --architecture "$ARCH" \
+        --architecture "$ARCH_CONVERTED" \
         --version "$VERSION" \
         --iteration 1 \
         -C "$PKG_ROOT" \


### PR DESCRIPTION
Further adjustments to docker-based build system to produce correctly-named arm rpm packages, to address influxdata/build-scripts#6.

Follow-on to #21750.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass