### PR TITLE
feat: port `influxd inspect deletetsm` to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21646](https://github.com/influxdata/influxdb/pull/21646): Ported the `influxd inspect verify-tombstone` command from 1.x.
 1. [21761](https://github.com/influxdata/influxdb/pull/21761): Ported the `influxd inspect dump-tsm` command from 1.x.
 1. [21784](https://github.com/influxdata/influxdb/pull/21784): Ported the `influxd inspect dumptsi` command from 1.x.
+1. [21786](https://github.com/influxdata/influxdb/pull/21786): Ported the `influxd inspect deletetsm` command from 1.x.
 
 ### Bug Fixes
 

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -25,7 +25,7 @@ func NewDeleteTSMCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate measurement or sanitize flag.
 			if arguments.measurement == "" && !arguments.sanitize {
-				return fmt.Errorf("-measurement or -sanitize flag required")
+				return fmt.Errorf("--measurement or --sanitize flag required")
 			}
 
 			// Process each TSM file.
@@ -68,9 +68,9 @@ func (a *args) process(cmd *cobra.Command, path string) error {
 	// Remove previous temporary files.
 	outputPath := path + ".rewriting.tmp"
 	if err := os.RemoveAll(outputPath); err != nil {
-		return fmt.Errorf("failed to remove all files in directory %q: %w", outputPath, err)
+		return fmt.Errorf("failed to remove existing temp file at %q: %w", outputPath, err)
 	} else if err := os.RemoveAll(outputPath + ".idx.tmp"); err != nil {
-		return fmt.Errorf("failed to remove all files in directory %q: %w", outputPath+".idx.tmp", err)
+		return fmt.Errorf("failed to remove existing temp file at %q: %w", outputPath+".idx.tmp", err)
 	}
 
 	// Create TSMWriter to temporary location.

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -1,0 +1,130 @@
+package delete_tsm
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/spf13/cobra"
+)
+
+type args struct {
+	measurement string // measurement to delete
+	sanitize    bool   // remove all keys with non-printable unicode
+	verbose     bool   // verbose logging
+}
+
+func NewDeleteTSMCommand() *cobra.Command {
+	var arguments args
+	cmd := &cobra.Command{
+		Use:   "deletetsm",
+		Short: "Deletes a measurement from a raw tsm file.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate measurement or sanitize flag.
+			if arguments.measurement == "" && !arguments.sanitize {
+				return fmt.Errorf("-measurement or -sanitize flag required")
+			}
+
+			// Process each TSM file.
+			for _, path := range args {
+				if arguments.verbose {
+					cmd.Printf("processing: %s", path)
+				}
+				if err := arguments.process(cmd, path); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&arguments.measurement, "measurement", "",
+		"The name of the measurement to remove")
+	cmd.Flags().BoolVar(&arguments.sanitize, "sanitize", false,
+		"Remove all keys with non-printable unicode characters")
+	cmd.Flags().BoolVar(&arguments.verbose, "verbose", false,
+		"Enable verbose logging")
+
+	return cmd
+}
+
+func (a *args) process(cmd *cobra.Command, path string) error {
+	// Open TSM reader.
+	input, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open file %q: %w", path, err)
+	}
+	defer input.Close()
+
+	r, err := tsm1.NewTSMReader(input)
+	if err != nil {
+		return fmt.Errorf("unable to read TSM file %q: %w", path, err)
+	}
+	defer r.Close()
+
+	// Remove previous temporary files.
+	outputPath := path + ".rewriting.tmp"
+	if err := os.RemoveAll(outputPath); err != nil {
+		return fmt.Errorf("failed to remove all files in directory %q: %w", outputPath, err)
+	} else if err := os.RemoveAll(outputPath + ".idx.tmp"); err != nil {
+		return fmt.Errorf("failed to remove all files in directory %q: %w", outputPath+".idx.tmp", err)
+	}
+
+	// Create TSMWriter to temporary location.
+	output, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file at %q: %w", outputPath, err)
+	}
+	defer output.Close()
+
+	w, err := tsm1.NewTSMWriter(output)
+	if err != nil {
+		return fmt.Errorf("failed to create TSM Reader for file %q: %w", output.Name(), err)
+	}
+	defer w.Close()
+
+	// Iterate over the input blocks.
+	itr := r.BlockIterator()
+	for itr.Next() {
+		// Read key & time range.
+		key, minTime, maxTime, _, _, block, err := itr.Read()
+		if err != nil {
+			return fmt.Errorf("failed to read block: %w", err)
+		}
+
+		// Skip block if this is the measurement and time range we are deleting.
+		series, _ := tsm1.SeriesAndFieldFromCompositeKey(key)
+		measurement, tags := models.ParseKey(series)
+		if measurement == a.measurement || (a.sanitize && !models.ValidKeyTokens(measurement, tags)) {
+			if a.verbose {
+				cmd.Printf("deleting block: %s (%s-%s) sz=%d",
+					key,
+					time.Unix(0, minTime).UTC().Format(time.RFC3339Nano),
+					time.Unix(0, maxTime).UTC().Format(time.RFC3339Nano),
+					len(block),
+				)
+			}
+			continue
+		}
+
+		if err := w.WriteBlock(key, minTime, maxTime, block); err != nil {
+			return fmt.Errorf("failed to write block %q: %w", block, err)
+		}
+	}
+
+	// Write index & close.
+	if err := w.WriteIndex(); err != nil {
+		return fmt.Errorf("failed to write index to TSM file: %w", err)
+	} else if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to close TSM Writer: %w", err)
+	}
+
+	// Replace original file with new file.
+	if err := os.Rename(outputPath, path); err != nil {
+		return fmt.Errorf("failed to update TSM file %q: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/delete_tsm"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/dump_tsi"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/dump_tsm"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/export_index"
@@ -34,6 +35,7 @@ func NewCommand(v *viper.Viper) (*cobra.Command, error) {
 	base.AddCommand(verify_tombstone.NewVerifyTombstoneCommand())
 	base.AddCommand(dump_tsm.NewDumpTSMCommand())
 	base.AddCommand(dump_tsi.NewDumpTSICommand())
+	base.AddCommand(delete_tsm.NewDeleteTSMCommand())
 
 	return base, nil
 }


### PR DESCRIPTION
Closes #19530

Ports the `./influx inspect deletetsm` inspect subcommand to 2.x.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass
