### PR TITLE
fix: require database authorization to see continuous queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 -	[#22106](https://github.com/influxdata/influxdb/pull/22106): fix: ensure log formatting (JSON) is respected
 - 	[#22090](https://github.com/influxdata/influxdb/pull/22090): fix: systemd service -- handle https, 40x, and block indefinitely
 -	[#22195](https://github.com/influxdata/influxdb/pull/22195): fix: avoid compaction queue stats flutter
+-	[#22283](https://github.com/influxdata/influxdb/pull/22283): fix: require database authorization to see continuous queries
 
 v1.9.2 [unreleased]
 -	[#21631](https://github.com/influxdata/influxdb/pull/21631): fix: group by returns multiple results per group in some circumstances


### PR DESCRIPTION
SHOW CONTINUOUS QUERIES now requires the same permissions
as SHOW DATABASES in order to see the continuous queries
in a database.

closes https://github.com/influxdata/influxdb/issues/10292

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass