### PR TITLE
build: multi-measurement & `group() |> aggregateWindow()` backports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,10 @@ workflows:
           record_ingest_results: true
           requires:
             - build_and_test
-          # filters:
-          #   branches:
-          #     only:
-          #       - "1.8"
+          filters:
+            branches:
+              only:
+                - "1.8"
   aws_destroy_daily:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,10 @@ workflows:
           record_ingest_results: true
           requires:
             - build_and_test
-          filters:
-            branches:
-              only:
-                - "1.8"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "1.8"
   aws_destroy_daily:
     triggers:
       - schedule:

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -255,9 +255,6 @@ query_types() {
     metaquery)
       echo field-keys tag-values
       ;;
-    iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
-      ;;
     *)
       echo "unknown use-case: $1"
       exit 1

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -250,7 +250,7 @@ query_types() {
       echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot battery-levels
       ;;
     metaquery)
       echo field-keys tag-values
@@ -261,6 +261,20 @@ query_types() {
     *)
       echo "unknown use-case: $1"
       exit 1
+      ;;
+  esac
+}
+
+query_interval() {
+  case $1 in
+    battery-levels)
+      echo -query-interval=5m
+      ;;
+    *)
+      # If a query interval is not matched in the cases above, do not pass this
+      # flag at all to the query generation tool so that the default value from
+      # the query generation tool can be used.
+      echo ""
       ;;
   esac
 }
@@ -277,7 +291,8 @@ for usecase in window-agg group-agg bare-agg group-window-transpose iot metaquer
         -timestamp-start=$(start_time $usecase $type) \
         -timestamp-end=$(end_time $usecase $type) \
         -queries=$queries \
-        -scale-var=$scale_var > \
+        -scale-var=$scale_var \
+        $(query_interval $type) > \
       ${DATASET_DIR}/$query_fname
     query_files="$query_files $query_fname"
   done


### PR DESCRIPTION
Closes #22227
Closes #22208

Cherry-pick of 2bf5f8ef3ed3927979f940a475f6d82f6efa2718 (multi-measurement) & d677fa1eebf0e536be22595bb951ac2a1c7843f9 (`group() |> aggregateWindow()`)

This backports the multi-measurement and `group() |> aggregateWindow()` perf tests from `master`. 