### PR TITLE
chore: set rust version to the same as latest tag from flux (#21996)

### DIFF
--- a/scripts/ci/install-rust.sh
+++ b/scripts/ci/install-rust.sh
@@ -2,8 +2,12 @@
 
 set -ex
 
+flux_dir=$(go list -m -f '{{.Dir}}' github.com/influxdata/flux)
+FLUX_RUST_VERSION=$(cat ${flux_dir}/Dockerfile_build | grep 'FROM rust:' | cut -d ' ' -f2 | cut -d ':' -f2)
+RUST_LATEST_VERSION=${FLUX_RUST_VERSION:-1.53}
+cd ..
+rm -rf flux-repo
 
-RUST_LATEST_VERSION=1.52.1
 # For security, we specify a particular rustup version and a SHA256 hash, computed
 # ourselves and hardcoded here. When updating `RUSTUP_LATEST_VERSION`:
 #   1. Download the new rustup script from https://github.com/rust-lang/rustup/releases.


### PR DESCRIPTION
Closes #22053 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass