### PR TITLE
fix(restore): parameter validation, Windows temp file deletion

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -167,6 +167,10 @@ func (cmd *Command) parseFlags(args []string) error {
 		return fmt.Errorf("backup path should be a valid directory: %s", cmd.backupFilesPath)
 	}
 
+	if cmd.destinationDatabase != "" && cmd.sourceDatabase == "" {
+		return fmt.Errorf("must specify a database to be restored into new database %s", cmd.destinationDatabase)
+	}
+
 	if cmd.portable || cmd.online {
 		// validate the arguments
 
@@ -184,6 +188,7 @@ func (cmd *Command) parseFlags(args []string) error {
 
 		if cmd.portable {
 			var err error
+
 			cmd.manifestMeta, cmd.manifestFiles, err = backup_util.LoadIncremental(cmd.backupFilesPath)
 			if err != nil {
 				return fmt.Errorf("restore failed while processing manifest files: %s", err.Error())

--- a/tsdb/engine/tsm1/copy_or_link_unix.go
+++ b/tsdb/engine/tsm1/copy_or_link_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package tsm1
+
+import (
+	"fmt"
+	"os"
+)
+
+// copyOrLink - allow substitution of a file copy for a hard link when running on Windows systems.
+func copyOrLink(oldPath, newPath string) error {
+	if err := os.Link(oldPath, newPath); err != nil {
+		return fmt.Errorf("error creating hard link for backup from %s to %s: %q", oldPath, newPath, err)
+	}
+	return nil
+}

--- a/tsdb/engine/tsm1/copy_or_link_windows.go
+++ b/tsdb/engine/tsm1/copy_or_link_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package tsm1
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// copyOrLink - Windows does not permit deleting a file with open file handles, so
+// instead of hard links, make temporary copies of files that can then be deleted.
+func copyOrLink(oldPath, newPath string) (returnErr error) {
+	rfd, err := os.Open(oldPath)
+	if err != nil {
+		return fmt.Errorf("error opening file for backup %s: %q", oldPath, err)
+	} else {
+		defer func() {
+			if e := rfd.Close(); returnErr == nil && e != nil {
+				returnErr = fmt.Errorf("error closing source file for backup %s: %q", oldPath, e)
+			}
+		}()
+	}
+	fi, err := rfd.Stat()
+	if err != nil {
+		fmt.Errorf("error collecting statistics from file for backup %s: %q", oldPath, err)
+	}
+	wfd, err := os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, fi.Mode())
+	if err != nil {
+		return fmt.Errorf("error creating temporary file for backup %s:  %q", newPath, err)
+	} else {
+		defer func() {
+			if e := wfd.Close(); returnErr == nil && e != nil {
+				returnErr = fmt.Errorf("error closing temporary file for backup %s: %q", newPath, e)
+			}
+		}()
+	}
+	if _, err := io.Copy(wfd, rfd); err != nil {
+		return fmt.Errorf("unable to copy file for backup from %s to %s: %q", oldPath, newPath, err)
+	}
+	if err := os.Chtimes(newPath, fi.ModTime(), fi.ModTime()); err != nil {
+		return fmt.Errorf("unable to set modification time on temporary backup file %s: %q", newPath, err)
+	}
+	return nil
+}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -477,6 +477,22 @@ func TestEngine_Backup(t *testing.T) {
 	if !strings.Contains(mostRecentFile, th.Name) || th.Name == "" {
 		t.Fatalf("file name doesn't match:\n\tgot: %s\n\texp: %s", th.Name, mostRecentFile)
 	}
+	storeDir := filepath.Dir(e.FileStore.Files()[0].Path())
+	dfd, err := os.Open(storeDir)
+	if err != nil {
+		t.Fatalf("cannot open filestore directory %s: %q", storeDir, err)
+	} else {
+		defer dfd.Close()
+	}
+	files, err := dfd.Readdirnames(0)
+	if err != nil {
+		t.Fatalf("cannot read directory %s: %q", storeDir, err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, tsm1.TmpTSMFileExtension) {
+			t.Fatalf("temporary directory for backup not cleaned up: %s", f)
+		}
+	}
 }
 
 func TestEngine_Export(t *testing.T) {

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1059,16 +1059,16 @@ func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 
 // MakeSnapshotLinks creates hardlinks from the supplied TSMFiles to
 // corresponding files under a supplied directory.
-func (f *FileStore) MakeSnapshotLinks(destPath string, files []TSMFile) error {
+func (f *FileStore) MakeSnapshotLinks(destPath string, files []TSMFile) (returnErr error) {
 	for _, tsmf := range files {
 		newpath := filepath.Join(destPath, filepath.Base(tsmf.Path()))
-		if err := os.Link(tsmf.Path(), newpath); err != nil {
-			return fmt.Errorf("error creating tsm hard link: %q", err)
+		if err := copyOrLink(tsmf.Path(), newpath); err != nil {
+			return err
 		}
 		if tf := tsmf.TombstoneStats(); tf.TombstoneExists {
 			newpath := filepath.Join(destPath, filepath.Base(tf.Path))
-			if err := os.Link(tf.Path, newpath); err != nil {
-				return fmt.Errorf("error creating tombstone hard link: %q", err)
+			if err := copyOrLink(tf.Path, newpath); err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
* fix(restore): enforce the -db parameter when -newdb used

    closes https://github.com/influxdata/influxdb/issues/15901
    (cherry picked from commit 1dde65bb75f3744c01313f5bd8f54f0262dd0da4)
    closes https://github.com/influxdata/influxdb/issues/22560

* fix: for Windows, copy snapshot files being backed up

    On Windows, make copies of files for snapshots, because
    Go does not support the FILE_SHARE_DELETE flag which
    allows files (and links) to be deleted while open. This
    causes temporary directories to be left behind after
    backups.

    closes https://github.com/influxdata/influxdb/issues/16289
    (cherry picked from commit 3702fe8e7688499dc6183ad20c90e6c3a6a812ed)
    closes https://github.com/influxdata/influxdb/issues/22559

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
