### PR TITLE
build: re-add branch as a tag in perftest results

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -43,7 +43,8 @@ cat << EOF > /etc/telegraf/telegraf.conf
   json_time_format = "unix"
   tag_keys = [
     "i_type",
-    "query_format"
+    "query_format",
+    "branch"
   ]
 EOF
 systemctl restart telegraf


### PR DESCRIPTION
I suspect that the cardinality explosion we saw before was due to including `commit` as a tag, and that `branch` should be safe. Using `branch` as a tag will make writing queries in our results dashboard a lot easier.