### PR TITLE
chore: remove annotations and rangeAnnotations flags

### DIFF
--- a/flags.yml
+++ b/flags.yml
@@ -90,18 +90,3 @@
   expose: true
   lifetime: temporary
 
-- name: Range Annotations
-  description: Enables the creation of Range Annotations on Drag (if annotation write mode is activated)
-  key: rangeAnnotations
-  default: false
-  contact: Jill Pelavin/ Dumplings Team
-  lifetime: temporary
-  expose: true
-
-- name: Annotations UI
-  description: Management, display, and manual addition of Annotations from the UI
-  key: annotations
-  default: true
-  contact: Monitoring Team
-  lifetime: temporary
-  expose: true

--- a/kit/feature/list.go
+++ b/kit/feature/list.go
@@ -156,34 +156,6 @@ func RefreshSingleCell() BoolFlag {
 	return refreshSingleCell
 }
 
-var rangeAnnotations = MakeBoolFlag(
-	"Range Annotations",
-	"rangeAnnotations",
-	"Jill Pelavin/ Dumplings Team",
-	false,
-	Temporary,
-	true,
-)
-
-// RangeAnnotations - Enables the creation of Range Annotations on Drag (if annotation write mode is activated)
-func RangeAnnotations() BoolFlag {
-	return rangeAnnotations
-}
-
-var annotations = MakeBoolFlag(
-	"Annotations UI",
-	"annotations",
-	"Monitoring Team",
-	true,
-	Temporary,
-	true,
-)
-
-// AnnotationsUi - Management, display, and manual addition of Annotations from the UI
-func AnnotationsUi() BoolFlag {
-	return annotations
-}
-
 var all = []Flag{
 	appMetrics,
 	groupWindowAggregateTranspose,
@@ -196,8 +168,6 @@ var all = []Flag{
 	timeFilterFlags,
 	cursorAtEOF,
 	refreshSingleCell,
-	rangeAnnotations,
-	annotations,
 }
 
 var byKey = map[string]Flag{
@@ -212,6 +182,4 @@ var byKey = map[string]Flag{
 	"timeFilterFlags":               timeFilterFlags,
 	"cursorAtEOF":                   cursorAtEOF,
 	"refreshSingleCell":             refreshSingleCell,
-	"rangeAnnotations":              rangeAnnotations,
-	"annotations":                   annotations,
 }


### PR DESCRIPTION
Closes influxdata/ui#2306

Removes the `annotations` and `rangeAnnotations` flags

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
