### PR TITLE
test: add acceptance tests and table tests for group|>first/last

### DIFF
--- a/query/stdlib/influxdata/influxdb/group_first_last_influxdb_test.flux
+++ b/query/stdlib/influxdata/influxdb/group_first_last_influxdb_test.flux
@@ -1,0 +1,45 @@
+package influxdb_test
+
+
+import "testing/expect"
+
+testcase push_down_group_one_tag_first extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_one_tag_first()
+}
+
+testcase push_down_group_all_filter_field_first extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_all_filter_field_first()
+}
+
+testcase push_down_group_one_tag_filter_field_first extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_one_tag_filter_field_first()
+}
+
+testcase push_down_group_two_tag_filter_field_first extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_two_tag_filter_field_first()
+}
+
+// Group + last tests
+testcase push_down_group_one_tag_last extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_one_tag_last()
+}
+
+testcase push_down_group_all_filter_field_last extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_all_filter_field_last()
+}
+
+testcase push_down_group_one_tag_filter_field_last extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_one_tag_filter_field_last()
+}
+
+testcase push_down_group_two_tag_filter_field_last extends "flux/planner/group_first_last_test" {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    group_first_last_test.group_two_tag_filter_field_last()
+}

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -3057,6 +3057,42 @@ func TestStorageReader_ReadGroup(t *testing.T) {
 			filter:    getStorageEqPred("t0", "z-9"),
 			want:      static.TableGroup{},
 		},
+		{
+			aggregate: storageflux.FirstKind,
+			want: static.TableGroup {
+				static.StringKey("_measurement", "m0"),
+				static.StringKey("_field", "f0"),
+				static.TimeKey("_start", "2019-11-25T00:00:00Z"),
+				static.TimeKey("_stop", "2019-11-25T00:02:00Z"),
+				static.TableMatrix{
+					static.StringKeys("t0", "a-0", "a-1", "a-2"),
+					{
+						static.Table{
+							static.Times("_time", "2019-11-25T00:00:00Z"),
+							static.Floats("_value", 1),
+						},
+					},
+				},
+			},
+		},
+		{
+			aggregate: storageflux.LastKind,
+			want: static.TableGroup {
+				static.StringKey("_measurement", "m0"),
+				static.StringKey("_field", "f0"),
+				static.TimeKey("_start", "2019-11-25T00:00:00Z"),
+				static.TimeKey("_stop", "2019-11-25T00:02:00Z"),
+				static.TableMatrix{
+					static.StringKeys("t0", "a-0", "a-1", "a-2"),
+					{
+						static.Table{
+							static.Times("_time", "2019-11-25T00:01:50Z"),
+							static.Floats("_value", 4),
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tt.aggregate, func(t *testing.T) {
 			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
@@ -3151,10 +3187,48 @@ func TestStorageReader_ReadGroupSelectTags(t *testing.T) {
 				},
 			},
 		},
+		{
+			aggregate: storageflux.FirstKind,
+			want: static.TableGroup{
+				static.TimeKey("_start", "2019-11-25T00:00:00Z"),
+				static.TimeKey("_stop", "2019-11-25T00:02:00Z"),
+				static.TableMatrix{
+					static.StringKeys("t0", "a-0", "a-1", "a-2"),
+					{
+						static.Table{
+							static.Strings("t1", "b-0"),
+							static.Strings("_measurement", "m0"),
+							static.Strings("_field", "f0"),
+							static.Times("_time", "2019-11-25T00:00:00Z"),
+							static.Floats("_value", 1.0),
+						},
+					},
+				},
+			},
+		},
+		{
+			aggregate: storageflux.LastKind,
+			want: static.TableGroup{
+				static.TimeKey("_start", "2019-11-25T00:00:00Z"),
+				static.TimeKey("_stop", "2019-11-25T00:02:00Z"),
+				static.TableMatrix{
+					static.StringKeys("t0", "a-0", "a-1", "a-2"),
+					{
+						static.Table{
+							static.Strings("t1", "b-1"),
+							static.Strings("_measurement", "m0"),
+							static.Strings("_field", "f0"),
+							static.Times("_time", "2019-11-25T00:01:50Z"),
+							static.Floats("_value", 8.0),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.aggregate, func(t *testing.T) {
 			mem := &memory.Allocator{}
 			got, err := reader.ReadGroup(context.Background(), query.ReadGroupSpec{
 				ReadFilterSpec: query.ReadFilterSpec{


### PR DESCRIPTION
This PR adds testing for our support of pushing down Flux operations `group|>first` and `group|>last` into the storage tier.

This optimization has been available for some time, this PR just adds tests for it.

Tests for the planner rule already existed, I only needed to extend Flux acceptance tests to show that the planner rule is actually applied. I also added "table tests" to test the `<datatype>GroupTable` structures used by storage to implement Flux sources.


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
