### PR TITLE
fix: detect misquoted tag values and return an error

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1833,7 +1833,7 @@ func isBadQuoteTagValueClause(e influxql.Expr) error {
 			_, lOk := e.LHS.(*influxql.VarRef)
 			_, rOk := e.RHS.(*influxql.VarRef)
 			if lOk && rOk {
-				return fmt.Errorf("bad WHERE clause. tag value must be inside single quotes: %s", e.String())
+				return fmt.Errorf("bad WHERE clause for metaquery; one term must be a string literal tag value within single quotes: %s", e.String())
 			}
 		case influxql.OR, influxql.AND:
 			if err := isBadQuoteTagValueClause(e.LHS); err != nil {


### PR DESCRIPTION
`SHOW TAG KEYS FROM "foo" where bar="misquoted"` is
erroneous, because the tag value must be enclosed
in single, not double, quotes. Although this
correctly returns no tag keys, it is very
inefficient and has caused out-of-memory failures
at a customer. This fix short-circuits the query and returns
an error. This fix also handles `SHOW TAG VALUES`
with a misquoted `WHERE` clause. 

Closes https://github.com/influxdata/influxdb/issues/22755

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
