### PR TITLE
fix: discard excessive errors (#22379)

### DIFF
--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1862,6 +1863,98 @@ func TestTSMReader_References(t *testing.T) {
 	if err := r.Remove(); err != nil {
 		t.Fatalf("unexpected error removing reader: %v", err)
 	}
+}
+
+func TestBatchKeyIterator_Errors(t *testing.T) {
+	const MaxErrors = 10
+
+	dir, name := createTestTSM(t)
+	defer os.RemoveAll(dir)
+	fr, err := os.Open(name)
+	if err != nil {
+		t.Fatalf("unexpected error opening file %s: %v", name, err)
+	}
+	r, err := NewTSMReader(fr)
+	if err != nil {
+		// Only have a deferred close if we could not create the TSMReader
+		defer func() {
+			if e := fr.Close(); e != nil {
+				t.Fatalf("unexpected error closing %s: %v", name, e)
+			}
+		}()
+
+		t.Fatalf("unexpected error creating TSMReader for %s: %v", name, err)
+	}
+	defer func() {
+		if e := r.Close(); e != nil {
+			t.Fatalf("error closing TSMReader for %s: %v", name, e)
+		}
+	}()
+	interrupts := make(chan struct{})
+	var iter KeyIterator
+	if iter, err = NewTSMBatchKeyIterator(3, false, MaxErrors, interrupts, []string{name}, r); err != nil {
+		t.Fatalf("unexpected error creating tsmBatchKeyIterator: %v", err)
+	}
+	var i int
+	for i = 0; i < MaxErrors*2; i++ {
+		saved := iter.(*tsmBatchKeyIterator).AppendError(fmt.Errorf("fake error: %d", i))
+		if i < MaxErrors && !saved {
+			t.Fatalf("error unexpectedly not saved: %d", i)
+		}
+		if i >= MaxErrors && saved {
+			t.Fatalf("error unexpectedly saved: %d", i)
+		}
+	}
+	errs := iter.Err()
+	if errCnt := len(errs.(TSMErrors)); errCnt != (MaxErrors + 1) {
+		t.Fatalf("saved wrong number of errors: expected %d, got %d", MaxErrors, errCnt)
+	}
+	expected := fmt.Sprintf("additional errors dropped: %d", i-MaxErrors)
+	if strings.Compare(errs.(TSMErrors)[MaxErrors].Error(), expected) != 0 {
+		t.Fatalf("expected: '%s', got: '%s", expected, errs.(TSMErrors)[MaxErrors].Error())
+	}
+}
+
+func createTestTSM(t *testing.T) (dir string, name string) {
+	dir = MustTempDir()
+	f := mustTempFile(dir)
+	name = f.Name()
+	w, err := NewTSMWriter(f)
+	if err != nil {
+		f.Close()
+		t.Fatalf("unexpected error creating writer for %s: %v", name, err)
+	}
+	defer func() {
+		if e := w.Close(); e != nil {
+			t.Fatalf("write TSM close of %s: %v", name, err)
+		}
+	}()
+
+	var data = map[string][]Value{
+		"float":  []Value{NewValue(1, 1.0)},
+		"int":    []Value{NewValue(1, int64(1))},
+		"uint":   []Value{NewValue(1, ^uint64(0))},
+		"bool":   []Value{NewValue(1, true)},
+		"string": []Value{NewValue(1, "foo")},
+	}
+
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		if err := w.Write([]byte(k), data[k]); err != nil {
+			t.Fatalf("write TSM value: %v", err)
+		}
+	}
+
+	if err := w.WriteIndex(); err != nil {
+		t.Fatalf("write TSM index: %v", err)
+	}
+
+	return dir, name
 }
 
 func BenchmarkIndirectIndex_UnmarshalBinary(b *testing.B) {


### PR DESCRIPTION
The tsmBatchKeyIterator discards excessive errors to avoid
out-of-memory crashes when compacting very corrupt files.
Any error beyond DefaultMaxSavedErrors (100) will be
discarded instead of appended to the error slice.

closes https://github.com/influxdata/influxdb/issues/22328

(cherry picked from commit e53f75e06d0d2576e6db0175fe96c486014663a0)

Closes https://github.com/influxdata/influxdb/issues/22382

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass