### PR TITLE
fix: influxdb packages should depend on curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v1.8.10 [unreleased]
 -------------------
 
 - [#22076](https://github.com/influxdata/influxdb/pull/22076): fix: systemd service -- handle 40x and block indefinitely
+- [#22253](https://github.com/influxdata/influxdb/pull/22253): fix: influxdb packages should depend on curl
 
 v1.8.9 [2021-08-04]
 -------------------

--- a/build.py
+++ b/build.py
@@ -727,7 +727,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                                 package_arch = "armv7hl"
                             elif package_arch == "arm64":
                                 package_arch = "aarch64"
-                        fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} ".format(
+                        fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} --depends curl ".format(
                             fpm_common_args,
                             name,
                             package_arch,

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -126,6 +126,7 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
       fpm \
         -s dir \
         $typeargs \
+        --depends curl \
         --log error \
         --vendor InfluxData \
         --url "https://influxdata.com" \


### PR DESCRIPTION
Closes #22225 for `1.8`.

The systemd wrapper script uses curl so it should be listed as a package dependency.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass