### PR TITLE
fix: allow flux http calls to be unlimited

### DIFF
--- a/query/stdlib/influxdata/influxdb/dependencies.go
+++ b/query/stdlib/influxdata/influxdb/dependencies.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/influxdata/flux"
 	fluxfeature "github.com/influxdata/flux/dependencies/feature"
+	"github.com/influxdata/flux/dependencies/http"
 	influxdeps "github.com/influxdata/flux/dependencies/influxdb"
+	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/feature"
 	"github.com/influxdata/influxdb/v2/kit/prom"
@@ -86,6 +88,7 @@ func NewDependencies(
 	metricLabelKeys []string,
 ) (Dependencies, error) {
 	fdeps := flux.NewDefaultDependencies()
+	fdeps.Deps.HTTPClient = http.NewDefaultClient(url.PassValidator{})
 	fdeps.Deps.SecretService = query.FromSecretService(ss)
 	deps := Dependencies{FluxDeps: fdeps}
 	bucketLookupSvc := query.FromBucketService(bucketSvc)


### PR DESCRIPTION
The `DefaultDependencies` behaviour is for flux http requests failed silently after 100MB of data transfer, which seems wrong.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass