### PR TITLE
feat: Add Bearer token auth

### DIFF
--- a/http/tokens.go
+++ b/http/tokens.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 )
 
-const tokenScheme = "Token " // TODO(goller): I'd like this to be Bearer
+const tokenScheme = "Token "
+const altTokenScheme = "Bearer "
 
 // errors
 var (
@@ -21,10 +22,14 @@ func GetToken(r *http.Request) (string, error) {
 	if header == "" {
 		return "", ErrAuthHeaderMissing
 	}
-	if !strings.HasPrefix(header, tokenScheme) {
-		return "", ErrAuthBadScheme
+
+	if strings.HasPrefix(header, tokenScheme) {
+		return header[len(tokenScheme):], nil
+	} else if strings.HasPrefix(header, altTokenScheme) {
+		return header[len(altTokenScheme):], nil
 	}
-	return header[len(tokenScheme):], nil
+
+	return "", ErrAuthBadScheme
 }
 
 // SetToken adds the token to the request.

--- a/http/tokens.go
+++ b/http/tokens.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 )
 
-const tokenScheme = "Token "
-const altTokenScheme = "Bearer "
+const (
+	tokenScheme  = "Token "
+	bearerScheme = "Bearer "
+)
 
 // errors
 var (
@@ -23,10 +25,12 @@ func GetToken(r *http.Request) (string, error) {
 		return "", ErrAuthHeaderMissing
 	}
 
-	if strings.HasPrefix(header, tokenScheme) {
+	if len(header) >= len(tokenScheme) &&
+		strings.EqualFold(header[:len(tokenScheme)], tokenScheme) {
 		return header[len(tokenScheme):], nil
-	} else if strings.HasPrefix(header, altTokenScheme) {
-		return header[len(altTokenScheme):], nil
+	} else if len(header) > len(bearerScheme) &&
+		strings.EqualFold(header[:len(bearerScheme)], bearerScheme) {
+		return header[len(bearerScheme):], nil
 	}
 
 	return "", ErrAuthBadScheme

--- a/http/tokens_test.go
+++ b/http/tokens_test.go
@@ -56,6 +56,15 @@ func TestGetToken(t *testing.T) {
 				result: "tok2",
 			},
 		},
+		{
+			name: "bearer token",
+			args: args{
+				header: "Bearer tok2",
+			},
+			wants: wants{
+				result: "tok2",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/http/tokens_test.go
+++ b/http/tokens_test.go
@@ -65,6 +65,15 @@ func TestGetToken(t *testing.T) {
 				result: "tok2",
 			},
 		},
+		{
+			name: "short header",
+			args: args{
+				header: "a",
+			},
+			wants: wants{
+				err: ErrAuthBadScheme,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

This change allows us to conform to standard Bearer token syntax and allows users to specify credentials as 

`Authorization: Bearer dfsdfsdf`

This allows our APIs to be easily used from tools that support configuring Bearer auth.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
