### PR TITLE
Update influxd-systemd-start.sh

### DIFF
--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -23,11 +23,12 @@ PORT=${BIND_ADDRESS##*:}
 
 set +e
 max_attempts=10
+max_time=2
 url="$PROTOCOL://$HOST:$PORT/health"
-result=$(curl -k -s -o /dev/null $url -w %{http_code})
+result=$(curl --max-time ${max_time} -k -s -o /dev/null $url -w %{http_code})
 while [ "$result" != "200" ]; do
   sleep 1
-  result=$(curl -k -s -o /dev/null $url -w %{http_code})
+  result=$(curl --max-time ${max_time} -k -s -o /dev/null $url -w %{http_code})
   max_attempts=$(($max_attempts-1))
   if [ $max_attempts -le 0 ]; then
     echo "Failed to reach influxdb $PROTOCOL endpoint at $url"


### PR DESCRIPTION
Adding a timeout to the curl test command on systemd startup.  There is a race condition where influx is not up, but curl has started. curl can block on the initial failure long enough for systemd to restart the process.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
