### PR TITLE
fix: handle https in systemd wrapper, and prevent it from looping forever

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,15 @@ jobs:
             sudo apt-get update && sudo apt-get install -y /home/ubuntu/influxdb.deb
             sudo service influxdb start
             EOF
+            ssh -o "StrictHostKeyChecking=no" ubuntu@$ec2_ip \<< EOF
+            sudo service influxdb stop
+            sudo sed -i 's/  # https-enabled = false/  https-enabled = true/' /etc/influxdb/influxdb.conf
+            sudo sed -i 's|  # https-certificate = "/etc/ssl/influxdb.pem"|  https-certificate = "/etc/ssl/influxdb.crt"|' /etc/influxdb/influxdb.conf
+            sudo sed -i 's|  # https-private-key = ""|  https-private-key = "/etc/ssl/influxdb.key"|' /etc/influxdb/influxdb.conf
+            sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/influxdb.key -out /etc/ssl/influxdb.crt -days 365 -subj /C=US/ST=CA/L=sanfrancisco/O=influxdata/OU=edgeteam/CN=localhost
+            sudo chown influxdb:influxdb /etc/ssl/influxdb.*
+            sudo service influxdb start
+            EOF
       - run:
           name: Terraform destroy
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v1.8.8 [unreleased]
 -	[#21953](https://github.com/influxdata/influxdb/pull/21953): fix: prevent silently dropped writes with overlapping shards
 -	[#21991](https://github.com/influxdata/influxdb/pull/21991): fix: restore portable backup bug
 - [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
+- [#22026](https://github.com/influxdata/influxdb/pull/22026): fix: handle https in systemd wrapper, and prevent it from looping forever
 
 v1.8.7 [2021-07-21]
 -------------------

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -e
-  
+
 /usr/bin/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS &
 PID=$!
 echo $PID > /var/lib/influxdb/influxd.pid
 
 PROTOCOL="http"
 BIND_ADDRESS=$(influxd config | grep -A5 "\[http\]" | grep '^  bind-address' | cut -d ' ' -f5 | tr -d '"')
-HTTPS_ENABLED_FOUND=$(influxd config | grep "https-enabled = true" | sed 's/^ *//g' | cut -d ' ' -f3)
+HTTPS_ENABLED_FOUND=$(influxd config | grep "https-enabled = true" | cut -d ' ' -f5)
 HTTPS_ENABLED=${HTTPS_ENABLED_FOUND:-"false"}
 if [ $HTTPS_ENABLED = "true" ]; then
-  HTTPS_CERT=$(influxd config | grep "https-certificate" | sed 's/^ *//g' | cut -d ' ' -f3 | tr -d '"')
+  HTTPS_CERT=$(influxd config | grep "https-certificate" | cut -d ' ' -f5 | tr -d '"')
   if [ ! -f "${HTTPS_CERT}" ]; then
     echo "${HTTPS_CERT} not found! Exiting..."
     exit 1
@@ -20,7 +20,7 @@ fi
 HOST=${BIND_ADDRESS%%:*}
 HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
-  
+
 set +e
 max_attempts=10
 url="$PROTOCOL://$HOST:$PORT/health"

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -1,17 +1,38 @@
 #!/bin/bash -e
-
+  
 /usr/bin/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS &
-echo $! > /var/lib/influxdb/influxd.pid
+PID=$!
+echo $PID > /var/lib/influxdb/influxd.pid
 
+PROTOCOL="http"
 BIND_ADDRESS=$(influxd config | grep -A5 "\[http\]" | grep '^  bind-address' | cut -d ' ' -f5 | tr -d '"')
+HTTPS_ENABLED_FOUND=$(influxd config | grep "https-enabled = true" | sed 's/^ *//g' | cut -d ' ' -f3)
+HTTPS_ENABLED=${HTTPS_ENABLED_FOUND:-"false"}
+if [ $HTTPS_ENABLED = "true" ]; then
+  HTTPS_CERT=$(influxd config | grep "https-certificate" | sed 's/^ *//g' | cut -d ' ' -f3 | tr -d '"')
+  if [ ! -f "${HTTPS_CERT}" ]; then
+    echo "${HTTPS_CERT} not found! Exiting..."
+    exit 1
+  fi
+  echo "$HTTPS_CERT found"
+  PROTOCOL="https"
+fi
 HOST=${BIND_ADDRESS%%:*}
 HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
-
+  
 set +e
-result=$(curl -s -o /dev/null http://$HOST:$PORT/health -w %{http_code})
+max_attempts=10
+url="$PROTOCOL://$HOST:$PORT/health"
+result=$(curl -k -s -o /dev/null $url -w %{http_code})
 while [ "$result" != "200" ]; do
   sleep 1
-  result=$(curl -s -o /dev/null http://$HOST:$PORT/health -w %{http_code})
+  result=$(curl -k -s -o /dev/null $url -w %{http_code})
+  max_attempts=$(($max_attempts-1))
+  if [ $max_attempts -le 0 ]; then
+    echo "Failed to reach influxdb $PROTOCOL endpoint at $url"
+    exit 1
+  fi
 done
 set -e
+


### PR DESCRIPTION
Closes #21967 

Check for https-enabled in influxdb config. Exit if certificate path does not exist or if 10 attempts have been made to contact the endpoint after startup.

This PR also updates the package install test to include a test of https using a self-signed certificate.
****
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass