### PR TITLE
refactor(query): rename the kind for experimental-to so that it is different from native flux

### DIFF
--- a/query/stdlib/experimental/to.go
+++ b/query/stdlib/experimental/to.go
@@ -5,16 +5,15 @@ import (
 	"errors"
 	"fmt"
 
-	platform2 "github.com/influxdata/influxdb/v2/kit/platform"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
-	"github.com/influxdata/flux/stdlib/experimental"
+	_ "github.com/influxdata/flux/stdlib/experimental"
 	platform "github.com/influxdata/influxdb/v2"
+	platform2 "github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/query"
 	"github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
@@ -22,7 +21,7 @@ import (
 )
 
 // ToKind is the kind for the `to` flux function
-const ExperimentalToKind = experimental.ExperimentalToKind
+const ExperimentalToKind = "influxdb-experimental-to"
 
 // ToOpSpec is the flux.OperationSpec for the `to` flux function.
 type ToOpSpec struct {
@@ -37,7 +36,6 @@ type ToOpSpec struct {
 func init() {
 	toSignature := runtime.MustLookupBuiltinType("experimental", "to")
 	runtime.ReplacePackageValue("experimental", "to", flux.MustValue(flux.FunctionValueWithSideEffect("to", createToOpSpec, toSignature)))
-	flux.RegisterOpSpec(ExperimentalToKind, func() flux.OperationSpec { return &ToOpSpec{} })
 	plan.RegisterProcedureSpecWithSideEffect(ExperimentalToKind, newToProcedure, ExperimentalToKind)
 	execute.RegisterTransformation(ExperimentalToKind, createToTransformation)
 }

--- a/query/stdlib/experimental/to_test.go
+++ b/query/stdlib/experimental/to_test.go
@@ -3,7 +3,6 @@ package experimental_test
 import (
 	"context"
 	"errors"
-	platform2 "github.com/influxdata/influxdb/v2/kit/platform"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/universe"
 	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
+	platform2 "github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/query/stdlib/experimental"
@@ -56,7 +56,7 @@ from(bucket:"mydb")
 							ValueColumn: "_value"},
 					},
 					{
-						ID: "experimental-to3",
+						ID: "influxdb-experimental-to3",
 						Spec: &experimental.ToOpSpec{
 							Bucket: "series1",
 							Org:    "fred",
@@ -68,7 +68,7 @@ from(bucket:"mydb")
 				Edges: []flux.Edge{
 					{Parent: "from0", Child: "range1"},
 					{Parent: "range1", Child: "pivot2"},
-					{Parent: "pivot2", Child: "experimental-to3"},
+					{Parent: "pivot2", Child: "influxdb-experimental-to3"},
 				},
 			},
 		},

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/values/valuestest"
+	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/models"
-	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
 	"github.com/influxdata/influxdb/v2/query/stdlib/influxdata/influxdb"
 )
 


### PR DESCRIPTION
The kind for experimental-to is in conflict with the one used by native
flux. In the past, native flux didn't use the kind and expected
implementations to register their own procedure spec with that value.

In the latest Flux, this isn't the case and it is using the kind for a
native implementation. As we have not implemented the requirements for
the native implementation, we are still replacing the procedure spec but
using a different name that's unique to our implementation.