### PR TITLE
fix `delete series in shard not working`

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -573,7 +573,7 @@ func (p *Partition) MeasurementSeriesIDIterator(name []byte) (tsdb.SeriesIDItera
 	if err != nil {
 		return nil, err
 	}
-	return newFileSetSeriesIDIterator(fs, fs.MeasurementSeriesIDIterator(name)), nil
+	return newFilterDeletedSeriesIDIterator(p, newFileSetSeriesIDIterator(fs, fs.MeasurementSeriesIDIterator(name))), nil
 }
 
 // DropMeasurement deletes a measurement from the index. DropMeasurement does
@@ -798,7 +798,7 @@ func (p *Partition) TagKeySeriesIDIterator(name, key []byte) (tsdb.SeriesIDItera
 		fs.Release()
 		return nil, nil
 	}
-	return newFileSetSeriesIDIterator(fs, itr), nil
+	return newFilterDeletedSeriesIDIterator(p, newFileSetSeriesIDIterator(fs, itr)), nil
 }
 
 // TagValueSeriesIDIterator returns a series iterator for a single key value.
@@ -816,7 +816,7 @@ func (p *Partition) TagValueSeriesIDIterator(name, key, value []byte) (tsdb.Seri
 		fs.Release()
 		return nil, nil
 	}
-	return newFileSetSeriesIDIterator(fs, itr), nil
+	return newFilterDeletedSeriesIDIterator(p, newFileSetSeriesIDIterator(fs, itr)), nil
 }
 
 // MeasurementTagKeysByExpr extracts the tag keys wanted by the expression.
@@ -1448,4 +1448,38 @@ func IsPartitionDir(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+type filterDeletedSeriesIDIterator struct {
+	itr tsdb.SeriesIDIterator
+	p *Partition
+}
+
+func newFilterDeletedSeriesIDIterator(p *Partition, itr tsdb.SeriesIDIterator) tsdb.SeriesIDIterator {
+	if itr == nil {
+		return nil
+	}
+
+	return &filterDeletedSeriesIDIterator{
+		itr: itr,
+		p:   p,
+	}
+}
+
+func (itr *filterDeletedSeriesIDIterator) Next() (tsdb.SeriesIDElem, error) {
+	for {
+		e, err := itr.itr.Next()
+		if err != nil {
+			return tsdb.SeriesIDElem{}, err
+		} else if e.SeriesID == 0 {
+			return tsdb.SeriesIDElem{}, nil
+		} else if !itr.p.seriesIDSet.ContainsNoLock(e.SeriesID) {
+			continue
+		}
+		return e, nil
+	}
+}
+
+func (itr *filterDeletedSeriesIDIterator) Close() error {
+	return itr.itr.Close()
 }

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1452,7 +1452,7 @@ func IsPartitionDir(path string) (bool, error) {
 
 type filterDeletedSeriesIDIterator struct {
 	itr tsdb.SeriesIDIterator
-	p *Partition
+	p   *Partition
 }
 
 func newFilterDeletedSeriesIDIterator(p *Partition, itr tsdb.SeriesIDIterator) tsdb.SeriesIDIterator {


### PR DESCRIPTION
I have a series cross two shards. If I delete the series in one shard, the points in this shard is deleted, but I still see the series using `show series from xxx where time = xxx`. Is this a bug or compromise? If it is a bug, then we can discuss the solution. Also forgive me to leave the following items undone because of some troubles of compiling.😀

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
