### PR TITLE
fix(models): reset provided slice correctly

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -2119,7 +2119,7 @@ func (a Tags) KeyValues(v [][]byte) [][]byte {
 	if cap(v) < l {
 		v = make([][]byte, 0, l)
 	} else {
-		v = v[:l]
+		v = v[:0]
 	}
 	for i := range a {
 		v = append(v, a[i].Key, a[i].Value)

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2/models"
 )
 
@@ -2425,6 +2426,27 @@ func TestParseName(t *testing.T) {
 				t.Errorf("%s produced measurement %s but expected %s", testCase.input, string(name), testCase.expectedName)
 			}
 		})
+	}
+}
+
+func TestTags_KeyValues(t *testing.T) {
+	tags := models.NewTags(map[string]string{
+		"tag0": "v0",
+		"tag1": "v1",
+		"tag2": "v2",
+	})
+
+	got := tags.KeyValues(nil)
+	exp := [][]byte{[]byte("tag0"), []byte("v0"), []byte("tag1"), []byte("v1"), []byte("tag2"), []byte("v2")}
+	if !cmp.Equal(got, exp) {
+		t.Errorf("unexpected, -got/+exp\n%s", cmp.Diff(got, exp))
+	}
+
+	v := make([][]byte, 0, 10)
+	v = tags.KeyValues(v)
+	got2 := tags.KeyValues(v)
+	if !cmp.Equal(got2, exp) {
+		t.Errorf("unexpected, -got/+exp\n%s", cmp.Diff(got2, exp))
 	}
 }
 


### PR DESCRIPTION
A preallocated slice needs to be cleared to be used with append,
otherwise the existing elements will be seen in the result and this does
not appear to be the intention. The bug doesn't seem to have caused
issues as no callsites use a preallocated slice.

Closes #

Describe your proposed changes here.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
