### PR TITLE
chore: add metaquery perf tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ workflows:
       - perf_test:
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ workflows:
       - perf_test:
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -124,6 +124,7 @@ force_compaction() {
   # restart daemon
   systemctl unmask influxdb.service
   systemctl start influxdb
+  sleep 1 # allow time for the service to fully initialize?
 }
 
 # Run and record tests
@@ -217,9 +218,9 @@ force_compaction
 
 # Run the query benchmarks
 for query_file in $query_files; do
-  format=$(echo $query_file | cut -d '-' -f3,4,5)
+  format=$(echo $query_file | cut -d '-' -f9)
   format=${format%.txt}
-  cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {is_metaquery: true, branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-$scale_seed_string-format-$format.json
+  cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {is_metaquery: true, branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-$scale_string-format-$format.json
 done
 
 # clean up the DB before exiting

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -222,7 +222,7 @@ for query_file in $query_files; do
   format=$(echo $query_file | cut -d '-' -f9)
   format=${format%.txt}
   query_type=$(echo $query_file | cut -d '-' -f7,8)
-  cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {use_case: \"metaquery\", query_type: \"${query_type}\", branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-$scale_string-format-$format.json
+  cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {use_case: \"metaquery\", query_type: \"${query_type}\", branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-$query_type-$scale_string-format-$format.json
 done
 
 # clean up the DB before exiting

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -170,8 +170,7 @@ done
 # series.
 scale_var=1000
 
-# How many queries to generate. Not particularly relevant right now since the
-# queries are all the same.
+# How many queries to generate.
 queries=100
 
 # The time range controls both the span over which data is generated, and the
@@ -183,7 +182,7 @@ end="2020-01-01T00:00:00Z"
 
 # How long to run the query phase of the benchmarks. It's best to specify a
 # duration to limit the maximum amount of time the queries can run for these,
-# since the queries can take a very long time.
+# since individual queries can take a long time to run.
 duration=30s
 
 # Generate data
@@ -209,7 +208,7 @@ cat ${DATASET_DIR}/$data_fname | $GOPATH/bin/bulk_load_influx $load_opts > /dev/
 
 force_compaction
 
-# Run the queries
+# Run the query benchmarks
 for query_file in $query_files; do
   format=$(echo $query_file | cut -d '-' -f3,4,5)
   format=${format%.txt}

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -25,7 +25,7 @@ cat << EOF > /etc/telegraf/telegraf.conf
   urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   token = "${DB_TOKEN}"
   organization = "${CLOUD2_ORG}"
-  bucket = "temp_bucket"
+  bucket = "${CLOUD2_BUCKET}"
 
 [[inputs.file]]
   files = ["$working_dir/*.json"]

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -25,7 +25,7 @@ cat << EOF > /etc/telegraf/telegraf.conf
   urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   token = "${DB_TOKEN}"
   organization = "${CLOUD2_ORG}"
-  bucket = "${CLOUD2_BUCKET}"
+  bucket = "temp_bucket"
 
 [[inputs.file]]
   files = ["$working_dir/*.json"]

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -221,7 +221,7 @@ cat ${DATASET_DIR}/$data_fname | $GOPATH/bin/bulk_load_influx $load_opts > /dev/
 for query_file in $query_files; do
   format=$(echo $query_file | cut -d '-' -f9)
   format=${format%.txt}
-  query_type=$(echo $query_file | cut -d '-' -f7,8))
+  query_type=$(echo $query_file | cut -d '-' -f7,8)
   cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {use_case: \"metaquery\", query_type: \"${query_type}\", branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-$scale_string-format-$format.json
 done
 

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -44,7 +44,6 @@ cat << EOF > /etc/telegraf/telegraf.conf
   tag_keys = [
     "i_type",
     "query_format",
-    "is_metaquery",
     "use_case",
     "query_type"
   ]

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -86,10 +86,44 @@ systemctl daemon-reload
 systemctl unmask influxdb.service
 systemctl start influxdb
 
-# Run and record tests
+# Common variables used across all tests
 datestring=$(date +%s)
 seed=$datestring
 db_name="benchmark_db"
+
+# Helper functions containing common logic
+bucket_id() {
+  bucket_id=$(curl -H "Authorization: Token $TEST_TOKEN" "http://${NGINX_HOST}:8086/api/v2/buckets?org=$TEST_ORG" | jq -r ".buckets[] | select(.name | contains(\"$db_name\")).id")
+  echo $bucket_id
+}
+
+clean_db () {
+  delete_response=$(curl -s -o /dev/null -X DELETE -H "Authorization: Token $TEST_TOKEN" "http://${NGINX_HOST}:8086/api/v2/buckets/$(bucket_id)?org=$TEST_ORG" -w %{http_code})
+  if [ $delete_response != "204" ]; then
+    echo "bucket not deleted!"
+    exit 1
+  fi
+}
+
+force_compaction() {
+  # stop daemon and force compaction
+  systemctl stop influxdb
+  set +e
+  shards=$(find /var/lib/influxdb/engine/data/$(bucket_id)/autogen/ -maxdepth 1 -mindepth 1)
+
+  set -e
+  for shard in $shards; do
+    /home/ubuntu/influx_tools compact-shard -force -verbose -path $shard
+  done
+
+  # restart daemon
+  systemctl unmask influxdb.service
+  systemctl start influxdb
+}
+
+# Run and record tests
+
+# General ingest and query tests
 for scale in 50 100 500; do
   # generate bulk data
   scale_string="scalevar-$scale"
@@ -117,20 +151,7 @@ for scale in 50 100 500; do
     # run ingest tests
     cat ${DATASET_DIR}/$data_fname | $GOPATH/bin/bulk_load_influx $load_opts | jq ". += {branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\"}" > $working_dir/test-ingest-$scale_string-batchsize-$batch-workers-$workers.json
 
-    bucket_id=$(curl -H "Authorization: Token $TEST_TOKEN" "http://${NGINX_HOST}:8086/api/v2/buckets?org=$TEST_ORG" | jq -r ".buckets[] | select(.name | contains(\"$db_name\")).id")
-    sleep 1
-    # stop daemon and force compaction
-    systemctl stop influxdb
-    set +e
-    shards=$(find /var/lib/influxdb/engine/data/$bucket_id/autogen/ -maxdepth 1 -mindepth 1)
-    set -e
-    for shard in $shards; do
-      /home/ubuntu/influx_tools compact-shard -force -verbose -path $shard
-    done
-
-    # restart daemon
-    systemctl unmask influxdb.service
-    systemctl start influxdb
+    force_compaction
 
     # run influxql and flux query tests
     for query_file in $query_files; do
@@ -138,14 +159,66 @@ for scale in 50 100 500; do
       cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://localhost:8086 --debug=0 --print-interval=0 --workers=$workers --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-$scale_string-format-$format-workers-$workers.json
     done
 
-    # delete db to start anew
-    delete_response=$(curl -s -o /dev/null -X DELETE -H "Authorization: Token $TEST_TOKEN" "http://${NGINX_HOST}:8086/api/v2/buckets/$bucket_id?org=$TEST_ORG" -w %{http_code})
-    if [ $delete_response != "204" ]; then
-      echo "bucket not deleted!"
-      exit 1
-    fi
+    clean_db
   done
 done
+
+# Metaquery tests
+if true; then
+  # Controls how many data points will be generated. The total number of points
+  # will be scale_var * scale_var, where each point is (approximately) a unique
+  # series.
+  scale_var=1000
+
+  # How many queries to generate. Not particularly relevant right now since the
+  # queries are all the same.
+  queries=100
+
+  # The time range controls both the span over which data is generated, and the
+  # span over which queries will be performed. timestamp-start and timestamp-end
+  # must be provided to both the data generation and query generation commands
+  # and must be the same to ensure that the queries cover the data range.
+  start="2019-01-01T00:00:00Z"
+  end="2020-01-01T00:00:00Z"
+
+  # How long to run the query phase of the benchmarks. It's best to specify a
+  # duration to limit the maximum amount of time the queries can run for these,
+  # since the queries can take a very long time.
+  duration=30s
+
+  # Generate data
+  data_fname="influx-bulk-records-usecase-metaquery.txt"
+  $GOPATH/bin/bulk_data_gen --seed=$seed -use-case metaquery -scale-var $scale_var -timestamp-start $start -timestamp-end $end > ${DATASET_DIR}/$data_fname
+
+  # Generate flux queries for field-keys and tag-values
+  query_files=""
+  for type in field-keys tag-values; do
+    for format in http flux-http; do
+      query_fname="query-metaquery-$type-$format.txt"
+      $GOPATH/bin/bulk_query_gen -use-case metaquery -query-type $type -format influx-$format -timestamp-start $start -timestamp-end $end -queries $queries > ${DATASET_DIR}/$query_fname
+      query_files="$query_files $query_fname"
+    done
+  done
+
+  # Load the data
+  load_opts="-urls=http://${NGINX_HOST}:8086 -do-abort-on-exist=false -do-db-create=true"
+  if [ -z $INFLUXDB2 ] || [ $INFLUXDB2 = true ]; then
+    load_opts="$load_opts -organization=$TEST_ORG -token=$TEST_TOKEN"
+  fi
+  cat ${DATASET_DIR}/$data_fname | $GOPATH/bin/bulk_load_influx $load_opts > /dev/null
+
+  force_compaction
+
+  # Run the queries
+  for query_file in $query_files; do
+    format=$(echo $query_file | cut -d '-' -f3,4,5)
+    format=${format%.txt}
+    cat ${DATASET_DIR}/$query_file | ${GOPATH}/bin/query_benchmarker_influxdb --urls=http://${NGINX_HOST}:8086 --benchmark-duration=$duration --debug=0 --print-interval=0 --json=true --organization=$TEST_ORG --token=$TEST_TOKEN | jq ". += {branch: \"${INFLUXDB_VERSION}\", commit: \"${TEST_COMMIT}\", time: \"$datestring\", i_type: \"${DATA_I_TYPE}\", query_format: \"$format\"}" > $working_dir/test-query-metaquery-format-$format.json
+  done
+
+  # clean up the DB before exiting
+  clean_db
+fi
 
 echo "Using Telegraph to report results from the following files:"
 ls $working_dir


### PR DESCRIPTION
This updates the `run_perftest.sh` script to also run a set of benchmarks to evaluate metaquery performance.

I extracted some of the common logic between the existing set of tests & the metaquery tests into separate functions so that it could be re-used.