### PR TITLE
chore: Revert "fix(tsdb): sync series segment to disk after writing (#22565)"

### DIFF
--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -212,10 +212,7 @@ func (s *SeriesSegment) Flush() error {
 	if s.w == nil {
 		return nil
 	}
-	if err := s.w.Flush(); err != nil {
-		return err
-	}
-	return s.file.Sync()
+	return s.w.Flush()
 }
 
 // AppendSeriesIDs appends all the segments ids to a slice. Returns the new slice.


### PR DESCRIPTION
This reverts commit 6692a14cf4569cfe73b888d5e3cde5cdc44a6a10.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass