### PR TITLE
chore: bump openapi sha for 2.1 release

### DIFF
--- a/scripts/fetch-swagger.sh
+++ b/scripts/fetch-swagger.sh
@@ -10,7 +10,7 @@ declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
 declare -r STATIC_DIR="$ROOT_DIR/static"
 
 # Pins the swagger that will be downloaded to a specific commit
-declare -r OPENAPI_SHA=d6f9073685dfb58e36f20c2ed351cf872ad31a86
+declare -r OPENAPI_SHA=ecdcd4b1baace6942e567771518ba19caf381652
 
 # Don't do a shallow clone since the commit we want might be several commits
 # back; but do only clone the main branch.


### PR DESCRIPTION
Backports #22745

Point at influxdata/openapi@ecdcd4b