### PR TITLE
refactor: use remote write func in NewDurableQueueManager

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -133,7 +133,8 @@ func (rq *replicationQueue) run() {
 		case <-rq.done: // end the goroutine when done is messaged
 			return
 		case <-rq.receive: // run the scanner on data append
-			for rq.SendWrite(rq.writeFunc) {}
+			for rq.SendWrite(rq.writeFunc) {
+			}
 		}
 	}
 }

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -3,13 +3,14 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"github.com/influxdata/influxdb/v2/kit/platform"
-	"github.com/influxdata/influxdb/v2/pkg/durablequeue"
-	"go.uber.org/zap"
 	"io"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/influxdata/influxdb/v2/pkg/durablequeue"
+	"go.uber.org/zap"
 )
 
 type replicationQueue struct {
@@ -141,6 +142,7 @@ func (rq *replicationQueue) run() {
 						// Handle this gracefully, as it is an expected error to receive
 					} else {
 						// Crash out the server if an unhandleable error occurs in SendWrite()
+						// Should ideally never be hit
 						panic(1)
 					}
 					break

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -28,7 +28,7 @@ func TestCreateNewQueueDirExists(t *testing.T) {
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 }
 
-func TestEnqueueScanLog(t *testing.T) {
+func TestEnqueueScan(t *testing.T) {
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -43,7 +43,7 @@ func TestEnqueueScanLog(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEnqueueScanLogMultiple(t *testing.T) {
+func TestEnqueueScanMultiple(t *testing.T) {
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -19,6 +19,8 @@ var (
 )
 
 func TestCreateNewQueueDirExists(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -29,6 +31,8 @@ func TestCreateNewQueueDirExists(t *testing.T) {
 }
 
 func TestEnqueueScan(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -44,6 +48,8 @@ func TestEnqueueScan(t *testing.T) {
 }
 
 func TestEnqueueScanMultiple(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -62,6 +68,8 @@ func TestEnqueueScanMultiple(t *testing.T) {
 }
 
 func TestCreateNewQueueDuplicateID(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -75,6 +83,8 @@ func TestCreateNewQueueDuplicateID(t *testing.T) {
 }
 
 func TestDeleteQueueDirRemoved(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -90,6 +100,8 @@ func TestDeleteQueueDirRemoved(t *testing.T) {
 }
 
 func TestDeleteQueueNonexistentID(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -99,6 +111,8 @@ func TestDeleteQueueNonexistentID(t *testing.T) {
 }
 
 func TestUpdateMaxQueueSizeNonexistentID(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -108,6 +122,8 @@ func TestUpdateMaxQueueSizeNonexistentID(t *testing.T) {
 }
 
 func TestStartReplicationQueue(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -136,6 +152,8 @@ func TestStartReplicationQueue(t *testing.T) {
 }
 
 func TestStartReplicationQueuePartialDelete(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -162,6 +180,8 @@ func TestStartReplicationQueuePartialDelete(t *testing.T) {
 }
 
 func TestStartReplicationQueuesMultiple(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -203,6 +223,8 @@ func TestStartReplicationQueuesMultiple(t *testing.T) {
 }
 
 func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
+	t.Parallel()
+
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -274,6 +296,8 @@ func getTestWriteFunc(t *testing.T, expected string) func([]byte) error {
 }
 
 func TestEnqueueData(t *testing.T) {
+	t.Parallel()
+
 	queuePath, err := os.MkdirTemp("", "testqueue")
 	require.NoError(t, err)
 	defer os.RemoveAll(queuePath)
@@ -309,6 +333,8 @@ func TestEnqueueData(t *testing.T) {
 }
 
 func TestGoroutineReceives(t *testing.T) {
+	t.Parallel()
+
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes))
@@ -330,6 +356,8 @@ func TestGoroutineReceives(t *testing.T) {
 }
 
 func TestGoroutineCloses(t *testing.T) {
+	t.Parallel()
+
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes))

--- a/replications/service.go
+++ b/replications/service.go
@@ -56,6 +56,7 @@ func NewService(store *sqlite.SqlStore, bktSvc BucketService, localWriter storag
 		durableQueueManager: internal.NewDurableQueueManager(
 			log,
 			filepath.Join(enginePath, "replicationq"),
+			internal.WriteFunc,
 		),
 	}
 }


### PR DESCRIPTION
Closes #22878

This PR moves to using a separated remote write function for the NewDurableQueueManager function, which is what will be called when the Scanner pops data off the queue for writing to a remote host.

It also refactors the `replicationQueue` struct to hold a ptr reference to the durableQueueManager, since it references several pieces of the queue manager (logger, writeFunc, maybe more to come in the future)

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass
