### PR TITLE
chore: move to `filepath.WalkDir` for slight performance gain in Go 1.16

### DIFF
--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -39,10 +39,10 @@ func TestVerifies_Invalid(t *testing.T) {
 	test := NewTest(t)
 	defer os.RemoveAll(test.Path)
 
-	require.NoError(t, filepath.Walk(test.Path, func(path string, info os.FileInfo, err error) error {
+	require.NoError(t, filepath.WalkDir(test.Path, func(path string, entry os.DirEntry, err error) error {
 		require.NoError(t, err)
 
-		if info.IsDir() {
+		if entry.IsDir() {
 			return nil
 		}
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone.go
@@ -59,7 +59,7 @@ func NewVerifyTombstoneCommand() *cobra.Command {
 }
 
 func (v *verifier) loadFiles() error {
-	return filepath.Walk(v.path, func(path string, f os.FileInfo, err error) error {
+	return filepath.WalkDir(v.path, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm.go
@@ -151,7 +151,7 @@ func (v *verifyChecksums) run(cmd *cobra.Command, dataPath string, verbose bool)
 }
 
 func (v *verifyTSM) loadFiles(dataPath string) error {
-	err := filepath.Walk(dataPath, func(path string, f os.FileInfo, err error) error {
+	err := filepath.WalkDir(dataPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/influxd/upgrade/fs.go
+++ b/cmd/influxd/upgrade/fs.go
@@ -11,11 +11,15 @@ import (
 // DirSize returns total size in bytes of containing files
 func DirSize(path string) (uint64, error) {
 	var size uint64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if !entry.IsDir() {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
 			size += uint64(info.Size())
 		}
 		return err

--- a/influxql/v1validation/validation_test.go
+++ b/influxql/v1validation/validation_test.go
@@ -48,7 +48,7 @@ type Test struct {
 }
 
 func TestGoldenFiles(t *testing.T) {
-	err := filepath.Walk("./goldenfiles", func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir("./goldenfiles", func(path string, info os.DirEntry, err error) error {
 		if info.IsDir() {
 			return nil
 		}

--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -42,7 +42,7 @@ func BoltFile() (string, error) {
 		return "", err
 	}
 	var file string
-	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+	filepath.WalkDir(dir, func(p string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/tar/stream.go
+++ b/pkg/tar/stream.go
@@ -24,19 +24,23 @@ func Stream(w io.Writer, dir, relativePath string, writeFunc func(f os.FileInfo,
 		writeFunc = StreamFile
 	}
 
-	return filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+	return filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip adding an entry for the root dir
-		if dir == path && f.IsDir() {
+		if dir == path && entry.IsDir() {
 			return nil
 		}
 
 		// Figure out the the full relative path including any sub-dirs
 		subDir, _ := filepath.Split(path)
 		subDir, err = filepath.Rel(dir, subDir)
+		if err != nil {
+			return err
+		}
+		f, err := entry.Info()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR changes all instances of `filepath.Walk()` to `filepath.WalkDir()` which is a new and more performant function introduced in Go 1.16. I started by just doing this for the `inspect` commands which used `filepath.Walk()` a few times, but when replacing these I noticed we only had a few extra uses of this function in the repository, so I went ahead and updated them as well.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass