### PR TITLE
build: better versioning and verification for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,6 +956,7 @@ jobs:
           name: Do local tags for testing
           command: |
             git tag zzz_i_am_a_bad_tag
+            git tag v9.9.9-testing-please-delete-me
       - run:
           name: Create RAM disk
           command: |
@@ -969,7 +970,7 @@ jobs:
       - upgrade_go
       - run_goreleaser:
           publish_release: true
-          build_tag: 'zzz_i_am_a_bad_tag'
+          build_tag: 'v9.9.9-testing-please-delete-me'
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,108 +62,112 @@ workflows:
           - << pipeline.parameters.aws_teardown >>
           - << pipeline.parameters.build_and_sign >>
     jobs:
-      - godeps
-      - test-race:
-          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
-          name: gotest
-      - test-build:
-          matrix:
-            parameters:
-              os: [ linux, darwin, windows ]
-              arch: [ amd64, arm64 ]
-            exclude:
-              - os: darwin
-                arch: arm64
-              - os: windows
-                arch: arm64
-              # linux/amd64 can be tested directly from our cross-builder image
-              # to save time & enable running with the race detector.
-              - os: linux
-                arch: amd64
-      - test-prebuilt:
-          name: test-linux-arm64
-          executor: linux-arm64
+#      - godeps
+#      - test-race:
+#          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
+#          name: gotest
+#      - test-build:
+#          matrix:
+#            parameters:
+#              os: [ linux, darwin, windows ]
+#              arch: [ amd64, arm64 ]
+#            exclude:
+#              - os: darwin
+#                arch: arm64
+#              - os: windows
+#                arch: arm64
+#              # linux/amd64 can be tested directly from our cross-builder image
+#              # to save time & enable running with the race detector.
+#              - os: linux
+#                arch: amd64
+#      - test-prebuilt:
+#          name: test-linux-arm64
+#          executor: linux-arm64
+#          requires:
+#            - test-build-arm64-linux
+#      - test-prebuilt:
+#          name: test-darwin
+#          executor: darwin
+#          requires:
+#            - test-build-amd64-darwin
+#      - test-prebuilt:
+#          name: test-windows
+#          executor: windows
+#          requires:
+#            - test-build-amd64-windows
+#      - fluxtest:
+#          requires:
+#            - godeps
+#      - tlstest:
+#          requires:
+#            - godeps
+#      - lint:
+#          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
+#          name: golint
+#      - build:
+#          requires:
+#            - godeps
+#      - cross_build:
+#          requires:
+#            - godeps
+#      - test-downgrade:
+#          requires:
+#            - build
+#      - e2e-monitor-ci:
+#          filters:
+#            branches:
+#              ignore: /pull\/[0-9]+/
+#          requires:
+#            - build
+#      - pkg_run_test:
+#          filters:
+#            branches:
+#              ignore: /pull\/[0-9]+/
+#          requires:
+#            - cross_build
+#      - perf_test:
+#          name: perf-test-flux
+#          format: flux-http
+#          record_ingest_results: true
+#          requires:
+#            - cross_build
+#          filters:
+#            branches:
+#              only:
+#                - "2.1"
+#      - perf_test:
+#          name: perf-test-influxql
+#          format: http
+#          record_ingest_results: false
+#          requires:
+#            - cross_build
+#          filters:
+#            branches:
+#              only:
+#                - "2.1"
+#      - grace_daily:
+#          requires:
+#            - build
+#      - litmus_daily:
+#          requires:
+#            - build
+#      - litmus_integration:
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              only: "2.1"
+#      - share-testing-image:
+#          filters:
+#            branches:
+#              only:
+#                - "2.1"
+#          requires:
+#            - e2e-monitor-ci
+      - changelog
+      - release:
           requires:
-            - test-build-arm64-linux
-      - test-prebuilt:
-          name: test-darwin
-          executor: darwin
-          requires:
-            - test-build-amd64-darwin
-      - test-prebuilt:
-          name: test-windows
-          executor: windows
-          requires:
-            - test-build-amd64-windows
-      - fluxtest:
-          requires:
-            - godeps
-      - tlstest:
-          requires:
-            - godeps
-      - lint:
-          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
-          name: golint
-      - build:
-          requires:
-            - godeps
-      - cross_build:
-          requires:
-            - godeps
-      - test-downgrade:
-          requires:
-            - build
-      - e2e-monitor-ci:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - build
-      - pkg_run_test:
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-          requires:
-            - cross_build
-      - perf_test:
-          name: perf-test-flux
-          format: flux-http
-          record_ingest_results: true
-          requires:
-            - cross_build
-          filters:
-            branches:
-              only:
-                - "2.1"
-      - perf_test:
-          name: perf-test-influxql
-          format: http
-          record_ingest_results: false
-          requires:
-            - cross_build
-          filters:
-            branches:
-              only:
-                - "2.1"
-      - grace_daily:
-          requires:
-            - build
-      - litmus_daily:
-          requires:
-            - build
-      - litmus_integration:
-          requires:
-            - build
-          filters:
-            branches:
-              only: "2.1"
-      - share-testing-image:
-          filters:
-            branches:
-              only:
-                - "2.1"
-          requires:
-            - e2e-monitor-ci
+            - changelog
 
   aws_destroy_daily:
     triggers:
@@ -541,6 +545,8 @@ commands:
                   goreleaser \
                     --debug \
                     release \
+                  --skip-publish \
+                  --skip-sign \
                       -p 1 \
                       --rm-dist \
                       --skip-validate
@@ -962,14 +968,18 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
-      - when:
-          condition: << pipeline.parameters.build_and_sign_tag >>
-          steps:
-            - run:
-                name: checkout by tag
-                command: |
-                  git fetch --all --tags
-                  git checkout tags/<< pipeline.parameters.build_and_sign_tag >> -b << pipeline.parameters.build_and_sign_tag >>
+#      - when:
+#          condition: << pipeline.parameters.build_and_sign_tag >>
+#          steps:
+#            - run:
+#                name: checkout by tag
+#                command: |
+#                  git fetch --all --tags
+#                  git checkout tags/<< pipeline.parameters.build_and_sign_tag >> -b << pipeline.parameters.build_and_sign_tag >>
+      - run:
+          name: Do local tags for testing
+          command: |
+            git tag v9.9.9-testing-please-delete-me
       - run:
           name: Create RAM disk
           command: |
@@ -983,7 +993,7 @@ jobs:
       - upgrade_go
       - run_goreleaser:
           publish_release: true
-          build_tag: << pipeline.parameters.build_and_sign_tag >>
+          build_tag: 'v9.9.9-testing-please-delete-me'
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,8 +431,8 @@ commands:
       - run:
           name: Install goreleaser
           environment:
-            GORELEASER_VERSION: 0.177.0
-            GO_RELEASER_SHA: 8dd5fff1d04eff3789d200920bf280391f96fd5cc1565dd0d6e0db2b9a710854
+            GORELEASER_VERSION: 0.184.0
+            GO_RELEASER_SHA: 0972c17d94f2a95aafbef0c9f6d01ea774abfb8d37b85778e8cb4885efc24511
           command: |
             # checksum from `checksums.txt` file at https://github.com/goreleaser/goreleaser/releases
             curl --proto '=https' --tlsv1.2 -sSfL --max-redirs 1 -O \
@@ -537,6 +537,7 @@ commands:
                   fi
                   S3_FOLDER="influxdb/releases/" \
                   VERSION=${VERSION_TAG##v} \
+                  GORELEASER_CURRENT_TAG=${VERSION_TAG} \
                   goreleaser \
                     --debug \
                     release \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,112 +62,108 @@ workflows:
           - << pipeline.parameters.aws_teardown >>
           - << pipeline.parameters.build_and_sign >>
     jobs:
-#      - godeps
-#      - test-race:
-#          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
-#          name: gotest
-#      - test-build:
-#          matrix:
-#            parameters:
-#              os: [ linux, darwin, windows ]
-#              arch: [ amd64, arm64 ]
-#            exclude:
-#              - os: darwin
-#                arch: arm64
-#              - os: windows
-#                arch: arm64
-#              # linux/amd64 can be tested directly from our cross-builder image
-#              # to save time & enable running with the race detector.
-#              - os: linux
-#                arch: amd64
-#      - test-prebuilt:
-#          name: test-linux-arm64
-#          executor: linux-arm64
-#          requires:
-#            - test-build-arm64-linux
-#      - test-prebuilt:
-#          name: test-darwin
-#          executor: darwin
-#          requires:
-#            - test-build-amd64-darwin
-#      - test-prebuilt:
-#          name: test-windows
-#          executor: windows
-#          requires:
-#            - test-build-amd64-windows
-#      - fluxtest:
-#          requires:
-#            - godeps
-#      - tlstest:
-#          requires:
-#            - godeps
-#      - lint:
-#          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
-#          name: golint
-#      - build:
-#          requires:
-#            - godeps
-#      - cross_build:
-#          requires:
-#            - godeps
-#      - test-downgrade:
-#          requires:
-#            - build
-#      - e2e-monitor-ci:
-#          filters:
-#            branches:
-#              ignore: /pull\/[0-9]+/
-#          requires:
-#            - build
-#      - pkg_run_test:
-#          filters:
-#            branches:
-#              ignore: /pull\/[0-9]+/
-#          requires:
-#            - cross_build
-#      - perf_test:
-#          name: perf-test-flux
-#          format: flux-http
-#          record_ingest_results: true
-#          requires:
-#            - cross_build
-#          filters:
-#            branches:
-#              only:
-#                - "2.1"
-#      - perf_test:
-#          name: perf-test-influxql
-#          format: http
-#          record_ingest_results: false
-#          requires:
-#            - cross_build
-#          filters:
-#            branches:
-#              only:
-#                - "2.1"
-#      - grace_daily:
-#          requires:
-#            - build
-#      - litmus_daily:
-#          requires:
-#            - build
-#      - litmus_integration:
-#          requires:
-#            - build
-#          filters:
-#            branches:
-#              only: "2.1"
-#      - share-testing-image:
-#          filters:
-#            branches:
-#              only:
-#                - "2.1"
-#          requires:
-#            - e2e-monitor-ci
-      - changelog
-      - release:
+      - godeps
+      - test-race:
+          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
+          name: gotest
+      - test-build:
+          matrix:
+            parameters:
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          executor: linux-arm64
           requires:
-            - changelog
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-darwin
+          executor: darwin
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          executor: windows
+          requires:
+            - test-build-amd64-windows
+      - fluxtest:
+          requires:
+            - godeps
+      - tlstest:
+          requires:
+            - godeps
+      - lint:
+          # TODO: Remove this alias as part of https://github.com/influxdata/influxdb/issues/22623
+          name: golint
+      - build:
+          requires:
+            - godeps
+      - cross_build:
+          requires:
+            - godeps
+      - test-downgrade:
+          requires:
+            - build
+      - e2e-monitor-ci:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - build
+      - pkg_run_test:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+          requires:
+            - cross_build
+      - perf_test:
+          name: perf-test-flux
+          format: flux-http
+          record_ingest_results: true
+          requires:
+            - cross_build
+          filters:
+            branches:
+              only:
+                - "2.1"
+      - perf_test:
+          name: perf-test-influxql
+          format: http
+          record_ingest_results: false
+          requires:
+            - cross_build
+          filters:
+            branches:
+              only:
+                - "2.1"
+      - grace_daily:
+          requires:
+            - build
+      - litmus_daily:
+          requires:
+            - build
+      - litmus_integration:
+          requires:
+            - build
+          filters:
+            branches:
+              only: "2.1"
+      - share-testing-image:
+          filters:
+            branches:
+              only:
+                - "2.1"
+          requires:
+            - e2e-monitor-ci
 
   aws_destroy_daily:
     triggers:
@@ -475,6 +471,7 @@ commands:
                 name: Import GPG key
                 command: |
                   echo -e "$GPG_PRIVATE_KEY" | gpg --batch --import --
+            - quay_login
             - run:
                 name: Copy changelog artifacts into checkout dir
                 # This step is required to enable goreleaser to find the
@@ -487,6 +484,29 @@ commands:
           command: |
             echo 'export GOPATH=/home/circleci/go' >> $BASH_ENV
             echo 'export PATH=${GOPATH}/bin:${PATH}' >> $BASH_ENV
+      - run:
+          name: Set up Docker cross-builder
+          command: |
+            # Get jq to parse binfmt output.
+            sudo apt-get update && sudo apt-get install -y jq
+
+            # Uninstall any emulators provided by the system.
+            emulators=($(docker run --rm --privileged tonistiigi/binfmt:latest | jq -r .emulators[]))
+            for e in ${emulators[@]}; do
+              docker run --rm --privileged tonistiigi/binfmt:latest --uninstall ${e}
+            done
+
+            # Install the QEMU emulators we need to cross-build.
+            docker run --rm --privileged tonistiigi/binfmt:latest --install all
+
+            # Create a new buildx context using the freshly-installed emulators.
+            docker buildx create --name cross-builder
+            docker buildx use --default cross-builder
+            docker buildx inspect --bootstrap
+
+            # Build the 1st stage of our Docker(s) on our target platforms, to flush out
+            # any problems in our emulator setup.
+            docker buildx build --target dependency-base --platform linux/amd64,linux/arm64 docker/influxd
       - install_cross_bin_deps
       - unless:
           condition:
@@ -521,8 +541,6 @@ commands:
                   goreleaser \
                     --debug \
                     release \
-                  --skip-publish \
-                  --skip-sign \
                       -p 1 \
                       --rm-dist \
                       --skip-validate
@@ -944,19 +962,14 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/influxdata/influxdb
     steps:
       - checkout
-#      - when:
-#          condition: << pipeline.parameters.build_and_sign_tag >>
-#          steps:
-#            - run:
-#                name: checkout by tag
-#                command: |
-#                  git fetch --all --tags
-#                  git checkout tags/<< pipeline.parameters.build_and_sign_tag >> -b << pipeline.parameters.build_and_sign_tag >>
-      - run:
-          name: Do local tags for testing
-          command: |
-            git tag v9.9.9-testing-please-delete-me
-            git tag zzz_i_am_a_bad_tag
+      - when:
+          condition: << pipeline.parameters.build_and_sign_tag >>
+          steps:
+            - run:
+                name: checkout by tag
+                command: |
+                  git fetch --all --tags
+                  git checkout tags/<< pipeline.parameters.build_and_sign_tag >> -b << pipeline.parameters.build_and_sign_tag >>
       - run:
           name: Create RAM disk
           command: |
@@ -970,7 +983,7 @@ jobs:
       - upgrade_go
       - run_goreleaser:
           publish_release: true
-          build_tag: 'v9.9.9-testing-please-delete-me'
+          build_tag: << pipeline.parameters.build_and_sign_tag >>
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,7 +475,6 @@ commands:
                 name: Import GPG key
                 command: |
                   echo -e "$GPG_PRIVATE_KEY" | gpg --batch --import --
-            - quay_login
             - run:
                 name: Copy changelog artifacts into checkout dir
                 # This step is required to enable goreleaser to find the
@@ -488,29 +487,6 @@ commands:
           command: |
             echo 'export GOPATH=/home/circleci/go' >> $BASH_ENV
             echo 'export PATH=${GOPATH}/bin:${PATH}' >> $BASH_ENV
-      - run:
-          name: Set up Docker cross-builder
-          command: |
-            # Get jq to parse binfmt output.
-            sudo apt-get update && sudo apt-get install -y jq
-
-            # Uninstall any emulators provided by the system.
-            emulators=($(docker run --rm --privileged tonistiigi/binfmt:latest | jq -r .emulators[]))
-            for e in ${emulators[@]}; do
-              docker run --rm --privileged tonistiigi/binfmt:latest --uninstall ${e}
-            done
-
-            # Install the QEMU emulators we need to cross-build.
-            docker run --rm --privileged tonistiigi/binfmt:latest --install all
-
-            # Create a new buildx context using the freshly-installed emulators.
-            docker buildx create --name cross-builder
-            docker buildx use --default cross-builder
-            docker buildx inspect --bootstrap
-
-            # Build the 1st stage of our Docker(s) on our target platforms, to flush out
-            # any problems in our emulator setup.
-            docker buildx build --target dependency-base --platform linux/amd64,linux/arm64 docker/influxd
       - install_cross_bin_deps
       - unless:
           condition:
@@ -979,7 +955,7 @@ jobs:
       - run:
           name: Do local tags for testing
           command: |
-            git tag v9.9.9-testing-please-delete-me
+            git tag zzz_i_am_a_bad_tag
       - run:
           name: Create RAM disk
           command: |
@@ -993,7 +969,7 @@ jobs:
       - upgrade_go
       - run_goreleaser:
           publish_release: true
-          build_tag: 'v9.9.9-testing-please-delete-me'
+          build_tag: 'zzz_i_am_a_bad_tag'
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -955,8 +955,8 @@ jobs:
       - run:
           name: Do local tags for testing
           command: |
-            git tag zzz_i_am_a_bad_tag
             git tag v9.9.9-testing-please-delete-me
+            git tag zzz_i_am_a_bad_tag
       - run:
           name: Create RAM disk
           command: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,6 +96,34 @@ checksum:
   name_template: "influxdb2-{{ .Env.VERSION }}.sha256"
   algorithm: sha256
 
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
+    dockerfile: docker/influxd/Dockerfile
+    extra_files:
+      - docker/influxd/entrypoint.sh
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    use_buildx: true
+  - goos: linux
+    goarch: arm64
+    image_templates:
+      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
+    dockerfile: docker/influxd/Dockerfile
+    extra_files:
+      - docker/influxd/entrypoint.sh
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+    use_buildx: true
+
+docker_manifests:
+  - name_template: "quay.io/influxdb/influxdb:{{ .Env.VERSION }}"
+    image_templates:
+      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
+      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
+
 signs:
   - signature: "${artifact}.asc"
     cmd: gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,34 +96,6 @@ checksum:
   name_template: "influxdb2-{{ .Env.VERSION }}.sha256"
   algorithm: sha256
 
-dockers:
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
-    dockerfile: docker/influxd/Dockerfile
-    extra_files:
-      - docker/influxd/entrypoint.sh
-    build_flag_templates:
-      - "--platform=linux/amd64"
-    use_buildx: true
-  - goos: linux
-    goarch: arm64
-    image_templates:
-      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
-    dockerfile: docker/influxd/Dockerfile
-    extra_files:
-      - docker/influxd/entrypoint.sh
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-    use_buildx: true
-
-docker_manifests:
-  - name_template: "quay.io/influxdb/influxdb:{{ .Env.VERSION }}"
-    image_templates:
-      - "quay.io/influxdb/influxdb-amd64:{{ .Env.VERSION }}"
-      - "quay.io/influxdb/influxdb-arm64v8:{{ .Env.VERSION }}"
-
 signs:
   - signature: "${artifact}.asc"
     cmd: gpg


### PR DESCRIPTION
Closes #22855
Closes #22854

Updates `goreleaser` to the latest version. The updated `goreleaser` does _not_ skip the semver tag check with `--skip-validate`. This will ensure our builds cannot use invalid versions.

Also adds the `GORELEASER_CURRENT_TAG` which [goreleaser uses to determine the version it should use for builds](https://github.com/goreleaser/goreleaser/blob/master/www/docs/cookbooks/set-a-custom-git-tag.md). This will ensure that the same version information is used for all binaries and packages produced by goreleaser, and that is consistent with the tag that triggered the release.

To test this, I temporarily modified the CI config so that the "release" job would run on commits (but not publish anything) and simulate what would happen if there were one or more good/bad tags (in terms of semver) on the current commit, and how the resolved `VERSION_TAG` would be handled by setting the `build_tag` pipeline parameter. The [logs](https://app.circleci.com/pipelines/github/influxdata/influxdb/25485/workflows/a67377fc-6521-48ef-9f5d-0e7ec33da92d/jobs/226746) for the defective `2.1.0` build showed the following, which was used to compare the logs generated by the test runs of the updated config:

```
...
      • running git               args=[-c log.showSignature=false tag --points-at HEAD --sort -version:refname]
      • git result                stderr= stdout=wb-test-2.test
v2.1.0

      • building...               commit=435907d68de26f330dbc7ac1cfb4eb7c2c146076 latest tag=wb-test-2.test
      • pipe skipped              error=validation is disabled
   • parsing tag      
         • DEPRECATED: 'wb-test-2.test' is not SemVer-compatible and may cause other issues in the pipeline, check https://goreleaser.com/deprecations#skipping-semver-validations for more info
      • pipe skipped              error=validation is disabled
...
```

- The happy path with a single semver tag complete successfully as expected: https://app.circleci.com/pipelines/github/influxdata/influxdb/25698/workflows/b6c0de67-33bf-4c67-b404-cf0c34f708a5
- A commit with a single tag that is non-semver fails, also as expected: https://app.circleci.com/pipelines/github/influxdata/influxdb/25699/workflows/822becca-01a1-491d-9e21-2e0d8ac27500, showing the following error in the logs:
```
building...               commit=848482ebda50200f52488ca6248ee934bebb0c5b latest tag=zzz_i_am_a_bad_tag
      • pipe skipped              error=validation is disabled
   • parsing tag      
   ⨯ release failed after 0.04s error=failed to parse tag 'zzz_i_am_a_bad_tag' as semver: Invalid Semantic Version

```

More interesting tests involve the current commit tagged with both a bad semver tag, and a good one. This is what happened with the initial `2.1.0` release. These cases were tested by applying the tags good before bad & bad before good separately, and the release workflow was triggered using the good tag as would happen for an actual release. In both cases, the job completed successfully, using the correct build tag:

- Bad tag applied before good tag: https://app.circleci.com/pipelines/github/influxdata/influxdb/25700/workflows/447be837-f350-4767-9f64-883027f0a208
- Good tag applied before bad tag: https://app.circleci.com/pipelines/github/influxdata/influxdb/25701/workflows/ea4a1022-2c60-4b7a-b7ef-1a8cd7da9171

In both of these cases, the job completed successfully, with the logs showing that the correct tag (the one that triggered the release workflow) was used for the build:

```
      • git result                stderr= stdout=git@github.com:influxdata/influxdb.git

      • building...               commit=937b25e8ea00c070e9178125f9038af46ecfb53b latest tag=v9.9.9-testing-please-delete-me
      • pipe skipped              error=validation is disabled
   • parsing tag      
   • skipped running before hooks
```