### PR TITLE
refactor: various cleanups to the TSI file set

### DIFF
--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -15,14 +15,12 @@ import (
 
 // FileSet represents a collection of files.
 type FileSet struct {
-	sfile *tsdb.SeriesFile
 	files []File
 }
 
 // NewFileSet returns a new instance of FileSet.
-func NewFileSet(sfile *tsdb.SeriesFile, files []File) *FileSet {
+func NewFileSet(files []File) *FileSet {
 	return &FileSet{
-		sfile: sfile,
 		files: files,
 	}
 }
@@ -63,14 +61,10 @@ func (fs *FileSet) Release() {
 	}
 }
 
-// SeriesFile returns the attached series file.
-func (fs *FileSet) SeriesFile() *tsdb.SeriesFile { return fs.sfile }
-
 // PrependLogFile returns a new file set with f added at the beginning.
 // Filters do not need to be rebuilt because log files have no bloom filter.
 func (fs *FileSet) PrependLogFile(f *LogFile) *FileSet {
 	return &FileSet{
-		sfile: fs.sfile,
 		files: append([]File{f}, fs.files...),
 	}
 }

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -15,27 +15,21 @@ import (
 
 // FileSet represents a collection of files.
 type FileSet struct {
-	levels       []CompactionLevel
-	sfile        *tsdb.SeriesFile
-	files        []File
-	manifestSize int64 // Size of the manifest file in bytes.
+	sfile *tsdb.SeriesFile
+	files []File
 }
 
 // NewFileSet returns a new instance of FileSet.
-func NewFileSet(levels []CompactionLevel, sfile *tsdb.SeriesFile, files []File) (*FileSet, error) {
+func NewFileSet(sfile *tsdb.SeriesFile, files []File) *FileSet {
 	return &FileSet{
-		levels: levels,
-		sfile:  sfile,
-		files:  files,
-	}, nil
+		sfile: sfile,
+		files: files,
+	}
 }
 
 // bytes estimates the memory footprint of this FileSet, in bytes.
 func (fs *FileSet) bytes() int {
 	var b int
-	for _, level := range fs.levels {
-		b += int(unsafe.Sizeof(level))
-	}
 	// Do not count SeriesFile because it belongs to the code that constructed this FileSet.
 	for _, file := range fs.files {
 		b += file.bytes()
@@ -76,9 +70,8 @@ func (fs *FileSet) SeriesFile() *tsdb.SeriesFile { return fs.sfile }
 // Filters do not need to be rebuilt because log files have no bloom filter.
 func (fs *FileSet) PrependLogFile(f *LogFile) *FileSet {
 	return &FileSet{
-		levels: fs.levels,
-		sfile:  fs.sfile,
-		files:  append([]File{f}, fs.files...),
+		sfile: fs.sfile,
+		files: append([]File{f}, fs.files...),
 	}
 }
 
@@ -88,7 +81,7 @@ func (fs *FileSet) Size() int64 {
 	for _, f := range fs.files {
 		total += f.Size()
 	}
-	return total + int64(fs.manifestSize)
+	return total
 }
 
 // MustReplace swaps a list of files for a single file and returns a new file set.
@@ -121,8 +114,7 @@ func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 
 	// Build new fileset and rebuild changed filters.
 	return &FileSet{
-		levels: fs.levels,
-		files:  other,
+		files: other,
 	}
 }
 

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -128,28 +128,6 @@ func (fs *FileSet) Files() []File {
 	return fs.files
 }
 
-// LogFiles returns all log files from the file set.
-func (fs *FileSet) LogFiles() []*LogFile {
-	var a []*LogFile
-	for _, f := range fs.files {
-		if f, ok := f.(*LogFile); ok {
-			a = append(a, f)
-		}
-	}
-	return a
-}
-
-// IndexFiles returns all index files from the file set.
-func (fs *FileSet) IndexFiles() []*IndexFile {
-	var a []*IndexFile
-	for _, f := range fs.files {
-		if f, ok := f.(*IndexFile); ok {
-			a = append(a, f)
-		}
-	}
-	return a
-}
-
 // LastContiguousIndexFilesByLevel returns the last contiguous files by level.
 // These can be used by the compaction scheduler.
 func (fs *FileSet) LastContiguousIndexFilesByLevel(level int) []*IndexFile {
@@ -284,14 +262,14 @@ func (fs *FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (ma
 			}
 			return nil, nil
 		default:
-			return nil, fmt.Errorf("invalid operator")
+			return nil, fmt.Errorf("invalid operator for tag keys by expression")
 		}
 
 	case *influxql.ParenExpr:
 		return fs.MeasurementTagKeysByExpr(name, e.Expr)
 	}
 
-	return nil, fmt.Errorf("%#v", expr)
+	return nil, fmt.Errorf("invalid measurement tag keys expression: %#v", expr)
 }
 
 // tagKeysByFilter will filter the tag keys for the measurement.

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -32,11 +32,11 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 		}
 		defer fs.Release()
 
-		itr := fs.SeriesFile().SeriesIDIterator()
+		itr := idx.SeriesFile.SeriesIDIterator()
 		if itr == nil {
 			t.Fatal("expected iterator")
 		}
-		if result := MustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		if result := MustReadAllSeriesIDIteratorString(idx.SeriesFile.SeriesFile, itr); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region west}]",
 			"mem,[{region east}]",
