### PR TITLE
feat: add replications queue scanner

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -110,7 +110,7 @@ func (rq *replicationQueue) Open() {
 func (rq *replicationQueue) Close() error {
 	close(rq.receive)
 	close(rq.done)
-	rq.wg.Wait()
+	rq.wg.Wait() // wait for goroutine to finish processing all messages
 	return rq.queue.Close()
 }
 
@@ -152,7 +152,7 @@ func (rq *replicationQueue) run() {
 	}
 }
 
-func (rq replicationQueue) SendWrite(dp func([]byte) error) (int, error) {
+func (rq *replicationQueue) SendWrite(dp func([]byte) error) (int, error) {
 	// err here can be io.EOF, indicating nothing to write
 	scan, err := rq.queue.NewScanner()
 	if err != nil {

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -245,7 +245,7 @@ func shutdown(t *testing.T, qm *durableQueueManager) {
 	require.NoError(t, err)
 
 	// Clear replication queues map
-	emptyMap := make(map[platform.ID]replicationQueue)
+	emptyMap := make(map[platform.ID]*replicationQueue)
 	qm.replicationQueues = emptyMap
 }
 

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -279,3 +279,7 @@ func TestEnqueueData(t *testing.T) {
 
 	require.Equal(t, data, string(written))
 }
+
+func TestGoroutineClose(t *testing.T) {
+
+}


### PR DESCRIPTION
Closes #22733

This PR adds a goroutine running a queue Scanner over each queue in the durable queue manager. The purpose of this Scanner is to gather data from the queue as it is appended, and process it quickly and sequentially to be sent across http to remote hosts. At this moment, all it is doing with the data is logging, and has very minimal error handling (only is prepared for the `io.EOF` error which is expected from the scanner and indicates a "finished" scanning state)

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
