### PR TITLE
fix: systemd-start script should be executable by group and others

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  terraform: circleci/terraform@2.1.0
+
 parameters:
   aws_teardown:
     default: false
@@ -51,6 +54,46 @@ jobs:
           paths:
             - packages/influx_tools
             - packages/*.deb
+
+  pkg_run_test:
+    executor: terraform/default
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+      - terraform/validate:
+          path: scripts/ci/
+      - run:
+          name: Terraform apply
+          command: |
+            set -x 
+            export DEBNAME=$(find /tmp/workspace/packages/influxdb*amd64.deb)
+            terraform -chdir=scripts/ci init -input=false
+            AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY terraform \
+              -chdir=scripts/ci \
+              apply \
+                -auto-approve \
+                -var package_path=${DEBNAME} \
+                -var instance_name=circleci-terraform-${CIRCLE_SHA1}
+      - run:
+          name: Install and run deb
+          command: |
+            set -x
+            ec2_ip=$(terraform -chdir=scripts/ci output -raw test_node_ssh)
+            ssh -o "StrictHostKeyChecking=no" ubuntu@$ec2_ip \<< EOF
+            sudo apt-get update && sudo apt-get install -y /home/ubuntu/influxdb.deb
+            sudo service influxdb start
+            EOF
+      - run:
+          name: Terraform destroy
+          command: |
+            AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY terraform \
+              -chdir=scripts/ci \
+              destroy \
+                -auto-approve
 
   perf_test:
     machine:
@@ -125,6 +168,9 @@ workflows:
       not: << pipeline.parameters.aws_teardown >>
     jobs:
       - build_and_test
+      - pkg_run_test:
+          requires:
+            - build_and_test
       - perf_test:
           requires:
             - build_and_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v1.8.8 [unreleased]
 
 -	[#21953](https://github.com/influxdata/influxdb/pull/21953): fix: prevent silently dropped writes with overlapping shards
 -	[#21991](https://github.com/influxdata/influxdb/pull/21991): fix: restore portable backup bug
+- [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
 
 v1.8.7 [2021-07-21]
 -------------------

--- a/build.py
+++ b/build.py
@@ -151,7 +151,7 @@ def package_scripts(build_root, config_only=False, windows=False):
         shutil.copyfile(SYSTEMD_SCRIPT, os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_SCRIPT.split('/')[1]))
         os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_SCRIPT.split('/')[1]), 0o644)
         shutil.copyfile(SYSTEMD_START_SCRIPT, os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]))
-        os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]), 0o744)
+        os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]), 0o755)
         shutil.copyfile(LOGROTATE_SCRIPT, os.path.join(build_root, LOGROTATE_DIR[1:], "influxdb"))
         os.chmod(os.path.join(build_root, LOGROTATE_DIR[1:], "influxdb"), 0o644)
         shutil.copyfile(DEFAULT_CONFIG, os.path.join(build_root, CONFIG_DIR[1:], "influxdb.conf"))

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -88,7 +88,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   cp /isrc/scripts/influxdb.service "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
   chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
   cp /isrc/scripts/influxd-systemd-start.sh "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
-  chmod 0744 "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
+  chmod 0755 "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
 
   # Copy logrotate script.
   cp /isrc/scripts/logrotate "$PKG_ROOT/etc/logrotate.d/influxdb"

--- a/scripts/ci/main.tf
+++ b/scripts/ci/main.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+}
+
+####################
+# Declare variables
+
+# Variables without default values
+# these variables need to be changed - see terraform.tfvars
+variable "key_name" { }
+variable "package_path" { }
+variable "instance_name" { }
+
+# Variables with default values
+variable "instance_type" {
+  type = string
+  default = "t3.micro"
+}
+
+variable "region" {
+  type = string
+  default = "us-west-2"
+}
+
+####################
+# Declare data
+locals {
+  package_path = "/tmp/workspace/packages"
+  ubuntu_home = "/home/ubuntu"
+  ubuntu_user = "ubuntu"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+####################
+# Declare resources
+provider "aws" {
+  profile = "default"
+  region  = var.region
+}
+
+# The security group defines access restrictions
+resource "aws_security_group" "influxdb_test_sg" {
+  ingress {
+    description = "Allow ssh connection"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# The data node for the cluster
+resource "aws_instance" "test_node" {
+  count = 1
+
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  key_name = var.key_name
+  vpc_security_group_ids = [aws_security_group.influxdb_test_sg.id]
+
+  tags = {
+    Name = var.instance_name
+  }
+
+  provisioner "file" {
+    source = var.package_path
+    destination = "${local.ubuntu_home}/influxdb.deb"
+
+    connection {
+      type     = "ssh"
+      user     = local.ubuntu_user
+      host     = self.public_dns
+      agent    = true
+    }
+  }
+}
+
+####################
+# Declare outputs
+output "test_node_ssh" { value = aws_instance.test_node.0.public_dns }

--- a/scripts/ci/terraform.tfvars
+++ b/scripts/ci/terraform.tfvars
@@ -1,0 +1,6 @@
+##################################
+# YOU MUST CHANGE THESE VARIABLES
+
+# find your key pair id (or create one) at https://console.aws.amazon.com/ec2/v2/home#KeyPairs
+# You will need your private key to ssh to your instances
+key_name = "circleci-oss-test"


### PR DESCRIPTION
These changes:

* fix an issue preventing systemd from executing startup script included in deb and rpm packages
* add a install-and-launch test for the deb package as a smoke test for that installation path

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass