### PR TITLE
refactor: influxd inspect consistent usage and flag naming

### DIFF
--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -20,7 +20,7 @@ type args struct {
 func NewDeleteTSMCommand() *cobra.Command {
 	var arguments args
 	cmd := &cobra.Command{
-		Use:   "deletetsm",
+		Use:   "delete-tsm",
 		Short: "Deletes a measurement from a raw tsm file.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -46,7 +46,7 @@ func NewDeleteTSMCommand() *cobra.Command {
 		"The name of the measurement to remove")
 	cmd.Flags().BoolVar(&arguments.sanitize, "sanitize", false,
 		"Remove all keys with non-printable unicode characters")
-	cmd.Flags().BoolVar(&arguments.verbose, "verbose", false,
+	cmd.Flags().BoolVarP(&arguments.verbose, "verbose", "v", false,
 		"Enable verbose logging")
 
 	return cmd

--- a/cmd/influxd/inspect/dump_tsi/dump_tsi.go
+++ b/cmd/influxd/inspect/dump_tsi/dump_tsi.go
@@ -35,7 +35,7 @@ func NewDumpTSICommand() *cobra.Command {
 	var arguments args
 	var measurementFilter, tagKeyFilter, tagValueFilter string
 	cmd := &cobra.Command{
-		Use:   "dumptsi",
+		Use:   "dump-tsi",
 		Short: "Dumps low-level details about tsi1 files.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm.go
@@ -39,7 +39,7 @@ func NewDumpTSMCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&arguments.path, "file", "",
+	cmd.Flags().StringVar(&arguments.path, "file-path", "",
 		"Path to TSM file")
 	cmd.Flags().BoolVar(&arguments.dumpIndex, "index", false,
 		"Dump raw index data")

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -169,11 +169,11 @@ func runCommand(t *testing.T, params cmdParams) {
 
 func makeArgs(path string, meas string) (args map[string][]string) {
 	args = make(map[string][]string)
-	args[argsKeys[0]] = []string{"--file", path, "--index"}
-	args[argsKeys[1]] = []string{"--file", path, "--blocks"}
-	args[argsKeys[2]] = []string{"--file", path, "--all"}
+	args[argsKeys[0]] = []string{"--file-path", path, "--index"}
+	args[argsKeys[1]] = []string{"--file-path", path, "--blocks"}
+	args[argsKeys[2]] = []string{"--file-path", path, "--all"}
 	if meas != "" {
-		args[argsKeys[3]] = []string{"--file", path, "--filter-key", meas, "--all"}
+		args[argsKeys[3]] = []string{"--file-path", path, "--filter-key", meas, "--all"}
 	}
 	return
 }

--- a/cmd/influxd/inspect/report_tsi/report_tsi.go
+++ b/cmd/influxd/inspect/report_tsi/report_tsi.go
@@ -62,7 +62,7 @@ cardinality of data within the files, segmented by shard and further by measurem
 	cmd.Flags().StringVarP(&arguments.bucketId, "bucket-id", "b", "", "Required - specify which bucket to report on. A bucket id must be a base-16 string")
 	cmd.Flags().StringVar(&arguments.dataPath, "data-path", os.Getenv("HOME")+"/.influxdbv2/engine/data", "Path to data directory")
 	cmd.Flags().IntVarP(&arguments.topN, "top", "t", 0, "Limit results to top n")
-	cmd.Flags().IntVar(&arguments.concurrency, "concurrency", runtime.GOMAXPROCS(0), "How many concurrent workers to run")
+	cmd.Flags().IntVarP(&arguments.concurrency, "concurrency", "c", runtime.GOMAXPROCS(0), "How many concurrent workers to run")
 	cmd.MarkFlagRequired("bucket-id")
 
 	return cmd

--- a/cmd/influxd/inspect/report_tsm/report_tsm.go
+++ b/cmd/influxd/inspect/report_tsm/report_tsm.go
@@ -75,7 +75,7 @@ in the following ways:
 		panic(err)
 	}
 	dir = filepath.Join(dir, "engine/data")
-	cmd.Flags().StringVarP(&arguments.dir, "data-dir", "", dir, "use provided data directory")
+	cmd.Flags().StringVarP(&arguments.dir, "data-path", "", dir, "use provided data directory")
 
 	return cmd
 }

--- a/cmd/influxd/inspect/report_tsm/report_tsm_test.go
+++ b/cmd/influxd/inspect/report_tsm/report_tsm_test.go
@@ -178,7 +178,7 @@ type testInfo struct {
 
 func runCommand(t *testing.T, info testInfo) {
 	cmd := NewReportTSMCommand()
-	cmd.SetArgs([]string{"--data-dir", info.dir})
+	cmd.SetArgs([]string{"--data-path", info.dir})
 
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile.go
@@ -83,15 +83,15 @@ func NewVerifySeriesfileCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&arguments.dir, "dir", filepath.Join(os.Getenv("HOME"), ".influxdbv2", "engine", "data"),
+	cmd.Flags().StringVar(&arguments.dir, "data-path", filepath.Join(os.Getenv("HOME"), ".influxdbv2", "engine", "data"),
 		"Data Directory.")
-	cmd.Flags().StringVar(&arguments.db, "db", "",
-		"Only use this database inside of the data directory.")
-	cmd.Flags().StringVar(&arguments.seriesFile, "series-file", "",
-		"Path to a series file. This overrides --db and --dir.")
-	cmd.Flags().BoolVar(&arguments.verbose, "v", false,
+	cmd.Flags().StringVar(&arguments.db, "bucket-id", "",
+		"Only use this bucket inside of the data directory.")
+	cmd.Flags().StringVar(&arguments.seriesFile, "series-path", "",
+		"Path to a series file. This overrides --data-path and --bucket-id.")
+	cmd.Flags().BoolVarP(&arguments.verbose, "verbose", "v", false,
 		"Verbose output.")
-	cmd.Flags().IntVar(&arguments.concurrent, "c", runtime.GOMAXPROCS(0),
+	cmd.Flags().IntVarP(&arguments.concurrent, "concurrency", "c", runtime.GOMAXPROCS(0),
 		"How many concurrent workers to run.")
 
 	return cmd

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -19,7 +19,7 @@ func TestVerifies_BasicCobra(t *testing.T) {
 	defer os.RemoveAll(test.Path)
 
 	verify := NewVerifySeriesfileCommand()
-	verify.SetArgs([]string{"--dir", test.Path})
+	verify.SetArgs([]string{"--data-path", test.Path})
 	require.NoError(t, verify.Execute())
 }
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone.go
@@ -46,9 +46,9 @@ func NewVerifyTombstoneCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&arguments.dir, "dir", filepath.Join(os.Getenv("HOME"), ".influxdbv2"),
+	cmd.Flags().StringVar(&arguments.dir, "engine-path", filepath.Join(os.Getenv("HOME"), ".influxdbv2", "engine"),
 		"Path to find tombstone files.")
-	cmd.Flags().BoolVar(&arguments.v, "v", false,
+	cmd.Flags().BoolVarP(&arguments.v, "verbose", "v", false,
 		"Verbose: Emit periodic progress.")
 	cmd.Flags().BoolVar(&arguments.vv, "vv", false,
 		"Very verbose: Emit every tombstone entry key and time range.")

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -29,7 +29,7 @@ func TestVerifies_InvalidFileType(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)
@@ -46,7 +46,7 @@ func TestVerifies_InvalidEmptyFile(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)
@@ -66,7 +66,7 @@ func TestVerifies_InvalidV2(t *testing.T) {
 	WriteBadData(t, file)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 	verify.SetOut(bytes.NewBufferString(""))
 
 	require.Error(t, verify.Execute())
@@ -81,7 +81,7 @@ func TestVerifies_ValidTS(t *testing.T) {
 	require.NoError(t, ts.Flush())
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path, "--vv"})
+	verify.SetArgs([]string{"--engine-path", path, "--vv"})
 	verify.SetOut(bytes.NewBufferString(""))
 
 	require.NoError(t, verify.Execute())
@@ -96,7 +96,7 @@ func TestVerifies_InvalidV3(t *testing.T) {
 	WriteBadData(t, file)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 	verify.SetOut(bytes.NewBufferString(""))
 
 	require.Error(t, verify.Execute())
@@ -111,7 +111,7 @@ func TestVerifies_InvalidV4(t *testing.T) {
 	WriteBadData(t, file)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 	verify.SetOut(bytes.NewBufferString(""))
 
 	require.Error(t, verify.Execute())
@@ -127,7 +127,7 @@ func TestTombstone_VeryVeryVerbose(t *testing.T) {
 	WriteBadData(t, file)
 
 	verify := NewVerifyTombstoneCommand()
-	verify.SetArgs([]string{"--dir", path, "--vvv"})
+	verify.SetArgs([]string{"--engine-path", path, "--vvv"})
 	verify.SetOut(bytes.NewBufferString(""))
 
 	require.Error(t, verify.Execute())

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm.go
@@ -55,9 +55,9 @@ func NewTSMVerifyCommand() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVar(&dir, "dir", os.Getenv("HOME")+"/.influxdbv2", "Root storage path.")
+	cmd.Flags().StringVar(&dir, "engine-path", os.Getenv("HOME")+"/.influxdbv2"+"/engine", "Root storage path.")
 	cmd.Flags().BoolVar(&checkUTF8, "check-utf8", false, "Verify series keys are valid UTF-8. This check skips verification of block checksums.")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	return cmd
 }
 

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
@@ -18,7 +18,7 @@ func TestInvalidChecksum(t *testing.T) {
 	verify := NewTSMVerifyCommand()
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 	require.NoError(t, verify.Execute())
 
 	out, err := io.ReadAll(b)
@@ -33,7 +33,7 @@ func TestValidChecksum(t *testing.T) {
 	verify := NewTSMVerifyCommand()
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)
-	verify.SetArgs([]string{"--dir", path})
+	verify.SetArgs([]string{"--engine-path", path})
 	require.NoError(t, verify.Execute())
 
 	out, err := io.ReadAll(b)
@@ -47,7 +47,7 @@ func TestInvalidUTF8(t *testing.T) {
 
 	verify := NewTSMVerifyCommand()
 	verify.SetOut(bytes.NewBufferString(""))
-	verify.SetArgs([]string{"--dir", path, "--check-utf8"})
+	verify.SetArgs([]string{"--engine-path", path, "--check-utf8"})
 	require.Error(t, verify.Execute())
 }
 
@@ -58,7 +58,7 @@ func TestValidUTF8(t *testing.T) {
 	verify := NewTSMVerifyCommand()
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)
-	verify.SetArgs([]string{"--dir", path, "--check-utf8"})
+	verify.SetArgs([]string{"--engine-path", path, "--check-utf8"})
 	require.NoError(t, verify.Execute())
 
 	out, err := io.ReadAll(b)

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -46,7 +46,7 @@ In the summary section, the following is printed:
 		panic(err)
 	}
 	dir = filepath.Join(dir, "engine/wal")
-	cmd.Flags().StringVar(&arguments.dir, "wal-dir", dir, "use provided WAL directory.")
+	cmd.Flags().StringVar(&arguments.dir, "wal-path", dir, "use provided WAL path.")
 	cmd.Flags().BoolVarP(&arguments.verbose, "verbose", "v", false, "enable verbose logging")
 	return cmd
 }

--- a/cmd/influxd/inspect/verify_wal/verify_wal_test.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal_test.go
@@ -85,7 +85,7 @@ func TestVerifies_Valid(t *testing.T) {
 
 func runCommand(args testInfo) {
 	verify := NewVerifyWALCommand()
-	verify.SetArgs([]string{"--wal-dir", args.path, "--verbose"})
+	verify.SetArgs([]string{"--wal-path", args.path, "--verbose"})
 
 	b := bytes.NewBufferString("")
 	verify.SetOut(b)


### PR DESCRIPTION
Small changes to usage text and flag naming for 2.x `influxd inspect` commands for consistency between sub-commands. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
