### PR TITLE
chore: fix dump_tsm test missing flag

### DIFF
--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -201,6 +201,7 @@ func makeTSMFile(t *testing.T, params tsmParams) (string, string) {
 	for _, key := range params.keys {
 		values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 		require.NoError(t, w.Write([]byte(key), values))
+		require.NoError(t, w.Flush())
 	}
 	if len(params.keys) != 0 {
 		require.NoError(t, w.WriteIndex())

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -171,7 +171,7 @@ func makeArgs(path string, meas string) (args map[string][]string) {
 	args[argsKeys[1]] = []string{"--file", path, "--blocks"}
 	args[argsKeys[2]] = []string{"--file", path, "--all"}
 	if meas != "" {
-		args[argsKeys[3]] = []string{"--file", path, "--filter-key", meas}
+		args[argsKeys[3]] = []string{"--file", path, "--filter-key", meas, "--all"}
 	}
 	return
 }


### PR DESCRIPTION
This PR should fix the issue with dump_tsm tests failing in CI reported by @danxmoran 

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass