### PR TITLE
build: upgrade to go1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,8 +280,8 @@ commands:
             MUSL_BUILD_TIME: 20210108172549
             MUSL_CROSS_MAKE_VERSION: 0.9.9
             MUSL_CROSS_ARM64_BUILD_TIME: 20210108174735
-            OSXCROSS_VERSION: c2ad5e859d12a295c3f686a15bd7181a165bfa82
-            OSXCROSS_BUILD_TIME: 20210108174800
+            OSXCROSS_VERSION: 5771a847950abefed9a37e2d16ee10e0dd90c641
+            OSXCROSS_BUILD_TIME: 20210608175207
           command: |
             MUSL_ARCHIVE=musl-${MUSL_VERSION}-${MUSL_BUILD_TIME}.tar.gz
             curl https://dl.influxdata.com/influxdb-ci/musl/${MUSL_VERSION}/${MUSL_ARCHIVE} -O && \
@@ -296,7 +296,7 @@ commands:
             echo 'export PATH=/usr/local/musl-cross/bin:${PATH}' >> $BASH_ENV
 
             OSXCROSS_ARCHIVE=osxcross-${OSXCROSS_VERSION}-${OSXCROSS_BUILD_TIME}.tar.gz
-            curl https://dl.influxdata.com/influxdb-ci/osxcross/${OSXCROSS_VERSION}/${OSXCROSS_ARCHIVE} -O && \
+            curl https://edge-xcc-archives.s3-us-west-2.amazonaws.com/${OSXCROSS_ARCHIVE} -O && \
               sudo tar xzf ${OSXCROSS_ARCHIVE} -C /usr/local && \
               rm ${OSXCROSS_ARCHIVE}
             echo 'export PATH=/usr/local/osxcross/target/bin:${PATH}' >> $BASH_ENV
@@ -314,7 +314,7 @@ commands:
               x86_64-pc-windows-gnu
             echo 'export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl/bin/musl-gcc' >> $BASH_ENV
             echo 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl-cross/bin/aarch64-unknown-linux-musl-gcc' >> $BASH_ENV
-            echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/local/osxcross/target/bin/x86_64-apple-darwin15-clang' >> $BASH_ENV
+            echo 'export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/local/osxcross/target/bin/x86_64-apple-darwin16-clang' >> $BASH_ENV
             echo 'export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=/usr/bin/x86_64-w64-mingw32-gcc' >> $BASH_ENV
       - run:
           name: Install goreleaser
@@ -378,7 +378,7 @@ jobs:
 
   godeps:
     docker:
-      - image: cimg/go:1.15.6
+      - image: cimg/go:1.16.5
     environment:
       GOCACHE: /tmp/go-cache
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
@@ -388,10 +388,11 @@ jobs:
           name: Restore GOPATH/pkg/mod
           keys:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
-            - influxdb-gomod-sum-
-      - run:
-          name: Install Dependencies
-          command: go mod download -x
+      # NOTE: On go1.16 `go mod download` and `go mod tidy` no longer agree
+      # with each other. The Go team recommends using `go mod tidy` to download
+      # all the modules needed for build/test, so we check tidiness while we're
+      # at it. See https://github.com/golang/go/issues/43994#issuecomment-770053099
+      - run: make checktidy
       - save_cache:
           name: Save GOPATH/pkg/mod
           key: influxdb-gomod-sum-{{ checksum "go.sum" }}
@@ -400,7 +401,7 @@ jobs:
 
   golint:
     docker:
-      - image: cimg/go:1.15.6
+      - image: cimg/go:1.16.5
     environment:
       GOCACHE: /tmp/go-cache
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
@@ -425,14 +426,13 @@ jobs:
           command: ./scripts/ci/lint/flags.bash
       - run: make vet
       - run: make checkfmt
-      - run: make checktidy
       - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
       - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
       - run: GO111MODULE=on ./env staticcheck ./...
 
   gotest:
     docker:
-      - image: cimg/go:1.15.6
+      - image: cimg/go:1.16.5
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache
@@ -471,7 +471,7 @@ jobs:
 
   fluxtest:
     docker:
-      - image: cimg/go:1.15.6
+      - image: cimg/go:1.16.5
     environment:
       GOCACHE: /tmp/go-cache
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
@@ -486,7 +486,7 @@ jobs:
 
   tlstest:
     docker:
-      - image: cimg/go:1.15.6
+      - image: cimg/go:1.16.5
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -569,7 +569,7 @@ jobs:
 
   build:
     docker:
-      - image: cimg/go:1.15.6-node
+      - image: cimg/go:1.16.5-node
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache
@@ -753,7 +753,7 @@ jobs:
 
   e2e:
     docker:
-      - image: cimg/go:1.15.6-browsers
+      - image: cimg/go:1.16.5-browsers
     resource_class: large
     environment:
       GOCACHE: /tmp/go-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,16 @@ commands:
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             echo 'export PATH=${HOME}/.cargo/bin:${PATH}' >> $BASH_ENV
 
+  upgrade_go:
+    steps:
+      - run:
+          name: Upgrade Go
+          command: |
+            mkdir -p ${HOME}/.tools
+            wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+            tar -C ${HOME}/.tools -xzf go1.16.5.linux-amd64.tar.gz
+            echo 'export PATH=${HOME}/.tools/go/bin:${PATH}' >> $BASH_ENV
+
   # Run goreleaser to cross-build or cross-publish influxd
   run_goreleaser:
     parameters:
@@ -629,6 +639,7 @@ jobs:
           keys:
             - yarn-deps-lock-{{ checksum "ui/yarn.lock" }}
       - install_core_deps
+      - upgrade_go
       - run_goreleaser:
           publish_release: false
       - run:
@@ -739,6 +750,7 @@ jobs:
           keys:
             - yarn-deps-lock-{{ checksum "ui/yarn.lock" }}
       - install_core_deps
+      - upgrade_go
       - run_goreleaser:
           publish_release: true
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## v2.0.8 [unreleased]
 ----------------------
 
+### Go Version
+
+This release upgrades the project to `go` version 1.16.
+
+#### Minimum macOS Version
+
+Because of the version bump to `go`, the macOS build for this release requires at least version 10.12 Sierra to run.
+
 ### Bug Fixes
 
 1. [21748](https://github.com/influxdata/influxdb/pull/21748): rename arm rpms with yum-compatible names.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb/v2
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1
@@ -54,7 +54,6 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef
-	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/kevinburke/go-bindata v3.11.0+incompatible
 	github.com/lib/pq v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.12
@@ -110,7 +109,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	honnef.co/go/tools v0.0.1-2020.1.4
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
 // Arrow has been taking too long to merge our PR that addresses some checkptr fixes.

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef h1:2jNeR4YUziVtswNP9sEFAI913cVrzH85T+8Q6LpYbT0=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kevinburke/go-bindata v3.11.0+incompatible h1:RcC+GJNmrBHbGaOpQ9MBD8z22rdzlIm0esDRDkyxd4s=
 github.com/kevinburke/go-bindata v3.11.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -818,7 +816,6 @@ gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJ
 gonum.org/v1/gonum v0.8.2 h1:CCXrcPKiGGotvnN6jfUsKk4rRqm7q09/YbKb5xCEvtM=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
-gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -908,8 +905,6 @@ honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/scripts/ci/xcc-builds/build-osxcross-clang.sh
+++ b/scripts/ci/xcc-builds/build-osxcross-clang.sh
@@ -5,7 +5,7 @@ declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r OUT_DIR=${SCRIPT_DIR}/out
 
 declare -r BUILD_IMAGE=ubuntu:20.04
-declare -r OSXCROSS_VERSION=c2ad5e859d12a295c3f686a15bd7181a165bfa82
+declare -r OSXCROSS_VERSION=5771a847950abefed9a37e2d16ee10e0dd90c641
 
 docker run --rm -i -v ${OUT_DIR}:/out -w /tmp ${BUILD_IMAGE} bash <<EOF
   set -euo pipefail
@@ -32,7 +32,7 @@ docker run --rm -i -v ${OUT_DIR}:/out -w /tmp ${BUILD_IMAGE} bash <<EOF
   git clone https://github.com/tpoechtrager/osxcross.git /usr/local/osxcross && \
     cd /usr/local/osxcross && \
     git checkout ${OSXCROSS_VERSION} && \
-    curl -L -o ./tarballs/MacOSX10.11.sdk.tar.xz https://macos-sdks.s3.amazonaws.com/MacOSX10.11.sdk.tar.xz && \
+    curl -L -o ./tarballs/MacOSX10.12.sdk.tar.xz https://storage.googleapis.com/influxdata-team-flux/macos-sdks/MacOSX10.12.sdk.tar.xz && \
     UNATTENDED=1 PORTABLE=true OCDEBUG=1 ./build.sh && \
     rm -rf .git build tarballs && \
     cd /tmp

--- a/scripts/ci/xcc.sh
+++ b/scripts/ci/xcc.sh
@@ -11,7 +11,7 @@ GOARCH=${GOARCH:-$(go env GOARCH)}
 case "${GOOS}_${GOARCH}" in
   linux_amd64)   CC=musl-gcc ;;
   linux_arm64)   CC=aarch64-unknown-linux-musl-gcc ;;
-  darwin_amd64)  CC=x86_64-apple-darwin15-clang ;;
+  darwin_amd64)  CC=x86_64-apple-darwin16-clang ;;
   windows_amd64) CC=x86_64-w64-mingw32-gcc ;;
   *) die "No cross-compiler set for ${GOOS}_${GOARCH}" ;;
 esac

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -232,7 +232,8 @@ func TestStore_DropConcurrentWriteMultipleShards(t *testing.T) {
 			for i := 0; i < 50; i++ {
 				err := s.DeleteMeasurement("db0", "cpu")
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 			}
 		}()
@@ -2062,11 +2063,13 @@ func TestStore_TagValues_ConcurrentDropShard(t *testing.T) {
 				default:
 					stmt, err := influxql.ParseStatement(`SHOW TAG VALUES WITH KEY = "host"`)
 					if err != nil {
-						t.Fatal(err)
+						t.Error(err)
+						return
 					}
 					rewrite, err := query.RewriteStatement(stmt)
 					if err != nil {
-						t.Fatal(err)
+						t.Error(err)
+						return
 					}
 
 					cond := rewrite.(*influxql.ShowTagValuesStatement).Condition


### PR DESCRIPTION
Backports #21642 and #21658

I was on the fence about this one, and decided to go through with it because:
* AFAIK it's low-risk
* It's needed to import the CLI as a dependency
  * Importing the CLI is needed to replace some test code & fix some bugs in `influxd upgrade`