### PR TITLE
fix: hard limit on field size while parsing line protocol (#21843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v1.9.4 [unreleased]
 -	[#22046](https://github.com/influxdata/influxdb/pull/22046): fix: export example and fix adjacent shards
 -	[#22048](https://github.com/influxdata/influxdb/pull/22048): fix: error instead of panic when enterprise tries to restore with OSS
 -	[#22067](https://github.com/influxdata/influxdb/pull/22067): fix: old tsl files should be compacted without new writes
+-	[#22095](https://github.com/influxdata/influxdb/pull/22095): fix: hard limit on field size while parsing line protocol
 
 
 v1.9.3 [unreleased]

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	// Enables unicode validation on series keys on write.
 	ValidateKeys bool `toml:"validate-keys"`
 
+	// When true, skips size validation on fields
+	SkipFieldSizeValidation bool `toml:"skip-field-size-validation"`
+
 	// Enables strict error handling. For example, forces SELECT INTO to err out on INF values.
 	StrictErrorHandling bool `toml:"strict-error-handling"`
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -186,9 +186,8 @@ type EngineOptions struct {
 	// nil will allow all combinations to pass.
 	ShardFilter func(database, rp string, id uint64) bool
 
-	Config         Config
-	SeriesIDSets   SeriesIDSets
-	FieldValidator FieldValidator
+	Config       Config
+	SeriesIDSets SeriesIDSets
 
 	OnNewEngine func(Engine)
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -159,9 +159,6 @@ type Shard struct {
 func NewShard(id uint64, path string, walPath string, sfile *SeriesFile, opt EngineOptions) *Shard {
 	db, rp := decodeStorePath(path)
 	logger := zap.NewNop()
-	if opt.FieldValidator == nil {
-		opt.FieldValidator = defaultFieldValidator{}
-	}
 
 	s := &Shard{
 		id:      id,
@@ -660,7 +657,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point, tracker StatsTrac
 		mf := engine.MeasurementFields(name)
 
 		// Check with the field validator.
-		if err := s.options.FieldValidator.Validate(mf, p); err != nil {
+		if err := ValidateFields(mf, p, s.options.Config.SkipFieldSizeValidation); err != nil {
 			switch err := err.(type) {
 			case PartialWriteError:
 				if reason == "" {


### PR DESCRIPTION
Per https://docs.influxdata.com/enterprise_influxdb/v1.9/write_protocols/line_protocol_reference/
we only support 64KB, but 1MB is a more realistic practical limit. Before this commit there was
no enforcement of field value size.

Closes #22094

(cherry picked from commit 6d22e69ef178abfeb546c736e367312989bbd49e)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
