### PR TITLE
build: add iot usecase tests to 1.8

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -233,6 +233,9 @@ query_types() {
     metaquery)
       echo field-keys tag-values
       ;;
+    iot)
+      echo aggregate-keep light-level-8-hr sorted-pivot
+      ;;
     *)
       echo "unknown use-case: $1"
       exit 1
@@ -243,7 +246,7 @@ query_types() {
 # Generate queries to test.
 query_files=""
 # Aggregate queries
-for usecase in window-agg group-agg bare-agg metaquery; do
+for usecase in window-agg group-agg bare-agg metaquery iot; do
   for type in $(query_types $usecase); do
     query_fname="${TEST_FORMAT}_${usecase}_${type}"
     $GOPATH/bin/bulk_query_gen \

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -234,7 +234,7 @@ query_types() {
       echo field-keys tag-values
       ;;
     iot)
-      echo aggregate-keep light-level-8-hr sorted-pivot
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
       ;;
     *)
       echo "unknown use-case: $1"


### PR DESCRIPTION
Adds the `iot` usecase and query-types `aggregate-keep`, `light-level-8-hr`, and `sorted-pivot` to 1.8 to track performance differences between master and 1.8
