### PR TITLE
fix: prevent silently dropped writes with overlapping shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 -	[#21863](https://github.com/influxdata/influxdb/pull/21863): fix: export example and fix adjacent shards
 -	[#21934](https://github.com/influxdata/influxdb/pull/21934): chore: use community maintained golang-jwt
 -	[#21943](https://github.com/influxdata/influxdb/pull/21943): fix: tsi index should compact old or too-large log files
+-	[#21947](https://github.com/influxdata/influxdb/pull/21947): fix: prevent silently dropped writes with overlapping shards
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -183,7 +183,7 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 	}
 
 	// Holds all the shard groups and shards that are required for writes.
-	list := make(sgList, 0, 8)
+	list := sgList{items: make(meta.ShardGroupInfos, 0, 8)}
 	min := time.Unix(0, models.MinNanoTime)
 	if rp.Duration > 0 {
 		min = time.Now().Add(-rp.Duration)
@@ -206,7 +206,7 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 		if sg == nil {
 			return nil, errors.New("nil shard group")
 		}
-		list = list.Append(*sg)
+		list.Add(*sg)
 	}
 
 	mapping := NewShardMapping(len(wp.Points))
@@ -228,10 +228,21 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 
 // sgList is a wrapper around a meta.ShardGroupInfos where we can also check
 // if a given time is covered by any of the shard groups in the list.
-type sgList meta.ShardGroupInfos
+type sgList struct {
+	items meta.ShardGroupInfos
+
+	// needsSort indicates if items has been modified without a sort operation.
+	needsSort bool
+
+	// earliest is the last begin time of any item in items.
+	earliest time.Time
+
+	// latest is the greatest end time of any item in items.
+	latest time.Time
+}
 
 func (l sgList) Covers(t time.Time) bool {
-	if len(l) == 0 {
+	if len(l.items) == 0 {
 		return false
 	}
 	return l.ShardGroupAt(t) != nil
@@ -247,20 +258,61 @@ func (l sgList) Covers(t time.Time) bool {
 //  - a shard group with the earliest end time;
 //  - (assuming identical end times) the shard group with the earliest start time.
 func (l sgList) ShardGroupAt(t time.Time) *meta.ShardGroupInfo {
-	idx := sort.Search(len(l), func(i int) bool { return l[i].EndTime.After(t) })
-
-	// We couldn't find a shard group the point falls into.
-	if idx == len(l) || t.Before(l[idx].StartTime) {
+	if l.items.Len() == 0 {
 		return nil
 	}
-	return &l[idx]
+
+	// find the earliest shardgroup that could contain this point using binary search.
+	if l.needsSort {
+		sort.Sort(l.items)
+		l.needsSort = false
+	}
+	idx := sort.Search(l.items.Len(), func(i int) bool { return l.items[i].EndTime.After(t) })
+
+	// Check if sort.Search actually found the proper shard. It feels like we should also
+	// be checking l.items[idx].EndTime, but sort.Search was looking at that field for us.
+	if idx == l.items.Len() || t.Before(l.items[idx].StartTime) {
+		// This could mean we are looking for a time not in the list, or we have
+		// overlaping shards. Overlapping shards do not work with binary searches
+		// on 1d arrays. You have to use an interval tree, but that's a lot of
+		// work for what is hopefully a rare event. Instead, we'll check if t
+		// should be in l, and perform a linear search if it is. This way we'll
+		// do the correct thing, it may just take a little longer. If we don't
+		// do this, then we may non-silently drop writes we should have accepted.
+
+		if t.Before(l.earliest) || t.After(l.latest) {
+			// t is not in range, we can avoid going through the linear search.
+			return nil
+		}
+
+		// Oh no, we've probably got overlapping shards. Perform a linear search.
+		for idx = 0; idx < l.items.Len(); idx++ {
+			if l.items[idx].Contains(t) {
+				// Found it!
+				break
+			}
+		}
+		if idx == l.items.Len() {
+			// We did not find a shard which contained t. This is very strange.
+			return nil
+		}
+	}
+
+	return &l.items[idx]
 }
 
-// Append appends a shard group to the list, and returns a sorted list.
-func (l sgList) Append(sgi meta.ShardGroupInfo) sgList {
-	next := append(l, sgi)
-	sort.Sort(meta.ShardGroupInfos(next))
-	return next
+// Add appends a shard group to the list, updating the earliest/latest times of the list if needed.
+func (l *sgList) Add(sgi meta.ShardGroupInfo) {
+	l.items = append(l.items, sgi)
+	l.needsSort = true
+
+	// Update our earliest and latest times for l.items
+	if l.earliest.IsZero() || l.earliest.After(sgi.StartTime) {
+		l.earliest = sgi.StartTime
+	}
+	if l.latest.IsZero() || l.latest.Before(sgi.EndTime) {
+		l.latest = sgi.EndTime
+	}
 }
 
 // WritePointsInto is a copy of WritePoints that uses a tsdb structure instead of

--- a/coordinator/points_writer_internal_test.go
+++ b/coordinator/points_writer_internal_test.go
@@ -14,18 +14,17 @@ func TestSgList_ShardGroupAt(t *testing.T) {
 		return base.Add(time.Duration(24*n) * time.Hour)
 	}
 
-	list := sgList{
-		items: meta.ShardGroupInfos{
-			{ID: 1, StartTime: day(0), EndTime: day(1)},
-			{ID: 2, StartTime: day(1), EndTime: day(2)},
-			{ID: 3, StartTime: day(2), EndTime: day(3)},
-			// SG day 3 to day 4 missing...
-			{ID: 4, StartTime: day(4), EndTime: day(5)},
-			{ID: 5, StartTime: day(5), EndTime: day(6)},
-		},
-		needsSort: true,
-		earliest:  day(0),
-		latest:    day(6),
+	items := meta.ShardGroupInfos{
+		{ID: 1, StartTime: day(0), EndTime: day(1)},
+		{ID: 2, StartTime: day(1), EndTime: day(2)},
+		{ID: 3, StartTime: day(2), EndTime: day(3)},
+		// SG day 3 to day 4 missing...
+		{ID: 4, StartTime: day(4), EndTime: day(5)},
+		{ID: 5, StartTime: day(5), EndTime: day(6)},
+	}
+	var list sgList
+	for _, i := range items {
+		list.Add(i)
 	}
 
 	examples := []struct {
@@ -62,16 +61,15 @@ func TestSgList_ShardGroupAtOverlapping(t *testing.T) {
 		return base.Add(time.Duration(24*n) * time.Hour)
 	}
 
-	list := sgList{
-		items: meta.ShardGroupInfos{
-			{ID: 1, StartTime: hour(5), EndTime: hour(6)},
-			{ID: 2, StartTime: hour(6), EndTime: hour(7)},
-			// Day-long shard overlaps with the two hour-long shards.
-			{ID: 3, StartTime: base, EndTime: day(1)},
-		},
-		needsSort: true,
-		earliest:  base,
-		latest:    day(1),
+	items := meta.ShardGroupInfos{
+		{ID: 1, StartTime: hour(5), EndTime: hour(6)},
+		{ID: 2, StartTime: hour(6), EndTime: hour(7)},
+		// Day-long shard overlaps with the two hour-long shards.
+		{ID: 3, StartTime: base, EndTime: day(1)},
+	}
+	var list sgList
+	for _, i := range items {
+		list.Add(i)
 	}
 
 	examples := []struct {

--- a/coordinator/points_writer_internal_test.go
+++ b/coordinator/points_writer_internal_test.go
@@ -3,6 +3,9 @@ package coordinator
 import (
 	"testing"
 	"time"
+
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSgList_ShardGroupAt(t *testing.T) {
@@ -12,12 +15,17 @@ func TestSgList_ShardGroupAt(t *testing.T) {
 	}
 
 	list := sgList{
-		{ID: 1, StartTime: day(0), EndTime: day(1)},
-		{ID: 2, StartTime: day(1), EndTime: day(2)},
-		{ID: 3, StartTime: day(2), EndTime: day(3)},
-		// SG day 3 to day 4 missing...
-		{ID: 4, StartTime: day(4), EndTime: day(5)},
-		{ID: 5, StartTime: day(5), EndTime: day(6)},
+		items: meta.ShardGroupInfos{
+			{ID: 1, StartTime: day(0), EndTime: day(1)},
+			{ID: 2, StartTime: day(1), EndTime: day(2)},
+			{ID: 3, StartTime: day(2), EndTime: day(3)},
+			// SG day 3 to day 4 missing...
+			{ID: 4, StartTime: day(4), EndTime: day(5)},
+			{ID: 5, StartTime: day(5), EndTime: day(6)},
+		},
+		needsSort: true,
+		earliest:  day(0),
+		latest:    day(6),
 	}
 
 	examples := []struct {
@@ -42,5 +50,50 @@ func TestSgList_ShardGroupAt(t *testing.T) {
 		if got, exp := id, example.ShardGroupID; got != exp {
 			t.Errorf("[Example %d] got %v, expected %v", i+1, got, exp)
 		}
+	}
+}
+
+func TestSgList_ShardGroupAtOverlapping(t *testing.T) {
+	base := time.Date(2016, 10, 19, 0, 0, 0, 0, time.UTC)
+	hour := func(n int) time.Time {
+		return base.Add(time.Duration(n) * time.Hour)
+	}
+	day := func(n int) time.Time {
+		return base.Add(time.Duration(24*n) * time.Hour)
+	}
+
+	list := sgList{
+		items: meta.ShardGroupInfos{
+			{ID: 1, StartTime: hour(5), EndTime: hour(6)},
+			{ID: 2, StartTime: hour(6), EndTime: hour(7)},
+			// Day-long shard overlaps with the two hour-long shards.
+			{ID: 3, StartTime: base, EndTime: day(1)},
+		},
+		needsSort: true,
+		earliest:  base,
+		latest:    day(1),
+	}
+
+	examples := []struct {
+		T            time.Time
+		ShardGroupID uint64 // 0 will indicate we don't expect a shard group
+	}{
+		{T: base.Add(-time.Minute), ShardGroupID: 0}, // Before any SG
+		{T: base, ShardGroupID: 3},
+		{T: hour(5), ShardGroupID: 1},
+		{T: hour(7).Add(-time.Minute), ShardGroupID: 2},
+		{T: hour(8), ShardGroupID: 3},
+		{T: day(2), ShardGroupID: 0}, // No matching SG
+	}
+
+	for _, example := range examples {
+		t.Run(example.T.String(), func(t *testing.T) {
+			sg := list.ShardGroupAt(example.T)
+			var id uint64
+			if sg != nil {
+				id = sg.ID
+			}
+			require.Equal(t, example.ShardGroupID, id)
+		})
 	}
 }


### PR DESCRIPTION
Backport of #21946