### PR TITLE
build: upgrade staticcheck, fix new linter warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,9 +384,8 @@ jobs:
       - run: make checkgenerate
       - run: make vet
       - run: make checkfmt
-      - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
-      - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
-      - run: GO111MODULE=on ./env staticcheck ./...
+      - run: go install honnef.co/go/tools/cmd/staticcheck
+      - run: staticcheck ./...
 
   gotest:
     docker:

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
-	honnef.co/go/tools v0.1.3
+	honnef.co/go/tools v0.2.0
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -925,8 +925,9 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.1.3 h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=

--- a/influxql/query/executor.go
+++ b/influxql/query/executor.go
@@ -351,8 +351,7 @@ func (e *Executor) recover(query *influxql.Query, results chan *Result) {
 
 		if willCrash {
 			e.log.Error("\n\n=====\nAll goroutines now follow:")
-			buf := debug.Stack()
-			e.log.Error(fmt.Sprintf("%s", buf))
+			e.log.Error(string(debug.Stack()))
 			os.Exit(1)
 		}
 	}

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -499,7 +499,7 @@ type Stats struct {
 	NTags    int
 }
 
-func (s Stats) Update(o Stats) {
+func (s Stats) Update(o Stats) Stats {
 	s.NRows += o.NRows
 	if s.Latest.IsZero() || o.Latest.Unix() > s.Latest.Unix() {
 		s.Latest = o.Latest
@@ -516,6 +516,7 @@ func (s Stats) Update(o Stats) {
 	if o.NTags > s.NTags {
 		s.NTags = o.NTags
 	}
+	return s
 }
 
 func writeTable(ctx context.Context, t *ToTransformation, tbl flux.Table) (err error) {
@@ -654,11 +655,10 @@ func writeTable(ctx context.Context, t *ToTransformation, tbl flux.Table) (err e
 				NTags:    len(kv) / 2,
 			}
 			_, ok := measurementStats[measurementName]
-			if !ok {
-				measurementStats[measurementName] = mstats
-			} else {
-				measurementStats[measurementName].Update(mstats)
+			if ok {
+				mstats = measurementStats[measurementName].Update(mstats)
 			}
+			measurementStats[measurementName] = mstats
 
 			tags, _ = models.NewTagsKeyValues(tags, kv...)
 			pt, err := models.NewPoint(measurementName, tags, fields, pointTime)


### PR DESCRIPTION
Noticed while messing around with the build, the latest version of `staticcheck` is more module-/cgo-aware and comes with more checks. Bumping the version revealed one style nitpick and one outright bug.