### PR TITLE
build: add CI jobs to natively test ARM64, Mac, and Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ orbs:
 executors:
   cross-builder:
     docker:
+      # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
+      # then update the version here to match. Until we finish the migration to using the cross-builder image,
+      # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
       - image: quay.io/influxdb/cross-builder:go1.17.1-41d944d749b2c130119eff7efaaa9883ccffe5a7
     resource_class: large
   linux-amd64:
@@ -16,7 +19,7 @@ executors:
     machine:
       image: ubuntu-2004:202101-01
       resource_class: arm.large
-  mac:
+  darwin:
     macos:
       xcode: 12.4.0
       resource_class: medium
@@ -74,8 +77,8 @@ workflows:
           requires:
             - test-build-arm64-linux
       - test-prebuilt:
-          name: test-mac
-          executor: mac
+          name: test-darwin
+          executor: darwin
           requires:
             - test-build-amd64-darwin
       - test-prebuilt:
@@ -200,8 +203,8 @@ workflows:
           requires:
             - test-build-arm64-linux
       - test-prebuilt:
-          name: test-mac
-          executor: mac
+          name: test-darwin
+          executor: darwin
           requires:
             - test-build-amd64-darwin
       - test-prebuilt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,28 @@ orbs:
   terraform: circleci/terraform@2.1.0
 
 executors:
-  linux-machine:
+  cross-builder:
+    docker:
+      - image: quay.io/influxdb/cross-builder:go1.17.1-41d944d749b2c130119eff7efaaa9883ccffe5a7
+    resource_class: large
+  linux-amd64:
     machine:
       image: ubuntu-2004:202107-02
       resource_class: large
+  linux-arm64:
+    machine:
+      image: ubuntu-2004:202101-01
+      resource_class: arm.large
+  mac:
+    macos:
+      xcode: 12.4.0
+      resource_class: medium
+    shell: /bin/bash -eo pipefail
+  windows:
+    machine:
+      image: windows-server-2019-vs2019:stable
+      resource_class: windows.medium
+    shell: bash.exe -eo pipefail
 
 parameters:
   aws_teardown:
@@ -36,6 +54,35 @@ workflows:
       - gotest:
           requires:
             - godeps
+      - test-build:
+          matrix:
+            parameters:
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          executor: linux-arm64
+          requires:
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-mac
+          executor: mac
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          executor: windows
+          requires:
+            - test-build-amd64-windows
       - fluxtest:
           requires:
             - godeps
@@ -133,6 +180,35 @@ workflows:
       - gotest:
           requires:
             - godeps
+      - test-build:
+          matrix:
+            parameters:
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          executor: linux-arm64
+          requires:
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-mac
+          executor: mac
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          executor: windows
+          requires:
+            - test-build-amd64-windows
       - golint:
           requires:
             - godeps
@@ -429,6 +505,46 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 
+  test-build:
+    executor: cross-builder
+    resource_class: large
+    parameters:
+      os:
+        type: string
+      arch:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Build test binaries
+          command: |
+            export GOOS=<< parameters.os >>
+            export GOARCH=<< parameters.arch >>
+            ./scripts/ci/build-tests.sh ./test-bin
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./test-bin
+
+  test-prebuilt:
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
+    parallelism: 8
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run tests
+          command: ./scripts/ci/run-prebuilt-tests.sh $(pwd)/test-bin $(pwd)/test-results
+      - store_test_results:
+          path: ./test-results
+      - store_artifacts:
+          path: ./test-results
+          destination: raw-test-results
+
   fluxtest:
     docker:
       - image: cimg/go:1.17.1
@@ -514,7 +630,7 @@ jobs:
           command: docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
 
   cross_build:
-    executor: linux-machine
+    executor: linux-amd64
     environment:
       TMPDIR: /mnt/ramdisk
     steps:
@@ -606,7 +722,7 @@ jobs:
 
 
   perf_test:
-    executor: linux-machine
+    executor: linux-amd64
     parameters:
       format:
         type: string
@@ -630,7 +746,7 @@ jobs:
             scripts/ci/perf_test.sh
 
   aws_destroy_by_date:
-    executor: linux-machine
+    executor: linux-amd64
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -660,7 +776,7 @@ jobs:
               fi
             done
   aws_destroy_by_name:
-    executor: linux-machine
+    executor: linux-amd64
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -678,7 +794,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 terminate-instances --instance-ids $instance_id
 
   deploy_nightly:
-    executor: linux-machine
+    executor: linux-amd64
     environment:
       TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
@@ -734,7 +850,7 @@ jobs:
           destination: test_artifacts/results/shared
 
   litmus_daily:
-    executor: linux-machine
+    executor: linux-amd64
     steps:
       - attach_workspace:
           at: ~/project
@@ -755,7 +871,7 @@ jobs:
           path: ~/project
 
   litmus_integration:
-    executor: linux-machine
+    executor: linux-amd64
     steps:
       - attach_workspace:
           at: ~/project
@@ -775,7 +891,7 @@ jobs:
           path: ~/project
 
   grace_daily:
-    executor: linux-machine
+    executor: linux-amd64
     steps:
       - attach_workspace:
           at: ~/project
@@ -803,7 +919,7 @@ jobs:
           path: ~/project/results
 
   share-testing-image:
-    executor: linux-machine
+    executor: linux-amd64
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - attach_workspace:

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -3,6 +3,28 @@ set -exo pipefail
 
 declare -r GOTESTSUM_VERSION=1.7.0
 
+# Values are from https://github.com/gotestyourself/gotestsum/releases/download/v${VERSION}/gotestsum-${VERSION}-checksums.txt
+function gotestsum_expected_sha () {
+    case "$(go env GOOS)_$(go env GOARCH)" in
+        linux_amd64)
+            echo b5c98cc408c75e76a097354d9487dca114996e821b3af29a0442aa6c9159bd40
+            ;;
+        linux_arm64)
+            echo ee57c91abadc464a7cd9f8abbffe94a673aab7deeb9af8c17b96de4bb8f37e41
+            ;;
+        darwin_amd64)
+            echo a8e2351604882af1a67601cbeeacdcfa9b17fc2f6fbac291cf5d434efdf2d85b
+            ;;
+        windows_amd64)
+            echo 7ae12ddb171375f0c14d6a09dd27a5c1d1fc72edeea674e3d6e7489a533b40c1
+            ;;
+        *)
+            >&2 echo Error: Unsupported OS/arch pair for gotestsum: "$(go env GOOS)_$(go env GOARCH)"
+            exit 1
+            ;;
+    esac
+}
+
 function build_linux () {
     local tags=osusergo,netgo,sqlite_foreign_keys,sqlite_json,static_build
     local cc
@@ -37,8 +59,13 @@ function build_windows () {
 
 function build_test_tools () {
     # Download gotestsum from its releases (faster than building it).
-    local -r gotestsum_url=https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz
-    curl -L "$gotestsum_url" | tar xz -C "${1}/"
+    local -r gotestsum_archive="gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz"
+    local -r gotestsum_url="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/${gotestsum_archive}"
+
+    curl -L "$gotestsum_url" -O
+    echo "$(gotestsum_expected_sha)  ${gotestsum_archive}" | sha256sum --check --
+    tar xzf "$gotestsum_archive" -C "${1}/"
+    rm "$gotestsum_archive"
 
     # Build test2json from the installed Go distribution.
     CGO_ENABLED=0 go build -o "${1}/" -ldflags="-s -w" cmd/test2json
@@ -59,7 +86,6 @@ function main () {
     fi
     local -r out_dir="$1"
 
-    rm -rf "$out_dir"
     mkdir -p "$out_dir"
     case $(go env GOOS) in
         linux)

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+declare -r GOTESTSUM_VERSION=1.7.0
+
+function build_linux () {
+    local tags=osusergo,netgo,sqlite_foreign_keys,sqlite_json,static_build
+    local cc
+    case $(go env GOARCH) in
+        amd64)
+            cc=musl-gcc
+            ;;
+        arm64)
+            cc=aarch64-unknown-linux-musl-gcc
+            tags="$tags,noasm"
+            ;;
+        *)
+            >&2 echo Error: Unknown arch $(go env GOARCH)
+            exit 1
+            ;;
+    esac
+
+    local -r extld="-fno-PIC -static -Wl,-z,stack-size=8388608"
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=${cc} go-test-compile \
+        -tags "$tags" -o "${1}/" -ldflags "-extldflags '$extld'" ./...
+}
+
+function build_mac () {
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=x86_64-apple-darwin16-clang go-test-compile \
+        -tags sqlite_foreign_keys,sqlite_json -o "${1}/" ./...
+}
+
+function build_windows () {
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=x86_64-w64-mingw32-gcc go-test-compile \
+        -tags sqlite_foreign_keys,sqlite_json,timetzdata -o "${1}/" ./...
+}
+
+function build_test_tools () {
+    # Download gotestsum from its releases (faster than building it).
+    local -r gotestsum_url=https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz
+    curl -L "$gotestsum_url" | tar xz -C "${1}/"
+
+    # Build test2json from the installed Go distribution.
+    CGO_ENABLED=0 go build -o "${1}/" -ldflags="-s -w" cmd/test2json
+}
+
+function write_test_metadata () {
+    # Write version that should be reported in test results.
+    echo "$(go env GOVERSION) $(go env GOOS)/$(go env GOARCH)" > "${1}/go.version"
+
+    # Write list of all packages.
+    go list ./... > "${1}/tests.list"
+}
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<output-dir>'
+        exit 1
+    fi
+    local -r out_dir="$1"
+
+    rm -rf "$out_dir"
+    mkdir -p "$out_dir"
+    case $(go env GOOS) in
+        linux)
+            build_linux "$out_dir"
+            ;;
+        darwin)
+            build_mac "$out_dir"
+            ;;
+        windows)
+            build_windows "$out_dir"
+            ;;
+        *)
+            >&2 echo Error: unknown OS $(go env GOOS)
+            exit 1
+            ;;
+    esac
+
+    # Build gotestsum and test2json so downstream jobs can use it without needing `go`.
+    build_test_tools "$out_dir"
+    # Write other metadata needed for testing.
+    write_test_metadata "$out_dir"
+}
+
+main ${@}

--- a/scripts/ci/run-prebuilt-tests.sh
+++ b/scripts/ci/run-prebuilt-tests.sh
@@ -37,7 +37,6 @@ function main () {
     fi
     local -r bin_dir="$1" result_dir="$2"
 
-    rm -rf "$result_dir"
     mkdir -p "$result_dir"
 
     local -r test_packages="$(cat "${bin_dir}/tests.list" | circleci tests split --split-by=timings --timings-type=classname)"

--- a/scripts/ci/run-prebuilt-tests.sh
+++ b/scripts/ci/run-prebuilt-tests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+function test_package () {
+    local -r pkg="$1" bin_dir="$2" result_dir="$3"
+
+    local -r test_file="${bin_dir}/${pkg}.test"
+    if [ ! -f "$test_file" ]; then
+        return
+    fi
+
+    out_dir="${result_dir}/${pkg}"
+    mkdir -p "${out_dir}"
+
+    # Run test files from within their original packages so any relative references
+    # to data files resolve properly.
+    local source_dir="${pkg##github.com/influxdata/influxdb/v2}"
+    source_dir="${source_dir##/}"
+    if [ -z "$source_dir" ]; then
+        source_dir="."
+    fi
+    (
+        set +e
+        cd "$source_dir"
+        GOVERSION="$(cat ${bin_dir}/go.version)" "${bin_dir}/gotestsum" --junitfile "${out_dir}/report.xml" --raw-command -- \
+            "${bin_dir}/test2json" -t -p "$pkg" "$test_file" -test.v
+        if [ $? != 0 ]; then
+            echo 1 > "${result_dir}/rc"
+        fi
+    )
+}
+
+function main () {
+    if [[ $# != 2 ]]; then
+        >&2 echo Usage: $0 '<test-bin-dir>' '<result-dir>'
+        exit 1
+    fi
+    local -r bin_dir="$1" result_dir="$2"
+
+    rm -rf "$result_dir"
+    mkdir -p "$result_dir"
+
+    local -r test_packages="$(cat "${bin_dir}/tests.list" | circleci tests split --split-by=timings --timings-type=classname)"
+
+    echo 0 > "${result_dir}/rc"
+    for pkg in ${test_packages[@]}; do
+        test_package "$pkg" "$bin_dir" "$result_dir"
+    done
+
+    exit $(cat "${result_dir}/rc")
+}
+
+main ${@}


### PR DESCRIPTION
Part of #20855

This is a subset of a broader change to switch the 2.x CI pipeline over to use our cross-builder image with additional parallelization. It extends the CLI pipeline to:
1. In parallel, compile our `_test.go` files into runnable binaries targeted at `linux/arm64`, `darwin/amd64`, and `windows/amd64`
2. In parallel, run the prebuilt binaries from step 1 on the native executors provided by Circle

The benefit of adding these steps is guarding against regressions on all of our target platforms. It doesn't speed up or slow down the overall runtime of our pipeline; to do that, we'll need to break up our `cross_build` step into parallel jobs and reimplement the packaging logic currently provided by goreleaser.