### PR TITLE
refactor: remove replications.current_queue_size_bytes from sqlite

### DIFF
--- a/pkg/durablequeue/queue.go
+++ b/pkg/durablequeue/queue.go
@@ -189,7 +189,7 @@ func (l *Queue) Open() error {
 		return l.trimHead(false)
 	}
 
-	l.queueTotalSize.Add(l.diskUsage())
+	l.queueTotalSize.Add(l.DiskUsage())
 
 	return nil
 }
@@ -365,8 +365,8 @@ func (l *Queue) Dir() string {
 	return l.dir
 }
 
-// diskUsage returns the total size on disk used by the Queue.
-func (l *Queue) diskUsage() int64 {
+// DiskUsage returns the total size on disk used by the Queue.
+func (l *Queue) DiskUsage() int64 {
 	var size int64
 	for _, s := range l.segments {
 		size += s.diskUsage()

--- a/pkg/durablequeue/queue_test.go
+++ b/pkg/durablequeue/queue_test.go
@@ -24,7 +24,7 @@ func BenchmarkQueueAppend(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		if err := q.Append([]byte(fmt.Sprintf("%d", i))); err != nil {
-			println(q.diskUsage())
+			println(q.DiskUsage())
 			b.Fatalf("Queue.Append failed: %v", err)
 		}
 	}

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -126,3 +126,20 @@ func (qm *durableQueueManager) UpdateMaxQueueSize(replicationID platform.ID, max
 
 	return nil
 }
+
+// CurrentQueueSizes returns the current size-on-disk for the requested set of durable queues.
+func (qm *durableQueueManager) CurrentQueueSizes(ids []platform.ID) (map[platform.ID]int64, error) {
+	qm.mutex.RLock()
+	defer qm.mutex.RUnlock()
+
+	sizes := make(map[platform.ID]int64, len(ids))
+
+	for _, id := range ids {
+		if qm.replicationQueues[id] == nil {
+			return nil, fmt.Errorf("durable queue not found for replication ID %q", id)
+		}
+		sizes[id] = qm.replicationQueues[id].DiskUsage()
+	}
+
+	return sizes, nil
+}

--- a/replications/mock/queue_management.go
+++ b/replications/mock/queue_management.go
@@ -34,6 +34,21 @@ func (m *MockDurableQueueManager) EXPECT() *MockDurableQueueManagerMockRecorder 
 	return m.recorder
 }
 
+// CurrentQueueSizes mocks base method.
+func (m *MockDurableQueueManager) CurrentQueueSizes(arg0 []platform.ID) (map[platform.ID]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentQueueSizes", arg0)
+	ret0, _ := ret[0].(map[platform.ID]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CurrentQueueSizes indicates an expected call of CurrentQueueSizes.
+func (mr *MockDurableQueueManagerMockRecorder) CurrentQueueSizes(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentQueueSizes", reflect.TypeOf((*MockDurableQueueManager)(nil).CurrentQueueSizes), arg0)
+}
+
 // DeleteQueue mocks base method.
 func (m *MockDurableQueueManager) DeleteQueue(arg0 platform.ID) error {
 	m.ctrl.T.Helper()

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -19,6 +19,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mock -destination ./mock/validator.go github.com/influxdata/influxdb/v2/replications ReplicationValidator
+//go:generate go run github.com/golang/mock/mockgen -package mock -destination ./mock/bucket_service.go github.com/influxdata/influxdb/v2/replications BucketService
+//go:generate go run github.com/golang/mock/mockgen -package mock -destination ./mock/queue_management.go github.com/influxdata/influxdb/v2/replications DurableQueueManager
+
 var (
 	ctx         = context.Background()
 	initID      = platform.ID(1)
@@ -99,6 +103,8 @@ func TestCreateAndGetReplication(t *testing.T) {
 	require.Equal(t, replication, *created)
 
 	// Read the created replication and assert it matches the creation response.
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+		Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 	got, err = svc.GetReplication(ctx, initID)
 	require.NoError(t, err)
 	require.Equal(t, replication, *got)
@@ -249,6 +255,8 @@ func TestUpdateAndGetReplication(t *testing.T) {
 
 	// Update the replication.
 	mocks.durableQueueManager.EXPECT().UpdateMaxQueueSize(initID, *updateReq.MaxQueueSizeBytes)
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+		Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 	updated, err = svc.UpdateReplication(ctx, initID, updateReq)
 	require.NoError(t, err)
 	require.Equal(t, updatedReplication, *updated)
@@ -279,6 +287,8 @@ func TestUpdateMissingRemote(t *testing.T) {
 	require.Nil(t, updated)
 
 	// Make sure nothing changed in the DB.
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+		Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 	got, err := svc.GetReplication(ctx, initID)
 	require.NoError(t, err)
 	require.Equal(t, replication, *got)
@@ -303,6 +313,8 @@ func TestUpdateNoop(t *testing.T) {
 	require.Equal(t, replication, *created)
 
 	// Send a no-op update, assert nothing changed.
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+		Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 	updated, err := svc.UpdateReplication(ctx, initID, influxdb.UpdateReplicationRequest{})
 	require.NoError(t, err)
 	require.Equal(t, replication, *updated)
@@ -334,6 +346,8 @@ func TestValidateUpdatedReplicationWithoutPersisting(t *testing.T) {
 			fmt.Sprintf("remote %q not found", *updateReq.RemoteID))
 
 		// Make sure nothing changed in the DB.
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+			Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 		got, err := svc.GetReplication(ctx, initID)
 		require.NoError(t, err)
 		require.Equal(t, replication, *got)
@@ -365,6 +379,8 @@ func TestValidateUpdatedReplicationWithoutPersisting(t *testing.T) {
 		require.Contains(t, svc.ValidateUpdatedReplication(ctx, initID, updateReq).Error(), fakeErr.Error())
 
 		// Make sure nothing changed in the DB.
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+			Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 		got, err := svc.GetReplication(ctx, initID)
 		require.NoError(t, err)
 		require.Equal(t, replication, *got)
@@ -395,6 +411,8 @@ func TestValidateUpdatedReplicationWithoutPersisting(t *testing.T) {
 		require.NoError(t, svc.ValidateUpdatedReplication(ctx, initID, updateReq))
 
 		// Make sure nothing changed in the DB.
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID}).
+			Return(map[platform.ID]int64{initID: replication.CurrentQueueSizeBytes}, nil)
 		got, err := svc.GetReplication(ctx, initID)
 		require.NoError(t, err)
 		require.Equal(t, replication, *got)
@@ -457,6 +475,8 @@ func TestDeleteReplications(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID, initID + 1, initID + 2}).
+		Return(map[platform.ID]int64{initID: 0, initID + 1: 0, initID + 2: 0}, nil)
 	listed, err := svc.ListReplications(ctx, influxdb.ReplicationListFilter{OrgID: replication.OrgID})
 	require.NoError(t, err)
 	require.Len(t, listed.Replications, 3)
@@ -466,6 +486,8 @@ func TestDeleteReplications(t *testing.T) {
 	require.NoError(t, svc.DeleteBucketReplications(ctx, createReq.LocalBucketID))
 
 	// Ensure they were deleted.
+	mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID + 1}).
+		Return(map[platform.ID]int64{initID + 1: 0}, nil)
 	listed, err = svc.ListReplications(ctx, influxdb.ReplicationListFilter{OrgID: replication.OrgID})
 	require.NoError(t, err)
 	require.Len(t, listed.Replications, 1)
@@ -505,6 +527,8 @@ func TestListReplications(t *testing.T) {
 		defer clean(t)
 		allRepls := setup(t, svc, mocks)
 
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID, initID + 1, initID + 2}).
+			Return(map[platform.ID]int64{initID: 0, initID + 1: 0, initID + 2: 0}, nil)
 		listed, err := svc.ListReplications(ctx, influxdb.ReplicationListFilter{OrgID: createReq.OrgID})
 		require.NoError(t, err)
 		require.Equal(t, influxdb.Replications{Replications: allRepls}, *listed)
@@ -517,6 +541,8 @@ func TestListReplications(t *testing.T) {
 		defer clean(t)
 		allRepls := setup(t, svc, mocks)
 
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID + 1}).
+			Return(map[platform.ID]int64{initID + 1: 0}, nil)
 		listed, err := svc.ListReplications(ctx, influxdb.ReplicationListFilter{
 			OrgID: createReq.OrgID,
 			Name:  &createReq2.Name,
@@ -532,6 +558,8 @@ func TestListReplications(t *testing.T) {
 		defer clean(t)
 		allRepls := setup(t, svc, mocks)
 
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID, initID + 1}).
+			Return(map[platform.ID]int64{initID: 0, initID + 1: 0}, nil)
 		listed, err := svc.ListReplications(ctx, influxdb.ReplicationListFilter{
 			OrgID:    createReq.OrgID,
 			RemoteID: &createReq.RemoteID,
@@ -547,6 +575,8 @@ func TestListReplications(t *testing.T) {
 		defer clean(t)
 		allRepls := setup(t, svc, mocks)
 
+		mocks.durableQueueManager.EXPECT().CurrentQueueSizes([]platform.ID{initID, initID + 2}).
+			Return(map[platform.ID]int64{initID: 0, initID + 2: 0}, nil)
 		listed, err := svc.ListReplications(ctx, influxdb.ReplicationListFilter{
 			OrgID:         createReq.OrgID,
 			LocalBucketID: &createReq.LocalBucketID,

--- a/sqlite/migrations/0005_create_replications_table.up.sql
+++ b/sqlite/migrations/0005_create_replications_table.up.sql
@@ -8,7 +8,6 @@ CREATE TABLE replications
     local_bucket_id          VARCHAR(16) NOT NULL,
     remote_bucket_id         VARCHAR(16) NOT NULL,
     max_queue_size_bytes     INTEGER     NOT NULL,
-    current_queue_size_bytes INTEGER     NOT NULL,
     latest_response_code     INTEGER,
     latest_error_message     TEXT,
     created_at               TIMESTAMP   NOT NULL,


### PR DESCRIPTION
Related to #22171

Maintaining the current queue size in a SQL column would require updating the DB on every queue operation. Avoid that contention by instead looking up the current size on the in-memory durable queue struct, which is already tracked & updated as data enters & leaves the queue.