### PR TITLE
fix: suggest setting flux Content-Type when query fails to parse as JSON

### DIFF
--- a/http/query.go
+++ b/http/query.go
@@ -357,6 +357,8 @@ func QueryRequestFromProxyRequest(req *query.ProxyRequest) (*QueryRequest, error
 	return qr, nil
 }
 
+const fluxContentType = "application/vnd.flux"
+
 func decodeQueryRequest(ctx context.Context, r *http.Request, svc influxdb.OrganizationService) (*QueryRequest, int, error) {
 	var req QueryRequest
 	body := &countReader{Reader: r.Body}
@@ -370,7 +372,7 @@ func decodeQueryRequest(ctx context.Context, r *http.Request, svc influxdb.Organ
 		return nil, body.bytesRead, err
 	}
 	switch mt {
-	case "application/vnd.flux":
+	case fluxContentType:
 		octets, err := ioutil.ReadAll(body)
 		if err != nil {
 			return nil, body.bytesRead, err
@@ -380,7 +382,8 @@ func decodeQueryRequest(ctx context.Context, r *http.Request, svc influxdb.Organ
 		fallthrough
 	default:
 		if err := json.NewDecoder(body).Decode(&req); err != nil {
-			return nil, body.bytesRead, err
+			return nil, body.bytesRead,
+				fmt.Errorf("failed parsing request body as JSON; if sending a raw Flux script, set 'Content-Type: %s' in your request headers: %w", fluxContentType, err)
 		}
 	}
 


### PR DESCRIPTION
Closes #16941

The linked issue suggests that when a query request fails to parse as JSON, we should try parsing it as Flux and (if successful) return a message saying to set the appropriate `Content-Type` header. This PR simplifies that idea by always returning the suggestion to try setting `Content-Type: application/vnd.flux` when a query fails to parse as JSON, and letting users decide whether or not the suggestion is appropriate. I feel better about this approach for two reasons:
1. We aren't burning CPU parsing request bodies just to return an error message
2. We end up showing the suggestion to more relevant failure cases (i.e. to users who try sending raw Flux queries, but typo their request bodies in a way that would cause parsing to fail)