### PR TITLE
chore: update OSS ci pipeline to match the updates to monitor-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
             docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
       - run:
           name: Run the tests
-          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} UI_SHA="cc65325af35078b6886dac24357a88c9f815369d" UI_BRANCH="OSS-2.1" RUN_WORKFLOW="build_oss_embedded" ./scripts/ci/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
             docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
       - run:
           name: Run the tests
-          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="master" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
             docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
       - run:
           name: Run the tests
-          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="master" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
             docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
       - run:
           name: Run the tests
-          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} UI_SHA="cc65325af35078b6886dac24357a88c9f815369d" UI_BRANCH="OSS-2.1" RUN_WORKFLOW="build_oss_embedded" ./scripts/ci/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="feat-CI-quartz-mock" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
             docker push quay.io/influxdb/oss-acceptance:${CIRCLE_SHA1}
       - run:
           name: Run the tests
-          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="master" OSS_SHA=${CIRCLE_SHA1} ./scripts/ci/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} MONITOR_CI_BRANCH="master" OSS_SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build_oss" ./scripts/ci/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/scripts/ci/run-monitor-ci-tests.bash
+++ b/scripts/ci/run-monitor-ci-tests.bash
@@ -180,13 +180,13 @@ if [[ -z "${API_KEY:-}" ]] || [[ -z "${MONITOR_CI_BRANCH:-}" ]]; then
 fi
 
 if [[ "${RUN_WORKFLOW}" == "build_oss" ]]; then
-	required_workflows=( "build-oss" )
+	required_workflows=( "build_oss" )
 	if [[ -z "${OSS_SHA:-}" ]]; then
 		printf "\nERROR: monitor-ci pipeline missing required env vars. Must set OSS_SHA.\n"
 		exit 1	
 	fi
 elif [[ "${RUN_WORKFLOW}" == "build_oss_embedded" ]]; then
-	required_workflows=( "build-oss-embedded" )
+	required_workflows=( "build_oss_embedded" )
 	if [[ -z "${UI_SHA:-}" ]] || [[ -z "${UI_BRANCH:-}" ]] || [[ -z "${OSS_SHA:-}" ]]; then
 		printf "\nERROR: monitor-ci pipeline missing required env vars. Must set UI_SHA, UI_BRANCH, and OSS_SHA.\n"
 		exit 1	
@@ -219,6 +219,7 @@ do
 		--header "Circle-Token: ${API_KEY}" \
 		--header 'content-type: application/json' \
 		--header 'Accept: application/json')
+
 
 	number_running_workflows=$(echo ${workflows} | jq  -r '.items | map(select(.status == "running" or .status == "failing")) | length')
 

--- a/scripts/ci/run-monitor-ci-tests.bash
+++ b/scripts/ci/run-monitor-ci-tests.bash
@@ -21,12 +21,15 @@ set -eu -o pipefail
 #  - If you rerun the private CI and it passes, this script will find that pipeline and will not start a new one.
 #  - In this situation the script will exit quickly with success.
 #
-# Required Env Vars for Running from the UI Repository:
-# - SHA: the UI repo commit SHA we're running against
+# Pipeline Workflow options:
+# - RUN_WORKFLOW Env Var required to determine which workflow to run.
+# - enum options: 'build_oss', 'build_oss_embedded'
+# - e.g. RUN_WORKFLOW='build_oss_embedded'
+#
+# Required Env Vars for all workflows:
+# - RUN_WORKFLOW: enum for which pipeline workflow
 # - API_KEY: the CircleCI API access key
-# - UI_BRANCH: the branch of the UI repo we're running against
 # - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
-# - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
 #
 # **For OSS-specific testing:**
 # Since the OSS private CI is very simple, retrying a failing job in the private CI is not supported.
@@ -37,16 +40,13 @@ set -eu -o pipefail
 # without needing to duplicate the entire private test infrastructure provided in monitor-ci.
 #
 # Required Env Vars for Testing Changes to OSS Master with the Latest Image Published from UI Master:
