### PR TITLE
build: pull SHA-specific image before tagging it as latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,10 @@ workflows:
             branches:
               only: master
       - share-testing-image:
-#          filters:
-#            branches:
-#              only:
-#                - master
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - e2e-monitor-ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,10 @@ workflows:
             branches:
               only: master
       - share-testing-image:
-          filters:
-            branches:
-              only:
-                - master
+#          filters:
+#            branches:
+#              only:
+#                - master
           requires:
             - e2e-monitor-ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,7 @@ jobs:
       - run:
           name: Push the image to Quay
           command: |
+            docker pull quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
             docker tag quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1} quay.io/influxdb/oss-acceptance:latest
             docker push quay.io/influxdb/oss-acceptance:latest
 


### PR DESCRIPTION
Successful run of job with these changes: https://app.circleci.com/pipelines/github/influxdata/influxdb/25872/workflows/36ac5268-649d-4453-b247-9cfe7fe5e821/jobs/230973