### PR TITLE
feat: un-revert add total-buffer-bytes config parameter to subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 -	[#21707](https://github.com/influxdata/influxdb/pull/21707): chore: add logging to compaction
+-	[#21752](https://github.com/influxdata/influxdb/pull/21752): feat: add total-buffer-bytes config parameter to subscriptions
 
 ### Bugfixes
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -80,6 +80,9 @@ type Client interface {
 	// Write takes a BatchPoints object and writes all Points to InfluxDB.
 	Write(bp BatchPoints) error
 
+	// WriteCtx takes a BatchPoints object and writes all Points to InfluxDB.
+	WriteCtx(ctx context.Context, bp BatchPoints) error
+
 	// Query makes an InfluxDB Query on the database. This will fail if using
 	// the UDP client.
 	Query(q Query) (*Response, error)
@@ -96,9 +99,15 @@ type Client interface {
 	Close() error
 }
 
+// For added performance users may want to send pre-serialized points.
+type HTTPClient interface {
+	Client
+	WriteRawCtx(ctx context.Context, bp BatchPoints, reqBody io.Reader) error
+}
+
 // NewHTTPClient returns a new Client from the provided config.
 // Client is safe for concurrent use by multiple goroutines.
-func NewHTTPClient(conf HTTPConfig) (Client, error) {
+func NewHTTPClient(conf HTTPConfig) (HTTPClient, error) {
 	if conf.UserAgent == "" {
 		conf.UserAgent = "InfluxDBClient"
 	}
@@ -377,6 +386,10 @@ func NewPointFrom(pt models.Point) *Point {
 }
 
 func (c *client) Write(bp BatchPoints) error {
+	return c.WriteCtx(context.Background(), bp)
+}
+
+func (c *client) WriteCtx(ctx context.Context, bp BatchPoints) error {
 	var b bytes.Buffer
 
 	for _, p := range bp.Points() {
@@ -391,11 +404,15 @@ func (c *client) Write(bp BatchPoints) error {
 			return err
 		}
 	}
+	return c.WriteRawCtx(ctx, bp, &b)
+}
 
+// WriteRawCtx uses reqBody instead of parsing bp.Points. Metadata still comes from bp.
+func (c *client) WriteRawCtx(ctx context.Context, bp BatchPoints, reqBody io.Reader) error {
 	u := c.url
 	u.Path = path.Join(u.Path, "write")
 
-	req, err := http.NewRequest("POST", u.String(), &b)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), reqBody)
 	if err != nil {
 		return err
 	}

--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -61,6 +61,10 @@ type udpclient struct {
 }
 
 func (uc *udpclient) Write(bp BatchPoints) error {
+	return uc.WriteCtx(context.Background(), bp)
+}
+
+func (uc *udpclient) WriteCtx(ctx context.Context, bp BatchPoints) error {
 	var b = make([]byte, 0, uc.payloadSize) // initial buffer size, it will grow as needed
 	var d, _ = time.ParseDuration("1" + bp.Precision())
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -39,14 +39,15 @@ import (
 	reads "github.com/influxdata/influxdb/storage/flux"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
-	client "github.com/influxdata/usage-client/v1"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 
 	// Initialize the engine package
 	_ "github.com/influxdata/influxdb/tsdb/engine"
+
 	// Initialize the index package
 	_ "github.com/influxdata/influxdb/tsdb/index"
+	client "github.com/influxdata/usage-client/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 )
 
 var startTime time.Time
@@ -475,6 +476,9 @@ func (s *Server) Open() error {
 		return fmt.Errorf("open tsdb store: %s", err)
 	}
 
+	// Add the subscriber before opening the PointsWriter
+	s.PointsWriter.Subscriber = s.Subscriber
+
 	// Open the subscriber service
 	if err := s.Subscriber.Open(); err != nil {
 		return fmt.Errorf("open subscriber: %s", err)
@@ -484,8 +488,6 @@ func (s *Server) Open() error {
 	if err := s.PointsWriter.Open(); err != nil {
 		return fmt.Errorf("open points writer: %s", err)
 	}
-
-	s.PointsWriter.AddWriteSubscriber(s.Subscriber.Points())
 
 	for _, service := range s.Services {
 		if err := service.Open(); err != nil {

--- a/models/points.go
+++ b/models/points.go
@@ -2529,6 +2529,7 @@ func appendField(b []byte, k string, v interface{}) []byte {
 
 // ValidKeyToken returns true if the token used for measurement, tag key, or tag
 // value is a valid unicode string and only contains printable, non-replacement characters.
+// Note \n (newline) is not printable.
 func ValidKeyToken(s string) bool {
 	if !utf8.ValidString(s) {
 		return false

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	// The number of in-flight writes buffered in the write channel.
 	WriteBufferSize int `toml:"write-buffer-size"`
 
+	// TotalBufferBytes is the total size in bytes allocated to buffering across all subscriptions.
+	// Each named subscription will receive an even division of the total.
+	TotalBufferBytes int `toml:"total-buffer-bytes"`
+
 	// TLS is a base tls config to use for https clients.
 	TLS *tls.Config `toml:"-"`
 }

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -3,12 +3,14 @@
 package subscriber // import "github.com/influxdata/influxdb/services/subscriber"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/coordinator"
 	"github.com/influxdata/influxdb/logger"
@@ -25,11 +27,71 @@ const (
 	statWriteFailures  = "writeFailures"
 )
 
+// WriteRequest is a parsed write request.
+type WriteRequest struct {
+	Database        string
+	RetentionPolicy string
+	// lineProtocol must be valid newline-separated line protocol.
+	lineProtocol []byte
+	// pointOffsets gives the starting index within lineProtocol of each point,
+	// for splitting batches if required.
+	pointOffsets []int
+}
+
+func NewWriteRequest(r *coordinator.WritePointsRequest, log *zap.Logger) (wr WriteRequest, numInvalid int64) {
+	log = log.With(zap.String("database", r.Database), zap.String("retention_policy", r.RetentionPolicy))
+	// Pre-allocate at least smallPointSize bytes per point.
+	const smallPointSize = 10
+	writeReq := WriteRequest{
+		Database:        r.Database,
+		RetentionPolicy: r.RetentionPolicy,
+		pointOffsets:    make([]int, 0, len(r.Points)),
+		lineProtocol:    make([]byte, 0, len(r.Points)*smallPointSize),
+	}
+	numInvalid = 0
+	for _, p := range r.Points {
+		if err := models.ValidPointStrings(p); err != nil {
+			log.Debug("discarding point", zap.Error(err))
+			numInvalid++
+			continue
+		}
+		// We are about to append a point of line protocol, so the new point's start index
+		// is the current length.
+		writeReq.pointOffsets = append(writeReq.pointOffsets, len(writeReq.lineProtocol))
+		// Append the new point and a newline
+		writeReq.lineProtocol = p.AppendString(writeReq.lineProtocol)
+		writeReq.lineProtocol = append(writeReq.lineProtocol, byte('\n'))
+	}
+	return writeReq, numInvalid
+}
+
+// pointAt uses pointOffsets to slice the lineProtocol buffer and retrieve the i_th point in the request.
+// It includes the trailing newline.
+func (w *WriteRequest) PointAt(i int) []byte {
+	start := w.pointOffsets[i]
+	// The end of the last point is the length of the buffer
+	end := len(w.lineProtocol)
+	// For points that are not the last point, the end is the start of the next point
+	if i+1 < len(w.pointOffsets) {
+		end = w.pointOffsets[i+1]
+	}
+	return w.lineProtocol[start:end]
+}
+
+func (w *WriteRequest) Length() int {
+	return len(w.pointOffsets)
+}
+
+func (w *WriteRequest) SizeOf() int {
+	const intSize = unsafe.Sizeof(w.pointOffsets[0])
+	return len(w.lineProtocol) + len(w.pointOffsets)*int(intSize) + len(w.Database) + len(w.RetentionPolicy)
+}
+
 // PointsWriter is an interface for writing points to a subscription destination.
 // Only WritePoints() needs to be satisfied.  PointsWriter implementations
 // must be goroutine safe.
 type PointsWriter interface {
-	WritePoints(p *coordinator.WritePointsRequest) error
+	WritePointsContext(ctx context.Context, request WriteRequest) error
 }
 
 // subEntry is a unique set that identifies a given subscription.
@@ -49,26 +111,25 @@ type Service struct {
 	}
 	NewPointsWriter func(u url.URL) (PointsWriter, error)
 	Logger          *zap.Logger
-	update          chan struct{}
 	stats           *Statistics
-	points          chan *coordinator.WritePointsRequest
 	wg              sync.WaitGroup
-	closed          bool
 	closing         chan struct{}
 	mu              sync.Mutex
 	conf            Config
+	subs            map[subEntry]*chanWriter
 
-	subs  map[subEntry]chanWriter
-	subMu sync.RWMutex
+	// subscriptionRouter is not locked by mu
+	router *subscriptionRouter
 }
 
 // NewService returns a subscriber service with given settings
 func NewService(c Config) *Service {
+	stats := &Statistics{}
 	s := &Service{
 		Logger: zap.NewNop(),
-		closed: true,
-		stats:  &Statistics{},
+		stats:  stats,
 		conf:   c,
+		router: newSubscriptionRouter(stats),
 	}
 	s.NewPointsWriter = s.newPointsWriter
 	return s
@@ -80,48 +141,74 @@ func (s *Service) Open() error {
 		return nil // Service disabled.
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.MetaClient == nil {
-		return errors.New("no meta store")
+	err := func() error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.MetaClient == nil {
+			return errors.New("no meta store")
+		}
+
+		s.closing = make(chan struct{})
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.waitForMetaUpdates()
+		}()
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
 
-	s.closed = false
-
-	s.closing = make(chan struct{})
-	s.update = make(chan struct{})
-	s.points = make(chan *coordinator.WritePointsRequest, 100)
-
-	s.wg.Add(2)
-	go func() {
-		defer s.wg.Done()
-		s.run()
-	}()
-	go func() {
-		defer s.wg.Done()
-		s.waitForMetaUpdates()
-	}()
+	// Create all subs with initial metadata
+	s.updateSubs()
 
 	s.Logger.Info("Opened service")
 	return nil
 }
 
 // Close terminates the subscription service.
-// It will panic if called multiple times or without first opening the service.
+// It will return an error if Open was not called first.
 func (s *Service) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// stop receiving new input
+	s.router.Close()
 
-	if s.closed {
-		return nil // Already closed.
+	err := func() error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.closing == nil {
+			return fmt.Errorf("closing unopened subscription service")
+		}
+
+		select {
+		case <-s.closing:
+			// already closed
+			return nil
+		default:
+		}
+
+		close(s.closing)
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
 
-	s.closed = true
+	// Note this section is safe for concurrent calls to Close - both calls will wait for the exits, one caller
+	// will win the right to close the channel writers, and the other will have to wait at the lock for that to finish.
+	// When the second caller gets the lock subs is nil which is safe.
 
-	close(s.points)
-	close(s.closing)
-
+	// wait, not under the lock, for waitForMetaUpdates to finish gracefully
 	s.wg.Wait()
+
+	// close all the subscriptions
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, cw := range s.subs {
+		cw.Close()
+	}
+	s.subs = nil
 	s.Logger.Info("Closed service")
 	return nil
 }
@@ -129,6 +216,7 @@ func (s *Service) Close() error {
 // WithLogger sets the logger on the service.
 func (s *Service) WithLogger(log *zap.Logger) {
 	s.Logger = log.With(zap.String("service", "subscriber"))
+	s.router.Logger = s.Logger
 }
 
 // Statistics maintains the statistics for the subscriber service.
@@ -150,38 +238,27 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 		},
 	}}
 
-	s.subMu.RLock()
-	defer s.subMu.RUnlock()
-
-	for _, sub := range s.subs {
-		statistics = append(statistics, sub.Statistics(tags)...)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, cw := range s.subs {
+		statistics = append(statistics, cw.Statistics(tags)...)
 	}
+
 	return statistics
 }
 
 func (s *Service) waitForMetaUpdates() {
+	ch := s.MetaClient.WaitForDataChanged()
 	for {
-		ch := s.MetaClient.WaitForDataChanged()
 		select {
 		case <-ch:
-			err := s.Update()
-			if err != nil {
-				s.Logger.Info("Error updating subscriptions", zap.Error(err))
-			}
+			// ch is closed on changes, so fetch the new channel to wait on to ensure we don't miss a new
+			// change while updating
+			ch = s.MetaClient.WaitForDataChanged()
+			s.updateSubs()
 		case <-s.closing:
 			return
 		}
-	}
-}
-
-// Update will start new and stop deleted subscriptions.
-func (s *Service) Update() error {
-	// signal update
-	select {
-	case s.update <- struct{}{}:
-		return nil
-	case <-s.closing:
-		return errors.New("service closed cannot update")
 	}
 }
 
@@ -224,103 +301,28 @@ func (s *Service) createSubscription(se subEntry, mode string, destinations []st
 	}, nil
 }
 
-// Points returns a channel into which write point requests can be sent.
-func (s *Service) Points() chan<- *coordinator.WritePointsRequest {
-	return s.points
+func (s *Service) Send(request *coordinator.WritePointsRequest) {
+	s.router.Send(request)
 }
 
-// run read points from the points channel and writes them to the subscriptions.
-func (s *Service) run() {
-	var wg sync.WaitGroup
-	s.subs = make(map[subEntry]chanWriter)
-	// Perform initial update
-	s.updateSubs(&wg)
-	for {
-		select {
-		case <-s.update:
-			s.updateSubs(&wg)
-		case p, ok := <-s.points:
-			if !ok {
-				// Close out all chanWriters
-				s.close(&wg)
-				return
-			}
+func (s *Service) updateSubs() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-			p = s.removeBadPoints(p)
-			for se, cw := range s.subs {
-				if p.Database == se.db && p.RetentionPolicy == se.rp {
-					select {
-					case cw.writeRequests <- p:
-					default:
-						atomic.AddInt64(&s.stats.WriteFailures, 1)
-					}
-				}
-			}
-		}
+	// check if we're closing while under the lock
+	select {
+	case <-s.closing:
+		return
+	default:
 	}
-}
-
-// removeBadPoints - if any non-UTF8 strings are found in the points in the WritePointRequest,
-// make a copy without those points
-func (s *Service) removeBadPoints(p *coordinator.WritePointsRequest) *coordinator.WritePointsRequest {
-	log := s.Logger.With(zap.String("database", p.Database), zap.String("retention_policy", p.RetentionPolicy))
-
-	firstBad, err := func() (int, error) {
-		for i, point := range p.Points {
-			if err := models.ValidPointStrings(point); err != nil {
-				atomic.AddInt64(&s.stats.WriteFailures, 1)
-				log.Debug("discarding point", zap.Error(err))
-				return i, err
-			}
-		}
-		return -1, nil
-	}()
-	if err != nil {
-		wrq := &coordinator.WritePointsRequest{
-			Database:        p.Database,
-			RetentionPolicy: p.RetentionPolicy,
-			Points:          make([]models.Point, 0, len(p.Points)-1),
-		}
-
-		// Copy all the points up to the first bad one.
-		wrq.Points = append(wrq.Points, p.Points[:firstBad]...)
-		for _, point := range p.Points[firstBad+1:] {
-			if err := models.ValidPointStrings(point); err != nil {
-				// Log and omit this point from subscription writes
-				atomic.AddInt64(&s.stats.WriteFailures, 1)
-				log.Debug("discarding point", zap.Error(err))
-			} else {
-				wrq.Points = append(wrq.Points, point)
-			}
-		}
-		p = wrq
-	}
-	return p
-}
-
-// close closes the existing channel writers.
-func (s *Service) close(wg *sync.WaitGroup) {
-	s.subMu.Lock()
-	defer s.subMu.Unlock()
-
-	for _, cw := range s.subs {
-		cw.Close()
-	}
-	// Wait for them to finish
-	wg.Wait()
-	s.subs = nil
-}
-
-func (s *Service) updateSubs(wg *sync.WaitGroup) {
-	s.subMu.Lock()
-	defer s.subMu.Unlock()
 
 	if s.subs == nil {
-		s.subs = make(map[subEntry]chanWriter)
+		s.subs = make(map[subEntry]*chanWriter)
 	}
 
 	dbis := s.MetaClient.Databases()
 	allEntries := make(map[subEntry]bool)
+	createdNew := false
 	// Add in new subscriptions
 	for _, dbi := range dbis {
 		for _, rpi := range dbi.RetentionPolicies {
@@ -334,27 +336,17 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) {
 				if _, ok := s.subs[se]; ok {
 					continue
 				}
+				createdNew = true
+				s.Logger.Info("Adding new subscription",
+					logger.Database(se.db),
+					logger.RetentionPolicy(se.rp))
 				sub, err := s.createSubscription(se, si.Mode, si.Destinations)
 				if err != nil {
 					atomic.AddInt64(&s.stats.CreateFailures, 1)
 					s.Logger.Info("Subscription creation failed", zap.String("name", si.Name), zap.Error(err))
 					continue
 				}
-				cw := chanWriter{
-					writeRequests: make(chan *coordinator.WritePointsRequest, s.conf.WriteBufferSize),
-					pw:            sub,
-					pointsWritten: &s.stats.PointsWritten,
-					failures:      &s.stats.WriteFailures,
-					logger:        s.Logger,
-				}
-				for i := 0; i < s.conf.WriteConcurrency; i++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						cw.Run()
-					}()
-				}
-				s.subs[se] = cw
+				s.subs[se] = newChanWriter(s, sub)
 				s.Logger.Info("Added new subscription",
 					logger.Database(se.db),
 					logger.RetentionPolicy(se.rp))
@@ -362,18 +354,36 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) {
 		}
 	}
 
-	// Remove deleted subs
-	for se := range s.subs {
+	toClose := make(map[subEntry]*chanWriter)
+	for se, cw := range s.subs {
 		if !allEntries[se] {
-			// Close the chanWriter
-			s.subs[se].Close()
-
-			// Remove it from the set
+			toClose[se] = cw
 			delete(s.subs, se)
-			s.Logger.Info("Deleted old subscription",
-				logger.Database(se.db),
-				logger.RetentionPolicy(se.rp))
 		}
+	}
+
+	if createdNew || len(toClose) > 0 {
+		memoryLimit := int64(0)
+		if s.conf.TotalBufferBytes != 0 {
+			memoryLimit = int64(s.conf.TotalBufferBytes / len(s.subs))
+			if memoryLimit == 0 {
+				memoryLimit = 1
+			}
+		}
+		// update the router before we close any subscriptions
+		s.router.Update(s.subs, memoryLimit)
+	}
+
+	for se, cw := range toClose {
+		s.Logger.Info("Deleting old subscription",
+			logger.Database(se.db),
+			logger.RetentionPolicy(se.rp))
+
+		cw.CancelAndClose()
+
+		s.Logger.Info("Deleted old subscription",
+			logger.Database(se.db),
+			logger.RetentionPolicy(se.rp))
 	}
 }
 
@@ -396,32 +406,95 @@ func (s *Service) newPointsWriter(u url.URL) (PointsWriter, error) {
 
 // chanWriter sends WritePointsRequest to a PointsWriter received over a channel.
 type chanWriter struct {
-	writeRequests chan *coordinator.WritePointsRequest
+	writeRequests chan WriteRequest
+	ctx           context.Context
+	cancel        context.CancelFunc
 	pw            PointsWriter
 	pointsWritten *int64
 	failures      *int64
 	logger        *zap.Logger
+	queueSize     int64
+	queueLimit    int64
+	wg            sync.WaitGroup
 }
 
-// Close closes the chanWriter.
-func (c chanWriter) Close() {
+func newChanWriter(s *Service, sub PointsWriter) *chanWriter {
+	ctx, cancel := context.WithCancel(context.Background())
+	cw := &chanWriter{
+		writeRequests: make(chan WriteRequest, s.conf.WriteBufferSize),
+		ctx:           ctx,
+		cancel:        cancel,
+		pw:            sub,
+		pointsWritten: &s.stats.PointsWritten,
+		failures:      &s.stats.WriteFailures,
+		logger:        s.Logger,
+	}
+	for i := 0; i < s.conf.WriteConcurrency; i++ {
+		cw.wg.Add(1)
+		go func() {
+			defer cw.wg.Done()
+			cw.Run()
+		}()
+	}
+	return cw
+}
+
+// Write is on the hot path for data ingest (to the whole database, not just subscriptions).
+// Be extra careful about latency.
+func (c *chanWriter) Write(wr WriteRequest) {
+	sz := wr.SizeOf()
+	newSize := atomic.AddInt64(&c.queueSize, int64(sz))
+	limit := atomic.LoadInt64(&c.queueLimit)
+
+	// If we would add more size than we should hold, reject the write
+	if limit > 0 && newSize > limit {
+		atomic.AddInt64(c.failures, 1)
+		atomic.AddInt64(&c.queueSize, -int64(sz))
+		return
+	}
+
+	// If the write queue is full, reject the write
+	select {
+	case c.writeRequests <- wr:
+	default:
+		atomic.AddInt64(c.failures, 1)
+	}
+}
+
+// limitTo sets a new limit on the size of the queue.
+func (c *chanWriter) limitTo(newLimit int64) {
+	atomic.StoreInt64(&c.queueLimit, newLimit)
+	// We don't immediately evict things if the queue is over the limit,
+	// since they should be shortly evicted in normal operation.
+}
+
+func (c *chanWriter) CancelAndClose() {
 	close(c.writeRequests)
+	c.cancel()
+	c.wg.Wait()
 }
 
-func (c chanWriter) Run() {
+// Close closes the chanWriter. It blocks until all the in-flight write requests are finished.
+func (c *chanWriter) Close() {
+	close(c.writeRequests)
+	c.wg.Wait()
+}
+
+func (c *chanWriter) Run() {
 	for wr := range c.writeRequests {
-		err := c.pw.WritePoints(wr)
+		err := c.pw.WritePointsContext(c.ctx, wr)
 		if err != nil {
 			c.logger.Info(err.Error())
 			atomic.AddInt64(c.failures, 1)
 		} else {
-			atomic.AddInt64(c.pointsWritten, int64(len(wr.Points)))
+			atomic.AddInt64(c.pointsWritten, int64(len(wr.pointOffsets)))
 		}
+		atomic.AddInt64(&c.queueSize, -int64(wr.SizeOf()))
 	}
 }
 
 // Statistics returns statistics for periodic monitoring.
-func (c chanWriter) Statistics(tags map[string]string) []models.Statistic {
+func (c *chanWriter) Statistics(tags map[string]string) []models.Statistic {
 	if m, ok := c.pw.(monitor.Reporter); ok {
 		return m.Statistics(tags)
 	}
@@ -454,7 +527,7 @@ type balancewriter struct {
 	i           int
 }
 
-func (b *balancewriter) WritePoints(p *coordinator.WritePointsRequest) error {
+func (b *balancewriter) WritePointsContext(ctx context.Context, request WriteRequest) error {
 	var lastErr error
 	for range b.writers {
 		// round robin through destinations.
@@ -463,12 +536,12 @@ func (b *balancewriter) WritePoints(p *coordinator.WritePointsRequest) error {
 		b.i = (b.i + 1) % len(b.writers)
 
 		// write points to destination.
-		err := w.WritePoints(p)
+		err := w.WritePointsContext(ctx, request)
 		if err != nil {
 			lastErr = err
 			atomic.AddInt64(&b.stats[i].failures, 1)
 		} else {
-			atomic.AddInt64(&b.stats[i].pointsWritten, int64(len(p.Points)))
+			atomic.AddInt64(&b.stats[i].pointsWritten, int64(len(request.pointOffsets)))
 			if b.bm == ANY {
 				break
 			}
@@ -493,4 +566,70 @@ func (b *balancewriter) Statistics(tags map[string]string) []models.Statistic {
 		}
 	}
 	return statistics
+}
+
+type dbrp struct {
+	db string
+	rp string
+}
+
+// subscriptionRouter has a mutex lock on the hot path for database writes - make sure that the lock is very tight.
+type subscriptionRouter struct {
+	mu            sync.RWMutex
+	ready         bool
+	m             map[dbrp][]*chanWriter
+	writeFailures *int64
+	Logger        *zap.Logger
+}
+
+func newSubscriptionRouter(statistics *Statistics) *subscriptionRouter {
+	return &subscriptionRouter{
+		ready:         true,
+		writeFailures: &statistics.WriteFailures,
+		Logger:        zap.NewNop(),
+	}
+}
+
+func (s *subscriptionRouter) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ready = false
+}
+
+func (s *subscriptionRouter) Send(request *coordinator.WritePointsRequest) {
+	// serialize points and put on writer
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.ready {
+		return
+	}
+	writers := s.m[dbrp{
+		db: request.Database,
+		rp: request.RetentionPolicy,
+	}]
+	if len(writers) == 0 {
+		return
+	}
+	writeReq, numInvalid := NewWriteRequest(request, s.Logger)
+	atomic.AddInt64(s.writeFailures, numInvalid)
+	for _, w := range writers {
+		w.Write(writeReq)
+	}
+}
+
+func (s *subscriptionRouter) Update(cws map[subEntry]*chanWriter, memoryLimit int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.ready {
+		panic("must be created with NewServer before calling update, must not call update after close")
+	}
+	s.m = make(map[dbrp][]*chanWriter)
+	for se, cw := range cws {
+		cw.limitTo(memoryLimit)
+		key := dbrp{
+			db: se.db,
+			rp: se.rp,
+		}
+		s.m[key] = append(s.m[key], cw)
+	}
 }

--- a/services/subscriber/udp.go
+++ b/services/subscriber/udp.go
@@ -1,9 +1,8 @@
 package subscriber
 
 import (
+	"context"
 	"net"
-
-	"github.com/influxdata/influxdb/coordinator"
 )
 
 // UDP supports writing points over UDP using the line protocol.
@@ -17,7 +16,7 @@ func NewUDP(addr string) *UDP {
 }
 
 // WritePoints writes points over UDP transport.
-func (u *UDP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
+func (u *UDP) WritePointsContext(_ context.Context, request WriteRequest) (err error) {
 	var addr *net.UDPAddr
 	var con *net.UDPConn
 	addr, err = net.ResolveUDPAddr("udp", u.addr)
@@ -31,12 +30,13 @@ func (u *UDP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
 	}
 	defer con.Close()
 
-	for _, p := range p.Points {
-		_, err = con.Write([]byte(p.String()))
+	for i := range request.pointOffsets {
+		// write the point without the trailing newline
+		pointRaw := request.PointAt(i)
+		_, err = con.Write(pointRaw[:pointRaw[len(pointRaw)-1]])
 		if err != nil {
 			return
 		}
-
 	}
 	return
 }


### PR DESCRIPTION
This reverts commit 4d82ed2c07dda05494b6824f5f5e7abff26ab31f.

Closes #21733

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
