### PR TITLE
test: skip signals test on Windows

### DIFF
--- a/kit/signals/context.go
+++ b/kit/signals/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"syscall"
 )
 
 // WithSignals returns a context that is canceled with any signal in sigs.
@@ -27,5 +26,5 @@ func WithSignals(ctx context.Context, sigs ...os.Signal) context.Context {
 
 // WithStandardSignals cancels the context on os.Interrupt, syscall.SIGTERM.
 func WithStandardSignals(ctx context.Context) context.Context {
-	return WithSignals(ctx, os.Interrupt, syscall.SIGTERM)
+	return WithSignals(ctx, os.Interrupt, os.Kill)
 }

--- a/kit/signals/context.go
+++ b/kit/signals/context.go
@@ -24,7 +24,7 @@ func WithSignals(ctx context.Context, sigs ...os.Signal) context.Context {
 	return ctx
 }
 
-// WithStandardSignals cancels the context on os.Interrupt, syscall.SIGTERM.
+// WithStandardSignals cancels the context on os.Interrupt, os.Kill.
 func WithStandardSignals(ctx context.Context) context.Context {
 	return WithSignals(ctx, os.Interrupt, os.Kill)
 }

--- a/kit/signals/context_test.go
+++ b/kit/signals/context_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package signals
 
 import (


### PR DESCRIPTION
`context_test.go` uses `syscall.SIGUSR1` and `syscall.SIGUSR2`, which aren't available on Windows. AFAIK the only signals shared between Windows and *nix Go platforms are Interrupt and Kill, both of which would be tricky to use in the existing test structure. Skip the test on Windows instead of going through the effort of refactoring the test.