### PR TITLE
fix(restore): enforce the -db parameter when -newdb used (#22542)

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -166,6 +166,10 @@ func (cmd *Command) parseFlags(args []string) error {
 		return fmt.Errorf("backup path should be a valid directory: %s", cmd.backupFilesPath)
 	}
 
+	if cmd.destinationDatabase != "" && cmd.sourceDatabase == "" {
+		return fmt.Errorf("must specify a database to be restored into new database %s", cmd.destinationDatabase)
+	}
+
 	if cmd.portable || cmd.online {
 		// validate the arguments
 
@@ -183,6 +187,7 @@ func (cmd *Command) parseFlags(args []string) error {
 
 		if cmd.portable {
 			var err error
+
 			cmd.manifestMeta, cmd.manifestFiles, err = backup_util.LoadIncremental(cmd.backupFilesPath)
 			if err != nil {
 				return fmt.Errorf("restore failed while processing manifest files: %s", err.Error())


### PR DESCRIPTION
closes https://github.com/influxdata/influxdb/issues/15901

(cherry picked from commit 1dde65bb75f3744c01313f5bd8f54f0262dd0da4)

Closes https://github.com/influxdata/influxdb/issues/22543

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
