### PR TITLE
chore: clean up protobuf loose ends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ $ go generate ./...
 
 If generating the protobuf code is failing for you, check each of the following:
 * Ensure the protobuf library can be found. Make sure that `LD_LIBRARY_PATH` includes the directory in which the library `libprotoc.so` has been installed.
-* Ensure the command `protoc-gen-gogo`, found in `GOPATH/bin`, is on your path. This can be done by adding `GOPATH/bin` to `PATH`.
+* Ensure the command `protoc-gen-go`, found in `GOPATH/bin`, is on your path. This can be done by adding `GOPATH/bin` to `PATH`.
 
 
 ## Generated Go Templates

--- a/gather/metrics.go
+++ b/gather/metrics.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"time"
 
-	gogoproto "github.com/gogo/protobuf/proto" // Used for Prometheus
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/models"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // MetricsCollection is the struct including metrics and other requirements.
@@ -23,7 +23,7 @@ type Metrics struct {
 	Tags      map[string]string      `json:"tags"`
 	Fields    map[string]interface{} `json:"fields"`
 	Timestamp time.Time              `json:"timestamp"`
-	Type      MetricType             `json:"type"`
+	Type      dto.MetricType         `json:"type"`
 }
 
 // MetricsSlice is a slice of Metrics
@@ -66,51 +66,4 @@ func (ms MetricsSlice) Reader() (io.Reader, error) {
 		}
 	}
 	return buf, nil
-}
-
-// MetricType is prometheus metrics type.
-type MetricType int
-
-// the set of metric types
-const (
-	MetricTypeCounter MetricType = iota
-	MetricTypeGauge
-	MetricTypeSummary
-	MetricTypeUntyped
-	MetricTypeHistogrm
-)
-
-var metricTypeName = []string{
-	"COUNTER",
-	"GAUGE",
-	"SUMMARY",
-	"UNTYPED",
-	"HISTOGRAM",
-}
-var metricTypeValue = map[string]int32{
-	"COUNTER":   0,
-	"GAUGE":     1,
-	"SUMMARY":   2,
-	"UNTYPED":   3,
-	"HISTOGRAM": 4,
-}
-
-// Valid returns whether the metrics type is valid.
-func (x MetricType) Valid() bool {
-	return x >= MetricTypeCounter && x <= MetricTypeHistogrm
-}
-
-// String returns the string value of MetricType.
-func (x MetricType) String() string {
-	return metricTypeName[x]
-}
-
-// UnmarshalJSON implements the unmarshaler interface.
-func (x *MetricType) UnmarshalJSON(data []byte) error {
-	value, err := gogoproto.UnmarshalJSONEnum(metricTypeValue, data, "MetricType")
-	if err != nil {
-		return err
-	}
-	*x = MetricType(value)
-	return nil
 }

--- a/gather/metrics_test.go
+++ b/gather/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestMetricsReader(t *testing.T) {
@@ -41,7 +42,7 @@ func TestMetricsReader(t *testing.T) {
 					Fields: map[string]interface{}{
 						"value": "yes",
 					},
-					Type:      MetricTypeGauge,
+					Type:      dto.MetricType_GAUGE,
 					Timestamp: time.Unix(0, 1422568543702900257),
 				},
 			},
@@ -59,7 +60,7 @@ func TestMetricsReader(t *testing.T) {
 					Fields: map[string]interface{}{
 						"value": 0.64,
 					},
-					Type:      MetricTypeGauge,
+					Type:      dto.MetricType_GAUGE,
 					Timestamp: time.Unix(0, 1422568543702900257),
 				},
 			},
@@ -148,7 +149,7 @@ func TestMetricsMarshal(t *testing.T) {
 						"x": 12.3,
 						"y": "a long string",
 					},
-					Type: MetricTypeSummary,
+					Type: dto.MetricType_SUMMARY,
 				},
 			},
 		},
@@ -166,7 +167,7 @@ func TestMetricsMarshal(t *testing.T) {
 						"x": 12.3,
 						"y": "a long string",
 					},
-					Type: MetricTypeSummary,
+					Type: dto.MetricType_SUMMARY,
 				},
 
 				{
@@ -180,7 +181,7 @@ func TestMetricsMarshal(t *testing.T) {
 						"x": 12.5,
 						"y": "a long string2",
 					},
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 				},
 			},
 		},

--- a/gather/prometheus.go
+++ b/gather/prometheus.go
@@ -116,7 +116,7 @@ func (p *prometheusScraper) parse(r io.Reader, header http.Header, target influx
 				Tags:      tags,
 				Fields:    fields,
 				Name:      name,
-				Type:      MetricType(family.GetType()),
+				Type:      family.GetType(),
 			}
 			ms = append(ms, me)
 		}

--- a/gather/scheduler_test.go
+++ b/gather/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/mock"
 	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
+	dto "github.com/prometheus/client_model/go"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -71,7 +72,7 @@ func TestScheduler(t *testing.T) {
 
 	want := Metrics{
 		Name: "go_goroutines",
-		Type: MetricTypeGauge,
+		Type: dto.MetricType_GAUGE,
 		Tags: map[string]string{},
 		Fields: map[string]interface{}{
 			"gauge": float64(36),

--- a/gather/scraper_test.go
+++ b/gather/scraper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/platform"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var (
@@ -49,7 +50,7 @@ func TestPrometheusScraper(t *testing.T) {
 			ms: []Metrics{
 				{
 					Name: "go_gc_duration_seconds",
-					Type: MetricTypeSummary,
+					Type: dto.MetricType_SUMMARY,
 					Fields: map[string]interface{}{
 						"count": float64(326),
 						"sum":   0.07497837,
@@ -63,7 +64,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_goroutines",
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 					Tags: map[string]string{},
 					Fields: map[string]interface{}{
 						"gauge": float64(36),
@@ -71,7 +72,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_info",
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 					Tags: map[string]string{
 						"version": "go1.10.3",
 					},
@@ -81,7 +82,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_memstats_alloc_bytes",
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 					Tags: map[string]string{},
 					Fields: map[string]interface{}{
 						"gauge": 2.0091312e+07,
@@ -89,7 +90,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_memstats_alloc_bytes_total",
-					Type: MetricTypeCounter,
+					Type: dto.MetricType_COUNTER,
 					Fields: map[string]interface{}{
 						"counter": 4.183173328e+09,
 					},
@@ -97,7 +98,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_memstats_buck_hash_sys_bytes",
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 					Tags: map[string]string{},
 					Fields: map[string]interface{}{
 						"gauge": 1.533852e+06,
@@ -105,7 +106,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_memstats_frees_total",
-					Type: MetricTypeCounter,
+					Type: dto.MetricType_COUNTER,
 					Tags: map[string]string{},
 					Fields: map[string]interface{}{
 						"counter": 1.8944339e+07,
@@ -113,7 +114,7 @@ func TestPrometheusScraper(t *testing.T) {
 				},
 				{
 					Name: "go_memstats_gc_cpu_fraction",
-					Type: MetricTypeGauge,
+					Type: dto.MetricType_GAUGE,
 					Tags: map[string]string{},
 					Fields: map[string]interface{}{
 						"gauge": 1.972734963012756e-05,

--- a/go.mod
+++ b/go.mod
@@ -24,11 +24,9 @@ require (
 	github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493 // indirect
 	github.com/go-chi/chi v4.1.0+incompatible
 	github.com/go-stack/stack v1.8.0
-	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/gddo v0.0.0-20181116215533-9bd4a3295021
 	github.com/golang/mock v1.5.0
-	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.3
 	github.com/google/btree v1.0.1
 	github.com/google/go-cmp v0.5.6
@@ -151,9 +149,11 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect

--- a/prometheus/filter.go
+++ b/prometheus/filter.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -119,9 +120,9 @@ func (l *labelPairs) Reset() {}
 func (l *labelPairs) String() string {
 	var a []string
 	for _, lbl := range l.Label {
-		a = append(a, lbl.String())
+		a = append(a, fmt.Sprintf("label:<%s> ", lbl.String()))
 	}
-	return strings.Join(a, "\n")
+	return strings.Join(a, "")
 }
 
 func (*labelPairs) ProtoMessage() {}

--- a/prometheus/filter.go
+++ b/prometheus/filter.go
@@ -2,10 +2,11 @@ package prometheus
 
 import (
 	"sort"
+	"strings"
 
-	"github.com/golang/protobuf/proto" //lint:ignore SA1019 this deprecated package will be removed by https://github.com/influxdata/influxdb/pull/22571
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ prometheus.Gatherer = (*Filter)(nil)
@@ -113,6 +114,14 @@ type labelPairs struct {
 	Label []*dto.LabelPair `protobuf:"bytes,1,rep,name=label" json:"label,omitempty"`
 }
 
-func (l *labelPairs) Reset()         {}
-func (l *labelPairs) String() string { return proto.CompactTextString(l) }
-func (*labelPairs) ProtoMessage()    {}
+func (l *labelPairs) Reset() {}
+
+func (l *labelPairs) String() string {
+	var a []string
+	for _, lbl := range l.Label {
+		a = append(a, lbl.String())
+	}
+	return strings.Join(a, "\n")
+}
+
+func (*labelPairs) ProtoMessage() {}

--- a/prometheus/filter_test.go
+++ b/prometheus/filter_test.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/proto" //lint:ignore SA1019 this deprecated package will be removed by https://github.com/influxdata/influxdb/pull/22571
 	pr "github.com/influxdata/influxdb/v2/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestFilter_Gather(t *testing.T) {

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,8 +1,8 @@
 package prometheus_test
 
 import (
-	"github.com/golang/protobuf/proto" //lint:ignore SA1019 this deprecated package will be removed by https://github.com/influxdata/influxdb/pull/22571
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 func NewCounter(name string, v float64, ls ...*dto.LabelPair) *dto.MetricFamily {

--- a/telemetry/push_test.go
+++ b/telemetry/push_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto" //lint:ignore SA1019 this deprecated package will be removed by https://github.com/influxdata/influxdb/pull/22571
 	"github.com/google/go-cmp/cmp"
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPusher_Push(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1,8 +1,8 @@
 package telemetry
 
 import (
-	"github.com/golang/protobuf/proto" //lint:ignore SA1019 this deprecated package will be removed by https://github.com/influxdata/influxdb/pull/22571
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 func NewCounter(name string, v float64, ls ...*dto.LabelPair) *dto.MetricFamily {


### PR DESCRIPTION
- Remove `gogo/protobuf` and `golang/protobuf` deps
- Fix mistake in `CONTRIBUTING.md`
- Use Prometheus `MetricType` type over our own copy-paste version

After this PR, Protobuf work on `master` should be fully complete

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass
