### PR TITLE
build: fix issue with changelog-commit file naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1056,7 +1056,7 @@ jobs:
                   set -x
                   S3_PATH="https://s3.amazonaws.com/dl.influxdata.com/influxdb/releases"
                   CHANGELOG_FILENAME="CHANGELOG-${CIRCLE_TAG}.md"
-                  COMMIT_FILE_PATH="changelog-commit-${CIRCLE_BRANCH}.txt"
+                  COMMIT_FILE_PATH="changelog-commit-2.1.txt"
 
                   curl -o ${COMMIT_FILE_PATH} ${S3_PATH}/${COMMIT_FILE_PATH}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,7 +128,7 @@ blobs:
     folder: "{{ .Env.S3_FOLDER }}"
     extra_files:
       - glob: ./changelog_artifacts/CHANGELOG*.md
-      - glob: ./changelog_artifacts/changelog-commit.txt
+      - glob: ./changelog_artifacts/changelog-commit*.txt
 
 checksum:
   name_template: "influxdb2-{{ .Env.VERSION }}.sha256"


### PR DESCRIPTION
Equivalent of https://github.com/influxdata/influxdb/pull/22718 for the `2.0` branch. Should fix goreleaser failure when trying to find the `changelog-commit` file.