### PR TITLE
feat(query/stdlib): update window planner rules for location changes to support fixed offsets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe
-	github.com/influxdata/flux v0.133.0
+	github.com/influxdata/flux v0.133.1-0.20211007185412-3d6c47d9113f
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influxql v1.1.1-0.20211004132434-7e7d61973256
 	github.com/influxdata/pkg-config v0.2.9-0.20210928145121-f721f9766b86

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe h1:7j4SdN/BvQwN6WoUq7mv0kg5U9NhnFBxPGMafYRKym0=
 github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe/go.mod h1:XabtPPW2qsCg0tl+kjaPU+cFS+CjQXEXbT1VJvHT4og=
-github.com/influxdata/flux v0.133.0 h1:U1zYP5qXjh6esGOMc4d8efkTgqNORDc9KRWc6NIZsEU=
-github.com/influxdata/flux v0.133.0/go.mod h1:RzogdNsdZoyDAw53BwLrhqyrVI7eT0IKEWW2UjAvTiw=
+github.com/influxdata/flux v0.133.1-0.20211007185412-3d6c47d9113f h1:AuluLA3NjQTEOzdYAFA5iJPSagT6M8eONFfimyCilRk=
+github.com/influxdata/flux v0.133.1-0.20211007185412-3d6c47d9113f/go.mod h1:RzogdNsdZoyDAw53BwLrhqyrVI7eT0IKEWW2UjAvTiw=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influx-cli/v2 v2.1.1-0.20211007122339-c4a5a13c8ee3 h1:DJFtOP/Gji5K6iut794K1pTKPd9SqM9J+Cb7vXgsnq0=

--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -716,7 +716,7 @@ func isPushableWindow(windowSpec *universe.WindowProcedureSpec) bool {
 	// every and period must be equal
 	// every.isNegative must be false
 	// offset.isNegative must be false
-	// location must be "UTC"
+	// location must be UTC with no offset
 	// timeColumn: must be "_time"
 	// startColumn: must be "_start"
 	// stopColumn: must be "_stop"
@@ -725,7 +725,7 @@ func isPushableWindow(windowSpec *universe.WindowProcedureSpec) bool {
 	return window.Every.Equal(window.Period) &&
 		!window.Every.IsNegative() &&
 		!window.Offset.IsNegative() &&
-		window.Location == "UTC" &&
+		window.Location.IsUTC() &&
 		windowSpec.TimeColumn == "_time" &&
 		windowSpec.StartColumn == "_start" &&
 		windowSpec.StopColumn == "_stop"

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1181,10 +1181,12 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 	window := func(dur values.Duration) universe.WindowProcedureSpec {
 		return universe.WindowProcedureSpec{
 			Window: plan.WindowSpec{
-				Every:    dur,
-				Period:   dur,
-				Offset:   dur0,
-				Location: "UTC",
+				Every:  dur,
+				Period: dur,
+				Offset: dur0,
+				Location: plan.Location{
+					Name: "UTC",
+				},
 			},
 			TimeColumn:  "_time",
 			StartColumn: "_start",
@@ -1346,10 +1348,12 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 		Rules:   []plan.Rule{influxdb.PushDownWindowAggregateRule{}},
 		Before: simplePlanWithWindowAgg(universe.WindowProcedureSpec{
 			Window: plan.WindowSpec{
-				Every:    dur2m,
-				Period:   dur2m,
-				Offset:   dur1m,
-				Location: "UTC",
+				Every:  dur2m,
+				Period: dur2m,
+				Offset: dur1m,
+				Location: plan.Location{
+					Name: "UTC",
+				},
 			},
 			TimeColumn:  "_time",
 			StartColumn: "_start",
@@ -1483,6 +1487,16 @@ func TestPushDownWindowAggregateRule(t *testing.T) {
 	badWindow5 := window1m
 	badWindow5.StopColumn = "_stappp"
 	simpleMinUnchanged("BadStop", badWindow5)
+
+	// Condition not met: non-UTC location
+	badWindow6 := window1m
+	badWindow6.Window.Location.Name = "America/Los_Angeles"
+	simpleMinUnchanged("BadLocation", badWindow6)
+
+	// Condition not met: non-zero location offset
+	badWindow7 := window1m
+	badWindow7.Window.Location.Offset = values.ConvertDurationNsecs(time.Hour)
+	simpleMinUnchanged("BadLocationOffset", badWindow7)
 
 	// Condition met: createEmpty is true.
 	windowCreateEmpty1m := window1m
@@ -2106,10 +2120,12 @@ func TestTransposeGroupToWindowAggregateRule(t *testing.T) {
 	window := func(dur values.Duration) universe.WindowProcedureSpec {
 		return universe.WindowProcedureSpec{
 			Window: plan.WindowSpec{
-				Every:    dur,
-				Period:   dur,
-				Offset:   dur0,
-				Location: "UTC",
+				Every:  dur,
+				Period: dur,
+				Offset: dur0,
+				Location: plan.Location{
+					Name: "UTC",
+				},
 			},
 			TimeColumn:  "_time",
 			StartColumn: "_start",
@@ -2338,7 +2354,9 @@ func TestTransposeGroupToWindowAggregateRule(t *testing.T) {
 						Every:    dur2m,
 						Period:   dur2m,
 						Offset:   dur1m,
-						Location: "UTC",
+						Location: plan.Location{
+							Name: "UTC",
+						},
 					},
 					TimeColumn:  "_time",
 					StartColumn: "_start",
@@ -2417,8 +2435,13 @@ func TestTransposeGroupToWindowAggregateRule(t *testing.T) {
 
 	// Condition not met: non-UTC location
 	badWindow6 := window1m
-	badWindow6.Window.Location = "America/Los_Angeles"
+	badWindow6.Window.Location.Name = "America/Los_Angeles"
 	simpleMinUnchanged("BadLocation", badWindow6)
+
+	// Condition not met: non-zero location offset
+	badWindow7 := window1m
+	badWindow7.Window.Location.Offset = values.ConvertDurationNsecs(time.Hour)
+	simpleMinUnchanged("BadLocationOffset", badWindow7)
 
 	// Condition met: createEmpty is true.
 	windowCreateEmpty1m := window1m


### PR DESCRIPTION
The pushdown does not support fixed offsets or non-UTC locations, but it
does now correctly compile and pushdown other windows.

Related to influxdata/flux#4116.