### PR TITLE
fix: influxdb packages should depend on curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 -	[#22283](https://github.com/influxdata/influxdb/pull/22283): fix: require database authorization to see continuous queries
 -	[#22273](https://github.com/influxdata/influxdb/pull/22273): fix: return correct count of ErrNotExecuted
 -	[#22338](https://github.com/influxdata/influxdb/pull/22338): fix: TSI logfile race
+-	[#22229](https://github.com/influxdata/influxdb/pull/22229): fix: influxdb packages should depend on curl bc of use in systemd script
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -127,6 +127,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
       fpm \
         -s dir \
         $typeargs \
+        --depends curl \
         --log error \
         --vendor InfluxData \
         --url "https://influxdata.com" \


### PR DESCRIPTION
Closes #22225 for `master-1.x`

The systemd wrapper script uses curl so it should be listed as a package dependency.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass