### PR TITLE
fix: restore portable backup error (#21978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v1.9.4 [unreleased]
 -	[#21890](https://github.com/influxdata/influxdb/pull/21890): chore: update protobuf library versions and remove influx_tsm
 -	[#22011](https://github.com/influxdata/influxdb/pull/22011): feat: SHOW TAG VALUES should produce results from one specific RP
 -	[#21988](https://github.com/influxdata/influxdb/pull/21988): fix: systemd-start script should be executable by group and others
+-	[#21993](https://github.com/influxdata/influxdb/pull/21993): fix: restore portable backup bug
 
 v1.9.3 [unreleased]
 

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -37,6 +37,8 @@ type Service struct {
 	MetaClient interface {
 		encoding.BinaryMarshaler
 		Database(name string) *meta.DatabaseInfo
+		Data() meta.Data
+		SetData(data *meta.Data) error
 	}
 
 	TSDBStore interface {
@@ -116,8 +118,7 @@ func (s *Service) serve() {
 func (s *Service) handleConn(conn net.Conn) error {
 	var typ [1]byte
 
-	_, err := conn.Read(typ[:])
-	if err != nil {
+	if _, err := io.ReadFull(conn, typ[:]); err != nil {
 		return err
 	}
 
@@ -158,8 +159,7 @@ func (s *Service) handleConn(conn net.Conn) error {
 
 func (s *Service) updateShardsLive(conn net.Conn) error {
 	var sidBytes [8]byte
-	_, err := conn.Read(sidBytes[:])
-	if err != nil {
+	if _, err := io.ReadFull(conn, sidBytes[:]); err != nil {
 		return err
 	}
 	sid := binary.BigEndian.Uint64(sidBytes[:])
@@ -182,7 +182,7 @@ func (s *Service) updateMetaStore(conn net.Conn, bits []byte, backupDBName, rest
 		return fmt.Errorf("failed to decode meta: %s", err)
 	}
 
-	data := s.MetaClient.(*meta.Client).Data()
+	data := s.MetaClient.Data()
 
 	IDMap, newDBs, err := data.ImportData(md, backupDBName, restoreDBName, backupRPName, restoreRPName)
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *Service) updateMetaStore(conn net.Conn, bits []byte, backupDBName, rest
 		return err
 	}
 
-	err = s.MetaClient.(*meta.Client).SetData(&data)
+	err = s.MetaClient.SetData(&data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Originally committed by rickif in https://github.com/influxdata/influxdb/pull/20115/files

This is manual copy of the changes to master-1.x

(cherry picked from commit 5bbb61b81525d2958add3d740c737bb707233171)

Closes #21989

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
