### PR TITLE
test: check post-compaction series file sizes before reopening

### DIFF
--- a/cmd/influxd/inspect/build_tsi/build_tsi_test.go
+++ b/cmd/influxd/inspect/build_tsi/build_tsi_test.go
@@ -227,6 +227,10 @@ func Test_BuildTSI_Invalid_Compact_Series_Specific_Shard(t *testing.T) {
 }
 
 func Test_BuildTSI_Valid_Compact_Series(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap implementation on Windows prevents series-file from shrinking during compaction")
+	}
+
 	tempDir := newTempDirectory(t, "", "build-tsi")
 	defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
Closes #22514

This refactors 1 test and skips another to work around Windows' requirement that files be resized to the target length before being mmap'd.