### PR TITLE
test: ensure compile takes time

### DIFF
--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -207,6 +207,8 @@ func TestController_QueryRuntimeError(t *testing.T) {
 
 			q, err := ctrl.Query(context.Background(), &mock.Compiler{
 				CompileFn: func(ctx context.Context) (flux.Program, error) {
+					// ensure we have non-zero compile time
+					time.Sleep(1*time.Millisecond)
 					return &mock.Program{
 						ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
 							q.SetErr(errors.New("runtime error"))


### PR DESCRIPTION
Add a sleep since part of the test is checking that the compile time is non-zero.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass