### PR TITLE
fix: pin UI to OSS-2.1.2 so tokens can be accessed

### DIFF
--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -18,29 +18,18 @@ declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
 declare -r STATIC_DIR="$ROOT_DIR/static"
 
-# Download the SHA256 checksum attached to the release. To verify the integrity
-# of the download, this checksum will be used to check the download tar file
-# containing the built UI assets.
-curl -Ls https://github.com/influxdata/ui/releases/download/OSS-Master/sha256.txt --output sha256.txt
+# This must be updated depending on the actual sha256 checksum of the tar file
+# attached to the release.
+EXPECTED_UI_CHECKSUM=7d78d284d25f28dfd940d407a17f7f3aee1706b5dabc237eadc3bef0031ce548
 
 # Download the tar file containing the built UI assets.
-curl -L https://github.com/influxdata/ui/releases/download/OSS-Master/build.tar.gz --output build.tar.gz
+curl -L https://github.com/influxdata/ui/releases/download/OSS-2.1.2/build.tar.gz --output build.tar.gz
 
 # Verify the checksums match; exit if they don't.
-case "$(uname -s)" in
-    FreeBSD | Darwin)
-        echo "$(cat sha256.txt)" | shasum --algorithm 256 --check \
-            || { echo "Checksums did not match for downloaded UI assets!"; exit 1; } ;;
-    Linux)
-        echo "$(cat sha256.txt)" | sha256sum --check -- \
-            || { echo "Checksums did not match for downloaded UI assets!"; exit 1; } ;;
-    *)
-        echo "The '$(uname -s)' operating system is not supported as a build host for the UI" >&2
-        exit 1
-esac
+echo "${EXPECTED_UI_CHECKSUM} build.tar.gz" | sha256sum --check -- \
+    || { echo "Checksums did not match for downloaded UI assets!"; exit 1; }
 
 # Extract the assets and clean up.
 mkdir -p "$STATIC_DIR/data"
 tar -xzf build.tar.gz -C "$STATIC_DIR/data"
-rm sha256.txt
 rm build.tar.gz


### PR DESCRIPTION
fix: pin UI version to 2.1.2 so that tokens can be accessed.

Closes #23235

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
