### PR TITLE
feat: error out when config file contains 1.x config values

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -34,7 +34,7 @@ const (
 
 func errInvalidFlags(flags []string, configFile string) error {
 	return fmt.Errorf(
-		"Error: unknown flags from config file at %s (see https://docs.influxdata.com/influxdb/latest/reference/config-options/ for supported flags): %s",
+		"error: unknown flags from config file at %s (see https://docs.influxdata.com/influxdb/latest/reference/config-options/ for supported flags): %s",
 		configFile,
 		strings.Join(flags, ","),
 	)

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -641,7 +641,7 @@ var (
 		// "reporting-disabled" is valid in both 1x and 2x configs
 		"bind-address", // global setting is called "http-bind-address" on 2x
 
-		// the rest of these would have a "." after them
+		// Remaining flags, when parsed from a 1.x config file, will be in sub-sections prefixed by these headers:
 		"collectd.",
 		"continuous_queries.",
 		"coordinator.",

--- a/cmd/influxd/launcher/cmd_test.go
+++ b/cmd/influxd/launcher/cmd_test.go
@@ -1,7 +1,6 @@
 package launcher
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -44,17 +43,17 @@ func TestInvalidFlags(t *testing.T) {
 		},
 		{
 			name:   "multiple valid flags",
-			config: fmt.Sprintf("validflag1: value\nvalidflag2: value"),
+			config: "validflag1: value\nvalidflag2: value",
 			want:   []string(nil),
 		},
 		{
 			name:   "multiple invalid flags",
-			config: fmt.Sprintf("invalid1: value\ninvalid2: value"),
+			config: "invalid1: value\ninvalid2: value",
 			want:   []string{"invalid1", "invalid2"},
 		},
 		{
 			name:   "mix of valid/invalid flags",
-			config: fmt.Sprintf("invalid1: value\ninvalid2: value\nvalidflag1: value\nvalidflag2: value"),
+			config: "invalid1: value\ninvalid2: value\nvalidflag1: value\nvalidflag2: value",
 			want:   []string{"invalid1", "invalid2"},
 		},
 	}

--- a/cmd/influxd/launcher/cmd_test.go
+++ b/cmd/influxd/launcher/cmd_test.go
@@ -4,22 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/influxdata/influxdb/v2/kit/cli"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidFlags(t *testing.T) {
 	t.Parallel()
-
-	testOpts := []cli.Opt{
-		{
-			Flag: "validflag1",
-		},
-		{
-			Flag: "validflag2",
-		},
-	}
 
 	tests := []struct {
 		name   string
@@ -32,29 +22,29 @@ func TestInvalidFlags(t *testing.T) {
 			want:   []string(nil),
 		},
 		{
-			name:   "one invalid flag",
-			config: "invalidflag: invalidValue",
-			want:   []string{"invalidflag"},
+			name:   "invalid flag with a dot",
+			config: "meta.something: value",
+			want:   []string{"meta.something"},
 		},
 		{
-			name:   "one valid flag",
-			config: "validflag1: value",
+			name:   "invalid global flag",
+			config: "bind-address: value",
+			want:   []string{"bind-address"},
+		},
+		{
+			name:   "invalid global and dot",
+			config: "bind-address: value\nmeta.something: value",
+			want:   []string{"meta.something", "bind-address"},
+		},
+		{
+			name:   "no invalid flags",
+			config: "flag1: value\nflag2: value",
 			want:   []string(nil),
-		},
-		{
-			name:   "multiple valid flags",
-			config: "validflag1: value\nvalidflag2: value",
-			want:   []string(nil),
-		},
-		{
-			name:   "multiple invalid flags",
-			config: "invalid1: value\ninvalid2: value",
-			want:   []string{"invalid1", "invalid2"},
 		},
 		{
 			name:   "mix of valid/invalid flags",
-			config: "invalid1: value\ninvalid2: value\nvalidflag1: value\nvalidflag2: value",
-			want:   []string{"invalid1", "invalid2"},
+			config: "bind-address: value\nmeta.something: value\nflag1: value\nflag2: value",
+			want:   []string{"meta.something", "bind-address"},
 		},
 	}
 
@@ -64,7 +54,7 @@ func TestInvalidFlags(t *testing.T) {
 			v := viper.GetViper()
 			v.SetConfigType("yaml")
 			require.NoError(t, v.ReadConfig(r))
-			got := invalidFlags(v, testOpts)
+			got := invalidFlags(v)
 			require.ElementsMatch(t, tt.want, got)
 		})
 	}

--- a/cmd/influxd/launcher/cmd_test.go
+++ b/cmd/influxd/launcher/cmd_test.go
@@ -1,0 +1,72 @@
+package launcher
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2/kit/cli"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidFlags(t *testing.T) {
+	t.Parallel()
+
+	testOpts := []cli.Opt{
+		{
+			Flag: "validflag1",
+		},
+		{
+			Flag: "validflag2",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		config string
+		want   []string
+	}{
+		{
+			name:   "empty config",
+			config: "",
+			want:   []string(nil),
+		},
+		{
+			name:   "one invalid flag",
+			config: "invalidflag: invalidValue",
+			want:   []string{"invalidflag"},
+		},
+		{
+			name:   "one valid flag",
+			config: "validflag1: value",
+			want:   []string(nil),
+		},
+		{
+			name:   "multiple valid flags",
+			config: fmt.Sprintf("validflag1: value\nvalidflag2: value"),
+			want:   []string(nil),
+		},
+		{
+			name:   "multiple invalid flags",
+			config: fmt.Sprintf("invalid1: value\ninvalid2: value"),
+			want:   []string{"invalid1", "invalid2"},
+		},
+		{
+			name:   "mix of valid/invalid flags",
+			config: fmt.Sprintf("invalid1: value\ninvalid2: value\nvalidflag1: value\nvalidflag2: value"),
+			want:   []string{"invalid1", "invalid2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.config)
+			v := viper.GetViper()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(r))
+			got := invalidFlags(v, testOpts)
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -216,6 +216,10 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	)
 	m.initTracing(opts)
 
+	if p := opts.Viper.ConfigFileUsed(); p != "" {
+		m.log.Debug("loaded config file", zap.String("path", p))
+	}
+
 	// Parse feature flags.
 	// These flags can be used to modify the remaining setup logic in this method.
 	// They will also be injected into the contexts of incoming HTTP requests at runtime,


### PR DESCRIPTION
Closes #22863

Throws an error on server startup if there are values in the config file ~which do not correspond to a valid configuration option~ which are determined to be from a 1.x config. Also adds debug logging if a config file is loaded.