### PR TITLE
fix: auth requests use org and user names if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [#22228](https://github.com/influxdata/influxdb/pull/22228): influxdb2 packages should depend on curl
 1. [#22211](https://github.com/influxdata/influxdb/pull/22211): Prevent scheduling an inactivated tasks after updating it
 1. [#22235](https://github.com/influxdata/influxdb/pull/22235): Avoid compaction queue stats flutter
+1. [#22272](https://github.com/influxdata/influxdb/pull/22272): Requests to `/api/v2/authorizations` fillter correctly on `org` and `user` parameters
 
 ## v2.0.7 [2021-06-04]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 1. [#22228](https://github.com/influxdata/influxdb/pull/22228): influxdb2 packages should depend on curl
 1. [#22211](https://github.com/influxdata/influxdb/pull/22211): Prevent scheduling an inactivated tasks after updating it
 1. [#22235](https://github.com/influxdata/influxdb/pull/22235): Avoid compaction queue stats flutter
-1. [#22272](https://github.com/influxdata/influxdb/pull/22272): Requests to `/api/v2/authorizations` fillter correctly on `org` and `user` parameters
+1. [#22272](https://github.com/influxdata/influxdb/pull/22272): Requests to `/api/v2/authorizations` filter correctly on `org` and `user` parameters
 
 ## v2.0.7 [2021-06-04]
 

--- a/authorization/storage_authorization_test.go
+++ b/authorization/storage_authorization_test.go
@@ -3,10 +3,9 @@ package authorization_test
 import (
 	"context"
 	"fmt"
+	"github.com/influxdata/influxdb/v2/kit/platform"
 	"reflect"
 	"testing"
-
-	"github.com/influxdata/influxdb/v2/kit/platform"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
@@ -15,42 +14,6 @@ import (
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
 	"go.uber.org/zap/zaptest"
 )
-
-// func TestListAuthorizations(t *testing.T) {
-// 	auths := []*influxdb.Authorization{
-// 		{
-// 			ID:     platform.ID(1),
-// 			Token:  fmt.Sprintf("randomtoken%d", 1),
-// 			OrgID:  platform.ID(1),
-// 			UserID: platform.ID(1),
-// 			Status: influxdb.Active,
-// 		},
-// 	}
-
-// 	store := inmem.NewKVStore()
-// 	require.NoError(t, all.Up(context.Background(), zaptest.NewLogger(t), store))
-
-// 	ts, err := authorization.NewStore(store)
-// 	require.NoError(t, err)
-
-// 	err = ts.Update(context.Background(), func(tx kv.Tx) error {
-// 		for i := 1; i <= 10; i++ {
-// 			err := ts.CreateAuthorization(context.Background(), tx, &influxdb.Authorization{
-// 				ID:     platform.ID(i),
-// 				Token:  fmt.Sprintf("randomtoken%d", i),
-// 				OrgID:  platform.ID(i),
-// 				UserID: platform.ID(i),
-// 				Status: influxdb.Active,
-// 			})
-
-// 			if err != nil {
-// 				return err
-// 			}
-// 		}
-// 		return nil
-// 	})
-// 	require.NoError(t, err)
-// }
 
 func TestAuth(t *testing.T) {
 	setup := func(t *testing.T, store *authorization.Store, tx kv.Tx) {

--- a/authorization/storage_authorization_test.go
+++ b/authorization/storage_authorization_test.go
@@ -3,9 +3,10 @@ package authorization_test
 import (
 	"context"
 	"fmt"
-	"github.com/influxdata/influxdb/v2/kit/platform"
 	"reflect"
 	"testing"
+
+	"github.com/influxdata/influxdb/v2/kit/platform"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
@@ -14,6 +15,42 @@ import (
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
 	"go.uber.org/zap/zaptest"
 )
+
+// func TestListAuthorizations(t *testing.T) {
+// 	auths := []*influxdb.Authorization{
+// 		{
+// 			ID:     platform.ID(1),
+// 			Token:  fmt.Sprintf("randomtoken%d", 1),
+// 			OrgID:  platform.ID(1),
+// 			UserID: platform.ID(1),
+// 			Status: influxdb.Active,
+// 		},
+// 	}
+
+// 	store := inmem.NewKVStore()
+// 	require.NoError(t, all.Up(context.Background(), zaptest.NewLogger(t), store))
+
+// 	ts, err := authorization.NewStore(store)
+// 	require.NoError(t, err)
+
+// 	err = ts.Update(context.Background(), func(tx kv.Tx) error {
+// 		for i := 1; i <= 10; i++ {
+// 			err := ts.CreateAuthorization(context.Background(), tx, &influxdb.Authorization{
+// 				ID:     platform.ID(i),
+// 				Token:  fmt.Sprintf("randomtoken%d", i),
+// 				OrgID:  platform.ID(i),
+// 				UserID: platform.ID(i),
+// 				Status: influxdb.Active,
+// 			})
+
+// 			if err != nil {
+// 				return err
+// 			}
+// 		}
+// 		return nil
+// 	})
+// 	require.NoError(t, err)
+// }
 
 func TestAuth(t *testing.T) {
 	setup := func(t *testing.T, store *authorization.Store, tx kv.Tx) {


### PR DESCRIPTION
Closes #22261

Fixes requests to `/api/v2/authorizations` so that the query parameters of `user` and/or `org` will be used to populate the filter with the respective ID's if `user`/`org` are present but `userID`/`orgID` are not in the query.

Giving precedence to the `ID` parameters if they are present over the "name" parameters seems to be consistent with how other resource endpoints work. For example, if you provide both a `user` and a `userID`, the `userID` will be used to filter the authorizations.