### PR TITLE
chore: don't look for non-existent changelog file in release job

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,6 @@ blobs:
     folder: "{{ .Env.S3_FOLDER }}"
     extra_files:
       - glob: ./changelog_artifacts/CHANGELOG*.md
-      - glob: ./changelog_artifacts/changelog-commit*.txt
 
 checksum:
   name_template: "influxdb2-{{ .Env.VERSION }}.sha256"


### PR DESCRIPTION
Backports https://github.com/influxdata/influxdb/pull/22842 for the `2.1` branch.