### PR TITLE
fix: influxdb packages should depend on curl

### DIFF
--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -127,6 +127,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
       fpm \
         -s dir \
         $typeargs \
+        --depends curl \
         --log error \
         --vendor InfluxData \
         --url "https://influxdata.com" \


### PR DESCRIPTION
Closes #22225 for `1.9`.

The systemd wrapper script uses curl so it should be listed as a package dependency.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass