### PR TITLE
build: refactor lint and race-test jobs to use cross-builder executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,8 @@ workflows:
       not: << pipeline.parameters.aws_teardown >>
     jobs:
       - godeps
-      - gotest:
-          requires:
-            - godeps
+      - test-race:
+          name: gotest # TODO: Rename to something more descriptive?
       - test-build:
           matrix:
             parameters:
@@ -180,9 +179,8 @@ workflows:
     jobs:
       - changelog
       - godeps
-      - gotest:
-          requires:
-            - godeps
+      - test-race:
+          name: gotest # TODO: Rename to something more descriptive?
       - test-build:
           matrix:
             parameters:
@@ -486,33 +484,19 @@ jobs:
       - run: go install honnef.co/go/tools/cmd/staticcheck
       - run: staticcheck ./...
 
-  gotest:
-    docker:
-      - image: cimg/go:1.17.1
-    resource_class: large
-    environment:
-      TMPDIR: /mnt/ramdisk
-    working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
+  test-race:
+    executor: cross-builder
     parallelism: 8
     steps:
       - checkout
-      - restore_cache:
-          name: Restore GOPATH/pkg/mod
-          keys:
-            - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - run: mkdir -p /tmp/test-results
-      - install_core_deps
       - run:
-          name: run parallel race tests
-          command: |
-            GO_TEST_CMD="gotestsum --format standard-quiet --junitfile /tmp/test-results/gotestsum.xml -- -p=4"
-            TESTFILES=($(go list ./... | circleci tests split --split-by=timings))
-            make GO_TEST_CMD="$GO_TEST_CMD" GO_TEST_PATHS="${TESTFILES[*]}" test-go-race
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: raw-test-output
+          name: Run race tests
+          command: ./scripts/ci/run-race-tests.sh $(pwd)/test-results
       - store_test_results:
-          path: /tmp/test-results
+          path: ./test-results
+      - store_artifacts:
+          path: ./test-results
+          destination: raw-test-results
 
   test-build:
     executor: cross-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,8 @@ workflows:
       - tlstest:
           requires:
             - godeps
-      - golint:
-          requires:
-            - godeps
+      - lint:
+          name: golint # TODO: Remove this alias?
       - build:
           requires:
             - godeps
@@ -210,9 +209,8 @@ workflows:
           executor: windows
           requires:
             - test-build-amd64-windows
-      - golint:
-          requires:
-            - godeps
+      - lint:
+          name: golint # TODO: Remove this alias?
       - fluxtest:
           requires:
             - godeps
@@ -447,42 +445,32 @@ jobs:
           paths:
             - /home/circleci/go/pkg/mod
 
-  golint:
-    docker:
-      - image: cimg/go:1.17.1
-    environment:
-      TMPDIR: /mnt/ramdisk
-    working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
+  lint:
+    executor: cross-builder
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - influxdb-gomod-sum-{{ checksum "go.sum" }}
-      - run: |
-          # this is not in a seperate bash script because it isn't meant to be run on local.
-          # it just checks to make sure that the same major/minor version of go is used in the mod file as on ci
-          # to prevent accidentally checking in a wrong go mod version.
-          gomodversiondiff=$( go mod edit -go=$( go version | sed -n 's/^.*go\([0-9]*.[0-9]*\).*$/\1/p') -print |diff - go.mod )
-          if [ "$gomodversiondiff" ]
-          then
-            echo unexpected go version $gomodversiondiff
-            exit 1
-          fi
-      - install_core_deps
       - run:
           name: Check flag generation
           command: ./scripts/ci/lint/flags.bash
-      - run: make checkgenerate
+          when: always
       - run:
-          name: Check generation when vendoring deps
+          name: Check formatting
+          command: make checkfmt
+          when: always
+      - run:
+          name: Check codegen
+          command: make checkgenerate
+          when: always
+      - run:
+          name: vet
+          command: make vet
+          when: always
+      - run:
+          name: staticcheck
           command: |
-            go mod vendor
-            make checkgenerate
-            rm -rf vendor
-      - run: make vet
-      - run: make checkfmt
-      - run: go install honnef.co/go/tools/cmd/staticcheck
-      - run: staticcheck ./...
+            go install honnef.co/go/tools/cmd/staticcheck
+            staticcheck ./...
+          when: always
 
   test-race:
     executor: cross-builder

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -1,29 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-declare -r GOTESTSUM_VERSION=1.7.0
-
-# Values are from https://github.com/gotestyourself/gotestsum/releases/download/v${VERSION}/gotestsum-${VERSION}-checksums.txt
-function gotestsum_expected_sha () {
-    case "$(go env GOOS)_$(go env GOARCH)" in
-        linux_amd64)
-            echo b5c98cc408c75e76a097354d9487dca114996e821b3af29a0442aa6c9159bd40
-            ;;
-        linux_arm64)
-            echo ee57c91abadc464a7cd9f8abbffe94a673aab7deeb9af8c17b96de4bb8f37e41
-            ;;
-        darwin_amd64)
-            echo a8e2351604882af1a67601cbeeacdcfa9b17fc2f6fbac291cf5d434efdf2d85b
-            ;;
-        windows_amd64)
-            echo 7ae12ddb171375f0c14d6a09dd27a5c1d1fc72edeea674e3d6e7489a533b40c1
-            ;;
-        *)
-            >&2 echo Error: Unsupported OS/arch pair for gotestsum: "$(go env GOOS)_$(go env GOARCH)"
-            exit 1
-            ;;
-    esac
-}
+declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 
 function build_linux () {
     local tags=osusergo,netgo,sqlite_foreign_keys,sqlite_json,static_build
@@ -59,13 +37,7 @@ function build_windows () {
 
 function build_test_tools () {
     # Download gotestsum from its releases (faster than building it).
-    local -r gotestsum_archive="gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz"
-    local -r gotestsum_url="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/${gotestsum_archive}"
-
-    curl -L "$gotestsum_url" -O
-    echo "$(gotestsum_expected_sha)  ${gotestsum_archive}" | sha256sum --check --
-    tar xzf "$gotestsum_archive" -C "${1}/"
-    rm "$gotestsum_archive"
+    "${SCRIPT_DIR}/install-gotestsum.sh" "$1"
 
     # Build test2json from the installed Go distribution.
     CGO_ENABLED=0 go build -o "${1}/" -ldflags="-s -w" cmd/test2json

--- a/scripts/ci/install-gotestsum.sh
+++ b/scripts/ci/install-gotestsum.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+declare -r GOTESTSUM_VERSION=1.7.0
+
+# Values are from https://github.com/gotestyourself/gotestsum/releases/download/v${VERSION}/gotestsum-${VERSION}-checksums.txt
+function gotestsum_expected_sha () {
+    case "$(go env GOOS)_$(go env GOARCH)" in
+        linux_amd64)
+            echo b5c98cc408c75e76a097354d9487dca114996e821b3af29a0442aa6c9159bd40
+            ;;
+        linux_arm64)
+            echo ee57c91abadc464a7cd9f8abbffe94a673aab7deeb9af8c17b96de4bb8f37e41
+            ;;
+        darwin_amd64)
+            echo a8e2351604882af1a67601cbeeacdcfa9b17fc2f6fbac291cf5d434efdf2d85b
+            ;;
+        windows_amd64)
+            echo 7ae12ddb171375f0c14d6a09dd27a5c1d1fc72edeea674e3d6e7489a533b40c1
+            ;;
+        *)
+            >&2 echo Error: Unsupported OS/arch pair for gotestsum: "$(go env GOOS)_$(go env GOARCH)"
+            exit 1
+            ;;
+    esac
+}
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<output-dir>'
+        exit 1
+    fi
+
+    local -r gotestsum_archive="gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz"
+    local -r gotestsum_url="https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/${gotestsum_archive}"
+
+    curl -L "$gotestsum_url" -O
+    echo "$(gotestsum_expected_sha)  ${gotestsum_archive}" | sha256sum --check --
+    tar xzf "$gotestsum_archive" -C "${1}/"
+    rm "$gotestsum_archive"
+}
+
+main "${@}"

--- a/scripts/ci/run-race-tests.sh
+++ b/scripts/ci/run-race-tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<output-dir>'
+        exit 1
+    fi
+    if [[ $(go env GOOS) != linux || $(go env GOARCH) != amd64 ]]; then
+        >&2 echo Race tests only supported on linux/amd64
+        exit 1
+    fi
+
+    local -r out_dir="$1"
+    mkdir -p "$out_dir"
+
+    # Install gotestsum.
+    "${SCRIPT_DIR}/install-gotestsum.sh" /go/bin
+
+    # Get list of packages to test on this node according to Circle's timings.
+    local -r test_packages="$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)"
+
+    # Run tests
+    local -r tags=osuergo,netgo,sqlite_foreign_keys,sqlite_json
+    gotestsum --junitfile "${out_dir}/report.xml" -- -tags "$tags" -race ${test_packages[@]}
+}
+
+main ${@}


### PR DESCRIPTION
Part of #20855

* Update the lint and race-test jobs to use our cross-builder executor
  * Avoids burning time on system setup every run
  * Reduces the number of places we need to update when bumping the Go or Rust version
* Moves some logic out of `.circleci/config.yml` into a shell script
  * (Hopefully) makes the script easier to read & edit in the future
* Sets `when: always` on the steps of our lint job
  * Flushes out all the linter issues in one shot, so we don't have to fix & push one tool at a time

I renamed the `job` entries to (hopefully) be more descriptive, but aliased them back to their old names in the top-level `workflow` definitions so we don't have to change the branch protection rules.