### PR TITLE
fix: return correct count of ErrNotExecuted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - 	[#22090](https://github.com/influxdata/influxdb/pull/22090): fix: systemd service -- handle https, 40x, and block indefinitely
 -	[#22195](https://github.com/influxdata/influxdb/pull/22195): fix: avoid compaction queue stats flutter
 -	[#22283](https://github.com/influxdata/influxdb/pull/22283): fix: require database authorization to see continuous queries
+-	[#22273](https://github.com/influxdata/influxdb/pull/22273): fix: return correct count of ErrNotExecuted
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances

--- a/query/execution_context.go
+++ b/query/execution_context.go
@@ -91,7 +91,6 @@ func (ctx *ExecutionContext) Value(key interface{}) interface{} {
 // send sends a Result to the Results channel and will exit if the query has
 // been aborted.
 func (ctx *ExecutionContext) send(result *Result) error {
-	result.StatementID = ctx.statementID
 	select {
 	case <-ctx.AbortCh:
 		return ErrQueryAborted

--- a/query/executor.go
+++ b/query/executor.go
@@ -380,7 +380,7 @@ LOOP:
 	}
 
 	// Send error results for any statements which were not executed.
-	for ; i < len(query.Statements)-1; i++ {
+	for i++; i < len(query.Statements); i++ {
 		if err := ctx.send(&Result{
 			StatementID: i,
 			Err:         ErrNotExecuted,

--- a/query/executor.go
+++ b/query/executor.go
@@ -331,7 +331,7 @@ LOOP:
 		// Normalize each statement if possible.
 		if normalizer, ok := e.StatementExecutor.(StatementNormalizer); ok {
 			if err := normalizer.NormalizeStatement(stmt, defaultDB, opt.RetentionPolicy); err != nil {
-				if err := ctx.send(&Result{Err: err}); err == ErrQueryAborted {
+				if err := ctx.send(&Result{Err: err, StatementID: i}); err == ErrQueryAborted {
 					return
 				}
 				break


### PR DESCRIPTION
executeQuery() iterates over statements until each is
processed or if an error is encountered that causes
the loop to exit pre-maturely. It should return
ErrNotExecuted for each remaining statement in the
query

closes https://github.com/influxdata/influxdb/issues/19136

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass