### PR TITLE
feat: set X-Influxdb-Version and X-Influxdb-Build headers

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -528,10 +528,14 @@ func (idx Index) Open() error {
 // Close closes and removes the index directory.
 func (idx *Index) Close() error {
 	defer os.RemoveAll(idx.Path())
+	// Series file is opened first and must be closed last
+	if err := idx.Index.Close(); err != nil {
+		return err
+	}
 	if err := idx.SeriesFile.Close(); err != nil {
 		return err
 	}
-	return idx.Index.Close()
+	return nil
 }
 
 // Reopen closes and opens the index.


### PR DESCRIPTION
Closes #20224
Also a forward port of #22038 since I saw the same test failing on 2.x


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
