### PR TITLE
fix repeat append block entry when execute select statement with `ORDER BY time DESC`

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1500,7 +1500,7 @@ func (c *KeyCursor) nextDescending() {
 	c.current[0] = c.seeks[c.pos]
 
 	// If we have ovelapping blocks, append all their values so we can dedup
-	for i := c.pos; i >= 0; i-- {
+	for i := c.pos - 1; i >= 0; i-- {
 		if c.seeks[i].read() {
 			continue
 		}


### PR DESCRIPTION
Closes #

Describe your proposed changes here.
when execute select statement with `ORDER BY time DESC`, the `nextDescending` function append block entry multi times, so it will repeat read block, it reduce performence.
<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
