### PR TITLE
fix: TSI logfile race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v1.9.4 [unreleased]
 -	[#22214](https://github.com/influxdata/influxdb/pull/22214): fix: avoid compaction queue stats flutter
 -	[#22289](https://github.com/influxdata/influxdb/pull/22289): fix: require database authorization to see continuous queries
 -	[#22294](https://github.com/influxdata/influxdb/pull/22294): fix: return correct count of ErrNotExecuted
+-	[#22341](https://github.com/influxdata/influxdb/pull/22341): fix: TSI logfile race
 
 v1.9.3 [unreleased]
 

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -86,6 +86,8 @@ func NewLogFile(sfile *tsdb.SeriesFile, path string) *LogFile {
 
 // bytes estimates the memory footprint of this LogFile, in bytes.
 func (f *LogFile) bytes() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	var b int
 	b += 24 // mu RWMutex is 24 bytes
 	b += 16 // wg WaitGroup is 16 bytes
@@ -258,6 +260,13 @@ func (f *LogFile) Size() int64 {
 	v := f.size
 	f.mu.RUnlock()
 	return v
+}
+
+// ModTime returns the last modified time of the file
+func (f *LogFile) ModTime() time.Time {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.modTime
 }
 
 // Measurement returns a measurement element.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1151,7 +1151,8 @@ func (p *Partition) Rebuild() {}
 // The caller must have at least a read lock on the partition
 func (p *Partition) needsLogCompaction() bool {
 	size := p.activeLogFile.Size()
-	return size >= p.MaxLogFileSize || (size > 0 && p.activeLogFile.modTime.Before(time.Now().Add(-p.MaxLogFileAge)))
+	modTime := p.activeLogFile.ModTime()
+	return size >= p.MaxLogFileSize || (size > 0 && modTime.Before(time.Now().Add(-p.MaxLogFileAge)))
 }
 
 func (p *Partition) CheckLogFile() error {


### PR DESCRIPTION
modTime should be protected by the read lock.

Closes #22340

(cherry picked from commit 1755b8f6d28bb24634830ec90c376c777b3cec79)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
