### PR TITLE
fix: For Windows, close temp file before removing

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -269,7 +269,7 @@ func (cmd *Command) backupShard(db, rp, sid string) (err error) {
 		}
 		defer func() {
 			if closeErr := f.Close(); err == nil {
-				err= closeErr
+				err = closeErr
 			}
 			if remErr := os.Remove(shardArchivePath); err == nil {
 				err = remErr

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -218,7 +218,7 @@ func (cmd *Command) parseFlags(args []string) (err error) {
 	return err
 }
 
-func (cmd *Command) backupShard(db, rp, sid string) (e error) {
+func (cmd *Command) backupShard(db, rp, sid string) (err error) {
 	reqType := snapshotter.RequestShardBackup
 	if !cmd.isBackup {
 		reqType = snapshotter.RequestShardExport
@@ -262,70 +262,62 @@ func (cmd *Command) backupShard(db, rp, sid string) (e error) {
 	}
 
 	if cmd.portable {
-		f, err := os.Open(shardArchivePath)
+		var f, out *os.File
+		f, err = os.Open(shardArchivePath)
 		if err != nil {
 			return err
 		}
 		defer func() {
-			if closeErr := f.Close(); e == nil {
-				e = closeErr
+			if closeErr := f.Close(); err == nil {
+				err= closeErr
 			}
-			if remErr := os.Remove(shardArchivePath); e == nil {
-				e = remErr
+			if remErr := os.Remove(shardArchivePath); err == nil {
+				err = remErr
 			}
 		}()
 
 		filePrefix := cmd.portableFileBase + ".s" + sid
 		filename := filePrefix + ".tar.gz"
-		out, err := os.OpenFile(filepath.Join(cmd.path, filename), os.O_CREATE|os.O_RDWR, 0600)
+		out, err = os.OpenFile(filepath.Join(cmd.path, filename), os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return err
 		}
-
+		defer func() {
+			if out != nil {
+				if e := out.Close(); err == nil {
+					err = e
+				}
+			}
+		}()
 		zw := gzip.NewWriter(out)
+		defer func() {
+			if zw != nil {
+				if e := zw.Close(); err == nil {
+					err = e
+				}
+			}
+		}()
 		zw.Name = filePrefix + ".tar"
 
 		cw := backup_util.CountingWriter{Writer: zw}
 
 		_, err = io.Copy(&cw, f)
 		if err != nil {
-			if err := zw.Close(); err != nil {
-				return err
-			}
-
-			if err := out.Close(); err != nil {
-				return err
-			}
 			return err
 		}
-
-		shardid, err := strconv.ParseUint(sid, 10, 64)
+		var shardID uint64
+		shardID, err = strconv.ParseUint(sid, 10, 64)
 		if err != nil {
-			if err := zw.Close(); err != nil {
-				return err
-			}
-
-			if err := out.Close(); err != nil {
-				return err
-			}
 			return err
 		}
 		cmd.manifest.Files = append(cmd.manifest.Files, backup_util.Entry{
 			Database:     db,
 			Policy:       rp,
-			ShardID:      shardid,
+			ShardID:      shardID,
 			FileName:     filename,
 			Size:         cw.Total,
 			LastModified: 0,
 		})
-
-		if err := zw.Close(); err != nil {
-			return err
-		}
-
-		if err := out.Close(); err != nil {
-			return err
-		}
 
 		cmd.BackupFiles = append(cmd.BackupFiles, filename)
 	}


### PR DESCRIPTION
Close temp files before removing them, because 
Windows does not permit open files to be removed.

Closes https://github.com/influxdata/influxdb/issues/21470

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
