### PR TITLE
fix: systemd unit should block on startup until http endpoint is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 -	[#21792](https://github.com/influxdata/influxdb/pull/21792): fix: error instead of panic for statement rewrite failure
 -	[#21795](https://github.com/influxdata/influxdb/pull/21795): fix: show shards gives empty expiry time for inf duration shards
 -	[#21843](https://github.com/influxdata/influxdb/pull/21843): fix: hard limit on field size while parsing line protocol
+-	[#21895](https://github.com/influxdata/influxdb/pull/21895): fix: systemd unit should block on startup until http endpoint is ready
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -88,6 +88,8 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/init.sh"
   cp /isrc/scripts/influxdb.service "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
   chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
+  cp /isrc/scripts/influxd-systemd-start.sh "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
+  chmod 0744 "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
 
   # Copy logrotate script.
   cp /isrc/scripts/logrotate "$PKG_ROOT/etc/logrotate.d/influxdb"

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+/usr/bin/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS &
+echo $! > /var/lib/influxdb/influxd.pid
+
+BIND_ADDRESS=$(influxd print-config --key-name http-bind-address)
+HOST=${BIND_ADDRESS%%:*}
+HOST=${HOST:-"localhost"}
+PORT=${BIND_ADDRESS##*:}
+
+set +e
+result=$(curl -s -o /dev/null http://$HOST:$PORT/ready -w %{http_code})
+while [ "$result" != "200" ]; do
+  sleep 1
+  result=$(curl -s -o /dev/null http://$HOST:$PORT/ready -w %{http_code})
+done
+set -e

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -13,6 +13,8 @@ EnvironmentFile=-/etc/default/influxdb
 ExecStart=/usr/bin/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS
 KillMode=control-group
 Restart=on-failure
+Type=forking
+PIDFile=/var/lib/influxdb/influxd.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #6068 

Backport from c8de72ddbc5fdf20f821ca473f1fdf92820f9ac3.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass