### PR TITLE
fix: systemd-start script should be executable by group and others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v1.9.4 [unreleased]
 -	[#21890](https://github.com/influxdata/influxdb/pull/21890): chore: update protobuf library versions and remove influx_tsm
+-	[#21988](https://github.com/influxdata/influxdb/pull/21988): fix: systemd-start script should be executable by group and others
 
 v1.9.3 [unreleased]
 

--- a/build.py
+++ b/build.py
@@ -149,7 +149,7 @@ def package_scripts(build_root, config_only=False, windows=False):
         shutil.copyfile(SYSTEMD_SCRIPT, os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_SCRIPT.split('/')[1]))
         os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_SCRIPT.split('/')[1]), 0o644)
         shutil.copyfile(SYSTEMD_START_SCRIPT, os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]))
-        os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]), 0o744)
+        os.chmod(os.path.join(build_root, SCRIPT_DIR[1:], SYSTEMD_START_SCRIPT.split('/')[1]), 0o755)
         shutil.copyfile(LOGROTATE_SCRIPT, os.path.join(build_root, LOGROTATE_DIR[1:], "influxdb"))
         os.chmod(os.path.join(build_root, LOGROTATE_DIR[1:], "influxdb"), 0o644)
         shutil.copyfile(DEFAULT_CONFIG, os.path.join(build_root, CONFIG_DIR[1:], "influxdb.conf"))

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -89,7 +89,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   cp /isrc/scripts/influxdb.service "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
   chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
   cp /isrc/scripts/influxd-systemd-start.sh "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
-  chmod 0744 "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
+  chmod 0755 "$PKG_ROOT/usr/lib/influxdb/scripts/influxd-systemd-start.sh"
 
   # Copy logrotate script.
   cp /isrc/scripts/logrotate "$PKG_ROOT/etc/logrotate.d/influxdb"


### PR DESCRIPTION
Fixes an issue where the systemd service won't start because of incorrect permissions on the script.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass