### PR TITLE
chore: omit VCS commands for changelog in favor of s3-only approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,10 +825,5 @@ jobs:
               -- \
               --tag $TIMESTAMP
             echo ${CIRCLE_SHA1} > $COMMIT_FILE_PATH
-            git add CHANGELOG.md $COMMIT_FILE_PATH
-            git config user.email "team-edge@influxdata.com"
-            git config user.name "Edge Team CircleCI Automation"
-            git commit -m "changelog: update $TIMESTAMP [skip ci]"
-            git push origin $CIRCLE_BRANCH
       - store_artifacts:
           path: CHANGELOG.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,6 +91,7 @@ blobs:
     folder: "platform/nightlies/"
     extra_files:
       - glob: ./CHANGELOG.md
+      - glob: ./scripts/ci/changelog-commit.txt
   # Duplicating the contents to another folder in the bucket ensures
   # scheme parity with release branches; eventually the artifacts should
   # __only__ appear in the branch-specific folder
@@ -100,6 +101,7 @@ blobs:
     folder: "platform/nightlies/master/"
     extra_files:
       - glob: ./CHANGELOG.md
+      - glob: ./scripts/ci/changelog-commit.txt
 
 checksum:
   name_template: "influxdb2-nightly.sha256"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+The Changelog has moved!
+
+You can find it at the following URL:
+
+https://dl.influxdata.com/platform/nightlies/master/CHANGELOG.md


### PR DESCRIPTION
Continuation of development on #19645 

Because `master` is a protected branch requiring at least 1 review of a PR for any push, we are instead electing to redirect those interested in the changelog to an s3 link instead of trying to update VCS with every changelog change.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass