### PR TITLE
chore: pin base Debian image in Docker builds

### DIFF
--- a/docker/flux/Dockerfile
+++ b/docker/flux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:buster-slim
 COPY fluxd /usr/bin/fluxd
 
 EXPOSE 8093

--- a/docker/influxd/Dockerfile
+++ b/docker/influxd/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS dependency-base
+FROM debian:buster-slim AS dependency-base
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Closes #22221.

Pin "buster" in dockerfiles instead of using latest "stable" Debian release, as this seems to be causing problems when fetching from the package archive.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass