### PR TITLE
fix(tsi): sync index file before close

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1007,6 +1007,11 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 		return
 	}
 
+	if err = f.Sync(); err != nil {
+		log.Error("Error sync index file", zap.Error(err))
+		return
+	}
+
 	// Close file.
 	if err := f.Close(); err != nil {
 		log.Error("Error closing index file", zap.Error(err))
@@ -1152,9 +1157,14 @@ func (p *Partition) compactLogFile(logFile *LogFile) {
 		return
 	}
 
+	if err = f.Sync(); err != nil {
+		log.Error("Cannot sync index file", zap.Error(err))
+		return
+	}
+
 	// Close file.
 	if err := f.Close(); err != nil {
-		log.Error("Cannot close log file", zap.Error(err))
+		log.Error("Cannot close index file", zap.Error(err))
 		return
 	}
 


### PR DESCRIPTION
Sync index file before close.

Index file may be broken after a system crash or a power failure, which will cause an error when loading shard after restart: unsupported index file version.