### PR TITLE
feat: metrics collection for replications remote writes

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -178,7 +178,7 @@ func (rq *replicationQueue) SendWrite() bool {
 
 	// Update metrics after the call to scan.Advance()
 	defer func() {
-		rq.metrics.Dequeue(rq.id, rq.queue.DiskUsage())
+		rq.metrics.Dequeue(rq.id, rq.queue.TotalBytes())
 	}()
 
 	if _, err = scan.Advance(); err != nil {
@@ -361,7 +361,7 @@ func (qm *durableQueueManager) EnqueueData(replicationID platform.ID, data []byt
 		return err
 	}
 	// Update metrics for this replication queue when adding data to the queue.
-	qm.metrics.EnqueueData(replicationID, len(data), numPoints, rq.queue.DiskUsage())
+	qm.metrics.EnqueueData(replicationID, len(data), numPoints, rq.queue.TotalBytes())
 
 	qm.replicationQueues[replicationID].receive <- struct{}{}
 

--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -107,7 +107,6 @@ func (w *writer) Write(ctx context.Context, data []byte) error {
 		}
 
 		// Update metrics and most recent error diagnostic information.
-		w.metrics.RemoteWriteError(w.replicationID, res.StatusCode)
 		if err := w.configStore.UpdateResponseInfo(ctx, w.replicationID, res.StatusCode, msg); err != nil {
 			return err
 		}
@@ -119,6 +118,7 @@ func (w *writer) Write(ctx context.Context, data []byte) error {
 			return nil
 		}
 
+		w.metrics.RemoteWriteError(w.replicationID, res.StatusCode)
 		w.logger.Debug("remote write error", zap.Int("attempt", attempts), zap.String("error message", "msg"), zap.Int("status code", res.StatusCode))
 
 		attempts++


### PR DESCRIPTION
Closes #22734

Finishes metrics implementation for replications by adding metrics for remote writes. Also improves debug logging for remote writes.