### PR TITLE
revert: add series cardinality test and fix backup port (#21787)

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -277,7 +277,7 @@ func TestServer_BackupAndRestore(t *testing.T) {
 }
 
 func freePort() string {
-	l, _ := net.Listen("tcp", "127.0.0.1:")
+	l, _ := net.Listen("tcp", "")
 	defer l.Close()
 	return l.Addr().String()
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -7366,11 +7366,6 @@ func TestServer_Query_ShowSeriesCardinalityEstimation(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 		},
 		&Query{
-			name:    `show series cardinality from cpu`,
-			command: "SHOW SERIES CARDINALITY FROM cpu",
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
 			name:    `show series cardinality on db0`,
 			command: "SHOW SERIES CARDINALITY ON db0",
 		},


### PR DESCRIPTION
This reverts commit 9a3bd84d61fca00287180c49642df023b0d432d2.

Reverting due to persistent test failures around the new test.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
