### PR TITLE
feat: update flux components to use flux/array instead of arrow/array…

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -1446,7 +1446,7 @@ func (f *formatter) valueBuf(i, j int, typ flux.ColType, cr flux.ColReader) []by
 		}
 	case flux.TString:
 		if cr.Strings(j).IsValid(i) {
-			buf = []byte(cr.Strings(j).ValueString(i))
+			buf = []byte(cr.Strings(j).Value(i))
 		}
 	case flux.TTime:
 		if cr.Times(j).IsValid(i) {

--- a/flux/stdlib/influxdata/influxdb/to.go
+++ b/flux/stdlib/influxdata/influxdb/to.go
@@ -321,7 +321,7 @@ func (t *ToTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 							Msg:  "Invalid type for tag column",
 						}
 					}
-					kv = append(kv, []byte(col.Label), er.Strings(j).Value(i))
+					kv = append(kv, []byte(col.Label), []byte(er.Strings(j).Value(i)))
 				}
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200923215132-ac86123a3f01
 	github.com/benbjohnson/tmpl v1.0.0
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40
-	github.com/boltdb/bolt v1.3.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8
@@ -19,10 +18,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.5.5
-	github.com/influxdata/flux v0.120.1
+	github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v1.1.1-0.20210223160523-b6ab99450c93
-	github.com/influxdata/pkg-config v0.2.7
+	github.com/influxdata/pkg-config v0.2.8
 	github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jsternberg/zap-logfmt v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -132,7 +132,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bonitoo-io/go-sql-bigquery v0.3.4-1.4.0 h1:MaVh0h9+KaMnJcoDvvIGp+O3fefdWm+8MBUX6ELTJTM=
 github.com/bonitoo-io/go-sql-bigquery v0.3.4-1.4.0/go.mod h1:J4Y6YJm0qTWB9aFziB7cPeSyc6dOZFyJdteSeybVpXQ=
@@ -327,7 +326,6 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -361,7 +359,6 @@ github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
-github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
@@ -380,7 +377,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -462,8 +458,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.65.0/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
-github.com/influxdata/flux v0.120.1 h1:M4x6e25+ao95N98kB65wd59juA+RV7WDhcsYuxL5/6M=
-github.com/influxdata/flux v0.120.1/go.mod h1:pGSAvyAA5d3et7SSzajaYShWYXmnRnJJq2qWi+WWZ2I=
+github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae h1:H6N4SU2birrb4LeTytC2WoC3hYnJTyr4p62QL/t4D/g=
+github.com/influxdata/flux v0.123.1-0.20210729174141-a0db406d1fae/go.mod h1:LMf1amHWjEjWW6K4XgJNfZjpdwTkU1NhxUEsk08614M=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxdb v1.8.0/go.mod h1:SIzcnsjaHRFpmlxpJ4S3NT64qtEKYweNTUMb/vh0OMQ=
@@ -476,8 +472,8 @@ github.com/influxdata/influxql v1.1.1-0.20210223160523-b6ab99450c93/go.mod h1:gH
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/influxdata/pkg-config v0.2.7 h1:LPTCWmcPkyMryHHnf+STK/zVUjQ6OCvvOukSDlJLY9I=
-github.com/influxdata/pkg-config v0.2.7/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.2.8 h1:9B5S+ajCLotPQq4tK7Ez26sZT2djoxZjLaSIJCgjQ4I=
+github.com/influxdata/pkg-config v0.2.8/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6 h1:UzJnB7VRL4PSkUJHwsyzseGOmrO/r4yA+AuxGJxiZmA=
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
@@ -939,7 +935,6 @@ golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1071,7 +1066,6 @@ golang.org/x/tools v0.0.0-20200304024140-c4206d458c3f/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200721032237-77f530d86f9a h1:kVMPw4f6EVqYdfGQTedjrpw1dbE2PEMfw4jwXsNdn9s=
 golang.org/x/tools v0.0.0-20200721032237-77f530d86f9a/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -1156,7 +1150,6 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
