### PR TITLE
fix: use copy when a rename spans volumes

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -2,6 +2,10 @@ package fs
 
 import (
 	"fmt"
+	"io"
+	"os"
+
+	"github.com/influxdata/influxdb/v2/pkg/errors"
 )
 
 // A FileExistsError is returned when an operation cannot be completed due to a
@@ -24,4 +28,39 @@ type DiskStatus struct {
 	Used  uint64
 	Free  uint64
 	Avail uint64
+}
+
+func copyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	defer errors.Capture(&err, out.Close)()
+
+	defer errors.Capture(&err, in.Close)()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return out.Sync()
+}
+
+// MoveFileWithReplacement copies the file contents at `src` to `dst`.
+// and deletes `src` on success.
+//
+// If the file at `dst` already exists, it will be truncated and its contents
+// overwritten.
+func MoveFileWithReplacement(src, dst string) error {
+	if err := copyFile(src, dst); err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return os.Remove(src)
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -10,6 +10,14 @@ import (
 )
 
 func TestRenameFileWithReplacement(t *testing.T) {
+	testFileMoveOrRename(t, "rename", fs.RenameFileWithReplacement)
+}
+
+func TestMoveFileWithReplacement(t *testing.T) {
+	testFileMoveOrRename(t, "move", fs.MoveFileWithReplacement)
+}
+
+func testFileMoveOrRename(t *testing.T, name string, testFunc func(src string, dst string) error) {
 	// sample data for loading into files
 	sampleData1 := "this is some data"
 	sampleData2 := "we got some more data"
@@ -29,8 +37,8 @@ func TestRenameFileWithReplacement(t *testing.T) {
 			t.Fatalf("got contents %q, expected %q", got, exp)
 		}
 
-		if err := fs.RenameFileWithReplacement(oldpath, newpath); err != nil {
-			t.Fatalf("ReplaceFileIfExists returned an error: %s", err)
+		if err := testFunc(oldpath, newpath); err != nil {
+			t.Fatalf("%s returned an error: %s", name, err)
 		}
 
 		if err := fs.SyncDir(filepath.Dir(oldpath)); err != nil {
@@ -60,8 +68,9 @@ func TestRenameFileWithReplacement(t *testing.T) {
 
 		root := filepath.Dir(oldpath)
 		newpath := filepath.Join(root, "foo")
-		if err := fs.RenameFileWithReplacement(oldpath, newpath); err != nil {
-			t.Fatalf("ReplaceFileIfExists returned an error: %s", err)
+
+		if err := testFunc(oldpath, newpath); err != nil {
+			t.Fatalf("%s returned an error: %s", name, err)
 		}
 
 		if err := fs.SyncDir(filepath.Dir(oldpath)); err != nil {


### PR DESCRIPTION
When a file rename fails with EXDEV
(cross device or volume error), copy the
file and delete the original instead.

closes https://github.com/influxdata/influxdb/issues/22890

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
