### PR TITLE
feat: upgrade UI to v2.0.8, `flux-lsp-browser` to v0.5.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Because of the version bump to `go`, the macOS build for this release requires a
 1. [21922](https://github.com/influxdata/influxdb/pull/21922): Add `--ui-disabled` option to `influxd` to allow for running with the UI disabled.
 1. [21969](https://github.com/influxdata/influxdb/pull/21969): Telemetry improvements: Do not record telemetry data for non-existant paths; replace invalid static asset paths with a slug.
 1. [22098](https://github.com/influxdata/influxdb/pull/22098): Upgrade Flux to v0.124.0.
+1. [22101](https://github.com/influxdata/influxdb/pull/22101): Upgrade UI to [v2.0.8](https://github.com/influxdata/ui/releases/tag/OSS-v2.0.8).
+1. [22101](https://github.com/influxdata/influxdb/pull/22101): Upgrade `flux-lsp-browser` to v0.5.53.
 
 ### Bug Fixes
 

--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -21,10 +21,10 @@ declare -r STATIC_DIR="$ROOT_DIR/static"
 # Download the SHA256 checksum attached to the release. To verify the integrity
 # of the download, this checksum will be used to check the download tar file
 # containing the built UI assets.
-curl -Ls https://github.com/influxdata/ui/releases/download/OSS-v2.0.7/sha256.txt --output sha256.txt
+curl -Ls https://github.com/influxdata/ui/releases/download/OSS-v2.0.8/sha256.txt --output sha256.txt
 
 # Download the tar file containing the built UI assets.
-curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.7/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.8/build.tar.gz --output build.tar.gz
 
 # Verify the checksums match; exit if they don't.
 echo "$(cat sha256.txt)" | sha256sum --check -- \


### PR DESCRIPTION
Closes #22080

Updates the pinned UI release version. The latest UI release uses the latest `flux-lsp-browser`.