### PR TITLE
build: Larger stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             export GOOS=linux
             export GOARCH=amd64
             for cmd in github.com/influxdata/influxdb/cmd/{influxd,influx,influx_inspect} ; do
-              go build -i -o "$TMPOUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+              go build -i -o "$TMPOUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' -tags "netgo osusergo static_build" $cmd
             done
             mkdir -p ./bins
             tarsum $TMPOUTDIR ./bins/influxdb_bin_${GOOS}_${GOARCH}-${CIRCLE_SHA1}.tar.gz

--- a/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
+++ b/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
@@ -66,17 +66,17 @@ OUTDIR=$(mktemp -d)
 		echo "env for go build: GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED"
 		# Note that we only do static builds for arm, to be consistent with influxdb 2.x
 		if [[ "$GOARCH" == arm64 ]] ; then
-			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
-			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+			echo go build -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' -tags "netgo osusergo static_build noasm" $cmd
+			go build -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' -tags "netgo osusergo static_build noasm" $cmd
 		elif [[ -n "$STATIC" ]]; then
-			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
-			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+			echo go build -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' -tags "netgo osusergo static_build" $cmd
+			go build -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' -tags "netgo osusergo static_build" $cmd
 		elif [[ "$GOOS" == windows ]] ; then
-			echo go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd
-			go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd
+			echo go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' $cmd
+			go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' $cmd
 		else
-			echo go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" $cmd
-			go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" $cmd
+			echo go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' $cmd
+			go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" -ldflags='-extldflags "-fno-PIC -static -Wl,-z,stack-size=8388608"' $cmd
 		fi
 	done
 )


### PR DESCRIPTION
This increases the stack size for the cgo (rust) portion of the flux compiler.  This is only necessary because the default stack size for musl is occasionally too small. 