### PR TITLE
fix: use consistent path separator in permission string representation

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	errors2 "github.com/influxdata/influxdb/v2/kit/platform/errors"
@@ -84,15 +84,15 @@ type Resource struct {
 // String stringifies a resource
 func (r Resource) String() string {
 	if r.OrgID != nil && r.ID != nil {
-		return filepath.Join(string(OrgsResourceType), r.OrgID.String(), string(r.Type), r.ID.String())
+		return path.Join(string(OrgsResourceType), r.OrgID.String(), string(r.Type), r.ID.String())
 	}
 
 	if r.OrgID != nil {
-		return filepath.Join(string(OrgsResourceType), r.OrgID.String(), string(r.Type))
+		return path.Join(string(OrgsResourceType), r.OrgID.String(), string(r.Type))
 	}
 
 	if r.ID != nil {
-		return filepath.Join(string(r.Type), r.ID.String())
+		return path.Join(string(r.Type), r.ID.String())
 	}
 
 	return string(r.Type)


### PR DESCRIPTION
Closes #22408 

Use `path.Join` instead of `filepath.Join` so auth resources have a consistent string representation across Linux, Mac, and Windows.