### PR TITLE
fix(handler): allow CORS for /ping, /health and /ready, enable Content-Encoding, HEAD

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -139,8 +139,8 @@ func NewRootHandler(name string, opts ...HandlerOptFn) *Handler {
 			kithttp.Metrics(name, h.requests, h.requestDur),
 		)
 		r.Mount(MetricsPath, opt.metricsHTTPHandler())
-		r.Mount(ReadyPath, opt.readyHandler)
-		r.Mount(HealthPath, opt.healthHandler)
+		r.Mount(ReadyPath, kithttp.SetCORS(opt.readyHandler))
+		r.Mount(HealthPath, kithttp.SetCORS(opt.healthHandler))
 		r.Mount(DebugPath, pprof.NewHTTPHandler(opt.pprofEnabled))
 	})
 

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -50,7 +50,7 @@ func NewPlatformHandler(b *APIBackend, opts ...APIHandlerOptFn) *PlatformHandler
 		AssetHandler:  assetHandler,
 		DocsHandler:   Redoc("/api/v2/swagger.json"),
 		APIHandler:    wrappedHandler,
-		LegacyHandler: legacy.NewInflux1xAuthenticationHandler(lh, b.AuthorizerV1, b.HTTPErrorHandler),
+		LegacyHandler: kithttp.SetCORS(legacy.NewInflux1xAuthenticationHandler(lh, b.AuthorizerV1, b.HTTPErrorHandler)),
 	}
 }
 

--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -28,8 +28,8 @@ func SetCORS(next http.Handler) http.Handler {
 		}
 		if r.Method == http.MethodOptions {
 			// allow and stop processing in pre-flight requests
-			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
-			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent")
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH, HEAD")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent, Content-Encoding")
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}

--- a/kit/transport/http/middleware_test.go
+++ b/kit/transport/http/middleware_test.go
@@ -217,6 +217,24 @@ func TestCors(t *testing.T) {
 				"Access-Control-Allow-Origin": "http://anotherapp.com",
 			},
 		},
+		{
+			name:           "Allow Content-Encoding header",
+			method:         "OPTIONS",
+			headers:        []string{"Origin", "http://myapp.com"},
+			expectedStatus: http.StatusNoContent,
+			expectedHeaders: map[string]string{
+				"Access-Control-Allow-Headers": "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, User-Agent, Content-Encoding",
+			},
+		},
+		{
+			name:           "Allow HEAD method",
+			method:         "OPTIONS",
+			headers:        []string{"Origin", "http://myapp.com"},
+			expectedStatus: http.StatusNoContent,
+			expectedHeaders: map[string]string{
+				"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, PATCH, HEAD",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb-client-dart/issues/24 

1. Allow to use CORS with  /ping, /health and /ready
1. Allow to use `Content-Encoding` header - useful for gzipped writes
1. Allow to use `HEAD` method - useful for `/ping` endpoint 

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
