### PR TITLE
fix: repair bad port dropping return value names (#22307)

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1337,15 +1337,15 @@ func (is IndexSet) HasField(measurement []byte, field string) bool {
 
 // MeasurementNamesByExpr returns a slice of measurement names matching the
 // provided condition. If no condition is provided then all names are returned.
-func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
+func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) (_ [][]byte, err error) {
 	release := is.SeriesFile.Retain()
 	defer release()
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		itr, err := is.measurementNamesByExpr(auth, expr)
-		if err != nil {
-			return nil, err
+		itr, returnErr := is.measurementNamesByExpr(auth, expr)
+		if returnErr != nil {
+			return nil, returnErr
 		} else if itr == nil {
 			return nil, nil
 		}
@@ -1499,15 +1499,15 @@ func (is IndexSet) measurementNamesByNameFilter(auth query.Authorizer, op influx
 // provided condition. If no condition is provided then all names are returned.
 // This behaves differently from MeasurementNamesByExpr because it will
 // return measurements using flux predicates.
-func (is IndexSet) MeasurementNamesByPredicate(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
+func (is IndexSet) MeasurementNamesByPredicate(auth query.Authorizer, expr influxql.Expr) (_ [][]byte, err error) {
 	release := is.SeriesFile.Retain()
 	defer release()
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		itr, err := is.measurementNamesByPredicate(auth, expr)
-		if err != nil {
-			return nil, err
+		itr, returnErr := is.measurementNamesByPredicate(auth, expr)
+		if returnErr != nil {
+			return nil, returnErr
 		}
 		if itr != nil {
 			defer func() {


### PR DESCRIPTION
Named returns were not cherry-picked correctly from
commit a989f8f8b6fc453c85075e5ae73033d5bd036e21 in
master-1.x branch.

closes https://github.com/influxdata/influxdb/issues/22303

(cherry picked from commit 99cfbfe8cf8f1c857c888aa633cc656507955c8b)

Closes https://github.com/influxdata/influxdb/issues/22304

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
