### PR TITLE
build: better versioning and verification for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,9 +343,14 @@ commands:
             GORELEASER_VERSION: 0.184.0
             GO_RELEASER_SHA: 0972c17d94f2a95aafbef0c9f6d01ea774abfb8d37b85778e8cb4885efc24511
           command: |
-            curl -sfL -o goreleaser-install https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh && \
-              sh goreleaser-install -b ${GOPATH}/bin v${GORELEASER_VERSION} && \
-              rm goreleaser-install
+            # checksum from `checksums.txt` file at https://github.com/goreleaser/goreleaser/releases
+            curl --proto '=https' --tlsv1.2 -sSfL --max-redirs 1 -O \
+              https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz
+            echo "${GO_RELEASER_SHA}  goreleaser_Linux_x86_64.tar.gz" | sha256sum --check -
+            # extract goreleaser binary only
+            tar --extract --file=goreleaser_Linux_x86_64.tar.gz goreleaser
+            mv goreleaser ${GOPATH}/bin
+            rm goreleaser_Linux_x86_64.tar.gz
       - run:
           name: Install pkg-config
           command: make pkg-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,8 @@ commands:
       - run:
           name: Install goreleaser
           environment:
-            GORELEASER_VERSION: 0.177.0
+            GORELEASER_VERSION: 0.184.0
+            GO_RELEASER_SHA: 0972c17d94f2a95aafbef0c9f6d01ea774abfb8d37b85778e8cb4885efc24511
           command: |
             curl -sfL -o goreleaser-install https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh && \
               sh goreleaser-install -b ${GOPATH}/bin v${GORELEASER_VERSION} && \
@@ -463,6 +464,7 @@ commands:
 
                   S3_FOLDER="influxdb/releases/" \
                   VERSION=${VERSION_TAG##v} \
+                  GORELEASER_CURRENT_TAG=${VERSION_TAG} \
                   goreleaser \
                     --debug \
                     release \


### PR DESCRIPTION
Closes #22867 
Backports https://github.com/influxdata/influxdb/pull/22856

Also ports the SHA verification of the `goreleaser` download, since that hadn't been backported to `2.0` yet.