### PR TITLE
feat(notebooks): add logging and metrics to notebooks service

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -941,13 +941,15 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		)
 	}
 
-	notebookSvc := notebooks.NewService(
-		m.log.With(zap.String("service", "notebooks")),
-		m.sqlStore,
-	)
+	notebookSvc := notebooks.NewService(m.sqlStore)
 	notebookServer := notebookTransport.NewNotebookHandler(
 		m.log.With(zap.String("handler", "notebooks")),
-		authorizer.NewNotebookService(notebookSvc),
+		authorizer.NewNotebookService(
+			notebooks.NewLoggingService(
+				m.log.With(zap.String("service", "notebooks")),
+				notebooks.NewMetricCollectingService(m.reg, notebookSvc),
+			),
+		),
 	)
 
 	annotationSvc := annotations.NewService(

--- a/notebooks/middleware_logging.go
+++ b/notebooks/middleware_logging.go
@@ -1,0 +1,84 @@
+package notebooks
+
+import (
+	"context"
+	"time"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"go.uber.org/zap"
+)
+
+func NewLoggingService(logger *zap.Logger, underlying influxdb.NotebookService) *loggingService {
+	return &loggingService{
+		logger:     logger,
+		underlying: underlying,
+	}
+}
+
+type loggingService struct {
+	logger     *zap.Logger
+	underlying influxdb.NotebookService
+}
+
+var _ influxdb.NotebookService = (*loggingService)(nil)
+
+func (l loggingService) GetNotebook(ctx context.Context, id platform.ID) (n *influxdb.Notebook, err error) {
+	defer func(start time.Time) {
+		dur := zap.Duration("took", time.Since(start))
+		if err != nil {
+			l.logger.Debug("failed to find notebook by ID", zap.Error(err), dur)
+			return
+		}
+		l.logger.Debug("notebook find by ID", dur)
+	}(time.Now())
+	return l.underlying.GetNotebook(ctx, id)
+}
+
+func (l loggingService) CreateNotebook(ctx context.Context, create *influxdb.NotebookReqBody) (n *influxdb.Notebook, err error) {
+	defer func(start time.Time) {
+		dur := zap.Duration("took", time.Since(start))
+		if err != nil {
+			l.logger.Debug("failed to create notebook", zap.Error(err), dur)
+			return
+		}
+		l.logger.Debug("notebook create", dur)
+	}(time.Now())
+	return l.underlying.CreateNotebook(ctx, create)
+}
+
+func (l loggingService) UpdateNotebook(ctx context.Context, id platform.ID, update *influxdb.NotebookReqBody) (n *influxdb.Notebook, err error) {
+	defer func(start time.Time) {
+		dur := zap.Duration("took", time.Since(start))
+		if err != nil {
+			l.logger.Debug("failed to update notebook", zap.Error(err), dur)
+			return
+		}
+		l.logger.Debug("notebook update", dur)
+	}(time.Now())
+	return l.underlying.UpdateNotebook(ctx, id, update)
+}
+
+func (l loggingService) DeleteNotebook(ctx context.Context, id platform.ID) (err error) {
+	defer func(start time.Time) {
+		dur := zap.Duration("took", time.Since(start))
+		if err != nil {
+			l.logger.Debug("failed to delete notebook", zap.Error(err), dur)
+			return
+		}
+		l.logger.Debug("notebook delete", dur)
+	}(time.Now())
+	return l.underlying.DeleteNotebook(ctx, id)
+}
+
+func (l loggingService) ListNotebooks(ctx context.Context, filter influxdb.NotebookListFilter) (ns []*influxdb.Notebook, err error) {
+	defer func(start time.Time) {
+		dur := zap.Duration("took", time.Since(start))
+		if err != nil {
+			l.logger.Debug("failed to find notebooks", zap.Error(err), dur)
+			return
+		}
+		l.logger.Debug("notebooks find", dur)
+	}(time.Now())
+	return l.underlying.ListNotebooks(ctx, filter)
+}

--- a/notebooks/middleware_metrics.go
+++ b/notebooks/middleware_metrics.go
@@ -1,0 +1,55 @@
+package notebooks
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/metric"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func NewMetricCollectingService(reg prometheus.Registerer, underlying influxdb.NotebookService, opts ...metric.ClientOptFn) *metricsService {
+	o := metric.ApplyMetricOpts(opts...)
+	return &metricsService{
+		rec:        metric.New(reg, o.ApplySuffix("notebook")),
+		underlying: underlying,
+	}
+}
+
+type metricsService struct {
+	// RED metrics
+	rec        *metric.REDClient
+	underlying influxdb.NotebookService
+}
+
+var _ influxdb.NotebookService = (*metricsService)(nil)
+
+func (m metricsService) GetNotebook(ctx context.Context, id platform.ID) (*influxdb.Notebook, error) {
+	rec := m.rec.Record("find_notebook_by_id")
+	nb, err := m.underlying.GetNotebook(ctx, id)
+	return nb, rec(err)
+}
+
+func (m metricsService) CreateNotebook(ctx context.Context, create *influxdb.NotebookReqBody) (*influxdb.Notebook, error) {
+	rec := m.rec.Record("create_notebook")
+	nb, err := m.underlying.CreateNotebook(ctx, create)
+	return nb, rec(err)
+}
+
+func (m metricsService) UpdateNotebook(ctx context.Context, id platform.ID, update *influxdb.NotebookReqBody) (*influxdb.Notebook, error) {
+	rec := m.rec.Record("update_notebook")
+	nb, err := m.underlying.UpdateNotebook(ctx, id, update)
+	return nb, rec(err)
+}
+
+func (m metricsService) DeleteNotebook(ctx context.Context, id platform.ID) (err error) {
+	rec := m.rec.Record("delete_notebook")
+	return rec(m.underlying.DeleteNotebook(ctx, id))
+}
+
+func (m metricsService) ListNotebooks(ctx context.Context, filter influxdb.NotebookListFilter) ([]*influxdb.Notebook, error) {
+	rec := m.rec.Record("find_notebooks")
+	nbs, err := m.underlying.ListNotebooks(ctx, filter)
+	return nbs, rec(err)
+}

--- a/notebooks/service.go
+++ b/notebooks/service.go
@@ -10,21 +10,18 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/snowflake"
 	"github.com/influxdata/influxdb/v2/sqlite"
-	"go.uber.org/zap"
 )
 
 var _ influxdb.NotebookService = (*Service)(nil)
 
 type Service struct {
 	store       *sqlite.SqlStore
-	log         *zap.Logger
 	idGenerator platform.IDGenerator
 }
 
-func NewService(logger *zap.Logger, store *sqlite.SqlStore) *Service {
+func NewService(store *sqlite.SqlStore) *Service {
 	return &Service{
 		store:       store,
-		log:         logger,
 		idGenerator: snowflake.NewIDGenerator(),
 	}
 }

--- a/notebooks/service_test.go
+++ b/notebooks/service_test.go
@@ -203,7 +203,7 @@ func newTestService(t *testing.T) (*Service, func(t *testing.T)) {
 	err := sqliteMigrator.Up(ctx, migrations.All)
 	require.NoError(t, err)
 
-	svc := NewService(zap.NewNop(), store)
+	svc := NewService(store)
 
 	return svc, clean
 }


### PR DESCRIPTION
Closes #22259

Adds logging and metrics middleware for the notebooks service. Follows the pattern used by other services.