### PR TITLE
refactor: use `T.TempDir` to create temporary test directory

### DIFF
--- a/bolt/bbolt_test.go
+++ b/bolt/bbolt_test.go
@@ -44,16 +44,7 @@ func newTestClient(t *testing.T) (*bolt.Client, func(), error) {
 }
 
 func TestClientOpen(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unable to create temporary test directory %v", err)
-	}
-
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("unable to delete temporary test directory %s: %v", tempDir, err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	boltFile := filepath.Join(tempDir, "test", "bolt.db")
 

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
@@ -154,10 +154,10 @@ type tsmParams struct {
 
 func createTSMFile(t *testing.T, params tsmParams) (string, string) {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "deletetsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	var file *os.File
+	var err error
 	if !params.improperExt {
 		file, err = os.CreateTemp(dir, "*."+tsm1.TSMFileExtension)
 	} else {

--- a/cmd/influxd/inspect/dump_tsi/dump_tsi_test.go
+++ b/cmd/influxd/inspect/dump_tsi/dump_tsi_test.go
@@ -19,9 +19,7 @@ func Test_DumpTSI_NoError(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Create the temp-dir for our un-tared files to live in
-	dir, err := os.MkdirTemp("", "dumptsitest-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Untar the test data
 	file, err := os.Open("../tsi-test-data.tar.gz")

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -187,8 +187,7 @@ type tsmParams struct {
 func makeTSMFile(t *testing.T, params tsmParams) (string, string) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "dumptsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	ext := tsm1.TSMFileExtension
 	if params.wrongExt {

--- a/cmd/influxd/inspect/dump_wal/dump_wal_test.go
+++ b/cmd/influxd/inspect/dump_wal/dump_wal_test.go
@@ -95,8 +95,7 @@ func Test_DumpWal_Find_Duplicates_Present(t *testing.T) {
 func newTempWal(t *testing.T, validExt bool, withDuplicate bool) (string, string) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "dump-wal")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	var file *os.File
 
 	if !validExt {
@@ -105,7 +104,7 @@ func newTempWal(t *testing.T, validExt bool, withDuplicate bool) (string, string
 		return dir, file.Name()
 	}
 
-	file, err = os.CreateTemp(dir, "dumpwaltest*"+"."+tsm1.WALFileExtension)
+	file, err := os.CreateTemp(dir, "dumpwaltest*"+"."+tsm1.WALFileExtension)
 	require.NoError(t, err)
 
 	p1 := tsm1.NewValue(10, 1.1)

--- a/cmd/influxd/inspect/report_tsi/report_tsi_test.go
+++ b/cmd/influxd/inspect/report_tsi/report_tsi_test.go
@@ -69,9 +69,7 @@ func Test_ReportTSI_GeneratedData(t *testing.T) {
 func Test_ReportTSI_TestData(t *testing.T) {
 
 	// Create temp directory for extracted test data
-	path, err := os.MkdirTemp("", "report-tsi-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Extract test data
 	file, err := os.Open("../tsi-test-data.tar.gz")
@@ -125,10 +123,9 @@ func Test_ReportTSI_TestData(t *testing.T) {
 func newTempDirectories(t *testing.T, withShards bool) string {
 	t.Helper()
 
-	dataDir, err := os.MkdirTemp("", "reporttsi")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(dataDir, bucketID, "autogen"), 0777)
+	err := os.MkdirAll(filepath.Join(dataDir, bucketID, "autogen"), 0777)
 	require.NoError(t, err)
 
 	if withShards {

--- a/cmd/influxd/inspect/report_tsm/report_tsm_test.go
+++ b/cmd/influxd/inspect/report_tsm/report_tsm_test.go
@@ -13,11 +13,9 @@ import (
 )
 
 func Test_Invalid_NotDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testInfo{
 		dir:       file.Name(),

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -76,11 +76,10 @@ type Test struct {
 func NewTest(t *testing.T) *Test {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-seriesfile-")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	// create a series file in the directory
-	err = func() error {
+	err := func() error {
 		seriesFile := tsdb.NewSeriesFile(dir)
 		if err := seriesFile.Open(); err != nil {
 			return err
@@ -128,7 +127,6 @@ func NewTest(t *testing.T) *Test {
 		return seriesFile.Close()
 	}()
 	if err != nil {
-		os.RemoveAll(dir)
 		t.Fatal(err)
 	}
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -21,12 +21,10 @@ const (
 
 // Run tests on a directory with no Tombstone files
 func TestVerifies_InvalidFileType(t *testing.T) {
-	path, err := os.MkdirTemp("", "verify-tombstone")
-	require.NoError(t, err)
+	path := t.TempDir()
 
-	_, err = os.CreateTemp(path, "verifytombstonetest*"+".txt")
+	_, err := os.CreateTemp(path, "verifytombstonetest*"+".txt")
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
 
 	verify := NewVerifyTombstoneCommand()
 	verify.SetArgs([]string{"--engine-path", path})
@@ -136,8 +134,7 @@ func TestTombstone_VeryVeryVerbose(t *testing.T) {
 func NewTempTombstone(t *testing.T) (string, *os.File) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tombstone")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	file, err := os.CreateTemp(dir, "verifytombstonetest*"+"."+tsm1.TombstoneFileExtension)
 	require.NoError(t, err)

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
@@ -69,8 +69,7 @@ func TestValidUTF8(t *testing.T) {
 func newUTFTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)
@@ -94,8 +93,7 @@ func newUTFTest(t *testing.T, withError bool) string {
 func newChecksumTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)

--- a/cmd/influxd/inspect/verify_wal/verify_wal_test.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal_test.go
@@ -21,12 +21,10 @@ type testInfo struct {
 }
 
 func TestVerifies_InvalidFileType(t *testing.T) {
-	path, err := os.MkdirTemp("", "verify-wal")
-	require.NoError(t, err)
+	path := t.TempDir()
 
-	_, err = os.CreateTemp(path, "verifywaltest*"+".txt")
+	_, err := os.CreateTemp(path, "verifywaltest*"+".txt")
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
 
 	runCommand(testInfo{
 		t:           t,
@@ -108,8 +106,7 @@ func runCommand(args testInfo) {
 func newTempWALValid(t *testing.T) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-wal")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	w := tsm1.NewWAL(dir, 0, 0, tsdb.EngineTags{})
 	defer w.Close()
@@ -129,7 +126,7 @@ func newTempWALValid(t *testing.T) string {
 		"cpu,host=A#!~#unsigned": {p5},
 	}
 
-	_, err = w.WriteMulti(context.Background(), values)
+	_, err := w.WriteMulti(context.Background(), values)
 	require.NoError(t, err)
 
 	return dir
@@ -138,8 +135,7 @@ func newTempWALValid(t *testing.T) string {
 func newTempWALInvalid(t *testing.T, empty bool) (string, *os.File) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-wal")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	file, err := os.CreateTemp(dir, "verifywaltest*."+tsm1.WALFileExtension)
 	require.NoError(t, err)

--- a/cmd/influxd/launcher/backup_restore_test.go
+++ b/cmd/influxd/launcher/backup_restore_test.go
@@ -2,8 +2,6 @@ package launcher_test
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/influxdata/influx-cli/v2/clients/backup"
@@ -19,9 +17,7 @@ func TestBackupRestore_Full(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	backupDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(backupDir)
+	backupDir := t.TempDir()
 
 	// Boot a server, write some data, and take a backup.
 	l1 := launcher.RunAndSetupNewLauncherOrFail(ctx, t, func(o *launcher.InfluxdOpts) {
@@ -84,7 +80,7 @@ func TestBackupRestore_Full(t *testing.T) {
 	l2.ResetHTTPCLient()
 
 	// Check that orgs and buckets were reset to match the original server's metadata.
-	_, err = l2.OrgService(t).FindOrganizationByID(ctx, l2.Org.ID)
+	_, err := l2.OrgService(t).FindOrganizationByID(ctx, l2.Org.ID)
 	require.Equal(t, errors.ENotFound, errors.ErrorCode(err))
 	rbkt1, err := l2.BucketService(t).FindBucket(ctx, influxdb.BucketFilter{OrganizationID: &l1.Org.ID, ID: &l1.Bucket.ID})
 	require.NoError(t, err)
@@ -117,9 +113,7 @@ func TestBackupRestore_Partial(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	backupDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(backupDir)
+	backupDir := t.TempDir()
 
 	// Boot a server, write some data, and take a backup.
 	l1 := launcher.RunAndSetupNewLauncherOrFail(ctx, t, func(o *launcher.InfluxdOpts) {

--- a/cmd/influxd/upgrade/fs_test.go
+++ b/cmd/influxd/upgrade/fs_test.go
@@ -2,7 +2,6 @@ package upgrade
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -13,13 +12,9 @@ import (
 )
 
 func TestCopyDirAndDirSize(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "tcd")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpdir, "1", "1", "1"), 0700)
+	err := os.MkdirAll(filepath.Join(tmpdir, "1", "1", "1"), 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,11 +45,7 @@ func TestCopyDirAndDirSize(t *testing.T) {
 	}
 	assert.Equal(t, uint64(1600), size)
 
-	targetDir, err := ioutil.TempDir("", "tcd")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(targetDir)
+	targetDir := t.TempDir()
 	targetDir = filepath.Join(targetDir, "x")
 	err = CopyDir(tmpdir, targetDir, nil, func(path string) bool {
 		base := filepath.Base(path)

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -29,10 +29,7 @@ import (
 )
 
 func TestPathValidations(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
-	require.Nil(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	v1Dir := filepath.Join(tmpdir, "v1db")
 	v2Dir := filepath.Join(tmpdir, "v2db")
@@ -41,7 +38,7 @@ func TestPathValidations(t *testing.T) {
 	configsPath := filepath.Join(v2Dir, "configs")
 	enginePath := filepath.Join(v2Dir, "engine")
 
-	err = os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
+	err := os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
 	require.Nil(t, err)
 
 	sourceOpts := &optionsV1{
@@ -89,10 +86,7 @@ func TestPathValidations(t *testing.T) {
 }
 
 func TestClearTargetPaths(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	v2Dir := filepath.Join(tmpdir, "v2db")
 	boltPath := filepath.Join(v2Dir, bolt.DefaultFilename)
@@ -101,7 +95,7 @@ func TestClearTargetPaths(t *testing.T) {
 	cqPath := filepath.Join(v2Dir, "cqs")
 	configPath := filepath.Join(v2Dir, "config")
 
-	err = os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
+	err := os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(boltPath, []byte{1}, 0777)
 	require.NoError(t, err)
@@ -176,11 +170,9 @@ func TestDbURL(t *testing.T) {
 func TestUpgradeRealDB(t *testing.T) {
 	ctx := context.Background()
 
-	tmpdir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 
-	defer os.RemoveAll(tmpdir)
-	err = testutil.Unzip(filepath.Join("testdata", "v1db.zip"), tmpdir)
+	err := testutil.Unzip(filepath.Join("testdata", "v1db.zip"), tmpdir)
 	require.NoError(t, err)
 
 	v1ConfigPath := filepath.Join(tmpdir, "v1.conf")

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -185,9 +185,7 @@ func Test_NewProgram(t *testing.T) {
 	for _, tt := range tests {
 		for _, writer := range configWriters {
 			fn := func(t *testing.T) {
-				testDir, err := ioutil.TempDir("", "")
-				require.NoError(t, err)
-				defer os.RemoveAll(testDir)
+				testDir := t.TempDir()
 
 				confFile, err := writer.writeFn(testDir, config)
 				require.NoError(t, err)
@@ -383,9 +381,7 @@ func Test_ConfigPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		fn := func(t *testing.T) {
-			testDir, err := ioutil.TempDir("", "")
-			require.NoError(t, err)
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 			defer setEnvVar("TEST_CONFIG_PATH", testDir)()
 
 			if tt.writeJson {
@@ -430,9 +426,7 @@ func Test_ConfigPrecedence(t *testing.T) {
 }
 
 func Test_ConfigPathDotDirectory(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	tests := []struct {
 		name string
@@ -461,7 +455,7 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 			configDir := filepath.Join(testDir, tc.dir)
 			require.NoError(t, os.Mkdir(configDir, 0700))
 
-			_, err = writeTomlConfig(configDir, config)
+			_, err := writeTomlConfig(configDir, config)
 			require.NoError(t, err)
 			defer setEnvVar("TEST_CONFIG_PATH", configDir)()
 
@@ -488,9 +482,7 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 }
 
 func Test_LoadConfigCwd(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/pkg/durablequeue/queue_test.go
+++ b/pkg/durablequeue/queue_test.go
@@ -606,11 +606,7 @@ func ReadSegment(segment *segment) string {
 }
 
 func TestSegment_repair(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hh_queue")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	examples := []struct {
 		In       *TestSegment

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -327,8 +327,7 @@ func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
 func initQueueManager(t *testing.T) (string, *durableQueueManager) {
 	t.Helper()
 
-	enginePath, err := os.MkdirTemp("", "engine")
-	require.NoError(t, err)
+	enginePath := t.TempDir()
 	queuePath := filepath.Join(enginePath, "replicationq")
 
 	logger := zaptest.NewLogger(t)
@@ -378,9 +377,7 @@ func getTestRemoteWriter(t *testing.T, expected string, returning error, wg *syn
 func TestEnqueueData(t *testing.T) {
 	t.Parallel()
 
-	queuePath, err := os.MkdirTemp("", "testqueue")
-	require.NoError(t, err)
-	defer os.RemoveAll(queuePath)
+	queuePath := t.TempDir()
 
 	logger := zaptest.NewLogger(t)
 	qm := NewDurableQueueManager(logger, queuePath, metrics.NewReplicationsMetrics(), replicationsMock.NewMockHttpConfigStore(nil))

--- a/sqlite/sqlite_test.go
+++ b/sqlite/sqlite_test.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -60,10 +59,8 @@ func TestBackupSqlStore(t *testing.T) {
 	// this temporary dir/file is is used as the source db path for testing a bacup
 	// from a non-memory database. each individual test also creates a separate temporary dir/file
 	// to backup into.
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	td := t.TempDir()
 	tf := fmt.Sprintf("%s/%s", td, DefaultFilename)
-	defer os.RemoveAll(td)
 
 	tests := []struct {
 		name   string
@@ -95,9 +92,7 @@ func TestBackupSqlStore(t *testing.T) {
 		require.NoError(t, err)
 
 		// create a file to write the backup to.
-		tempDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 
 		// open the file to use as a writer for BackupSqlStore
 		backupPath := tempDir + "/db.sqlite"
@@ -131,10 +126,8 @@ func TestRestoreSqlStore(t *testing.T) {
 	// this temporary dir/file is is used as the destination db path for testing a restore
 	// into a non-memory database. each individual test also creates a separate temporary dir/file
 	// to hold a test db to restore from.
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	td := t.TempDir()
 	tf := fmt.Sprintf("%s/%s", td, DefaultFilename)
-	defer os.RemoveAll(td)
 
 	tests := []struct {
 		name   string
@@ -154,10 +147,8 @@ func TestRestoreSqlStore(t *testing.T) {
 		ctx := context.Background()
 
 		// create the test db to restore from
-		tempDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
+		tempDir := t.TempDir()
 		tempFileName := fmt.Sprintf("%s/%s", tempDir, DefaultFilename)
-		defer os.RemoveAll(tempDir)
 
 		restoreDB, err := NewSqlStore(tempFileName, zap.NewNop())
 		require.NoError(t, err)

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -3,7 +3,6 @@ package storageflux_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -51,10 +50,7 @@ type StorageReader struct {
 }
 
 func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
-	rootDir, err := ioutil.TempDir("", "storage-flux-test")
-	if err != nil {
-		tb.Fatal(err)
-	}
+	rootDir := tb.TempDir()
 
 	var closers []io.Closer
 	close := func() {
@@ -63,7 +59,6 @@ func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
 				tb.Errorf("close error: %s", err)
 			}
 		}
-		_ = os.RemoveAll(rootDir)
 	}
 
 	// Create an underlying kv store. We use the inmem version to speed

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -2,7 +2,6 @@ package backend_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -179,10 +178,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	// Mostly copied out of cmd/influxd/main.go.
 	logger := zaptest.NewLogger(t)
 
-	rootDir, err := ioutil.TempDir("", "task-logreaderwriter-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	rootDir := t.TempDir()
 
 	engine := storage.NewEngine(rootDir, storage.NewConfig(), storage.WithMetaClient(metaClient))
 	engine.WithLogger(logger)
@@ -194,7 +190,6 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	defer func() {
 		if t.Failed() {
 			engine.Close()
-			os.RemoveAll(rootDir)
 		}
 	}()
 

--- a/tsdb/engine/tsm1/array_cursor_test.go
+++ b/tsdb/engine/tsm1/array_cursor_test.go
@@ -20,14 +20,6 @@ type keyValues struct {
 	values []Value
 }
 
-func MustTempDir() string {
-	dir, err := os.MkdirTemp("", "tsm1-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir
-}
-
 func MustTempFile(dir string) *os.File {
 	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
@@ -72,8 +64,7 @@ func newFiles(dir string, values ...keyValues) ([]string, error) {
 
 func TestDescendingCursor_SinglePointStartTime(t *testing.T) {
 	t.Run("cache", func(t *testing.T) {
-		dir := MustTempDir()
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		fs := NewFileStore(dir, tsdb.EngineTags{})
 
 		const START, END = 10, 1
@@ -95,8 +86,7 @@ func TestDescendingCursor_SinglePointStartTime(t *testing.T) {
 		}
 	})
 	t.Run("tsm", func(t *testing.T) {
-		dir := MustTempDir()
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		fs := NewFileStore(dir, tsdb.EngineTags{})
 
 		const START, END = 10, 1
@@ -132,8 +122,7 @@ func TestDescendingCursor_SinglePointStartTime(t *testing.T) {
 }
 
 func TestFileStore_DuplicatePoints(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := NewFileStore(dir, tsdb.EngineTags{})
 
 	makeVals := func(ts ...int64) []Value {
@@ -217,8 +206,7 @@ func (p Int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // When calling `nextTSM`, a single block of 1200 timestamps will be returned and the
 // array cursor must chuck the values in the Next call.
 func TestFileStore_MergeBlocksLargerThat1000_SecondEntirelyContained(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := NewFileStore(dir, tsdb.EngineTags{})
 
 	// makeVals creates count points starting at ts and incrementing by step
@@ -319,8 +307,7 @@ func (a *FloatArray) Swap(i, j int) {
 // To verify intersecting data from the second file replaces the first, the values differ,
 // so the enumerated results can be compared with the expected output.
 func TestFileStore_MergeBlocksLargerThat1000_MultipleBlocksInEachFile(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := NewFileStore(dir, tsdb.EngineTags{})
 
 	// makeVals creates count points starting at ts and incrementing by step
@@ -413,8 +400,7 @@ func TestFileStore_MergeBlocksLargerThat1000_MultipleBlocksInEachFile(t *testing
 }
 
 func TestFileStore_SeekBoundaries(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := NewFileStore(dir, tsdb.EngineTags{})
 
 	// makeVals creates count points starting at ts and incrementing by step

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -541,8 +541,7 @@ func TestCache_Deduplicate_Concurrent(t *testing.T) {
 // Ensure the CacheLoader can correctly load from a single segment, even if it's corrupted.
 func TestCacheLoader_LoadSingle(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	w := NewWALSegmentWriter(f)
 
@@ -613,8 +612,7 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 // Ensure the CacheLoader can correctly load from two segments, even if one is corrupted.
 func TestCacheLoader_LoadDouble(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f1, f2 := mustTempFile(dir), mustTempFile(dir)
 	w1, w2 := NewWALSegmentWriter(f1), NewWALSegmentWriter(f2)
 
@@ -678,8 +676,7 @@ func TestCacheLoader_LoadDouble(t *testing.T) {
 // Ensure the CacheLoader can load deleted series
 func TestCacheLoader_LoadDeleted(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	w := NewWALSegmentWriter(f)
 
@@ -779,14 +776,6 @@ func TestCache_Split(t *testing.T) {
 			t.Fatalf("missing key, exp %s, got %v", key, nil)
 		}
 	}
-}
-
-func mustTempDir() string {
-	dir, err := os.MkdirTemp("", "tsm1-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir
 }
 
 func mustTempFile(dir string) *os.File {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -17,8 +17,7 @@ import (
 
 //  Tests compacting a Cache snapshot into a single TSM file
 func TestCompactor_Snapshot(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(1, float64(1))
 	v2 := tsm1.NewValue(1, float64(1))
@@ -91,8 +90,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 }
 
 func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var vals tsm1.Values
 	ts := int64(1e9)
@@ -144,8 +142,7 @@ func TestCompactor_CompactFullLastTimestamp(t *testing.T) {
 
 // Ensures that a compaction will properly merge multiple TSM files
 func TestCompactor_CompactFull(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -248,8 +245,7 @@ func TestCompactor_CompactFull(t *testing.T) {
 
 // Ensures that a compaction will properly merge multiple TSM files
 func TestCompactor_DecodeError(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -304,8 +300,7 @@ func TestCompactor_DecodeError(t *testing.T) {
 
 // Ensures that a compaction will properly merge multiple TSM files
 func TestCompactor_Compact_OverlappingBlocks(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(4, 1.1)
@@ -375,8 +370,7 @@ func TestCompactor_Compact_OverlappingBlocks(t *testing.T) {
 
 // Ensures that a compaction will properly merge multiple TSM files
 func TestCompactor_Compact_OverlappingBlocksMultiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(4, 1.1)
@@ -454,8 +448,7 @@ func TestCompactor_Compact_OverlappingBlocksMultiple(t *testing.T) {
 }
 
 func TestCompactor_Compact_UnsortedBlocks(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 2 TSM files with different data and one new point
 	a1 := tsm1.NewValue(4, 1.1)
@@ -522,8 +515,7 @@ func TestCompactor_Compact_UnsortedBlocks(t *testing.T) {
 }
 
 func TestCompactor_Compact_UnsortedBlocksOverlapping(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files where two blocks are overlapping and with unsorted order
 	a1 := tsm1.NewValue(1, 1.1)
@@ -597,8 +589,7 @@ func TestCompactor_Compact_UnsortedBlocksOverlapping(t *testing.T) {
 
 // Ensures that a compaction will properly merge multiple TSM files
 func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -692,8 +683,7 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 // Ensures that a full compaction will skip over blocks that have the full
 // range of time contained in the block tombstoned
 func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -794,8 +784,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 // Ensures that a full compaction will decode and combine blocks with
 // partial tombstoned values
 func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -898,8 +887,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 // multiple tombstoned ranges within the block e.g. (t1, t2, t3, t4)
 // having t2 and t3 removed
 func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write 3 TSM files with different data and one new point
 	a1 := tsm1.NewValue(1, 1.1)
@@ -1009,8 +997,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 	if testing.Short() || os.Getenv("CI") != "" || os.Getenv("GORACE") != "" {
 		t.Skip("Skipping max keys compaction test")
 	}
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// write two files where the first contains a single key with the maximum
 	// number of full blocks that can fit in a TSM file
@@ -1088,8 +1075,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 
 // Tests that a single TSM file can be read and iterated over
 func TestTSMKeyIterator_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(1, 1.1)
 	writes := map[string][]tsm1.Value{
@@ -1140,8 +1126,7 @@ func TestTSMKeyIterator_Single(t *testing.T) {
 // No data is lost but the same point time/value would exist in two files until
 // compaction corrects it.
 func TestTSMKeyIterator_Duplicate(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(1, int64(1))
 	v2 := tsm1.NewValue(1, int64(2))
@@ -1195,8 +1180,7 @@ func TestTSMKeyIterator_Duplicate(t *testing.T) {
 // Tests that deleted keys are not seen during iteration with
 // TSM files.
 func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(2, int64(1))
 	points1 := map[string][]tsm1.Value{
@@ -1264,8 +1248,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 // Tests that deleted keys are not seen during iteration with
 // TSM files.
 func TestTSMKeyIterator_SingleDeletes(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(10, int64(1))
 	v2 := tsm1.NewValue(20, int64(1))
@@ -1346,8 +1329,7 @@ func TestTSMKeyIterator_SingleDeletes(t *testing.T) {
 
 // Tests that the TSMKeyIterator will abort if the interrupt channel is closed
 func TestTSMKeyIterator_Abort(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	v1 := tsm1.NewValue(1, 1.1)
 	writes := map[string][]tsm1.Value{

--- a/tsdb/engine/tsm1/digest_test.go
+++ b/tsdb/engine/tsm1/digest_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDigest_None(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -62,7 +62,7 @@ func TestDigest_None(t *testing.T) {
 }
 
 func TestDigest_One(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -125,7 +125,7 @@ func TestDigest_One(t *testing.T) {
 }
 
 func TestDigest_TimeFilter(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -206,7 +206,7 @@ func TestDigest_TimeFilter(t *testing.T) {
 }
 
 func TestDigest_KeyFilter(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -284,8 +284,7 @@ func TestDigest_KeyFilter(t *testing.T) {
 
 func TestDigest_Manifest(t *testing.T) {
 	// Create temp directory to hold test files.
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	digestFile := filepath.Join(dir, tsm1.DigestFilename)
 

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "shard_test")
-	require.NoError(t, err, "error creating temporary directory")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -41,7 +39,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 			time.Unix(int64(i), 0),
 		))
 	}
-	err = sh.WritePoints(context.Background(), points)
+	err := sh.WritePoints(context.Background(), points)
 	require.NoError(t, err)
 
 	engineInterface, err := sh.Engine()
@@ -82,10 +80,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 func NewSeriesFile(tb testing.TB, tmpDir string) *tsdb.SeriesFile {
 	tb.Helper()
 
-	dir, err := os.MkdirTemp(tmpDir, "tsdb-series-file-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 	f := tsdb.NewSeriesFile(dir)
 	f.Logger = zaptest.NewLogger(tb)
 	if err := f.Open(); err != nil {

--- a/tsdb/engine/tsm1/file_store_array_test.go
+++ b/tsdb/engine/tsm1/file_store_array_test.go
@@ -2,7 +2,6 @@ package tsm1_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -310,8 +309,7 @@ func TestFileStore_Array(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := MustTempDir()
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 			fs := tsm1.NewFileStore(dir, tsdb.EngineTags{})
 
 			files, err := newFiles(dir, tc.data...)

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestFileStore_Read(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -54,8 +53,7 @@ func TestFileStore_Read(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -93,8 +91,7 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -166,8 +163,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -207,8 +203,7 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -274,8 +269,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -340,8 +334,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -406,8 +399,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -472,8 +464,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -538,8 +529,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -618,8 +608,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -697,8 +686,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -776,8 +764,7 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -855,8 +842,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -932,8 +918,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_Middle(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -990,8 +975,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_End(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1028,8 +1012,7 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1066,8 +1049,7 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1125,8 +1107,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1190,8 +1171,7 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1252,8 +1232,7 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 	}
 }
 func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1315,8 +1294,7 @@ func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1378,8 +1356,7 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1441,8 +1418,7 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1479,8 +1455,7 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 4 files
@@ -1576,8 +1551,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1653,8 +1627,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1730,8 +1703,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1827,8 +1799,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -1924,8 +1895,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_Middle(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2001,8 +1971,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_End(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2039,8 +2008,7 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2083,8 +2051,7 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2126,8 +2093,7 @@ func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2170,8 +2136,7 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2214,8 +2179,7 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2258,8 +2222,7 @@ func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2302,8 +2265,7 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2346,8 +2308,7 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 }
 
 func TestFileStore_Open(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2377,8 +2338,7 @@ func TestFileStore_Open(t *testing.T) {
 }
 
 func TestFileStore_Remove(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2418,8 +2378,7 @@ func TestFileStore_Remove(t *testing.T) {
 }
 
 func TestFileStore_Replace(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2509,8 +2468,7 @@ func TestFileStore_Replace(t *testing.T) {
 }
 
 func TestFileStore_Open_Deleted(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2550,8 +2508,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 }
 
 func TestFileStore_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2584,8 +2541,7 @@ func TestFileStore_Delete(t *testing.T) {
 }
 
 func TestFileStore_Apply(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2621,8 +2577,7 @@ func TestFileStore_Apply(t *testing.T) {
 }
 
 func TestFileStore_Stats(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2696,8 +2651,7 @@ func TestFileStore_Stats(t *testing.T) {
 }
 
 func TestFileStore_CreateSnapshot(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 
 	// Setup 3 files
@@ -2791,8 +2745,7 @@ func TestFileStore_Observer(t *testing.T) {
 		}
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fs := newTestFileStore(dir)
 	fs.WithObserver(m)
 
@@ -2930,14 +2883,6 @@ type keyValues struct {
 	values []tsm1.Value
 }
 
-func MustTempDir() string {
-	dir, err := os.MkdirTemp("", "tsm1-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir
-}
-
 func MustTempFile(dir string) *os.File {
 	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
@@ -2953,8 +2898,7 @@ func fatal(t *testing.T, msg string, err error) {
 var fsResult []tsm1.FileStat
 
 func BenchmarkFileStore_Stats(b *testing.B) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	// Create some TSM files...
 	data := make([]keyValues, 0, 1000)

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -17,8 +17,7 @@ func fatal(t *testing.T, msg string, err error) {
 }
 
 func TestTSMReader_Type(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -59,8 +58,7 @@ func TestTSMReader_Type(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_ReadAll(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -133,8 +131,7 @@ func TestTSMReader_MMAP_ReadAll(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Read(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -212,8 +209,7 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Keys(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -291,8 +287,7 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Tombstone(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -344,8 +339,7 @@ func TestTSMReader_MMAP_Tombstone(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -409,8 +403,7 @@ func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -471,8 +464,7 @@ func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -533,8 +525,7 @@ func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -599,8 +590,7 @@ func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -652,8 +642,7 @@ func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneFullRangeMultiple(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -725,8 +714,7 @@ func TestTSMReader_MMAP_TombstoneFullRangeMultiple(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -784,8 +772,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRangesFull(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -844,8 +831,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRangesFull(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRangesNoOverlap(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -905,8 +891,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRangesNoOverlap(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -989,8 +974,7 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Stats(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1052,8 +1036,7 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 
 // Ensure that we return an error if we try to open a non-tsm file
 func TestTSMReader_VerifiesFileType(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1184,8 +1167,7 @@ func TestDirectIndex_KeyCount(t *testing.T) {
 }
 
 func TestBlockIterator_Single(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1253,8 +1235,7 @@ func TestBlockIterator_Single(t *testing.T) {
 }
 
 func TestBlockIterator_Tombstone(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1302,8 +1283,7 @@ func TestBlockIterator_Tombstone(t *testing.T) {
 }
 
 func TestBlockIterator_MultipleBlocks(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1380,8 +1360,7 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 }
 
 func TestBlockIterator_Sorted(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1457,8 +1436,7 @@ func TestBlockIterator_Sorted(t *testing.T) {
 }
 
 func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1492,8 +1470,7 @@ func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
 }
 
 func TestCompacted_NotFull(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1544,8 +1521,7 @@ func TestCompacted_NotFull(t *testing.T) {
 }
 
 func TestTSMReader_File_ReadAll(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1653,8 +1629,7 @@ func TestTSMReader_FuzzCrashes(t *testing.T) {
 
 	for _, c := range cases {
 		func() {
-			dir := mustTempDir()
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			filename := filepath.Join(dir, "x.tsm")
 			if err := os.WriteFile(filename, []byte(c), 0600); err != nil {
@@ -1692,8 +1667,7 @@ func TestTSMReader_FuzzCrashes(t *testing.T) {
 }
 
 func TestTSMReader_File_Read(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1771,8 +1745,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 }
 
 func TestTSMReader_References(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1915,7 +1888,7 @@ func TestBatchKeyIterator_Errors(t *testing.T) {
 }
 
 func createTestTSM(t *testing.T) (dir string, name string) {
-	dir = MustTempDir()
+	dir = t.TempDir()
 	f := mustTempFile(dir)
 	name = f.Name()
 	w, err := NewTSMWriter(f)

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestTombstoner_Add(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
@@ -58,8 +57,7 @@ func TestTombstoner_Add(t *testing.T) {
 }
 
 func TestTombstoner_Add_LargeKey(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
@@ -107,8 +105,7 @@ func TestTombstoner_Add_LargeKey(t *testing.T) {
 }
 
 func TestTombstoner_Add_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
@@ -170,8 +167,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 }
 
 func TestTombstoner_Add_Empty(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
@@ -199,8 +195,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 }
 
 func TestTombstoner_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
@@ -237,8 +232,7 @@ func TestTombstoner_Delete(t *testing.T) {
 }
 
 func TestTombstoner_ReadV1(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	if err := os.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
@@ -279,8 +273,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 }
 
 func TestTombstoner_ReadEmptyV1(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	f := MustTempFile(dir)
 	f.Close()

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -25,8 +25,7 @@ func NewWAL(path string, maxConcurrentWrites int, maxWriteDelay time.Duration) *
 }
 
 func TestWALWriter_WriteMulti_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -69,8 +68,7 @@ func TestWALWriter_WriteMulti_Single(t *testing.T) {
 }
 
 func TestWALWriter_WriteMulti_LargeBatch(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -109,8 +107,7 @@ func TestWALWriter_WriteMulti_LargeBatch(t *testing.T) {
 }
 
 func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -157,8 +154,7 @@ func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
 }
 
 func TestWALWriter_WriteDelete_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -184,8 +180,7 @@ func TestWALWriter_WriteDelete_Single(t *testing.T) {
 }
 
 func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -236,8 +231,7 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 }
 
 func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -295,8 +289,7 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 }
 
 func TestWAL_ClosedSegments(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -326,8 +319,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 }
 
 func TestWAL_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -354,8 +346,7 @@ func TestWAL_Delete(t *testing.T) {
 }
 
 func TestWALWriter_Corrupt(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
 	corruption := []byte{1, 4, 0, 0, 0}
@@ -401,8 +392,7 @@ func TestWALWriter_Corrupt(t *testing.T) {
 // Reproduces a `panic: runtime error: makeslice: cap out of range` when run with
 // GOARCH=386 go test -run TestWALSegmentReader_Corrupt -v ./tsdb/engine/tsm1/
 func TestWALSegmentReader_Corrupt(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
@@ -439,8 +429,7 @@ func TestWALSegmentReader_Corrupt(t *testing.T) {
 }
 
 func TestWALRollSegment(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -509,8 +498,7 @@ func TestWAL_DiskSize(t *testing.T) {
 		require.Equal(t, old+cur, w.DiskSizeBytes(), "total disk size")
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 
@@ -690,8 +678,7 @@ func BenchmarkWAL_WriteMulti_Concurrency(b *testing.B) {
 				points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 			}
 
-			dir := MustTempDir()
-			defer os.RemoveAll(dir)
+			dir := b.TempDir()
 
 			w := NewWAL(dir, 0, 0)
 			defer w.Close()
@@ -748,8 +735,7 @@ func BenchmarkWALSegmentWriter(b *testing.B) {
 		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
@@ -771,8 +757,7 @@ func BenchmarkWALSegmentReader(b *testing.B) {
 		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -47,8 +47,7 @@ func TestTSMWriter_Write_NoValues(t *testing.T) {
 }
 
 func TestTSMWriter_Write_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -113,8 +112,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 }
 
 func TestTSMWriter_Write_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -174,8 +172,7 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -242,8 +239,7 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 
 // Tests that writing keys in reverse is able to read them back.
 func TestTSMWriter_Write_SameKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -311,8 +307,7 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 // Tests that calling Read returns all the values for block matching the key
 // and timestamp
 func TestTSMWriter_Read_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -395,8 +390,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -429,8 +423,7 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -544,8 +537,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 
 	w, err := tsm1.NewTSMWriter(f)
@@ -564,8 +556,7 @@ func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
 }
 
 func TestTSMWriter_Write_MaxKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := MustTempFile(dir)
 	defer f.Close()
 

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -369,10 +369,7 @@ func MustNewIndex(tb testing.TB, index string, eopts ...EngineOption) *Index {
 		opt(&opts)
 	}
 
-	rootPath, err := os.MkdirTemp("", "influxdb-tsdb")
-	if err != nil {
-		panic(err)
-	}
+	rootPath := tb.TempDir()
 
 	seriesPath, err := os.MkdirTemp(rootPath, tsdb.SeriesFileDirectory)
 	if err != nil {

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -54,7 +54,7 @@ func TestParseSeriesKeyInto(t *testing.T) {
 
 // Ensure that broken series files are closed
 func TestSeriesFile_Open_WhenFileCorrupt_ShouldReturnErr(t *testing.T) {
-	f := NewBrokenSeriesFile([]byte{0, 0, 0, 0, 0})
+	f := NewBrokenSeriesFile(t, []byte{0, 0, 0, 0, 0})
 	defer f.Close()
 	f.Logger = zaptest.NewLogger(t)
 
@@ -320,16 +320,13 @@ type SeriesFile struct {
 }
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
-func NewSeriesFile() *SeriesFile {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
-	if err != nil {
-		panic(err)
-	}
+func NewSeriesFile(tb testing.TB) *SeriesFile {
+	dir := tb.TempDir()
 	return &SeriesFile{SeriesFile: tsdb.NewSeriesFile(dir)}
 }
 
-func NewBrokenSeriesFile(content []byte) *SeriesFile {
-	sFile := NewSeriesFile()
+func NewBrokenSeriesFile(tb testing.TB, content []byte) *SeriesFile {
+	sFile := NewSeriesFile(tb)
 	fPath := sFile.Path()
 	sFile.Open()
 	sFile.SeriesFile.Close()
@@ -349,7 +346,7 @@ func NewBrokenSeriesFile(content []byte) *SeriesFile {
 func MustOpenSeriesFile(tb testing.TB) *SeriesFile {
 	tb.Helper()
 
-	f := NewSeriesFile()
+	f := NewSeriesFile(tb)
 	f.Logger = zaptest.NewLogger(tb)
 	if err := f.Open(); err != nil {
 		panic(err)

--- a/tsdb/series_index_test.go
+++ b/tsdb/series_index_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestSeriesIndex_Count(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -30,8 +29,7 @@ func TestSeriesIndex_Count(t *testing.T) {
 }
 
 func TestSeriesIndex_Delete(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -53,8 +51,7 @@ func TestSeriesIndex_Delete(t *testing.T) {
 }
 
 func TestSeriesIndex_FindIDBySeriesKey(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -86,8 +83,7 @@ func TestSeriesIndex_FindIDBySeriesKey(t *testing.T) {
 }
 
 func TestSeriesIndex_FindOffsetByID(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {

--- a/tsdb/series_segment_test.go
+++ b/tsdb/series_segment_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestSeriesSegment(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	// Create a new initial segment (4mb) and initialize for writing.
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
@@ -69,8 +68,7 @@ func TestSeriesSegment(t *testing.T) {
 }
 
 func TestSeriesSegment_AppendSeriesIDs(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
 	if err != nil {
@@ -97,8 +95,7 @@ func TestSeriesSegment_AppendSeriesIDs(t *testing.T) {
 }
 
 func TestSeriesSegment_MaxSeriesID(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
 	if err != nil {
@@ -142,8 +139,7 @@ func TestSeriesSegmentHeader(t *testing.T) {
 }
 
 func TestSeriesSegment_PartialWrite(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	// Create a new initial segment (4mb) and initialize for writing.
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -3,7 +3,6 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -337,10 +336,7 @@ func NewTempShard(tb testing.TB, index string) *TempShard {
 	tb.Helper()
 
 	// Create temporary path for data and WAL.
-	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 
 	// Create series file.
 	sfile := NewSeriesFile(filepath.Join(dir, "db0", SeriesFileDirectory))

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -100,8 +99,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 }
 
 func TestShardRebuildIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -178,8 +176,7 @@ func TestShardRebuildIndex(t *testing.T) {
 }
 
 func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -228,8 +225,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 }
 
 func TestWriteTimeTag(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -278,8 +274,7 @@ func TestWriteTimeTag(t *testing.T) {
 }
 
 func TestWriteTimeField(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -313,8 +308,7 @@ func TestWriteTimeField(t *testing.T) {
 }
 
 func TestShardWriteAddNewField(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -365,8 +359,7 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	if testing.Short() || runtime.GOOS == "windows" {
 		t.Skip("Skipping on short and windows")
 	}
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -453,8 +446,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -603,8 +595,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 // Ensures that when a shard is closed, it removes any series meta-data
 // from the index.
 func TestShard_Close_RemoveIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -1518,8 +1509,7 @@ _reserved,region=uswest value="foo" 0
 }
 
 func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	mf, err := tsdb.NewMeasurementFieldSet(path)
@@ -1553,8 +1543,7 @@ func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
 }
 
 func TestMeasurementFieldSet_Corrupt(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	func() {
@@ -1592,8 +1581,7 @@ func TestMeasurementFieldSet_Corrupt(t *testing.T) {
 	}
 }
 func TestMeasurementFieldSet_DeleteEmpty(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	mf, err := tsdb.NewMeasurementFieldSet(path)
@@ -1636,8 +1624,7 @@ func TestMeasurementFieldSet_DeleteEmpty(t *testing.T) {
 }
 
 func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 
@@ -1654,8 +1641,7 @@ func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
 
 func TestMeasurementFieldSet_ConcurrentSave(t *testing.T) {
 	var iterations int
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	if testing.Short() {
 		iterations = 50
@@ -2209,10 +2195,7 @@ func NewShards(tb testing.TB, index string, n int) Shards {
 	tb.Helper()
 
 	// Create temporary path for data and WAL.
-	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 
 	sfile := MustOpenSeriesFile(tb)
 
@@ -2305,14 +2288,6 @@ func (sh *Shard) MustWritePointsString(s string) {
 	if err := sh.WritePoints(context.Background(), a); err != nil {
 		panic(err)
 	}
-}
-
-func MustTempDir() (string, func()) {
-	dir, err := ioutil.TempDir("", "shard-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir, func() { os.RemoveAll(dir) }
 }
 
 type seriesIterator struct {

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -2271,10 +2270,7 @@ type Store struct {
 func NewStore(tb testing.TB, index string) *Store {
 	tb.Helper()
 
-	path, err := ioutil.TempDir("", "influxdb-tsdb-")
-	if err != nil {
-		panic(err)
-	}
+	path := tb.TempDir()
 
 	s := &Store{Store: tsdb.NewStore(path), index: index}
 	s.EngineOptions.IndexVersion = index


### PR DESCRIPTION
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
