### PR TITLE
chore: change commit and branch keys to fields instead of tags

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -33,9 +33,7 @@ cat << EOF > /etc/telegraf/telegraf.conf
   json_time_key = "time"
   json_time_format = "unix"
   tag_keys = [
-    "i_type",
-    "branch",
-    "commit"
+    "i_type"
   ]
 EOF
 systemctl restart telegraf


### PR DESCRIPTION
context: configuring unique data as tags causes series cardinality to
grow in an unbounded manner; data with unique values should be set
as fields

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass