### PR TITLE
build: add perf test for filtered queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -240,7 +240,7 @@ query_types() {
       echo min mean max first last count sum
       ;;
     iot)
-      echo 1-home-12-hours
+      echo 1-home-12-hours light-level-8-hr
       ;;
     metaquery)
       echo field-keys tag-values


### PR DESCRIPTION
Closes #22149

This adds a performance test for queries which just return a filtered set of data, with no additional transformations. Queries like this have been reported as being slower with Flux compared to InfluxQL. Based on the initial results of these tests, it looks like the Flux queries are actually now faster, so this test will help prevent performance regression.

Also see: https://github.com/influxdata/influxdb-comparisons/pull/188 & https://github.com/influxdata/influxdb-comparisons/pull/189