### PR TITLE
fix: error instead of panic when enterprise tries to restore with OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ v1.8.8 [2021-08-03]
 -	[#21991](https://github.com/influxdata/influxdb/pull/21991): fix: restore portable backup bug
 - [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
 - [#22026](https://github.com/influxdata/influxdb/pull/22026): fix: handle https in systemd wrapper, and prevent it from looping forever
-- [#xxxx](https://github.com/influxdata/influxdb/pull/xxxx): fix: error instead of panic when enterprise tries to restore with OSS
+- [#22039](https://github.com/influxdata/influxdb/pull/22039): fix: error instead of panic when enterprise tries to restore with OSS
 
 v1.8.7 [2021-07-21]
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v1.8.8 [2021-08-03]
 -	[#21991](https://github.com/influxdata/influxdb/pull/21991): fix: restore portable backup bug
 - [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
 - [#22026](https://github.com/influxdata/influxdb/pull/22026): fix: handle https in systemd wrapper, and prevent it from looping forever
+- [#xxxx](https://github.com/influxdata/influxdb/pull/xxxx): fix: error instead of panic when enterprise tries to restore with OSS
 
 v1.8.7 [2021-07-21]
 -------------------


### PR DESCRIPTION
Closes #22028

Backport from #22019.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass