### PR TITLE
fix: Increase loop length for making sure influx is up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ v1.8.8 [unreleased]
 - [#21987](https://github.com/influxdata/influxdb/pull/21987): fix: systemd-startup script should be executable by group and others
 - [#22026](https://github.com/influxdata/influxdb/pull/22026): fix: handle https in systemd wrapper, and prevent it from looping forever
 - [#22039](https://github.com/influxdata/influxdb/pull/22039): fix: error instead of panic when enterprise tries to restore with OSS
+- [#22075](https://github.com/influxdata/influxdb/pull/22075): fix: Increase loop length for making sure influx is up
 
 v1.8.7 [2021-07-21]
 -------------------

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -22,11 +22,11 @@ HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
 
 set +e
-max_attempts=10
+max_attempts=12
 url="$PROTOCOL://$HOST:$PORT/health"
 result=$(curl -k -s -o /dev/null $url -w %{http_code})
 while [ "$result" != "200" ]; do
-  sleep 1
+  sleep 5
   result=$(curl -k -s -o /dev/null $url -w %{http_code})
   max_attempts=$(($max_attempts-1))
   if [ $max_attempts -le 0 ]; then


### PR DESCRIPTION
With the current script, a large database doesn't have time to finish starting up in the 10 seconds alotted by this script.  This causes the service to fail to start up, and systemd to sit looping forever.

This PR increases the sleep value to 5 seconds, and the max_attempts to 12, meaning the script will attempt to connect for up to 1 minute before giving up.

Part of #21967 

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created [provide link to issue/pr](https://github.com/influxdata/influxdb/issues/21967#issuecomment-894228696)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
