### PR TITLE
fix: copy names from mmapped memory before closing iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 -	[#21978](https://github.com/influxdata/influxdb/pull/21978): fix: restore portable backup bug
 -	[#21992](https://github.com/influxdata/influxdb/pull/21992): fix: systemd-start script should be executable by group and others
 -	[#22019](https://github.com/influxdata/influxdb/pull/22019): fix: error instead of panic when enterprise tries to restore with OSS
+-	[#22040](https://github.com/influxdata/influxdb/pull/22040): fix: copy names from mmapped memory before closing iterator
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1012,7 +1012,7 @@ func (itr *fileMeasurementSliceIterator) Close() error {
 
 func newFileMeasurementSliceIterator(names [][]byte, itrs MeasurementIterators) *fileMeasurementSliceIterator {
 	return &fileMeasurementSliceIterator{
-		measurementSliceIterator: measurementSliceIterator {
+		measurementSliceIterator: measurementSliceIterator{
 			names: names,
 		},
 		fileIterators: itrs,
@@ -1392,7 +1392,11 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.FineAuthorizer, expr influx
 		} else if itr == nil {
 			return nil, nil
 		}
-		defer func() { if e := itr.Close(); err == nil { err = e } }()
+		defer func() {
+			if e := itr.Close(); err == nil {
+				err = e
+			}
+		}()
 
 		if names, err := ToSlice(itr); err != nil {
 			return nil, err
@@ -1407,7 +1411,11 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.FineAuthorizer, expr influx
 	} else if itr == nil {
 		return nil, nil
 	}
-	defer func() { if e := itr.Close(); err == nil { err = e } }()
+	defer func() {
+		if e := itr.Close(); err == nil {
+			err = e
+		}
+	}()
 
 	// Iterate over all measurements if no condition exists.
 	for {
@@ -1468,7 +1476,7 @@ func (is IndexSet) measurementNamesByExpr(auth query.FineAuthorizer, expr influx
 
 		case influxql.OR, influxql.AND:
 
-			exprToSlice := func(e influxql.Expr) (slice [][]byte, iterator *fileMeasurementSliceIterator, err error){
+			exprToSlice := func(e influxql.Expr) (slice [][]byte, iterator *fileMeasurementSliceIterator, err error) {
 				mi, err := is.measurementNamesByExpr(auth, e)
 				if err != nil {
 					return nil, nil, err
@@ -1562,7 +1570,11 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.FineAuthorizer, expr i
 			return nil, err
 		}
 		if itr != nil {
-			defer func() { if e := itr.Close(); err == nil { err = e } }()
+			defer func() {
+				if e := itr.Close(); err == nil {
+					err = e
+				}
+			}()
 		}
 		if names, err = ToSlice(itr); err != nil {
 			return nil, err
@@ -1576,7 +1588,11 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.FineAuthorizer, expr i
 	} else if itr == nil {
 		return nil, nil
 	}
-	defer func() { if e := itr.Close(); err == nil { err = e } }()
+	defer func() {
+		if e := itr.Close(); err == nil {
+			err = e
+		}
+	}()
 
 	// Iterate over all measurements if no condition exists.
 	for {
@@ -1636,7 +1652,7 @@ func (is IndexSet) measurementNamesByPredicate(auth query.FineAuthorizer, expr i
 			return is.measurementNamesByTagPredicate(auth, e.Op, tag.Val, value, regex)
 
 		case influxql.OR, influxql.AND:
-			predToSlice := func(e influxql.Expr) (slice [][]byte, iterator *fileMeasurementSliceIterator, err error){
+			predToSlice := func(e influxql.Expr) (slice [][]byte, iterator *fileMeasurementSliceIterator, err error) {
 				mi, err := is.measurementNamesByPredicate(auth, e)
 				if err != nil {
 					return nil, nil, err
@@ -1687,7 +1703,11 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.FineAuthorizer, op inf
 	} else if mitr == nil {
 		return nil, nil
 	}
-	defer func() {if failed { mitr.Close() } }()
+	defer func() {
+		if failed {
+			mitr.Close()
+		}
+	}()
 
 	// valEqual determines if the provided []byte is equal to the tag value
 	// to be filtered on.
@@ -1803,7 +1823,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.FineAuthorizer, op inf
 
 	bytesutil.Sort(names)
 	failed = false
-	return newFileMeasurementSliceIterator(names,MeasurementIterators{mitr}), nil
+	return newFileMeasurementSliceIterator(names, MeasurementIterators{mitr}), nil
 }
 
 func (is IndexSet) measurementNamesByTagPredicate(auth query.FineAuthorizer, op influxql.Token, key, val string, regex *regexp.Regexp) (MeasurementIterator, error) {
@@ -1816,7 +1836,11 @@ func (is IndexSet) measurementNamesByTagPredicate(auth query.FineAuthorizer, op 
 	} else if mitr == nil {
 		return nil, nil
 	}
-	defer func() {if failed { mitr.Close() } }()
+	defer func() {
+		if failed {
+			mitr.Close()
+		}
+	}()
 
 	var checkMeasurement func(auth query.FineAuthorizer, me []byte) (bool, error)
 	switch op {


### PR DESCRIPTION
This fix ensures that memory-mapped files are not released
before pointers into them are copied into heap memory.
MeasurementNamesByExpr() and MeasurementNamesByPredicate() can
cause panics by copying memory from mmapped files that have been
released. The functions they call use iterators to files which
are closed (releasing the mmapped files) before the memory is
safely copied to the heap.

closes https://github.com/influxdata/influxdb/issues/22000

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
