### PR TITLE
fix: return 404 instead of links page on bad /api/v2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21839](https://github.com/influxdata/influxdb/pull/21839): Fix display and parsing of `influxd upgrade` CLI prompts in PowerShell.
 1. [21850](https://github.com/influxdata/influxdb/pull/21850): Systemd unit should block on startup until http endpoint is ready
 1. [21925](https://github.com/influxdata/influxdb/pull/21925): Upgrade to golang-jwt 3.2.1.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
 
 ## v2.0.7 [2021-06-04]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21839](https://github.com/influxdata/influxdb/pull/21839): Fix display and parsing of `influxd upgrade` CLI prompts in PowerShell.
 1. [21850](https://github.com/influxdata/influxdb/pull/21850): Systemd unit should block on startup until http endpoint is ready
 1. [21925](https://github.com/influxdata/influxdb/pull/21925): Upgrade to golang-jwt 3.2.1.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
+1. [21950](https://github.com/influxdata/influxdb/pull/21950): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
 
 ## v2.0.7 [2021-06-04]
 

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -140,7 +140,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	b.UserResourceMappingService = authorizer.NewURMService(b.OrgLookupService, b.UserResourceMappingService)
 
-	h.Mount("/api/v2", serveLinksHandler(b.HTTPErrorHandler))
+	h.Handle("/api/v2", serveLinksHandler(b.HTTPErrorHandler))
 
 	checkBackend := NewCheckBackend(b.Logger.With(zap.String("handler", "check")), b)
 	checkBackend.CheckService = authorizer.NewCheckService(b.CheckService,


### PR DESCRIPTION
Closes #21620

In the `APIHandler`, the `serveLinksHandler` is incorporated using `h.Mount`. This causes any arbitrary requests to a subpath of `/api/v2` to hit the `serveLinksHandler`, for example `/api/v2/anyrandomthing`, or something more confusing like `/api/v2/query&foo=bar` where the correct request should look like `/api/v2/query?foo=bar`. These invalid requests will return a successful status code currently.

Changing `h.Mount` to `h.Handle` fixes this, so that only requests specifically made to `/api/v2` (or `/api/v2/`) will return the links page. Invalid requests will return a 404 Not Found.

This will also help with https://github.com/influxdata/influxdb/issues/21167

See equivalent PR in IDPE: https://github.com/influxdata/idpe/pull/9069