### PR TITLE
fix(templates): disable use of jsonnet with `/api/v2/templates/apply`

### DIFF
--- a/pkger/doc.go
+++ b/pkger/doc.go
@@ -4,7 +4,10 @@ templates for what will eventually come to support all influxdb
 resources.
 
 The parser supports JSON, Jsonnet, and YAML encodings as well as a number
-of different ways to read the file/reader/string as it may.
+of different ways to read the file/reader/string as it may. While the parser
+supports Jsonnet, due to issues in the go-jsonnet implementation, only trusted
+input should be given to the parser and therefore the EnableJsonnet() option
+must be used with Parse() to enable Jsonnet support.
 
 As an example, you can use the following to parse and validate a YAML
 file and see a summary of its contents:


### PR DESCRIPTION
Disables server-side jsonnet processing to eliminate potential issues with the `go-jsonnet` implementation.