### PR TITLE
refactor: move interfaces for remotes & replication services out of root package

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -853,13 +853,8 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	)
 
 	remotesSvc := remotes.NewService(m.sqlStore)
-	remotesServer := remotesTransport.NewRemoteConnectionHandler(
-		m.log.With(zap.String("handler", "remotes")),
-		remotes.NewLoggingService(
-			m.log.With(zap.String("service", "remotes")),
-			remotes.NewMetricCollectingService(m.reg, remotesSvc),
-		),
-	)
+	remotesServer := remotesTransport.NewInstrumentedRemotesHandler(
+		m.log.With(zap.String("handler", "remotes")), m.reg, remotesSvc)
 
 	replicationSvc := replications.NewService(m.sqlStore, ts)
 	replicationServer := replicationTransport.NewReplicationHandler(

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -857,13 +857,8 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		m.log.With(zap.String("handler", "remotes")), m.reg, remotesSvc)
 
 	replicationSvc := replications.NewService(m.sqlStore, ts)
-	replicationServer := replicationTransport.NewReplicationHandler(
-		m.log.With(zap.String("handler", "replications")),
-		replications.NewLoggingService(
-			m.log.With(zap.String("service", "replications")),
-			replications.NewMetricCollectingService(m.reg, replicationSvc),
-		),
-	)
+	replicationServer := replicationTransport.NewInstrumentedReplicationHandler(
+		m.log.With(zap.String("handler", "replications")), m.reg, replicationSvc)
 
 	platformHandler := http.NewPlatformHandler(
 		m.apibackend,

--- a/remote_connection.go
+++ b/remote_connection.go
@@ -1,39 +1,8 @@
 package influxdb
 
 import (
-	"context"
-
 	"github.com/influxdata/influxdb/v2/kit/platform"
 )
-
-type RemoteConnectionService interface {
-	// ListRemoteConnections returns all info about registered remote InfluxDB connections matching a filter.
-	ListRemoteConnections(context.Context, RemoteConnectionListFilter) (*RemoteConnections, error)
-
-	// CreateRemoteConnection registers a new remote InfluxDB connection.
-	CreateRemoteConnection(context.Context, CreateRemoteConnectionRequest) (*RemoteConnection, error)
-
-	// ValidateNewRemoteConnection validates that the given settings for a remote InfluxDB connection are usable,
-	// without persisting the connection info.
-	ValidateNewRemoteConnection(context.Context, CreateRemoteConnectionRequest) error
-
-	// GetRemoteConnection returns metadata about the remote InfluxDB connection with the given ID.
-	GetRemoteConnection(context.Context, platform.ID) (*RemoteConnection, error)
-
-	// UpdateRemoteConnection updates the settings for the remote InfluxDB connection with the given ID.
-	UpdateRemoteConnection(context.Context, platform.ID, UpdateRemoteConnectionRequest) (*RemoteConnection, error)
-
-	// ValidateUpdatedRemoteConnection validates that a remote InfluxDB connection is still usable after applying the
-	// given update, without persisting the new info.
-	ValidateUpdatedRemoteConnection(context.Context, platform.ID, UpdateRemoteConnectionRequest) error
-
-	// DeleteRemoteConnection deletes all info for the remote InfluxDB connection with the given ID.
-	DeleteRemoteConnection(context.Context, platform.ID) error
-
-	// ValidateRemoteConnection checks that the remote InfluxDB connection with the given ID is still usable
-	// with its persisted settings.
-	ValidateRemoteConnection(context.Context, platform.ID) error
-}
 
 // RemoteConnection contains all info about a remote InfluxDB instance that should be returned to users.
 // Note that the auth token used by the request is *not* included here.

--- a/remotes/mock/service.go
+++ b/remotes/mock/service.go
@@ -5,12 +5,12 @@
 package mock
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	influxdb "github.com/influxdata/influxdb/v2"
-	platform "github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
 )
 
 // MockRemoteConnectionService is a mock of RemoteConnectionService interface.

--- a/remotes/service.go
+++ b/remotes/service.go
@@ -39,8 +39,6 @@ type service struct {
 	validator   RemoteConnectionValidator
 }
 
