### PR TITLE
build: fix nightly litmus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -992,6 +992,8 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Create RAM disk
           command: |
@@ -1010,6 +1012,8 @@ jobs:
           root: .
           paths:
             - dist/influxd_linux_amd64/influxd
+            - etc/litmus_success_notify.sh
+            - etc/litmus_fail_notify.sh
 
   #################################
   ### e2e/integration test jobs ###


### PR DESCRIPTION
Closes #22723

This will persist the files necessary to run the litmus integration tests. Verification that this fixes the problem can be see here: https://app.circleci.com/pipelines/github/influxdata/influxdb/25107/workflows/1d4bed4a-f164-48da-b64f-adc5bf638a1d