### PR TITLE
fix:  use body of the post request for queries

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -666,7 +666,11 @@ func (c *client) createDefaultRequest(ctx context.Context, q Query) (*http.Reque
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), nil)
+	queryParams := make(url.Values)
+	queryParams.Add("q", q.Command)
+	queryParams.Add("params", string(jsonParameters))
+
+	req, err := http.NewRequest("POST", u.String(), strings.NewReader(queryParams.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -675,7 +679,7 @@ func (c *client) createDefaultRequest(ctx context.Context, q Query) (*http.Reque
 		req = req.WithContext(ctx)
 	}
 
-	req.Header.Set("Content-Type", "")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", c.useragent)
 
 	if c.username != "" {
@@ -683,12 +687,10 @@ func (c *client) createDefaultRequest(ctx context.Context, q Query) (*http.Reque
 	}
 
 	params := req.URL.Query()
-	params.Set("q", q.Command)
 	params.Set("db", q.Database)
 	if q.RetentionPolicy != "" {
 		params.Set("rp", q.RetentionPolicy)
 	}
-	params.Set("params", string(jsonParameters))
 
 	if q.Precision != "" {
 		params.Set("epoch", q.Precision)


### PR DESCRIPTION
Closes #22694

For very large queries the InfluxDB's HTTP server  returns `"431 Request Header Fields Too Large"` response.. 
looking at the code the `q=` is set at the URL, which as a limit..
Since the request is already `POST` method, this change moves the larger (`q=`, and `params`)  key/value pairs to the body of the request.

from influxdb logs
used to be
```
[httpd] 10.244.0.27 - admin [18/Oct/2021:13:00:14 -0700] "POST /query?db=tsdb&params=null&q=SELECT+%2A+FROM+%22tsdb%22.%22default%22.%2Fstats%5C%2Ffpg%5C%2Fnu.%2A%2F++WHERE+%22dpu_id%22%3D%27c8%3Ac2%3A2b%3A00%3A0e%3Aec%27+AND++time+%3C%3D+now%28%29++ORDER+BY+time+DESC+LIMIT+1+%3BSELECT+%2A+FROM+%22tsdb%22.%22hourly%22.%2Fstats%5C%2Ffpg%5C%2Fnu.%2A%2F++WHERE+%22dpu_id%22%3D%27c8%3Ac2%3A2b%3A00%3A0e%3Aec%27+AND++time+%3C%3D+now%28%29++ORDER+BY+time+DESC+LIMIT+1+%3BSELECT+%2A+FROM+%22tsdb%22.%22daily%22.%2Fstats%5C%2Ffpg%5C%2Fnu.%2A%2F++WHERE+%22dpu_id%22%3D%27c8%3Ac2%3A2b%3A00%3A0e%3Aec%27+AND++time+%3C%3D+now%28%29++ORDER+BY+time+DESC+LIMIT+1+%3B HTTP/1.1 " 200 65 "-" "TMService/InfluxDB" 01fbcbd6-304e-11ec-a0fb-329a85d2c7b4 117205
```

now

```
[httpd] 127.0.0.1 - - [18/Oct/2021:13:01:35 -0700] "POST /query?db=tsdb HTTP/1.1 {'params': 'null'}, {'q': 'SELECT * FROM "tsdb"."default"./stats\/fpg\/nu.*/  WHERE "dpu_id"='c8:c2:2b:00:0e:c0' AND  time <= now()  ORDER BY time DESC LIMIT 1 ;SELECT * FROM "tsdb"."hourly"./stats\/fpg\/nu.*/  WHERE "dpu_id"='c8:c2:2b:00:0e:c0' AND  time <= now()  ORDER BY time DESC LIMIT 1 ;SELECT * FROM "tsdb"."daily"./stats\/fpg\/nu.*/  WHERE "dpu_id"='c8:c2:2b:00:0e:c0' AND  time <= now()  ORDER BY time DESC LIMIT 1 ;'}" 200 74604 "-" "curl/7.79.1" 328e5e8d-304e-11ec-af89-329a85d2c7b4 221527
```

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
