### PR TITLE
chore: enable nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ commands:
                 name: Build release
                 # `goreleaser release --skip-publish` builds Docker images, but doesn't push them.
                 # As opposed to `goreleaser build`, which stops before building Dockers.
-                command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe)" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
+                command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//')" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
       - when:
           condition: << parameters.publish_release >>
           steps:
@@ -406,14 +406,12 @@ commands:
           steps:
             - run:
                 name: Publish nightly
-                #TODO: remove --skip-publish flag
                 command: |
                   S3_FOLDER="platform/nightlies/2.0" \
                   VERSION="2.0-nightly" \
                   goreleaser \
                     --debug \
                     release \
-                      --skip-publish \
                       -p 1 \
                       --rm-dist \
                       --skip-validate
@@ -585,7 +583,7 @@ jobs:
       - install_core_deps
       - install_cross_bin_deps
       # Build the static binary for linux
-      - run: S3_FOLDER="influxdb/releases/" VERSION="$(git describe)" goreleaser build --snapshot --single-target
+      - run: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//')" goreleaser build --snapshot --single-target
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,13 +109,13 @@ workflows:
       - aws_destroy_by_name
 
   nightly:
-    #triggers:
-    #  - schedule:
-    #      cron: "0 5 * * *"
-    #      filters:
-    #        branches:
-    #          only:
-    #            - "2.0"
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - "2.0"
     jobs:
       - godeps
       - jsdeps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: "2.1"
 
+executors:
+  linux-machine:
+    machine:
+      image: ubuntu-2004:202107-02
+      resource_class: large
+
 parameters:
   aws_teardown:
     default: false
@@ -101,6 +107,36 @@ workflows:
     when: << pipeline.parameters.aws_teardown >>
     jobs:
       - aws_destroy_by_name
+
+  nightly:
+    #triggers:
+    #  - schedule:
+    #      cron: "0 5 * * *"
+    #      filters:
+    #        branches:
+    #          only:
+    #            - "2.0"
+    jobs:
+      - godeps
+      - jsdeps
+      - gotest:
+          requires:
+            - godeps
+      - golint:
+          requires:
+            - godeps
+      - fluxtest:
+          requires:
+            - godeps
+      - tlstest:
+          requires:
+            - godeps
+      - deploy_nightly:
+          requires:
+            - gotest
+            - golint
+            - fluxtest
+            - tlstest
 
   release:
     jobs:
@@ -271,9 +307,15 @@ commands:
     parameters:
       publish_release:
         type: boolean
+      nightly:
+        type: boolean
+        default: false
     steps:
       - when:
-          condition: << parameters.publish_release >>
+          condition:
+            or:
+              - << parameters.publish_release >>
+              - << parameters.nightly >>
           steps:
             - run:
                 name: Import GPG key
@@ -335,19 +377,46 @@ commands:
             docker buildx build --target dependency-base --platform linux/amd64,linux/arm64 docker/influxd
       - install_cross_bin_deps
       - unless:
-          condition: << parameters.publish_release >>
+          condition:
+            or:
+              - << parameters.publish_release >>
+              - << parameters.nightly >>
           steps:
             - run:
                 name: Build release
                 # `goreleaser release --skip-publish` builds Docker images, but doesn't push them.
                 # As opposed to `goreleaser build`, which stops before building Dockers.
-                command: goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
+                command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe)" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
       - when:
           condition: << parameters.publish_release >>
           steps:
             - run:
                 name: Publish release
-                command: goreleaser --debug release -p 1 --rm-dist --skip-validate
+                command: |
+                  S3_FOLDER="influxdb/releases/" \
+                  VERSION=${CIRCLE_TAG} \
+                  goreleaser \
+                    --debug \
+                    release \
+                      -p 1 \
+                      --rm-dist \
+                      --skip-validate
+      - when:
+          condition: << parameters.nightly >>
+          steps:
+            - run:
+                name: Publish nightly
+                #TODO: remove --skip-publish flag
+                command: |
+                  S3_FOLDER="platform/nightlies/2.0" \
+                  VERSION="2.0-nightly" \
+                  goreleaser \
+                    --debug \
+                    release \
+                      --skip-publish \
+                      -p 1 \
+                      --rm-dist \
+                      --skip-validate
 
 jobs:
   ####################
