### PR TITLE
build: hard-code commit file path for release changelogs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1163,7 +1163,7 @@ jobs:
                   set -x
                   S3_PATH="https://s3.amazonaws.com/dl.influxdata.com/influxdb/releases"
                   CHANGELOG_FILENAME="CHANGELOG-${CIRCLE_TAG}.md"
-                  COMMIT_FILE_PATH="changelog-commit-${CIRCLE_BRANCH}.txt"
+                  COMMIT_FILE_PATH="changelog-commit-2.1.txt"
                   curl -o ${COMMIT_FILE_PATH} ${S3_PATH}/${COMMIT_FILE_PATH}
                   LAST_COMMIT=$(git describe --abbrev=0 --tags --exclude='*[rc]*' $(git rev-list --tags='v2.1*' --skip=1 --max-count=1))
                   NEWEST_COMMIT=${CIRCLE_SHA1}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,7 @@ blobs:
     folder: "{{ .Env.S3_FOLDER }}"
     extra_files:
       - glob: ./changelog_artifacts/CHANGELOG*.md
-      - glob: ./changelog_artifacts/changelog-commit.txt
+      - glob: ./changelog_artifacts/changelog-commit*.txt
 
 checksum:
   name_template: "influxdb2-{{ .Env.VERSION }}.sha256"


### PR DESCRIPTION
The `${CIRCLE_BRANCH}` env variable does not appear to be available when the job is triggered by a tag, so this needs to be hardcoded.

Also the `.goreleaser.yml` config needed updated to allow for matching the full path of the `changelog-commit-2.1` (etc.) file.