### PR TITLE
fix: ensure files are closed before they are deleted or moved in `deletetsm`

### DIFF
--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/pkg/file"
 	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	"github.com/spf13/cobra"
 )
@@ -143,7 +144,7 @@ func (a *args) process(cmd *cobra.Command, path string) error {
 	}
 
 	// Replace original file with new file.
-	if err := os.Rename(outputPath, path); err != nil {
+	if err := file.RenameFile(outputPath, path); err != nil {
 		return fmt.Errorf("failed to update TSM file %q: %w", path, err)
 	}
 	if !hasData {

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -142,6 +142,9 @@ func (a *args) process(cmd *cobra.Command, path string) error {
 	if err := w.Close(); err != nil {
 		return fmt.Errorf("failed to close TSM Writer: %w", err)
 	}
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("failed to close TSM Reader: %w", err)
+	}
 
 	// Replace original file with new file.
 	if err := file.RenameFile(outputPath, path); err != nil {

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
@@ -164,9 +164,12 @@ func createTSMFile(t *testing.T, params tsmParams) (string, string) {
 		file, err = os.CreateTemp(dir, "*.txt")
 	}
 	require.NoError(t, err)
+	defer file.Close()
 
 	w, err := tsm1.NewTSMWriter(file)
 	require.NoError(t, err)
+	defer w.Close()
+
 	for _, key := range params.keys {
 		values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 		require.NoError(t, w.Write([]byte(key), values))
@@ -179,7 +182,6 @@ func createTSMFile(t *testing.T, params tsmParams) (string, string) {
 	if params.invalid {
 		require.NoError(t, binary.Write(file, binary.BigEndian, []byte("foobar\n")))
 	}
-	require.NoError(t, w.Close())
 
 	return dir, file.Name()
 }


### PR DESCRIPTION
Windows is apparently really strict about enforcing that there are no open handles to a file when you try to move or delete it; if there's a dangling reference, you get a permissions error. It also prevents a move that overwrites an existing file; you have to delete the file at the destination first, then move.