### PR TITLE
build: enable testing of release workflow via *test tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ commands:
                 name: Build release
                 # `goreleaser release --skip-publish` builds Docker images, but doesn't push them.
                 # As opposed to `goreleaser build`, which stops before building Dockers.
-                command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//')" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
+                command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//' | sed 's/^[a-zA-Z]/2\.0-&/')" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
       - when:
           condition:
             and:
@@ -434,14 +434,8 @@ commands:
             - run:
                 name: Publish release
                 command: |
-                  case "${CIRCLE_TAG}" in
-                    *test )
-                      exit 1;;
-                    *)
-                      ;;
-                  esac
                   S3_FOLDER="influxdb/releases/" \
-                  VERSION=${CIRCLE_TAG} \
+                  VERSION=${CIRCLE_TAG##v} \
                   goreleaser \
                     --debug \
                     release \
@@ -460,7 +454,7 @@ commands:
                 name: Publish release
                 command: |
                   S3_FOLDER="platform/nightlies/test" \
-                  VERSION=${CIRCLE_TAG} \
+                  VERSION=2.0-${CIRCLE_TAG} \
                   goreleaser \
                     --debug \
                     release \
@@ -649,7 +643,7 @@ jobs:
       - install_core_deps
       - install_cross_bin_deps
       # Build the static binary for linux
-      - run: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//')" goreleaser build --snapshot --single-target
+      - run: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//' | sed 's/^[a-zA-Z]/2\.0-&/')" goreleaser build --snapshot --single-target
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -718,7 +712,7 @@ jobs:
           name: Terraform apply
           command: |
             set -x
-            export DEBNAME=$(find /tmp/workspace/artifacts/influxdb2-2*amd64.deb)
+            export DEBNAME=$(find /tmp/workspace/artifacts/influxdb2-*amd64.deb ! -name "*influxdb2-client*")
             terraform -chdir=scripts/ci init -input=false
             AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY terraform \
               -chdir=scripts/ci \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,13 +148,17 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - jsdeps:
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - gotest:
           requires:
             - godeps
@@ -162,7 +166,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - golint:
           requires:
             - godeps
@@ -170,7 +176,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - fluxtest:
           requires:
             - godeps
@@ -178,7 +186,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - tlstest:
           requires:
             - godeps
@@ -186,7 +196,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - changelog:
           nightly: false
           requires:
@@ -198,7 +210,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
       - release:
           requires:
             - changelog
@@ -206,7 +220,9 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)\.[0-9]+)?$/
+                - /^.*test$/
 
 orbs:
   # Needed to install chrome for e2e testing.
@@ -407,12 +423,43 @@ commands:
                 # As opposed to `goreleaser build`, which stops before building Dockers.
                 command: S3_FOLDER="influxdb/releases/" VERSION="$(git describe | sed 's/^v//')" goreleaser --debug release --skip-publish --skip-sign -p 1 --rm-dist --skip-validate
       - when:
-          condition: << parameters.publish_release >>
+          condition:
+            and:
+              - << parameters.publish_release >>
+              - not:
+                  matches:
+                    pattern: "^.*test$"
+                    value: << pipeline.git.tag >>
           steps:
             - run:
                 name: Publish release
                 command: |
+                  case "${CIRCLE_TAG}" in
+                    *test )
+                      exit 1;;
+                    *)
+                      ;;
+                  esac
                   S3_FOLDER="influxdb/releases/" \
+                  VERSION=${CIRCLE_TAG} \
+                  goreleaser \
+                    --debug \
+                    release \
+                      -p 1 \
+                      --rm-dist \
+                      --skip-validate
+      - when:
+          condition:
+            and:
+              - << parameters.publish_release >>
+              - matches:
+                  pattern: "^.*test$"
+                  value: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Publish release
+                command: |
+                  S3_FOLDER="platform/nightlies/test" \
                   VERSION=${CIRCLE_TAG} \
                   goreleaser \
                     --debug \


### PR DESCRIPTION
* push artifacts to "experimental" folder in s3
* otherwise build in the same way

This PR will help prevent surprises on release day and avoid us having to e.g. move tags because of build failures in tagged commit.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass