### PR TITLE
build: run perf test queries only on specific datasets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,20 +69,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          # filters:
-          #   branches:
-          #     only:
-          #       - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,20 +69,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+          # filters:
+          #   branches:
+          #     only:
+          #       - "master"
       - grace_daily:
           requires:
             - build

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -177,29 +177,9 @@ force_compaction() {
 # must be provided to both the data generation and query generation commands
 # and must be the same to ensure that the queries cover the data range.
 start_time() {
-  case $1 in
-    iot|window-agg|group-agg|bare-agg)
-      echo 2018-01-01T00:00:00Z
-      ;;
-    group-window-transpose)
-      cardinality=$(echo $2 | cut -d '-' -f2)
-      if [ "$cardinality" = "low" ]; then
-        echo 2018-01-01T00:00:00Z
-      else
-        echo 2019-01-01T00:00:00Z
-      fi
-      ;;
-    metaquery)
-      echo 2019-01-01T00:00:00Z
-      ;;
-    multi-measurement)
-      echo 2017-01-01T00:00:00Z
-      ;;
-    *)
-      echo "unknown use-case: $1"
-      exit 1
-      ;;
-  esac
+  # All queries and datasets can start at the same time. Certain queries and
+  # datasets will use case-dependent end-times.
+  echo 2018-01-01T00:00:00Z
 }
 
 end_time() {
@@ -207,19 +187,20 @@ end_time() {
     iot|window-agg|group-agg|bare-agg)
       echo 2018-01-01T12:00:00Z
       ;;
+    multi-measurement|metaquery)
+      echo 2019-01-01T00:00:00Z
+      ;;
     group-window-transpose)
+    # The group-window transpose tests currently require special handling due to
+    # the difference in performance between having the existing pushdown enabled
+    # or disabled for data with varying degrees of cardinality. Ideally this
+    # pushdown will be optimized and this test can be simplified in the future.
       cardinality=$(echo $2 | cut -d '-' -f2)
       if [ "$cardinality" = "low" ]; then
         echo 2018-01-01T12:00:00Z
       else
-        echo 2020-01-01T00:00:00Z
+        echo 2019-01-01T00:00:00Z
       fi
-      ;;
-    metaquery)
-      echo 2020-01-01T00:00:00Z
-      ;;
-    multi-measurement)
-      echo 2018-01-01T00:00:00Z
       ;;
     *)
       echo "unknown use-case: $1"

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -361,8 +361,8 @@ for usecase in iot metaquery multi-measurement; do
       systemctl start influxdb
   done
 
-   # Delete DB to start anew.
-  influx bucket delete -o $TEST_ORG -t $TEST_TOKEN -n $db_name
+  # Delete DB to start anew.
+  curl -X DELETE -H "Authorization: Token ${TEST_TOKEN}" http://${NGINX_HOST}:8086/api/v2/buckets/$(bucket_id)
 done
 
 echo "Using Telegraph to report results from the following files:"

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -384,8 +384,6 @@ for usecase in iot metaquery multi-measurement; do
   influx bucket delete -o $TEST_ORG -t $TEST_TOKEN -n $db_name
 done
 
-exit 0
-
 echo "Using Telegraph to report results from the following files:"
 ls $working_dir
 


### PR DESCRIPTION
Closes #22350

Updates the perf test script to populate the database with the data from one use case at a time and run all applicable tests against that data, removing the data from the database between runs.