### PR TITLE
feat: SHOW TAG VALUES should produce results from one specific RP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -	[#21707](https://github.com/influxdata/influxdb/pull/21707): chore: add logging to compaction
 -	[#21752](https://github.com/influxdata/influxdb/pull/21752): feat: add total-buffer-bytes config parameter to subscriptions
 -	[#21820](https://github.com/influxdata/influxdb/pull/21820): chore: update flux to v0.120.1
+-	[#21983](https://github.com/influxdata/influxdb/pull/21983): feat: SHOW TAG VALUES should produce results from one specific RP
 
 ### Bugfixes
 

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1039,10 +1039,25 @@ func (e *StatementExecutor) executeShowTagValues(ctx *query.ExecutionContext, q 
 		return err
 	}
 
-	// Get all shards for all retention policies.
+	// If measurements include retention policies
+	// only look at those policies
+	rps := make([]string, 0, len(di.RetentionPolicies))
+	// Collect retention policies if specified
+	for _, m := range q.Sources.Measurements() {
+		if len(m.RetentionPolicy) > 0 {
+			rps = append(rps, m.RetentionPolicy)
+		}
+	}
+	// If no retention policies specified, use
+	// all retention policies
+	if len(rps) == 0 {
+		for _, rp := range di.RetentionPolicies {
+			rps = append(rps, rp.Name)
+		}
+	}
 	var allGroups []meta.ShardGroupInfo
-	for _, rpi := range di.RetentionPolicies {
-		sgis, err := e.MetaClient.ShardGroupsByTimeRange(q.Database, rpi.Name, timeRange.MinTime(), timeRange.MaxTime())
+	for _, rp := range rps {
+		sgis, err := e.MetaClient.ShardGroupsByTimeRange(q.Database, rp, timeRange.MinTime(), timeRange.MaxTime())
 		if err != nil {
 			return err
 		}
@@ -1312,6 +1327,8 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 			case *influxql.DropSeriesStatement, *influxql.DeleteSeriesStatement:
 				// DB and RP not supported by these statements so don't rewrite into invalid
 				// statements
+			case *influxql.ShowTagValuesStatement:
+				// SHOW TAG VALUES should span multiple RPs if one is not specified.
 			default:
 				err = e.normalizeMeasurement(node, defaultDatabase, defaultRetentionPolicy)
 			}

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1054,6 +1054,12 @@ func (e *StatementExecutor) executeShowTagValues(ctx *query.ExecutionContext, q 
 		for _, rp := range di.RetentionPolicies {
 			rps = append(rps, rp.Name)
 		}
+	} else {
+		for _, rp := range rps {
+			if rp != rps[0] {
+				return fmt.Errorf("only one retention policy allowed in SHOW TAG VALUES query: \"%s\", \"%s\"", rp, rps[0])
+			}
+		}
 	}
 	var allGroups []meta.ShardGroupInfo
 	for _, rp := range rps {

--- a/query/statement_rewriter.go
+++ b/query/statement_rewriter.go
@@ -300,6 +300,7 @@ func rewriteShowTagValuesStatement(stmt *influxql.ShowTagValuesStatement) (influ
 
 	return &influxql.ShowTagValuesStatement{
 		Database:   stmt.Database,
+		Sources:    stmt.Sources,
 		Op:         stmt.Op,
 		TagKeyExpr: stmt.TagKeyExpr,
 		Condition:  condition,

--- a/query/statement_rewriter_test.go
+++ b/query/statement_rewriter_test.go
@@ -302,7 +302,11 @@ func TestRewriteStatement(t *testing.T) {
 		},
 		{
 			stmt: `SHOW TAG VALUES FROM cpu WITH KEY = "region"`,
-			s:    `SHOW TAG VALUES WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
+			s:    `SHOW TAG VALUES FROM cpu WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
+		},
+		{
+			stmt: `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY = "region"`,
+			s:    `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
 		},
 		{
 			stmt: `SHOW TAG VALUES WITH KEY != "region"`,

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -8343,7 +8343,7 @@ func TestServer_Query_ShowTagValues(t *testing.T) {
 		},
 		&Query{
 			name:    "show tag values with multiple retention policies",
-			command: `SHOW TAG VALUES FROM ` + rps[0] + `.cpu, ` + rps[1] +`.cpu WITH KEY IN (host, region)`,
+			command: `SHOW TAG VALUES FROM ` + rps[0] + `.cpu, ` + rps[1] + `.cpu WITH KEY IN (host, region)`,
 			exp:     `{"results":[{"statement_id":0,"error":"only one retention policy allowed in SHOW TAG VALUES query: \"rp1\", \"rp0\""}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -8341,6 +8341,12 @@ func TestServer_Query_ShowTagValues(t *testing.T) {
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
+		&Query{
+			name:    "show tag values with multiple retention policies",
+			command: `SHOW TAG VALUES FROM ` + rps[0] + `.cpu, ` + rps[1] +`.cpu WITH KEY IN (host, region)`,
+			exp:     `{"results":[{"statement_id":0,"error":"only one retention policy allowed in SHOW TAG VALUES query: \"rp1\", \"rp0\""}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
 	}...)
 
 	// Retention policy filtration of tag values only works on TSI


### PR DESCRIPTION
Ensure that the Sources field of the ShowTagValuesStatement is
filled in. Then use the sources to limit the retention policies,
and thus the shards from which tag values are collected.

This fix only works on TSI databases; INMEM shards share
indices, so restricting shard indices used does not restrict
the tag values returned.

Closes https://github.com/influxdata/influxdb/issues/21981

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass