### PR TITLE
fix: for low-end hardware

### DIFF
--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -22,7 +22,7 @@ HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
 
 set +e
-max_attempts=10
+max_attempts=60
 url="$PROTOCOL://$HOST:$PORT/health"
 result=$(curl -k -s -o /dev/null $url -w %{http_code})
 while [ "$result" != "200" ]; do


### PR DESCRIPTION
On eg. a Raspberry Pi the startup takes more than 25 seconds.

Closes #22004 #21967

Increased max attempts to 60, just to give it a reasonable amount of time.