### PR TITLE
fix: return correct count of ErrNotExecuted (#22273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ v1.9.4 [unreleased]
 -	[#22091](https://github.com/influxdata/influxdb/pull/22091): fix: systemd service -- handle https, 40x, and block indefinitely
 -	[#22214](https://github.com/influxdata/influxdb/pull/22214): fix: avoid compaction queue stats flutter
 -	[#22289](https://github.com/influxdata/influxdb/pull/22289): fix: require database authorization to see continuous queries
+-	[#22294](https://github.com/influxdata/influxdb/pull/22294): fix: return correct count of ErrNotExecuted
 
 v1.9.3 [unreleased]
 

--- a/query/execution_context.go
+++ b/query/execution_context.go
@@ -91,7 +91,6 @@ func (ctx *ExecutionContext) Value(key interface{}) interface{} {
 // send sends a Result to the Results channel and will exit if the query has
 // been aborted.
 func (ctx *ExecutionContext) send(result *Result) error {
-	result.StatementID = ctx.statementID
 	select {
 	case <-ctx.AbortCh:
 		return ErrQueryAborted

--- a/query/executor.go
+++ b/query/executor.go
@@ -331,7 +331,7 @@ LOOP:
 		// Normalize each statement if possible.
 		if normalizer, ok := e.StatementExecutor.(StatementNormalizer); ok {
 			if err := normalizer.NormalizeStatement(stmt, defaultDB, opt.RetentionPolicy); err != nil {
-				if err := ctx.send(&Result{Err: err}); err == ErrQueryAborted {
+				if err := ctx.send(&Result{Err: err, StatementID: i}); err == ErrQueryAborted {
 					return
 				}
 				break
@@ -380,7 +380,7 @@ LOOP:
 	}
 
 	// Send error results for any statements which were not executed.
-	for ; i < len(query.Statements)-1; i++ {
+	for i++; i < len(query.Statements); i++ {
 		if err := ctx.send(&Result{
 			StatementID: i,
 			Err:         ErrNotExecuted,


### PR DESCRIPTION
executeQuery() iterates over statements until each is
processed or if an error is encountered that causes
the loop to exit pre-maturely. It should return
ErrNotExecuted for each remaining statement in the
query

closes https://github.com/influxdata/influxdb/issues/19136

(cherry-picked from commit 0090c5b11141e99ee80dc8980cff615c3b63dfd6)

closes https://github.com/influxdata/influxdb/issues/22274

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass