### PR TITLE
build: fix the executor for release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -951,9 +951,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${TEST_AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${TEST_AWS_SECRET_ACCESS_KEY} aws --region us-west-2 ec2 terminate-instances --instance-ids $instance_id
 
   release:
-    machine:
-      image: linux-amd64
-    resource_class: large
+    executor: linux-amd64
     environment:
       TMPDIR: /mnt/ramdisk
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb


### PR DESCRIPTION
Fixes the executor of the `release` job to be the correct syntax.

Verification that it works correctly (the release job starts successfully, even though the job itself ultimately fails, due to a separate problem with the changelog auotmation file name, possibly due to the test tag name I used): https://app.circleci.com/pipelines/github/influxdata/influxdb/25079/workflows/2ec0e990-2601-485c-a120-a5a83be2bc1b