### PR TITLE
chore: initialized `CHANGELOG_OLD.md` with initial changes for this release branch

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -24,7 +24,6 @@ This release adds an embedded SQLite database for storing metadata required by t
 
 ### Features
 
-1. [19811](https://github.com/influxdata/influxdb/pull/19811): Add Geo graph type to be able to store in Dashboard cells
 1. [21218](https://github.com/influxdata/influxdb/pull/21218): Add the properties of a static legend for line graphs and band plots
 1. [21367](https://github.com/influxdata/influxdb/pull/21367): List users via the API now supports pagination
 1. [21543](https://github.com/influxdata/influxdb/pull/21543): Added `influxd` configuration flag `--sqlite-path` for specifying a user-defined path to the SQLite database file
@@ -65,9 +64,7 @@ This release adds an embedded SQLite database for storing metadata required by t
 ### Bug Fixes
 
 1. [21648](https://github.com/influxdata/influxdb/pull/21648): Change static legend's `hide` to `show` to let users decide if they want it
-1. [22442](https://github.com/influxdata/influxdb/pull/22442): Detect noninteractive prompt when displaying warning in `buildtsi`
-1. [22458](https://github.com/influxdata/influxdb/pull/22458): Ensure files are closed before they are deleted or moved in `deletetsm`
-1. [22448](https://github.com/influxdata/influxdb/pull/22448): More expressive errors
+1. [22448](https://github.com/influxdata/influxdb/pull/22448): Log API errors to server logs and tell clients to check the server logs for the error message
 1. [22545](https://github.com/influxdata/influxdb/pull/22545): Sync series segment to disk after writing
 1. [22604](https://github.com/influxdata/influxdb/pull/22604): Do not allow shard creation to create overlapping shards
 1. [22650](https://github.com/influxdata/influxdb/pull/22650): Don't drop shard-group durations when upgrading DBs


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb/issues/22716

This creates an initial changelog file for the `2.1` release branch. Since our changelog automation is not yet capable of generating the first changelog for a release branch, I did it manually by reviewing the commit history on `master` and `2.0`. This is the file we will actually include with the release.

To generate this new changelog, I started from the `CHANGELOG_OLD` file on the `master` branch and:
- Deleted all of the sections for previous releases: `2.0.8`, `2.0.7`, etc. Only the "unreleased" section was kept.
- Reviewed the [release notes](https://github.com/influxdata/influxdb/releases/tag/v2.0.9) for the `v2.0.9` release and removed all of the changes listed there.
- Starting from commit 824e76c18d101e831ea25f3ac28aff74b2b283b6 which is where the changelog automation began and we generally stopped manually adding changelog entries, I went through all the commits in the `2.1` branch and selected anything that was a `fix` or a `feat`, + the latest flux upgrade which is a `build`. Any of these that were not included with the `2.0.9` release were added.

Some of the `feat` commits represent partial implementations of a feature (for example, many commits are related to replications). These do not have any user-facing impact and I did not include them.

For reference, this is a chronological list of commits (oldest on top) tagged as either `fix` or `feat` on the `2.1` branch since commit 824e76c18d101e831ea25f3ac28aff74b2b283b6, along with their categorization per the above process:

- [fix: use consistent path separator in permission string representation](https://github.com/influxdata/influxdb/pull/22412) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22517
- [feat: partial support for series cardinality flux query](https://github.com/influxdata/influxdb/pull/22378) - partial feature implementation; no changelog entry needed
- [feat: deleting a bucket also deletes all associated replications](https://github.com/influxdata/influxdb/pull/22424) - partial feature implementation; no changelog entry needed
- [fix: detect noninteractive prompt when displaying warning in `buildtsi`](https://github.com/influxdata/influxdb/pull/22442) - unreleased change
- [fix: ensure files are closed before they are deleted or moved in `deletetsm`](https://github.com/influxdata/influxdb/pull/22458) - unreleased change
- [feat: multi-measurement query optimization](https://github.com/influxdata/influxdb/pull/22301) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22464
- [fix: more expressive errors](https://github.com/influxdata/influxdb/pull/22448) - unreleased change - NOT backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22612
- [feat: support for flux cardinality query](https://github.com/influxdata/influxdb/pull/22441) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22466
- [feat: allow new telegraf input plugins and update toml](https://github.com/influxdata/influxdb/pull/22476) - unreleased change
- [fix: upgrade influxql to latest version & fix predicate handling for show tag values metaqueries](https://github.com/influxdata/influxdb/pull/22500) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22504
- [feat: set X-Influxdb-Version and X-Influxdb-Build headers](https://github.com/influxdata/influxdb/pull/22535) - backported to `2.0.9` https://github.com/influxdata/influxdb/pull/22547
- [fix: suggest setting flux Content-Type when query fails to parse as JSON](https://github.com/influxdata/influxdb/pull/22537) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22548
- [fix: for Windows, copy snapshot files being backed up](https://github.com/influxdata/influxdb/pull/22562) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22563
- [fix(tsdb): sync series segment to disk after writing](https://github.com/influxdata/influxdb/pull/22545) - unreleased change
- [fix: allow empty request bodies to write API](https://github.com/influxdata/influxdb/pull/22574) - backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22578
- [fix: do not allow shard creation to create overlapping shards](https://github.com/influxdata/influxdb/pull/22604) - NOT backported to `2.0.9` via https://github.com/influxdata/influxdb/pull/22609
- [feat(query/stdlib): update push down window logic for location option](https://github.com/influxdata/influxdb/pull/22607) - unreleased change
- [feat: add --storage-write-timeout flag to set write request timeouts](https://github.com/influxdata/influxdb/pull/22617) - unreleased change
- [feat: show measurement database and retention policy wildcards](https://github.com/influxdata/influxdb/pull/22396) - unreleased change
- [feat: implement replication validation](https://github.com/influxdata/influxdb/pull/22581) - partial feature implementation; no changelog entry needed
- [feat: new recovery subcommand allows creating recovery user/token](https://github.com/influxdata/influxdb/pull/22590) - unreleased change
- [feat: return new operator token during backup overwrite](https://github.com/influxdata/influxdb/pull/22629) - unreleased change
- [fix: change session cookie name used by UI to avoid conflict with incompatible 2.0.x cookie](https://github.com/influxdata/influxdb/pull/22632) - no user impact since the bug this fixed never existed in anything that was released
- [feat(query/stdlib): update window planner rules for location changes to support fixed offsets](https://github.com/influxdata/influxdb/pull/22635) - unreleased change
- [fix(upgrade): don't drop shard-group durations when upgrading DBs](https://github.com/influxdata/influxdb/pull/22650) - unreleased change
- [feat(flux): enable writing to remote hosts via to() and experimental.to()](https://github.com/influxdata/influxdb/pull/22634) - unreleased change
- [feat: Add Bearer token auth](https://github.com/influxdata/influxdb/pull/22498) - unreleased change
- [feat: enable new dashboard autorefresh](https://github.com/influxdata/influxdb/pull/22669) - unreleased change
- [feat: list-bucket API supports pagination when filtering by org](https://github.com/influxdata/influxdb/pull/22674) - unreleased change
- [build(flux): update flux to v0.134.0](https://github.com/influxdata/influxdb/pull/22671) - unreleased change
- [feat: update UI to OSS-2.1.0](https://github.com/influxdata/influxdb/pull/22692) - unreleased change
