### PR TITLE
chore: increase `TestMonitor_Reporter` timeout timer

### DIFF
--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -220,7 +220,7 @@ func TestMonitor_Reporter(t *testing.T) {
 	defer s.Close()
 	defer cancel()
 
-	timer := time.NewTimer(300 * time.Millisecond)
+	timer := time.NewTimer(5 * time.Second)
 	select {
 	case points := <-ch:
 		timer.Stop()


### PR DESCRIPTION
Increases the timer for a flaky test, `TestMonitor_Reporter`, which fairly frequently fails due to a timeout

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass