### PR TITLE
test: add tests for group and count/sum

### DIFF
--- a/query/stdlib/influxdata/influxdb/group_agg_influxdb_test.flux
+++ b/query/stdlib/influxdata/influxdb/group_agg_influxdb_test.flux
@@ -1,0 +1,43 @@
+package influxdb_test
+
+import "testing/expect"
+
+testcase push_down_group_one_tag_count extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_one_tag_count()
+}
+
+testcase push_down_group_all_filter_field_count extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_all_filter_field_count()
+}
+
+testcase push_down_group_one_tag_filter_field_count extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_one_tag_filter_field_count()
+}
+
+testcase push_down_group_two_tag_filter_field_count extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_two_tag_filter_field_count()
+}
+
+testcase push_down_group_one_tag_sum extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_one_tag_sum()
+}
+
+testcase push_down_group_all_filter_field_sum extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_all_filter_field_sum()
+}
+
+testcase push_down_group_one_tag_filter_field_sum extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_one_tag_filter_field_sum()
+}
+
+testcase push_down_group_two_tag_filter_field_sum extends "flux/planner/group_agg_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_agg_test.group_two_tag_filter_field_sum()
+}


### PR DESCRIPTION
This PR adds testing for pushdowns of `group|> count` and `group|>sum`.

Pushing down these operations has been enabled for some time in OSS 2.0. These changes only extend existing tests in the `flux` repo to assert that the planner rule to push down these operations actually fire.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
