### PR TITLE
fix: correctly handle PartialWriteError

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -737,10 +737,13 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 	var droppedKeys [][]byte
 	if err := engine.CreateSeriesListIfNotExists(keys, names, tagsSlice); err != nil {
 		switch err := err.(type) {
-		// TODO(jmw): why is this a *PartialWriteError when everything else is not a pointer?
-		// Maybe we can just change it to be consistent if we change it also in all
-		// the places that construct it.
+		// (DSB) This was previously *PartialWriteError. Now catch pointer and value types.
 		case *PartialWriteError:
+			reason = err.Reason
+			dropped += err.Dropped
+			droppedKeys = err.DroppedKeys
+			s.stats.writesDropped.Add(float64(err.Dropped))
+		case PartialWriteError:
 			reason = err.Reason
 			dropped += err.Dropped
 			droppedKeys = err.DroppedKeys


### PR DESCRIPTION
Check for the correctly returned PartialWriteError
in (*shard).validateSeriesAndFields, allow partial
writes.

closes https://github.com/influxdata/influxdb/issues/23096

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
