### PR TITLE
test: fix order of index teardown (#22038)

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -559,10 +559,13 @@ func (idx Index) Open() error {
 // Close closes and removes the index directory.
 func (idx *Index) Close() error {
 	defer os.RemoveAll(idx.Path())
+	if err := idx.Index.Close(); err != nil {
+		return err
+	}
 	if err := idx.SeriesFile.Close(); err != nil {
 		return err
 	}
-	return idx.Index.Close()
+	return nil
 }
 
 // Reopen closes and opens the index.


### PR DESCRIPTION
Closes #22055

(cherry picked from commit 444c22b67d425dbd23d8b71690effcfe8cbcba58)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue) - no changelog for test fix
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