@@ -516,7 +585,7 @@ jobs:
       - install_core_deps
       - install_cross_bin_deps
       # Build the static binary for linux
-      - run: goreleaser build --snapshot --single-target
+      - run: S3_FOLDER="influxdb/releases/" VERSION="$(git describe)" goreleaser build --snapshot --single-target
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -721,6 +790,33 @@ jobs:
           paths:
             - etc/litmus_success_notify.sh
             - etc/litmus_fail_notify.sh
+
+  deploy_nightly:
+    executor: linux-machine
+    environment:
+      TMPDIR: /mnt/ramdisk
+    working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
+    steps:
+      - checkout
+      - run:
+          name: Create RAM disk
+          command: |
+            sudo mkdir -p ${TMPDIR}
+            sudo mount -t tmpfs -o size=4G tmpfs ${TMPDIR}
+      - restore_cache:
+          name: Restore GOPATH/pkg/mod
+          keys:
+            - influxdb-gomod-sum-{{ checksum "go.sum" }}
+      - install_core_deps
+      - upgrade_go
+      - run_goreleaser:
+          publish_release: false
+          nightly: true
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist/influxd_linux_amd64/influxd
+
 
   #################################
   ### e2e/integration test jobs ###

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - PKG_CONFIG=$GOPATH/bin/pkg-config
       - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} {{if eq .Os "linux"}}-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"{{end}}
+      - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} {{if eq .Os "linux"}}-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"{{end}}
     binary: influx
 
   - id: influxd
@@ -51,7 +51,7 @@ builds:
       - PKG_CONFIG=$GOPATH/bin/pkg-config
       - MACOSX_DEPLOYMENT_TARGET=10.11
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} {{if eq .Os "linux"}}-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"{{end}}
+      - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} {{if eq .Os "linux"}}-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"{{end}}
     binary: influxd
     hooks:
       pre: make generate-web-assets
@@ -89,9 +89,9 @@ nfpms:
           amd64: x86_64
           arm64: aarch64
           armhf: armv7hl
-        file_name_template: "influxdb2-{{ .Version }}.{{ .Arch }}"
+        file_name_template: "influxdb2-{{ .Env.VERSION }}.{{ .Arch }}"
       deb:
-        file_name_template: "influxdb2-{{ .Version }}-{{ .Arch }}"
+        file_name_template: "influxdb2-{{ .Env.VERSION }}-{{ .Arch }}"
     vendor: InfluxData
     homepage: https://influxdata.com
     maintainer: support@influxdb.com
@@ -106,7 +106,7 @@ archives:
       - goos: windows
         format: zip
     wrap_in_directory: true
-    name_template: "influxdb2-client-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "influxdb2-client-{{ .Env.VERSION }}-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -116,7 +116,7 @@ archives:
       - goos: windows
         format: zip
     wrap_in_directory: true
-    name_template: "influxdb2-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "influxdb2-{{ .Env.VERSION }}-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -125,10 +125,10 @@ blobs:
   - provider: "s3"
     bucket: "dl.influxdata.com"
     region: "us-east-1"
-    folder: "influxdb/releases/"
+    folder: "{{ .Env.S3_FOLDER }}"
 
 checksum:
-  name_template: "influxdb2-{{ .Version }}.sha256"
+  name_template: "influxdb2-{{ .Env.VERSION }}.sha256"
   algorithm: sha256
 
 dockers:


### PR DESCRIPTION
Incremental CI improvement in service of #19645 

This PR enables nightly builds of the `2.0` branch, to be "published" to s3 and quay

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass