### PR TITLE
feat: add thread-safe access to CountingWriter byte total

### DIFF
--- a/cmd/influxd/backup_util/backup_util.go
+++ b/cmd/influxd/backup_util/backup_util.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gogo/protobuf/proto"
 	internal "github.com/influxdata/influxdb/cmd/influxd/backup_util/internal"
@@ -209,8 +210,12 @@ type CountingWriter struct {
 
 func (w *CountingWriter) Write(p []byte) (n int, err error) {
 	n, err = w.Writer.Write(p)
-	w.Total += int64(n)
+	atomic.AddInt64(&w.Total, int64(n))
 	return
+}
+
+func (w *CountingWriter) BytesWritten() int64 {
+	return atomic.LoadInt64(&w.Total)
 }
 
 // retentionAndShardFromPath will take the shard relative path and split it into the


### PR DESCRIPTION
Use `atomic` operations to update and report CountingWriter.Total through a new method.

Closes https://github.com/influxdata/influxdb/issues/22618

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
