### PR TITLE
test: update various tests to pass on Windows

### DIFF
--- a/cmd/influxd/inspect/dump_wal/dump_wal_test.go
+++ b/cmd/influxd/inspect/dump_wal/dump_wal_test.go
@@ -28,7 +28,7 @@ func Test_DumpWal_Bad_Path(t *testing.T) {
 		findDuplicates: false,
 		walPaths:       []string{"badpath.wal"},
 		expectErr:      true,
-		expectedOut:    "open badpath.wal: no such file or directory",
+		expectedOut:    "open badpath.wal",
 	}
 
 	runCommand(t, params)
@@ -198,7 +198,7 @@ func runCommand(t *testing.T, params cmdParams) {
 	cmd := initCommand(t, params)
 
 	if params.expectErr {
-		require.EqualError(t, cmd.Execute(), params.expectedOut)
+		require.Contains(t, cmd.Execute().Error(), params.expectedOut)
 		return
 	}
 

--- a/cmd/influxd/inspect/report_tsi/report_tsi_test.go
+++ b/cmd/influxd/inspect/report_tsi/report_tsi_test.go
@@ -36,7 +36,7 @@ func Test_ReportTSI_Bucket_Does_Not_Exist(t *testing.T) {
 	params := cmdParams{
 		bucketId:    "12345",
 		expectErr:   true,
-		expectedOut: fmt.Sprintf("open %s: no such file or directory", filepath.Join("12345", "autogen")),
+		expectedOut: fmt.Sprintf("open %s", filepath.Join("12345", "autogen")),
 	}
 	runCommand(t, params)
 }
@@ -174,7 +174,7 @@ func runCommand(t *testing.T, params cmdParams) {
 	cmd := initCommand(t, params)
 
 	if params.expectErr {
-		require.EqualError(t, cmd.Execute(), params.expectedOut)
+		require.Contains(t, cmd.Execute().Error(), params.expectedOut)
 		return
 	}
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -141,6 +141,7 @@ func NewTempTombstone(t *testing.T) (string, *os.File) {
 
 	file, err := os.CreateTemp(dir, "verifytombstonetest*"+"."+tsm1.TombstoneFileExtension)
 	require.NoError(t, err)
+	defer file.Close()
 
 	return dir, file
 }


### PR DESCRIPTION
* Assert on subset of error messages common between Windows and Unix
* Assert that file permissions don't change after being moved instead of asserting on a unix-specific permission
* Use generic filepath separators instead of hard-coding `/`
* Ensure files are closed before moving / deleting them