### PR TITLE
build: update deb and rpm names to match 2.0.8

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,9 +61,9 @@ nfpms:
           amd64: x86_64
           arm64: aarch64
           armhf: armv7hl
-        file_name_template: "influxdb2-nightly.{{ .Arch }}"
+        file_name_template: "influxdb2-server-nightly.{{ .Arch }}"
       deb:
-        file_name_template: "influxdb2-nightly-{{ .Arch }}"
+        file_name_template: "influxdb2-server-nightly-{{ .Arch }}"
     vendor: InfluxData
     homepage: https://influxdata.com
     maintainer: support@influxdb.com
@@ -89,7 +89,7 @@ blobs:
     folder: "platform/nightlies/"
 
 checksum:
-  name_template: "influxdb2-nightly.sha256"
+  name_template: "influxdb2-server-nightly.sha256"
   algorithm: sha256
 
 dockers:

--- a/scripts/ci/perf_test.sh
+++ b/scripts/ci/perf_test.sh
@@ -44,7 +44,7 @@ done
 trap "aws --region us-west-2 ec2 terminate-instances --instance-ids $ec2_instance_id" KILL
 
 # push binary and script to instance
-debname=$(find /tmp/workspace/artifacts/influxdb*amd64.deb)
+debname=$(find /tmp/workspace/artifacts/nfluxdb2-server*amd64.deb)
 base_debname=$(basename $debname)
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/scripts/ci/perf_test.sh
+++ b/scripts/ci/perf_test.sh
@@ -44,7 +44,7 @@ done
 trap "aws --region us-west-2 ec2 terminate-instances --instance-ids $ec2_instance_id" KILL
 
 # push binary and script to instance
-debname=$(find /tmp/workspace/artifacts/nfluxdb2-server*amd64.deb)
+debname=$(find /tmp/workspace/artifacts/influxdb2-server*amd64.deb)
 base_debname=$(basename $debname)
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Making the names of these files match what's going to be used in 2.0.8