### PR TITLE
build: include query-format in EC2 perftest instance names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ parameters:
   aws_teardown_datestring:
     default: "n/a"
     type: string
+  aws_teardown_query_format:
+    default: "n/a"
+    type: string
 
 workflows:
   version: 2
@@ -625,7 +628,7 @@ jobs:
           no_output_timeout: 20m
           command: |
             set -x
-            name=oss-perftest-<< pipeline.parameters.aws_teardown_datestring >>-<< pipeline.parameters.aws_teardown_branch >>-<< pipeline.parameters.aws_teardown_sha >>
+            name=oss-perftest-<< pipeline.parameters.aws_teardown_datestring >>-<< pipeline.parameters.aws_teardown_branch >>-<< pipeline.parameters.aws_teardown_sha >>-<< pipeline.parameters.aws_teardown_query_format >>
             instance_id=$(AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 describe-instances --filters "Name=tag:Name,Values=$name" --query 'Reservations[].Instances[].InstanceId' --output text)
             AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 terminate-instances --instance-ids $instance_id
 

--- a/scripts/ci/perf_test.sh
+++ b/scripts/ci/perf_test.sh
@@ -22,7 +22,7 @@ instance_info=$(aws --region us-west-2 ec2 run-instances \
   --key-name circleci-oss-test \
   --security-group-ids sg-03004366a38eccc97 \
   --subnet-id subnet-0c079d746f27ede5e \
-  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=oss-perftest-$datestring-${CIRCLE_BRANCH}-${CIRCLE_SHA1}}]")
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=oss-perftest-$datestring-${CIRCLE_BRANCH}-${CIRCLE_SHA1}-${TEST_FORMAT}}]")
 
 # get instance info
 ec2_instance_id=$(echo $instance_info | jq -r .Instances[].InstanceId)

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -24,7 +24,7 @@ cleanup() {
       --url https://circleci.com/api/v2/project/github/influxdata/influxdb/pipeline \
       --header "Circle-Token: ${CIRCLE_TOKEN}" \
       --header 'content-type: application/json' \
-      --data "{\"branch\":\"${INFLUXDB_VERSION}\", \"parameters\":{\"aws_teardown\": true, \"aws_teardown_branch\":\"${INFLUXDB_VERSION}\", \"aws_teardown_sha\":\"${TEST_COMMIT}\", \"aws_teardown_datestring\":\"${CIRCLE_TEARDOWN_DATESTRING}\"}}"
+      --data "{\"branch\":\"${INFLUXDB_VERSION}\", \"parameters\":{\"aws_teardown\": true, \"aws_teardown_branch\":\"${INFLUXDB_VERSION}\", \"aws_teardown_sha\":\"${TEST_COMMIT}\", \"aws_teardown_datestring\":\"${CIRCLE_TEARDOWN_DATESTRING}\", \"aws_teardown_query_format\":\"${TEST_FORMAT}\"}}"
   fi
 }
 trap "cleanup" EXIT KILL


### PR DESCRIPTION
Follow-up to #22118

Prevent naming collisions when a single commit launches multiple perf-test VMs