### PR TITLE
build: changelog output needs to be catted to file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,7 +967,7 @@ jobs:
               --commit-range "$LAST_COMMIT..$NEWEST_COMMIT" \
               --prepend CHANGELOG.md \
               -- \
-              --tag $TIMESTAMP
+              --tag $TIMESTAMP > CHANGELOG.md
             echo ${CIRCLE_SHA1} > $COMMIT_FILE_PATH
 
             mkdir changelog_artifacts


### PR DESCRIPTION
`update-changelog.sh` just echoes its output, so it needs to be captured in a file redirect.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass