### PR TITLE
test: sleep between 2nd and 3rd checks of engine last-modified time

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1801,7 +1801,7 @@ func TestEngine_LastModified(t *testing.T) {
 			// Artificial sleep added due to filesystems caching the mod time
 			// of files.  This prevents the WAL last modified time from being
 			// returned and newer than the filestore's mod time.
-			time.Sleep(2 * time.Second) // Covers most filesystems.
+			time.Sleep(time.Second) // Covers most filesystems.
 
 			if err := e.WriteSnapshot(); err != nil {
 				t.Fatalf("failed to snapshot: %s", err.Error())
@@ -1812,6 +1812,9 @@ func TestEngine_LastModified(t *testing.T) {
 			if got, exp := lm.Equal(lm2), false; exp != got {
 				t.Fatalf("expected time change, got %v, exp %v: %s == %s", got, exp, lm.String(), lm2.String())
 			}
+
+			// Another arbitrary sleep.
+			time.Sleep(time.Second)
 
 			itr := &seriesIterator{keys: [][]byte{[]byte("cpu,host=A")}}
 			if err := e.DeleteSeriesRange(context.Background(), itr, math.MinInt64, math.MaxInt64); err != nil {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
 	"github.com/influxdata/influxql"
 	tassert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -1776,26 +1777,17 @@ func TestEngine_LastModified(t *testing.T) {
 			p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
 
 			e, err := NewEngine(t, index)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			// mock the planner so compactions don't run during the test
 			e.CompactionPlan = &mockPlanner{}
 			e.SetEnabled(false)
-			if err := e.Open(context.Background()); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, e.Open(context.Background()))
 			defer e.Close()
 
-			if err := e.writePoints(p1, p2, p3); err != nil {
-				t.Fatalf("failed to write points: %s", err.Error())
-			}
-
+			require.NoError(t, e.writePoints(p1, p2, p3))
 			lm := e.LastModified()
-			if lm.IsZero() {
-				t.Fatalf("expected non-zero time, got %v", lm.UTC())
-			}
+			require.Falsef(t, lm.IsZero(), "expected non-zero time, got %v", lm.UTC())
 			e.SetEnabled(true)
 
 			// Artificial sleep added due to filesystems caching the mod time
@@ -1803,28 +1795,17 @@ func TestEngine_LastModified(t *testing.T) {
 			// returned and newer than the filestore's mod time.
 			time.Sleep(time.Second) // Covers most filesystems.
 
-			if err := e.WriteSnapshot(); err != nil {
-				t.Fatalf("failed to snapshot: %s", err.Error())
-			}
-
+			require.NoError(t, e.WriteSnapshot())
 			lm2 := e.LastModified()
-
-			if got, exp := lm.Equal(lm2), false; exp != got {
-				t.Fatalf("expected time change, got %v, exp %v: %s == %s", got, exp, lm.String(), lm2.String())
-			}
+			require.NotEqual(t, lm, lm2)
 
 			// Another arbitrary sleep.
 			time.Sleep(time.Second)
 
 			itr := &seriesIterator{keys: [][]byte{[]byte("cpu,host=A")}}
-			if err := e.DeleteSeriesRange(context.Background(), itr, math.MinInt64, math.MaxInt64); err != nil {
-				t.Fatalf("failed to delete series: %v", err)
-			}
-
+			require.NoError(t, e.DeleteSeriesRange(context.Background(), itr, math.MinInt64, math.MaxInt64))
 			lm3 := e.LastModified()
-			if got, exp := lm2.Equal(lm3), false; exp != got {
-				t.Fatalf("expected time change, got %v, exp %v", got, exp)
-			}
+			require.NotEqual(t, lm2, lm3)
 		})
 	}
 }


### PR DESCRIPTION
I've seen `TestEngine_LastModified` fail occasionally on the Windows executor. My guess is the root cause is the same as #22479, where the test is running faster than `time.Now()` updates on Windows.

This test already had a `time.Sleep` between two checks of `LastModified()`, so I added another one. The timing of the existing sleep felt excessive, so I borrowed time from it to use in the 2nd sleep so the total test time stays about the same.