### PR TITLE
feat: option to log flux queries cancelled because of server shutdown

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -262,7 +262,7 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 		},
 		{
 			DestP:   &o.LogShutdownQueries,
-			Flag:    "log-shutdown-flux-queries",
+			Flag:    "log-flux-queries-on-shutdown",
 			Default: o.LogShutdownQueries,
 			Desc:    "logs flux queries that are cancelled due to server shutdown",
 		},

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -262,9 +262,9 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 		},
 		{
 			DestP:   &o.LogShutdownQueries,
-			Flag:    "log-shutdown-queries",
+			Flag:    "log-shutdown-flux-queries",
 			Default: o.LogShutdownQueries,
-			Desc:    "logs queries that are cancelled due to server shutdown",
+			Desc:    "logs flux queries that are cancelled due to server shutdown",
 		},
 		{
 			DestP: &o.TracingType,

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -141,10 +141,11 @@ type InfluxdOpts struct {
 	Testing                 bool
 	TestingAlwaysAllowSetup bool
 
-	LogLevel          zapcore.Level
-	FluxLogEnabled    bool
-	TracingType       string
-	ReportingDisabled bool
+	LogLevel           zapcore.Level
+	FluxLogEnabled     bool
+	LogShutdownQueries bool
+	TracingType        string
+	ReportingDisabled  bool
 
 	AssetsPath string
 	BoltPath   string
@@ -203,9 +204,10 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		StorageConfig:     storage.NewConfig(),
 		CoordinatorConfig: coordinator.NewConfig(),
 
-		LogLevel:          zapcore.InfoLevel,
-		FluxLogEnabled:    false,
-		ReportingDisabled: false,
+		LogLevel:           zapcore.InfoLevel,
+		FluxLogEnabled:     false,
+		LogShutdownQueries: false,
+		ReportingDisabled:  false,
 
 		BoltPath:   filepath.Join(dir, bolt.DefaultFilename),
 		SqLitePath: filepath.Join(dir, sqlite.DefaultFilename),
@@ -257,6 +259,12 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "flux-log-enabled",
 			Default: o.FluxLogEnabled,
 			Desc:    "enables detailed logging for flux queries",
+		},
+		{
+			DestP:   &o.LogShutdownQueries,
+			Flag:    "log-shutdown-queries",
+			Default: o.LogShutdownQueries,
+			Desc:    "logs queries that are cancelled due to server shutdown",
 		},
 		{
 			DestP: &o.TracingType,

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -141,11 +141,10 @@ type InfluxdOpts struct {
 	Testing                 bool
 	TestingAlwaysAllowSetup bool
 
-	LogLevel           zapcore.Level
-	FluxLogEnabled     bool
-	LogShutdownQueries bool
-	TracingType        string
-	ReportingDisabled  bool
+	LogLevel          zapcore.Level
+	FluxLogEnabled    bool
+	TracingType       string
+	ReportingDisabled bool
 
 	AssetsPath string
 	BoltPath   string
@@ -204,10 +203,9 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		StorageConfig:     storage.NewConfig(),
 		CoordinatorConfig: coordinator.NewConfig(),
 
-		LogLevel:           zapcore.InfoLevel,
-		FluxLogEnabled:     false,
-		LogShutdownQueries: false,
-		ReportingDisabled:  false,
+		LogLevel:          zapcore.InfoLevel,
+		FluxLogEnabled:    false,
+		ReportingDisabled: false,
 
 		BoltPath:   filepath.Join(dir, bolt.DefaultFilename),
 		SqLitePath: filepath.Join(dir, sqlite.DefaultFilename),
@@ -259,12 +257,6 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "flux-log-enabled",
 			Default: o.FluxLogEnabled,
 			Desc:    "enables detailed logging for flux queries",
-		},
-		{
-			DestP:   &o.LogShutdownQueries,
-			Flag:    "log-flux-queries-on-shutdown",
-			Default: o.LogShutdownQueries,
-			Desc:    "logs flux queries that are cancelled due to server shutdown",
 		},
 		{
 			DestP: &o.TracingType,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -404,6 +404,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		MaxMemoryBytes:                  opts.MaxMemoryBytes,
 		QueueSize:                       opts.QueueSize,
 		ExecutorDependencies:            dependencyList,
+		LogShutdownQueries:              opts.LogShutdownQueries,
 	}, m.log.With(zap.String("service", "storage-reads")))
 	if err != nil {
 		m.log.Error("Failed to create query controller", zap.Error(err))

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -404,7 +404,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		MaxMemoryBytes:                  opts.MaxMemoryBytes,
 		QueueSize:                       opts.QueueSize,
 		ExecutorDependencies:            dependencyList,
-		LogShutdownQueries:              opts.LogShutdownQueries,
+		FluxLogEnabled:                  opts.FluxLogEnabled,
 	}, m.log.With(zap.String("service", "storage-reads")))
 	if err != nil {
 		m.log.Error("Failed to create query controller", zap.Error(err))

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -553,14 +553,16 @@ func (c *Controller) Shutdown(ctx context.Context) error {
 	// Cancel all of the currently active queries.
 	c.queriesMu.RLock()
 	for _, q := range c.queries {
-		var fluxScript string
-		fc, ok := q.compiler.(lang.FluxCompiler)
-		if !ok {
-			fluxScript = "unknown"
-		} else {
-			fluxScript = fc.Query
+		if c.logShutdownQueries {
+			var fluxScript string
+			fc, ok := q.compiler.(lang.FluxCompiler)
+			if !ok {
+				fluxScript = "unknown"
+			} else {
+				fluxScript = fc.Query
+			}
+			c.log.Info("Cancelling Flux query because of server shutdown", zap.String("query", fluxScript))
 		}
-		c.log.Info("Cancelling Flux query because of server shutdown", zap.String("query", fluxScript))
 
 		q.Cancel()
 	}

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -67,6 +67,8 @@ type Controller struct {
 	log *zap.Logger
 
 	dependencies []flux.Dependency
+
+	logShutdownQueries bool
 }
 
 type Config struct {
@@ -115,6 +117,9 @@ type Config struct {
 	MetricLabelKeys []string
 
 	ExecutorDependencies []flux.Dependency
+
+	// LogShutdownQueries logs any in-progress queries that get cancelled due to the server being shut down.
+	LogShutdownQueries bool
 }
 
 // complete will fill in the defaults, validate the configuration, and
@@ -205,16 +210,17 @@ func New(config Config, logger *zap.Logger) (*Controller, error) {
 		queryQueue = nil
 	}
 	ctrl := &Controller{
-		config:       c,
-		queries:      make(map[QueryID]*Query),
-		queryQueue:   queryQueue,
-		done:         make(chan struct{}),
-		abort:        make(chan struct{}),
-		memory:       mm,
-		log:          logger,
-		metrics:      newControllerMetrics(metricLabelKeys),
-		labelKeys:    metricLabelKeys,
-		dependencies: c.ExecutorDependencies,
+		config:             c,
+		queries:            make(map[QueryID]*Query),
+		queryQueue:         queryQueue,
+		done:               make(chan struct{}),
+		abort:              make(chan struct{}),
+		memory:             mm,
+		log:                logger,
+		metrics:            newControllerMetrics(metricLabelKeys),
+		labelKeys:          metricLabelKeys,
+		dependencies:       c.ExecutorDependencies,
+		logShutdownQueries: config.LogShutdownQueries,
 	}
 	if c.ConcurrencyQuota != 0 {
 		quota := int(c.ConcurrencyQuota)
@@ -257,7 +263,7 @@ func (c *Controller) Query(ctx context.Context, req *query.Request) (flux.Query,
 // query submits a query for execution returning immediately.
 // Done must be called on any returned Query objects.
 func (c *Controller) query(ctx context.Context, compiler flux.Compiler) (flux.Query, error) {
-	q, err := c.createQuery(ctx, compiler.CompilerType())
+	q, err := c.createQuery(ctx, compiler)
 	if err != nil {
 		return nil, handleFluxError(err)
 	}
@@ -277,7 +283,7 @@ func (c *Controller) query(ctx context.Context, compiler flux.Compiler) (flux.Qu
 	return q, nil
 }
 
-func (c *Controller) createQuery(ctx context.Context, ct flux.CompilerType) (*Query, error) {
+func (c *Controller) createQuery(ctx context.Context, compiler flux.Compiler) (*Query, error) {
 	c.queriesMu.RLock()
 	if c.shutdown {
 		c.queriesMu.RUnlock()
@@ -300,7 +306,7 @@ func (c *Controller) createQuery(ctx context.Context, ct flux.CompilerType) (*Qu
 		labelValues[i] = str
 		compileLabelValues[i] = str
 	}
-	compileLabelValues[len(compileLabelValues)-1] = string(ct)
+	compileLabelValues[len(compileLabelValues)-1] = string(compiler.CompilerType())
 
 	cctx, cancel := context.WithCancel(ctx)
 	parentSpan, parentCtx := tracing.StartSpanFromContextWithPromMetrics(
@@ -320,6 +326,7 @@ func (c *Controller) createQuery(ctx context.Context, ct flux.CompilerType) (*Qu
 		parentSpan:         parentSpan,
 		cancel:             cancel,
 		doneCh:             make(chan struct{}),
+		compiler:           compiler,
 	}
 
 	// Lock the queries mutex for the rest of this method.
@@ -546,6 +553,15 @@ func (c *Controller) Shutdown(ctx context.Context) error {
 	// Cancel all of the currently active queries.
 	c.queriesMu.RLock()
 	for _, q := range c.queries {
+		var fluxScript string
+		fc, ok := q.compiler.(lang.FluxCompiler)
+		if !ok {
+			fluxScript = "unknown"
+		} else {
+			fluxScript = fc.Query
+		}
+		c.log.Info("Cancelling Flux query because of server shutdown", zap.String("query", fluxScript))
+
 		q.Cancel()
 	}
 	c.queriesMu.RUnlock()
@@ -608,9 +624,10 @@ type Query struct {
 	done   sync.Once
 	doneCh chan struct{}
 
-	program flux.Program
-	exec    flux.Query
-	results chan flux.Result
+	program  flux.Program
+	exec     flux.Query
+	results  chan flux.Result
+	compiler flux.Compiler
 
 	memoryManager *queryMemoryManager
 	alloc         *memory.Allocator


### PR DESCRIPTION
Closes #21286

Results in a log line like this if the server is shutdown with SIGINT while a flux query is in-progress:

```
2021-12-29T21:34:54.612657Z	info	Cancelling Flux query because of server shutdown	{"log_id": "0Yj1cVWW000", "service": "storage-reads", "query": "import \"http\" http.post(url: \"http://localhost:8080\") from(bucket: \"bucket\") |> range(start: 0) |> yield()"}
```