### PR TITLE
fix(task): inactive task runs when updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [22186](https://github.com/influxdata/influxdb/pull/22186): Preserve comments in flux queries when saving task definitions
 1. [#22174](https://github.com/influxdata/influxdb/pull/22174): systemd service -- handle 40x and block indefinitely
 1. [#22228](https://github.com/influxdata/influxdb/pull/22228): influxdb2 packages should depend on curl
+1. [#22211](https://github.com/influxdata/influxdb/pull/22211): Prevent scheduling an inactivated tasks after updating it
 
 ## v2.0.7 [2021-06-04]
 

--- a/task/backend/coordinator/coordinator.go
+++ b/task/backend/coordinator/coordinator.go
@@ -130,6 +130,11 @@ func (c *Coordinator) TaskUpdated(ctx context.Context, from, to *taskmodel.Task)
 		return err
 	}
 
+	// if the tasks is already inactive, we don't do anything
+	if to.Status == from.Status && to.Status == string(taskmodel.TaskInactive) {
+		return nil
+	}
+
 	// if disabling the task, release it before schedule update
 	if to.Status != from.Status && to.Status == string(taskmodel.TaskInactive) {
 		if err := c.sch.Release(sid); err != nil && err != taskmodel.ErrTaskNotClaimed {

--- a/task/backend/coordinator/coordinator_test.go
+++ b/task/backend/coordinator/coordinator_test.go
@@ -227,6 +227,15 @@ func Test_Coordinator_Scheduler_Methods(t *testing.T) {
 			},
 		},
 		{
+			name: "TaskUpdated - inactive task is not scheduled",
+			call: func(t *testing.T, c *Coordinator) {
+				if err := c.TaskUpdated(context.Background(), taskTwoInactive, taskTwoInactive); err != nil {
+					t.Errorf("expected nil error found %q", err)
+				}
+			},
+			scheduler: &schedulerC{},
+		},
+		{
 			name: "TaskDeleted",
 			call: func(t *testing.T, c *Coordinator) {
 				if err := c.TaskDeleted(context.Background(), runOne.ID); err != nil {


### PR DESCRIPTION
Closes #21874

When a tasks is being updated, ensure is scheduled only when the tasks status is active. Otherwise, an already-inactivated tasks might be scheduled if the task status is not being changed. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
