### PR TITLE
feat(telemetry): Do not record telemetry data for invalid requests; replace invalid static asset paths with a slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Because of the version bump to `go`, the macOS build for this release requires a
 ### Features
 
 1. [21922](https://github.com/influxdata/influxdb/pull/21922): Add `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Because of the version bump to `go`, the macOS build for this release requires a
 ### Features
 
 1. [21922](https://github.com/influxdata/influxdb/pull/21922): Add `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
+1. [21969](https://github.com/influxdata/influxdb/pull/21969): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
 
 ### Bug Fixes
 

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -43,14 +43,21 @@ func Metrics(name string, reqMetric *prometheus.CounterVec, durMetric *prometheu
 			statusW := NewStatusResponseWriter(w)
 
 			defer func(start time.Time) {
+				statusCode := statusW.Code()
+				// only log metrics for 2XX or 5XX requests
+				if !reportFromCode(statusCode) {
+					return
+				}
+
 				label := prometheus.Labels{
 					"handler":       name,
 					"method":        r.Method,
 					"path":          normalizePath(r.URL.Path),
 					"status":        statusW.StatusCodeClass(),
-					"response_code": fmt.Sprintf("%d", statusW.Code()),
+					"response_code": fmt.Sprintf("%d", statusCode),
 					"user_agent":    UserAgent(r),
 				}
+
 				durMetric.With(label).Observe(time.Since(start).Seconds())
 				reqMetric.With(label).Inc()
 			}(time.Now())
@@ -234,4 +241,10 @@ func OrgIDFromContext(ctx context.Context) *influxdb.ID {
 	}
 	id := v.(influxdb.ID)
 	return &id
+}
+
+// reportFromCode is a helper function to determine if telemetry data should be
+// reported for this response.
+func reportFromCode(c int) bool {
+	return (c >= 200 && c <= 299) || (c >= 500 && c <= 599)
 }

--- a/static/static.go
+++ b/static/static.go
@@ -30,6 +30,11 @@ const (
 	// uiBaseDir is the directory in embedBaseDir where the built UI assets
 	// reside.
 	uiBaseDir = "build"
+
+	// fallbackPathSlug is the path to re-write on the request if the requested
+	// path does not match a file and the default file is served. For telemetry
+	// and metrics reporting purposes.
+	fallbackPathSlug = "/:fallback_path"
 )
 
 // NewAssetHandler returns an http.Handler to serve files from the provided
@@ -68,24 +73,35 @@ func mwSetCacheControl(next http.Handler) http.Handler {
 }
 
 // assetHandler returns a handler that either serves the file at that path, or
-// the default file if a file cannot be found at that path.
+// the default file if a file cannot be found at that path. If the default file
+// is served, the request path is re-written to the root path to simplify
+// metrics reporting.
 func assetHandler(fileOpener http.FileSystem) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
 		// If the root directory is being requested, respond with the default file.
 		if name == "" {
 			name = defaultFile
+			r.URL.Path = "/" + defaultFile
 		}
 
 		// Try to open the file requested by name, falling back to the default file.
 		// If even the default file can't be found, the binary must not have been
 		// built with assets, so respond with not found.
-		f, err := openAsset(fileOpener, name)
+		f, fallback, err := openAsset(fileOpener, name)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
 		defer f.Close()
+
+		// If the default file will be served because the requested path didn't
+		// match any existing files, re-write the request path a placeholder value.
+		// This is to ensure that metrics do not get collected for an arbitrarily
+		// large range of incorrect paths.
+		if fallback {
+			r.URL.Path = fallbackPathSlug
+		}
 
 		staticFileHandler(f).ServeHTTP(w, r)
 	}
@@ -130,18 +146,21 @@ func staticFileHandler(f fs.File) http.Handler {
 // openAsset attempts to open the asset by name in the given directory, falling
 // back to the default file if the named asset can't be found. Returns an error
 // if even the default asset can't be opened.
-func openAsset(fileOpener http.FileSystem, name string) (fs.File, error) {
+func openAsset(fileOpener http.FileSystem, name string) (fs.File, bool, error) {
+	var fallback bool
+
 	f, err := fileOpener.Open(name)
 	if err != nil {
 		if os.IsNotExist(err) {
+			fallback = true
 			f, err = fileOpener.Open(defaultFile)
 		}
 		if err != nil {
-			return nil, err
+			return nil, fallback, err
 		}
 	}
 
-	return f, nil
+	return f, fallback, nil
 }
 
 // modTimeFromInfo gets the modification time from an fs.FileInfo. If this

--- a/static/static_test.go
+++ b/static/static_test.go
@@ -1,9 +1,11 @@
 package static
 
 import (
+	"io"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -11,7 +13,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAssetHandler(t *testing.T) {
+	t.Parallel()
+
+	defaultData := []byte("this is the default file")
+	otherData := []byte("this is a different file")
+
+	m := http.FS(fstest.MapFS{
+		defaultFile: {
+			Data:    defaultData,
+			ModTime: time.Now(),
+		},
+		"somethingElse.js": {
+			Data:    otherData,
+			ModTime: time.Now(),
+		},
+	})
+
+	tests := []struct {
+		name     string
+		reqPath  string
+		newPath  string
+		wantData []byte
+	}{
+		{
+			name:     "path matches default",
+			reqPath:  "/" + defaultFile,
+			newPath:  "/" + defaultFile,
+			wantData: defaultData,
+		},
+		{
+			name:     "root path",
+			reqPath:  "/",
+			newPath:  "/" + defaultFile,
+			wantData: defaultData,
+		},
+		{
+			name:     "path matches a file",
+			reqPath:  "/somethingElse.js",
+			newPath:  "/somethingElse.js",
+			wantData: otherData,
+		},
+		{
+			name:     "path matches nothing",
+			reqPath:  "/something_random",
+			newPath:  fallbackPathSlug,
+			wantData: defaultData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := assetHandler(m)
+			r := httptest.NewRequest("GET", tt.reqPath, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+
+			b, err := io.ReadAll(w.Result().Body)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusOK, w.Result().StatusCode)
+			require.Equal(t, tt.wantData, b)
+			require.Equal(t, tt.newPath, r.URL.Path)
+		})
+	}
+}
+
 func TestModTimeFromInfo(t *testing.T) {
+	t.Parallel()
+
 	nowTime := time.Now()
 
 	timeFunc := func() (time.Time, error) {
@@ -76,31 +146,36 @@ func TestOpenAsset(t *testing.T) {
 	})
 
 	tests := []struct {
-		name string
-		file string
-		want []byte
+		name     string
+		file     string
+		fallback bool
+		want     []byte
 	}{
 		{
 			"default file by name",
 			defaultFile,
+			false,
 			defaultData,
 		},
 		{
 			"other file by name",
 			"somethingElse.js",
+			false,
 			otherData,
 		},
 		{
 			"falls back to default if can't find",
 			"badFile.exe",
+			true,
 			defaultData,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFile, err := openAsset(m, tt.file)
+			gotFile, fallback, err := openAsset(m, tt.file)
 			require.NoError(t, err)
+			require.Equal(t, tt.fallback, fallback)
 
 			got, err := ioutil.ReadAll(gotFile)
 			require.NoError(t, err)
@@ -108,7 +183,6 @@ func TestOpenAsset(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
-
 }
 
 func TestEtag(t *testing.T) {


### PR DESCRIPTION
Closes #21968

Backport of 4db7978b32b4b11a29b2d3cc7ffbb653cf9d38e1