### PR TITLE
build: disable docker-layer-caching in machine executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ executors:
   linux-machine:
     machine:
       image: ubuntu-2004:202107-02
-      docker_layer_caching: true
       resource_class: large
 
 parameters:


### PR DESCRIPTION
Closes #22431

`docker_layer_caching` was enabled in #22402. Since then we've seen spurious failures in the `cross_build` job when setting up docker cross-builders. [This community post](https://discuss.circleci.com/t/build-docker-image-fails-randomly-with-error-response-from-daemon-container-is-marked-for-removal-and-cannot-be-started/39429/3) suggests that bad caching is to blame for the failures we've seen. Revert the caching config to see if that stabilizes things for us.