### PR TITLE
chore: upgrade to go1.17.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     docker:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile
       # in the edge repo, then update the version here to match.
-      - image: quay.io/influxdb/cross-builder:go1.17.2-b0fe7d5303a9c02b07141d4f7d209ec1bd5e06e0
+      - image: quay.io/influxdb/cross-builder:go1.17.8-4dd0d223592ec7d57f20cf132c3bc9de3f93570a
     resource_class: large
   linux-amd64:
     machine:


### PR DESCRIPTION
Upgrades to go1.17.8 to address several [minor security issues](https://go.dev/doc/devel/release#go1.17.minor) within Go and its standard library
