### PR TITLE
feat: configurable DELETE concurrency

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -112,7 +112,7 @@
   # max-concurrent-compactions = 0
 
   # MaxConcurrentDeletes is the maximum number of simultaneous DELETE calls on a shard
-  # The default is 1, which was the previous hard-coded value.
+  # The default is 1, and should be left unchanged for most users
   # MaxConcurrentDeletes = 1
 
   # CompactThroughput is the rate limit in bytes per second that we

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -111,6 +111,10 @@
   # to cache snapshotting.
   # max-concurrent-compactions = 0
 
+  # MaxConcurrentDeletes is the maximum number of simultaneous DELETE calls on a shard
+  # The default is 1, which was the previous hard-coded value.
+  # MaxConcurrentDeletes = 1
+
   # CompactThroughput is the rate limit in bytes per second that we
   # will allow TSM compactions to write to disk. Note that short bursts are allowed
   # to happen at a possibly larger value, set by CompactThroughputBurst

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1000,9 +1000,9 @@ func (s *Store) DeleteMeasurement(database, name string) error {
 	epochs := s.epochsForShards(shards)
 	s.mu.RUnlock()
 
-	// Limit to 1 delete for each shard since expanding the measurement into the list
+	// Limit deletes for each shard since expanding the measurement into the list
 	// of series keys can be very memory intensive if run concurrently.
-	limit := limiter.NewFixed(1)
+	limit := limiter.NewFixed(s.EngineOptions.Config.MaxConcurrentDeletes)
 	return s.walkShards(shards, func(sh *Shard) error {
 		limit.Take()
 		defer limit.Release()
@@ -1391,9 +1391,9 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 	epochs := s.epochsForShards(shards)
 	s.mu.RUnlock()
 
-	// Limit to 1 delete for each shard since expanding the measurement into the list
+	// Limit deletes for each shard since expanding the measurement into the list
 	// of series keys can be very memory intensive if run concurrently.
-	limit := limiter.NewFixed(1)
+	limit := limiter.NewFixed(s.EngineOptions.Config.MaxConcurrentDeletes)
 
 	return s.walkShards(shards, func(sh *Shard) error {
 		// Determine list of measurements from sources.


### PR DESCRIPTION
Currently, deletion of series or measurements are
serialized. This new feature will add
max-concurrent-deletes to the [data] section of the
 configuration file. Legal values are any positive
 number, defaulting to 1, the current behavior.

 closes https://github.com/influxdata/influxdb/issues/23054

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Documentation updated or issue created https://github.com/influxdata/docs-v2/issues/3676
