### PR TITLE
fix: embed tzinfo into Windows builds to avoid panics in InfluxQL engine

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
         goarch: arm64
     main: ./cmd/influxd/
     flags:
-      - -tags=assets,sqlite_foreign_keys,sqlite_json{{if eq .Os "linux"}},osusergo,netgo,static_build{{if not (eq .Arch "amd64")}},noasm{{end}}{{end}}
+      - -tags=assets,sqlite_foreign_keys,sqlite_json{{if eq .Os "linux"}},osusergo,netgo,static_build{{if not (eq .Arch "amd64")}},noasm{{end}}{{end}}{{if eq .Os "windows"}},timetzdata{{end}}
       - -buildmode={{if eq .Os "windows"}}exe{{else}}pie{{end}}
     env:
       - GO111MODULE=on


### PR DESCRIPTION
Closes #22444

Set the `timetzdata` flag when building Windows binaries to embed fallback time-zone info. This prevents a panic when using `time.LoadLocation` on a Windows machine that doesn't have Go installed. 