### PR TITLE
test: close temp sfile before running buildtsi compaction test

### DIFF
--- a/cmd/influxd/inspect/build_tsi/build_tsi.go
+++ b/cmd/influxd/inspect/build_tsi/build_tsi.go
@@ -259,7 +259,7 @@ func (buildTSICmd *buildTSI) compactSeriesFilePartition(path string) error {
 		src := dst + tmpExt
 
 		buildTSICmd.Logger.Debug("Renaming new segment", zap.String("prev", src), zap.String("new", dst))
-		if err = file.RenameFile(src, dst); err != nil && !os.IsNotExist(err) {
+		if err := file.RenameFile(src, dst); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("serious failure. Please rebuild index and series file: %w", err)
 		}
 	}
@@ -267,7 +267,7 @@ func (buildTSICmd *buildTSI) compactSeriesFilePartition(path string) error {
 	// Remove index file so it will be rebuilt when reopened.
 	buildTSICmd.Logger.Debug("Removing index file", zap.String("path", indexPath))
 
-	if err = os.Remove(indexPath); err != nil && !os.IsNotExist(err) { // index won't exist for low cardinality
+	if err := os.Remove(indexPath); err != nil && !os.IsNotExist(err) { // index won't exist for low cardinality
 		return err
 	}
 

--- a/cmd/influxd/inspect/build_tsi/build_tsi_test.go
+++ b/cmd/influxd/inspect/build_tsi/build_tsi_test.go
@@ -372,6 +372,7 @@ func runCommand(t *testing.T, params cmdParams, outs cmdOuts) {
 		require.DirExists(t, filepath.Join(params.dataPath, "12345", "_series"))
 
 		// Get size of all partitions after series compaction
+		require.NoError(t, sfile.Open())
 		afterSize, err := sfile.FileSize()
 		require.NoError(t, err)
 


### PR DESCRIPTION
* Make sure any series files created as part of test setup are fully closed before running the `buildtsi` command
* Replace hard-coded unix paths with use of `filepath.Join`