### PR TITLE
fix: copy names from mmapped memory before closing iterator (#22040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [21946](https://github.com/influxdata/influxdb/pull/21946): Prevent silently dropped writes when there are overlapping shards.
 1. [21950](https://github.com/influxdata/influxdb/pull/21950): Invalid requests to /api/v2 subroutes now return 404 instead of a list of links.
 1. [21962](https://github.com/influxdata/influxdb/pull/21962): Flux metaqueries for `_field` take fast path if `_measurement` is the only predicate.
+1. [22059](https://github.com/influxdata/influxdb/pull/22059): Copy names from mmapped memory before closing iterator
 
 ## v2.0.7 [2021-06-04]
 

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1388,7 +1388,7 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
-func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
+func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) (MeasurementSliceIterator, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -1457,7 +1457,7 @@ func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.E
 }
 
 // measurementNamesByNameFilter returns matching measurement names in sorted order.
-func (is IndexSet) measurementNamesByNameFilter(auth query.Authorizer, op influxql.Token, val string, regex *regexp.Regexp) ([][]byte, error) {
+func (is IndexSet) measurementNamesByNameFilter(auth query.Authorizer, op influxql.Token, val string, regex *regexp.Regexp) (MeasurementSliceIterator, error) {
 	itr, err := is.measurementIterator()
 	if err != nil {
 		return nil, err
@@ -1550,7 +1550,7 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.Authorizer, expr influ
 	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
-func (is IndexSet) measurementNamesByPredicate(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
+func (is IndexSet) measurementNamesByPredicate(auth query.Authorizer, expr influxql.Expr) (MeasurementSliceIterator, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -1617,7 +1617,7 @@ func (is IndexSet) measurementNamesByPredicate(auth query.Authorizer, expr influ
 	}
 }
 
-func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) ([][]byte, error) {
+func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) (MeasurementSliceIterator, error) {
 	var names [][]byte
 	failed := true
 
@@ -1750,7 +1750,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 	return newFileMeasurementSliceIterator(names, MeasurementIterators{mitr}), nil
 }
 
-func (is IndexSet) measurementNamesByTagPredicate(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) ([][]byte, error) {
+func (is IndexSet) measurementNamesByTagPredicate(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) (MeasurementSliceIterator, error) {
 	var names [][]byte
 	failed := true
 

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -962,6 +962,11 @@ func (a MeasurementIterators) Close() (err error) {
 	return err
 }
 
+type MeasurementSliceIterator interface {
+	MeasurementIterator
+	UnderlyingSlice() [][]byte
+}
+
 type measurementSliceIterator struct {
 	names [][]byte
 }
@@ -979,6 +984,37 @@ func (itr *measurementSliceIterator) Next() (name []byte, err error) {
 	}
 	name, itr.names = itr.names[0], itr.names[1:]
 	return name, nil
+}
+
+func (itr *measurementSliceIterator) UnderlyingSlice() [][]byte {
+	return itr.names
+}
+
+// fileMeasurementSliceIterator is designed to allow a tag value slice
+// iterator to use memory from a memory-mapped file, pinning it
+// with the underlying file iterators
+type fileMeasurementSliceIterator struct {
+	measurementSliceIterator
+	fileIterators MeasurementIterators
+}
+
+func (itr *fileMeasurementSliceIterator) Close() error {
+	e1 := itr.fileIterators.Close()
+	e2 := itr.measurementSliceIterator.Close()
+	if e1 != nil {
+		return e1
+	} else {
+		return e2
+	}
+}
+
+func newFileMeasurementSliceIterator(names [][]byte, itrs MeasurementIterators) *fileMeasurementSliceIterator {
+	return &fileMeasurementSliceIterator{
+		measurementSliceIterator: measurementSliceIterator{
+			names: names,
+		},
+		fileIterators: itrs,
+	}
 }
 
 // MergeMeasurementIterators returns an iterator that merges a set of iterators.
@@ -1307,11 +1343,18 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		names, err := is.measurementNamesByExpr(auth, expr)
+		itr, err := is.measurementNamesByExpr(auth, expr)
 		if err != nil {
 			return nil, err
+		} else if itr == nil {
+			return nil, nil
 		}
-		return slices.CopyChunkedByteSlices(names, 1000), nil
+		defer func() {
+			if e := itr.Close(); err == nil {
+				err = e
+			}
+		}()
+		return slices.CopyChunkedByteSlices(itr.UnderlyingSlice(), 1000), nil
 	}
 
 	itr, err := is.measurementIterator()
@@ -1320,10 +1363,14 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 	} else if itr == nil {
 		return nil, nil
 	}
-	defer itr.Close()
+	defer func() {
+		if e := itr.Close(); err == nil {
+			err = e
+		}
+	}()
 
-	// Iterate over all measurements if no condition exists.
 	var names [][]byte
+	// Iterate over all measurements if no condition exists.
 	for {
 		e, err := itr.Next()
 		if err != nil {
@@ -1381,20 +1428,22 @@ func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.E
 			return is.measurementNamesByTagFilter(auth, e.Op, tag.Val, value, regex)
 
 		case influxql.OR, influxql.AND:
+
 			lhs, err := is.measurementNamesByExpr(auth, e.LHS)
 			if err != nil {
 				return nil, err
 			}
-
 			rhs, err := is.measurementNamesByExpr(auth, e.RHS)
 			if err != nil {
+				lhs.Close()
 				return nil, err
 			}
 
+			mis := MeasurementIterators{lhs, rhs}
 			if e.Op == influxql.OR {
-				return bytesutil.Union(lhs, rhs), nil
+				return newFileMeasurementSliceIterator(bytesutil.Union(lhs.UnderlyingSlice(), rhs.UnderlyingSlice()), mis), nil
 			}
-			return bytesutil.Intersect(lhs, rhs), nil
+			return newFileMeasurementSliceIterator(bytesutil.Intersect(lhs.UnderlyingSlice(), rhs.UnderlyingSlice()), mis), nil
 
 		default:
 			return nil, fmt.Errorf("invalid tag comparison operator")
@@ -1415,12 +1464,12 @@ func (is IndexSet) measurementNamesByNameFilter(auth query.Authorizer, op influx
 	} else if itr == nil {
 		return nil, nil
 	}
-	defer itr.Close()
 
 	var names [][]byte
 	for {
 		e, err := itr.Next()
 		if err != nil {
+			itr.Close()
 			return nil, err
 		} else if e == nil {
 			break
@@ -1443,7 +1492,7 @@ func (is IndexSet) measurementNamesByNameFilter(auth query.Authorizer, op influx
 		}
 	}
 	bytesutil.Sort(names)
-	return names, nil
+	return newFileMeasurementSliceIterator(names, MeasurementIterators{itr}), nil
 }
 
 // MeasurementNamesByPredicate returns a slice of measurement names matching the
@@ -1456,11 +1505,18 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.Authorizer, expr influ
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		names, err := is.measurementNamesByPredicate(auth, expr)
+		itr, err := is.measurementNamesByPredicate(auth, expr)
 		if err != nil {
 			return nil, err
 		}
-		return slices.CopyChunkedByteSlices(names, 1000), nil
+		if itr != nil {
+			defer func() {
+				if e := itr.Close(); err == nil {
+					err = e
+				}
+			}()
+		}
+		return slices.CopyChunkedByteSlices(itr.UnderlyingSlice(), 1000), nil
 	}
 
 	itr, err := is.measurementIterator()
@@ -1469,10 +1525,14 @@ func (is IndexSet) MeasurementNamesByPredicate(auth query.Authorizer, expr influ
 	} else if itr == nil {
 		return nil, nil
 	}
-	defer itr.Close()
+	defer func() {
+		if e := itr.Close(); err == nil {
+			err = e
+		}
+	}()
 
-	// Iterate over all measurements if no condition exists.
 	var names [][]byte
+	// Iterate over all measurements if no condition exists.
 	for {
 		e, err := itr.Next()
 		if err != nil {
@@ -1534,16 +1594,17 @@ func (is IndexSet) measurementNamesByPredicate(auth query.Authorizer, expr influ
 			if err != nil {
 				return nil, err
 			}
-
 			rhs, err := is.measurementNamesByPredicate(auth, e.RHS)
 			if err != nil {
+				lhs.Close()
 				return nil, err
 			}
+			mis := MeasurementIterators{lhs, rhs}
 
 			if e.Op == influxql.OR {
-				return bytesutil.Union(lhs, rhs), nil
+				return newFileMeasurementSliceIterator(bytesutil.Union(lhs.UnderlyingSlice(), rhs.UnderlyingSlice()), mis), nil
 			}
-			return bytesutil.Intersect(lhs, rhs), nil
+			return newFileMeasurementSliceIterator(bytesutil.Intersect(lhs.UnderlyingSlice(), rhs.UnderlyingSlice()), mis), nil
 
 		default:
 			return nil, fmt.Errorf("invalid tag comparison operator")
@@ -1558,6 +1619,7 @@ func (is IndexSet) measurementNamesByPredicate(auth query.Authorizer, expr influ
 
 func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) ([][]byte, error) {
 	var names [][]byte
+	failed := true
 
 	mitr, err := is.measurementIterator()
 	if err != nil {
@@ -1565,7 +1627,11 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 	} else if mitr == nil {
 		return nil, nil
 	}
-	defer mitr.Close()
+	defer func() {
+		if failed {
+			mitr.Close()
+		}
+	}()
 
 	// valEqual determines if the provided []byte is equal to the tag value
 	// to be filtered on.
@@ -1680,11 +1746,13 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 	}
 
 	bytesutil.Sort(names)
-	return names, nil
+	failed = false
+	return newFileMeasurementSliceIterator(names, MeasurementIterators{mitr}), nil
 }
 
 func (is IndexSet) measurementNamesByTagPredicate(auth query.Authorizer, op influxql.Token, key, val string, regex *regexp.Regexp) ([][]byte, error) {
 	var names [][]byte
+	failed := true
 
 	mitr, err := is.measurementIterator()
 	if err != nil {
@@ -1692,7 +1760,11 @@ func (is IndexSet) measurementNamesByTagPredicate(auth query.Authorizer, op infl
 	} else if mitr == nil {
 		return nil, nil
 	}
-	defer mitr.Close()
+	defer func() {
+		if failed {
+			mitr.Close()
+		}
+	}()
 
 	var checkMeasurement func(auth query.Authorizer, me []byte) (bool, error)
 	switch op {
@@ -1743,7 +1815,8 @@ func (is IndexSet) measurementNamesByTagPredicate(auth query.Authorizer, op infl
 	}
 
 	bytesutil.Sort(names)
-	return names, nil
+	failed = false
+	return newFileMeasurementSliceIterator(names, MeasurementIterators{mitr}), nil
 }
 
 // measurementAuthorizedSeries determines if the measurement contains a series


### PR DESCRIPTION
This fix ensures that memory-mapped files are not released
before pointers into them are copied into heap memory.
MeasurementNamesByExpr() and MeasurementNamesByPredicate() can
cause panics by copying memory from mmapped files that have been
released. The functions they call use iterators to files which
are closed (releasing the mmapped files) before the memory is
safely copied to the heap.

closes https://github.com/influxdata/influxdb/issues/22000

(cherry picked from commit a989f8f8b6fc453c85075e5ae73033d5bd036e21)

Closes https://github.com/influxdata/influxdb/issues/22002

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass