### PR TITLE
ci: Verify checksum of goreleaser install script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,9 +256,9 @@ commands:
           name: Install goreleaser
           environment:
             GORELEASER_VERSION: 0.177.0
+            GO_RELEASER_SHA: 8dd5fff1d04eff3789d200920bf280391f96fd5cc1565dd0d6e0db2b9a710854
           command: |
             # checksum from `checksums.txt` file at https://github.com/goreleaser/goreleaser/releases
-            GO_RELEASER_SHA="8dd5fff1d04eff3789d200920bf280391f96fd5cc1565dd0d6e0db2b9a710854"
             curl --proto '=https' --tlsv1.2 -sSfL --max-redirs 1 -O \
               https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz
             echo "${GO_RELEASER_SHA}  goreleaser_Linux_x86_64.tar.gz" | sha256sum --check -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,9 +257,15 @@ commands:
           environment:
             GORELEASER_VERSION: 0.177.0
           command: |
-            curl -sfL -o goreleaser-install https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh && \
-              sh goreleaser-install -b ${GOPATH}/bin v${GORELEASER_VERSION} && \
-              rm goreleaser-install
+            # checksum from `checksums.txt` file at https://github.com/goreleaser/goreleaser/releases
+            GO_RELEASER_SHA="8dd5fff1d04eff3789d200920bf280391f96fd5cc1565dd0d6e0db2b9a710854"
+            curl --proto '=https' --tlsv1.2 -sSfL --max-redirs 1 -O \
+              https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz
+            echo "${GO_RELEASER_SHA}  goreleaser_Linux_x86_64.tar.gz" | sha256sum --check -
+            # extract goreleaser binary only
+            tar --extract --file=goreleaser_Linux_x86_64.tar.gz goreleaser
+            mv goreleaser ${GOPATH}/bin
+            rm goreleaser_Linux_x86_64.tar.gz
       - run:
           name: Install pkg-config
           command: make pkg-config


### PR DESCRIPTION
I also looked into downloading the Linux binary and using the public-key crypographic verification method outlined in the goreleaser docs here: https://goreleaser.com/install/#verifying-the-binaries. However, this uses `cosign`. I felt this would have added too much complexity. Instead, we just use the checksum provided on the release page.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
