### PR TITLE
build: use alterate names for IoT query types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,10 @@ workflows:
           record_ingest_results: true
           requires:
             - build_and_test
-          # filters:
-          #   branches:
-          #     only:
-          #       - "1.8"
+          filters:
+            branches:
+              only:
+                - "1.8"
   aws_destroy_daily:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,10 @@ workflows:
           record_ingest_results: true
           requires:
             - build_and_test
-          filters:
-            branches:
-              only:
-                - "1.8"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "1.8"
   aws_destroy_daily:
     triggers:
       - schedule:

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -250,7 +250,7 @@ query_types() {
       echo min-high-card mean-high-card max-high-card first-high-card last-high-card count-high-card sum-high-card min-low-card mean-low-card max-low-card first-low-card last-low-card count-low-card sum-low-card
       ;;
     iot)
-      echo 1-home-12-hours light-level-8-hr aggregate-keep sorted-pivot battery-levels
+      echo fast-query-small-data standalone-filter aggregate-keep sorted-pivot multi-measurement-or
       ;;
     metaquery)
       echo field-keys tag-values
@@ -264,7 +264,7 @@ query_types() {
 
 query_interval() {
   case $1 in
-    battery-levels)
+    multi-measurement-or)
       echo -query-interval=5m
       ;;
     *)


### PR DESCRIPTION
Backports #22244

Updates the benchmark perf test script to use the alternate IoT query type names that are more descriptive of the type of query