### PR TITLE
fix: tag value metaqueries work with additional flux predicates

### DIFF
--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -33,7 +33,7 @@ build_test_harness() {
 
 run_integration_tests() {
   log "Running integration tests..."
-  ./fluxtest -v -p flux.zip -p query/ --test tag_values_measurement_or_predicate --test tag_values_measurement_or_regex --test tag_values_measurement_or_negation
+  ./fluxtest -v -p flux.zip -p query/
 }
 
 cleanup() {

--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -33,7 +33,7 @@ build_test_harness() {
 
 run_integration_tests() {
   log "Running integration tests..."
-  ./fluxtest -v -p flux.zip -p query/
+  ./fluxtest -v -p flux.zip -p query/ --test tag_values_measurement_or_predicate --test tag_values_measurement_or_regex --test tag_values_measurement_or_negation
 }
 
 cleanup() {

--- a/query/stdlib/influxdata/influxdb/tag_values_measurement_or_predicate_test.flux
+++ b/query/stdlib/influxdata/influxdb/tag_values_measurement_or_predicate_test.flux
@@ -1,0 +1,125 @@
+package influxdb_test
+
+import "csv"
+import "testing"
+
+option now = () => 2030-01-01T00:00:00Z
+
+input = "
+#group,false,false,false,false,true,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,_result,,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,mode,path
+,,0,2020-10-21T20:48:30Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:40Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:50Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,1,2020-10-21T20:48:30Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:40Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:50Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,2,2020-10-21T20:48:30Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:40Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:50Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,3,2020-10-21T20:48:30Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:40Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:50Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+
+#group,false,false,false,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string
+#default,_result,,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host,region
+,,4,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,euterpe.local,south
+,,4,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,euterpe.local,south
+,,4,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,euterpe.local,south
+,,5,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,euterpe.local,south
+,,5,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,euterpe.local,south
+,,5,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,euterpe.local,south
+
+#group,false,false,false,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string
+#default,_result,,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host,region
+,,6,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,6,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,6,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,7,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,mnemosyne.local,east
+,,7,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,mnemosyne.local,east
+,,7,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,mnemosyne.local,east
+
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,string,string,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_field,_measurement,_time,_value,cpu,host,region
+,,8,usage_user,cpu,2020-10-21T20:48:30Z,19.30000000007567,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:40Z,20.020020020038682,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:50Z,18.581418581407107,cpu0,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:30Z,2.3000000000138243,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:40Z,2.4000000000536965,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:50Z,2.0999999999423746,cpu1,euterpe.local,north
+"
+
+testcase tag_values_measurement_or_predicate {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] == "cpu")
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["host"] == "euterpe.local")
+        |> keep(columns: ["region"])
+        |> group()
+        |> distinct(column: "region")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,north
+,,0,south
+")
+
+    testing.diff(got, want)
+}
+
+testcase tag_values_measurement_or_negation {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] != "cpu")
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["host"] == "euterpe.local")
+        |> keep(columns: ["fstype"])
+        |> group()
+        |> distinct(column: "fstype")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,apfs
+,,0,hfs
+")
+
+    testing.diff(got, want)
+}
+
+testcase tag_values_measurement_or_regex {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] =~ /cp.*/)
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["host"] !~ /mnemo.*/)
+        |> keep(columns: ["region"])
+        |> group()
+        |> distinct(column: "region")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,north
+,,0,south
+")
+
+    testing.diff(got, want)
+}
+

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -96,6 +96,7 @@ type TSDBStore interface {
 	Shards(ids []uint64) []*tsdb.Shard
 	TagKeys(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
 	TagValues(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
+	TagValuesByPredicate(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
 	SeriesCardinality(ctx context.Context, database string) (int64, error)
 	SeriesCardinalityFromShards(ctx context.Context, shards []*tsdb.Shard) (*tsdb.SeriesIDSet, error)
 	SeriesFile(database string) *tsdb.SeriesFile

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1771,9 +1771,6 @@ func (s *Store) TagValuesByPredicate(ctx context.Context, auth query.Authorizer,
 	return s.tagValues(ctx, names, is, auth, cond)
 }
 
-// tagValues takes an influxql condition and a list of measurement names and
-// returns a slice of TagValues for those measurement names matching the
-// condition.
 func (s *Store) tagValues(ctx context.Context, names [][]byte, is IndexSet, auth query.Authorizer, cond influxql.Expr) ([]TagValues, error) {
 	filterExpr := influxql.CloneExpr(cond)
 	filterExpr = influxql.Reduce(influxql.RewriteExpr(filterExpr, func(e influxql.Expr) influxql.Expr {

--- a/v1/services/storage/store.go
+++ b/v1/services/storage/store.go
@@ -30,8 +30,7 @@ type TSDBStore interface {
 	ShardGroup(ids []uint64) tsdb.ShardGroup
 	Shards(ids []uint64) []*tsdb.Shard
 	TagKeys(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
-	TagValues(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
-	SeriesCardinality(ctx context.Context, database string) (int64, error)
+	TagValuesByPredicate(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
 	SeriesCardinalityFromShards(ctx context.Context, shards []*tsdb.Shard) (*tsdb.SeriesIDSet, error)
 	SeriesFile(database string) *tsdb.SeriesFile
 }
@@ -450,7 +449,7 @@ func (s *Store) tagValues(ctx context.Context, mqAttrs *metaqueryAttributes, tag
 
 	// TODO(jsternberg): Use a real authorizer.
 	auth := query.OpenAuthorizer
-	values, err := s.TSDBStore.TagValues(ctx, auth, shardIDs, mqAttrs.pred)
+	values, err := s.TSDBStore.TagValuesByPredicate(ctx, auth, shardIDs, mqAttrs.pred)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #22385

This allows for more complex flux predicates to properly work with the tag values metaquery.

The existing code path for the flux tag values pushdown goes through the `tsdb.Store` `TagValues` method. The existing logic in this method was reducing query AST's in a way that would result in incorrect results for some kinds of predicates that can be constructed only using Flux - see example and additional information in linked issue.

This PR fixes that by adding a separate code path that gets the names of applicable measurements using the flux predicate and the `MeasurementNamesByPredicate` method added in https://github.com/influxdata/influxdb/pull/19566 to get the correct list of names, which does not have [problems with negation operators](https://github.com/influxdata/influxdb/issues/9976). 

I also tried using a single code path, wherein InfluxQL queries would also use `MeasurementNamesByPredicate`, but ran into issues along the lines of those described in https://github.com/influxdata/idpe/issues/7592, where the special handling of `value` in the `WHERE` clause of an InfluxQL query made this impractical. There should be no change to existing InfluxQL queries with this change.