### PR TITLE
build: setup docker before trying to push image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,6 +623,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
+      - setup_remote_docker
       - quay_login
       - run:
           name: Push the image to Quay

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,7 +479,7 @@ jobs:
       - run:
           name: Set up AWS instance
           command: |
-            scripts/ci/perf-test.sh
+            scripts/ci/perf_test.sh
       - run:
           name: Run perf test
           no_output_timeout: 20m


### PR DESCRIPTION
Fixup for #22877, to prevent failures like [this](https://app.circleci.com/pipelines/github/influxdata/influxdb/25839/workflows/f52234dd-febf-4078-a1e2-b38b822ea604/jobs/230474)