### PR TITLE
refactor: improve logging during `influxd upgrade` 

### DIFF
--- a/cmd/influxd/upgrade/database.go
+++ b/cmd/influxd/upgrade/database.go
@@ -98,7 +98,7 @@ func upgradeDatabases(ctx context.Context, cli clients.CLI, v1 *influxDBv1, v2 *
 				OrganizationID:  orgID,
 				BucketID:        bucket.ID,
 			}
-			log.Debug(
+			log.Info(
 				"Creating mapping",
 				zap.String("database", mapping.Database),
 				zap.String("retention policy", mapping.RetentionPolicy),
@@ -155,7 +155,7 @@ func upgradeDatabases(ctx context.Context, cli clients.CLI, v1 *influxDBv1, v2 *
 					return nil, fmt.Errorf("error copying v1 data from %s to %s: %w", sourcePath, targetPath, err)
 				}
 			} else {
-				log.Warn("Empty retention policy")
+				log.Warn("Empty retention policy, no shards found", zap.String("source", sourcePath))
 			}
 		}
 


### PR DESCRIPTION
Closes #23041 

Small changes to influxd upgrade logging - changes log level for DBRP mapping creation to info level rather than debug, and includes the sourcePath in the warning log message if no data/shards are found in a particular 1.x database. This will make it clear by default which databases/retention policies have been migrated to 2.x and which have not.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
