### PR TITLE
build: add multi measurement query benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,20 +60,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,20 +60,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -261,7 +261,7 @@ query_types() {
       echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot battery-levels
       ;;
     metaquery)
       echo field-keys tag-values
@@ -269,6 +269,17 @@ query_types() {
     *)
       echo "unknown use-case: $1"
       exit 1
+      ;;
+  esac
+}
+
+query_interval() {
+  case $1 in
+    battery-levels)
+      echo -query-interval=5m
+      ;;
+    *)
+      echo ""
       ;;
   esac
 }
@@ -285,7 +296,8 @@ for usecase in window-agg group-agg bare-agg group-window-transpose iot metaquer
         -timestamp-start=$(start_time $usecase $type) \
         -timestamp-end=$(end_time $usecase $type) \
         -queries=$queries \
-        -scale-var=$scale_var > \
+        -scale-var=$scale_var \
+        $(query_interval $type) > \
       ${DATASET_DIR}/$query_fname
     query_files="$query_files $query_fname"
   done

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -279,6 +279,9 @@ query_interval() {
       echo -query-interval=5m
       ;;
     *)
+      # If a query interval is not matched in the cases above, do not pass this
+      # flag at all to the query generation tool so that the default value from
+      # the query generation tool can be used.
       echo ""
       ;;
   esac


### PR DESCRIPTION
Closes #22216

Adds the queries generated via https://github.com/influxdata/influxdb-comparisons/pull/193 to the performance tests that are automatically run.