### PR TITLE
pkg/fs: make RenameFile* use a proper copy when os.Rename() errors

### DIFF
--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -10,6 +10,14 @@ import (
 )
 
 func TestRenameFileWithReplacement(t *testing.T) {
+	testFileCopyOrRename(t, "rename", fs.RenameFileWithReplacement)
+}
+
+func TestCopyFileWithReplacement(t *testing.T) {
+	testFileCopyOrRename(t, "move", fs.MoveFileWithReplacement)
+}
+
+func testFileCopyOrRename(t *testing.T, name string, testFunc func(src string, dst string) error) {
 	// sample data for loading into files
 	sampleData1 := "this is some data"
 	sampleData2 := "we got some more data"
@@ -29,8 +37,8 @@ func TestRenameFileWithReplacement(t *testing.T) {
 			t.Fatalf("got contents %q, expected %q", got, exp)
 		}
 
-		if err := fs.RenameFileWithReplacement(oldpath, newpath); err != nil {
-			t.Fatalf("ReplaceFileIfExists returned an error: %s", err)
+		if err := testFunc(oldpath, newpath); err != nil {
+			t.Fatalf("%s returned an error: %s", name, err)
 		}
 
 		if err := fs.SyncDir(filepath.Dir(oldpath)); err != nil {
@@ -60,8 +68,8 @@ func TestRenameFileWithReplacement(t *testing.T) {
 
 		root := filepath.Dir(oldpath)
 		newpath := filepath.Join(root, "foo")
-		if err := fs.RenameFileWithReplacement(oldpath, newpath); err != nil {
-			t.Fatalf("ReplaceFileIfExists returned an error: %s", err)
+		if err := testFunc(oldpath, newpath); err != nil {
+			t.Fatalf("%s returned an error: %s", name, err)
 		}
 
 		if err := fs.SyncDir(filepath.Dir(oldpath)); err != nil {


### PR DESCRIPTION
Closes #22890.

On Unix hardlinks (as done by ``os.Rename()``) may only be done on the same partition. The restore command often produces files in ``/tmp`` and tries to move them over (e.g. to ``/var/lib/influx2/...``) using ``os.Rename``. This has good chances to fail since in many (most?) setups those paths are not on the same partition. In that case the right approach is to copy the file, which is what this PR do.

------


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
