### PR TITLE
build: don't include host tag on perf test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,20 +54,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -50,6 +50,7 @@ cat << EOF > /etc/telegraf/telegraf.conf
     "time",
     "use_case"
   ]
+  tagexclude = ["host"]
   json_time_key = "time"
   json_time_format = "unix"
   tag_keys = [
@@ -72,6 +73,7 @@ cat << EOF > /etc/telegraf/telegraf.conf
     "time",
     "use_case"
   ]
+  tagexclude = ["host"]
   json_time_key = "time"
   json_time_format = "unix"
   tag_keys = [


### PR DESCRIPTION
Closes #22180

This is a simple adjustment to prevent the `host` tag from being included with the perf test results, to prevent unbounded growth in cardinality.