### PR TITLE
build: backport current perf tests to 2.0

### DIFF
--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -137,6 +137,7 @@ queries=500
 
 # Lines to write per request during ingest
 batch=5000
+
 # Concurrent workers to use during ingest/query
 workers=4
 
@@ -240,6 +241,9 @@ query_types() {
     window-agg|group-agg|bare-agg)
       echo min mean max first last count sum
       ;;
+    iot)
+      echo 1-home-12-hours
+      ;;
     metaquery)
       echo field-keys tag-values
       ;;
@@ -252,8 +256,7 @@ query_types() {
 
 # Generate queries to test.
 query_files=""
-# Aggregate queries
-for usecase in window-agg group-agg bare-agg metaquery; do
+for usecase in window-agg group-agg bare-agg iot metaquery; do
   for type in $(query_types $usecase); do
     query_fname="${TEST_FORMAT}_${usecase}_${type}"
     $GOPATH/bin/bulk_query_gen \

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -181,6 +181,14 @@ start_time() {
     iot|window-agg|group-agg|bare-agg)
       echo 2018-01-01T00:00:00Z
       ;;
+    group-window-transpose)
+      cardinality=$(echo $2 | cut -d '-' -f2)
+      if [ "$cardinality" = "low" ]; then
+        echo 2018-01-01T00:00:00Z
+      else
+        echo 2019-01-01T00:00:00Z
+      fi
+      ;;
     metaquery)
       echo 2019-01-01T00:00:00Z
       ;;
@@ -194,6 +202,14 @@ end_time() {
   case $1 in
     iot|window-agg|group-agg|bare-agg)
       echo 2018-01-01T12:00:00Z
+      ;;
+    group-window-transpose)
+      cardinality=$(echo $2 | cut -d '-' -f2)
+      if [ "$cardinality" = "low" ]; then
+        echo 2018-01-01T12:00:00Z
+      else
+        echo 2020-01-01T00:00:00Z
+      fi
       ;;
     metaquery)
       echo 2020-01-01T00:00:00Z
@@ -241,6 +257,9 @@ query_types() {
     window-agg|group-agg|bare-agg)
       echo min mean max first last count sum
       ;;
+    group-window-transpose)
+      echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
+      ;;
     iot)
       echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
       ;;
@@ -256,15 +275,15 @@ query_types() {
 
 # Generate queries to test.
 query_files=""
-for usecase in window-agg group-agg bare-agg iot metaquery; do
+for usecase in window-agg group-agg bare-agg group-window-transpose iot metaquery; do
   for type in $(query_types $usecase); do
     query_fname="${TEST_FORMAT}_${usecase}_${type}"
     $GOPATH/bin/bulk_query_gen \
         -use-case=$usecase \
         -query-type=$type \
         -format=influx-${TEST_FORMAT} \
-        -timestamp-start=$(start_time $usecase) \
-        -timestamp-end=$(end_time $usecase) \
+        -timestamp-start=$(start_time $usecase $type) \
+        -timestamp-end=$(end_time $usecase $type) \
         -queries=$queries \
         -scale-var=$scale_var > \
       ${DATASET_DIR}/$query_fname

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -242,7 +242,7 @@ query_types() {
       echo min mean max first last count sum
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
       ;;
     metaquery)
       echo field-keys tag-values

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -37,7 +37,6 @@ cat << EOF > /etc/telegraf/telegraf.conf
   token = "${DB_TOKEN}"
   organization = "${CLOUD2_ORG}"
   bucket = "${CLOUD2_BUCKET}"
-
 [[inputs.file]]
   name_override = "ingest"
   files = ["$working_dir/test-ingest-*.json"]
@@ -58,7 +57,6 @@ cat << EOF > /etc/telegraf/telegraf.conf
     "use_case",
     "branch"
   ]
-
 [[inputs.file]]
   name_override = "query"
   files = ["$working_dir/test-query-*.json"]

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -242,7 +242,7 @@ query_types() {
       echo min mean max first last count sum
       ;;
     iot)
-      echo 1-home-12-hours
+      echo 1-home-12-hours light-level-8-hr
       ;;
     metaquery)
       echo field-keys tag-values

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -261,7 +261,7 @@ query_types() {
       echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot
+      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot battery-levels
       ;;
     metaquery)
       echo field-keys tag-values
@@ -269,6 +269,20 @@ query_types() {
     *)
       echo "unknown use-case: $1"
       exit 1
+      ;;
+  esac
+}
+
+query_interval() {
+  case $1 in
+    battery-levels)
+      echo -query-interval=5m
+      ;;
+    *)
+      # If a query interval is not matched in the cases above, do not pass this
+      # flag at all to the query generation tool so that the default value from
+      # the query generation tool can be used.
+      echo ""
       ;;
   esac
 }
@@ -285,7 +299,8 @@ for usecase in window-agg group-agg bare-agg group-window-transpose iot metaquer
         -timestamp-start=$(start_time $usecase $type) \
         -timestamp-end=$(end_time $usecase $type) \
         -queries=$queries \
-        -scale-var=$scale_var > \
+        -scale-var=$scale_var \
+        $(query_interval $type) > \
       ${DATASET_DIR}/$query_fname
     query_files="$query_files $query_fname"
   done


### PR DESCRIPTION
Closes #22226, #22209, #22178
Backports #22148, #22159, #22175, #22192, #22199, #22217 

This syncs the `run_perftest.sh ` for the `2.0` branch with the `master` branch. With this PR, the two scripts are identical.