### PR TITLE
test: fix order of index teardown

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -575,10 +575,13 @@ func (idx Index) Open() error {
 // Close closes and removes the index directory.
 func (idx *Index) Close() error {
 	defer os.RemoveAll(idx.Path())
+	if err := idx.Index.Close(); err != nil {
+		return err
+	}
 	if err := idx.SeriesFile.Close(); err != nil {
 		return err
 	}
-	return idx.Index.Close()
+	return nil
 }
 
 // Reopen closes and opens the index.


### PR DESCRIPTION
Closes #22054

The recent change to actually test TSI index compaction exposed a test bug where the series file gets torn down before the index.

The index is still compacting:

```
unexpected fault address 0x7f371ca0501f
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f371ca0501f pc=0x8beea0]

goroutine 64 [running]:
runtime.throw(0xc902bd, 0x5)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0004eefe0 sp=0xc0004eefb0 pc=0x439632
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:749 +0x405 fp=0xc0004ef010 sp=0xc0004eefe0 pc=0x44f965
github.com/cespare/xxhash.Sum64(0x7f371ca0501f, 0x5, 0x3fffe1, 0x0)
        /root/go/pkg/mod/github.com/cespare/xxhash@v1.1.0/xxhash_amd64.s:130 +0x160 fp=0xc0004ef018 sp=0xc0004ef010 pc=0x8beea0
github.com/influxdata/influxdb/pkg/rhh.HashKey(0x7f371ca0501f, 0x5, 0x3fffe1, 0xd80f20)
        /root/influxdb/pkg/rhh/rhh.go:238 +0x3f fp=0xc0004ef048 sp=0xc0004ef018 pc=0x9465bf
github.com/influxdata/influxdb/pkg/rhh.(*HashMap).Put(0xc0004f6070, 0x7f371ca0501f, 0x5, 0x3fffe1, 0xb86160, 0x11a0aa8)
        /root/influxdb/pkg/rhh/rhh.go:60 +0x5d fp=0xc0004ef098 sp=0xc0004ef048 pc=0x9455dd
github.com/influxdata/influxdb/tsdb/index/tsi1.(*TagBlockEncoder).EncodeValue(0xc00016a0c0, 0x7f371ca0501f, 0x5, 0x3fffe1, 0xc0000de700, 0xc000414080, 0x0, 0x4)
        /root/influxdb/tsdb/index/tsi1/tag_block.go:618 +0x11d fp=0xc0004ef138 sp=0xc0004ef098 pc=0xae80fd
github.com/influxdata/influxdb/tsdb/index/tsi1.(*LogFile).writeTagsetTo(0xc0001e02d0, 0xd61da0, 0xc0000d4340, 0xc0004f01c8, 0x3, 0xc0004ef440, 0xc0004ef5a0, 0x0, 0x3000107)
        /root/influxdb/tsdb/index/tsi1/log_file.go:960 +0x665 fp=0xc0004ef2e8 sp=0xc0004ef138 pc=0xad3085
github.com/influxdata/influxdb/tsdb/index/tsi1.(*LogFile).writeTagsetsTo(0xc0001e02d0, 0xd61da0, 0xc0000d4340, 0xc000414000, 0x2, 0x2, 0xc0004ef440, 0xc0004ef5a0, 0xc0004ef438, 0x0)
        /root/influxdb/tsdb/index/tsi1/log_file.go:920 +0xa5 fp=0xc0004ef350 sp=0xc0004ef2e8 pc=0xad29a5
github.com/influxdata/influxdb/tsdb/index/tsi1.(*LogFile).CompactTo(0xc0001e02d0, 0xd62e40, 0xc000010008, 0x2000000, 0x6, 0xc000090840, 0x4, 0x0, 0x0)
        /root/influxdb/tsdb/index/tsi1/log_file.go:850 +0x2ce fp=0xc0004ef570 sp=0xc0004ef350 pc=0xad210e
github.com/influxdata/influxdb/tsdb/index/tsi1.(*Partition).compactLogFile(0xc0000a2120, 0xc0001e02d0)
        /root/influxdb/tsdb/index/tsi1/partition.go:1225 +0x6f3 fp=0xc0004effb0 sp=0xc0004ef570 pc=0xae37d3
github.com/influxdata/influxdb/tsdb/index/tsi1.(*Partition).compact.func1(0xc0000a2120, 0xc0001e02d0)
        /root/influxdb/tsdb/index/tsi1/partition.go:984 +0x35 fp=0xc0004effd0 sp=0xc0004effb0 pc=0xaf15d5
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc0004effd8 sp=0xc0004effd0 pc=0x4710e1
created by github.com/influxdata/influxdb/tsdb/index/tsi1.(*Partition).compact
        /root/influxdb/tsdb/index/tsi1/partition.go:983 +0x33f
```

But the series file is being unmapped:
```
syscall.Syscall(0x107, 0xffffffffffffff9c, 0xc0000381c0, 0x200, 0xffffffffffffffff, 0x0, 0x27)
        /usr/local/go/src/syscall/asm_linux_amd64.s:18 +0x5
syscall.unlinkat(0xffffffffffffff9c, 0xc0000d8040, 0x1f, 0x200, 0xd63e40, 0x11a0b48)
        /usr/local/go/src/syscall/zsyscall_linux_amd64.go:126 +0xa5
syscall.Rmdir(...)
        /usr/local/go/src/syscall/syscall_linux.go:172
os.Remove(0xc0000d8040, 0x1f, 0xc000010138, 0xab6a80)
        /usr/local/go/src/os/file_unix.go:284 +0x93
os.removeAll(0xc0000d8040, 0x1f, 0x0, 0x0)
        /usr/local/go/src/os/removeall_at.go:29 +0x14d
os.RemoveAll(0xc0000d8040, 0x1f, 0x0, 0xb015da)
        /usr/local/go/src/os/path.go:67 +0x35
github.com/influxdata/influxdb/tsdb/index/tsi1_test.(*SeriesFile).Close(0xc000010010, 0x0, 0x0)
        /root/influxdb/tsdb/index/tsi1/tsi1_test.go:311 +0xb6
github.com/influxdata/influxdb/tsdb/index/tsi1_test.(*Index).Close(0xc0000a0510, 0x0, 0x0)
        /root/influxdb/tsdb/index/tsi1/index_test.go:578 +0x85
github.com/influxdata/influxdb/tsdb/index/tsi1_test.TestFileSet_SeriesIDIterator(0xc0001ec480)
        /root/influxdb/tsdb/index/tsi1/file_set_test.go:80 +0x99c
testing.tRunner(0xc0001ec480, 0xcbaf38)
        /usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1168 +0x2b3
```

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue) - no changelog for tests
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
