### PR TITLE
chore: restore "fix(tsdb): sync series segment to disk after writing (#22565)"

### DIFF
--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -212,7 +212,10 @@ func (s *SeriesSegment) Flush() error {
 	if s.w == nil {
 		return nil
 	}
-	return s.w.Flush()
+	if err := s.w.Flush(); err != nil {
+		return err
+	}
+	return s.file.Sync()
 }
 
 // AppendSeriesIDs appends all the segments ids to a slice. Returns the new slice.


### PR DESCRIPTION
Reverts #22605, which reverted #22565 to avoid placing it in the 1.9.5 release