### PR TITLE
chore(Makefile): allow specifying -gcflags via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ COMMON_TAGS := sqlite_foreign_keys,sqlite_json
 GO_TEST_ARGS := -tags '$(COMMON_TAGS),$(GO_TEST_TAGS)'
 GO_BUILD_ARGS := -tags '$(COMMON_TAGS),$(GO_BUILD_TAGS)'
 
+# Use default flags, but allow adding -gcflags "..." if desired. Eg, for debug
+# builds, may want to use GCFLAGS="all=-N -l" in the build environment.
+GCFLAGS ?=
+ifneq ($(GCFLAGS),)
+GO_BUILD_ARGS += -gcflags "$(GCFLAGS)"
+endif
+
 ifeq ($(OS), Windows_NT)
 	VERSION := $(shell git describe --exact-match --tags 2>nil)
 else
@@ -49,7 +56,6 @@ GO_TEST_PATHS=./...
 # Test vars can be used by all recursive Makefiles
 export PKG_CONFIG:=$(PWD)/scripts/pkg-config.sh
 export GO_BUILD=env GO111MODULE=on go build $(GO_BUILD_ARGS) -ldflags "$(LDFLAGS)"
-export GO_BUILD_SM=env GO111MODULE=on go build $(GO_BUILD_ARGS) -ldflags "-s -w $(LDFLAGS)"
 export GO_INSTALL=env GO111MODULE=on go install $(GO_BUILD_ARGS) -ldflags "$(LDFLAGS)"
 export GO_TEST=env GOTRACEBACK=all GO111MODULE=on $(GO_TEST_CMD) $(GO_TEST_ARGS)
 # Do not add GO111MODULE=on to the call to go generate so it doesn't pollute the environment.


### PR DESCRIPTION
Various make targets call '$(GO_BUILD)' but there is no facility for
specifying arguments to 'go build'. As a first step, introduce the
GCFLAGS Makefile variable that when unset, operates as always, but when
set, adds '-gcflags "$(GCFLAGS)"' to go build. Eg, when unspecified,
maintain the current behavior:
```
$ make
...
env GO111MODULE=on go build -tags ... -ldflags ...
```
When specified, add the specified -gcflags:
```
$ GCFLAGS="all=-N -l" make
...
env GO111MODULE=on go build -tags ... -gcflags "all=-N -l" -ldflags ...
```
This could be useful in various situations such as producing unoptimized
builds (like in the above).

In addition, remove the now unused (since cmd/influx was removed)
GO_BUILD_SM environment variable.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass