### PR TITLE
feat: optimize group aggregate flux queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,20 +69,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-#          filters:
-#            branches:
-#              only:
-#                - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-#          filters:
-#            branches:
-#              only:
-#                - "master"
+          filters:
+            branches:
+              only:
+                - "master"
       - grace_daily:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,20 +69,20 @@ workflows:
           record_ingest_results: true
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+#          filters:
+#            branches:
+#              only:
+#                - "master"
       - perf_test:
           name: perf-test-influxql
           format: http
           record_ingest_results: false
           requires:
             - cross_build
-          filters:
-            branches:
-              only:
-                - "master"
+#          filters:
+#            branches:
+#              only:
+#                - "master"
       - grace_daily:
           requires:
             - build
@@ -854,4 +854,3 @@ jobs:
           root: .
           paths:
             - changelog_artifacts
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -854,3 +854,4 @@ jobs:
           root: .
           paths:
             - changelog_artifacts
+

--- a/query/stdlib/influxdata/influxdb/group_agg_with_time_ranges_test.flux
+++ b/query/stdlib/influxdata/influxdb/group_agg_with_time_ranges_test.flux
@@ -1,0 +1,91 @@
+// TODO(whb): These tests should get ported to the flux repo and removed here when they are included with a flux release
+// that InfluxDB uses to remove the redundancy.
+
+package influxdb_test
+
+import "csv"
+import "testing"
+import "testing/expect"
+
+option now = () => 2030-01-01T00:00:00Z
+
+input = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
+,,1,2018-05-23T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-23T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-23T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-23T19:53:56Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-23T19:54:06Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-23T19:54:16Z,648,io_time,diskio,host.local,disk2
+"
+
+// Basic matching of series by the predicate - verifies that non-matching series do not get included in the result. Time
+// range covers the entire dataset.
+testcase group_agg_with_time_ranges_filters {
+    got = testing.loadStorage(csv: input)
+        |> range(start: 2018-05-22T00:00:00Z, stop: 2018-05-24T00:00:00Z)
+        |> filter(fn: (r) => r["_measurement"] == "diskio" and r["name"] == "disk0")
+        |> group(columns: ["_measurement"], mode:"by")
+        |> last()
+
+outData = "#group,false,false,true,true,false,false,false,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T00:00:00Z,2018-05-24T00:00:00Z,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0"
+
+    want = csv.from(csv: outData)
+
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    testing.diff(got, want)
+}
+
+// Multiple series match the predicate - verifies that series without data in the requested time range do not get
+// included in the result.
+testcase group_agg_with_time_ranges_multiple_series_match_filter {
+    got = testing.loadStorage(csv: input)
+        |> range(start: 2018-05-23T19:53:36Z, stop: 2018-05-23T19:54:07Z)
+        |> filter(fn: (r) => r["_measurement"] == "diskio")
+        |> group(columns: ["_measurement"], mode:"by")
+        |> first()
+
+outData = "#group,false,false,true,true,false,false,false,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2018-05-23T19:53:36Z,2018-05-23T19:54:07Z,2018-05-23T19:53:36Z,648,io_time,diskio,host.local,disk2"
+
+    want = csv.from(csv: outData)
+
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    testing.diff(got, want)
+}
+
+// Same as above but with "count" instead of "first".
+testcase group_agg_with_time_ranges_multiple_series_match_filter_count {
+    got = testing.loadStorage(csv: input)
+        |> range(start: 2018-05-23T19:53:36Z, stop: 2018-05-23T19:54:07Z)
+        |> filter(fn: (r) => r["_measurement"] == "diskio")
+        |> group(columns: ["_measurement"], mode:"by")
+        |> count()
+
+outData = "#group,false,false,true,true,false,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,long,string
+#default,_result,,,,,
+,result,table,_start,_stop,_value,_measurement
+,,0,2018-05-23T19:53:36Z,2018-05-23T19:54:07Z,4,diskio"
+
+    want = csv.from(csv: outData)
+
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+    testing.diff(got, want)
+}

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -366,16 +366,18 @@ READ:
 		cur = nil
 		gc = nil
 
-		if err := f(table); err != nil {
-			table.Close()
-			table = nil
-			return err
-		}
-		select {
-		case <-done:
-		case <-gi.ctx.Done():
-			table.Cancel()
-			break READ
+		if !table.Empty() {
+			if err := f(table); err != nil {
+				table.Close()
+				table = nil
+				return err
+			}
+			select {
+			case <-done:
+			case <-gi.ctx.Done():
+				table.Cancel()
+				break READ
+			}
 		}
 
 		stats := table.Statistics()

--- a/storage/reads/group_resultset.go
+++ b/storage/reads/group_resultset.go
@@ -227,33 +227,30 @@ func (g *groupResultSet) groupBySort() (int, error) {
 	var seriesRows []*SeriesRow
 	vals := make([][]byte, len(g.keys))
 	tagsBuf := &tagsBuffer{sz: 4096}
-	allTime := g.req.Hints.HintSchemaAllTime()
 
 	seriesRow := seriesCursor.Next()
 	for seriesRow != nil {
-		if allTime || g.seriesHasPoints(seriesRow) {
-			nr := *seriesRow
-			nr.SeriesTags = tagsBuf.copyTags(nr.SeriesTags)
-			nr.Tags = tagsBuf.copyTags(nr.Tags)
+		nr := *seriesRow
+		nr.SeriesTags = tagsBuf.copyTags(nr.SeriesTags)
+		nr.Tags = tagsBuf.copyTags(nr.Tags)
 
-			l := len(g.keys) // for sort key separators
-			for i, k := range g.keys {
-				vals[i] = nr.Tags.Get(k)
-				if len(vals[i]) == 0 {
-					vals[i] = g.nilSort
-				}
-				l += len(vals[i])
+		l := len(g.keys) // for sort key separators
+		for i, k := range g.keys {
+			vals[i] = nr.Tags.Get(k)
+			if len(vals[i]) == 0 {
+				vals[i] = g.nilSort
 			}
-
-			nr.SortKey = make([]byte, 0, l)
-			for _, v := range vals {
-				nr.SortKey = append(nr.SortKey, v...)
-				// separate sort key values with ascii null character
-				nr.SortKey = append(nr.SortKey, '\000')
-			}
-
-			seriesRows = append(seriesRows, &nr)
+			l += len(vals[i])
 		}
+
+		nr.SortKey = make([]byte, 0, l)
+		for _, v := range vals {
+			nr.SortKey = append(nr.SortKey, v...)
+			// separate sort key values with ascii null character
+			nr.SortKey = append(nr.SortKey, '\000')
+		}
+
+		seriesRows = append(seriesRows, &nr)
 		seriesRow = seriesCursor.Next()
 	}
 

--- a/storage/reads/group_resultset_test.go
+++ b/storage/reads/group_resultset_test.go
@@ -293,15 +293,9 @@ func TestNewGroupResultSet_GroupNone_NoDataReturnsNil(t *testing.T) {
 	}
 }
 
-func TestNewGroupResultSet_GroupBy_NoDataReturnsNil(t *testing.T) {
-	t.Skip("skipping for now")
-
+func TestNewGroupResultSet_GroupBy_NoSeriesReturnsNil(t *testing.T) {
 	newCursor := func() (reads.SeriesCursor, error) {
-		return &sliceSeriesCursor{
-			rows: newSeriesRows(
-				"aaa,tag0=val00",
-				"aaa,tag0=val01",
-			)}, nil
+		return &sliceSeriesCursor{}, nil
 	}
 
 	rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupBy, GroupKeys: []string{"tag0"}}, newCursor)

--- a/storage/reads/group_resultset_test.go
+++ b/storage/reads/group_resultset_test.go
@@ -294,6 +294,8 @@ func TestNewGroupResultSet_GroupNone_NoDataReturnsNil(t *testing.T) {
 }
 
 func TestNewGroupResultSet_GroupBy_NoDataReturnsNil(t *testing.T) {
+	t.Skip("skipping for now")
+
 	newCursor := func() (reads.SeriesCursor, error) {
 		return &sliceSeriesCursor{
 			rows: newSeriesRows(


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb/issues/22467

This removes the filtering of series based on those series containing data from `NewGroupResultSet`. Removing this filter reduces the duration of our group-aggregate benchmarks by about 30% (see below). As it currently works, series will often have the same TSM data accessed twice. Removing the filter here allows the data access and consideration for including the series in the output to happen at the same time, with the possible downside of needing to hold a larger list of series keys in memory that may not all contain relevant data.

Before and after results for our Flux benchmarks is shown below, along with a reference to the benchmark for the equivalent InfluxQL time. After this change, the performance of all Flux queries improves, and the `first` & `last` aggregates become roughly equivalent to InfluxQL:

|       	| InfluxQL (1.8) [ms] 	| Flux - Before [ms] 	| Flux - After [ms] 	| % Flux Improvement 	|
|-------	|---------------------	|--------------------	|-------------------	|---------------	|
| Count 	|                 845 	|                309 	|               185 	|           40% 	|
| First 	|                 214 	|                310 	|               190 	|           39% 	|
| Last  	|                 194 	|                276 	|               172 	|           38% 	|
| Max   	|                 854 	|                323 	|               205 	|           37% 	|
| Min   	|                 856 	|                322 	|               205 	|           36% 	|
| Mean  	|                 836 	|                492 	|               372 	|           24% 	|
| Sum   	|                 846 	|                306 	|               190 	|           38% 	|

Propagating series that do not contain data for the requested time range is not an issue since empty tables are specifically handled by flagging the table as empty if none of the series in the table contain data here: https://github.com/influxdata/influxdb/blob/0f6614ffa7ef8507f77434fa6bd8cdccdc643032/storage/flux/table.go#L73-L75

We can then skip processing the table in a similar fashion as other iterators, for example: https://github.com/influxdata/influxdb/blob/0f6614ffa7ef8507f77434fa6bd8cdccdc643032/storage/flux/reader.go#L226-L238