### PR TITLE
fix(tsdb): (1.x) sync series segment to disk after writing

### DIFF
--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -212,7 +212,10 @@ func (s *SeriesSegment) Flush() error {
 	if s.w == nil {
 		return nil
 	}
-	return s.w.Flush()
+	if err := s.w.Flush(); err != nil {
+		return err
+	}
+	return s.file.Sync()
 }
 
 // AppendSeriesIDs appends all the segments ids to a slice. Returns the new slice.


### PR DESCRIPTION
Clean cherrypick of #22545 

Closes #20245