### PR TITLE
test: close test SQL store before deleting its tmp dir in tests

### DIFF
--- a/sqlite/sqlite_helpers.go
+++ b/sqlite/sqlite_helpers.go
@@ -5,24 +5,20 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
 func NewTestStore(t *testing.T) (*SqlStore, func(t *testing.T)) {
 	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unable to create temporary test directory %v", err)
-	}
-
-	cleanUpFn := func(t *testing.T) {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("unable to delete temporary test directory %s: %v", tempDir, err)
-		}
-	}
+	require.NoError(t, err, "unable to create temporary test directory")
 
 	s, err := NewSqlStore(tempDir+"/"+DefaultFilename, zap.NewNop())
-	if err != nil {
-		t.Fatal("unable to open testing database")
+	require.NoError(t, err, "unable to open testing database")
+
+	cleanUpFn := func(t *testing.T) {
+		require.NoError(t, s.Close(), "failed to close testing database")
+		require.NoErrorf(t, os.RemoveAll(tempDir), "unable to delete temporary test directory %s", tempDir)
 	}
 
 	return s, cleanUpFn


### PR DESCRIPTION
Linux & Mac are apparently forgiving enough to allow the `os.RemoveAll` to pass even when the SQL store is still pointing at the files inside, but Windows fails the deletion.