### PR TITLE
chore: use `io`/`os` over `ioutil`

### DIFF
--- a/http/check_test.go
+++ b/http/check_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -309,7 +309,7 @@ func TestService_handleGetChecks(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handleGetChecks() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
@@ -594,7 +594,7 @@ func TestService_handleGetCheck(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 			t.Logf(res.Header.Get("X-Influx-Error"))
 
 			if res.StatusCode != tt.wants.statusCode {
@@ -756,7 +756,7 @@ func TestService_handlePostCheck(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handlePostCheck() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
@@ -865,7 +865,7 @@ func TestService_handleDeleteCheck(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handleDeleteCheck() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
@@ -1042,7 +1042,7 @@ func TestService_handlePatchCheck(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handlePatchCheck() = %v, want %v %v", tt.name, res.StatusCode, tt.wants.statusCode, w.Header())
@@ -1232,7 +1232,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handlePutCheck() = %v, want %v %v %v", tt.name, res.StatusCode, tt.wants.statusCode, w.Header(), string(body))
@@ -1333,7 +1333,7 @@ func TestService_handlePostCheckMember(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handlePostCheckMember() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
@@ -1427,7 +1427,7 @@ func TestService_handlePostCheckOwner(t *testing.T) {
 
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handlePostCheckOwner() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)

--- a/http/points/points_parser.go
+++ b/http/points/points_parser.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	io2 "github.com/influxdata/influxdb/v2/kit/io"
@@ -113,7 +112,7 @@ func readAll(ctx context.Context, rc io.ReadCloser) (data []byte, err error) {
 		span.Finish()
 	}()
 
-	data, err = ioutil.ReadAll(rc)
+	data, err = io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 

--- a/tsdb/engine/tsm1/array_cursor_test.go
+++ b/tsdb/engine/tsm1/array_cursor_test.go
@@ -3,7 +3,6 @@ package tsm1
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,7 +20,7 @@ type keyValues struct {
 }
 
 func MustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -29,7 +28,7 @@ func MustTempDir() string {
 }
 
 func MustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -802,7 +801,7 @@ func TestCache_Split(t *testing.T) {
 }
 
 func mustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -810,7 +809,7 @@ func mustTempDir() string {
 }
 
 func mustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -2299,7 +2298,7 @@ func (e *Engine) reloadCache() error {
 // cleanup removes all temp files and dirs that exist on disk.  This is should only be run at startup to avoid
 // removing tmp files that are still in use.
 func (e *Engine) cleanup() error {
-	allfiles, err := ioutil.ReadDir(e.path)
+	allfiles, err := os.ReadDir(e.path)
 	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -2,7 +2,6 @@ package tsm1
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "shard_test")
+	tmpDir, err := os.MkdirTemp("", "shard_test")
 	require.NoError(t, err, "error creating temporary directory")
 	defer os.RemoveAll(tmpDir)
 
@@ -83,7 +82,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 func NewSeriesFile(tb testing.TB, tmpDir string) *tsdb.SeriesFile {
 	tb.Helper()
 
-	dir, err := ioutil.TempDir(tmpDir, "tsdb-series-file-")
+	dir, err := os.MkdirTemp(tmpDir, "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -379,7 +378,7 @@ func TestEngine_Backup(t *testing.T) {
 	defer sfile.Close()
 
 	// Generate temporary file.
-	f, _ := ioutil.TempFile("", "tsm")
+	f, _ := os.CreateTemp("", "tsm")
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
@@ -498,7 +497,7 @@ func TestEngine_Backup(t *testing.T) {
 
 func TestEngine_Export(t *testing.T) {
 	// Generate temporary file.
-	f, _ := ioutil.TempFile("", "tsm")
+	f, _ := os.CreateTemp("", "tsm")
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
@@ -1831,7 +1830,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	defer sfile.Close()
 
 	// Generate temporary file.
-	dir, _ := ioutil.TempDir("", "tsm")
+	dir, _ := os.MkdirTemp("", "tsm")
 	walPath := filepath.Join(dir, "wal")
 	os.MkdirAll(walPath, 0777)
 	defer os.RemoveAll(dir)
@@ -2594,7 +2593,7 @@ type Engine struct {
 func NewEngine(tb testing.TB, index string) (*Engine, error) {
 	tb.Helper()
 
-	root, err := ioutil.TempDir("", "tsm1-")
+	root, err := os.MkdirTemp("", "tsm1-")
 	if err != nil {
 		panic(err)
 	}
@@ -2768,7 +2767,7 @@ type SeriesFile struct {
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
 func NewSeriesFile() *SeriesFile {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
+	dir, err := os.MkdirTemp("", "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -489,7 +488,7 @@ func (f *FileStore) Open(ctx context.Context) error {
 	}
 
 	// find the current max ID for temp directories
-	tmpfiles, err := ioutil.ReadDir(f.dir)
+	tmpfiles, err := os.ReadDir(f.dir)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -3,7 +3,6 @@ package tsm1_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2725,7 +2724,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 	}
 	t.Logf("temp file for hard links: %q", s)
 
-	tfs, e := ioutil.ReadDir(s)
+	tfs, e := os.ReadDir(s)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -2927,7 +2926,7 @@ type keyValues struct {
 }
 
 func MustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -2935,7 +2934,7 @@ func MustTempDir() string {
 }
 
 func MustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -2,7 +2,6 @@ package tsm1
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -1658,7 +1657,7 @@ func TestTSMReader_FuzzCrashes(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			filename := filepath.Join(dir, "x.tsm")
-			if err := ioutil.WriteFile(filename, []byte(c), 0600); err != nil {
+			if err := os.WriteFile(filename, []byte(c), 0600); err != nil {
 				t.Fatalf("exp no error, got %s", err)
 			}
 			defer os.RemoveAll(dir)

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -270,7 +269,7 @@ func (t *Tombstoner) Walk(fn func(t Tombstone) error) error {
 }
 
 func (t *Tombstoner) writeTombstoneV3(tombstones []Tombstone) error {
-	tmp, err := ioutil.TempFile(filepath.Dir(t.Path), TombstoneFileExtension)
+	tmp, err := os.CreateTemp(filepath.Dir(t.Path), TombstoneFileExtension)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -2,7 +2,6 @@ package tsm1_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -242,7 +241,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	if err := ioutil.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
+	if err := os.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
 		t.Fatalf("write v1 file: %v", err)
 	}
 	f.Close()

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -75,7 +74,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 		t.Fatalf("unexpected error open file: %v", err)
 	}
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error reading: %v", err)
 	}
@@ -419,7 +418,7 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 	}
 	defer fd.Close()
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error read all: %v", err)
 	}
@@ -467,7 +466,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	}
 	defer fd.Close()
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error read all: %v", err)
 	}
@@ -596,7 +595,7 @@ func TestTSMWriter_Sync(t *testing.T) {
 		io.Writer
 		fakeSyncer
 	}{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	w, err := tsm1.NewTSMWriter(f)

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -3,7 +3,7 @@ package tsdb_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -369,12 +369,12 @@ func MustNewIndex(tb testing.TB, index string, eopts ...EngineOption) *Index {
 		opt(&opts)
 	}
 
-	rootPath, err := ioutil.TempDir("", "influxdb-tsdb")
+	rootPath, err := os.MkdirTemp("", "influxdb-tsdb")
 	if err != nil {
 		panic(err)
 	}
 
-	seriesPath, err := ioutil.TempDir(rootPath, tsdb.SeriesFileDirectory)
+	seriesPath, err := os.MkdirTemp(rootPath, tsdb.SeriesFileDirectory)
 	if err != nil {
 		panic(err)
 	}
@@ -492,7 +492,7 @@ func BenchmarkIndexSet_TagSets(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -590,7 +590,7 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
This PR updates all instances of `ioutil` to use `io` or `os`, which was recommended as of go 1.16. Now in go 1.17, all functions in this package simply redirect to functions in `io` or `os`, except for one, being `ioutil.ReadDir`.

`ioutil.ReadDir` returned a list of `fs.FileInfo`, where `os.ReadDir` returns a list of `fs.DirEntry`. In most cases, this change does nothing except require an extra call to `Info()`, but in one place, `file_store#Open()`, FileInfo was not needed and DirEntry was enough, so this may see a slight performance gain.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass