### PR TITLE
build: add perf test for aggregate-keep

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -240,7 +240,7 @@ query_types() {
       echo min mean max first last count sum
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr
+      echo 1-home-12-hours light-level-8-hr aggregate-keep
       ;;
     metaquery)
       echo field-keys tag-values


### PR DESCRIPTION
Related to #18088

This adds performance tests for a set of data where an aggregateWindow function is called, followed by a keep and a mean. This query was orders of magnitude slower in Flux than in InfluxQL originally, but seems to have improved significantly since the original issue was opened.

See also https://github.com/influxdata/influxdb-comparisons/pull/182