-# - API_KEY: See "Required Env Vars for Running from the UI Repository".
+# - RUN_WORKFLOW='build_oss'
 # - OSS_SHA: the influxdb repo commit SHA we're running against
-# - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 #
 # Required Env Vars for Testing Changes to an OSS Image with Embedded UI with e2e tests from a Specific UI Commit:
-# - API_KEY: See "Required Env Vars for Running from the UI Repository".
-# - SHA: the UI repo commit SHA we want to build and run e2e tests from
-# - UI_BRANCH: the branch of the UI repo we're running against
+# - RUN_WORKFLOW='build_oss_embedded'
+# - UI_SHA: the UI repo commit SHA we want to build and run e2e tests from
 # - OSS_SHA: the influxdb repo commit SHA we're running against
-# - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 
 ########################
 
@@ -104,22 +104,17 @@ retryFailedPipeline() {
 	printf "\nmonitor-ci pipeline re-run has begun. Running pipeline number ${pipeline_number} with id ${pipeline_id}\n"
 }
 
-# make dir for artifacts
-mkdir -p monitor-ci/test-artifacts/results/{build-oss-image,oss-e2e,build-image,cloud-e2e,cloud-e2e-firefox,cloud-e2e-k8s-idpe,cloud-lighthouse,smoke,build-prod-image,deploy}/{shared,oss,cloud}
-
-# get monitor-ci pipelines we've already run on this SHA
-found_passing_pipeline=0
-found_failed_pipeline=0
-
-# If OSS_SHA is not set, run the standard UI pipeline with the latest OSS backend docker image.
-if [[ -z "${OSS_SHA:-}" ]]; then
-  required_workflows=( "build" )
+# cancel if already have a passing pipeline for a given SHA
+earlyTermination() {
+	local current_sha=$1
+	local regex_line=$2
+	local regex_exclusion=$3
 
 	all_pipelines=$(curl -s --request GET \
-			--url "https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline" \
-			--header "Circle-Token: ${API_KEY}" \
-			--header 'content-type: application/json' \
-			--header 'Accept: application/json')
+		--url "https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline" \
+		--header "Circle-Token: ${API_KEY}" \
+		--header 'content-type: application/json' \
+		--header 'Accept: application/json')
 
 	# check the status of the workflows for each of these pipelines
 	all_pipelines_ids=( $(echo ${all_pipelines} | jq -r '.items | .[].id') )
@@ -131,10 +126,10 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 			--header 'content-type: application/json' \
 			--header 'Accept: application/json')
 
-		# finds the UI SHA parameter used in this pipeline by hunting for the line "export UI_SHA="
-		pipeline_ui_sha=$(echo ${config} | jq '.compiled' | grep -o 'export UI_SHA=[^\]*' | grep -v 'export UI_SHA=${LATEST_SHA}' | head -1 | sed 's/=/\n/g' | tail -1 || true)
+		# finds the SHA parameter used in this pipeline by hunting for a specific line
+		pipeline_sha=$(echo ${config} | jq '.compiled' | grep -o ${regex_line} | grep -v ${regex_exclusion} | head -1 | sed 's/=/\n/g' | tail -1 || true)
 
-		if [[ "${SHA}" == "${pipeline_ui_sha}" ]]; then
+		if [[ "${current_sha}" == "${pipeline_sha}" ]]; then
 			# check if this pipeline's 'build' workflow is passing
 			workflows=$(curl -s --request GET \
 				--url "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" \
@@ -170,44 +165,40 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 	else
 		printf "\nno passing monitor-ci pipelines found for this SHA, starting a new one\n"
 	fi
+}
 
-	# set the parameters for starting the monitor-ci pipeline from the UI repo
-	DEPLOY_PROD=false
-	if [[ "${UI_BRANCH}" == "master" ]]; then
-		# In order to deploy to prod:
-		# - UI_BRANCH must be 'master'
-		# - MONITOR_CI_BRANCH must be 'master'
-		# - DEPLOY_PROD must be 'true'
-		# - UI_GITHUB_ORG must be 'influxdata'
-		# UI_BRANCH, DEPLOY_PROD are both neccesary to ensure that UI_BRANCH parameter's default in the monitor-ci pipeline doesn't deploy us to production unless started by this script.
-		DEPLOY_PROD=true
-	fi
-	if [ -n "${PULL_REQUEST}" ]; then
-		# if running from pull request, use github api to get source org and branch.
-		# this is needed to support forks of the UI repo.
-		pr=$(echo ${PULL_REQUEST} | grep -oE "[^/]+$")
-		github=$(curl -s --fail --request GET \
-			--url https://api.github.com/repos/influxdata/ui/pulls/${pr})
-		UI_BRANCH=$(echo ${github} | jq -r '.head.ref')
-		UI_GITHUB_ORG=$(echo ${github} | jq -r '.head.repo.owner.login')
-	fi
+# make dir for artifacts
+mkdir -p monitor-ci/test-artifacts/results/{build-oss-image,oss-e2e,build-image,cloud-e2e,cloud-e2e-firefox,cloud-e2e-k8s-idpe,cloud-lighthouse,smoke,build-prod-image,deploy}/{shared,oss,cloud}
 
-	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"
-	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-github-org\":\"${UI_GITHUB_ORG:-influxdata}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"ui-pr-author\":\"${CIRCLE_USERNAME}\", \"deploy-prod\":${DEPLOY_PROD}}}"
-else
-  # if OSS_SHA parameter is set, run a minimal pipeline for OSS-specific testing.
-	if [[ -z "${SHA:-}" ]]; then
-    # no UI sha means to run the tests through the latest UI docker image with the OSS API backend based on the provided OSS commit SHA
-	  required_workflows=( "build-oss" )
-	  pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}"
-    reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"oss-sha\":\"${OSS_SHA}\" }}"
-	else
-	  # if both a UI and OSS SHA are provided, run with the OSS backend with an embedded UI, and run the tests on it built from the commit referenced by the UI SHA..
-    required_workflows=( "build-oss-embedded" )
-    pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA} and UI SHA ${SHA}"
-    reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"oss-sha\":\"${OSS_SHA}\", \"ui-branch\":\"${UI_BRANCH}\" }}"
-  fi
+# get monitor-ci pipelines we've already run on this SHA
+found_passing_pipeline=0
+found_failed_pipeline=0
+
+if [[ -z "${API_KEY:-}" ]] || [[ -z "${MONITOR_CI_BRANCH:-}" ]]; then
+	printf "\nERROR: monitor-ci pipeline missing required env vars. Must set API_KEY and MONITOR_CI_BRANCH.\n"
+	exit 1	
 fi
+
+if [[ "${RUN_WORKFLOW}" == "build_oss" ]]; then
+	required_workflows=( "build-oss" )
+	if [[ -z "${OSS_SHA:-}" ]]; then
+		printf "\nERROR: monitor-ci pipeline missing required env vars. Must set OSS_SHA.\n"
+		exit 1	
+	fi
+elif [[ "${RUN_WORKFLOW}" == "build_oss_embedded" ]]; then
+	required_workflows=( "build-oss-embedded" )
+	if [[ -z "${UI_SHA:-}" ]] || [[ -z "${UI_BRANCH:-}" ]] || [[ -z "${OSS_SHA:-}" ]]; then
+		printf "\nERROR: monitor-ci pipeline missing required env vars. Must set UI_SHA, UI_BRANCH, and OSS_SHA.\n"
+		exit 1	
+	fi
+else
+	printf "\nERROR: monitor-ci pipeline missing env var RUN_WORKFLOW.\nMust choose one of: 'build_oss', 'build_oss_embedded'\n"
+	exit 1	
+fi
+
+pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH:-'master'} and using UI SHA ${UI_SHA:-'latest'}, using OSS SHA ${OSS_SHA:-'latest'}."
+
+reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"run-workflow\":\"${RUN_WORKFLOW}\", \"ui-sha\":\"${UI_SHA:-'not-a-real-sha'}\", \"ui-branch\":\"${UI_BRANCH:-'master'}\", \"oss-sha\":\"${OSS_SHA:-''}\"}}"
 
 # start a new pipeline if we didn't find an existing one to retry
 if [ $found_failed_pipeline -eq 0 ]; then

--- a/scripts/ci/run-monitor-ci-tests.bash
+++ b/scripts/ci/run-monitor-ci-tests.bash
@@ -46,6 +46,7 @@ set -eu -o pipefail
 # Required Env Vars for Testing Changes to an OSS Image with Embedded UI with e2e tests from a Specific UI Commit:
 # - RUN_WORKFLOW='build_oss_embedded'
 # - UI_SHA: the UI repo commit SHA we want to build and run e2e tests from
+# - UI_BRANCH: the UI branch where the commit exists
 # - OSS_SHA: the influxdb repo commit SHA we're running against
 
 ########################

--- a/scripts/ci/run-monitor-ci-tests.bash
+++ b/scripts/ci/run-monitor-ci-tests.bash
@@ -196,9 +196,9 @@ else
 	exit 1	
 fi
 
-pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH:-'master'} and using UI SHA ${UI_SHA:-'latest'}, using OSS SHA ${OSS_SHA:-'latest'}."
+pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH:-master} and using UI SHA ${UI_SHA:-latest}, using OSS SHA ${OSS_SHA:-latest}."
 
-reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"run-workflow\":\"${RUN_WORKFLOW}\", \"ui-sha\":\"${UI_SHA:-'not-a-real-sha'}\", \"ui-branch\":\"${UI_BRANCH:-'master'}\", \"oss-sha\":\"${OSS_SHA:-''}\"}}"
+reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"run-workflow\":\"${RUN_WORKFLOW}\", \"ui-sha\":\"${UI_SHA:-not-a-real-sha}\", \"ui-branch\":\"${UI_BRANCH:-master}\", \"oss-sha\":\"${OSS_SHA:-}\"}}"
 
 # start a new pipeline if we didn't find an existing one to retry
 if [ $found_failed_pipeline -eq 0 ]; then


### PR DESCRIPTION
Partial #https://github.com/influxdata/ui/issues/3565

### Purpose:
* When making changes in quartz-mock PR, incorporate CI tests including e2e with UI.
* Make it such that bad mock bad (in quartz-mock), does not break our CI pipeline.
* This included updates for our monitor-ci pipeline (making it a bit cleaner)...which is why this PR in oss exists.


### Done in this PR:
* explicitly set the workflow enum which is run.
* update the `run-monitor-ci-tests.bash` to match the updated script in monitor-ci.
    * note: removed the other workflows which are not oss.
    * note to @wbaker85 the updated script, for embedded UI, uses `UI_SHA` (not `SHA`)
* tested by running against the monitor-ci branch (which has all the updates).
    * temp commit: https://github.com/influxdata/influxdb/pull/23169/commits/694ce3aa3dd79b1c2b6001d3e55e3a3f07707f19

### Before merge:
- [x] merge in monitor-ci PR first.
     * this PR:  https://github.com/influxdata/monitor-ci/pull/349
- [x] reset this to master branch: `MONITOR_CI_BRANCH="feat-CI-quartz-mock"`
     * revert commit https://github.com/influxdata/influxdb/pull/23169/commits/694ce3aa3dd79b1c2b6001d3e55e3a3f07707f19
- [x] ~~revert test commit: https://github.com/influxdata/influxdb/pull/23169/commits/22e27bbad7caad9d3f41bff8ab5f9e4eb73120ea~~ Done
