### PR TITLE
feat: metrics for WAL subsystem

### DIFF
--- a/cmd/influxd/inspect/verify_wal/verify_wal_test.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal_test.go
@@ -110,7 +110,7 @@ func newTempWALValid(t *testing.T) string {
 	dir, err := os.MkdirTemp("", "verify-wal")
 	require.NoError(t, err)
 
-	w := tsm1.NewWAL(dir, 0, 0)
+	w := tsm1.NewWAL(dir, 0, 0, tsm1.EngineTags{})
 	defer w.Close()
 	require.NoError(t, w.Open())
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -224,7 +224,7 @@ type cacheMetrics struct {
 }
 
 func newAllCacheMetrics() *allCacheMetrics {
-	labels := engineLabelNames()
+	labels := EngineLabelNames()
 	return &allCacheMetrics{
 		MemBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: storageNamespace,
@@ -277,7 +277,7 @@ func CacheCollectors() []prometheus.Collector {
 }
 
 func newCacheMetrics(tags EngineTags) *cacheMetrics {
-	labels := tags.getLabels()
+	labels := tags.GetLabels()
 	return &cacheMetrics{
 		MemBytes:     globalCacheMetrics.MemBytes.With(labels),
 		DiskBytes:    globalCacheMetrics.DiskBytes.With(labels),

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -280,7 +280,6 @@ func (f *FileStore) WithLogger(log *zap.Logger) {
 
 var globalFileStoreMetrics = newAllFileStoreMetrics()
 
-const namespace = "storage"
 const filesSubsystem = "tsm_files"
 
 type allFileStoreMetrics struct {
@@ -309,16 +308,16 @@ func (f *fileStoreMetrics) SetFiles(n int64) {
 }
 
 func newAllFileStoreMetrics() *allFileStoreMetrics {
-	labels := engineLabelNames()
+	labels := EngineLabelNames()
 	return &allFileStoreMetrics{
 		files: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: storageNamespace,
 			Subsystem: filesSubsystem,
 			Name:      "total",
 			Help:      "Gauge of number of files per shard",
 		}, labels),
 		size: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: storageNamespace,
 			Subsystem: filesSubsystem,
 			Name:      "disk_bytes",
 			Help:      "Gauge of data size in bytes for each shard",
@@ -334,7 +333,7 @@ func FileStoreCollectors() []prometheus.Collector {
 }
 
 func newFileStoreMetrics(tags EngineTags) *fileStoreMetrics {
-	labels := tags.getLabels()
+	labels := tags.GetLabels()
 	return &fileStoreMetrics{
 		files: globalFileStoreMetrics.files.With(labels),
 		size:  globalFileStoreMetrics.size.With(labels),


### PR DESCRIPTION
Depends on https://github.com/influxdata/influxdb/pull/22915

Closes #20026

Example:

```
➜  ~ curl localhost:8086/metrics | grep storage_wal
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32082    0 32082    0     0  15.2M      0 --:--:-- --:--:-- --:--:-- 15.2M
# HELP storage_wal_size Gauge of size of WAL in bytes
# TYPE storage_wal_size gauge
storage_wal_size{bucket="b7da63cc2f6d922f",engine="tsm1",id="5",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/5",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/5"} 0
storage_wal_size{bucket="b7da63cc2f6d922f",engine="tsm1",id="7",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/7",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/7"} 134623
storage_wal_size{bucket="d2dc443f48b2c910",engine="tsm1",id="1",path="/Users/sarnold/.influxdbv2/engine/data/d2dc443f48b2c910/autogen/1",walPath="/Users/sarnold/.influxdbv2/engine/wal/d2dc443f48b2c910/autogen/1"} 0
# HELP storage_wal_writes Number of write attempts to the WAL
# TYPE storage_wal_writes counter
storage_wal_writes{bucket="b7da63cc2f6d922f",engine="tsm1",id="5",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/5",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/5"} 0
storage_wal_writes{bucket="b7da63cc2f6d922f",engine="tsm1",id="7",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/7",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/7"} 2
storage_wal_writes{bucket="d2dc443f48b2c910",engine="tsm1",id="1",path="/Users/sarnold/.influxdbv2/engine/data/d2dc443f48b2c910/autogen/1",walPath="/Users/sarnold/.influxdbv2/engine/wal/d2dc443f48b2c910/autogen/1"} 0
# HELP storage_wal_writes_err Number of failed write attempts to the WAL
# TYPE storage_wal_writes_err counter
storage_wal_writes_err{bucket="b7da63cc2f6d922f",engine="tsm1",id="5",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/5",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/5"} 0
storage_wal_writes_err{bucket="b7da63cc2f6d922f",engine="tsm1",id="7",path="/Users/sarnold/.influxdbv2/engine/data/b7da63cc2f6d922f/autogen/7",walPath="/Users/sarnold/.influxdbv2/engine/wal/b7da63cc2f6d922f/autogen/7"} 0
storage_wal_writes_err{bucket="d2dc443f48b2c910",engine="tsm1",id="1",path="/Users/sarnold/.influxdbv2/engine/data/d2dc443f48b2c910/autogen/1",walPath="/Users/sarnold/.influxdbv2/engine/wal/d2dc443f48b2c910/autogen/1"} 0
```

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
