### PR TITLE
feat: add --hardening-enabled option to limit flux/pkger HTTP requests

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -187,6 +187,8 @@ type InfluxdOpts struct {
 	StorageConfig storage.Config
 
 	Viper *viper.Viper
+
+	HardeningEnabled bool
 }
 
 // NewOpts constructs options with default values.
@@ -237,6 +239,8 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 
 		Testing:                 false,
 		TestingAlwaysAllowSetup: false,
+
+		HardeningEnabled: false,
 	}
 }
 
@@ -626,6 +630,24 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "ui-disabled",
 			Default: o.UIDisabled,
 			Desc:    "Disable the InfluxDB UI",
+		},
+
+		// hardening options
+		// --hardening-enabled is meant to enable all hardending
+		// options in one go. Today it enables the IP validator for
+		// flux and pkger templates HTTP requests. In the future,
+		// --hardening-enabled might be used to enable other security
+		// features, at which point we can add per-feature flags so
+		// that users can either opt into all features
+		// (--hardening-enabled) or to precisely the features they
+		// require. Since today there is but one feature, there is no
+		// need to introduce --hardening-ip-validation-enabled (or
+		// similar).
+		{
+			DestP:   &o.HardeningEnabled,
+			Flag:    "hardening-enabled",
+			Default: o.HardeningEnabled,
+			Desc:    "enable hardening options (disallow private IPs within flux and templates HTTP requests)",
 		},
 	}
 }

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/authorization"
 	icontext "github.com/influxdata/influxdb/v2/context"
@@ -208,7 +209,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	storageStore := storage2.NewStore(engine.TSDBStore(), engine.MetaClient())
 	readsReader := storageflux.NewReader(storageStore)
 
-	deps, err := stdlib.NewDependencies(readsReader, engine, bucketSvc, orgSvc, nil, nil)
+	deps, err := stdlib.NewDependencies(readsReader, engine, bucketSvc, orgSvc, nil, nil, stdlib.WithURLValidator(url.PassValidator{}))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Flux HTTP and template fetching requests do not perform IP address checks for local addresses. This behavior on the one hand allows SSRF (Server Side Request Forgery) attacks via authenticated requests but on the other hand is useful for scenarios that have legitimate requirements to fetch from private addresses (eg, hosting templates internally or performing flux queries to local resources during development.

To not break existing installations, the default behavior will remain the same but a new `--hardening-enabled` option is added to influxd turn on IP address verification and limit both flux and template fetching HTTP requests to non-private addresses. We plan to enable new security features that aren't suitable for the default install with this option. Put another way, this new option is intended to be used to make it easy to turn on all security options when running in production environments. The 'Manage security and authorization' section of the docs will also be updated for this option.

Specifically for flux, when `--hardening-enabled` is specified, we now pass in `PrivateIPValidator{}` to the flux dependency configuration. The flux url validator will then tap into the `http.Client` 'Control' mechanism to validate the IP address since it is called after DNS lookup but before the connection starts.

For pkger (template fetching), when `--hardening-enabled` is specified, the template parser's HTTP client will be configured to also use `PrivateIPValidator{}`. Note that `/api/v2/stacks POST` ('init', aka create) and PATCH ('update') only store the new url to be applied later with `/api/v2/templates/apply`. While it is possible to have `InitStack()` and `UpdateStack()` mimic `net.DialContext()` to setup a go routine to perform a DNS lookup and then loop through the returned addresses to verify none are for a private IP before storing the url, this would add considerable complexity to the stacks implementation. Since the stack's urls are fetched when it is applied and the IP address is verified as part of apply (see above), for now we'll keep this simple and not validate the IPs of the stack's urls during init or update.

Lastly, update `pkger/http_server_template_test.go`'s `Templates()` test for disabled jsonnet to also check the contents of the 422 error (since the flux validator also returns a 422 with different message). Also, fix the URL in one of these tests to use a valid path.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass (verified: `make test` (this is `test-go`, `make test-flux`, `make test-tls`, `make test-integration`)
- [x] Documentation updated or issue created - https://github.com/influxdata/docs-v2/pull/3867
