### PR TITLE
build: revert renaming of influxd-only release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,9 +112,9 @@ nfpms:
           amd64: x86_64
           arm64: aarch64
           armhf: armv7hl
-        file_name_template: "influxdb2-server-{{ .Version }}.{{ .Arch }}"
+        file_name_template: "influxdb2-{{ .Version }}.{{ .Arch }}"
       deb:
-        file_name_template: "influxdb2-server-{{ .Version }}-{{ .Arch }}"
+        file_name_template: "influxdb2-{{ .Version }}-{{ .Arch }}"
     vendor: InfluxData
     homepage: https://influxdata.com
     maintainer: support@influxdb.com

--- a/scripts/ci/perf_test.sh
+++ b/scripts/ci/perf_test.sh
@@ -44,7 +44,7 @@ done
 trap "aws --region us-west-2 ec2 terminate-instances --instance-ids $ec2_instance_id" KILL
 
 # push binary and script to instance
-debname=$(find /tmp/workspace/artifacts/influxdb2-server*amd64.deb)
+debname=$(find /tmp/workspace/artifacts/influxdb2*amd64.deb)
 base_debname=$(basename $debname)
 source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Closes #22078 

Backports #22086

The diff isn't clean because only the deb & rpm got renamed on 2.0, since the old CLI code is still being built & included in the raw archives.