### PR TITLE
chore: add route to delete individual secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21828](https://github.com/influxdata/influxdb/pull/21828): Added the command `influx inspect verify-wal`.
 1. [21814](https://github.com/influxdata/influxdb/pull/21814): Ported the `influxd inspect report-tsm` command from 1.x.
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
+1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
 
 ### Bug Fixes
 


### PR DESCRIPTION
This adds a route to delete individual secrets in preparation to remove the old `post` to `/secrets/delete` route.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (github.com/influxdata/openapi/pull/169)
- [ ] Documentation updated or issue created (provide link to issue/pr)
