### PR TITLE
chore: move to os/io for inspect test code

### DIFF
--- a/cmd/influxd/inspect/export_lp/export_lp_test.go
+++ b/cmd/influxd/inspect/export_lp/export_lp_test.go
@@ -3,7 +3,6 @@ package export_lp
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sort"
@@ -373,7 +372,7 @@ func makeStringsCorpus(numSeries, numStringsPerSeries int) corpus {
 // writeCorpusToWALFile writes the given corpus as a WAL file, and returns a handle to that file.
 // It is the caller's responsibility to remove the returned temp file.
 func writeCorpusToWALFile(c corpus) (*os.File, error) {
-	walFile, err := ioutil.TempFile("", "export_test_corpus_wal")
+	walFile, err := os.CreateTemp("", "export_test_corpus_wal")
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +402,7 @@ func writeCorpusToWALFile(c corpus) (*os.File, error) {
 // writeCorpusToTSMFile writes the given corpus as a TSM file, and returns a handle to that file.
 // It is the caller's responsibility to remove the returned temp file.
 func writeCorpusToTSMFile(c corpus) (*os.File, error) {
-	tsmFile, err := ioutil.TempFile("", "export_test_corpus_tsm")
+	tsmFile, err := os.CreateTemp("", "export_test_corpus_tsm")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile.go
@@ -3,7 +3,6 @@ package verify_seriesfile
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -59,7 +58,7 @@ func NewVerifySeriesfileCommand() *cobra.Command {
 				return err
 			}
 
-			dbs, err := ioutil.ReadDir(arguments.dir)
+			dbs, err := os.ReadDir(arguments.dir)
 			if err != nil {
 				return err
 			}
@@ -133,7 +132,7 @@ func (v verify) verifySeriesFile(filePath string) (valid bool, err error) {
 		}
 	}()
 
-	partitionInfos, err := ioutil.ReadDir(filePath)
+	partitionInfos, err := os.ReadDir(filePath)
 	if os.IsNotExist(err) {
 		v.Logger.Error("Series file does not exist")
 		return false, nil
@@ -205,7 +204,7 @@ func (v verify) verifyPartition(partitionPath string) (valid bool, err error) {
 		}
 	}()
 
-	segmentInfos, err := ioutil.ReadDir(partitionPath)
+	segmentInfos, err := os.ReadDir(partitionPath)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -3,7 +3,6 @@ package verify_seriesfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +76,7 @@ type Test struct {
 func NewTest(t *testing.T) *Test {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "verify-seriesfile-")
+	dir, err := os.MkdirTemp("", "verify-seriesfile-")
 	require.NoError(t, err)
 
 	// create a series file in the directory

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -3,7 +3,7 @@ package verify_tombstone
 import (
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -21,10 +21,10 @@ const (
 
 // Run tests on a directory with no Tombstone files
 func TestVerifies_InvalidFileType(t *testing.T) {
-	path, err := ioutil.TempDir("", "verify-tombstone")
+	path, err := os.MkdirTemp("", "verify-tombstone")
 	require.NoError(t, err)
 
-	_, err = ioutil.TempFile(path, "verifytombstonetest*"+".txt")
+	_, err = os.CreateTemp(path, "verifytombstonetest*"+".txt")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -35,7 +35,7 @@ func TestVerifies_InvalidFileType(t *testing.T) {
 	verify.SetOut(b)
 	require.NoError(t, verify.Execute())
 
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Contains(t, string(out), "No tombstone files found")
 }
@@ -52,7 +52,7 @@ func TestVerifies_InvalidEmptyFile(t *testing.T) {
 	verify.SetOut(b)
 	require.NoError(t, verify.Execute())
 
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Contains(t, string(out), "has no tombstone entries")
 }
@@ -136,10 +136,10 @@ func TestTombstone_VeryVeryVerbose(t *testing.T) {
 func NewTempTombstone(t *testing.T) (string, *os.File) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "verify-tombstone")
+	dir, err := os.MkdirTemp("", "verify-tombstone")
 	require.NoError(t, err)
 
-	file, err := ioutil.TempFile(dir, "verifytombstonetest*"+"."+tsm1.TombstoneFileExtension)
+	file, err := os.CreateTemp(dir, "verifytombstonetest*"+"."+tsm1.TombstoneFileExtension)
 	require.NoError(t, err)
 
 	return dir, file

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
@@ -3,7 +3,7 @@ package verify_tsm
 import (
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -21,7 +21,7 @@ func TestInvalidChecksum(t *testing.T) {
 	verify.SetArgs([]string{"--dir", path})
 	require.NoError(t, verify.Execute())
 
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Contains(t, string(out), "Broken Blocks: 1 / 1")
 }
@@ -36,7 +36,7 @@ func TestValidChecksum(t *testing.T) {
 	verify.SetArgs([]string{"--dir", path})
 	require.NoError(t, verify.Execute())
 
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Contains(t, string(out), "Broken Blocks: 0 / 1")
 }
@@ -61,7 +61,7 @@ func TestValidUTF8(t *testing.T) {
 	verify.SetArgs([]string{"--dir", path, "--check-utf8"})
 	require.NoError(t, verify.Execute())
 
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.NoError(t, err)
 	require.Contains(t, string(out), "Invalid Keys: 0 / 1")
 }
@@ -69,10 +69,10 @@ func TestValidUTF8(t *testing.T) {
 func newUTFTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "verify-tsm")
+	dir, err := os.MkdirTemp("", "verify-tsm")
 	require.NoError(t, err)
 
-	f, err := ioutil.TempFile(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
+	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -94,10 +94,10 @@ func newUTFTest(t *testing.T, withError bool) string {
 func newChecksumTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "verify-tsm")
+	dir, err := os.MkdirTemp("", "verify-tsm")
 	require.NoError(t, err)
 
-	f, err := ioutil.TempFile(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
+	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)
 
 	w, err := tsm1.NewTSMWriter(f)


### PR DESCRIPTION
This PR simply moves away from using `ioutil` in the `inspect` command package for test cases, and favors using their replacements in `io` and `os` instead, as is recommended in Go 1.16.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass