### PR TITLE
chore: pin rust version

### DIFF
--- a/releng/raw-binaries/Dockerfile
+++ b/releng/raw-binaries/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
+ENV RUST_VERSION=1.52.1
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION} -y \
   && . $HOME/.cargo/env && rustup target add \
     aarch64-unknown-linux-musl \
     x86_64-apple-darwin \

--- a/releng/source-tarball/Dockerfile
+++ b/releng/source-tarball/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
+ENV RUST_VERSION=1.52.1
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION} -y \
   && . $HOME/.cargo/env && rustup target add \
     aarch64-unknown-linux-musl \
     x86_64-apple-darwin \

--- a/releng/unit-tests/Dockerfile
+++ b/releng/unit-tests/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y \
+ENV RUST_VERSION=1.52.1
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION} -y \
   && . $HOME/.cargo/env && rustup target add \
     aarch64-unknown-linux-musl \
     x86_64-apple-darwin \


### PR DESCRIPTION
Prevent unexpected breakages from rust updates by pinning the rust version

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass