### PR TITLE
chore: don't look for non-existent changelog file in release job

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,7 +101,6 @@ blobs:
     folder: "platform/nightlies/master/"
     extra_files:
       - glob: ./changelog_artifacts/CHANGELOG.md
-      - glob: ./changelog_artifacts/changelog-commit.txt
 
 checksum:
   name_template: "influxdb2-nightly.sha256"


### PR DESCRIPTION
Follow-up to https://github.com/influxdata/influxdb/pull/22835; should fix the nightly deploy & release job problems with goreleaser not able to find the `changelog-commit` file (because it is no longer generated or needed).