### PR TITLE
fix: systemd service - operator in host detection fixed

### DIFF
--- a/scripts/influxd-systemd-start.sh
+++ b/scripts/influxd-systemd-start.sh
@@ -12,7 +12,7 @@ if [ -n "${TLS_CERT}" ] && [ -n "${TLS_KEY}" ]; then
   echo "TLS cert and key found -- using https"
   PROTOCOL="https"
 fi
-HOST=${BIND_ADDRESS%%:*}
+HOST=${BIND_ADDRESS%:*}
 HOST=${HOST:-"localhost"}
 PORT=${BIND_ADDRESS##*:}
 


### PR DESCRIPTION
Closes #x

Describe your proposed changes here.
I experienced some issues under Debian Bullseye, with a InfluxDB listening on IPv6 localhost only.

So if i configured the bind address to [::1]:8086, the health check at startup failed. The current script in production is basically doing the following:
```
root@monitoring:/usr/lib/influxdb/scripts# BIND_ADDRESS="[::1]:8086"
root@monitoring:/usr/lib/influxdb/scripts# echo ${BIND_ADDRESS%%:*}
[
root@monitoring:/usr/lib/influxdb/scripts# 
```

If we just reduce it by one char, it will work as expected - for IPv4 and IPv6:
```
root@monitoring:/usr/lib/influxdb/scripts# BIND_ADDRESS="[::1]:8086"
root@monitoring:/usr/lib/influxdb/scripts# echo ${BIND_ADDRESS%:*}
[::1]
root@monitoring:/usr/lib/influxdb/scripts# BIND_ADDRESS="1.2.3.4:8086"
root@monitoring:/usr/lib/influxdb/scripts# echo ${BIND_ADDRESS%:*}
1.2.3.4
root@monitoring:/usr/lib/influxdb/scripts#
```

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
