### PR TITLE
fix: influxdb-server packages should depend on curl

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,8 @@ nfpms:
       postremove: scripts/post-uninstall.sh
     conflicts:
       - influxdb
+    dependencies:
+      - curl
     recommends:
       - influxdb2-cli
     overrides:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [22059](https://github.com/influxdata/influxdb/pull/22059): Copy names from mmapped memory before closing iterator
 1. [22186](https://github.com/influxdata/influxdb/pull/22186): Preserve comments in flux queries when saving task definitions
 1. [#22174](https://github.com/influxdata/influxdb/pull/22174): systemd service -- handle 40x and block indefinitely
+1. [#22228](https://github.com/influxdata/influxdb/pull/22228): influxdb2 packages should depend on curl
 
 ## v2.0.7 [2021-06-04]
 


### PR DESCRIPTION
Closes #22225 for `master`

The systemd wrapper script uses `curl` so it should be listed as a package dependency.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass