### PR TITLE
feat: SHOW TAG VALUES should produce results from one specific RP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v1.9.4 [unreleased]
 -	[#21890](https://github.com/influxdata/influxdb/pull/21890): chore: update protobuf library versions and remove influx_tsm
+-	[#22011](https://github.com/influxdata/influxdb/pull/22011): feat: SHOW TAG VALUES should produce results from one specific RP
 
 v1.9.3 [unreleased]
 

--- a/query/statement_rewriter.go
+++ b/query/statement_rewriter.go
@@ -300,6 +300,7 @@ func rewriteShowTagValuesStatement(stmt *influxql.ShowTagValuesStatement) (influ
 
 	return &influxql.ShowTagValuesStatement{
 		Database:   stmt.Database,
+		Sources:    stmt.Sources,
 		Op:         stmt.Op,
 		TagKeyExpr: stmt.TagKeyExpr,
 		Condition:  condition,

--- a/query/statement_rewriter_test.go
+++ b/query/statement_rewriter_test.go
@@ -302,7 +302,11 @@ func TestRewriteStatement(t *testing.T) {
 		},
 		{
 			stmt: `SHOW TAG VALUES FROM cpu WITH KEY = "region"`,
-			s:    `SHOW TAG VALUES WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
+			s:    `SHOW TAG VALUES FROM cpu WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
+		},
+		{
+			stmt: `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY = "region"`,
+			s:    `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY = region WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
 		},
 		{
 			stmt: `SHOW TAG VALUES WITH KEY != "region"`,

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -8125,28 +8125,34 @@ func TestServer_Query_ShowTagKeys(t *testing.T) {
 
 func TestServer_Query_ShowTagValues(t *testing.T) {
 	t.Parallel()
-	s := OpenServer(NewConfig())
+	conf := NewConfig()
+	s := OpenServer(conf)
 	defer s.Close()
+	rps := []string{"rp0", "rp1", "rp2", "rp3"}
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", NewRetentionPolicySpec("rp0", 1, 0), true); err != nil {
-		t.Fatal(err)
+	writes := [][]string{
+		[]string{
+			fmt.Sprintf(`cpu,host=server01 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`cpu,host=server01,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`cpu,host=server01,region=uswest value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+		},
+		[]string{
+			fmt.Sprintf(`cpu,host=server02,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`gpu,host=server02,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`gpu,host=server03,region=caeast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+		},
+		[]string{
+			fmt.Sprintf(`disk,host=server03,region=caeast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`_,__name__=metric1 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+			fmt.Sprintf(`_,__name__=metric2 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
+		},
 	}
 
-	writes := []string{
-		fmt.Sprintf(`cpu,host=server01 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`cpu,host=server01,region=uswest value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`cpu,host=server01,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`cpu,host=server02,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`gpu,host=server02,region=useast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`gpu,host=server03,region=caeast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`disk,host=server03,region=caeast value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`_,__name__=metric1 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-		fmt.Sprintf(`_,__name__=metric2 value=100 %d`, mustParseTime(time.RFC3339Nano, "2009-11-10T23:00:00Z").UnixNano()),
-	}
-
-	test := NewTest("db0", "rp0")
+	test := NewTest("db0", rps[0])
 	test.writes = Writes{
-		&Write{data: strings.Join(writes, "\n")},
+		&Write{db: test.database(), rp: rps[0], data: strings.Join(writes[0], "\n")},
+		&Write{db: test.database(), rp: rps[1], data: strings.Join(writes[1], "\n")},
+		&Write{db: test.database(), rp: rps[2], data: strings.Join(writes[2], "\n")},
 	}
 
 	test.addQueries([]*Query{
@@ -8306,7 +8312,37 @@ func TestServer_Query_ShowTagValues(t *testing.T) {
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
+		&Query{
+			name:    "show tag values with multiple retention policies",
+			command: `SHOW TAG VALUES FROM ` + rps[0] + `.cpu, ` + rps[1] + `.cpu WITH KEY IN (host, region)`,
+			exp:     `{"results":[{"statement_id":0,"error":"only one retention policy allowed in SHOW TAG VALUES query: \"rp1\", \"rp0\""}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
 	}...)
+
+	// Retention policy filtration of tag values only works on TSI
+	if conf.Data.Index != tsdb.InmemIndexName {
+		test.addQueries([]*Query{
+			&Query{
+				name:    `show tag values from retention policy zero with key in and where does not match the regular expression`,
+				command: `SHOW TAG VALUES FROM ` + rps[0] + `.cpu WITH KEY IN (host, region) WHERE region = 'useast'`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["region","useast"]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    `show tag values from retention policy one with key in and where does not match the regular expression`,
+				command: `SHOW TAG VALUES FROM ` + rps[1] + `.cpu WITH KEY IN (host, region) WHERE region = 'useast'`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server02"],["region","useast"]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    `show tag values from retention policy with key and measurement matches regular expression`,
+				command: `SHOW TAG VALUES FROM ` + rps[1] + `./[cg]pu/ WITH KEY = host`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server02"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+		}...)
+	}
 
 	var once sync.Once
 	for _, query := range test.queries {


### PR DESCRIPTION
Ensure that the Sources field of the ShowTagValuesStatement is
filled in. Then use the sources to limit the retention policies,
and thus the shards from which tag values are collected.

This fix only works on TSI databases; INMEM shards share
indices, so restricting shard indices used does not restrict the
tag values returned.

This will not permit multiple retention policies to be specified in
a query; either all RPs or one are permitted.

Closes https://github.com/influxdata/influxdb/issues/21981

(cherry picked from commit 519e23b86a295e1df964000def6d5ebb23db6987)

Closes https://github.com/influxdata/influxdb/issues/21982

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass