### PR TITLE
test: fix flaky enqueue test

### DIFF
--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -57,60 +58,58 @@ func TestEnqueueScan(t *testing.T) {
 			testData:        []string{data},
 			writeFuncReturn: nil,
 		},
-		// {
-		// 	name:            "multiple points with successful write",
-		// 	testData:        []string{data, data, data},
-		// 	writeFuncReturn: nil,
-		// },
-		// {
-		// 	name:            "single point with unsuccessful write",
-		// 	testData:        []string{data},
-		// 	writeFuncReturn: errors.New("some error"),
-		// },
-		// {
-		// 	name:            "multiple points with unsuccessful write",
-		// 	testData:        []string{data, data, data},
-		// 	writeFuncReturn: errors.New("some error"),
-		// },
+		{
+			name:            "multiple points with successful write",
+			testData:        []string{data, data, data},
+			writeFuncReturn: nil,
+		},
+		{
+			name:            "single point with unsuccessful write",
+			testData:        []string{data},
+			writeFuncReturn: errors.New("some error"),
+		},
+		{
+			name:            "multiple points with unsuccessful write",
+			testData:        []string{data, data, data},
+			writeFuncReturn: errors.New("some error"),
+		},
 	}
 
-	for i := 0; i < 1000; i++ {
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				queuePath, qm := initQueueManager(t)
-				defer os.RemoveAll(filepath.Dir(queuePath))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queuePath, qm := initQueueManager(t)
+			defer os.RemoveAll(filepath.Dir(queuePath))
 
-				// Create new queue
-				err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+			// Create new queue
+			err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+			require.NoError(t, err)
+			rq := qm.replicationQueues[id1]
+			var writeCounter sync.WaitGroup
+			rq.remoteWriter = getTestRemoteWriter(t, data, tt.writeFuncReturn, &writeCounter)
+
+			// Enqueue the data
+			for _, dat := range tt.testData {
+				writeCounter.Add(1)
+				err = qm.EnqueueData(id1, []byte(dat), 1)
 				require.NoError(t, err)
-				rq := qm.replicationQueues[id1]
-				var writeCounter sync.WaitGroup
-				rq.remoteWriter = getTestRemoteWriter(t, data, tt.writeFuncReturn, &writeCounter)
+			}
+			writeCounter.Wait()
 
-				// Enqueue the data
-				for _, dat := range tt.testData {
-					writeCounter.Add(1)
-					err = qm.EnqueueData(id1, []byte(dat), 1)
-					require.NoError(t, err)
+			// Check queue position
+			closeRq(rq)
+			scan, err := rq.queue.NewScanner()
+
+			if tt.writeFuncReturn == nil {
+				require.ErrorIs(t, err, io.EOF)
+			} else {
+				// Queue should not have advanced at all
+				for range tt.testData {
+					require.True(t, scan.Next())
 				}
-				writeCounter.Wait()
-
-				// Check queue position
-				closeRq(rq)
-				scan, err := rq.queue.NewScanner()
-
-				if tt.writeFuncReturn == nil {
-					require.ErrorIs(t, err, io.EOF)
-				} else {
-					// Queue should not have advanced at all
-					for range tt.testData {
-						require.True(t, scan.Next())
-					}
-					// Should now be at the end of the queue
-					require.False(t, scan.Next())
-				}
-			})
-		}
+				// Should now be at the end of the queue
+				require.False(t, scan.Next())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #23002

See dcdd46be3adf27fe15abec287ab1f4f18f80ea5f for a run with a failure; this was manipulated to run the test a large number of times. The race tests in particular showed many failures: https://app.circleci.com/pipelines/github/influxdata/influxdb/26540/workflows/0d2f953d-0293-43b1-a4c1-5c76955eb435/jobs/238266

9f9ed84f9c5b1c01dfc2866cc2fb6e8ffad2e14f & 5cdabe8ef50b38d79ab44db51236b4a2afffdbb2 also both ran the test ~1000 times each, without failure, after the fix was applied.

The failure was pretty hard to reproduce, but I think what was happening was the test closing the `done` channel simultaneously with the `receive` channel having a message available, and that was (rarely) causing the write function to return before actually processing the enqueue'd data, hence the lack of an error when there should have been one: https://github.com/influxdata/influxdb/blob/11c00813f106062829759a97673c7c945d5859ca/replications/internal/queue_management.go#L135-L151

Adding this sync mechanism to the test write function allows for this behavior to be prevented.