### PR TITLE
fix: ensure log formatting (JSON) is respected (#22106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ v1.9.4 [unreleased]
 -	[#22048](https://github.com/influxdata/influxdb/pull/22048): fix: error instead of panic when enterprise tries to restore with OSS
 -	[#22067](https://github.com/influxdata/influxdb/pull/22067): fix: old tsl files should be compacted without new writes
 -	[#22095](https://github.com/influxdata/influxdb/pull/22095): fix: hard limit on field size while parsing line protocol
-
+-	[#22107](https://github.com/influxdata/influxdb/pull/22107): fix: ensure log formatting (JSON) is respected
 
 v1.9.3 [unreleased]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -636,7 +636,7 @@ func (s *Server) startProfile() error {
 			return err
 		}
 
-		log.Printf("Writing CPU profile to: %s\n", s.CPUProfile)
+		s.Logger.Info("writing CPU profile", zap.String("location", s.CPUProfile))
 	}
 
 	if s.MemProfile != "" {
@@ -648,7 +648,7 @@ func (s *Server) startProfile() error {
 		s.MemProfileWriteCloser = f
 		runtime.MemProfileRate = 4096
 
-		log.Printf("Writing mem profile to: %s\n", s.MemProfile)
+		s.Logger.Info("writing mem profile", zap.String("location", s.MemProfile))
 	}
 
 	return nil
@@ -661,7 +661,7 @@ func (s *Server) stopProfile() error {
 		if err := s.CPUProfileWriteCloser.Close(); err != nil {
 			return err
 		}
-		log.Println("CPU profile stopped")
+		s.Logger.Info("CPU profile stopped")
 	}
 
 	if s.MemProfileWriteCloser != nil {
@@ -669,7 +669,7 @@ func (s *Server) stopProfile() error {
 		if err := s.MemProfileWriteCloser.Close(); err != nil {
 			return err
 		}
-		log.Println("mem profile stopped")
+		s.Logger.Info("mem profile stopped")
 	}
 
 	return nil


### PR DESCRIPTION
Replace usage of the Go log package with the zap
logger and respect the formatting specified in
the configuration file.

closes https://github.com/influxdata/influxdb/issues/22104

(cherry picked from commit 0315d2ede106c18dc2b54172b569990ecb0fd3f8)

closes https://github.com/influxdata/influxdb/issues/22105

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass