### PR TITLE
feat(telemetry): Do not record telemetry data for invalid requests; replace invalid static asset paths with a slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21936](https://github.com/influxdata/influxdb/pull/21936): Ported the `influxd inspect build-tsi` command from 1.x.
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
-1. [21958](https://github.com/influxdata/influxdb/pull/21958): Telemetry improvements: Do not record telemetry data for invalid requests; replace invalid static asset paths with a slug.
+1. [21958](https://github.com/influxdata/influxdb/pull/21958): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21936](https://github.com/influxdata/influxdb/pull/21936): Ported the `influxd inspect build-tsi` command from 1.x.
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Do not record telemetry data for invalid requests.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry data for requests to the server root reported as root path if returning the default file regardless of the request path.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21936](https://github.com/influxdata/influxdb/pull/21936): Ported the `influxd inspect build-tsi` command from 1.x.
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry improvements: Do not record telemetry data for invalid requests and replace invalid static asset paths with a slug.
+1. [21958](https://github.com/influxdata/influxdb/pull/21958): Telemetry improvements: Do not record telemetry data for invalid requests; replace invalid static asset paths with a slug.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21936](https://github.com/influxdata/influxdb/pull/21936): Ported the `influxd inspect build-tsi` command from 1.x.
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Do not record telemetry data for invalid requests.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry data for requests to the server root reported as root path if returning the default file regardless of the request path.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry improvements: Do not record telemetry data for invalid requests and replace invalid static asset paths with a slug.
 
 ### Bug Fixes
 

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -59,6 +59,7 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 					"response_code": fmt.Sprintf("%d", statusCode),
 					"user_agent":    UserAgent(r),
 				}
+
 				durMetric.With(label).Observe(time.Since(start).Seconds())
 				reqMetric.With(label).Inc()
 			}(time.Now())

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -46,8 +46,8 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 
 			defer func(start time.Time) {
 				statusCode := statusW.Code()
-				// do not log metrics for invalid requests
-				if statusCode < 200 || statusCode > 299 {
+				// only log metrics for 2XX or 5XX requests
+				if !reportFromCode(statusCode) {
 					return
 				}
 
@@ -245,4 +245,17 @@ func OrgIDFromContext(ctx context.Context) *platform.ID {
 	}
 	id := v.(platform.ID)
 	return &id
+}
+
+// reportFromCode is a helper function to determine if telemetry data should be
+// reported for this response.
+func reportFromCode(c int) bool {
+	switch {
+	case c >= 200 && c <= 299:
+		return true
+	case c >= 500 && c <= 599:
+		return true
+	default:
+		return false
+	}
 }

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -44,8 +44,6 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			statusW := NewStatusResponseWriter(w)
 
-			fmt.Println(statusW.ResponseWriter.Header().Get("content-type"))
-
 			defer func(start time.Time) {
 				statusCode := statusW.Code()
 				// do not log metrics for invalid paths

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -46,7 +46,7 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 
 			defer func(start time.Time) {
 				statusCode := statusW.Code()
-				// do not log metrics for invalid paths
+				// do not log metrics for invalid requests
 				if statusCode < 200 || statusCode > 299 {
 					return
 				}

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -250,12 +250,5 @@ func OrgIDFromContext(ctx context.Context) *platform.ID {
 // reportFromCode is a helper function to determine if telemetry data should be
 // reported for this response.
 func reportFromCode(c int) bool {
-	switch {
-	case c >= 200 && c <= 299:
-		return true
-	case c >= 500 && c <= 599:
-		return true
-	default:
-		return false
-	}
+	return (c >= 200 && c <= 299) || (c >= 500 && c <= 599)
 }

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/kit/prom"
 	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap/zaptest"
-
 	"github.com/influxdata/influxdb/v2/pkg/testttp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestMetrics(t *testing.T) {
@@ -54,11 +53,9 @@ func TestMetrics(t *testing.T) {
 			labelStatus:   "2XX",
 		},
 		{
-			name:          "counter does not increment on not found (4XX)",
-			reqPath:       "/badpath",
-			wantCount:     0,
-			labelResponse: "404",
-			labelStatus:   "4XX",
+			name:      "counter does not increment on not found (4XX)",
+			reqPath:   "/badpath",
+			wantCount: 0,
 		},
 		{
 			name:          "counter increments on server error (5XX)",
@@ -68,11 +65,9 @@ func TestMetrics(t *testing.T) {
 			labelStatus:   "5XX",
 		},
 		{
-			name:          "counter does not increment on redirect (3XX)",
-			reqPath:       "/redirect",
-			wantCount:     0,
-			labelResponse: "500",
-			labelStatus:   "5XX",
+			name:      "counter does not increment on redirect (3XX)",
+			reqPath:   "/redirect",
+			wantCount: 0,
 		},
 	}
 

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -81,7 +81,6 @@ func TestMetrics(t *testing.T) {
 			}
 
 			require.Equal(t, tt.wantCount, int(m.Counter.GetValue()))
-			t.Fatal("lol")
 		})
 	}
 }

--- a/static/static_test.go
+++ b/static/static_test.go
@@ -43,6 +43,12 @@ func TestAssetHandler(t *testing.T) {
 			wantData: defaultData,
 		},
 		{
+			name:     "root path",
+			reqPath:  "/",
+			newPath:  "/" + defaultFile,
+			wantData: defaultData,
+		},
+		{
 			name:     "path matches a file",
 			reqPath:  "/somethingElse.js",
 			newPath:  "/somethingElse.js",
@@ -51,7 +57,7 @@ func TestAssetHandler(t *testing.T) {
 		{
 			name:     "path matches nothing",
 			reqPath:  "/something_random",
-			newPath:  "/",
+			newPath:  fallbackPathSlug,
 			wantData: defaultData,
 		},
 	}

--- a/static/static_test.go
+++ b/static/static_test.go
@@ -1,9 +1,11 @@
 package static
 
 import (
+	"io"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -11,7 +13,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAssetHandler(t *testing.T) {
+	t.Parallel()
+
+	defaultData := []byte("this is the default file")
+	otherData := []byte("this is a different file")
+
+	m := http.FS(fstest.MapFS{
+		defaultFile: {
+			Data:    defaultData,
+			ModTime: time.Now(),
+		},
+		"somethingElse.js": {
+			Data:    otherData,
+			ModTime: time.Now(),
+		},
+	})
+
+	tests := []struct {
+		name     string
+		reqPath  string
+		newPath  string
+		wantData []byte
+	}{
+		{
+			name:     "path matches default",
+			reqPath:  "/" + defaultFile,
+			newPath:  "/" + defaultFile,
+			wantData: defaultData,
+		},
+		{
+			name:     "path matches a file",
+			reqPath:  "/somethingElse.js",
+			newPath:  "/somethingElse.js",
+			wantData: otherData,
+		},
+		{
+			name:     "path matches nothing",
+			reqPath:  "/something_random",
+			newPath:  "/",
+			wantData: defaultData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := assetHandler(m)
+			r := httptest.NewRequest("GET", tt.reqPath, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+
+			b, err := io.ReadAll(w.Result().Body)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusOK, w.Result().StatusCode)
+			require.Equal(t, tt.wantData, b)
+			require.Equal(t, tt.newPath, r.URL.Path)
+		})
+	}
+}
+
 func TestModTimeFromInfo(t *testing.T) {
+	t.Parallel()
+
 	nowTime := time.Now()
 
 	timeFunc := func() (time.Time, error) {
@@ -76,31 +140,36 @@ func TestOpenAsset(t *testing.T) {
 	})
 
 	tests := []struct {
-		name string
-		file string
-		want []byte
+		name     string
+		file     string
+		fallback bool
+		want     []byte
 	}{
 		{
 			"default file by name",
 			defaultFile,
+			false,
 			defaultData,
 		},
 		{
 			"other file by name",
 			"somethingElse.js",
+			false,
 			otherData,
 		},
 		{
 			"falls back to default if can't find",
 			"badFile.exe",
+			true,
 			defaultData,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFile, err := openAsset(m, tt.file)
+			gotFile, fallback, err := openAsset(m, tt.file)
 			require.NoError(t, err)
+			require.Equal(t, tt.fallback, fallback)
 
 			got, err := ioutil.ReadAll(gotFile)
 			require.NoError(t, err)
@@ -108,7 +177,6 @@ func TestOpenAsset(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
-
 }
 
 func TestEtag(t *testing.T) {


### PR DESCRIPTION
Closes #21167

This PR will reduce the cardinality of reported telemetry metrics in the following two ways:

- Requests which do not result in a successful status code (in the range of `200` - `299`) OR result in a server error (in the range of `500` - `599`) will not have metrics collected. This is to prevent arbitrary requests from endpoints like `/api/v2/...` from being able to generate unbounded cardinality. Also see https://github.com/influxdata/influxdb/pull/21950
- Requests to the server root `/` will have their paths normalized to a placeholder slug if they do not match a file contained on the server. This should eliminate the huge amount of unique series reported in telemetry data for arbitrary requests to the server root.

A side-effect of the second point is that requests made to the server via the UI to paths like `http://localhost:8086/orgs/<org-id>/dashboards-list` will have their path normalized to the placeholder slug as well. This is because the static file handler will receive the request for `/orgs/<org-id>/dashboards-list`, see that it does not match a file on the server, and respond with the default `index.html` file to serve the React application. This should be rare, since the vast majority of user interactions for UI navigation goes through the client-side router and does not hit the server. The only time it would happen is if a user refreshes a page at some point in the UI, or possibly returns to a page by using a URL in their address bar, etc.