### PR TITLE
test: skip HoltWinters tests when GOARCH != amd64

### DIFF
--- a/influxql/query/functions_test.go
+++ b/influxql/query/functions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -22,6 +23,10 @@ func almostEqual(got, exp float64) bool {
 }
 
 func TestHoltWinters_AusTourists(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	hw := query.NewFloatHoltWintersReducer(10, 4, false, 1)
 	// Dataset from http://www.inside-r.org/packages/cran/fpp/docs/austourists
 	austourists := []query.FloatPoint{
@@ -108,6 +113,10 @@ func TestHoltWinters_AusTourists(t *testing.T) {
 }
 
 func TestHoltWinters_AusTourists_Missing(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	hw := query.NewFloatHoltWintersReducer(10, 4, false, 1)
 	// Dataset from http://www.inside-r.org/packages/cran/fpp/docs/austourists
 	austourists := []query.FloatPoint{
@@ -187,6 +196,10 @@ func TestHoltWinters_AusTourists_Missing(t *testing.T) {
 }
 
 func TestHoltWinters_USPopulation(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	series := []query.FloatPoint{
 		{Time: 1, Value: 3.93},
 		{Time: 2, Value: 5.31},
@@ -260,6 +273,10 @@ func TestHoltWinters_USPopulation(t *testing.T) {
 }
 
 func TestHoltWinters_USPopulation_Missing(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	series := []query.FloatPoint{
 		{Time: 1, Value: 3.93},
 		{Time: 2, Value: 5.31},
@@ -329,6 +346,10 @@ func TestHoltWinters_USPopulation_Missing(t *testing.T) {
 	}
 }
 func TestHoltWinters_RoundTime(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	maxTime := time.Unix(0, influxql.MaxTime).Round(time.Second).UnixNano()
 	data := []query.FloatPoint{
 		{Time: maxTime - int64(5*time.Second), Value: 1},
@@ -365,6 +386,10 @@ func TestHoltWinters_RoundTime(t *testing.T) {
 }
 
 func TestHoltWinters_MaxTime(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("Expected HoltWinters outputs only valid when GOARCH = amd64")
+	}
+
 	data := []query.FloatPoint{
 		{Time: influxql.MaxTime - 1, Value: 1},
 		{Time: influxql.MaxTime, Value: 2},

--- a/query/stdlib/testing/testing.go
+++ b/query/stdlib/testing/testing.go
@@ -1,5 +1,7 @@
 package testing
 
+import "runtime"
+
 var FluxEndToEndSkipList = map[string]map[string]string{
 	"universe": {
 		// TODO(adam) determine the reason for these test failures.
@@ -173,6 +175,12 @@ var FluxEndToEndSkipList = map[string]map[string]string{
 	"contrib/RohanSreerama5/naiveBayesClassifier": {
 		"bayes": "error calling tableFind: ",
 	},
+}
+
+func init() {
+	if runtime.GOOS != "amd64" {
+		FluxEndToEndSkipList["universe"]["holt_winters"] = "expected HoltWinters outputs only valid on amd64"
+	}
 }
 
 type PerTestFeatureFlagMap = map[string]map[string]map[string]string


### PR DESCRIPTION
Closes #22410

The logic used in our HoltWintersReducer produces different floating-point results depending on the CPU architecture. Tests that assert on specific outputs of the functions fail on non-amd64 architectures (see #18254 for an example).