### PR TITLE
feat: `query-memory-bytes` zero-value is unlimited

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,11 +24,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap/zapcore"
-)
-
-const (
-	// Max Integer
-	MaxInt = 1<<uint(strconv.IntSize-1) - 1
 )
 
 func errInvalidFlags(flags []string, configFile string) error {
@@ -239,7 +233,7 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 
 		ConcurrencyQuota:                1024,
 		InitialMemoryBytesQuotaPerQuery: 0,
-		MemoryBytesQuotaPerQuery:        MaxInt,
+		MemoryBytesQuotaPerQuery:        0,
 		MaxMemoryBytes:                  0,
 		QueueSize:                       1024,
 

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -20,6 +20,7 @@ package control
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -120,6 +121,10 @@ type Config struct {
 // return the new Config.
 func (c *Config) complete(log *zap.Logger) (Config, error) {
 	config := *c
+	if config.MemoryBytesQuotaPerQuery == 0 {
+		// 0 means unlimited
+		config.MemoryBytesQuotaPerQuery = math.MaxInt64
+	}
 	if config.InitialMemoryBytesQuotaPerQuery == 0 {
 		config.InitialMemoryBytesQuotaPerQuery = config.MemoryBytesQuotaPerQuery
 	}


### PR DESCRIPTION
Closes #23012
Helps with https://github.com/influxdata/influxdb/issues/22917

Instead of defaulting to the maximum `int64` value while parsing the configuration and binding the variables, set the `MemoryBytesQuotaPerQuery` to unlimited in the query controller if a config value is not set. This will prevent the runtime configuration from including a large number that cannot be parsed accurately from a config file in JSON format.

The small change here is actually identical to code on the 1.x branch: https://github.com/influxdata/influxdb/blob/e8c9f545323371ab9a4a1129f97ca16351daecae/query/control/controller.go#L119
Which was implemented in https://github.com/influxdata/influxdb/pull/21100
...so it does not introduce divergence between common areas of 1.x and 2.x code.