### PR TITLE
fix: remove influx CLI output from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,34 +124,41 @@ You also need `clang`, `make`, `pkg-config`, and `protobuf` installed.
 - Linux (Ubuntu): `sudo apt install make clang pkg-config protobuf-compiler libprotobuf-dev`
 - Linux (RHEL): See below
 
-#### Redhat-specific instructions
+#### RedHat-specific instructions
 
 For RedHat, you must enable the [EPEL](https://fedoraproject.org/wiki/EPEL)
 
 ### Building with make
 
-A successful `make` run results in two binaries, with platform-dependent paths:
-
-```
-$ make
-...
-env GO111MODULE=on go build -tags 'assets ' -o bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx ./cmd/influx
-env GO111MODULE=on go build -tags 'assets ' -o bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influxd ./cmd/influxd
-```
-
 `influxd` is the InfluxDB service.
-`influx` is the CLI management tool.
 
-Start the service.
-Logs to stdout by default:
+For `influx`, the InfluxDB CLI tool, see the [influx-cli repository on Github](https://github.com/influxdata/influx-cli).
 
-```
-$ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influxd
-```
+Once you've installed the dependencies,
+follow these steps to build `influxd` from source and start the service:
+
+1. Clone this repo (influxdb).
+2. In your influxdb directory, run `make`.
+
+   `make` generates the influxd binary at a platform-dependent path:
+
+   ```
+   $ make
+   ...
+   env GO111MODULE=on go build -tags 'assets ' -o bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influxd ./cmd/influxd
+   ```
+
+3. Start the `influxd` service.
+
+   ```
+   $ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influxd
+   ```
+
+   `influxd` logs to stdout by default.
 
 ### Testing
 
-This project is built from various languages. To run test for all langauges and components use:
+This project is built from various languages. To run test for all languages and components use:
 
 ```bash
 $ make test

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The list of InfluxDB Client Libraries that are compatible with the latest versio
 
 If you are looking for the 1.x line of releases, there are branches for each minor version as well as a `master-1.x` branch that will contain the code for the next 1.x release. The master-1.x [working branch is here](https://github.com/influxdata/influxdb/tree/master-1.x). The [InfluxDB 1.x Go Client can be found here](https://github.com/influxdata/influxdb1-client).
 
-## Installing
+## Install
 
 We have nightly and versioned Docker images, Debian packages, RPM packages, and tarballs of InfluxDB available at the [InfluxData downloads page](https://portal.influxdata.com/downloads/). We also provide the `influx` command line interface (CLI) client as a separate binary available at the same location.
 
 If you are interested in building from source, see the [building from source](CONTRIBUTING.md#building-from-source) guide for contributors.
 
-## Getting Started
+## Get Started
 
 For a complete getting started guide, please see our full [online documentation site](https://docs.influxdata.com/influxdb/latest/).
 
@@ -76,7 +76,7 @@ Active	Name	URL			            Org
 *	    default	http://localhost:8086	InfluxData
 ```
 
-## Writing Data
+## Write Data
 Write to measurement `m`, with tag `v=2`, in bucket `telegraf`, which belongs to organization `InfluxData`:
 
 ```bash
@@ -106,7 +106,7 @@ Table: keys: [_start, _stop, _field, _measurement]
 
 Use the `-r, --raw` option to return the raw flux response from the query. This is useful for moving data from one instance to another as the `influx write` command can accept the Flux response using the `--format csv` option.
 
-## Flux
+## Script with Flux
 
 Flux (previously named IFQL) is an open source functional data scripting language designed for querying, analyzing, and acting on data. Flux supports multiple data source types, including:
 
@@ -117,7 +117,7 @@ Flux (previously named IFQL) is an open source functional data scripting languag
 The source for Flux is [available on GitHub](https://github.com/influxdata/flux).
 To learn more about Flux, see the latest [InfluxData Flux documentation](https://docs.influxdata.com/flux/) and [CTO Paul Dix's presentation](https://speakerdeck.com/pauldix/flux-number-fluxlang-a-new-time-series-data-scripting-language).
 
-## Contributing to the Project
+## Contribute to the Project
 
 InfluxDB is an [MIT licensed](LICENSE) open source project and we love our community. The fastest way to get something fixed is to open a PR. Check out our [contributing](CONTRIBUTING.md) guide if you're interested in helping out. Also, join us on our [Community Slack Workspace](https://influxdata.com/slack) if you have questions or comments for our engineering teams.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are interested in building from source, see the [building from source](CO
 
 ## Getting Started
 
-For a complete getting started guide, please see our full [online documentation site](https://docs.influxdata.com/influxdb/latest/). 
+For a complete getting started guide, please see our full [online documentation site](https://docs.influxdata.com/influxdb/latest/).
 
 To write and query data or use the API in any way, you'll need to first create a user, credentials, organization and bucket.
 Everything in InfluxDB is organized under a concept of an organization. The API is designed to be multi-tenant.
@@ -32,9 +32,9 @@ $ bin/$(uname -s | tr '[:upper:]' '[:lower:]')/influx setup
 Welcome to InfluxDB 2.0!
 Please type your primary username: marty
 
-Please type your password: 
+Please type your password:
 
-Please type your password again: 
+Please type your password again:
 
 Please type your primary organization name.: InfluxData
 
@@ -104,11 +104,18 @@ Table: keys: [_start, _stop, _field, _measurement]
 2019-12-30T22:19:39.043918000Z  2019-12-30T23:19:39.043918000Z                       v                       m  2019-12-30T23:17:02.000000000Z                             2
 ```
 
-Use the `-r, --raw` option to return the raw flux response from the query. This is useful for moving data from one instance to another as the `influx write` command can accept the Flux response using the `--format csv` option. 
+Use the `-r, --raw` option to return the raw flux response from the query. This is useful for moving data from one instance to another as the `influx write` command can accept the Flux response using the `--format csv` option.
 
-## Introducing Flux
+## Flux
 
-Flux is an MIT-licensed data scripting language (previously named IFQL) used for querying time series data from InfluxDB. The source for Flux is [available on GitHub](https://github.com/influxdata/flux). Learn more about Flux from [CTO Paul Dix's presentation](https://speakerdeck.com/pauldix/flux-number-fluxlang-a-new-time-series-data-scripting-language).
+Flux (previously named IFQL) is an open source functional data scripting language designed for querying, analyzing, and acting on data. Flux supports multiple data source types, including:
+
+- Time series databases (such as InfluxDB)
+- Relational SQL databases (such as MySQL and PostgreSQL)
+- CSV
+
+The source for Flux is [available on GitHub](https://github.com/influxdata/flux).
+To learn more about Flux, see the latest [InfluxData Flux documentation](https://docs.influxdata.com/flux/) and [CTO Paul Dix's presentation](https://speakerdeck.com/pauldix/flux-number-fluxlang-a-new-time-series-data-scripting-language).
 
 ## Contributing to the Project
 
@@ -164,7 +171,7 @@ If you re-generate a file and find that `staticcheck` has failed, please see thi
 
 #### End-to-End Tests
 
-CI also runs end-to-end tests. These test the integration between the `influxd` server the UI. 
+CI also runs end-to-end tests. These test the integration between the `influxd` server the UI.
 Since the UI is used by interal repositories as well as the `influxdb` repository, the
 end-to-end tests cannot be run on forked pull requests or run locally. The extent of end-to-end
 testing required for forked pull requests will be determined as part of the review process.


### PR DESCRIPTION

Update CONTRIBUTING doc to reflect the separation of influxdata/influx (CLI) from influxdata/influxdb (influxd).
Order and cleanup build instructions.
Update Flux description in README.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