-google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -11,8 +11,8 @@ import (
 	"math"
 	"sync"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interval"
@@ -154,7 +154,7 @@ func (t *floatWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -177,8 +177,8 @@ func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -197,8 +197,8 @@ func (t *floatWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -379,7 +379,7 @@ func (t *floatWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.Int64 {
+func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -392,10 +392,10 @@ func (t *floatWindowSelectorTable) startTimes(arr *cursors.FloatArray) *array.In
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int64 {
+func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -408,7 +408,7 @@ func (t *floatWindowSelectorTable) stopTimes(arr *cursors.FloatArray) *array.Int
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -489,12 +489,12 @@ func (t *floatEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewFloat64Array()
+	cr.cols[valueColIdx] = values.NewFloatArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.Float64Builder) *array.Int64 {
+func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.FloatBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -538,10 +538,10 @@ func (t *floatEmptyWindowSelectorTable) startTimes(builder *array.Float64Builder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.Float64Builder) *array.Int64 {
+func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.FloatBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -585,10 +585,10 @@ func (t *floatEmptyWindowSelectorTable) stopTimes(builder *array.Float64Builder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.Float64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.FloatBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -649,7 +649,7 @@ func (t *floatEmptyWindowSelectorTable) startStopTimes(builder *array.Float64Bui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -1131,7 +1131,7 @@ func (t *integerWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -1154,8 +1154,8 @@ func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -1174,8 +1174,8 @@ func (t *integerWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -1356,7 +1356,7 @@ func (t *integerWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *array.Int64 {
+func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -1369,10 +1369,10 @@ func (t *integerWindowSelectorTable) startTimes(arr *cursors.IntegerArray) *arra
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array.Int64 {
+func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -1385,7 +1385,7 @@ func (t *integerWindowSelectorTable) stopTimes(arr *cursors.IntegerArray) *array
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -1466,12 +1466,12 @@ func (t *integerEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewInt64Array()
+	cr.cols[valueColIdx] = values.NewIntArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.Int64Builder) *array.Int64 {
+func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.IntBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -1515,10 +1515,10 @@ func (t *integerEmptyWindowSelectorTable) startTimes(builder *array.Int64Builder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.Int64Builder) *array.Int64 {
+func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.IntBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -1562,10 +1562,10 @@ func (t *integerEmptyWindowSelectorTable) stopTimes(builder *array.Int64Builder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.Int64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.IntBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -1626,7 +1626,7 @@ func (t *integerEmptyWindowSelectorTable) startStopTimes(builder *array.Int64Bui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -2107,7 +2107,7 @@ func (t *unsignedWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -2130,8 +2130,8 @@ func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64,
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -2150,8 +2150,8 @@ func (t *unsignedWindowTable) createNextBufferTimes() (start, stop *array.Int64,
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -2332,7 +2332,7 @@ func (t *unsignedWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *array.Int64 {
+func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -2345,10 +2345,10 @@ func (t *unsignedWindowSelectorTable) startTimes(arr *cursors.UnsignedArray) *ar
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *array.Int64 {
+func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -2361,7 +2361,7 @@ func (t *unsignedWindowSelectorTable) stopTimes(arr *cursors.UnsignedArray) *arr
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -2442,12 +2442,12 @@ func (t *unsignedEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewUint64Array()
+	cr.cols[valueColIdx] = values.NewUintArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.Uint64Builder) *array.Int64 {
+func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.UintBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -2491,10 +2491,10 @@ func (t *unsignedEmptyWindowSelectorTable) startTimes(builder *array.Uint64Build
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.Uint64Builder) *array.Int64 {
+func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.UintBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -2538,10 +2538,10 @@ func (t *unsignedEmptyWindowSelectorTable) stopTimes(builder *array.Uint64Builde
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.Uint64Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.UintBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -2602,7 +2602,7 @@ func (t *unsignedEmptyWindowSelectorTable) startStopTimes(builder *array.Uint64B
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -3082,7 +3082,7 @@ func (t *stringWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -3105,8 +3105,8 @@ func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, o
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -3125,8 +3125,8 @@ func (t *stringWindowTable) createNextBufferTimes() (start, stop *array.Int64, o
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -3307,7 +3307,7 @@ func (t *stringWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.Int64 {
+func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -3320,10 +3320,10 @@ func (t *stringWindowSelectorTable) startTimes(arr *cursors.StringArray) *array.
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.Int64 {
+func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -3336,7 +3336,7 @@ func (t *stringWindowSelectorTable) stopTimes(arr *cursors.StringArray) *array.I
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -3417,12 +3417,12 @@ func (t *stringEmptyWindowSelectorTable) advance() bool {
 		cr.cols[timeColIdx] = time
 	}
 
-	cr.cols[valueColIdx] = values.NewBinaryArray()
+	cr.cols[valueColIdx] = values.NewStringArray()
 	t.appendTags(cr)
 	return true
 }
 
-func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.BinaryBuilder) *array.Int64 {
+func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.StringBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -3466,10 +3466,10 @@ func (t *stringEmptyWindowSelectorTable) startTimes(builder *array.BinaryBuilder
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.BinaryBuilder) *array.Int64 {
+func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.StringBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -3513,10 +3513,10 @@ func (t *stringEmptyWindowSelectorTable) stopTimes(builder *array.BinaryBuilder)
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.BinaryBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.StringBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -3577,7 +3577,7 @@ func (t *stringEmptyWindowSelectorTable) startStopTimes(builder *array.BinaryBui
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table
@@ -4001,7 +4001,7 @@ func (t *booleanWindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -4024,8 +4024,8 @@ func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -4044,8 +4044,8 @@ func (t *booleanWindowTable) createNextBufferTimes() (start, stop *array.Int64, 
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -4226,7 +4226,7 @@ func (t *booleanWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *array.Int64 {
+func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -4239,10 +4239,10 @@ func (t *booleanWindowSelectorTable) startTimes(arr *cursors.BooleanArray) *arra
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array.Int64 {
+func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -4255,7 +4255,7 @@ func (t *booleanWindowSelectorTable) stopTimes(arr *cursors.BooleanArray) *array
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -4341,7 +4341,7 @@ func (t *booleanEmptyWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuilder) *array.Int64 {
+func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuilder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -4385,10 +4385,10 @@ func (t *booleanEmptyWindowSelectorTable) startTimes(builder *array.BooleanBuild
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilder) *array.Int64 {
+func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -4432,10 +4432,10 @@ func (t *booleanEmptyWindowSelectorTable) stopTimes(builder *array.BooleanBuilde
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanBuilder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanBuilder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -4496,7 +4496,7 @@ func (t *booleanEmptyWindowSelectorTable) startStopTimes(builder *array.BooleanB
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -5,8 +5,8 @@ import (
 	"math"
 	"sync"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interval"
@@ -150,7 +150,7 @@ func (t *{{.name}}WindowTable) Do(f func(flux.ColReader) error) error {
 
 // createNextBufferTimes will read the timestamps from the array
 // cursor and construct the values for the next buffer.
-func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64, ok bool) {
+func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int, ok bool) {
 	startB := arrow.NewIntBuilder(t.alloc)
 	stopB := arrow.NewIntBuilder(t.alloc)
 
@@ -173,8 +173,8 @@ func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64
 			startB.Append(startT)
 			stopB.Append(stopT)
 		}
-		start = startB.NewInt64Array()
-		stop = stopB.NewInt64Array()
+		start = startB.NewIntArray()
+		stop = stopB.NewIntArray()
 		return start, stop, true
 	}
 
@@ -193,8 +193,8 @@ func (t *{{.name}}WindowTable) createNextBufferTimes() (start, stop *array.Int64
 		startB.Append(startT)
 		stopB.Append(stopT)
 	}
-	start = startB.NewInt64Array()
-	stop = stopB.NewInt64Array()
+	start = startB.NewIntArray()
+	stop = stopB.NewIntArray()
 	return start, stop, true
 }
 
@@ -375,7 +375,7 @@ func (t *{{.name}}WindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(arr.Len())
 
@@ -388,10 +388,10 @@ func (t *{{.name}}WindowSelectorTable) startTimes(arr *cursors.{{.Name}}Array) *
 			start.Append(windowStart)
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *array.Int64 {
+func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(arr.Len())
 
@@ -404,7 +404,7 @@ func (t *{{.name}}WindowSelectorTable) stopTimes(arr *cursors.{{.Name}}Array) *a
 			stop.Append(windowStop)
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
 // This table implementation may contain empty windows
@@ -490,7 +490,7 @@ func (t *{{.name}}EmptyWindowSelectorTable) advance() bool {
 	return true
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowType}}Builder) *array.Int {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -534,10 +534,10 @@ func (t *{{.name}}EmptyWindowSelectorTable) startTimes(builder *array.{{.ArrowTy
 			break
 		}
 	}
-	return start.NewInt64Array()
+	return start.NewIntArray()
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowType}}Builder) *array.Int64 {
+func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowType}}Builder) *array.Int {
 	stop := arrow.NewIntBuilder(t.alloc)
 	stop.Resize(storage.MaxPointsPerBlock)
 
@@ -581,10 +581,10 @@ func (t *{{.name}}EmptyWindowSelectorTable) stopTimes(builder *array.{{.ArrowTyp
 			break
 		}
 	}
-	return stop.NewInt64Array()
+	return stop.NewIntArray()
 }
 
-func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.ArrowType}}Builder) (*array.Int64, *array.Int64, *array.Int64) {
+func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.ArrowType}}Builder) (*array.Int, *array.Int, *array.Int) {
 	start := arrow.NewIntBuilder(t.alloc)
 	start.Resize(storage.MaxPointsPerBlock)
 
@@ -645,7 +645,7 @@ func (t *{{.name}}EmptyWindowSelectorTable) startStopTimes(builder *array.{{.Arr
 			break
 		}
 	}
-	return start.NewInt64Array(), stop.NewInt64Array(), time.NewInt64Array()
+	return start.NewIntArray(), stop.NewIntArray(), time.NewIntArray()
 }
 
 // group table

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
@@ -165,29 +165,29 @@ func (cr *colReader) Bools(j int) *array.Boolean {
 	return cr.cols[j].(*array.Boolean)
 }
 
-func (cr *colReader) Ints(j int) *array.Int64 {
+func (cr *colReader) Ints(j int) *array.Int {
 	execute.CheckColType(cr.colMeta[j], flux.TInt)
-	return cr.cols[j].(*array.Int64)
+	return cr.cols[j].(*array.Int)
 }
 
-func (cr *colReader) UInts(j int) *array.Uint64 {
+func (cr *colReader) UInts(j int) *array.Uint {
 	execute.CheckColType(cr.colMeta[j], flux.TUInt)
-	return cr.cols[j].(*array.Uint64)
+	return cr.cols[j].(*array.Uint)
 }
 
-func (cr *colReader) Floats(j int) *array.Float64 {
+func (cr *colReader) Floats(j int) *array.Float {
 	execute.CheckColType(cr.colMeta[j], flux.TFloat)
-	return cr.cols[j].(*array.Float64)
+	return cr.cols[j].(*array.Float)
 }
 
-func (cr *colReader) Strings(j int) *array.Binary {
+func (cr *colReader) Strings(j int) *array.String {
 	execute.CheckColType(cr.colMeta[j], flux.TString)
-	return cr.cols[j].(*array.Binary)
+	return cr.cols[j].(*array.String)
 }
 
-func (cr *colReader) Times(j int) *array.Int64 {
+func (cr *colReader) Times(j int) *array.Int {
 	execute.CheckColType(cr.colMeta[j], flux.TTime)
-	return cr.cols[j].(*array.Int64)
+	return cr.cols[j].(*array.Int)
 }
 
 // readTags populates b.tags with the provided tags
@@ -239,37 +239,37 @@ func (t *table) closeDone() {
 	}
 }
 
-func (t *floatTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatGroupTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatWindowSelectorTable) toArrowBuffer(vs []float64) *array.Float64 {
+func (t *floatWindowSelectorTable) toArrowBuffer(vs []float64) *array.Float {
 	return arrow.NewFloat(vs, t.alloc)
 }
-func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float64 {
+func (t *floatWindowTable) mergeValues(intervals []int64) *array.Float {
 	b := arrow.NewFloatBuilder(t.alloc)
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
-	return b.NewFloat64Array()
+	return b.NewFloatArray()
 }
-func (t *floatEmptyWindowSelectorTable) arrowBuilder() *array.Float64Builder {
+func (t *floatEmptyWindowSelectorTable) arrowBuilder() *array.FloatBuilder {
 	return arrow.NewFloatBuilder(t.alloc)
 }
-func (t *floatEmptyWindowSelectorTable) append(builder *array.Float64Builder, v float64) {
+func (t *floatEmptyWindowSelectorTable) append(builder *array.FloatBuilder, v float64) {
 	builder.Append(v)
 }
-func (t *integerTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerWindowSelectorTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerWindowSelectorTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int64 {
+func (t *integerGroupTable) toArrowBuffer(vs []int64) *array.Int {
 	return arrow.NewInt(vs, t.alloc)
 }
-func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
+func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int {
 	b := arrow.NewIntBuilder(t.alloc)
 	b.Resize(len(intervals))
 	appendNull := b.AppendNull
@@ -277,55 +277,55 @@ func (t *integerWindowTable) mergeValues(intervals []int64) *array.Int64 {
 		appendNull = func() { b.Append(*t.fillValue) }
 	}
 	t.appendValues(intervals, b.Append, appendNull)
-	return b.NewInt64Array()
+	return b.NewIntArray()
 }
-func (t *integerEmptyWindowSelectorTable) arrowBuilder() *array.Int64Builder {
+func (t *integerEmptyWindowSelectorTable) arrowBuilder() *array.IntBuilder {
 	return arrow.NewIntBuilder(t.alloc)
 }
-func (t *integerEmptyWindowSelectorTable) append(builder *array.Int64Builder, v int64) {
+func (t *integerEmptyWindowSelectorTable) append(builder *array.IntBuilder, v int64) {
 	builder.Append(v)
 }
-func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedGroupTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedWindowSelectorTable) toArrowBuffer(vs []uint64) *array.Uint64 {
+func (t *unsignedWindowSelectorTable) toArrowBuffer(vs []uint64) *array.Uint {
 	return arrow.NewUint(vs, t.alloc)
 }
-func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint64 {
+func (t *unsignedWindowTable) mergeValues(intervals []int64) *array.Uint {
 	b := arrow.NewUintBuilder(t.alloc)
 	b.Resize(len(intervals))
 	t.appendValues(intervals, b.Append, b.AppendNull)
-	return b.NewUint64Array()
+	return b.NewUintArray()
 }
-func (t *unsignedEmptyWindowSelectorTable) arrowBuilder() *array.Uint64Builder {
+func (t *unsignedEmptyWindowSelectorTable) arrowBuilder() *array.UintBuilder {
 	return arrow.NewUintBuilder(t.alloc)
 }
-func (t *unsignedEmptyWindowSelectorTable) append(builder *array.Uint64Builder, v uint64) {
+func (t *unsignedEmptyWindowSelectorTable) append(builder *array.UintBuilder, v uint64) {
 	builder.Append(v)
 }
-func (t *stringTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringGroupTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringGroupTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringWindowSelectorTable) toArrowBuffer(vs []string) *array.Binary {
+func (t *stringWindowSelectorTable) toArrowBuffer(vs []string) *array.String {
 	return arrow.NewString(vs, t.alloc)
 }
-func (t *stringWindowTable) mergeValues(intervals []int64) *array.Binary {
+func (t *stringWindowTable) mergeValues(intervals []int64) *array.String {
 	b := arrow.NewStringBuilder(t.alloc)
 	b.Resize(len(intervals))
-	t.appendValues(intervals, b.AppendString, b.AppendNull)
-	return b.NewBinaryArray()
+	t.appendValues(intervals, b.Append, b.AppendNull)
+	return b.NewStringArray()
 }
-func (t *stringEmptyWindowSelectorTable) arrowBuilder() *array.BinaryBuilder {
+func (t *stringEmptyWindowSelectorTable) arrowBuilder() *array.StringBuilder {
 	return arrow.NewStringBuilder(t.alloc)
 }
-func (t *stringEmptyWindowSelectorTable) append(builder *array.BinaryBuilder, v string) {
-	builder.AppendString(v)
+func (t *stringEmptyWindowSelectorTable) append(builder *array.StringBuilder, v string) {
+	builder.Append(v)
 }
 func (t *booleanTable) toArrowBuffer(vs []bool) *array.Boolean {
 	return arrow.NewBool(vs, t.alloc)

--- a/storage/flux/tags_cache_test.go
+++ b/storage/flux/tags_cache_test.go
@@ -79,7 +79,7 @@ func TestTagsCache_GetTags_Concurrency(t *testing.T) {
 				l := rand.Intn(128) + 1
 				vs := cache.GetTag(value, l, mem)
 				for i := 0; i < l; i++ {
-					if want, got := value, vs.ValueString(i); want != got {
+					if want, got := value, vs.Value(i); want != got {
 						t.Errorf("unexpected value in array: %s != %s", want, got)
 						vs.Release()
 						return

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/values"

--- a/storage/reads/types.tmpldata
+++ b/storage/reads/types.tmpldata
@@ -3,25 +3,25 @@
 		"Name":"Float",
 		"name":"float",
 		"Type":"float64",
-		"ArrowType":"Float64"
+		"ArrowType":"Float"
 	},
 	{
 		"Name":"Integer",
 		"name":"integer",
 		"Type":"int64",
-		"ArrowType":"Int64"
+		"ArrowType":"Int"
 	},
 	{
 		"Name":"Unsigned",
 		"name":"unsigned",
 		"Type":"uint64",
-		"ArrowType":"Uint64"
+		"ArrowType":"Uint"
 	},
 	{
 		"Name":"String",
 		"name":"string",
 		"Type":"string",
-		"ArrowType":"Binary"
+		"ArrowType":"String"
 	},
 	{
 		"Name":"Boolean",


### PR DESCRIPTION
… (#21979)

Closes #22031

This updates the flux integration to use the `flux/array` package rather
than directly using the `arrow/array` package.

Flux recently switched to wrapping the array types from arrow and
creating its own array package to be used for table columns instead of
directly referencing the arrow package. This allows us to keep a
consistent interface, but potentially change internal implementations
without changing downstream consumers. Most recently, the
`*array.String` type has some of its own optimizations for certain array
patterns.

This change updates the flux integration to use the new API.

(cherry picked from commit 8fae484a668f96321515a5ecbd01facd7aa46c3e)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue) https://github.com/influxdata/influxdb/issues/22042
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
