### PR TITLE
fix: updating a check does not require an owner id

### DIFF
--- a/checks/service.go
+++ b/checks/service.go
@@ -500,7 +500,7 @@ func (s *Service) updateCheck(ctx context.Context, tx kv.Tx, id platform.ID, chk
 		}
 	}
 
-	// ID and OrganizationID can not be updated
+	// ID, OrganizationID, and OwnerID can not be updated.
 	chk.SetID(current.GetID())
 	chk.SetOrgID(current.GetOrgID())
 	chk.SetOwnerID(current.GetOwnerID())

--- a/notification/check/check.go
+++ b/notification/check/check.go
@@ -52,12 +52,6 @@ func (b Base) Valid(lang fluxlang.FluxLanguageService) error {
 			Msg:  "Check Name can't be empty",
 		}
 	}
-	if !b.OwnerID.Valid() {
-		return &errors.Error{
-			Code: errors.EInvalid,
-			Msg:  "Check OwnerID is invalid",
-		}
-	}
 	if !b.OrgID.Valid() {
 		return &errors.Error{
 			Code: errors.EInvalid,

--- a/notification/check/check_test.go
+++ b/notification/check/check_test.go
@@ -66,19 +66,6 @@ func TestValidCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid owner id",
-			src: &check.Threshold{
-				Base: check.Base{
-					ID:   influxTesting.MustIDBase16(id1),
-					Name: "name1",
-				},
-			},
-			err: &errors.Error{
-				Code: errors.EInvalid,
-				Msg:  "Check OwnerID is invalid",
-			},
-		},
-		{
 			name: "invalid org id",
 			src: &check.Threshold{
 				Base: check.Base{


### PR DESCRIPTION
Closes #16317

Straightforward change, since the [API spec](https://github.com/influxdata/openapi/blob/master/src/common/schemas/CheckBase.yml) already doesn't show this field as being required, [OwnerID](https://github.com/influxdata/influxdb/blob/11c00813f106062829759a97673c7c945d5859ca/notification/check/check.go#L21) is already an optional field in the JSON struct, and as it currently works even if you tried to update the `ownerID` it wouldn't do anything anyway since the existing `ownerID` is always set by the storage service: https://github.com/influxdata/influxdb/blob/11c00813f106062829759a97673c7c945d5859ca/checks/service.go#L506