@@ -62,12 +62,12 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 		}
 		defer fs.Release()
 
-		itr := fs.SeriesFile().SeriesIDIterator()
+		itr := idx.SeriesFile.SeriesIDIterator()
 		if itr == nil {
 			t.Fatal("expected iterator")
 		}
 
-		if result := MustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		if result := MustReadAllSeriesIDIteratorString(idx.SeriesFile.SeriesFile, itr); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region north}]",
 			"cpu,[{region west}]",
@@ -106,7 +106,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 			t.Fatal("expected iterator")
 		}
 
-		if result := MustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		if result := MustReadAllSeriesIDIteratorString(idx.SeriesFile.SeriesFile, itr); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region west}]",
 		}) {
@@ -135,7 +135,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 			t.Fatalf("expected iterator")
 		}
 
-		if result := MustReadAllSeriesIDIteratorString(fs.SeriesFile(), itr); !reflect.DeepEqual(result, []string{
+		if result := MustReadAllSeriesIDIteratorString(idx.SeriesFile.SeriesFile, itr); !reflect.DeepEqual(result, []string{
 			"cpu,[{region east}]",
 			"cpu,[{region north}]",
 			"cpu,[{region west}]",

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -1089,7 +1089,7 @@ func (i *Index) RetainFileSet() (*FileSet, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
-	fs := NewFileSet(i.sfile, nil)
+	fs := NewFileSet(nil)
 	for _, p := range i.partitions {
 		pfs, err := p.RetainFileSet()
 		if err != nil {

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -1089,7 +1089,7 @@ func (i *Index) RetainFileSet() (*FileSet, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
-	fs, _ := NewFileSet(nil, i.sfile, nil)
+	fs := NewFileSet(i.sfile, nil)
 	for _, p := range i.partitions {
 		pfs, err := p.RetainFileSet()
 		if err != nil {

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -212,11 +212,7 @@ func (p *Partition) Open() error {
 			files = append(files, f)
 		}
 	}
-	fs, err := NewFileSet(p.levels, p.sfile, files)
-	if err != nil {
-		return err
-	}
-	p.fileSet = fs
+	p.fileSet = NewFileSet(p.sfile, files)
 
 	// Set initial sequence number.
 	p.seq = p.fileSet.MaxID()

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -212,7 +212,7 @@ func (p *Partition) Open() error {
 			files = append(files, f)
 		}
 	}
-	p.fileSet = NewFileSet(p.sfile, files)
+	p.fileSet = NewFileSet(files)
 
 	// Set initial sequence number.
 	p.seq = p.fileSet.MaxID()


### PR DESCRIPTION
Backports #20770, #21831, and #22309

Useful to backport because it makes cherry-picking other changes easier