### PR TITLE
chore: increase timeout timers for `TestMonitor` tests

### DIFF
--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -144,7 +144,7 @@ func TestMonitor_StoreStatistics(t *testing.T) {
 	defer s.Close()
 	defer cancel()
 
-	timer := time.NewTimer(100 * time.Millisecond)
+	timer := time.NewTimer(5 * time.Second)
 	select {
 	case points := <-ch:
 		timer.Stop()
@@ -345,7 +345,7 @@ func TestMonitor_Expvar(t *testing.T) {
 	defer cancel()
 
 	hostname, _ := os.Hostname()
-	timer := time.NewTimer(100 * time.Millisecond)
+	timer := time.NewTimer(5 * time.Second)
 	select {
 	case points := <-ch:
 		timer.Stop()


### PR DESCRIPTION
Similar to #22662, but increases the timer in a similar manner for 2 more tests that have been regularly flaky for me lately

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass