### PR TITLE
feat: add route to return platform known resources (#22135)

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -187,6 +187,8 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	h.Mount("/api/v2/flags", b.FlagsHandler)
 
+	h.Mount(prefixResources, NewResourceListHandler())
+
 	variableBackend := NewVariableBackend(b.Logger.With(zap.String("handler", "variable")), b)
 	variableBackend.VariableService = authorizer.NewVariableService(b.VariableService)
 	h.Mount(prefixVariables, NewVariableHandler(b.Logger, variableBackend))

--- a/http/resources.go
+++ b/http/resources.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/influxdata/influxdb/v2"
+)
+
+const prefixResources = "/api/v2/resources"
+
+// NewResourceListHandler is the HTTP handler for the GET /api/v2/resources route.
+func NewResourceListHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(influxdb.AllResourceTypes)
+	})
+}

--- a/http/resources_test.go
+++ b/http/resources_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2"
+)
+
+func TestResourceListHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	NewResourceListHandler().ServeHTTP(w,
+		httptest.NewRequest(
+			"GET",
+			"http://howdy.tld/api/v2/resources",
+			nil,
+		),
+	)
+
+	expectedResponse := []string{
+		string(influxdb.AuthorizationsResourceType),
+		string(influxdb.BucketsResourceType),
+		string(influxdb.DashboardsResourceType),
+		string(influxdb.OrgsResourceType),
+		string(influxdb.SourcesResourceType),
+		string(influxdb.TasksResourceType),
+		string(influxdb.TelegrafsResourceType),
+		string(influxdb.UsersResourceType),
+		string(influxdb.VariablesResourceType),
+		string(influxdb.ScraperResourceType),
+		string(influxdb.SecretsResourceType),
+		string(influxdb.LabelsResourceType),
+		string(influxdb.ViewsResourceType),
+		string(influxdb.DocumentsResourceType),
+		string(influxdb.NotificationRuleResourceType),
+		string(influxdb.NotificationEndpointResourceType),
+		string(influxdb.ChecksResourceType),
+		string(influxdb.DBRPResourceType),
+	}
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Logf(string(body))
+		t.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	var actualReponse []string
+	if err := json.Unmarshal(body, &actualReponse); err != nil {
+		t.Errorf("unexpected response format: %v, error: %v", string(body), err)
+	}
+
+	if !reflect.DeepEqual(actualReponse, expectedResponse) {
+		t.Errorf("expected response to equal %+#v, but was %+#v", expectedResponse, actualReponse)
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 7aaba338b2c4eeda57a6155badedad1900645855)

Backports #22135

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
