### PR TITLE
build(flux): update flux to v0.122.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe
-	github.com/influxdata/flux v0.120.1
+	github.com/influxdata/flux v0.122.0
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influx-cli/v2 v2.0.0-20210702141951-3ca681b1dd48
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe h1:7j4SdN/BvQwN6WoUq7mv0kg5U9NhnFBxPGMafYRKym0=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.120.1 h1:M4x6e25+ao95N98kB65wd59juA+RV7WDhcsYuxL5/6M=
-github.com/influxdata/flux v0.120.1/go.mod h1:pGSAvyAA5d3et7SSzajaYShWYXmnRnJJq2qWi+WWZ2I=
+github.com/influxdata/flux v0.122.0 h1:nAOezylrjyJ7FAzuCUaTC2+mxsq4Oy0Lde5WZ1j9IZ8=
+github.com/influxdata/flux v0.122.0/go.mod h1:pGSAvyAA5d3et7SSzajaYShWYXmnRnJJq2qWi+WWZ2I=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influx-cli/v2 v2.0.0-20210702141951-3ca681b1dd48 h1:UjL3ISuDYyy3wLXzFdsuO9deesA9C0LP4mQXcVGDivc=

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -957,7 +957,7 @@ func selectorLastGroupsFloat(ts int64, v float64, timestamps []int64, values []f
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}
@@ -1941,7 +1941,7 @@ func selectorLastGroupsInteger(ts int64, v int64, timestamps []int64, values []i
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}
@@ -2922,7 +2922,7 @@ func selectorLastGroupsUnsigned(ts int64, v uint64, timestamps []int64, values [
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}
@@ -3847,7 +3847,7 @@ func selectorLastGroupsString(ts int64, v string, timestamps []int64, values []s
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}
@@ -4772,7 +4772,7 @@ func selectorLastGroupsBoolean(ts int64, v bool, timestamps []int64, values []bo
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -987,7 +987,7 @@ func selectorLastGroups{{.Name}}(ts int64, v {{.Type}}, timestamps []int64, valu
 	index := -1
 
 	for ; i < len(values); i++ {
-		if ts < timestamps[i] {
+		if ts <= timestamps[i] {
 			index = i
 			ts = timestamps[i]
 		}


### PR DESCRIPTION
This is a straightforward upgrade of the Flux version, save for I needed to tweak how pushdowns of `group|>last` work. New tests added to the latest `flux` version test this change. Shortly I'll have another PR that will include more test coverage for `group()` and `first` and `last`.

See also this issue for a more in-depth discussion of `group` and `last`:
https://github.com/influxdata/idpe/issues/11201