### PR TITLE
fix: make TSI index compact old and too-large log files

### DIFF
--- a/pkg/estimator/hll/hll.go
+++ b/pkg/estimator/hll/hll.go
@@ -151,9 +151,10 @@ func (h *Plus) Add(v []byte) {
 
 		if uint32(len(h.tmpSet))*100 > h.m {
 			h.mergeSparse()
-			if uint32(h.sparseList.Len()) > h.m {
-				h.toNormal()
-			}
+		}
+		if uint32(h.sparseList.Len()) > h.m {
+			h.mergeSparse()
+			h.toNormal()
 		}
 	} else {
 		i := bextr(x, 64-h.p, h.p) // {x63,...,x64-p}
@@ -241,6 +242,10 @@ func (h *Plus) MarshalBinary() (data []byte, err error) {
 		return nil, nil
 	}
 
+	if h.sparse {
+		h.mergeSparse()
+	}
+
 	// Marshal a version marker.
 	data = append(data, version)
 
@@ -251,7 +256,7 @@ func (h *Plus) MarshalBinary() (data []byte, err error) {
 		// It's using the sparse representation.
 		data = append(data, byte(1))
 
-		// Add the tmp_set
+		// Add the tmp_set (should be empty)
 		tsdata, err := h.tmpSet.MarshalBinary()
 		if err != nil {
 			return nil, err

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/influxdata/influxdb/v2/tsdb"
 )
 
+// This function is used to log the components of disk size when DiskSizeBytes fails
+func (i *Index) LogDiskSize(t *testing.T) {
+	fs, err := i.RetainFileSet()
+	if err != nil {
+		t.Log("could not retain fileset")
+	}
+	defer fs.Release()
+	var size int64
+	// Get MANIFEST sizes from each partition.
+	for count, p := range i.partitions {
+		sz := p.manifestSize
+		t.Logf("Parition %d has size %d", count, sz)
+		size += sz
+	}
+	for _, f := range fs.files {
+		sz := f.Size()
+		t.Logf("Size of file %s is %d", f.Path(), sz)
+		size += sz
+	}
+	t.Logf("Total size is %d", size)
+}
+
 func TestTagValueSeriesIDCache(t *testing.T) {
 	m0k0v0 := tsdb.NewSeriesIDSet(1, 2, 3, 4, 5)
 	m0k0v1 := tsdb.NewSeriesIDSet(10, 20, 30, 40, 50)

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -87,6 +87,8 @@ func NewLogFile(sfile *tsdb.SeriesFile, path string) *LogFile {
 
 // bytes estimates the memory footprint of this LogFile, in bytes.
 func (f *LogFile) bytes() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	var b int
 	b += 24 // mu RWMutex is 24 bytes
 	b += 16 // wg WaitGroup is 16 bytes
@@ -261,6 +263,13 @@ func (f *LogFile) Size() int64 {
 	v := f.size
 	f.mu.RUnlock()
 	return v
+}
+
+// ModTime returns the last modified time of the file
+func (f *LogFile) ModTime() time.Time {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.modTime
 }
 
 // Measurement returns a measurement element.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -71,6 +71,7 @@ type Partition struct {
 
 	// Log file compaction thresholds.
 	MaxLogFileSize int64
+	MaxLogFileAge  time.Duration
 	nosync         bool // when true, flushing and syncing of LogFile will be disabled.
 	logbufferSize  int  // the LogFile's buffer is set to this value.
 
@@ -130,6 +131,7 @@ func (p *Partition) bytes() int {
 	b += int(unsafe.Sizeof(p.path)) + len(p.path)
 	b += int(unsafe.Sizeof(p.id)) + len(p.id)
 	b += int(unsafe.Sizeof(p.MaxLogFileSize))
+	b += int(unsafe.Sizeof(p.MaxLogFileAge))
 	b += int(unsafe.Sizeof(p.compactionInterrupt))
 	b += int(unsafe.Sizeof(p.compactionsDisabled))
 	b += int(unsafe.Sizeof(p.logger))
@@ -238,7 +240,7 @@ func (p *Partition) Open() error {
 	p.opened = true
 
 	// Send a compaction request on start up.
-	p.compact()
+	go p.runPeriodicCompaction()
 
 	return nil
 }
@@ -473,6 +475,7 @@ func (p *Partition) prependActiveLogFile() error {
 	manifestSize, err := p.Manifest().Write()
 	if err != nil {
 		// TODO: Close index if write fails.
+		p.logger.Error("manifest write failed, index is potentially damaged", zap.Error(err))
 		return err
 	}
 	p.manifestSize = manifestSize
@@ -892,7 +895,54 @@ func (p *Partition) compactionsEnabled() bool {
 	return p.compactionsDisabled == 0
 }
 
+func (p *Partition) runPeriodicCompaction() {
+	// kick off an initial compaction at startup without the optimization check
+	p.Compact()
+
+	// Avoid a race when using Reopen in tests
+	p.mu.RLock()
+	closing := p.closing
+	p.mu.RUnlock()
+
+	// check for compactions once an hour (usually not necessary but a nice safety check)
+	t := time.NewTicker(1 * time.Hour)
+	defer t.Stop()
+	for {
+		select {
+		case <-closing:
+			return
+		case <-t.C:
+			if p.NeedsCompaction() {
+				p.Compact()
+			}
+		}
+	}
+}
+
+// NeedsCompaction only requires a read lock and checks if there are files that could be compacted.
+// If compact is updated we should also update NeedsCompaction.
+func (p *Partition) NeedsCompaction() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.needsLogCompaction() {
+		return true
+	}
+	levelCount := make(map[int]int)
+	maxLevel := len(p.levels) - 2
+	// If we have 2 log files (level 0), or if we have 2 files at the same level, we should do a compaction.
+	for _, f := range p.fileSet.files {
+		level := f.Level()
+		levelCount[level]++
+		if level <= maxLevel && levelCount[level] > 1 && !p.levelCompacting[level] {
+			return true
+		}
+	}
+	return false
+}
+
 // compact compacts continguous groups of files that are not currently compacting.
+//
+// compact requires that mu is write-locked.
 func (p *Partition) compact() {
 	if p.isClosing() {
 		return
@@ -903,6 +953,37 @@ func (p *Partition) compact() {
 
 	fs := p.retainFileSet()
 	defer fs.Release()
+
+	// check if the current active log file should be rolled
+	if p.needsLogCompaction() {
+		if err := p.prependActiveLogFile(); err != nil {
+			p.logger.Error("failed to retire active log file", zap.Error(err))
+		}
+	}
+
+	// compact any non-active log files first
+	for _, f := range p.fileSet.files {
+		if f.Level() == 0 {
+			logFile := f.(*LogFile) // It is an invariant that a file is level 0 iff it is a log file
+			if logFile == p.activeLogFile {
+				continue
+			}
+			if p.levelCompacting[0] {
+				break
+			}
+			// Mark the level as compacting.
+			p.levelCompacting[0] = true
+			p.currentCompactionN++
+			go func() {
+				p.compactLogFile(logFile)
+				p.mu.Lock()
+				p.currentCompactionN--
+				p.levelCompacting[0] = false
+				p.mu.Unlock()
+				p.Compact()
+			}()
+		}
+	}
 
 	// Iterate over each level we are going to compact.
 	// We skip the first level (0) because it is log files and they are compacted separately.
@@ -956,6 +1037,11 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 	assert(len(files) >= 2, "at least two index files are required for compaction")
 	assert(level > 0, "cannot compact level zero")
 
+	// Files have already been retained by caller.
+	// Ensure files are released only once.
+	var once sync.Once
+	defer once.Do(func() { IndexFiles(files).Release() })
+
 	// Build a logger for this compaction.
 	log, logEnd := logger.NewOperation(context.TODO(), p.logger, "TSI level compaction", "tsi1_compact_to_level", zap.Int("tsi1_level", level))
 	defer logEnd()
@@ -967,11 +1053,6 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 		return
 	default:
 	}
-
-	// Files have already been retained by caller.
-	// Ensure files are released only once.
-	var once sync.Once
-	defer once.Do(func() { IndexFiles(files).Release() })
 
 	// Track time to compact.
 	start := time.Now()
@@ -1060,13 +1141,22 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 
 func (p *Partition) Rebuild() {}
 
+// needsLogCompaction returns true if the log file is too big or too old
+// The caller must have at least a read lock on the partition
+func (p *Partition) needsLogCompaction() bool {
+	size := p.activeLogFile.Size()
+	modTime := p.activeLogFile.ModTime()
+	return size >= p.MaxLogFileSize || (size > 0 && modTime.Before(time.Now().Add(-p.MaxLogFileAge)))
+}
+
 func (p *Partition) CheckLogFile() error {
-	// Check log file size under read lock.
-	if size := func() int64 {
+	// Check log file under read lock.
+	needsCompaction := func() bool {
 		p.mu.RLock()
 		defer p.mu.RUnlock()
-		return p.activeLogFile.Size()
-	}(); size < p.MaxLogFileSize {
+		return p.needsLogCompaction()
+	}()
+	if !needsCompaction {
 		return nil
 	}
 
@@ -1077,12 +1167,9 @@ func (p *Partition) CheckLogFile() error {
 }
 
 func (p *Partition) checkLogFile() error {
-	if p.activeLogFile.Size() < p.MaxLogFileSize {
+	if !p.needsLogCompaction() {
 		return nil
 	}
-
-	// Swap current log file.
-	logFile := p.activeLogFile
 
 	// Open new log file and insert it into the first position.
 	if err := p.prependActiveLogFile(); err != nil {
@@ -1090,14 +1177,7 @@ func (p *Partition) checkLogFile() error {
 	}
 
 	// Begin compacting in a background goroutine.
-	p.currentCompactionN++
 	go func() {
-		p.compactLogFile(logFile)
-
-		p.mu.Lock()
-		p.currentCompactionN-- // compaction is now complete
-		p.mu.Unlock()
-
 		p.Compact() // check for new compactions
 	}()
 


### PR DESCRIPTION
Closes #22306

Backports #22334 and a small part of #22322 (not backporting the entirety of #22322 since it introduces new InfluxQL features)