### PR TITLE
chore: persist changelog artifacts to workspace for uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,14 @@ jobs:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
       - install_core_deps
       - upgrade_go
+      - run:
+          # These files do not get uploaded by goreleaser when publish_release
+          # is false, but must be present to prevent a stat error
+          name: Touch dummy changelog files
+          command: |
+            mkdir changelog_artifacts
+            touch changelog_artifacts/CHANGELOG.md
+            touch changelog_artifacts/changelog-commit.txt
       - run_goreleaser:
           publish_release: false
       - run:
@@ -676,6 +684,8 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Create RAM disk
           command: |
@@ -687,6 +697,11 @@ jobs:
             - influxdb-gomod-sum-{{ checksum "go.sum" }}
       - install_core_deps
       - upgrade_go
+      - run:
+          # Goreleaser's blob stanza requires relative paths
+          name: Copy changelog artifacts into checkout dir
+          command: |
+            cp -a /tmp/workspace/changelog_artifacts ./changelog_artifacts
       - run_goreleaser:
           publish_release: true
       - persist_to_workspace:
@@ -829,5 +844,14 @@ jobs:
               -- \
               --tag $TIMESTAMP
             echo ${CIRCLE_SHA1} > $COMMIT_FILE_PATH
+
+            mkdir changelog_artifacts
+            cp CHANGELOG.md changelog_artifacts
+            cp $COMMIT_FILE_PATH changelog_artifacts
       - store_artifacts:
-          path: CHANGELOG.md
+          path: changelog_artifacts/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - changelog_artifacts
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,8 +90,8 @@ blobs:
     region: "us-east-1"
     folder: "platform/nightlies/"
     extra_files:
-      - glob: ./CHANGELOG.md
-      - glob: ./scripts/ci/changelog-commit.txt
+      - glob: ./changelog_artifacts/CHANGELOG.md
+      - glob: ./changelog_artifacts/changelog-commit.txt
   # Duplicating the contents to another folder in the bucket ensures
   # scheme parity with release branches; eventually the artifacts should
   # __only__ appear in the branch-specific folder
@@ -100,8 +100,8 @@ blobs:
     region: "us-east-1"
     folder: "platform/nightlies/master/"
     extra_files:
-      - glob: ./CHANGELOG.md
-      - glob: ./scripts/ci/changelog-commit.txt
+      - glob: ./changelog_artifacts/CHANGELOG.md
+      - glob: ./changelog_artifacts/changelog-commit.txt
 
 checksum:
   name_template: "influxdb2-nightly.sha256"


### PR DESCRIPTION
Allows changelogs to be successfully found and uploaded to S3 by goreleaser

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass