### PR TITLE
fix: migrate all-access tokens to grant notebook/annotation permissions

### DIFF
--- a/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens.go
+++ b/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens.go
@@ -46,9 +46,7 @@ var Migration0017_AddAnnotationsNotebooksToAllAccessTokens = UpOnlyMigration(
 			return err
 		}
 
-		// Go through the list of operator tokens found and update their permissions
-		// list. There should be only 1, but if there are somehow more this will
-		// update all of them.
+		// Go through the list of all-access tokens found and update their permissions list.
 		for _, t := range tokens {
 			encodedID, err := t.ID.Encode()
 			if err != nil {

--- a/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens.go
+++ b/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens.go
@@ -1,0 +1,99 @@
+package all
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/influxdata/influxdb/v2/kv"
+)
+
+var Migration0017_AddAnnotationsNotebooksToAllAccessTokens = UpOnlyMigration(
+	"add annotations and notebooks resource types to all-access tokens",
+	func(ctx context.Context, store kv.SchemaStore) error {
+		authBucket := []byte("authorizationsv1")
+
+		// Find all-access tokens that need to be updated.
+
+		tokens := []influxdb.Authorization{}
+		if err := store.View(ctx, func(tx kv.Tx) error {
+			bkt, err := tx.Bucket(authBucket)
+			if err != nil {
+				return err
+			}
+
+			cursor, err := bkt.ForwardCursor(nil)
+			if err != nil {
+				return err
+			}
+
+			return kv.WalkCursor(ctx, cursor, func(_, v []byte) (bool, error) {
+				var t influxdb.Authorization
+				if err := json.Unmarshal(v, &t); err != nil {
+					return false, err
+				}
+
+				// Add any tokens to the list that match the list of permission from an
+				// "old" all-access token
+				if permListsMatch(oldAllAccessPerms(t.OrgID), t.Permissions) {
+					tokens = append(tokens, t)
+				}
+
+				return true, nil
+			})
+		}); err != nil {
+			return err
+		}
+
+		// Go through the list of operator tokens found and update their permissions
+		// list. There should be only 1, but if there are somehow more this will
+		// update all of them.
+		for _, t := range tokens {
+			encodedID, err := t.ID.Encode()
+			if err != nil {
+				return err
+			}
+
+			t.Permissions = append(t.Permissions, extraAllAccessPerms(t.OrgID)...)
+
+			v, err := json.Marshal(t)
+			if err != nil {
+				return err
+			}
+
+			if err := store.Update(ctx, func(tx kv.Tx) error {
+				bkt, err := tx.Bucket(authBucket)
+				if err != nil {
+					return err
+				}
+
+				return bkt.Put(encodedID, v)
+			}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+)
+
+// extraAllAccessPerms returns the list of additional permissions that need added for
+// annotations and notebooks.
+func extraAllAccessPerms(orgId platform.ID) []influxdb.Permission {
+	perms := extraPerms()
+	for i := range perms {
+		perms[i].Resource.OrgID = &orgId
+	}
+	return perms
+}
+
+// oldAllAccessPerms is the list of permissions from an "old" all-access token - prior to
+// the addition of the notebooks an annotations resource type.
+func oldAllAccessPerms(orgId platform.ID) []influxdb.Permission {
+	perms := oldOpPerms()
+	for i := range perms {
+		perms[i].Resource.OrgID = &orgId
+	}
+	return perms
+}

--- a/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
+++ b/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
@@ -22,25 +22,7 @@ func TestMigration_AnnotationsNotebooksAllAccessToken(t *testing.T) {
 	// Auth bucket contains the authorizations AKA tokens
 	authBucket := []byte("authorizationsv1")
 
-	// The store returned by newService will include an operator token with the
-	// current system's entire list of resources already, so remove that before
-	// proceeding with the tests.
-	err := ts.Store.Update(context.Background(), func(tx kv.Tx) error {
-		bkt, err := tx.Bucket(authBucket)
-		require.NoError(t, err)
-
-		cursor, err := bkt.ForwardCursor(nil)
-		require.NoError(t, err)
-
-		return kv.WalkCursor(ctx, cursor, func(k, _ []byte) (bool, error) {
-			err := bkt.Delete(k)
-			require.NoError(t, err)
-			return true, nil
-		})
-	})
-	require.NoError(t, err)
-
-	// Verify that running the migration in the absence of an operator token will
+	// Verify that running the migration in the absence of an all-access token will
 	// not crash influxdb.
 	require.NoError(t, Migration0017_AddAnnotationsNotebooksToAllAccessTokens.Up(context.Background(), ts.Store))
 

--- a/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
+++ b/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
@@ -1,0 +1,141 @@
+package all
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/snowflake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigration_AnnotationsNotebooksAllAccessToken(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	// Run up to migration 16.
+	ts := newService(t, ctx, 16)
+
+	// Auth bucket contains the authorizations AKA tokens
+	authBucket := []byte("authorizationsv1")
+
+	// The store returned by newService will include an operator token with the
+	// current system's entire list of resources already, so remove that before
+	// proceeding with the tests.
+	err := ts.Store.Update(context.Background(), func(tx kv.Tx) error {
+		bkt, err := tx.Bucket(authBucket)
+		require.NoError(t, err)
+
+		cursor, err := bkt.ForwardCursor(nil)
+		require.NoError(t, err)
+
+		return kv.WalkCursor(ctx, cursor, func(k, _ []byte) (bool, error) {
+			err := bkt.Delete(k)
+			require.NoError(t, err)
+			return true, nil
+		})
+	})
+	require.NoError(t, err)
+
+	// Verify that running the migration in the absence of an operator token will
+	// not crash influxdb.
+	require.NoError(t, Migration0017_AddAnnotationsNotebooksToAllAccessTokens.Up(context.Background(), ts.Store))
+
+	// Seed some authorizations
+	id1 := snowflake.NewIDGenerator().ID()
+	id2 := snowflake.NewIDGenerator().ID()
+	OrgID := ts.Org.ID
+	UserID := ts.User.ID
+
+	auths := []influxdb.Authorization{
+		{
+			ID:          id1, // a non-all-access token
+			OrgID:       OrgID,
+			UserID:      UserID,
+			Permissions: orgPermsShouldNotChange(OrgID),
+		},
+		{
+			ID:          id2, // an all-access token
+			OrgID:       OrgID,
+			UserID:      UserID,
+			Permissions: oldAllAccessPerms(OrgID),
+		},
+	}
+
+	for _, a := range auths {
+		js, err := json.Marshal(a)
+		require.NoError(t, err)
+		idBytes, err := a.ID.Encode()
+		require.NoError(t, err)
+
+		err = ts.Store.Update(context.Background(), func(tx kv.Tx) error {
+			bkt, err := tx.Bucket(authBucket)
+			require.NoError(t, err)
+			return bkt.Put(idBytes, js)
+		})
+		require.NoError(t, err)
+	}
+
+	// Run the migration
+	require.NoError(t, Migration0017_AddAnnotationsNotebooksToAllAccessTokens.Up(context.Background(), ts.Store))
+
+	// the first item should not be changed
+	encoded1, err := id1.Encode()
+	require.NoError(t, err)
+	err = ts.Store.View(context.Background(), func(tx kv.Tx) error {
+		bkt, err := tx.Bucket(authBucket)
+		require.NoError(t, err)
+
+		b, err := bkt.Get(encoded1)
+		require.NoError(t, err)
+
+		var token influxdb.Authorization
+		require.NoError(t, json.Unmarshal(b, &token))
+		require.Equal(t, auths[0], token)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// the second item is a 2.0.x all-access token and should have been updated
+	// with a new permissions list
+	encoded2, err := id2.Encode()
+	require.NoError(t, err)
+	err = ts.Store.View(context.Background(), func(tx kv.Tx) error {
+		bkt, err := tx.Bucket(authBucket)
+		require.NoError(t, err)
+
+		b, err := bkt.Get(encoded2)
+		require.NoError(t, err)
+
+		var token influxdb.Authorization
+		require.NoError(t, json.Unmarshal(b, &token))
+
+		require.ElementsMatch(t, append(oldAllAccessPerms(OrgID), extraAllAccessPerms(OrgID)...), token.Permissions)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// This set of permissions shouldn't change - it doesn't match an all-access token.
+func orgPermsShouldNotChange(orgId platform.ID) []influxdb.Permission {
+	return []influxdb.Permission{
+		{
+			Action: influxdb.ReadAction,
+			Resource: influxdb.Resource{
+				Type:  influxdb.ChecksResourceType,
+				OrgID: &orgId,
+			},
+		},
+		{
+			Action: influxdb.WriteAction,
+			Resource: influxdb.Resource{
+				Type:  influxdb.ChecksResourceType,
+				OrgID: &orgId,
+			},
+		},
+	}
+}

--- a/kv/migration/all/all.go
+++ b/kv/migration/all/all.go
@@ -39,5 +39,7 @@ var Migrations = [...]migration.Spec{
 	Migration0015_RecordShardGroupDurationsInBucketMetadata,
 	// add annotations and notebooks resource types to the operator token
 	Migration0016_AddAnnotationsNotebooksToOperToken,
+	// add annotations and notebooks resource types to all-access tokens
+	Migration0017_AddAnnotationsNotebooksToAllAccessTokens,
 	// {{ do_not_edit . }}
 }


### PR DESCRIPTION
Closes #22256

The actual logic in the migration & unit tests is largely copy-pasted from migration 16, introduced in #21840