### PR TITLE
build: revert renaming of influxd-only release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,9 +61,9 @@ nfpms:
           amd64: x86_64
           arm64: aarch64
           armhf: armv7hl
-        file_name_template: "influxdb2-server-nightly.{{ .Arch }}"
+        file_name_template: "influxdb2-nightly.{{ .Arch }}"
       deb:
-        file_name_template: "influxdb2-server-nightly-{{ .Arch }}"
+        file_name_template: "influxdb2-nightly-{{ .Arch }}"
     vendor: InfluxData
     homepage: https://influxdata.com
     maintainer: support@influxdb.com
@@ -77,7 +77,7 @@ archives:
       - goos: windows
         format: zip
     wrap_in_directory: true
-    name_template: "influxdb2-server-nightly-{{ .Os }}-{{ .Arch }}"
+    name_template: "influxdb2-nightly-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -89,7 +89,7 @@ blobs:
     folder: "platform/nightlies/"
 
 checksum:
-  name_template: "influxdb2-server-nightly.sha256"
+  name_template: "influxdb2-nightly.sha256"
   algorithm: sha256
 
 dockers:

--- a/scripts/ci/perf_test.sh
+++ b/scripts/ci/perf_test.sh
@@ -44,7 +44,7 @@ done
 trap "aws --region us-west-2 ec2 terminate-instances --instance-ids $ec2_instance_id" KILL
 
 # push binary and script to instance
-debname=$(find /tmp/workspace/artifacts/influxdb2-server*amd64.deb)
+debname=$(find /tmp/workspace/artifacts/influxdb2*amd64.deb)
 base_debname=$(basename $debname)
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Closes #22077

@jdstrand warned that changing the file names here breaks some conventions, and could cause problems with other tooling in the packaging ecosystem. Revert back to the names we used before splitting out the CLI.