### PR TITLE
fix: old tsl files should be compacted without new writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 -	[#21863](https://github.com/influxdata/influxdb/pull/21863): fix: export example and fix adjacent shards
 -	[#21934](https://github.com/influxdata/influxdb/pull/21934): chore: use community maintained golang-jwt
 -	[#21943](https://github.com/influxdata/influxdb/pull/21943): fix: tsi index should compact old or too-large log files
+-	[#22006](https://github.com/influxdata/influxdb/pull/22006): fix: old tsl files should be compacted without new writes
 -	[#21947](https://github.com/influxdata/influxdb/pull/21947): fix: prevent silently dropped writes with overlapping shards
 -	[#21978](https://github.com/influxdata/influxdb/pull/21978): fix: restore portable backup bug
 


### PR DESCRIPTION
Closes #21942

In addition to previous fixes in #21943 , check during each compaction for if the active log file should be rolled.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr) - https://github.com/influxdata/docs-v2/issues/2959
