### PR TITLE
feat: enable notebooks and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
 1. [21958](https://github.com/influxdata/influxdb/pull/21958): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
-1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Added support for notebooks and annotations.
+1. [21972](https://github.com/influxdata/influxdb/pull/21972): Added support for notebooks and annotations.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This release upgrades the project to `go` version 1.16.
 
 Because of the version bump to `go`, the macOS build for this release requires at least version 10.12 Sierra to run.
 
+### Notebooks and Annotations
+
+Support for Notebooks and Annotations is included with this release.
+
 ### SQLite Metadata Store
 
 This release adds an embedded SQLite database for storing metadata required by the latest UI features like Notebooks and Annotations.
@@ -53,6 +57,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21910](https://github.com/influxdata/influxdb/pull/21910): Added `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21938](https://github.com/influxdata/influxdb/pull/21938): Added route to delete individual secret.
 1. [21958](https://github.com/influxdata/influxdb/pull/21958): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
+1. [XXXXX](https://github.com/influxdata/influxdb/pull/XXXXX): Added support for notebooks and annotations.
 
 ### Bug Fixes
 

--- a/flags.yml
+++ b/flags.yml
@@ -74,22 +74,6 @@
   default: false
   expose: true
 
-- name: UI CSV Uploader
-  description: Adds the ability to upload data from a CSV file to a bucket
-  key: csvUploader
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
-- name: Editable Telegraf Configurations
-  description: Edit telegraf configurations from the UI
-  key: editTelegrafs
-  default: true
-  contact: Monitoring Team
-  expose: true
-  lifetime: temporary
-
 - name: Default Monaco Selection to EOF
   description: Positions the cursor at the end of the line(s) when using the monaco editor
   key: cursorAtEOF

--- a/flags.yml
+++ b/flags.yml
@@ -55,26 +55,6 @@
   contact: Query Team
   lifetime: permanent
 
-- name: Notebooks
-  description: Determine if the notebook feature's route and navbar icon are visible to the user
-  key: notebooks
-  default: false
-  contact: Monitoring Team
-  lifetime: temporary
-  expose: true
-
-# This notebooksApi flag only controls the specific API calls that the frontend uses,
-# not if the notebooks button is enabled on the sidebar. The notebooks flag (above) controls
-# the display of the notebooks button on the sidebar. The notebooksAPI flag should be set to true
-# to ensure the UI sends requests that the OSS backend can handle.
-- name: Notebooks Service API
-  description: Enable the Equivalent notebooksd Service API
-  key: notebooksApi
-  default: true
-  contact: Edge Team
-  lifetime: temporary
-  expose: true
-
 - name: Inject Latest Success Time
   description: Inject the latest successful task run timestamp into a Task query extern when executing.
   key: injectLatestSuccessTime

--- a/flags.yml
+++ b/flags.yml
@@ -117,7 +117,7 @@
 - name: Annotations UI
   description: Management, display, and manual addition of Annotations from the UI
   key: annotations
-  default: false
+  default: true
   contact: Monitoring Team
   lifetime: temporary
   expose: true

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -86,34 +86,6 @@ func QueryTracing() BoolFlag {
 	return queryTracing
 }
 
-var notebooks = MakeBoolFlag(
-	"Notebooks",
-	"notebooks",
-	"Monitoring Team",
-	false,
-	Temporary,
-	true,
-)
-
-// Notebooks - Determine if the notebook feature's route and navbar icon are visible to the user
-func Notebooks() BoolFlag {
-	return notebooks
-}
-
-var notebooksApi = MakeBoolFlag(
-	"Notebooks Service API",
-	"notebooksApi",
-	"Edge Team",
-	true,
-	Temporary,
-	true,
-)
-
-// NotebooksServiceApi - Enable the Equivalent notebooksd Service API
-func NotebooksServiceApi() BoolFlag {
-	return notebooksApi
-}
-
 var injectLatestSuccessTime = MakeBoolFlag(
 	"Inject Latest Success Time",
 	"injectLatestSuccessTime",
@@ -247,8 +219,6 @@ var all = []Flag{
 	memoryOptimizedFill,
 	memoryOptimizedSchemaMutation,
 	queryTracing,
-	notebooks,
-	notebooksApi,
 	injectLatestSuccessTime,
 	enforceOrgDashboardLimits,
 	timeFilterFlags,
@@ -267,8 +237,6 @@ var byKey = map[string]Flag{
 	"memoryOptimizedFill":           memoryOptimizedFill,
 	"memoryOptimizedSchemaMutation": memoryOptimizedSchemaMutation,
 	"queryTracing":                  queryTracing,
-	"notebooks":                     notebooks,
-	"notebooksApi":                  notebooksApi,
 	"injectLatestSuccessTime":       injectLatestSuccessTime,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
 	"timeFilterFlags":               timeFilterFlags,

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -202,7 +202,7 @@ var annotations = MakeBoolFlag(
 	"Annotations UI",
 	"annotations",
 	"Monitoring Team",
-	false,
+	true,
 	Temporary,
 	true,
 )

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -128,34 +128,6 @@ func TimeFilterFlags() BoolFlag {
 	return timeFilterFlags
 }
 
-var csvUploader = MakeBoolFlag(
-	"UI CSV Uploader",
-	"csvUploader",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// UiCsvUploader - Adds the ability to upload data from a CSV file to a bucket
-func UiCsvUploader() BoolFlag {
-	return csvUploader
-}
-
-var editTelegrafs = MakeBoolFlag(
-	"Editable Telegraf Configurations",
-	"editTelegrafs",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// EditableTelegrafConfigurations - Edit telegraf configurations from the UI
-func EditableTelegrafConfigurations() BoolFlag {
-	return editTelegrafs
-}
-
 var cursorAtEOF = MakeBoolFlag(
 	"Default Monaco Selection to EOF",
 	"cursorAtEOF",
@@ -222,8 +194,6 @@ var all = []Flag{
 	injectLatestSuccessTime,
 	enforceOrgDashboardLimits,
 	timeFilterFlags,
-	csvUploader,
-	editTelegrafs,
 	cursorAtEOF,
 	refreshSingleCell,
 	rangeAnnotations,
@@ -240,8 +210,6 @@ var byKey = map[string]Flag{
 	"injectLatestSuccessTime":       injectLatestSuccessTime,
 	"enforceOrgDashboardLimits":     enforceOrgDashboardLimits,
 	"timeFilterFlags":               timeFilterFlags,
-	"csvUploader":                   csvUploader,
-	"editTelegrafs":                 editTelegrafs,
 	"cursorAtEOF":                   cursorAtEOF,
 	"refreshSingleCell":             refreshSingleCell,
 	"rangeAnnotations":              rangeAnnotations,


### PR DESCRIPTION
Closes #21217
Closes #21266

This PR enables notebooks and annotations by removing the feature flag for `notebooks` and `notebooksApi`, both of which are no longer checked for in the UI (they are always on in the latest UI), and turns the feature flag for `annotations` to be `true` by default.

I also cleaned up a few other UI-related feature flags that have been removed from the UI