### PR TITLE
fix: data loss on non portable offline restore

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -564,7 +564,7 @@ func (cmd *Command) unpackTar(tarFile string) error {
 		return fmt.Errorf("backup tarfile name incorrect format")
 	}
 
-	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.Trim(pathParts[2], "0"))
+	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.TrimLeft(pathParts[2], "0"))
 	os.MkdirAll(shardPath, 0755)
 
 	return tarstream.Restore(f, shardPath)


### PR DESCRIPTION
Trim only left zeros so shard folders with trailing zeros do not get messed up on restore.

Closes #

Describe your proposed changes here.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
