### PR TITLE
build: delete duplicate jobs for grace/litmus, update nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,10 +141,10 @@ workflows:
             branches:
               only:
                 - master
-      - litmus_nightly:
+      - litmus_integration:
           requires:
             - deploy_nightly
-      - grace_nightly:
+      - grace_daily:
           requires:
             - deploy_nightly
 
@@ -714,6 +714,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - dist/influxd_linux_amd64/influxd
             - etc/litmus_success_notify.sh
             - etc/litmus_fail_notify.sh
 
@@ -779,38 +780,6 @@ jobs:
           destination: raw-daily-output
       - store_test_results:
           path: ~/project
-
-  litmus_nightly:
-    machine: true
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list -e DOCKERIMAGE=true --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
-      - run:
-          name: Litmus Nightly Tests Success
-          when: on_success
-          command: bash ~/project/etc/litmus_success_notify.sh Nightly
-      - run:
-          name: Litmus Nightly Tests Fail
-          when: on_fail
-          command: bash ~/project/etc/litmus_fail_notify.sh Nightly
-      - store_artifacts:
-          path: ~/project
-          destination: raw-nightly-output
-      - store_test_results:
-          path: ~/project
-
-  grace_nightly:
-    machine: true
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - run: mkdir -p ~/project/results
-      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project/results:/grace/test-results/grace-results -e TEST_RESULTS=~/project/results quay.io/influxdb/grace:latest
-      - store_artifacts:
-          path: ~/project/results
-      - store_test_results:
-          path: ~/project/results
 
   grace_daily:
     machine: true


### PR DESCRIPTION
Ever since #22186, litmus tests have been passing against merges to `master` but failing in our nightly builds. I investigated and found that the way litmus is invoked in the nightly build caused it to pull & test the [`quay.io/influxdb/influxdb2:nightly`](https://github.com/influxdata/litmus-2.0/blob/master/src/cloud/conftest.py#L323) image. This image is:
1. Undocumented
2. Not auto-updated by any process

Rather than pour more energy into litmus, I've updated the nightly workflow to use the same litmus-test process as the workflow that runs per-commit.

I made a similar change for our grace tests because I've noticed they can be flaky in nightly runs, I think because of timing issues when the grace suite tries to launch `influxd` in Docker vs. us launching `influxd` as a pre-step before the tests.