### PR TITLE
build: add perf test for fast query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -135,6 +135,7 @@ queries=500
 
 # Lines to write per request during ingest
 batch=5000
+
 # Concurrent workers to use during ingest/query
 workers=4
 
@@ -238,6 +239,9 @@ query_types() {
     window-agg|group-agg|bare-agg)
       echo min mean max first last count sum
       ;;
+    iot)
+      echo 1-home-12-hours
+      ;;
     metaquery)
       echo field-keys tag-values
       ;;
@@ -250,8 +254,7 @@ query_types() {
 
 # Generate queries to test.
 query_files=""
-# Aggregate queries
-for usecase in window-agg group-agg bare-agg metaquery; do
+for usecase in window-agg group-agg bare-agg iot metaquery; do
   for type in $(query_types $usecase); do
     query_fname="${TEST_FORMAT}_${usecase}_${type}"
     $GOPATH/bin/bulk_query_gen \


### PR DESCRIPTION
Closes #22147

This adds the existing IoT `1-home-12-hours` query test to the list of benchmarks that are run. As configured, this query runs very fast and takes ~1-2 ms with InfluxQl compared to ~10 ms with flux. See #22147 for the reasoning to do this.