### PR TITLE
build: bigger stack for musl builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,8 @@ jobs:
             export GOOS=linux
             export GOARCH=amd64
             for cmd in github.com/influxdata/influxdb/cmd/{influxd,influx,influx_inspect} ; do
-              go build -i -o "$TMPOUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+              go build -o $TMPOUTDIR/$(basename $cmd) -tags "netgo osusergo static_build" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+
             done
             mkdir -p ./bins
             tarsum $TMPOUTDIR ./bins/influxdb_bin_${GOOS}_${GOARCH}-${CIRCLE_SHA1}.tar.gz

--- a/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
+++ b/releng/raw-binaries/fs/usr/local/bin/influxdb_raw_binaries.bash
@@ -66,17 +66,30 @@ OUTDIR=$(mktemp -d)
 		echo "env for go build: GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED"
 		# Note that we only do static builds for arm, to be consistent with influxdb 2.x
 		if [[ "$GOARCH" == arm64 ]] ; then
-			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
-			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+			if "$GOOS"=="darwin";then
+				echo go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+				go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" $cmd
+			else
+				echo go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+				go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build noasm" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+			fi
 		elif [[ -n "$STATIC" ]]; then
-			echo go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
-			go build -i -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+			if "$GOOS"=="darwin";then
+				echo go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+				go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+			else
+				echo go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+				go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+			fi
 		elif [[ "$GOOS" == windows ]] ; then
 			echo go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd
 			go build $RACE_FLAG -buildmode=exe -i -o "$OUTDIR/$(basename $cmd).exe" $cmd
+		elif [[ "$GOOS"=="darwin" ]]; then
+			echo go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
+			go build -o "$OUTDIR/$(basename $cmd)" -tags "netgo osusergo static_build" $cmd
 		else
-			echo go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" $cmd
-			go build $RACE_FLAG -i -o "$OUTDIR/$(basename $cmd)" $cmd
+			echo go build $RACE_FLAG -o "$OUTDIR/$(basename $cmd)"  -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
+			go build $RACE_FLAG -o "$OUTDIR/$(basename $cmd)" -ldflags="-s -extldflags \"-fno-PIC -Wl,-z,stack-size=8388608\"" $cmd
 		fi
 	done
 )


### PR DESCRIPTION
This increases the c-stack size because the MUSL stack is too small for the rust-based flux parser.