### PR TITLE
fix: do not update queue stats if compaction has locked files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 -	[#22019](https://github.com/influxdata/influxdb/pull/22019): fix: error instead of panic when enterprise tries to restore with OSS
 -	[#22040](https://github.com/influxdata/influxdb/pull/22040): fix: copy names from mmapped memory before closing iterator
 -	[#22106](https://github.com/influxdata/influxdb/pull/22106): fix: ensure log formatting (JSON) is respected
+-	[#22140](https://github.com/influxdata/influxdb/pull/22140): fix: do not update queue stats if compaction has locked files
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -98,6 +98,7 @@ type CompactionPlanner interface {
 	// ForceFull causes the planner to return a full compaction plan the next
 	// time Plan() is called if there are files that could be compacted.
 	ForceFull()
+	IsFull() bool
 
 	SetFileStore(fs *FileStore)
 }
@@ -231,6 +232,12 @@ func (c *DefaultPlanner) ForceFull() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.forceFull = true
+}
+
+func (c *DefaultPlanner) IsFull() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.forceFull
 }
 
 // PlanLevel returns a set of TSM files to rewrite for a specific level.

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2878,6 +2878,7 @@ func (m *mockPlanner) PlanOptimize() []tsm1.CompactionGroup            { return 
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)           {}
 func (m *mockPlanner) FullyCompacted() (bool, string)                  { return false, "not compacted" }
 func (m *mockPlanner) ForceFull()                                      {}
+func (m *mockPlanner) IsFull() bool                                    { return false }
 func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore)                 {}
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.


### PR DESCRIPTION
When the compaction planner runs, if it cannot acquire
a lock on the files it plans to compact, it returns a
nil list of compaction groups. This, in turn, sets the
engine statistics for compaction queues to zero,
which is incorrect.

closes https://github.com/influxdata/influxdb/issues/22138

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass