### PR TITLE
fix: allow empty reqeust bodies to write API

### DIFF
--- a/http/points/points_parser.go
+++ b/http/points/points_parser.go
@@ -25,9 +25,8 @@ var (
 )
 
 const (
-	opPointsWriter           = "http/pointsWriter"
-	msgUnableToReadData      = "unable to read data"
-	msgWritingRequiresPoints = "writing requires points"
+	opPointsWriter      = "http/pointsWriter"
+	msgUnableToReadData = "unable to read data"
 )
 
 // ParsedPoints contains the points parsed as well as the total number of bytes
@@ -67,15 +66,6 @@ func (pw *Parser) parsePoints(ctx context.Context, orgID, bucketID platform.ID, 
 		}
 	}
 
-	requestBytes := len(data)
-	if requestBytes == 0 {
-		return nil, &errors2.Error{
-			Op:   opPointsWriter,
-			Code: errors2.EInvalid,
-			Msg:  msgWritingRequiresPoints,
-		}
-	}
-
 	span, _ := tracing.StartSpanFromContextWithOperationName(ctx, "encoding and parsing")
 
 	points, err := models.ParsePointsWithPrecision(data, time.Now().UTC(), pw.Precision)
@@ -102,7 +92,7 @@ func (pw *Parser) parsePoints(ctx context.Context, orgID, bucketID platform.ID, 
 
 	return &ParsedPoints{
 		Points:  points,
-		RawSize: requestBytes,
+		RawSize: len(data),
 	}, nil
 }
 

--- a/http/write_handler_test.go
+++ b/http/write_handler_test.go
@@ -226,7 +226,7 @@ func TestWriteHandler_handleWrite(t *testing.T) {
 			},
 		},
 		{
-			name: "empty request body returns 400 error",
+			name: "empty request body is ok",
 			request: request{
 				org:    "043e0780ee2b1000",
 				bucket: "04504b356e23b000",
@@ -237,8 +237,7 @@ func TestWriteHandler_handleWrite(t *testing.T) {
 				bucket: testBucket("043e0780ee2b1000", "04504b356e23b000"),
 			},
 			wants: wants{
-				code: 400,
-				body: `{"code":"invalid","message":"writing requires points"}`,
+				code: 204,
 			},
 		},
 		{


### PR DESCRIPTION
Closes #22573

Allow empty writes. Cloud has allowed this since influxdata/idpe#9724, some of the changes here match that PR 1:1