### PR TITLE
fix: enable organization paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21522](https://github.com/influxdata/influxdb/pull/21522): Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files.
 1. [21540](https://github.com/influxdata/influxdb/pull/21540): Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows.
 1. [21545](https://github.com/influxdata/influxdb/pull/21545): Make InfluxQL meta queries respect query timeouts.
+1. [](): Enable organization paging
 
 ## v2.0.6 [2021-04-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21522](https://github.com/influxdata/influxdb/pull/21522): Replace telemetry file name with slug for `ttf`, `woff`, and `eot` files.
 1. [21540](https://github.com/influxdata/influxdb/pull/21540): Enable use of absolute path for `--upgrade-log` when running `influxd upgrade` on Windows.
 1. [21545](https://github.com/influxdata/influxdb/pull/21545): Make InfluxQL meta queries respect query timeouts.
-1. [](): Enable organization paging
+1. [21783](https://github.com/influxdata/influxdb/pull/21783): Enable organization paging
 
 ## v2.0.6 [2021-04-29]
 

--- a/organization.go
+++ b/organization.go
@@ -87,3 +87,17 @@ func ErrInternalOrgServiceError(op string, err error) *errors.Error {
 		Err:  err,
 	}
 }
+
+func (f OrganizationFilter) QueryParams() map[string][]string {
+	queryParams := make(map[string][]string)
+	if f.Name != nil {
+		queryParams["org"] = []string{*f.Name}
+	}
+	if f.ID != nil {
+		queryParams["orgID"] = []string{f.ID.String()}
+	}
+	if f.UserID != nil {
+		queryParams["userID"] = []string{f.UserID.String()}
+	}
+	return queryParams
+}

--- a/tenant/http_server_org.go
+++ b/tenant/http_server_org.go
@@ -88,15 +88,13 @@ func newOrgResponse(o influxdb.Organization) orgResponse {
 }
 
 type orgsResponse struct {
-	Links         map[string]string `json:"links"`
-	Organizations []orgResponse     `json:"orgs"`
+	Links         *influxdb.PagingLinks `json:"links"`
+	Organizations []orgResponse         `json:"orgs"`
 }
 
-func newOrgsResponse(orgs []*influxdb.Organization) *orgsResponse {
+func newOrgsResponse(orgs []*influxdb.Organization, opts influxdb.FindOptions, f influxdb.OrganizationFilter) *orgsResponse {
 	res := orgsResponse{
-		Links: map[string]string{
-			"self": "/api/v2/orgs",
-		},
+		Links:         influxdb.NewPagingLinks(prefixOrganizations, opts, f, len(orgs)),
 		Organizations: []orgResponse{},
 	}
 	for _, org := range orgs {
@@ -177,7 +175,7 @@ func (h *OrgHandler) handleGetOrgs(w http.ResponseWriter, r *http.Request) {
 	}
 	h.log.Debug("Orgs retrieved", zap.String("org", fmt.Sprint(orgs)))
 
-	h.api.Respond(w, r, http.StatusOK, newOrgsResponse(orgs))
+	h.api.Respond(w, r, http.StatusOK, newOrgsResponse(orgs, *opts, filter))
 }
 
 // handlePatchOrg is the HTTP handler for the PATH /api/v2/orgs route.


### PR DESCRIPTION
Enable organization paging in InfluxDB. The paging can be enabled independent from UI side

I closed the previous pull-request for org paging: https://github.com/influxdata/influxdb/pull/20985 because it contained code for UI which should now be directed into a different repository: `influxdata/ui`

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
