### PR TITLE
chore: upgrade Go to 1.17 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.15.10-f7b4e805fa9588c1c2fa4562ea29e576557fb797
+    default: go1.17.2-c9371c24dc3e9daabf19786cf9638428dfe2637a
 
 commands:
   install_rust:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb
 
-go 1.15
+go 1.17
 
 require (
 	collectd.org v0.3.0
@@ -54,4 +54,91 @@ require (
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	cloud.google.com/go v0.56.0 // indirect
+	cloud.google.com/go/bigquery v1.4.0 // indirect
+	cloud.google.com/go/bigtable v1.3.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.9 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/azure/auth v0.5.3 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
+	github.com/Masterminds/semver v1.4.2 // indirect
+	github.com/Masterminds/sprig v2.16.0+incompatible // indirect
+	github.com/SAP/go-hdb v0.14.1 // indirect
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 // indirect
+	github.com/aokoli/goutils v1.0.1 // indirect
+	github.com/aws/aws-sdk-go v1.30.12 // indirect
+	github.com/benbjohnson/immutable v0.2.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bonitoo-io/go-sql-bigquery v0.3.4-1.4.0 // indirect
+	github.com/c-bata/go-prompt v0.2.2 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/deepmap/oapi-codegen v1.6.0 // indirect
+	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/eclipse/paho.mqtt.golang v1.2.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd // indirect
+	github.com/go-sql-driver/mysql v1.5.0 // indirect
+	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/flatbuffers v2.0.0+incompatible // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.14.4 // indirect
+	github.com/huandu/xstrings v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 // indirect
+	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
+	github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6 // indirect
+	github.com/lib/pq v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-runewidth v0.0.3 // indirect
+	github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae // indirect
+	github.com/philhofer/fwd v1.0.0 // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
+	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/procfs v0.0.11 // indirect
+	github.com/segmentio/kafka-go v0.2.0 // indirect
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/snowflakedb/gosnowflake v1.3.13 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/uber-go/tally v3.3.15+incompatible // indirect
+	github.com/uber/athenadriver v1.1.4 // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	go.opencensus.io v0.22.3 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.3.0 // indirect
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gonum.org/v1/gonum v0.8.2 // indirect
+	google.golang.org/api v0.22.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
 )

--- a/models/inline_strconv_parse.go
+++ b/models/inline_strconv_parse.go
@@ -1,7 +1,6 @@
 package models // import "github.com/influxdata/influxdb/models"
 
 import (
-	"reflect"
 	"strconv"
 	"unsafe"
 )
@@ -30,15 +29,6 @@ func parseBoolBytes(b []byte) (bool, error) {
 }
 
 // unsafeBytesToString converts a []byte to a string without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
 func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
+	return *(*string)(unsafe.Pointer(&in))
 }

--- a/models/uint_support.go
+++ b/models/uint_support.go
@@ -1,3 +1,4 @@
+//go:build uint || uint64
 // +build uint uint64
 
 package models

--- a/pkg/file/file_unix.go
+++ b/pkg/file/file_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package file

--- a/pkg/mmap/mmap_solaris.go
+++ b/pkg/mmap/mmap_solaris.go
@@ -1,3 +1,4 @@
+//go:build solaris
 // +build solaris
 
 package mmap

--- a/pkg/mmap/mmap_unix.go
+++ b/pkg/mmap/mmap_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd
 // +build darwin dragonfly freebsd linux nacl netbsd openbsd
 
 // Copyright 2015 The Go Authors. All rights reserved.

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9
 // +build !windows,!plan9
 
 package tsm1


### PR DESCRIPTION
* chore: upgrade Go to 1.17

* fix: update circleci container to go1.17

* fix: correct unsafe conversion of []byte to string

Co-authored-by: Sam Arnold <sarnold@influxdata.com>
(cherry picked from commit 08a4a710ebc54bd5ce7b57e6828e2266f093961f)

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
