### PR TITLE
fix: add created_at and updated_at columns to replications table

### DIFF
--- a/sqlite/migrations/0004_create_replications_table.sql
+++ b/sqlite/migrations/0004_create_replications_table.sql
@@ -15,6 +15,8 @@ CREATE TABLE replications
     current_queue_size_bytes INTEGER     NOT NULL,
     latest_response_code     INTEGER,
     latest_error_message     TEXT,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
 
     CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
     FOREIGN KEY (remote_id) REFERENCES remotes(id) ON DELETE CASCADE

--- a/sqlite/migrations/0004_create_replications_table.sql
+++ b/sqlite/migrations/0004_create_replications_table.sql
@@ -15,11 +15,11 @@ CREATE TABLE replications
     current_queue_size_bytes INTEGER     NOT NULL,
     latest_response_code     INTEGER,
     latest_error_message     TEXT,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL,
+    created_at               TIMESTAMP   NOT NULL,
+    updated_at               TIMESTAMP   NOT NULL,
 
     CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
-    FOREIGN KEY (remote_id) REFERENCES remotes(id) ON DELETE CASCADE
+    FOREIGN KEY (remote_id) REFERENCES remotes (id) ON DELETE CASCADE
 );
 
 -- Create indexes on lookup patterns we expect to be common


### PR DESCRIPTION
Quick-fix for #22165 