### PR TITLE
test: expose tcpaddr for enterprise tests (#22172)

### DIFF
--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -43,10 +43,6 @@ func TestServer_BackupAndRestore(t *testing.T) {
 		s := OpenServer(config)
 		defer s.Close()
 
-		if _, ok := s.(*RemoteServer); ok {
-			t.Skip("Skipping.  Cannot modify remote server config")
-		}
-
 		if err := s.CreateDatabaseAndRetentionPolicy(db, NewRetentionPolicySpec(rp, 1, 0), true); err != nil {
 			t.Fatal(err)
 		}

--- a/tests/server_concurrent_test.go
+++ b/tests/server_concurrent_test.go
@@ -22,10 +22,6 @@ func TestConcurrentServer_WriteValues(t *testing.T) {
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Not implemented on remote server")
-	}
-
 	// The first %%d becomes a %d once fmt is done, so we can then inject new
 	// measurement names later on.
 	write := strings.Join([]string{
@@ -53,10 +49,6 @@ func TestConcurrentServer_TagValues(t *testing.T) {
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
-
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Not implemented on remote server")
-	}
 
 	write := strings.Join([]string{
 		fmt.Sprintf(`a,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
@@ -112,10 +104,6 @@ func TestConcurrentServer_ShowMeasurements(t *testing.T) {
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
-
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Not implemented on remote server")
-	}
 
 	write := strings.Join([]string{
 		fmt.Sprintf(`a,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),

--- a/tests/server_delete_test.go
+++ b/tests/server_delete_test.go
@@ -131,10 +131,6 @@ func TestServer_DELETE_DROP_SERIES_DROP_MEASUREMENT(t *testing.T) {
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping. Not implemented on remote server")
-	}
-
 	localServer := s.(*LocalServer)
 
 	// First initialize some writes such that we end up with 10 shards.

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -333,10 +333,6 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 	s := OpenServer(c)
 	defer s.Close()
 
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping. Cannot alter auto create rp remotely")
-	}
-
 	test := tests.load(t, "retention_policy_commands")
 
 	// Create a database.
@@ -425,10 +421,6 @@ func TestServer_ShowDatabases_WithAuth(t *testing.T) {
 	c.HTTPD.AuthEnabled = true
 	s := OpenServer(c)
 	defer s.Close()
-
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Cannot enable auth on remote server")
-	}
 
 	adminParams := map[string][]string{"u": []string{"admin"}, "p": []string{"admin"}}
 	readerParams := map[string][]string{"u": []string{"reader"}, "p": []string{"r"}}
@@ -1279,10 +1271,6 @@ func TestServer_Query_MaxSelectSeriesN(t *testing.T) {
 	config.Coordinator.MaxSelectSeriesN = 3
 	s := OpenServer(config)
 	defer s.Close()
-
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Cannot modify MaxSelectSeriesN remotely")
-	}
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -9324,10 +9312,6 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Cannot restart remote server")
-	}
-
 	writes := []string{
 		fmt.Sprintf(`cpu value=100 %d`, models.MaxNanoTime),
 	}
@@ -9424,9 +9408,6 @@ func TestServer_ConcurrentPointsWriter_Subscriber(t *testing.T) {
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
-	if _, ok := s.(*RemoteServer); ok {
-		t.Skip("Skipping.  Cannot access PointsWriter remotely")
-	}
 	// goroutine to write points
 	done := make(chan struct{})
 	var wg sync.WaitGroup

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -342,6 +342,8 @@ func (s *Shard) Open() error {
 		}
 
 		// Load metadata index for the inmem index only.
+		// If the shard already has data, this is what loads the series ids into the series file, even
+		// if we are on TSI indexing.
 		if err := e.LoadMetadataIndex(s.id, s.index); err != nil {
 			return err
 		}


### PR DESCRIPTION
* docs: update comment for series updates

* fix: expose TCP address for Enterprise test harness

* refactor: remove dead RemoteServer code

(cherry picked from commit fd81373937c5823c7d131f79c733473c82a7aaf1)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
