### PR TITLE
fix: copy names from mmapped memory before closing iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 -	[#22006](https://github.com/influxdata/influxdb/pull/22006): fix: old tsl files should be compacted without new writes
 -	[#21947](https://github.com/influxdata/influxdb/pull/21947): fix: prevent silently dropped writes with overlapping shards
 -	[#21978](https://github.com/influxdata/influxdb/pull/21978): fix: restore portable backup bug
+-	[#21999](https://github.com/influxdata/influxdb/pull/21999): fix: copy names from mmapped memory before closing iterator
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1330,7 +1330,8 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.FineAuthorizer, expr influx
 		if err != nil {
 			return nil, err
 		}
-		return slices.CopyChunkedByteSlices(names, 1000), nil
+		// Requires that names is a copy of the names from the mmapped file
+		return names, nil
 	}
 
 	itr, err := is.measurementIterator()
@@ -1462,7 +1463,7 @@ func (is IndexSet) measurementNamesByNameFilter(auth query.FineAuthorizer, op in
 		}
 	}
 	bytesutil.Sort(names)
-	return names, nil
+	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
 // MeasurementNamesByPredicate returns a slice of measurement names matching the
@@ -1479,7 +1480,7 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.FineAuthorizer, expr i
 		if err != nil {
 			return nil, err
 		}
-		return slices.CopyChunkedByteSlices(names, 1000), nil
+		return names, nil
 	}
 
 	itr, err := is.measurementIterator()
@@ -1699,7 +1700,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.FineAuthorizer, op inf
 	}
 
 	bytesutil.Sort(names)
-	return names, nil
+	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
 func (is IndexSet) measurementNamesByTagPredicate(auth query.FineAuthorizer, op influxql.Token, key, val string, regex *regexp.Regexp) ([][]byte, error) {
@@ -1762,7 +1763,7 @@ func (is IndexSet) measurementNamesByTagPredicate(auth query.FineAuthorizer, op 
 	}
 
 	bytesutil.Sort(names)
-	return names, nil
+	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
 // measurementAuthorizedSeries determines if the measurement contains a series


### PR DESCRIPTION
Ensure that when looking up measurement names all
pointers to mmapped memory are copied to heap memory
before the mmapped iterators are closed.

closes https://github.com/influxdata/influxdb/issues/22000

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass