### PR TITLE
chore: fix KV migration to add notebooks and annotations to all-access tokens

### DIFF
--- a/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
+++ b/kv/migration/all/0017_add-annotations-notebooks-to-all-access-tokens_test.go
@@ -43,7 +43,7 @@ func TestMigration_AnnotationsNotebooksAllAccessToken(t *testing.T) {
 			ID:          id2, // an all-access token
 			OrgID:       OrgID,
 			UserID:      UserID,
-			Permissions: oldAllAccessPerms(OrgID),
+			Permissions: oldAllAccessPerms(OrgID, UserID),
 		},
 	}
 
@@ -96,7 +96,7 @@ func TestMigration_AnnotationsNotebooksAllAccessToken(t *testing.T) {
 		var token influxdb.Authorization
 		require.NoError(t, json.Unmarshal(b, &token))
 
-		require.ElementsMatch(t, append(oldAllAccessPerms(OrgID), extraAllAccessPerms(OrgID)...), token.Permissions)
+		require.ElementsMatch(t, append(oldAllAccessPerms(OrgID, UserID), extraAllAccessPerms(OrgID)...), token.Permissions)
 		return nil
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #22737
Backports #22738