### PR TITLE
feat: add subscription buffer size usage metric (#22020)

### DIFF
--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -25,6 +25,7 @@ const (
 	statCreateFailures = "createFailures"
 	statPointsWritten  = "pointsWritten"
 	statWriteFailures  = "writeFailures"
+	statMemUsage       = "memUsage"
 )
 
 // WriteRequest is a parsed write request.
@@ -240,9 +241,12 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	totalSize := int64(0)
 	for _, cw := range s.subs {
 		statistics = append(statistics, cw.Statistics(tags)...)
+		totalSize += atomic.LoadInt64(&cw.queueSize)
 	}
+	statistics[0].Values[statMemUsage] = totalSize
 
 	return statistics
 }


### PR DESCRIPTION
Closes #22027

(cherry picked from commit 733a6b42457507a27ec96c209dcb90653950b919)


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue) https://github.com/influxdata/influxdb/issues/22042
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
