### PR TITLE
chore: update master-1.x changelog to track v1.8.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ v1.9.0 [unreleased]
 -	[#21452](https://github.com/influxdata/influxdb/pull/21452): chore(ae): add more logging
 -	[#21516](https://github.com/influxdata/influxdb/pull/21516): fix: FGA enablement
 
+
+v1.8.8 [2021-08-03]
+-------------------
+
+-	[#21953](https://github.com/influxdata/influxdb/pull/21953): fix: prevent silently dropped writes with overlapping shards
+-	[#21991](https://github.com/influxdata/influxdb/pull/21991): fix: restore portable backup bug
+- [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
+
 v1.8.7 [2021-07-21]
 -------------------
 


### PR DESCRIPTION
Track v1.8.8 release in master-1.x changelog

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass