### PR TITLE
feat: add `ui-disabled` flag to run server with UI disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21888](https://github.com/influxdata/influxdb/pull/21888/): Ported the `influxd inspect dump-wal` command from 1.x.
 1. [21828](https://github.com/influxdata/influxdb/pull/21828): Added the command `influx inspect verify-wal`.
 1. [21814](https://github.com/influxdata/influxdb/pull/21814): Ported the `influxd inspect report-tsm` command from 1.x.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21888](https://github.com/influxdata/influxdb/pull/21888/): Ported the `influxd inspect dump-wal` command from 1.x.
 1. [21828](https://github.com/influxdata/influxdb/pull/21828): Added the command `influx inspect verify-wal`.
 1. [21814](https://github.com/influxdata/influxdb/pull/21814): Ported the `influxd inspect report-tsm` command from 1.x.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
+1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -587,7 +587,7 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			DestP:   &o.UIDisabled,
 			Flag:    "ui-disabled",
 			Default: o.UIDisabled,
-			Desc:    "disable the InfluxDB ui",
+			Desc:    "Disable the InfluxDB UI",
 		},
 	}
 }

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -149,6 +149,7 @@ type InfluxdOpts struct {
 
 	ProfilingDisabled bool
 	MetricsDisabled   bool
+	UIDisabled        bool
 
 	NatsPort            int
 	NatsMaxPayloadBytes int
@@ -199,6 +200,7 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 
 		ProfilingDisabled: false,
 		MetricsDisabled:   false,
+		UIDisabled:        false,
 
 		StoreType:   DiskStore,
 		SecretStore: BoltStore,
@@ -579,6 +581,13 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "metrics-disabled",
 			Desc:    "Don't expose metrics over HTTP at /metrics",
 			Default: o.MetricsDisabled,
+		},
+		// UI Config
+		{
+			DestP:   &o.UIDisabled,
+			Flag:    "ui-disabled",
+			Default: o.UIDisabled,
+			Desc:    "disable the InfluxDB ui",
 		},
 	}
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -759,6 +759,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 
 	m.apibackend = &http.APIBackend{
 		AssetsPath:           opts.AssetsPath,
+		UIDisabled:           opts.UIDisabled,
 		HTTPErrorHandler:     kithttp.ErrorHandler(0),
 		Logger:               m.log,
 		SessionRenewDisabled: opts.SessionRenewDisabled,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -34,6 +34,7 @@ type APIHandler struct {
 // an APIHandler.
 type APIBackend struct {
 	AssetsPath string // if empty then assets are served from bindata.
+	UIDisabled bool   // if true requests for the UI will return 404
 	Logger     *zap.Logger
 	errors.HTTPErrorHandler
 	SessionRenewDisabled bool

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -35,6 +35,10 @@ func NewPlatformHandler(b *APIBackend, opts ...APIHandlerOptFn) *PlatformHandler
 	h.RegisterNoAuthRoute("GET", "/api/v2/swagger.json")
 
 	assetHandler := static.NewAssetHandler(b.AssetsPath)
+	if b.UIDisabled {
+		b.Logger.Debug("http server running with UI disabled")
+		assetHandler = http.NotFoundHandler()
+	}
 
 	wrappedHandler := kithttp.SetCORS(h)
 	wrappedHandler = kithttp.SkipOptions(wrappedHandler)


### PR DESCRIPTION
Closes #21896

Adds the config flag `--ui-disabled` to `influxd` to allow for running the `influxd` server with the UI disabled. 

With this change, if the boolean flag `--ui-disabled` is provided, requests to the "root" path where the UI would normally be served (for example, http://localhost:8086) will return a 404.