### PR TITLE
fix: return 404 instead of links page on bad /api/v2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Because of the version bump to `go`, the macOS build for this release requires a
 1. [21898](https://github.com/influxdata/influxdb/pull/21898): Removed unused `chronograf-migator` package & chronograf API service, and updated various "chronograf" references.
 1. [21919](https://github.com/influxdata/influxdb/pull/21919): Fix display and parsing of interactive `influx` CLI prompts in PowerShell.
 1. [21941](https://github.com/influxdata/influxdb/pull/21941): Upgrade to golang-jwt 3.2.1.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
 
 ## v2.0.7 [2021-06-04]
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Because of the version bump to `go`, the macOS build for this release requires a
 1. [21898](https://github.com/influxdata/influxdb/pull/21898): Removed unused `chronograf-migator` package & chronograf API service, and updated various "chronograf" references.
 1. [21919](https://github.com/influxdata/influxdb/pull/21919): Fix display and parsing of interactive `influx` CLI prompts in PowerShell.
 1. [21941](https://github.com/influxdata/influxdb/pull/21941): Upgrade to golang-jwt 3.2.1.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
+1. [21955](https://github.com/influxdata/influxdb/pull/21955): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
 
 ## v2.0.7 [2021-06-04]
 ----------------------

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -134,7 +134,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	b.UserResourceMappingService = authorizer.NewURMService(b.OrgLookupService, b.UserResourceMappingService)
 
-	h.Mount("/api/v2", serveLinksHandler(b.HTTPErrorHandler))
+	h.Handle("/api/v2", serveLinksHandler(b.HTTPErrorHandler))
 
 	checkBackend := NewCheckBackend(b.Logger.With(zap.String("handler", "check")), b)
 	checkBackend.CheckService = authorizer.NewCheckService(b.CheckService,


### PR DESCRIPTION
Closes #21954

Cherry-pick of 096a478ff6073c3d69a4ccd19a6879e6671a91b0