### PR TITLE
fix: add database to MaxSeriesPerDatabase error message

### DIFF
--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -194,7 +194,7 @@ func (i *Index) CreateSeriesListIfNotExists(seriesIDSet *tsdb.SeriesIDSet, measu
 		i.mu.RLock()
 		if max := opt.Config.MaxSeriesPerDatabase; max > 0 && len(i.series)+len(keys) > max {
 			i.mu.RUnlock()
-			return errMaxSeriesPerDatabaseExceeded{limit: opt.Config.MaxSeriesPerDatabase, series: len(i.series), keys: len(keys)}
+			return errMaxSeriesPerDatabaseExceeded{database: i.database, limit: opt.Config.MaxSeriesPerDatabase, series: len(i.series), keys: len(keys)}
 		}
 		i.mu.RUnlock()
 	}
@@ -1362,11 +1362,12 @@ func (itr *seriesIDIterator) nextKeys() error {
 // errMaxSeriesPerDatabaseExceeded is a marker error returned during series creation
 // to indicate that a new series would exceed the limits of the database.
 type errMaxSeriesPerDatabaseExceeded struct {
-	limit  int
-	series int
-	keys   int
+	limit    int
+	series   int
+	keys     int
+	database string
 }
 
 func (e errMaxSeriesPerDatabaseExceeded) Error() string {
-	return fmt.Sprintf("max-series-per-database exceeded limit=%d series=%d keys=%d", e.limit, e.series, e.keys)
+	return fmt.Sprintf("max-series-per-database exceeded database=%s limit=%d series=%d keys=%d", e.database, e.limit, e.series, e.keys)
 }

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -164,7 +164,8 @@ func TestMaxSeriesLimit(t *testing.T) {
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 	opts.Config.MaxSeriesPerDatabase = 1000
-	opts.InmemIndex = inmem.NewIndex(filepath.Base(tmpDir), sfile.SeriesFile)
+	index := inmem.NewIndex(filepath.Base(tmpDir), sfile.SeriesFile)
+	opts.InmemIndex = index
 
 	sh := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
 
@@ -206,7 +207,8 @@ func TestMaxSeriesLimit(t *testing.T) {
 	err = sh.WritePoints([]models.Point{pt}, tsdb.NoopStatsTracker())
 	if err == nil {
 		t.Fatal("expected error")
-	} else if exp, got := `partial write: max-series-per-database exceeded limit=1000 series=1000 keys=1 dropped=1`, err.Error(); exp != got {
+	} else if exp, got :=
+		fmt.Sprintf(`partial write: max-series-per-database exceeded database=%s limit=1000 series=1000 keys=1 dropped=1`, index.Database()), err.Error(); exp != got {
 		t.Fatalf("unexpected error message:\n\texp = %s\n\tgot = %s", exp, got)
 	} else {
 		st := sh.Statistics(map[string]string{})

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1366,7 +1366,7 @@ func TestStore_Cardinality_Limit_On_InMem_Index(t *testing.T) {
 		to := from + pointsPerShard
 
 		if err := store.Store.WriteToShard(tsdb.WriteContext{}, uint64(shardID), points[from:to]); err != nil {
-			if !strings.Contains(err.Error(), "partial write: max-series-per-database exceeded limit") {
+			if !strings.Contains(err.Error(), "partial write: max-series-per-database exceeded") {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
To simplify debugging, print the database name when the
max-series-per-database limit is exceeded in InMem indices.

closes https://github.com/influxdata/influxdb/issues/23112

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
