### PR TITLE
chore: fetch changelog files prior to updating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -815,6 +815,10 @@ jobs:
             cargo install git-cliff
             cd ..
 
+            S3_PATH="dl.influxdata.com/platform/nightlies/master"
+            curl -o CHANGELOG.md ${S3_PATH}/CHANGELOG.md
+            curl -o scripts/ci/changelog-commit.txt ${S3_PATH}/changelog-commit.txt
+
             TIMESTAMP="$(date -u '+%Y%m%d')"
             COMMIT_FILE_PATH="scripts/ci/changelog-commit.txt"
             LAST_COMMIT=$(cat $COMMIT_FILE_PATH)


### PR DESCRIPTION
Nightly changelog automation needs to first fetch changelog files from the previous night.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass