### PR TITLE
fix: longer retry to support low-end hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 v1.8.10 [unreleased]
 -------------------
 
+- [#22109](https://github.com/influxdata/influxdb/pull/22109): fix: longer retry to support low-end hardware
+
 v1.8.9 [2021-08-04]
 -------------------
 

--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -22,7 +22,7 @@ HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
 
 set +e
-max_attempts=10
+max_attempts=60
 url="$PROTOCOL://$HOST:$PORT/health"
 result=$(curl -k -s -o /dev/null $url -w %{http_code})
 while [ "$result" != "200" ]; do


### PR DESCRIPTION
On eg. a Raspberry Pi the startup takes more than 25 seconds.

Closes partial #22004 and #21967

Increased max attempts to 60, just to give it a reasonable amount of time.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
