### PR TITLE
fix: systemd unit should block on startup until http endpoint is ready

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,8 @@ nfpms:
         dst: /etc/logrotate.d/influxdb
       - src: scripts/influxdb2-upgrade.sh
         dst: /usr/share/influxdb/influxdb2-upgrade.sh
+      - src: scripts/influxd-systemd-start.sh
+        dst: /usr/lib/influxdb/scripts/influxd-systemd-start.sh
     scripts:
       preinstall:  "scripts/pre-install.sh"
       postinstall: "scripts/post-install.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21844](https://github.com/influxdata/influxdb/pull/21844): Upgrade to latest version of `influxdata/cron` so that tasks can be created with interval of `every: 1w`.
 1. [21849](https://github.com/influxdata/influxdb/pull/21849): Specify which fields are missing when rejecting an incomplete onboarding request.
 1. [21839](https://github.com/influxdata/influxdb/pull/21839): Fix display and parsing of `influxd upgrade` CLI prompts in PowerShell.
+1. [21850](https://github.com/influxdata/influxdb/pull/21850): Systemd unit should block on startup until http endpoint is ready
 
 ## v2.0.7 [2021-06-04]
 

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+/usr/bin/influxd &
+echo $! > /var/lib/influxdb/influxd.pid
+
+BIND_ADDRESS=$(influxd print-config --key-name http-bind-address)
+HOST=${BIND_ADDRESS%%:*}
+HOST=${HOST:-"localhost"}
+PORT=${BIND_ADDRESS##*:}
+
+set +e
+result=$(curl -s -o /dev/null http://$HOST:$PORT/ready -w %{http_code})
+while [ "$result" != "200" ]; do
+  sleep 1
+  result=$(curl -s -o /dev/null http://$HOST:$PORT/ready -w %{http_code})
+done
+set -e

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -10,9 +10,11 @@ User=influxdb
 Group=influxdb
 LimitNOFILE=65536
 EnvironmentFile=-/etc/default/influxdb2
-ExecStart=/usr/bin/influxd
+ExecStart=/usr/lib/influxdb/scripts/influxd-systemd-start.sh
 KillMode=control-group
 Restart=on-failure
+Type=forking
+PIDFile=/var/lib/influxdb/influxd.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #6068 

Implements a wrapper around influxd when called by systemd to wait until the server is ready before exiting startup.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass