### PR TITLE
build: use alterate names for IoT query types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,20 +63,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,20 +63,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -261,7 +261,7 @@ query_types() {
       echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot battery-levels
+      echo fast-query-small-data standalone-filter aggregate-keep sorted-pivot multi-measurement-or
       ;;
     metaquery)
       echo field-keys tag-values
@@ -275,7 +275,7 @@ query_types() {
 
 query_interval() {
   case $1 in
-    battery-levels)
+    multi-measurement-or)
       echo -query-interval=5m
       ;;
     *)


### PR DESCRIPTION
Updates the benchmark perf test script to use the alternate IoT query type names implemented by https://github.com/influxdata/influxdb-comparisons/pull/195