### PR TITLE
revert: revert add total-buffer-bytes config parameter to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Features
 
 -	[#21707](https://github.com/influxdata/influxdb/pull/21707): chore: add logging to compaction
--	[#21752](https://github.com/influxdata/influxdb/pull/21752): feat: add total-buffer-bytes config parameter to subscriptions
 
 ### Bugfixes
 

--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -61,10 +61,6 @@ type udpclient struct {
 }
 
 func (uc *udpclient) Write(bp BatchPoints) error {
-	return uc.WriteCtx(context.Background(), bp)
-}
-
-func (uc *udpclient) WriteCtx(ctx context.Context, bp BatchPoints) error {
 	var b = make([]byte, 0, uc.payloadSize) // initial buffer size, it will grow as needed
 	var d, _ = time.ParseDuration("1" + bp.Precision())
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -39,15 +39,14 @@ import (
 	reads "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
-
-	// Initialize the engine package
-	_ "github.com/influxdata/influxdb/tsdb/engine"
-
-	// Initialize the index package
-	_ "github.com/influxdata/influxdb/tsdb/index"
 	client "github.com/influxdata/usage-client/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+
+	// Initialize the engine package
+	_ "github.com/influxdata/influxdb/tsdb/engine"
+	// Initialize the index package
+	_ "github.com/influxdata/influxdb/tsdb/index"
 )
 
 var startTime time.Time
@@ -476,9 +475,6 @@ func (s *Server) Open() error {
 		return fmt.Errorf("open tsdb store: %s", err)
 	}
 
-	// Add the subscriber before opening the PointsWriter
-	s.PointsWriter.Subscriber = s.Subscriber
-
 	// Open the subscriber service
 	if err := s.Subscriber.Open(); err != nil {
 		return fmt.Errorf("open subscriber: %s", err)
@@ -488,6 +484,8 @@ func (s *Server) Open() error {
 	if err := s.PointsWriter.Open(); err != nil {
 		return fmt.Errorf("open points writer: %s", err)
 	}
+
+	s.PointsWriter.AddWriteSubscriber(s.Subscriber.Points())
 
 	for _, service := range s.Services {
 		if err := service.Open(); err != nil {

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -25,6 +25,7 @@ const (
 	statWriteTimeout       = "writeTimeout"
 	statWriteErr           = "writeError"
 	statSubWriteOK         = "subWriteOk"
+	statSubWriteDrop       = "subWriteDrop"
 )
 
 var (
@@ -59,11 +60,7 @@ type PointsWriter struct {
 		WriteToShard(ctx tsdb.WriteContext, shardID uint64, points []models.Point) error
 	}
 
-	Subscriber interface {
-		Send(*WritePointsRequest)
-	}
-
-	subPoints chan<- *WritePointsRequest
+	subPoints []chan<- *WritePointsRequest
 
 	stats *WriteStatistics
 }
@@ -124,16 +121,30 @@ func (s *ShardMapping) MapPoint(shardInfo *meta.ShardInfo, p models.Point) {
 
 // Open opens the communication channel with the point writer.
 func (w *PointsWriter) Open() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.closing = make(chan struct{})
 	return nil
 }
 
 // Close closes the communication channel with the point writer.
 func (w *PointsWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.closing != nil {
 		close(w.closing)
 	}
+	if w.subPoints != nil {
+		// 'nil' channels always block so this makes the
+		// select statement in WritePoints hit its default case
+		// dropping any in-flight writes.
+		w.subPoints = nil
+	}
 	return nil
+}
+
+func (w *PointsWriter) AddWriteSubscriber(c chan<- *WritePointsRequest) {
+	w.subPoints = append(w.subPoints, c)
 }
 
 // WithLogger sets the Logger on w.
@@ -151,6 +162,7 @@ type WriteStatistics struct {
 	WriteTimeout       int64
 	WriteErr           int64
 	SubWriteOK         int64
+	SubWriteDrop       int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -167,6 +179,7 @@ func (w *PointsWriter) Statistics(tags map[string]string) []models.Statistic {
 			statWriteTimeout:       atomic.LoadInt64(&w.stats.WriteTimeout),
 			statWriteErr:           atomic.LoadInt64(&w.stats.WriteErr),
 			statSubWriteOK:         atomic.LoadInt64(&w.stats.SubWriteOK),
+			statSubWriteDrop:       atomic.LoadInt64(&w.stats.SubWriteDrop),
 		},
 	}}
 }
@@ -315,18 +328,35 @@ func (w *PointsWriter) WritePointsPrivileged(writeCtx tsdb.WriteContext, databas
 		}(writeCtx, shardMappings.Shards[shardID], database, retentionPolicy, points)
 	}
 
-	timeout := time.NewTimer(w.WriteTimeout)
-	defer timeout.Stop()
-
-	// Send points to subscriptions
+	// Send points to subscriptions if possible.
+	var ok, dropped int64
 	pts := &WritePointsRequest{Database: database, RetentionPolicy: retentionPolicy, Points: points}
-	w.Subscriber.Send(pts)
-	atomic.AddInt64(&w.stats.SubWriteOK, 1)
+	// We need to lock just in case the channel is about to be nil'ed
+	w.mu.RLock()
+	for _, ch := range w.subPoints {
+		select {
+		case ch <- pts:
+			ok++
+		default:
+			dropped++
+		}
+	}
+	w.mu.RUnlock()
+
+	if ok > 0 {
+		atomic.AddInt64(&w.stats.SubWriteOK, ok)
+	}
+
+	if dropped > 0 {
+		atomic.AddInt64(&w.stats.SubWriteDrop, dropped)
+	}
 
 	if err == nil && len(shardMappings.Dropped) > 0 {
 		err = tsdb.PartialWriteError{Reason: "points beyond retention policy", Dropped: len(shardMappings.Dropped)}
-	}
 
+	}
+	timeout := time.NewTimer(w.WriteTimeout)
+	defer timeout.Stop()
 	for range shardMappings.Points {
 		select {
 		case <-w.closing:

--- a/models/points.go
+++ b/models/points.go
@@ -2529,7 +2529,6 @@ func appendField(b []byte, k string, v interface{}) []byte {
 
 // ValidKeyToken returns true if the token used for measurement, tag key, or tag
 // value is a valid unicode string and only contains printable, non-replacement characters.
-// Note \n (newline) is not printable.
 func ValidKeyToken(s string) bool {
 	if !utf8.ValidString(s) {
 		return false

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -44,10 +44,6 @@ type Config struct {
 	// The number of in-flight writes buffered in the write channel.
 	WriteBufferSize int `toml:"write-buffer-size"`
 
-	// TotalBufferBytes is the total size in bytes allocated to buffering across all subscriptions.
-	// Each named subscription will receive an even division of the total.
-	TotalBufferBytes int `toml:"total-buffer-bytes"`
-
 	// TLS is a base tls config to use for https clients.
 	TLS *tls.Config `toml:"-"`
 }


### PR DESCRIPTION
Reverts PR #21752

This reverts commit 85abb3af36e153d87b99589bf4db1a63c81cbf9c.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
