### PR TITLE
chore: pkg_run_test should not run on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,6 +550,7 @@ jobs:
   pkg_run_test:
     executor: terraform/default
     steps:
+      - bail_if_forked
       - attach_workspace:
           at: /tmp/workspace
       - checkout


### PR DESCRIPTION
Closes #22428 for `master`

The `pkg_run_test` should not run on forks because of the credentials required.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass