### PR TITLE
chore: remove some flaky checks from `dump_tsm_test`

### DIFF
--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -96,7 +96,6 @@ func Test_DumpTSM_ManyKeys(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			[]string{"cpu", "foobar", "mem", "float64"},
 		),
 	})
 }
@@ -113,8 +112,6 @@ func Test_DumpTSM_FilterKey(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			[]string{"cpu", "foobar", "mem", "float64"},
-			[]string{"Points:\n    Total: 1", "s8b: 1 (33%)", "gor: 1 (33%)"},
 		),
 	})
 }

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -96,7 +96,7 @@ func Test_DumpTSM_ManyKeys(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			// TODO See Issue influxDB/22145
+			// TODO https://github.com/influxdata/influxdb/issues/22145
 			//[]string{"cpu", "foobar", "mem", "float64"},
 		),
 	})
@@ -114,7 +114,7 @@ func Test_DumpTSM_FilterKey(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			// TODO See Issue influxDB/22145
+			// TODO https://github.com/influxdata/influxdb/issues/22145
 			//[]string{"cpu", "foobar", "mem", "float64"},
 			//[]string{"Points:\n    Total: 1", "s8b: 1 (33%)", "gor: 1 (33%)"},
 		),

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -96,6 +96,8 @@ func Test_DumpTSM_ManyKeys(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
+			// See Issue influxDB/22145
+			//[]string{"cpu", "foobar", "mem", "float64"},
 		),
 	})
 }
@@ -112,6 +114,9 @@ func Test_DumpTSM_FilterKey(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
+			// See Issue influxDB/22145
+			//[]string{"cpu", "foobar", "mem", "float64"},
+			//[]string{"Points:\n    Total: 1", "s8b: 1 (33%)", "gor: 1 (33%)"},
 		),
 	})
 }

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -96,7 +96,7 @@ func Test_DumpTSM_ManyKeys(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			// See Issue influxDB/22145
+			// TODO See Issue influxDB/22145
 			//[]string{"cpu", "foobar", "mem", "float64"},
 		),
 	})
@@ -114,7 +114,7 @@ func Test_DumpTSM_FilterKey(t *testing.T) {
 		expectOuts: makeExpectOut(
 			[]string{"Total: 3", "Size: 102"},
 			[]string{"Blocks:", "float64", "s8b/gor", "9/19"},
-			// See Issue influxDB/22145
+			// TODO See Issue influxDB/22145
 			//[]string{"cpu", "foobar", "mem", "float64"},
 			//[]string{"Points:\n    Total: 1", "s8b: 1 (33%)", "gor: 1 (33%)"},
 		),


### PR DESCRIPTION
Removes a couple output checks in a testcase that seems to fail occasionally.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass