### PR TITLE
fix(tsi): sync index file before close

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1082,6 +1082,11 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 		return
 	}
 
+	if err = f.Sync(); err != nil {
+		log.Error("Error sync index file", zap.Error(err))
+		return
+	}
+
 	// Close file.
 	if err := f.Close(); err != nil {
 		log.Error("Error closing index file", zap.Error(err))
@@ -1226,9 +1231,14 @@ func (p *Partition) compactLogFile(logFile *LogFile) {
 		return
 	}
 
+	if err = f.Sync(); err != nil {
+		log.Error("Cannot sync index file", zap.Error(err))
+		return
+	}
+
 	// Close file.
 	if err := f.Close(); err != nil {
-		log.Error("Cannot close log file", zap.Error(err))
+		log.Error("Cannot close index file", zap.Error(err))
 		return
 	}
 


### PR DESCRIPTION
(cherry picked from commit 5fd1b29d74bc17ba63806cca0a2abaea3e8e9a90)

Forward ports https://github.com/influxdata/influxdb/pull/21932

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
