### PR TITLE
feat: add `influx_inspect verify-wal` to 1.x

### DIFF
--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/seriesfile"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/tombstone"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/tsm"
+	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/wal"
 	_ "github.com/influxdata/influxdb/tsdb/engine"
 )
 
@@ -123,6 +124,11 @@ func (m *Main) Run(args ...string) error {
 		name := tombstone.NewCommand()
 		if err := name.Run(args...); err != nil {
 			return fmt.Errorf("verify-tombstone: %s", err)
+		}
+	case "verify-wal":
+		name := wal.NewCommand()
+		if err := name.Run(args...); err != nil {
+			return fmt.Errorf("verify-wal: %s", err)
 		}
 	default:
 		return fmt.Errorf(`unknown command "%s"`+"\n"+`Run 'influx_inspect help' for usage`, name)

--- a/cmd/influx_inspect/verify/wal/verify.go
+++ b/cmd/influx_inspect/verify/wal/verify.go
@@ -1,0 +1,171 @@
+package wal
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+)
+
+// Command represents the program execution for "influx_inspect verify-wal".
+type Command struct {
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+// NewCommand returns a new instance of Command.
+func NewCommand() *Command {
+	return &Command{
+		Stderr: os.Stderr,
+		Stdout: os.Stdout,
+	}
+}
+
+func (cmd *Command) Run(args ...string) error {
+	var path string
+	var v bool
+	fs := flag.NewFlagSet("verify-wal", flag.ExitOnError)
+	fs.StringVar(&path, "wal-dir", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
+	fs.BoolVar(&v, "verbose", false, "Enable verbose logging")
+
+	fs.SetOutput(cmd.Stdout)
+	fs.Usage = cmd.printUsage
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	walPath := filepath.Join(path, "wal")
+	tw := tabwriter.NewWriter(cmd.Stdout, 16, 8, 0, '\t', 0)
+	err := cmd.verifyWAL(tw, walPath, v)
+	tw.Flush()
+	return err
+}
+
+func (cmd *Command) verifyWAL(tw *tabwriter.Writer, path string, v bool) error {
+	// Verify valid directory
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat %q: %w", path, err)
+	} else if !fi.IsDir() {
+		return fmt.Errorf("%q is not a directory", path)
+	}
+
+	// Find all WAL files in provided directory
+	files, err := loadFiles(path)
+	if err != nil {
+		return fmt.Errorf("failed to search for WAL files in directory %s: %w", path, err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no WAL files found in directory %s", path)
+	}
+
+	start := time.Now()
+	var corruptFiles []string
+	var totalEntriesScanned int
+
+	// Scan each WAL file
+	for _, fpath := range files {
+		var entriesScanned int
+		f, err := os.OpenFile(fpath, os.O_RDONLY, 0600)
+		if err != nil {
+			return fmt.Errorf("error opening file %s: %w. Exiting", fpath, err)
+		}
+
+		clean := true
+		reader := tsm1.NewWALSegmentReader(f)
+
+		// Check for corrupted entries
+		for reader.Next() {
+			entriesScanned++
+			_, err := reader.Read()
+			if err != nil {
+				clean = false
+				_, _ = fmt.Fprintf(cmd.Stderr, "%s: corrupt entry found at position %d\n", fpath, reader.Count())
+				corruptFiles = append(corruptFiles, fpath)
+				break
+			}
+		}
+
+		if v {
+			if entriesScanned == 0 {
+				// No data found in file
+				_, _ = fmt.Fprintf(cmd.Stderr, "%s: no WAL entries found\n", f.Name())
+			} else if clean {
+				// No corrupted entry found
+				_, _ = fmt.Fprintf(cmd.Stderr, "%s: clean\n", fpath)
+			}
+		}
+		totalEntriesScanned += entriesScanned
+		_ = tw.Flush()
+	}
+
+	// Print Summary
+	_, _ = fmt.Fprintf(tw, "Results:\n")
+	_, _ = fmt.Fprintf(tw, "  Files checked: %d\n", len(files))
+	_, _ = fmt.Fprintf(tw, "  Total entries checked: %d\n", totalEntriesScanned)
+	_, _ = fmt.Fprintf(tw, "  Corrupt files found: ")
+	if len(corruptFiles) == 0 {
+		_, _ = fmt.Fprintf(tw, "None")
+	} else {
+		for _, name := range corruptFiles {
+			_, _ = fmt.Fprintf(tw, "\n    %s", name)
+		}
+	}
+
+	_, _ = fmt.Fprintf(tw, "\nCompleted in %v\n", time.Since(start))
+	_ = tw.Flush()
+
+	return nil
+}
+
+func loadFiles(dir string) (files []string, err error) {
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == "."+tsm1.WALFileExtension {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return
+}
+
+type walParams struct {
+	dir     string
+	verbose bool
+}
+
+func (cmd *Command) printUsage() {
+	usage := fmt.Sprintf(`This command will analyze the WAL (Write-Ahead Log) in a storage directory to 
+ check if there are any corrupt files. If any corrupt files are found, the names
+ of said corrupt files will be reported. The tool will also count the total number
+ of entries in the scanned WAL files, in case this is of interest.
+ For each file, the following is output:
+ 	* The file name;
+ 	* "clean" (if the file is clean) OR 
+       The first position of any corruption that is found
+ In the summary section, the following is printed:
+	* The number of WAL files scanned;
+ 	* The number of WAL entries scanned;
+ 	* A list of files found to be corrupt
+
+Usage: influx_inspect verify-wal [flags]
+
+	-wal-dir <path>
+		The root WAL storage path.
+		Must be changed if you are using a non-default storage directory.
+            Defaults to "%[1]s/.influxdb".
+
+	-verbose
+		Enable verbose logging
+`, os.Getenv("HOME"))
+
+	fmt.Fprintf(cmd.Stdout, usage)
+}

--- a/cmd/influx_inspect/verify/wal/verify_test.go
+++ b/cmd/influx_inspect/verify/wal/verify_test.go
@@ -1,0 +1,156 @@
+package wal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"text/tabwriter"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"github.com/stretchr/testify/require"
+)
+
+type testInfo struct {
+	path        string
+	expectedOut string
+	expectErr   bool
+	withStdErr  bool
+}
+
+func TestVerifies_InvalidFileType(t *testing.T) {
+	path, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	_, err = os.CreateTemp(path, "verifywaltest*"+".txt")
+	require.NoError(t, err)
+	defer os.RemoveAll(path)
+
+	runCommand(t, testInfo{
+		path:        path,
+		expectedOut: "no WAL files found in directory",
+		expectErr:   true,
+	})
+}
+
+func TestVerifies_InvalidNotDir(t *testing.T) {
+	path, file := newTempWALInvalid(t, true)
+	defer os.RemoveAll(path)
+
+	runCommand(t, testInfo{
+		path:        file.Name(),
+		expectedOut: "is not a directory",
+		expectErr:   true,
+	})
+}
+
+func TestVerifies_InvalidEmptyFile(t *testing.T) {
+	path, _ := newTempWALInvalid(t, true)
+	defer os.RemoveAll(path)
+
+	runCommand(t, testInfo{
+		path:        path,
+		expectedOut: "no WAL entries found",
+		withStdErr:  true,
+	})
+}
+
+func TestVerifies_Invalid(t *testing.T) {
+	path, _ := newTempWALInvalid(t, false)
+	defer os.RemoveAll(path)
+
+	runCommand(t, testInfo{
+		path:        path,
+		expectedOut: "corrupt entry found at position",
+		withStdErr:  true,
+	})
+}
+
+func TestVerifies_Valid(t *testing.T) {
+	path := newTempWALValid(t)
+	defer os.RemoveAll(path)
+
+	runCommand(t, testInfo{
+		path:        path,
+		expectedOut: "clean",
+		withStdErr:  true,
+	})
+}
+
+func runCommand(t *testing.T, args testInfo) {
+	verify := NewCommand()
+
+	b := bytes.NewBufferString("")
+	tw := tabwriter.NewWriter(b, 16, 8, 0, '\n', 0)
+	verify.Stdout = b
+	if args.withStdErr {
+		verify.Stderr = b
+	}
+
+	if args.expectErr {
+		err := verify.verifyWAL(tw, args.path, true)
+		require.Error(t, err)
+		_, err = fmt.Fprint(tw, err.Error())
+		require.NoError(t, err)
+	} else {
+		require.NoError(t, verify.verifyWAL(tw, args.path, true))
+	}
+
+	require.NoError(t, tw.Flush())
+	out, err := io.ReadAll(b)
+	require.NoError(t, err)
+	require.Contains(t, string(out), args.expectedOut)
+}
+
+func newTempWALValid(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	w := tsm1.NewWAL(dir)
+	defer w.Close()
+	require.NoError(t, w.Open())
+
+	p1 := tsm1.NewValue(1, 1.1)
+	p2 := tsm1.NewValue(1, int64(1))
+	p3 := tsm1.NewValue(1, true)
+	p4 := tsm1.NewValue(1, "string")
+	p5 := tsm1.NewValue(1, ^uint64(0))
+
+	values := map[string][]tsm1.Value{
+		"cpu,host=A#!~#float":    {p1},
+		"cpu,host=A#!~#int":      {p2},
+		"cpu,host=A#!~#bool":     {p3},
+		"cpu,host=A#!~#string":   {p4},
+		"cpu,host=A#!~#unsigned": {p5},
+	}
+
+	_, err = w.WriteMulti(values)
+	require.NoError(t, err)
+
+	return dir
+}
+
+func newTempWALInvalid(t *testing.T, empty bool) (string, *os.File) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "verify-wal")
+	require.NoError(t, err)
+
+	file, err := os.CreateTemp(dir, "verifywaltest*."+tsm1.WALFileExtension)
+	require.NoError(t, err)
+
+	if !empty {
+		writer, err := os.OpenFile(file.Name(), os.O_APPEND|os.O_WRONLY, 0644)
+		require.NoError(t, err)
+		defer writer.Close()
+
+		written, err := writer.Write([]byte("foobar"))
+		require.NoError(t, err)
+		require.Equal(t, 6, written)
+	}
+
+	return dir, file
+}


### PR DESCRIPTION
Creates the `influx_inspect verify-wal` command, which was recently added to 2.x via #21828

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass