### PR TITLE
fix: FileStore WalkKeys defer bug

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -395,8 +395,12 @@ func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) e
 	// Ensure files are not unmapped while we're iterating over them.
 	for _, r := range f.files {
 		r.Ref()
-		defer r.Unref()
 	}
+	defer func() {
+		for _, r := range f.files {
+			r.Unref()
+		}
+	}()
 
 	ki := newMergeKeyIterator(f.files, seek)
 	f.mu.RUnlock()


### PR DESCRIPTION
Closes #

fix: FileStore WalkKeys defer bug, it possible resource leak, 'defer' is called in the 'for' loop

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
