### PR TITLE
feat: update ui to v2.0.9

### DIFF
--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -21,10 +21,10 @@ declare -r STATIC_DIR="$ROOT_DIR/static"
 # Download the SHA256 checksum attached to the release. To verify the integrity
 # of the download, this checksum will be used to check the download tar file
 # containing the built UI assets.
-curl -Ls https://github.com/influxdata/ui/releases/download/OSS-v2.0.8/sha256.txt --output sha256.txt
+curl -Ls https://github.com/influxdata/ui/releases/download/OSS-v2.0.9/sha256.txt --output sha256.txt
 
 # Download the tar file containing the built UI assets.
-curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.8/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-v2.0.9/build.tar.gz --output build.tar.gz
 
 # Verify the checksums match; exit if they don't.
 echo "$(cat sha256.txt)" | sha256sum --check -- \


### PR DESCRIPTION
Closes #22241
Updates the UI to `OSS-v2.0.9`: https://github.com/influxdata/ui/releases/tag/OSS-v2.0.9