### PR TITLE
fix: return underlying error creating a subscription

### DIFF
--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -282,11 +282,11 @@ func (s *Service) createSubscription(se subEntry, mode string, destinations []st
 	for _, dest := range destinations {
 		u, err := url.Parse(dest)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse destination: %s", dest)
+			return nil, fmt.Errorf("failed to parse destination %q: %w", dest, err)
 		}
 		w, err := s.NewPointsWriter(*u)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create writer for destination: %s", dest)
+			return nil, fmt.Errorf("failed to create writer for destination %q: %w", dest, err)
 		}
 		writers = append(writers, w)
 		stats = append(stats, writerStats{dest: dest})


### PR DESCRIPTION
When creating a subscription, return the wrapped error
on failure

closes https://github.com/influxdata/influxdb/issues/23216

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass