### PR TITLE
refactor: use updated API in restore service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe
 	github.com/influxdata/flux v0.125.0
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
-	github.com/influxdata/influx-cli/v2 v2.0.0-20210713195937-a69f06b41b45
+	github.com/influxdata/influx-cli/v2 v2.1.1-0.20210813175002-13799e7662c0
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/pkg-config v0.2.8
 	github.com/jmoiron/sqlx v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/influxdata/flux v0.125.0 h1:udS539xvFOwMDhwgtCPvm7K1qtwWOoR/iUJX9S3X6
 github.com/influxdata/flux v0.125.0/go.mod h1:atoyXj60GRia0R6TlRTIuKpcXvK50GGQh4VJ/kcRWws=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
-github.com/influxdata/influx-cli/v2 v2.0.0-20210713195937-a69f06b41b45 h1:81jaYQW3KeukYoKFAJzGQyqVRv49a9wIl2KmyvJmRUo=
-github.com/influxdata/influx-cli/v2 v2.0.0-20210713195937-a69f06b41b45/go.mod h1:xjodigDVNVCkwvJt+ePXI0s5tMPv8rWUA8xJmqsLSTE=
+github.com/influxdata/influx-cli/v2 v2.1.1-0.20210813175002-13799e7662c0 h1:llPYnejbp/s9JkkS2xjSlAsdPKqIAsabhAgiOLV1NHw=
+github.com/influxdata/influx-cli/v2 v2.1.1-0.20210813175002-13799e7662c0/go.mod h1:3KoUqKdsfmm7CREOuWnbYJZbl6j2akSdQUaLctE42so=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 h1:MBLCfcSsUyFPDJp6T7EoHp/Ph3Jkrm4EuUKLD2rUWHg=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=
@@ -923,7 +923,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
 honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=

--- a/http/restore_service.go
+++ b/http/restore_service.go
@@ -59,8 +59,9 @@ const (
 	restoreSqlPath   = prefixRestore + "/sql"
 	restoreShardPath = prefixRestore + "/shards/:shardID"
 
-	restoreBucketPath         = prefixRestore + "/buckets/:bucketID" // Deprecated
-	restoreBucketMetadataPath = prefixRestore + "/bucket-metadata"
+	restoreBucketPath                   = prefixRestore + "/buckets/:bucketID" // Deprecated. Used by 2.0.x clients.
+	restoreBucketMetadataDeprecatedPath = prefixRestore + "/bucket-metadata"   // Deprecated. Used by 2.1.0 of the CLI
+	restoreBucketMetadataPath           = prefixRestore + "/bucketMetadata"
 )
 
 // NewRestoreHandler creates a new handler at /api/v2/restore to receive restore requests.
@@ -78,6 +79,7 @@ func NewRestoreHandler(b *RestoreBackend) *RestoreHandler {
 	h.HandlerFunc(http.MethodPost, restoreKVPath, h.handleRestoreKVStore)
 	h.HandlerFunc(http.MethodPost, restoreSqlPath, h.handleRestoreSqlStore)
 	h.HandlerFunc(http.MethodPost, restoreBucketPath, h.handleRestoreBucket)
+	h.HandlerFunc(http.MethodPost, restoreBucketMetadataDeprecatedPath, h.handleRestoreBucketMetadata)
 	h.HandlerFunc(http.MethodPost, restoreBucketMetadataPath, h.handleRestoreBucketMetadata)
 	h.HandlerFunc(http.MethodPost, restoreShardPath, h.handleRestoreShard)
 

--- a/scripts/fetch-swagger.sh
+++ b/scripts/fetch-swagger.sh
@@ -10,7 +10,7 @@ declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
 declare -r STATIC_DIR="$ROOT_DIR/static"
 
 # Pins the swagger that will be downloaded to a specific commit
-declare -r OPENAPI_SHA=c87a08f832e79bc338a37509028641cda9e1875b
+declare -r OPENAPI_SHA=20706d0876987520eb2c57cfc5364005ad4bcbed
 
 # Don't do a shallow clone since the commit we want might be several commits
 # back; but do only clone the main branch.


### PR DESCRIPTION
The inconsistent form of the API remains (marked as deprecated) since v2.1.0 of the CLI uses it.