### PR TITLE
build: add perf test for sorted-pivot

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -242,7 +242,7 @@ query_types() {
       echo min mean max first last count sum
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
       ;;
     metaquery)
       echo field-keys tag-values


### PR DESCRIPTION
Closes #22016 

This adds performance tests to ensure that sorted-pivot pushdown occurs for Flux. Also can be used to catch any regressions in performance, as currently the time difference between Flux and InfluxQL is minimal.

See also https://github.com/influxdata/influxdb-comparisons/pull/190