### PR TITLE
fix: show shards gives empty expiry time for inf duration shards (#21…

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -810,7 +810,10 @@ func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShards
 					for i, owner := range si.Owners {
 						ownerIDs[i] = owner.NodeID
 					}
-
+					expiry := ""
+					if rpi.Duration != 0 {
+						expiry = sgi.EndTime.Add(rpi.Duration).UTC().Format(time.RFC3339)
+					}
 					row.Values = append(row.Values, []interface{}{
 						si.ID,
 						di.Name,
@@ -818,7 +821,7 @@ func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShards
 						sgi.ID,
 						sgi.StartTime.UTC().Format(time.RFC3339),
 						sgi.EndTime.UTC().Format(time.RFC3339),
-						sgi.EndTime.Add(rpi.Duration).UTC().Format(time.RFC3339),
+						expiry,
 						joinUint64(ownerIDs),
 					})
 				}


### PR DESCRIPTION
…795)

(cherry picked from commit 8fa4d82ce7fb8ee9d628b6654f99ef6de19b5abd)

Partial close of #21805 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