-var _ influxdb.RemoteConnectionService = (*service)(nil)
-
 func (s service) ListRemoteConnections(ctx context.Context, filter influxdb.RemoteConnectionListFilter) (*influxdb.RemoteConnections, error) {
 	q := sq.Select("id", "org_id", "name", "description", "remote_url", "remote_org_id", "allow_insecure_tls").
 		From("remotes").

--- a/remotes/transport/http_test.go
+++ b/remotes/transport/http_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/kit/platform"
-	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/influxdata/influxdb/v2/remotes/mock"
 	"github.com/stretchr/testify/assert"
 	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -230,7 +230,7 @@ func TestRemoteConnectionHandler(t *testing.T) {
 func newTestServer(t *testing.T) (*httptest.Server, *mock.MockRemoteConnectionService) {
 	ctrlr := gomock.NewController(t)
 	svc := mock.NewMockRemoteConnectionService(ctrlr)
-	server := annotatedTestServer(NewRemoteConnectionHandler(zaptest.NewLogger(t), svc))
+	server := annotatedTestServer(newRemoteConnectionHandler(zaptest.NewLogger(t), svc))
 	return httptest.NewServer(server), svc
 }
 

--- a/remotes/transport/middleware_logging.go
+++ b/remotes/transport/middleware_logging.go
@@ -1,4 +1,4 @@
-package remotes
+package transport
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewLoggingService(logger *zap.Logger, underlying influxdb.RemoteConnectionService) *loggingService {
+func newLoggingService(logger *zap.Logger, underlying RemoteConnectionService) *loggingService {
 	return &loggingService{
 		logger:     logger,
 		underlying: underlying,
@@ -18,10 +18,10 @@ func NewLoggingService(logger *zap.Logger, underlying influxdb.RemoteConnectionS
 
 type loggingService struct {
 	logger     *zap.Logger
-	underlying influxdb.RemoteConnectionService
+	underlying RemoteConnectionService
 }
 
-var _ influxdb.RemoteConnectionService = (*loggingService)(nil)
+var _ RemoteConnectionService = (*loggingService)(nil)
 
 func (l loggingService) ListRemoteConnections(ctx context.Context, filter influxdb.RemoteConnectionListFilter) (cs *influxdb.RemoteConnections, err error) {
 	defer func(start time.Time) {

--- a/remotes/transport/middleware_metrics.go
+++ b/remotes/transport/middleware_metrics.go
@@ -1,4 +1,4 @@
-package remotes
+package transport
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewMetricCollectingService(reg prometheus.Registerer, underlying influxdb.RemoteConnectionService, opts ...metric.ClientOptFn) *metricsService {
+func newMetricCollectingService(reg prometheus.Registerer, underlying RemoteConnectionService, opts ...metric.ClientOptFn) *metricsService {
 	o := metric.ApplyMetricOpts(opts...)
 	return &metricsService{
 		rec:        metric.New(reg, o.ApplySuffix("remote")),
@@ -20,10 +20,10 @@ func NewMetricCollectingService(reg prometheus.Registerer, underlying influxdb.R
 type metricsService struct {
 	// RED metrics
 	rec        *metric.REDClient
-	underlying influxdb.RemoteConnectionService
+	underlying RemoteConnectionService
 }
 
-var _ influxdb.RemoteConnectionService = (*metricsService)(nil)
+var _ RemoteConnectionService = (*metricsService)(nil)
 
 func (m metricsService) ListRemoteConnections(ctx context.Context, filter influxdb.RemoteConnectionListFilter) (*influxdb.RemoteConnections, error) {
 	rec := m.rec.Record("find_remotes")

--- a/replication.go
+++ b/replication.go
@@ -1,7 +1,6 @@
 package influxdb
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/influxdata/influxdb/v2/kit/platform"
@@ -16,35 +15,6 @@ const (
 var ErrMaxQueueSizeTooSmall = errors.Error{
 	Code: errors.EInvalid,
 	Msg:  fmt.Sprintf("maxQueueSize too small, must be at least %d", MinReplicationMaxQueueSizeBytes),
-}
-
-type ReplicationService interface {
-	// ListReplications returns all info about registered replications matching a filter.
-	ListReplications(context.Context, ReplicationListFilter) (*Replications, error)
-
-	// CreateReplication registers a new replication stream.
-	CreateReplication(context.Context, CreateReplicationRequest) (*Replication, error)
-
-	// ValidateNewReplication validates that the given settings for a replication are usable,
-	// without persisting the configuration.
-	ValidateNewReplication(context.Context, CreateReplicationRequest) error
-
-	// GetReplication returns metadata about the replication with the given ID.
-	GetReplication(context.Context, platform.ID) (*Replication, error)
-
-	// UpdateReplication updates the settings for the replication with the given ID.
-	UpdateReplication(context.Context, platform.ID, UpdateReplicationRequest) (*Replication, error)
-
-	// ValidateUpdatedReplication valdiates that a replication is still usable after applying the
-	// given update, without persisting the new configuration.
-	ValidateUpdatedReplication(context.Context, platform.ID, UpdateReplicationRequest) error
-
-	// DeleteReplication deletes all info for the replication with the given ID.
-	DeleteReplication(context.Context, platform.ID) error
-
-	// ValidateReplication checks that the replication with the given ID is still usable with its
-	// persisted settings.
-	ValidateReplication(context.Context, platform.ID) error
 }
 
 // Replication contains all info about a replication that should be returned to users.

--- a/replications/mock/service.go
+++ b/replications/mock/service.go
@@ -5,12 +5,12 @@
 package mock
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	influxdb "github.com/influxdata/influxdb/v2"
-	platform "github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/kit/platform"
 )
 
 // MockReplicationService is a mock of ReplicationService interface.

--- a/replications/service.go
+++ b/replications/service.go
@@ -63,8 +63,6 @@ type service struct {
 	validator     ReplicationValidator
 }
 
-var _ influxdb.ReplicationService = (*service)(nil)
-
 func (s service) ListReplications(ctx context.Context, filter influxdb.ReplicationListFilter) (*influxdb.Replications, error) {
 	q := sq.Select(
 		"id", "org_id", "name", "description",

--- a/replications/transport/http_test.go
+++ b/replications/transport/http_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/kit/platform"
-	"github.com/influxdata/influxdb/v2/mock"
+	"github.com/influxdata/influxdb/v2/replications/mock"
 	"github.com/stretchr/testify/assert"
 	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -314,7 +314,7 @@ func TestReplicationHandler(t *testing.T) {
 func newTestServer(t *testing.T) (*httptest.Server, *mock.MockReplicationService) {
 	ctrl := gomock.NewController(t)
 	svc := mock.NewMockReplicationService(ctrl)
-	server := annotatedTestServer(NewReplicationHandler(zaptest.NewLogger(t), svc))
+	server := annotatedTestServer(newReplicationHandler(zaptest.NewLogger(t), svc))
 	return httptest.NewServer(server), svc
 }
 

--- a/replications/transport/middleware_logging.go
+++ b/replications/transport/middleware_logging.go
@@ -1,4 +1,4 @@
-package replications
+package transport
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewLoggingService(logger *zap.Logger, underlying influxdb.ReplicationService) *loggingService {
+func newLoggingService(logger *zap.Logger, underlying ReplicationService) *loggingService {
 	return &loggingService{
 		logger:     logger,
 		underlying: underlying,
@@ -18,10 +18,10 @@ func NewLoggingService(logger *zap.Logger, underlying influxdb.ReplicationServic
 
 type loggingService struct {
 	logger     *zap.Logger
-	underlying influxdb.ReplicationService
+	underlying ReplicationService
 }
 
-var _ influxdb.ReplicationService = (*loggingService)(nil)
+var _ ReplicationService = (*loggingService)(nil)
 
 func (l loggingService) ListReplications(ctx context.Context, filter influxdb.ReplicationListFilter) (rs *influxdb.Replications, err error) {
 	defer func(start time.Time) {

--- a/replications/transport/middleware_metrics.go
+++ b/replications/transport/middleware_metrics.go
@@ -1,4 +1,4 @@
-package replications
+package transport
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewMetricCollectingService(reg prometheus.Registerer, underlying influxdb.ReplicationService, opts ...metric.ClientOptFn) *metricsService {
+func newMetricCollectingService(reg prometheus.Registerer, underlying ReplicationService, opts ...metric.ClientOptFn) *metricsService {
 	o := metric.ApplyMetricOpts(opts...)
 	return &metricsService{
 		rec:        metric.New(reg, o.ApplySuffix("replication")),
@@ -19,10 +19,10 @@ func NewMetricCollectingService(reg prometheus.Registerer, underlying influxdb.R
 
 type metricsService struct {
 	rec        *metric.REDClient
-	underlying influxdb.ReplicationService
+	underlying ReplicationService
 }
 
-var _ influxdb.ReplicationService = (*metricsService)(nil)
+var _ ReplicationService = (*metricsService)(nil)
 
 func (m metricsService) ListReplications(ctx context.Context, filter influxdb.ReplicationListFilter) (*influxdb.Replications, error) {
 	rec := m.rec.Record("find_replications")


### PR DESCRIPTION
Instead of keeping these interfaces at the root, move them to their use-sites (the HTTP layer). I expect that different pieces of the system will have different requirements for what a "remote service" and (especially) a "replication service" means. 

Rather than bloating a single centralized interface, shift towards a model of client-side interfaces.

This also moves the logging & metrics middlewares into the `transport` package, since they're HTTP-focused layers.