### PR TITLE
refactor: clean up launcher code

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -136,9 +136,8 @@ type Launcher struct {
 	httpPort   int
 	tlsEnabled bool
 
-	scheduler          stoppingScheduler
-	executor           *executor.Executor
-	taskControlService taskbackend.TaskControlService
+	scheduler stoppingScheduler
+	executor  *executor.Executor
 
 	log *zap.Logger
 	reg *prom.Registry
@@ -434,7 +433,6 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			executor)
 
 		taskSvc = middleware.New(combinedTaskService, taskCoord)
-		m.taskControlService = combinedTaskService
 		if err := taskbackend.TaskNotifyCoordinatorOfExisting(
 			ctx,
 			taskSvc,
@@ -1244,11 +1242,6 @@ func (m *Launcher) UserService() platform.UserService {
 	return m.apibackend.UserService
 }
 
-// UserResourceMappingService returns the internal user resource mapping service.
-func (m *Launcher) UserResourceMappingService() platform.UserResourceMappingService {
-	return m.apibackend.UserResourceMappingService
-}
-
 // AuthorizationService returns the internal authorization service.
 func (m *Launcher) AuthorizationService() platform.AuthorizationService {
 	return m.apibackend.AuthorizationService
@@ -1263,24 +1256,9 @@ func (m *Launcher) SecretService() platform.SecretService {
 	return m.apibackend.SecretService
 }
 
-// TaskService returns the internal task service.
-func (m *Launcher) TaskService() taskmodel.TaskService {
-	return m.apibackend.TaskService
-}
-
-// TaskControlService returns the internal store service.
-func (m *Launcher) TaskControlService() taskbackend.TaskControlService {
-	return m.taskControlService
-}
-
 // CheckService returns the internal check service.
 func (m *Launcher) CheckService() platform.CheckService {
 	return m.apibackend.CheckService
-}
-
-// KeyValueService returns the internal key-value service.
-func (m *Launcher) KeyValueService() *kv.Service {
-	return m.kvService
 }
 
 func (m *Launcher) DBRPMappingServiceV2() platform.DBRPMappingServiceV2 {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -994,7 +994,6 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 			m.log.Error("Failed opening sqlite store", zap.Error(err))
 			return "", err
 		}
-		m.sqlStore = sqlStore
 
 	case MemoryStore:
 		kvStore = inmem.NewKVStore()
@@ -1013,7 +1012,7 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 	m.closers = append(m.closers, labeledCloser{
 		label: "sqlite",
 		closer: func(context.Context) error {
-			return m.sqlStore.Close()
+			return sqlStore.Close()
 		},
 	})
 	if opts.Testing {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -76,13 +76,8 @@ import (
 	telegrafservice "github.com/influxdata/influxdb/v2/telegraf/service"
 	"github.com/influxdata/influxdb/v2/telemetry"
 	"github.com/influxdata/influxdb/v2/tenant"
-	"github.com/prometheus/client_golang/prometheus"
-
-	// needed for tsm1
-	_ "github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
-
-	// needed for tsi1
-	_ "github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
+	_ "github.com/influxdata/influxdb/v2/tsdb/engine/tsm1" // needed for tsm1
+	_ "github.com/influxdata/influxdb/v2/tsdb/index/tsi1"  // needed for tsi1
 	authv1 "github.com/influxdata/influxdb/v2/v1/authorization"
 	iqlcoordinator "github.com/influxdata/influxdb/v2/v1/coordinator"
 	"github.com/influxdata/influxdb/v2/v1/services/meta"
@@ -90,6 +85,7 @@ import (
 	"github.com/influxdata/influxdb/v2/vault"
 	pzap "github.com/influxdata/influxdb/v2/zap"
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
 	jaegerconfig "github.com/uber/jaeger-client-go/config"
 	"go.uber.org/zap"
 )

--- a/prometheus/influx.go
+++ b/prometheus/influx.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	platform2 "github.com/influxdata/influxdb/v2/kit/platform"
-
 	platform "github.com/influxdata/influxdb/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,9 +16,7 @@ type influxCollector struct {
 }
 
 // NewInfluxCollector returns a collector which exports influxdb process metrics.
-func NewInfluxCollector(procID platform2.IDGenerator, build platform.BuildInfo) prometheus.Collector {
-	id := procID.ID().String()
-
+func NewInfluxCollector(procID string, build platform.BuildInfo) prometheus.Collector {
 	return &influxCollector{
 		influxInfoDesc: prometheus.NewDesc(
 			"influxdb_info",
@@ -38,7 +34,7 @@ func NewInfluxCollector(procID platform2.IDGenerator, build platform.BuildInfo) 
 			"influxdb_uptime_seconds",
 			"influxdb process uptime in seconds",
 			nil, prometheus.Labels{
-				"id": id,
+				"id": procID,
 			},
 		),
 		start: time.Now(),


### PR DESCRIPTION
Part of #19976

(Probably) best reviewed commit-by-commit.
* f72c752 switches the launcher to track a `closers` array so it doesn't have to track named references to various subsystems for use in `Shutdown`
* a5b1d6e moves the setup of tracing & metadata DBs out of `run` and into their own methods
* 8263c96 deletes some unused getters and their linked fields
* 613217f cleans up imports