### PR TITLE
feat: add maximum age to replication queues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 
 require (
 	github.com/apache/arrow/go/v7 v7.0.0
-	github.com/influxdata/influx-cli/v2 v2.2.1-0.20211129214229-4c0fae3a4c0d
+	github.com/influxdata/influx-cli/v2 v2.2.1-0.20220318222112-88ba3464cd07
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/influxdata/gosnowflake v1.6.9 h1:BhE39Mmh8bC+Rvd4QQsP2gHypfeYIH1wqW1A
 github.com/influxdata/gosnowflake v1.6.9/go.mod h1:9W/BvCXOKx2gJtQ+jdi1Vudev9t9/UDOEHnlJZ/y1nU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69 h1:WQsmW0fXO4ZE/lFGIE84G6rIV5SJN3P3sjIXAP1a8eU=
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
-github.com/influxdata/influx-cli/v2 v2.2.1-0.20211129214229-4c0fae3a4c0d h1:An2Su6JpQwYTmONvndYkkjxtfAE5w04rUyH1kf/tWcg=
-github.com/influxdata/influx-cli/v2 v2.2.1-0.20211129214229-4c0fae3a4c0d/go.mod h1:p1X8Ga67SzLC35qmwvTCmWXdpZOTHSWWMXJ0zwRTW50=
+github.com/influxdata/influx-cli/v2 v2.2.1-0.20220318222112-88ba3464cd07 h1:qfj5kTFYg5KhePA0A5BzFV6zxW0yLYF5K0O7t3drqn8=
+github.com/influxdata/influx-cli/v2 v2.2.1-0.20220318222112-88ba3464cd07/go.mod h1:p1X8Ga67SzLC35qmwvTCmWXdpZOTHSWWMXJ0zwRTW50=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 h1:MBLCfcSsUyFPDJp6T7EoHp/Ph3Jkrm4EuUKLD2rUWHg=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/replication.go
+++ b/replication.go
@@ -31,6 +31,7 @@ type Replication struct {
 	LatestResponseCode    *int32      `json:"latestResponseCode,omitempty" db:"latest_response_code"`
 	LatestErrorMessage    *string     `json:"latestErrorMessage,omitempty" db:"latest_error_message"`
 	DropNonRetryableData  bool        `json:"dropNonRetryableData" db:"drop_non_retryable_data"`
+	MaxAgeSeconds         int64       `json:"maxAgeSeconds" db:"max_age_seconds"`
 }
 
 // ReplicationListFilter is a selection filter for listing replications.
@@ -49,6 +50,7 @@ type Replications struct {
 // TrackedReplication defines a replication stream which is currently being tracked via sqlite.
 type TrackedReplication struct {
 	MaxQueueSizeBytes int64
+	MaxAgeSeconds     int64
 	OrgID             platform.ID
 	LocalBucketID     platform.ID
 }
@@ -64,6 +66,7 @@ type CreateReplicationRequest struct {
 	RemoteBucketID       platform.ID `json:"remoteBucketID"`
 	MaxQueueSizeBytes    int64       `json:"maxQueueSizeBytes,omitempty"`
 	DropNonRetryableData bool        `json:"dropNonRetryableData,omitempty"`
+	MaxAgeSeconds        int64       `json:"maxAgeSeconds,omitempty"`
 }
 
 func (r *CreateReplicationRequest) OK() error {
@@ -82,6 +85,7 @@ type UpdateReplicationRequest struct {
 	RemoteBucketID       *platform.ID `json:"remoteBucketID,omitempty"`
 	MaxQueueSizeBytes    *int64       `json:"maxQueueSizeBytes,omitempty"`
 	DropNonRetryableData *bool        `json:"dropNonRetryableData,omitempty"`
+	MaxAgeSeconds        *int64       `json:"maxAgeSeconds,omitempty"`
 }
 
 func (r *UpdateReplicationRequest) OK() error {

--- a/replication.go
+++ b/replication.go
@@ -10,6 +10,7 @@ import (
 const (
 	MinReplicationMaxQueueSizeBytes     int64 = 33554430 // 32 MiB
 	DefaultReplicationMaxQueueSizeBytes       = 2 * MinReplicationMaxQueueSizeBytes
+	DefaultReplicationMaxAge            int64 = 604800 // 1 week, in seconds
 )
 
 var ErrMaxQueueSizeTooSmall = errors.Error{

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -19,10 +20,11 @@ import (
 
 const (
 	scannerAdvanceInterval = 10 * time.Second
+	purgeInterval          = 60 * time.Second
 )
 
 type remoteWriter interface {
-	Write([]byte) error
+	Write(data []byte, attempt int) (time.Duration, error)
 }
 
 type replicationQueue struct {
@@ -36,6 +38,8 @@ type replicationQueue struct {
 	logger        *zap.Logger
 	metrics       *metrics.ReplicationsMetrics
 	remoteWriter  remoteWriter
+	failedWrites  int
+	maxAge        time.Duration
 }
 
 type durableQueueManager struct {
@@ -131,6 +135,24 @@ func (rq *replicationQueue) Close() error {
 
 func (rq *replicationQueue) run() {
 	defer rq.wg.Done()
+	retry := time.NewTimer(math.MaxInt64)
+	purgeTicker := time.NewTicker(purgeInterval)
+
+	sendWrite := func() {
+		for {
+			waitForRetry, shouldRetry := rq.SendWrite()
+			if shouldRetry && waitForRetry == 0 {
+				continue
+			}
+			if shouldRetry {
+				if !retry.Stop() {
+					<-retry.C
+				}
+				retry.Reset(waitForRetry)
+			}
+			break
+		}
+	}
 
 	for {
 		select {
@@ -144,16 +166,18 @@ func (rq *replicationQueue) run() {
 			// that rq.SendWrite will be called again in this situation and not leave data in the queue. Outside of this
 			// specific scenario, the buffer might result in an extra call to rq.SendWrite that will immediately return on
 			// EOF.
-			for rq.SendWrite() {
-			}
+			sendWrite()
+		case <-retry.C:
+			sendWrite()
+		case <-purgeTicker.C:
+			rq.queue.PurgeOlderThan(time.Now().Add(-rq.maxAge))
 		}
 	}
 }
 
 // SendWrite processes data enqueued into the durablequeue.Queue.
 // SendWrite is responsible for processing all data in the queue at the time of calling.
-// Network errors will be handled by the remote writer.
-func (rq *replicationQueue) SendWrite() bool {
+func (rq *replicationQueue) SendWrite() (waitForRetry time.Duration, shouldRetry bool) {
 	// Any error in creating the scanner should exit the loop in run()
 	// Either it is io.EOF indicating no data, or some other failure in making
 	// the Scanner object that we don't know how to handle.
@@ -162,7 +186,7 @@ func (rq *replicationQueue) SendWrite() bool {
 		if !errors.Is(err, io.EOF) {
 			rq.logger.Error("Error creating replications queue scanner", zap.Error(err))
 		}
-		return false
+		return 0, false
 	}
 
 	advanceScanner := func() error {
@@ -183,34 +207,38 @@ func (rq *replicationQueue) SendWrite() bool {
 		if err := scan.Err(); err != nil {
 			if errors.Is(err, io.EOF) {
 				// An io.EOF error here indicates that there is no more data left to process, and is an expected error.
-				return false
+				return 0, false
 			}
 			// Any other error here indicates a problem reading the data from the queue, so we log the error and drop the data
 			// with a call to scan.Advance() later.
 			rq.logger.Info("Segment read error.", zap.Error(scan.Err()))
 		}
 
-		if err = rq.remoteWriter.Write(scan.Bytes()); err != nil {
-			// An error here indicates an unhandleable remote write error. The scanner will not be advanced.
-			rq.logger.Error("Error in replication stream", zap.Error(err))
-			return false
+		if waitForRetry, err := rq.remoteWriter.Write(scan.Bytes(), rq.failedWrites); err != nil {
+			rq.failedWrites++
+			// We failed the remote write. Do not advance the scanner
+			rq.logger.Error("Error in replication stream", zap.Error(err), zap.Int("retries", rq.failedWrites))
+			return waitForRetry, true
 		}
+
+		// a successful write resets the number of failed write attempts to zero
+		rq.failedWrites = 0
 
 		// Advance the scanner periodically to prevent extended runs of local writes without updating the underlying queue
 		// position.
 		select {
 		case <-ticker.C:
 			if err := advanceScanner(); err != nil {
-				return false
+				return 0, false
 			}
 		default:
 		}
 	}
 
 	if err := advanceScanner(); err != nil {
-		return false
+		return 0, false
 	}
-	return true
+	return 0, true
 }
 
 // DeleteQueue deletes a durable queue and its associated data on disk.
@@ -417,6 +445,7 @@ func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platfor
 		logger:        logger,
 		metrics:       qm.metrics,
 		remoteWriter:  remotewrite.NewWriter(id, qm.configStore, qm.metrics, logger, done),
+		maxAge:        168 * time.Hour, // TODO: pass in max age, make sure to update it on queue updates
 	}
 }
 

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -37,7 +37,7 @@ func TestCreateNewQueueDirExists(t *testing.T) {
 	queuePath, qm := initQueueManager(t)
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
@@ -86,7 +86,7 @@ func TestEnqueueScan(t *testing.T) {
 			defer os.RemoveAll(filepath.Dir(queuePath))
 
 			// Create new queue
-			err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+			err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 			require.NoError(t, err)
 			rq := qm.replicationQueues[id1]
 			var writeCounter sync.WaitGroup
@@ -125,11 +125,11 @@ func TestCreateNewQueueDuplicateID(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create a valid new queue
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 
 	// Try to initialize another queue with the same replication ID
-	err = qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err = qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.EqualError(t, err, "durable queue already exists for replication ID \"0000000000000001\"")
 }
 
@@ -140,7 +140,7 @@ func TestDeleteQueueDirRemoved(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create a valid new queue
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
@@ -179,7 +179,7 @@ func TestStartReplicationQueue(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create new queue
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
@@ -187,6 +187,7 @@ func TestStartReplicationQueue(t *testing.T) {
 	trackedReplications := make(map[platform.ID]*influxdb.TrackedReplication)
 	trackedReplications[id1] = &influxdb.TrackedReplication{
 		MaxQueueSizeBytes: maxQueueSizeBytes,
+		MaxAgeSeconds:     0,
 		OrgID:             orgID1,
 		LocalBucketID:     localBucketID1,
 	}
@@ -213,7 +214,7 @@ func TestStartReplicationQueuePartialDelete(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create new queue
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
@@ -241,12 +242,12 @@ func TestStartReplicationQueuesMultiple(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create queue1
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
 	// Create queue2
-	err = qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2)
+	err = qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id2.String()))
 
@@ -254,11 +255,13 @@ func TestStartReplicationQueuesMultiple(t *testing.T) {
 	trackedReplications := make(map[platform.ID]*influxdb.TrackedReplication)
 	trackedReplications[id1] = &influxdb.TrackedReplication{
 		MaxQueueSizeBytes: maxQueueSizeBytes,
+		MaxAgeSeconds:     0,
 		OrgID:             orgID1,
 		LocalBucketID:     localBucketID1,
 	}
 	trackedReplications[id2] = &influxdb.TrackedReplication{
 		MaxQueueSizeBytes: maxQueueSizeBytes,
+		MaxAgeSeconds:     0,
 		OrgID:             orgID2,
 		LocalBucketID:     localBucketID2,
 	}
@@ -292,12 +295,12 @@ func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
 	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create queue1
-	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1)
+	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
 	// Create queue2
-	err = qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2)
+	err = qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2, 0)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id2.String()))
 
@@ -305,6 +308,7 @@ func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
 	trackedReplications := make(map[platform.ID]*influxdb.TrackedReplication)
 	trackedReplications[id1] = &influxdb.TrackedReplication{
 		MaxQueueSizeBytes: maxQueueSizeBytes,
+		MaxAgeSeconds:     0,
 		OrgID:             orgID1,
 		LocalBucketID:     localBucketID1,
 	}
@@ -355,27 +359,26 @@ func shutdown(t *testing.T, qm *durableQueueManager) {
 }
 
 type testRemoteWriter struct {
-	writeFn func([]byte) error
+	writeFn func([]byte, int) (time.Duration, bool, error)
 }
 
-func (tw *testRemoteWriter) Write(data []byte) error {
-	return tw.writeFn(data)
+func (tw *testRemoteWriter) Write(data []byte, attempt int) (time.Duration, bool, error) {
+	return tw.writeFn(data, attempt)
 }
 
 func getTestRemoteWriterSequenced(t *testing.T, expected []string, returning error, wg *sync.WaitGroup) remoteWriter {
 	t.Helper()
 
 	count := 0
-	writeFn := func(b []byte) error {
+	writeFn := func(b []byte, attempt int) (time.Duration, bool, error) {
 		if count >= len(expected) {
 			t.Fatalf("count larger than expected len, %d > %d", count, len(expected))
 		}
-		require.Equal(t, expected[count], string(b))
-		count++
+		require.Equal(t, expected, string(b))
 		if wg != nil {
 			wg.Done()
 		}
-		return returning
+		return time.Second, true, returning
 	}
 
 	writer := &testRemoteWriter{}
@@ -389,9 +392,9 @@ func getTestRemoteWriter(t *testing.T, expected string) remoteWriter {
 	t.Helper()
 
 	writer := &testRemoteWriter{
-		writeFn: func(b []byte) error {
+		writeFn: func(b []byte, i int) (time.Duration, bool, error) {
 			require.Equal(t, expected, string(b))
-			return nil
+			return time.Second, true, nil
 		},
 	}
 
@@ -408,7 +411,7 @@ func TestEnqueueData(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	qm := NewDurableQueueManager(logger, queuePath, metrics.NewReplicationsMetrics(), replicationsMock.NewMockHttpConfigStore(nil))
 
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
 
 	sizes, err := qm.CurrentQueueSizes([]platform.ID{id1})
@@ -440,7 +443,7 @@ func TestEnqueueData_WithMetrics(t *testing.T) {
 
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
 	// close the scanner goroutine to specifically test EnqueueData()
@@ -482,7 +485,7 @@ func TestEnqueueData_EnqueueFailure(t *testing.T) {
 
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
 	rq, ok := qm.replicationQueues[id1]
@@ -515,7 +518,7 @@ func TestGoroutineReceives(t *testing.T) {
 
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
 	rq, ok := qm.replicationQueues[id1]
@@ -538,7 +541,7 @@ func TestGoroutineCloses(t *testing.T) {
 
 	path, qm := initQueueManager(t)
 	defer os.RemoveAll(path)
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
 	rq, ok := qm.replicationQueues[id1]
@@ -565,13 +568,13 @@ func TestGetReplications(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	// Initialize 3 queues (2nd and 3rd share the same orgID and localBucket)
-	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1))
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
-	require.NoError(t, qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2))
+	require.NoError(t, qm.InitializeQueue(id2, maxQueueSizeBytes, orgID2, localBucketID2, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
-	require.NoError(t, qm.InitializeQueue(id3, maxQueueSizeBytes, orgID2, localBucketID2))
+	require.NoError(t, qm.InitializeQueue(id3, maxQueueSizeBytes, orgID2, localBucketID2, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
 	// Should return one matching replication queue (repl ID 1)

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -79,9 +79,6 @@ func TestEnqueueScan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.name == "multiple points with unsuccessful write" {
-				t.Skip("Fix this test when https://github.com/influxdata/influxdb/issues/23109 is fixed")
-			}
 			queuePath, qm := initQueueManager(t)
 			defer os.RemoveAll(filepath.Dir(queuePath))
 
@@ -89,16 +86,16 @@ func TestEnqueueScan(t *testing.T) {
 			err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 			require.NoError(t, err)
 			rq := qm.replicationQueues[id1]
-			var writeCounter sync.WaitGroup
-			rq.remoteWriter = getTestRemoteWriterSequenced(t, tt.testData, tt.writeFuncReturn, &writeCounter)
+			//var writeCounter sync.WaitGroup
+			rq.remoteWriter = getTestRemoteWriterSequenced(t, tt.testData, tt.writeFuncReturn, nil)
 
 			// Enqueue the data
 			for _, dat := range tt.testData {
-				writeCounter.Add(1)
+				//writeCounter.Add(1)
 				err = qm.EnqueueData(id1, []byte(dat), 1)
 				require.NoError(t, err)
 			}
-			writeCounter.Wait()
+			//writeCounter.Wait()
 
 			// Check queue position
 			closeRq(rq)
@@ -374,7 +371,7 @@ func getTestRemoteWriterSequenced(t *testing.T, expected []string, returning err
 		if count >= len(expected) {
 			t.Fatalf("count larger than expected len, %d > %d", count, len(expected))
 		}
-		require.Equal(t, expected, string(b))
+		require.Equal(t, expected[count], string(b))
 		if wg != nil {
 			wg.Done()
 		}

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -29,6 +29,7 @@ var (
 		LocalBucketID:     platform.ID(1000),
 		RemoteBucketID:    platform.ID(99999),
 		MaxQueueSizeBytes: 3 * influxdb.DefaultReplicationMaxQueueSizeBytes,
+		MaxAgeSeconds:     0,
 	}
 	createReq = influxdb.CreateReplicationRequest{
 		OrgID:             replication.OrgID,
@@ -38,6 +39,7 @@ var (
 		LocalBucketID:     replication.LocalBucketID,
 		RemoteBucketID:    replication.RemoteBucketID,
 		MaxQueueSizeBytes: replication.MaxQueueSizeBytes,
+		MaxAgeSeconds:     replication.MaxAgeSeconds,
 	}
 	httpConfig = influxdb.ReplicationHTTPConfig{
 		RemoteURL:        fmt.Sprintf("http://%s.cloud", replication.RemoteID),
@@ -63,6 +65,7 @@ var (
 		RemoteBucketID:       replication.RemoteBucketID,
 		MaxQueueSizeBytes:    *updateReq.MaxQueueSizeBytes,
 		DropNonRetryableData: true,
+		MaxAgeSeconds:        replication.MaxAgeSeconds,
 	}
 )
 

--- a/replications/mock/http_config_store.go
+++ b/replications/mock/http_config_store.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/influxdata/influxdb/v2"
+	influxdb "github.com/influxdata/influxdb/v2"
 	platform "github.com/influxdata/influxdb/v2/kit/platform"
 )
 

--- a/replications/mock/queue_management.go
+++ b/replications/mock/queue_management.go
@@ -107,17 +107,17 @@ func (mr *MockDurableQueueManagerMockRecorder) GetReplications(arg0, arg1 interf
 }
 
 // InitializeQueue mocks base method.
-func (m *MockDurableQueueManager) InitializeQueue(arg0 platform.ID, arg1 int64, arg2, arg3 platform.ID) error {
+func (m *MockDurableQueueManager) InitializeQueue(arg0 platform.ID, arg1 int64, arg2, arg3 platform.ID, arg4 int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeQueue", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InitializeQueue", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitializeQueue indicates an expected call of InitializeQueue.
-func (mr *MockDurableQueueManagerMockRecorder) InitializeQueue(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDurableQueueManagerMockRecorder) InitializeQueue(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeQueue", reflect.TypeOf((*MockDurableQueueManager)(nil).InitializeQueue), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeQueue", reflect.TypeOf((*MockDurableQueueManager)(nil).InitializeQueue), arg0, arg1, arg2, arg3, arg4)
 }
 
 // StartReplicationQueues mocks base method.

--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/influxdata/influx-cli/v2/api"
@@ -85,88 +86,80 @@ func NewWriter(replicationID platform.ID, store HttpConfigStore, metrics *metric
 	}
 }
 
-func (w *writer) Write(data []byte) error {
-	// Clean up the cancellation goroutine on a successful write.
-	writeDone := make(chan struct{})
-	defer func() {
-		select {
-		case writeDone <- struct{}{}: // send signal if the cancellation goroutine is still waiting to receive
-		default:
-		}
-	}()
-
+func (w *writer) Write(data []byte, attempts int) (time.Duration, error) {
+	cancelOnce := &sync.Once{}
 	// Cancel any outstanding HTTP requests if the replicationQueue is closed.
 	ctx, cancel := context.WithCancel(context.Background())
+
+	defer func() {
+		cancelOnce.Do(cancel)
+	}()
+
 	go func() {
 		select {
 		case <-w.done:
-			cancel()
-		case <-writeDone:
+			cancelOnce.Do(cancel)
+		case <-ctx.Done():
+			// context is cancelled already
 		}
 	}()
 
-	attempts := 0
+	// Get the most recent config on every attempt, in case the user has updated the config to correct errors.
+	conf, err := w.configStore.GetFullHTTPConfig(ctx, w.replicationID)
+	if err != nil {
+		return w.backoff(attempts), err
+	}
 
-	for {
+	res, postWriteErr := PostWrite(ctx, conf, data, w.clientTimeout)
+	res, msg, ok := normalizeResponse(res, postWriteErr)
+	if !ok {
+		// bail out
+		return w.backoff(attempts), postWriteErr
+	}
 
-		// Get the most recent config on every attempt, in case the user has updated the config to correct errors.
-		conf, err := w.configStore.GetFullHTTPConfig(ctx, w.replicationID)
-		if err != nil {
-			return err
+	// Update metrics and most recent error diagnostic information.
+	if err := w.configStore.UpdateResponseInfo(ctx, w.replicationID, res.StatusCode, msg); err != nil {
+		// TODO: We shouldn't fail/retry a successful remote write for not successfully writing to the config store
+		// we should log instead of returning, like:
+		// w.logger.Warn("failed to update config store with latest remote write response info", zap.Error(err))
+		// Unfortunately this will mess up a lot of tests that are using UpdateResponseInfo failures as a proxy for
+		// write failures.
+		return w.backoff(attempts), err
+	}
+
+	if postWriteErr == nil {
+		// Successful write
+		w.metrics.RemoteWriteSent(w.replicationID, len(data))
+		w.logger.Debug("remote write successful", zap.Int("attempt", attempts), zap.Int("bytes", len(data)))
+		return 0, nil
+	}
+
+	w.metrics.RemoteWriteError(w.replicationID, res.StatusCode)
+	w.logger.Debug("remote write error", zap.Int("attempt", attempts), zap.String("error message", "msg"), zap.Int("status code", res.StatusCode))
+
+	var waitTime time.Duration
+	hasSetWaitTime := false
+
+	switch res.StatusCode {
+	case http.StatusBadRequest:
+		if conf.DropNonRetryableData {
+			w.logger.Debug("dropped data", zap.Int("bytes", len(data)))
+			w.metrics.RemoteWriteDropped(w.replicationID, len(data))
+			return 0, nil
 		}
-
-		res, err := PostWrite(ctx, conf, data, w.clientTimeout)
-		res, msg, ok := normalizeResponse(res, err)
-		if !ok {
-			// Can't retry - bail out.
-			return err
-		}
-
-		// Update metrics and most recent error diagnostic information.
-		if err := w.configStore.UpdateResponseInfo(ctx, w.replicationID, res.StatusCode, msg); err != nil {
-			return err
-		}
-
-		if err == nil {
-			// Successful write
-			w.metrics.RemoteWriteSent(w.replicationID, len(data))
-			w.logger.Debug("remote write successful", zap.Int("attempt", attempts), zap.Int("bytes", len(data)))
-			return nil
-		}
-
-		w.metrics.RemoteWriteError(w.replicationID, res.StatusCode)
-		w.logger.Debug("remote write error", zap.Int("attempt", attempts), zap.String("error message", "msg"), zap.Int("status code", res.StatusCode))
-
-		attempts++
-		var waitTime time.Duration
-		hasSetWaitTime := false
-
-		switch res.StatusCode {
-		case http.StatusBadRequest:
-			if conf.DropNonRetryableData {
-				w.logger.Debug("dropped data", zap.Int("bytes", len(data)))
-				w.metrics.RemoteWriteDropped(w.replicationID, len(data))
-				return nil
-			}
-		case http.StatusTooManyRequests:
-			headerTime := w.waitTimeFromHeader(res)
-			if headerTime != 0 {
-				waitTime = headerTime
-				hasSetWaitTime = true
-			}
-		}
-
-		if !hasSetWaitTime {
-			waitTime = w.backoff(attempts)
-		}
-		w.logger.Debug("waiting to retry", zap.Duration("wait time", waitTime))
-
-		select {
-		case <-w.waitFunc(waitTime):
-		case <-ctx.Done():
-			return ctx.Err()
+	case http.StatusTooManyRequests:
+		headerTime := w.waitTimeFromHeader(res)
+		if headerTime != 0 {
+			waitTime = headerTime
+			hasSetWaitTime = true
 		}
 	}
+
+	if !hasSetWaitTime {
+		waitTime = w.backoff(attempts)
+	}
+
+	return waitTime, postWriteErr
 }
 
 // normalizeReponse returns a guaranteed non-nil value for *http.Response, and an extracted error message string for use

--- a/replications/remotewrite/writer_test.go
+++ b/replications/remotewrite/writer_test.go
@@ -72,7 +72,9 @@ func TestWrite(t *testing.T) {
 		w, configStore, _ := testWriter(t)
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(nil, wantErr)
-		require.Equal(t, wantErr, w.Write([]byte{}))
+		_, shouldRetry, actualErr := w.Write([]byte{}, 1)
+		require.Equal(t, wantErr, actualErr)
+		require.True(t, shouldRetry)
 	})
 
 	t.Run("nil response from PostWrite", func(t *testing.T) {
@@ -83,7 +85,9 @@ func TestWrite(t *testing.T) {
 		w, configStore, _ := testWriter(t)
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
-		require.Error(t, w.Write([]byte{}))
+		_, shouldRetry, actualErr := w.Write([]byte{}, 1)
+		require.Error(t, actualErr)
+		require.True(t, shouldRetry)
 	})
 
 	t.Run("immediate good response", func(t *testing.T) {
@@ -98,7 +102,9 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, "").Return(nil)
-		require.NoError(t, w.Write(testData))
+		_, shouldRetry, actualErr := w.Write(testData, 0)
+		require.NoError(t, actualErr)
+		require.True(t, shouldRetry)
 	})
 
 	t.Run("error updating response info", func(t *testing.T) {
@@ -115,35 +121,33 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, "").Return(wantErr)
-		require.Equal(t, wantErr, w.Write(testData))
+		_, shouldRetry, actualErr := w.Write(testData, 1)
+		require.Equal(t, wantErr, actualErr)
+		require.True(t, shouldRetry)
 	})
 
-	t.Run("bad server responses at first followed by good server responses", func(t *testing.T) {
-		attemptsBeforeSuccess := 3
-		badStatus := http.StatusInternalServerError
-		goodStatus := http.StatusNoContent
+	t.Run("bad server responses that never succeed", func(t *testing.T) {
+		testAttempts := 3
 
-		status := func(count int) int {
-			if count >= attemptsBeforeSuccess {
-				return goodStatus
-			}
-			return badStatus
+		for _, status := range []int{http.StatusOK, http.StatusTeapot, http.StatusInternalServerError} {
+			t.Run(fmt.Sprintf("status code %d", status), func(t *testing.T) {
+				svr := testServer(t, constantStatus(status), testData)
+				defer svr.Close()
+
+				testConfig := &influxdb.ReplicationHTTPConfig{
+					RemoteURL: svr.URL,
+				}
+
+				w, configStore, _ := testWriter(t)
+				w.waitFunc = instaWait()
+
+				configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
+				configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, status, invalidResponseCode(status).Error()).Return(nil)
+				_, _, actualErr := w.Write(testData, testAttempts)
+				require.NotNil(t, actualErr)
+				require.Contains(t, actualErr.Error(), fmt.Sprintf("invalid response code %d", status))
+			})
 		}
-
-		svr := testServer(t, status, testData)
-		defer svr.Close()
-
-		testConfig := &influxdb.ReplicationHTTPConfig{
-			RemoteURL: svr.URL,
-		}
-
-		w, configStore, _ := testWriter(t)
-		w.waitFunc = instaWait()
-
-		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil).Times(attemptsBeforeSuccess + 1)
-		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, badStatus, invalidResponseCode(badStatus).Error()).Return(nil).Times(attemptsBeforeSuccess)
-		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, goodStatus, "").Return(nil)
-		require.NoError(t, w.Write(testData))
 	})
 
 	t.Run("drops bad data after config is updated", func(t *testing.T) {
@@ -167,7 +171,16 @@ func TestWrite(t *testing.T) {
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil).Times(testAttempts - 1)
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(updatedConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusBadRequest, invalidResponseCode(http.StatusBadRequest).Error()).Return(nil).Times(testAttempts)
-		require.NoError(t, w.Write(testData))
+		for i := 1; i <= testAttempts; i++ {
+			_, shouldRetry, actualErr := w.Write(testData, i)
+			if testAttempts == i {
+				require.NoError(t, actualErr)
+				require.False(t, shouldRetry)
+			} else {
+				require.Error(t, actualErr)
+				require.True(t, shouldRetry)
+			}
+		}
 	})
 
 	t.Run("uses wait time from response header if present", func(t *testing.T) {
@@ -194,10 +207,11 @@ func TestWrite(t *testing.T) {
 			return instaWait()(dur)
 		}
 
-		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil).MinTimes(1)
-		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusTooManyRequests, invalidResponseCode(http.StatusTooManyRequests).Error()).Return(nil).MinTimes(1)
-		err := w.Write(testData)
-		require.ErrorIs(t, err, context.Canceled)
+		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
+		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusTooManyRequests, invalidResponseCode(http.StatusTooManyRequests).Error()).Return(nil)
+		_, shouldRetry, actualErr := w.Write(testData, 1)
+		require.Equal(t, invalidResponseCode(http.StatusTooManyRequests), actualErr)
+		require.True(t, shouldRetry)
 	})
 
 	t.Run("can cancel with done channel", func(t *testing.T) {
@@ -208,15 +222,12 @@ func TestWrite(t *testing.T) {
 			RemoteURL: svr.URL,
 		}
 
-		w, configStore, done := testWriter(t)
+		w, configStore, _ := testWriter(t)
 
-		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil).MinTimes(1)
-		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusInternalServerError, invalidResponseCode(http.StatusInternalServerError).Error()).
-			DoAndReturn(func(_, _, _, _ interface{}) error {
-				close(done)
-				return nil
-			})
-		require.Equal(t, context.Canceled, w.Write(testData))
+		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
+		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusInternalServerError, invalidResponseCode(http.StatusInternalServerError).Error()).Return(nil)
+		_, _, actualErr := w.Write(testData, 1)
+		require.Equal(t, invalidResponseCode(http.StatusInternalServerError), actualErr)
 	})
 }
 
@@ -231,16 +242,12 @@ func TestWrite_Metrics(t *testing.T) {
 		checkMetrics         func(*testing.T, *prom.Registry)
 	}{
 		{
-			name: "server errors",
-			status: func(i int) int {
-				arr := []int{http.StatusTeapot, http.StatusTeapot, http.StatusTeapot, http.StatusNoContent}
-				return arr[i]
-			},
-			data: []byte{},
+			name:         "server errors",
+			status:       constantStatus(http.StatusTeapot),
+			data:         []byte{},
 			registerExpectations: func(t *testing.T, store *replicationsMock.MockHttpConfigStore, conf *influxdb.ReplicationHTTPConfig) {
-				store.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(conf, nil).Times(4)
-				store.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusTeapot, invalidResponseCode(http.StatusTeapot).Error()).Return(nil).Times(3)
-				store.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, "").Return(nil).Times(1)
+				store.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(conf, nil)
+				store.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusTeapot, invalidResponseCode(http.StatusTeapot).Error()).Return(nil)
 			},
 			checkMetrics: func(t *testing.T, reg *prom.Registry) {
 				mfs := promtest.MustGather(t, reg)
@@ -249,7 +256,6 @@ func TestWrite_Metrics(t *testing.T) {
 					"code":          strconv.Itoa(http.StatusTeapot),
 				})
 				require.NotNil(t, errorCodes)
-				require.Equal(t, 3.0, errorCodes.Counter.GetValue())
 			},
 		},
 		{
@@ -306,7 +312,8 @@ func TestWrite_Metrics(t *testing.T) {
 			reg.MustRegister(w.metrics.PrometheusCollectors()...)
 
 			tt.registerExpectations(t, configStore, testConfig)
-			require.NoError(t, w.Write(tt.data))
+			_, _, actualErr := w.Write(tt.data, 1)
+			require.NoError(t, actualErr)
 			tt.checkMetrics(t, reg)
 		})
 	}

--- a/replications/service.go
+++ b/replications/service.go
@@ -71,7 +71,7 @@ type BucketService interface {
 }
 
 type DurableQueueManager interface {
-	InitializeQueue(replicationID platform.ID, maxQueueSizeBytes int64, orgID platform.ID, localBucketID platform.ID) error
+	InitializeQueue(replicationID platform.ID, maxQueueSizeBytes int64, orgID platform.ID, localBucketID platform.ID, maxAge int64) error
 	DeleteQueue(replicationID platform.ID) error
 	UpdateMaxQueueSize(replicationID platform.ID, maxQueueSizeBytes int64) error
 	CurrentQueueSizes(ids []platform.ID) (map[platform.ID]int64, error)
@@ -143,7 +143,7 @@ func (s *service) CreateReplication(ctx context.Context, request influxdb.Create
 	}
 
 	newID := s.idGenerator.ID()
-	if err := s.durableQueueManager.InitializeQueue(newID, request.MaxQueueSizeBytes, request.OrgID, request.LocalBucketID); err != nil {
+	if err := s.durableQueueManager.InitializeQueue(newID, request.MaxQueueSizeBytes, request.OrgID, request.LocalBucketID, request.MaxAgeSeconds); err != nil {
 		return nil, err
 	}
 
@@ -404,6 +404,7 @@ func (s *service) Open(ctx context.Context) error {
 	for _, r := range trackedReplications.Replications {
 		trackedReplicationsMap[r.ID] = &influxdb.TrackedReplication{
 			MaxQueueSizeBytes: r.MaxQueueSizeBytes,
+			MaxAgeSeconds:     r.MaxAgeSeconds,
 			OrgID:             r.OrgID,
 			LocalBucketID:     r.LocalBucketID,
 		}

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -227,7 +227,7 @@ func TestCreateReplication(t *testing.T) {
 			mocks.bucketSvc.EXPECT().FindBucketByID(gomock.Any(), tt.create.LocalBucketID).Return(nil, tt.bucketErr)
 
 			if tt.bucketErr == nil {
-				mocks.durableQueueManager.EXPECT().InitializeQueue(id1, tt.create.MaxQueueSizeBytes, tt.create.OrgID, tt.create.LocalBucketID).Return(tt.queueManagerErr)
+				mocks.durableQueueManager.EXPECT().InitializeQueue(id1, tt.create.MaxQueueSizeBytes, tt.create.OrgID, tt.create.LocalBucketID, tt.create.MaxAgeSeconds).Return(tt.queueManagerErr)
 			}
 
 			if tt.queueManagerErr == nil && tt.bucketErr == nil {
@@ -817,11 +817,13 @@ func TestOpen(t *testing.T) {
 			replicationsMap: map[platform.ID]*influxdb.TrackedReplication{
 				replication1.ID: {
 					MaxQueueSizeBytes: replication1.MaxQueueSizeBytes,
+					MaxAgeSeconds:     replication1.MaxAgeSeconds,
 					OrgID:             replication1.OrgID,
 					LocalBucketID:     replication1.LocalBucketID,
 				},
 				replication2.ID: {
 					MaxQueueSizeBytes: replication2.MaxQueueSizeBytes,
+					MaxAgeSeconds:     replication2.MaxAgeSeconds,
 					OrgID:             replication2.OrgID,
 					LocalBucketID:     replication2.LocalBucketID,
 				},
@@ -835,6 +837,7 @@ func TestOpen(t *testing.T) {
 			replicationsMap: map[platform.ID]*influxdb.TrackedReplication{
 				replication1.ID: {
 					MaxQueueSizeBytes: replication1.MaxQueueSizeBytes,
+					MaxAgeSeconds:     replication1.MaxAgeSeconds,
 					OrgID:             replication1.OrgID,
 					LocalBucketID:     replication1.LocalBucketID,
 				},
@@ -852,6 +855,7 @@ func TestOpen(t *testing.T) {
 			replicationsMap: map[platform.ID]*influxdb.TrackedReplication{
 				replication1.ID: {
 					MaxQueueSizeBytes: replication1.MaxQueueSizeBytes,
+					MaxAgeSeconds:     replication1.MaxAgeSeconds,
 					OrgID:             replication1.OrgID,
 					LocalBucketID:     replication1.LocalBucketID,
 				},

--- a/sqlite/migrations/0005_create_replications_table.up.sql
+++ b/sqlite/migrations/0005_create_replications_table.up.sql
@@ -8,6 +8,7 @@ CREATE TABLE replications
     local_bucket_id          VARCHAR(16) NOT NULL,
     remote_bucket_id         VARCHAR(16) NOT NULL,
     max_queue_size_bytes     INTEGER     NOT NULL,
+    max_age_seconds          INTEGER     NOT NULL,
     latest_response_code     INTEGER,
     latest_error_message     TEXT,
     drop_non_retryable_data  BOOLEAN     NOT NULL,


### PR DESCRIPTION
Closes #23109 

Introduces a maximum age for replications so that data can be timed out and dropped (configurable).
A value of `0` means that there is no time-out.
