### PR TITLE
feat: create `influxd inspect verify-wal` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21784](https://github.com/influxdata/influxdb/pull/21784): Ported the `influxd inspect dumptsi` command from 1.x.
 1. [21786](https://github.com/influxdata/influxdb/pull/21786): Ported the `influxd inspect deletetsm` command from 1.x.
 1. [21802](https://github.com/influxdata/influxdb/pull/21802): Removed unused `chronograf-migator` package & chronograf API service, and updated various "chronograf" references.
+1. [21828](https://github.com/influxdata/influxdb/pull/21828): Added the command `influx inspect verify-wal`.
 
 ### Bug Fixes
 

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_seriesfile"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_tombstone"
 	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_tsm"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/inspect/verify_wal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,6 +37,7 @@ func NewCommand(v *viper.Viper) (*cobra.Command, error) {
 	base.AddCommand(dump_tsm.NewDumpTSMCommand())
 	base.AddCommand(dump_tsi.NewDumpTSICommand())
 	base.AddCommand(delete_tsm.NewDeleteTSMCommand())
+	base.AddCommand(verify_wal.NewVerifyWALCommand())
 
 	return base, nil
 }

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -1,0 +1,121 @@
+package verify_wal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/internal/fs"
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/spf13/cobra"
+)
+
+type args struct {
+	dir string
+}
+
+func NewVerifyWALCommand() *cobra.Command {
+	var arguments args
+	cmd := &cobra.Command{
+		Use:   `verify-wal`,
+		Short: "Check for WAL corruption",
+		Long: `
+This command will analyze the WAL (Write-Ahead Log) in a storage directory to 
+check if there are any corrupt files. If any corrupt files are found, the names
+of said corrupt files will be reported. The tool will also count the total number
+of entries in the scanned WAL files, in case this is of interest.
+For each file, the following is output:
+	* The file name;
+	* "clean" (if the file is clean) OR 
+      The first position of any corruption that is found
+In the summary section, the following is printed:
+	* The number of WAL files scanned;
+	* The number of WAL entries scanned;
+	* A list of files found to be corrupt`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return arguments.Run(cmd)
+		},
+	}
+
+	dir, err := fs.InfluxDir()
+	if err != nil {
+		panic(err)
+	}
+	dir = filepath.Join(dir, "engine/wal")
+	cmd.Flags().StringVarP(&arguments.dir, "data-dir", "", dir, fmt.Sprintf("use provided data directory (defaults to %s).", dir))
+	return cmd
+}
+
+func (a args) Run(cmd *cobra.Command) error {
+	// Verify valid directory
+	dir, err := os.Stat(a.dir)
+	if err != nil {
+		return fmt.Errorf("failed to get directory from %s", a.dir)
+	} else if !dir.IsDir() {
+		return errors.New("invalid data directory")
+	}
+
+	// Find all WAL files in provided directory
+	files, err := filepath.Glob(path.Join(a.dir, "*."+tsm1.WALFileExtension))
+	if err != nil {
+		return fmt.Errorf("failed to find WAL files in directory %s: %w", a.dir, err)
+	}
+
+	start := time.Now()
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 8, 2, 1, ' ', 0)
+
+	var corruptFiles []string
+	var entriesScanned int
+
+	// Scan each WAL file
+	for _, fpath := range files {
+		f, err := os.OpenFile(fpath, os.O_RDONLY, 0600)
+		if err != nil {
+			return fmt.Errorf("error opening file %s: %w. Exiting", fpath, err)
+		}
+
+		clean := true
+		reader := tsm1.NewWALSegmentReader(f)
+
+		// Check for corrupted entries
+		for reader.Next() {
+			entriesScanned++
+			_, err := reader.Read()
+			if err != nil {
+				clean = false
+				_, _ = fmt.Fprintf(tw, "%s: corrupt entry found at position %d\n", fpath, reader.Count())
+				corruptFiles = append(corruptFiles, fpath)
+				break
+			}
+
+		}
+
+		// No corrupted entry found
+		if clean {
+			_, _ = fmt.Fprintf(tw, "%s: clean\n", fpath)
+		}
+	}
+
+	// Print Summary
+	_, _ = fmt.Fprintf(tw, "Results:\n")
+	_, _ = fmt.Fprintf(tw, "  Files checked: %d\n", len(files))
+	_, _ = fmt.Fprintf(tw, "  Total entries checked: %d\n", entriesScanned)
+	_, _ = fmt.Fprintf(tw, "  Corrupt files found: ")
+	if len(corruptFiles) == 0 {
+		_, _ = fmt.Fprintf(tw, "None")
+	} else {
+		for _, name := range corruptFiles {
+			_, _ = fmt.Fprintf(tw, "\n    %s", name)
+		}
+	}
+
+	_, _ = fmt.Fprintf(tw, "\nCompleted in %v\n", time.Since(start))
+	_ = tw.Flush()
+
+	return nil
+}

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -98,12 +98,14 @@ func (a args) Run(cmd *cobra.Command) error {
 			}
 		}
 
-		if entriesScanned == 0 {
-			// No data found in file
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "no WAL entries found for file %s, skipping", f.Name())
-		} else if clean && a.verbose {
-			// No corrupted entry found
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: clean\n", fpath)
+		if a.verbose {
+			if entriesScanned == 0 {
+				// No data found in file
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: no WAL entries found\n", f.Name())
+			} else if clean {
+				// No corrupted entry found
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s: clean\n", fpath)
+			}
 		}
 		totalEntriesScanned += entriesScanned
 		_ = tw.Flush()

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -65,7 +65,7 @@ func (a args) Run(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to search for WAL files in directory %s: %w", a.dir, err)
 	}
-	if files == nil || len(files) == 0 {
+	if len(files) == 0 {
 		return fmt.Errorf("failed to find WAL files in directory %s: %w", a.dir, err)
 	}
 

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -3,7 +3,6 @@ package verify_wal
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"text/tabwriter"
 	"time"
@@ -62,7 +61,7 @@ func (a args) Run(cmd *cobra.Command) error {
 	}
 
 	// Find all WAL files in provided directory
-	files, err := filepath.Glob(path.Join(a.dir, "*."+tsm1.WALFileExtension))
+	files, err := loadFiles(a.dir)
 	if err != nil {
 		return fmt.Errorf("failed to search for WAL files in directory %s: %w", a.dir, err)
 	}
@@ -127,4 +126,17 @@ func (a args) Run(cmd *cobra.Command) error {
 	_ = tw.Flush()
 
 	return nil
+}
+
+func loadFiles(dir string) (files []string, err error) {
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == "."+tsm1.WALFileExtension {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return
 }

--- a/cmd/influxd/inspect/verify_wal/verify_wal_test.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal_test.go
@@ -54,7 +54,7 @@ func TestVerifies_InvalidEmptyFile(t *testing.T) {
 	runCommand(testInfo{
 		t:           t,
 		path:        path,
-		expectedOut: "no WAL entries found for file",
+		expectedOut: "no WAL entries found",
 		withStdErr:  true,
 	})
 }

--- a/cmd/influxd/inspect/verify_wal/verify_wal_test.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal_test.go
@@ -1,0 +1,120 @@
+package verify_wal
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifies_InvalidFileType(t *testing.T) {
+	path, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	_, err = os.CreateTemp(path, "verifywaltest*"+".txt")
+	require.NoError(t, err)
+	defer os.RemoveAll(path)
+
+	runCommand(t, path, "failed to find WAL files in directory", true)
+}
+
+func TestVerifies_InvalidNotDir(t *testing.T) {
+	path, file := newTempWALInvalid(t, true)
+	defer os.RemoveAll(path)
+
+	runCommand(t, file.Name(), "invalid data directory", true)
+}
+
+func TestVerifies_InvalidEmptyFile(t *testing.T) {
+	path, _ := newTempWALInvalid(t, true)
+	defer os.RemoveAll(path)
+
+	runCommand(t, path, "no WAL entries found for file", false)
+}
+
+func TestVerifies_Invalid(t *testing.T) {
+	path, _ := newTempWALInvalid(t, false)
+	defer os.RemoveAll(path)
+
+	runCommand(t, path, "corrupt entry found at position", false)
+}
+
+func TestVerifies_Valid(t *testing.T) {
+	path := newTempWALValid(t)
+	defer os.RemoveAll(path)
+
+	runCommand(t, path, "clean", false)
+}
+
+func runCommand(t *testing.T, dir string, expected string, expectErr bool) {
+	verify := NewVerifyWALCommand()
+	verify.SetArgs([]string{"--data-dir", dir})
+
+	b := bytes.NewBufferString("")
+	verify.SetOut(b)
+	if expectErr {
+		require.Error(t, verify.Execute())
+	} else {
+		require.NoError(t, verify.Execute())
+	}
+
+	out, err := io.ReadAll(b)
+	require.NoError(t, err)
+	require.Contains(t, string(out), expected)
+}
+
+func newTempWALValid(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	w := tsm1.NewWAL(dir, 0, 0)
+	defer w.Close()
+	require.NoError(t, w.Open())
+
+	p1 := tsm1.NewValue(1, 1.1)
+	p2 := tsm1.NewValue(1, int64(1))
+	p3 := tsm1.NewValue(1, true)
+	p4 := tsm1.NewValue(1, "string")
+	p5 := tsm1.NewValue(1, ^uint64(0))
+
+	values := map[string][]tsm1.Value{
+		"cpu,host=A#!~#float":    {p1},
+		"cpu,host=A#!~#int":      {p2},
+		"cpu,host=A#!~#bool":     {p3},
+		"cpu,host=A#!~#string":   {p4},
+		"cpu,host=A#!~#unsigned": {p5},
+	}
+
+	_, err = w.WriteMulti(context.Background(), values)
+	require.NoError(t, err)
+
+	return dir
+}
+
+func newTempWALInvalid(t *testing.T, empty bool) (string, *os.File) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	file, err := os.CreateTemp(dir, "verifywaltest*."+tsm1.WALFileExtension)
+	require.NoError(t, err)
+
+	if !empty {
+		writer, err := os.OpenFile(file.Name(), os.O_APPEND|os.O_WRONLY, 0644)
+		require.NoError(t, err)
+		defer writer.Close()
+
+		written, err := writer.Write([]byte("foobar"))
+		require.NoError(t, err)
+		require.Equal(t, 6, written)
+	}
+
+	return dir, file
+}


### PR DESCRIPTION
Closes #19539

This PR creates the `./influxd inspect verify-wal` subcommand. I created test cases which give about 93% coverage of the command file, only skipping basic error handling like `os` failing to open a file.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass