### PR TITLE
build: dont run `pkg_run_test` on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ workflows:
           requires:
             - build
       - pkg_run_test:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
           requires:
             - cross_build
       - perf_test:


### PR DESCRIPTION
Closes #22231

This makes it so that `pkg_run_test` will not run on forks, duplicating the filter that the `e2e-monitor-ci` job uses for the same purpose.