### PR TITLE
build: the tag used for quay images should be determined by the VERSION

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,7 +135,7 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - "quay.io/influxdb/influxdb-amd64:{{ .Tag }}"
+      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
     dockerfile: docker/influxd/Dockerfile
     extra_files:
       - docker/influxd/entrypoint.sh
@@ -145,7 +145,7 @@ dockers:
   - goos: linux
     goarch: arm64
     image_templates:
-      - "quay.io/influxdb/influxdb-arm64v8:{{ .Tag }}"
+      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
     dockerfile: docker/influxd/Dockerfile
     extra_files:
       - docker/influxd/entrypoint.sh
@@ -154,10 +154,10 @@ dockers:
     use_buildx: true
 
 docker_manifests:
-  - name_template: "quay.io/influxdb/influxdb:{{ .Tag }}"
+  - name_template: "quay.io/influxdb/influxdb:{{ .Env.VERSION }}"
     image_templates:
-      - "quay.io/influxdb/influxdb-amd64:{{ .Tag }}"
-      - "quay.io/influxdb/influxdb-arm64v8:{{ .Tag }}"
+      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
+      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
 
 signs:
   - signature: "${artifact}.asc"


### PR DESCRIPTION
Closes #22456

Goreleaser should use the version it is passed for quay.io tags, instead of the latest git tag; this is to prevent nightly builds from stepping on releases.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass