### PR TITLE
feat: Add MeasurementNames method to MeasurementFieldSet

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1939,6 +1939,20 @@ func (fs *MeasurementFieldSet) Bytes() int {
 	return b
 }
 
+// MeasurementNames returns the names of all of the measurements in the field set in
+// lexographical order.
+func (fs *MeasurementFieldSet) MeasurementNames() []string {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	names := make([]string, 0, len(fs.fields))
+	for name := range fs.fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // Fields returns fields for a measurement by name.
 func (fs *MeasurementFieldSet) Fields(name []byte) *MeasurementFields {
 	fs.mu.RLock()

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/influxdata/influxdb/v2/tsdb/engine"
 	_ "github.com/influxdata/influxdb/v2/tsdb/index"
 	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
@@ -1703,6 +1704,24 @@ func TestMeasurementFieldSet_ConcurrentSave(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMeasurementFieldSet_MeasurementNames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fields.idx")
+	mf, err := tsdb.NewMeasurementFieldSet(path)
+	if err != nil {
+		t.Fatalf("NewMeasurementFieldSet error: %v", err)
+	}
+	defer mf.Close()
+
+	mf.CreateFieldsIfNotExists([]byte("cpu"))
+	mf.CreateFieldsIfNotExists([]byte("memory"))
+	mf.CreateFieldsIfNotExists([]byte("disk_usage"))
+
+	exp := []string{"cpu", "disk_usage", "memory"}
+	got := mf.MeasurementNames()
+	assert.Equal(t, exp, got)
 }
 
 func testFieldMaker(t *testing.T, wg *sync.WaitGroup, mf *tsdb.MeasurementFieldSet, measurement string, fieldNames []string) {


### PR DESCRIPTION
When migrating users from OSS/Enterprise to Cloud2, we have run into issues with series having different types on different shards. In cloud2, this causes a type collision and we end up dropping a lot of the data. To prevent this, we'd like to get information about any type collisions up front and we have the "fields.idx" files available to us, which we would like to read.

This PR introduces a new method to help us read these files, and get a list of all measurement names. This will not impact the running of the service at all, but will allow us to import this into the tooling that we are building around the migration process.



- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

