### PR TITLE
fix: require database authorization to see continuous queries (#22283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ v1.9.4 [unreleased]
 -	[#22107](https://github.com/influxdata/influxdb/pull/22107): fix: ensure log formatting (JSON) is respected
 -	[#22091](https://github.com/influxdata/influxdb/pull/22091): fix: systemd service -- handle https, 40x, and block indefinitely
 -	[#22214](https://github.com/influxdata/influxdb/pull/22214): fix: avoid compaction queue stats flutter
+-	[#22289](https://github.com/influxdata/influxdb/pull/22289): fix: require database authorization to see continuous queries
 
 v1.9.3 [unreleased]
 


### PR DESCRIPTION
SHOW CONTINUOUS QUERIES now requires the same permissions
as SHOW DATABASES in order to see the continuous queries
in a database.

closes https://github.com/influxdata/influxdb/issues/10292

(cherry picked from commit 71b3d064943f3b0f940aaa4bdb1b6fa35b91a35a)

closes https://github.com/influxdata/influxdb/issues/22284

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass