### PR TITLE
fix: task scheduler test uses a fixed time

### DIFF
--- a/task/backend/scheduler/scheduler_test.go
+++ b/task/backend/scheduler/scheduler_test.go
@@ -94,7 +94,10 @@ func TestSchedule_Next(t *testing.T) {
 					}
 				}}
 				mockTime := clock.NewMock()
-				mockTime.Set(time.Now())
+				// need to run on a time window which does not include daylight savings
+				// time for testing on systems which do not default to UTC.
+				testTime, _ := time.Parse("2006-01-02", "2020-04-01")
+				mockTime.Set(testTime)
 				sch, _, err := NewScheduler(
 					exe,
 					&mockSchedulableService{fn: func(ctx context.Context, id ID, t time.Time) error {

--- a/task/backend/scheduler/scheduler_test.go
+++ b/task/backend/scheduler/scheduler_test.go
@@ -96,7 +96,10 @@ func TestSchedule_Next(t *testing.T) {
 				mockTime := clock.NewMock()
 				// need to run on a time window which does not include daylight savings
 				// time for testing on systems which do not default to UTC.
-				testTime, _ := time.Parse("2006-01-02", "2020-04-01")
+				testTime, err := time.Parse(time.RFC3339, "2020-04-01T00:00:00Z")
+				if err != nil {
+					t.Fatal(err)
+				}
 				mockTime.Set(testTime)
 				sch, _, err := NewScheduler(
 					exe,


### PR DESCRIPTION
Closes #21883

Use a fixed time for the task scheduler tests which do not include a DST change to ensure that the test suite can be run on systems which do not determine time differences based on UTC. 