### PR TITLE
feat: update flux components to use flux/array instead of arrow/array

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,11 +40,11 @@ require (
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe
-	github.com/influxdata/flux v0.123.0
+	github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influx-cli/v2 v2.0.0-20210713195937-a69f06b41b45
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
-	github.com/influxdata/pkg-config v0.2.7
+	github.com/influxdata/pkg-config v0.2.8
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe h1:7j4SdN/BvQwN6WoUq7mv0kg5U9NhnFBxPGMafYRKym0=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.123.0 h1:eEgigQgeXsM/+TDZVbPJpEw8a3U/dNWoSr6OxlKoVfc=
-github.com/influxdata/flux v0.123.0/go.mod h1:pGSAvyAA5d3et7SSzajaYShWYXmnRnJJq2qWi+WWZ2I=
+github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae h1:H6N4SU2birrb4LeTytC2WoC3hYnJTyr4p62QL/t4D/g=
+github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae/go.mod h1:LMf1amHWjEjWW6K4XgJNfZjpdwTkU1NhxUEsk08614M=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influx-cli/v2 v2.0.0-20210713195937-a69f06b41b45 h1:81jaYQW3KeukYoKFAJzGQyqVRv49a9wIl2KmyvJmRUo=
@@ -349,8 +349,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/influxdata/nats-streaming-server v0.11.3-0.20201112040610-c277f7560803 h1:LpaVAM5Www2R7M0GJAxAdL3swBvmna8Pyzw6F7o+j04=
 github.com/influxdata/nats-streaming-server v0.11.3-0.20201112040610-c277f7560803/go.mod h1:qgAMR6M9EokX+R5X7jUQfubwBdS1tBIl4yVJ3shhcWk=
-github.com/influxdata/pkg-config v0.2.7 h1:LPTCWmcPkyMryHHnf+STK/zVUjQ6OCvvOukSDlJLY9I=
-github.com/influxdata/pkg-config v0.2.7/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.2.8 h1:9B5S+ajCLotPQq4tK7Ez26sZT2djoxZjLaSIJCgjQ4I=
+github.com/influxdata/pkg-config v0.2.8/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b h1:i44CesU68ZBRvtCjBi3QSosCIKrjmMbYlQMFAwVLds4=
 github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=

--- a/query/influxql/response_iterator.go
+++ b/query/influxql/response_iterator.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
@@ -175,7 +175,7 @@ func (t *queryTable) translateRowsToColumns() error {
 				if !ok {
 					return fmt.Errorf("unsupported type %T found in column %s of type %s", val, col.Label, col.Type)
 				}
-				b.AppendString(val)
+				b.Append(val)
 			}
 			t.cols[i] = b.NewArray()
 			b.Release()
@@ -229,7 +229,7 @@ func (t *queryTable) translateRowsToColumns() error {
 		}
 
 		for i := 0; i < t.Len(); i++ {
-			b.AppendString(value)
+			b.Append(value)
 		}
 		t.cols[j] = b.NewArray()
 		b.Release()
@@ -369,34 +369,34 @@ func (r *queryTable) Bools(j int) *array.Boolean {
 // Ints returns the values in column index j as ints.
 // It will panic if the column is not a []int64.
 // It is used to implement flux.ColReader.
-func (r *queryTable) Ints(j int) *array.Int64 {
-	return r.cols[j].(*array.Int64)
+func (r *queryTable) Ints(j int) *array.Int {
+	return r.cols[j].(*array.Int)
 }
 
 // UInts returns the values in column index j as ints.
 // It will panic if the column is not a []uint64.
 // It is used to implement flux.ColReader.
-func (r *queryTable) UInts(j int) *array.Uint64 {
-	return r.cols[j].(*array.Uint64)
+func (r *queryTable) UInts(j int) *array.Uint {
+	return r.cols[j].(*array.Uint)
 }
 
 // Floats returns the values in column index j as floats.
 // It will panic if the column is not a []float64.
 // It is used to implement flux.ColReader.
-func (r *queryTable) Floats(j int) *array.Float64 {
-	return r.cols[j].(*array.Float64)
+func (r *queryTable) Floats(j int) *array.Float {
+	return r.cols[j].(*array.Float)
 }
 
 // Strings returns the values in column index j as strings.
 // It will panic if the column is not a []string.
 // It is used to implement flux.ColReader.
-func (r *queryTable) Strings(j int) *array.Binary {
-	return r.cols[j].(*array.Binary)
+func (r *queryTable) Strings(j int) *array.String {
+	return r.cols[j].(*array.String)
 }
 
 // Times returns the values in column index j as values.Times.
 // It will panic if the column is not a []values.Time.
 // It is used to implement flux.ColReader.
-func (r *queryTable) Times(j int) *array.Int64 {
-	return r.cols[j].(*array.Int64)
+func (r *queryTable) Times(j int) *array.Int {
+	return r.cols[j].(*array.Int)
 }

--- a/query/influxql/result.go
+++ b/query/influxql/result.go
@@ -133,7 +133,7 @@ func (e *MultiResultEncoder) Encode(w io.Writer, results flux.ResultIterator) (i
 						vs := cr.Strings(idx)
 						for i := 0; i < vs.Len(); i++ {
 							if vs.IsValid(i) {
-								values[i][j] = vs.ValueString(i)
+								values[i][j] = vs.Value(i)
 							}
 						}
 					case flux.TUInt:

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -599,7 +599,7 @@ func writeTable(ctx context.Context, t *ToTransformation, tbl flux.Table) (err e
 						}
 					}
 					// TODO(docmerlin): instead of doing this sort of thing, it would be nice if we had a way that allocated a lot less.
-					kv = append(kv, []byte(col.Label), er.Strings(j).Value(i))
+					kv = append(kv, []byte(col.Label), []byte(er.Strings(j).Value(i)))
 				}
 			}
 

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -11,8 +11,8 @@ import (
 	"math"
 	"sync"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interval"
@@ -157,7 +157,7 @@ func (t *floatWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -180,8 +180,8 @@ func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -200,8 +200,8 @@ func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -385,7 +385,7 @@ func (t *floatWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.Int64 {
+func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -398,10 +398,10 @@ func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.In
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int64 {
+func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -414,7 +414,7 @@ func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -495,12 +495,12 @@ func (t *floatEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewFloat64Array()
+	cr.cols[valueColIdx] = values.NewFloatArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.Float64Builder) *array.Int64 {
+func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.FloatBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -544,10 +544,10 @@ func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.Float64Builder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.Float64Builder) *array.Int64 {
+func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.FloatBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -591,10 +591,10 @@ func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.Float64Builder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.Float64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.FloatBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -655,7 +655,7 @@ func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.Float64Bui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -1140,7 +1140,7 @@ func (t *integerWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -1163,8 +1163,8 @@ func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -1183,8 +1183,8 @@ func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -1368,7 +1368,7 @@ func (t *integerWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *array.Int64 {
+func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -1381,10 +1381,10 @@ func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *arra
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array.Int64 {
+func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -1397,7 +1397,7 @@ func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -1478,12 +1478,12 @@ func (t *integerEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewInt64Array()
+	cr.cols[valueColIdx] = values.NewIntArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.Int64Builder) *array.Int64 {
+func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.IntBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -1527,10 +1527,10 @@ func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.Int64Builder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.Int64Builder) *array.Int64 {
+func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.IntBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -1574,10 +1574,10 @@ func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.Int64Builder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.Int64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.IntBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -1638,7 +1638,7 @@ func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.Int64Bui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -2122,7 +2122,7 @@ func (t *unsignedWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -2145,8 +2145,8 @@ func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64,
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -2165,8 +2165,8 @@ func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64,
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -2350,7 +2350,7 @@ func (t *unsignedWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *array.Int64 {
+func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -2363,10 +2363,10 @@ func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *ar
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *array.Int64 {
+func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -2379,7 +2379,7 @@ func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *arr
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -2460,12 +2460,12 @@ func (t *unsignedEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewUint64Array()
+	cr.cols[valueColIdx] = values.NewUintArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.Uint64Builder) *array.Int64 {
+func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.UintBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -2509,10 +2509,10 @@ func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.Uint64Build
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.Uint64Builder) *array.Int64 {
+func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.UintBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -2556,10 +2556,10 @@ func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.Uint64Builde
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.Uint64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.UintBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -2620,7 +2620,7 @@ func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.Uint64B
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -3103,7 +3103,7 @@ func (t *stringWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -3126,8 +3126,8 @@ func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, o
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -3146,8 +3146,8 @@ func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, o
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -3331,7 +3331,7 @@ func (t *stringWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.Int64 {
+func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -3344,10 +3344,10 @@ func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.Int64 {
+func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -3360,7 +3360,7 @@ func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.I
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -3441,12 +3441,12 @@ func (t *stringEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewBinaryArray()
+	cr.cols[valueColIdx] = values.NewStringArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.BinaryBuilder) *array.Int64 {
+func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.StringBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -3490,10 +3490,10 @@ func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.BinaryBuilder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.BinaryBuilder) *array.Int64 {
+func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.StringBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -3537,10 +3537,10 @@ func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.BinaryBuilder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.BinaryBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.StringBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -3601,7 +3601,7 @@ func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.BinaryBui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -4028,7 +4028,7 @@ func (t *booleanWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -4051,8 +4051,8 @@ func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -4071,8 +4071,8 @@ func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -4256,7 +4256,7 @@ func (t *booleanWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *array.Int64 {
+func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -4269,10 +4269,10 @@ func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *arra
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array.Int64 {
+func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -4285,7 +4285,7 @@ func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -4371,7 +4371,7 @@ func (t *booleanEmptyWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuilder) *array.Int64 {
+func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -4415,10 +4415,10 @@ func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuild
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilder) *array.Int64 {
+func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -4462,10 +4462,10 @@ func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilde
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -4526,7 +4526,7 @@ func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanB
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -5,8 +5,8 @@ import (
 	"math"
 	"sync"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interval"
@@ -154,7 +154,7 @@ func (t *{{.name}}WindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -177,8 +177,8 @@ func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -197,8 +197,8 @@ func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -382,7 +382,7 @@ func (t *{{.name}}WindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -395,10 +395,10 @@ func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -411,7 +411,7 @@ func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *a
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -497,7 +497,7 @@ func (t *{{.name}}EmptyWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowType}}Builder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -541,10 +541,10 @@ func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowTy
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowType}}Builder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -588,10 +588,10 @@ func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowTyp
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.ArrowType}}Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.ArrowType}}Builder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -652,7 +652,7 @@ func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.Arr
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
@@ -165,29 +165,29 @@ func (cr *colReader) Bools(j int) *array.Boolean {
 	return cr.cols[j].(*array.Boolean)
 }
 
-func (cr *colReader) Ints(j int) *array.Int64 {
+func (cr *colReader) Ints(j int) *array.Int {
 	execute.CheckColType(cr.colMeta[j], flux.TInt)
-	return cr.cols[j].(*array.Int64)
+	return cr.cols[j].(*array.Int)
 }
 
-func (cr *colReader) UInts(j int) *array.Uint64 {
+func (cr *colReader) UInts(j int) *array.Uint {
 	execute.CheckColType(cr.colMeta[j], flux.TUInt)
-	return cr.cols[j].(*array.Uint64)
+	return cr.cols[j].(*array.Uint)
 }
 
-func (cr *colReader) Floats(j int) *array.Float64 {
+func (cr *colReader) Floats(j int) *array.Float {
 	execute.CheckColType(cr.colMeta[j], flux.TFloat)
-	return cr.cols[j].(*array.Float64)
+	return cr.cols[j].(*array.Float)
 }
 
-func (cr *colReader) Strings(j int) *array.Binary {
+func (cr *colReader) Strings(j int) *array.String {
 	execute.CheckColType(cr.colMeta[j], flux.TString)
-	return cr.cols[j].(*array.Binary)
+	return cr.cols[j].(*array.String)
 }
 
-func (cr *colReader) Times(j int) *array.Int64 {
+func (cr *colReader) Times(j int) *array.Int {
 	execute.CheckColType(cr.colMeta[j], flux.TTime)
-	return cr.cols[j].(*array.Int64)
+	return cr.cols[j].(*array.Int)
 }
 
 // readTags populates b.tags with the provided tags
@@ -239,37 +239,37 @@ func (t *table) closeDone() {
 	}
 }
 
-func (t *floatTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatWindowSelectorTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatWindowSelectorTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float64 {
+func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float {
 	b := arrow.NewFloatBuilder(t.alloc)
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
-	return b.NewFloat64Array()
+	return b.NewFloatArray()
 }
-func (t *floatEmptyWindowSelectorTable) arrowBuilder() *array.Float64Builder {
+func (t *floatEmptyWindowSelectorTable) arrowBuilder() *array.FloatBuilder {
 	return arrow.NewFloatBuilder(t.alloc)
 }
-func (t *floatEmptyWindowSelectorTable) append(builder *array.Float64Builder, v float64) {
+func (t *floatEmptyWindowSelectorTable) append(builder *array.FloatBuilder, v float64) {
 	builder.Append(v)
 }
-func (t *integerTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerWindowSelectorTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerWindowSelectorTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
+func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int {
 	b := arrow.NewIntBuilder(t.alloc)
 	b.Resize(len(intervals))
 	appendNull := b.AppendNull
@@ -277,55 +277,55 @@ func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
 		appendNull = func() { b.Append(*t.fillValue) }
 	}
 	t.appendValues(intervals, b.Append, appendNull)
-	return b.NewInt64Array()
+	return b.NewIntArray()
 }
-func (t *integerEmptyWindowSelectorTable) arrowBuilder() *array.Int64Builder {
+func (t *integerEmptyWindowSelectorTable) arrowBuilder() *array.IntBuilder {
 	return arrow.NewIntBuilder(t.alloc)
 }
-func (t *integerEmptyWindowSelectorTable) append(builder *array.Int64Builder, v int64) {
+func (t *integerEmptyWindowSelectorTable) append(builder *array.IntBuilder, v int64) {
 	builder.Append(v)
 }
-func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedWindowSelectorTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedWindowSelectorTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint64 {
+func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint {
 	b := arrow.NewUintBuilder(t.alloc)
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
-	return b.NewUint64Array()
+	return b.NewUintArray()
 }
-func (t *unsignedEmptyWindowSelectorTable) arrowBuilder() *array.Uint64Builder {
+func (t *unsignedEmptyWindowSelectorTable) arrowBuilder() *array.UintBuilder {
 	return arrow.NewUintBuilder(t.alloc)
 }
-func (t *unsignedEmptyWindowSelectorTable) append(builder *array.Uint64Builder, v uint64) {
+func (t *unsignedEmptyWindowSelectorTable) append(builder *array.UintBuilder, v uint64) {
 	builder.Append(v)
 }
-func (t *stringTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringGroupTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringGroupTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringWindowSelectorTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringWindowSelectorTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringWindowTable) mergeValues(intervals []int64) *array.Binary {
+func (t *stringWindowTable) mergeValues(intervals []int64) *array.String {
 	b := arrow.NewStringBuilder(t.alloc)
 	b.Resize(len(intervals))
-	t.appendValues(intervals, b.AppendString, b.AppendNull)
-	return b.NewBinaryArray()
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewStringArray()
 }
-func (t *stringEmptyWindowSelectorTable) arrowBuilder() *array.BinaryBuilder {
+func (t *stringEmptyWindowSelectorTable) arrowBuilder() *array.StringBuilder {
 	return arrow.NewStringBuilder(t.alloc)
 }
-func (t *stringEmptyWindowSelectorTable) append(builder *array.BinaryBuilder, v string) {
-	builder.AppendString(v)
+func (t *stringEmptyWindowSelectorTable) append(builder *array.StringBuilder, v string) {
+	builder.Append(v)
 }
 func (t *booleanTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)

--- a/storage/flux/tags_cache_test.go
+++ b/storage/flux/tags_cache_test.go
@@ -79,7 +79,7 @@ func TestTagsCache_GetTags_Concurrency(t *testing.T) {
 				l := rand.Intn(128) + 1
 				vs := cache.GetTag(value, l, mem)
 				for i := 0; i < l; i++ {
-					if want, got := value, vs.ValueString(i); want != got {
+					if want, got := value, vs.Value(i); want != got {
 						t.Errorf("unexpected value in array: %s != %s", want, got)
 						vs.Release()
 						return

--- a/storage/flux/types.tmpldata
+++ b/storage/flux/types.tmpldata
@@ -3,25 +3,25 @@
 		"Name":"Float",
 		"name":"float",
 		"Type":"float64",
-		"ArrowType":"Float64"
+		"ArrowType":"Float"
 	},
 	{
 		"Name":"Integer",
 		"name":"integer",
 		"Type":"int64",
-		"ArrowType":"Int64"
+		"ArrowType":"Int"
 	},
 	{
 		"Name":"Unsigned",
 		"name":"unsigned",
 		"Type":"uint64",
-		"ArrowType":"Uint64"
+		"ArrowType":"Uint"
 	},
 	{
 		"Name":"String",
 		"name":"string",
 		"Type":"string",
-		"ArrowType":"Binary"
+		"ArrowType":"String"
 	},
 	{
 		"Name":"Boolean",

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/influxdata/influxdb/v2/kit/platform/errors"
-
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 )
 
 // splitWindows will split a windowTable by creating a new table from each

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -374,8 +374,8 @@ func (re *runReader) readRuns(cr flux.ColReader) error {
 		for j, col := range cr.Cols() {
 			switch col.Label {
 			case runIDField:
-				if cr.Strings(j).ValueString(i) != "" {
-					id, err := platform.IDFromString(cr.Strings(j).ValueString(i))
+				if cr.Strings(j).Value(i) != "" {
+					id, err := platform.IDFromString(cr.Strings(j).Value(i))
 					if err != nil {
 						re.log.Info("Failed to parse runID", zap.Error(err))
 						continue
@@ -383,8 +383,8 @@ func (re *runReader) readRuns(cr flux.ColReader) error {
 					r.ID = *id
 				}
 			case taskIDTag:
-				if cr.Strings(j).ValueString(i) != "" {
-					id, err := platform.IDFromString(cr.Strings(j).ValueString(i))
+				if cr.Strings(j).Value(i) != "" {
+					id, err := platform.IDFromString(cr.Strings(j).Value(i))
 					if err != nil {
 						re.log.Info("Failed to parse taskID", zap.Error(err))
 						continue
@@ -392,37 +392,37 @@ func (re *runReader) readRuns(cr flux.ColReader) error {
 					r.TaskID = *id
 				}
 			case startedAtField:
-				started, err := time.Parse(time.RFC3339Nano, cr.Strings(j).ValueString(i))
+				started, err := time.Parse(time.RFC3339Nano, cr.Strings(j).Value(i))
 				if err != nil {
 					re.log.Info("Failed to parse startedAt time", zap.Error(err))
 					continue
 				}
 				r.StartedAt = started.UTC()
 			case requestedAtField:
-				requested, err := time.Parse(time.RFC3339Nano, cr.Strings(j).ValueString(i))
+				requested, err := time.Parse(time.RFC3339Nano, cr.Strings(j).Value(i))
 				if err != nil {
 					re.log.Info("Failed to parse requestedAt time", zap.Error(err))
 					continue
 				}
 				r.RequestedAt = requested.UTC()
 			case scheduledForField:
-				scheduled, err := time.Parse(time.RFC3339, cr.Strings(j).ValueString(i))
+				scheduled, err := time.Parse(time.RFC3339, cr.Strings(j).Value(i))
 				if err != nil {
 					re.log.Info("Failed to parse scheduledFor time", zap.Error(err))
 					continue
 				}
 				r.ScheduledFor = scheduled.UTC()
 			case statusTag:
-				r.Status = cr.Strings(j).ValueString(i)
+				r.Status = cr.Strings(j).Value(i)
 			case finishedAtField:
-				finished, err := time.Parse(time.RFC3339Nano, cr.Strings(j).ValueString(i))
+				finished, err := time.Parse(time.RFC3339Nano, cr.Strings(j).Value(i))
 				if err != nil {
 					re.log.Info("Failed to parse finishedAt time", zap.Error(err))
 					continue
 				}
 				r.FinishedAt = finished.UTC()
 			case logField:
-				logBytes := bytes.TrimSpace(cr.Strings(j).Value(i))
+				logBytes := bytes.TrimSpace([]byte(cr.Strings(j).Value(i)))
 				if len(logBytes) != 0 {
 					err := json.Unmarshal(logBytes, &r.Log)
 					if err != nil {


### PR DESCRIPTION
This updates the flux integration to use the `flux/array` package rather than
directly using the `arrow/array` package.

Flux recently switched to wrapping the array types from arrow and creating its
own array package to be used for table columns instead of directly referencing
the arrow package. This allows us to keep a consistent interface, but
potentially change internal implementations without changing downstream
consumers. Most recently, the `*array.String` type has some of its own
optimizations for certain array patterns.

This change updates the flux integration to use the new API.

Related to influxdata/flux#3897.