### PR TITLE
fix: field metaqueries take fast path if predicate is only on `_measurement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21925](https://github.com/influxdata/influxdb/pull/21925): Upgrade to golang-jwt 3.2.1.
 1. [21946](https://github.com/influxdata/influxdb/pull/21946): Prevent silently dropped writes when there are overlapping shards.
 1. [21950](https://github.com/influxdata/influxdb/pull/21950): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
+1. [21962](https://github.com/influxdata/influxdb/pull/21962): Flux metaqueries for `_field` take fast path if `_measurement` is the only predicate.
 
 ## v2.0.7 [2021-06-04]
 

--- a/query/stdlib/influxdata/influxdb/show_fields_with_meas_pred_test.flux
+++ b/query/stdlib/influxdata/influxdb/show_fields_with_meas_pred_test.flux
@@ -1,0 +1,95 @@
+package influxdb_test
+
+
+import "testing"
+
+option now = () => 2030-01-01T00:00:00Z
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+
+,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98
+,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64
+
+#datatype,string,long,dateTime:RFC3339,string,string,string,long
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,4,2018-05-22T19:53:26Z,sys,host.global,load7,183
+,,4,2018-05-22T19:53:36Z,sys,host.global,load7,172
+,,4,2018-05-22T19:53:46Z,sys,host.global,load7,174
+,,4,2018-05-22T19:53:56Z,sys,host.global,load7,163
+,,4,2018-05-22T19:54:06Z,sys,host.global,load7,191
+,,4,2018-05-22T19:54:16Z,sys,host.global,load7,184
+
+,,5,2018-05-22T19:53:26Z,sys,host.local,load8,198
+,,5,2018-05-22T19:53:36Z,sys,host.local,load8,197
+,,5,2018-05-22T19:53:46Z,sys,host.local,load8,197
+,,5,2018-05-22T19:53:56Z,sys,host.local,load8,196
+,,5,2018-05-22T19:54:06Z,sys,host.local,load8,198
+,,5,2018-05-22T19:54:16Z,sys,host.local,load8,197
+
+,,6,2018-05-22T19:53:26Z,sys,host.global,load9,195
+,,6,2018-05-22T19:53:36Z,sys,host.global,load9,192
+,,6,2018-05-22T19:53:46Z,sys,host.global,load9,192
+,,6,2018-05-22T19:53:56Z,sys,host.global,load9,189
+,,6,2018-05-22T19:54:06Z,sys,host.global,load9,194
+,,6,2018-05-22T19:54:16Z,sys,host.global,load9,193
+
+,,7,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298
+,,7,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259
+,,7,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259
+,,7,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259
+,,7,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259
+,,7,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264
+"
+
+testcase show_fields_with_meas_pred {
+    result = testing.loadStorage(csv: inData)
+        |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)
+        |> filter(fn: (r) => r._measurement == "sys")
+        |> keep(columns: ["_field"])
+        |> group()
+        |> distinct(column: "_field")
+        |> sort()
+
+    out_fields = "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,load3
+,,0,load7
+,,0,load8
+,,0,load9
+"
+
+    testing.diff(got: result, want: testing.loadMem(csv: out_fields)) |> yield()
+}

--- a/v1/services/storage/predicate_influxql.go
+++ b/v1/services/storage/predicate_influxql.go
@@ -123,7 +123,10 @@ func (v *hasAnyTagKeys) Visit(node influxql.Node) influxql.Visitor {
 	}
 
 	if n, ok := node.(*influxql.VarRef); ok {
-		if n.Val != fieldKey && n.Val != measurementKey && n.Val != "$" {
+		// The influxql expression will have had references to "_measurement"
+		// remapped to "_name" at this point by reads.NodeToExpr, so be sure to
+		// check for the appropriate value here using the measurementRemap map.
+		if n.Val != fieldKey && n.Val != measurementRemap[measurementKey] && n.Val != "$" {
 			v.found = true
 			return nil
 		}


### PR DESCRIPTION
Closes #21961

This PR updates the logic for detecting if a query that is attempting to get values for `_field` contains a predicate on something other than `_measurement`.

Since the `influxql` expression will have had references to `_measurement` or the bytes equivalent `\x00` replaced with `_name` by `reads.NodeToExpr`: https://github.com/influxdata/influxdb/blob/5d84c602c8d68ef71c2e9bb11b5443d9822af67f/storage/reads/influxql_predicate.go#L137-L143

...we need to check for that equivalent remapped value when determining if an expression node contains something other than that.

This will allow a query like the one in #21961 to avoid a performance-intensive block scan. The performance increase can be dramatic when querying a large number of series, and this kind of query is very common when exploring data via the UI.

A relevant existing test is https://github.com/influxdata/flux/blob/master/stdlib/influxdata/influxdb/schema/show_fields_with_pred_test.flux, which ensures that the correct result is produced when a query for fields does include a non-measurement predicate. I've also verified locally that a query for fields with a predicate of only `_measurement` produces the correct result, and adding that test case would probably be a good idea as well.

Loading a database with ~1 million series and running the query listed in #21961 results in the following from [query_benchmarker_influxdb](https://github.com/influxdata/influxdb-comparisons) when running locally on my machine, an average query time of ~10ms over 100 queries executed: 

```json
{
   "InfluxDB (Flux) field keys":{
      "count":100,
      "max":12.232133,
      "maxRate":81.75189069641411,
      "mean":9.265909370000003,
      "meanRate":107.92248877780678,
      "min":8.842354,
      "minRate":113.09205670797617,
      "sum":0.9265909370000003
   }
}
```

Running the same benchmark against the build from the commit just prior to this one results in a query time of ~4 seconds (note: the benchmark time was limited to 30 seconds, so only 9 queries ran):

```json
{
   "InfluxDB (Flux) field keys":{
      "count":9,
      "max":4275.679762,
      "maxRate":0.23388093956134784,
      "mean":4110.049170444445,
      "meanRate":0.24330609161346453,
      "min":3619.381888,
      "minRate":0.27629027025732855,
      "sum":36.990442534
   }
}
```