### PR TITLE
build: changelog job should use aws domain to avoid CDN caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,7 @@ jobs:
             cargo install git-cliff
             cd ..
 
-            S3_PATH="dl.influxdata.com/platform/nightlies/master"
+            S3_PATH="https://s3.amazonaws.com/dl.influxdata.com/platform/nightlies/master"
             curl -o CHANGELOG.md ${S3_PATH}/CHANGELOG.md
             curl -o scripts/ci/changelog-commit.txt ${S3_PATH}/changelog-commit.txt
 


### PR DESCRIPTION
Fixes a flaky issue with changelog job in CI where a `curl` to `dl.influxdata.com` will sometimes fetch an old file, likely due to the CDN distribution not having been invalidated since the previous nightly.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass