### PR TITLE
fix: implement v2/api/delete

### DIFF
--- a/internal/storage_store.go
+++ b/internal/storage_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )
@@ -21,6 +22,7 @@ import (
 type StorageStoreMock struct {
 	ReadFilterFn func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error)
 	ReadGroupFn  func(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error)
+	DeleteFn     func(database string, sources []influxql.Source, condition influxql.Expr) error
 
 	TagKeysFn    func(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
 	TagValuesFn  func(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
@@ -44,6 +46,11 @@ func NewStorageStoreMock() *StorageStoreMock {
 	store.ReadGroupFn = func(context.Context, *datatypes.ReadGroupRequest) (reads.GroupResultSet, error) {
 		return nil, errors.New("implement me")
 	}
+
+	store.DeleteFn = func(database string, sources []influxql.Source, condition influxql.Expr) error {
+		return errors.New("implement me")
+	}
+
 	store.TagKeysFn = func(context.Context, *datatypes.TagKeysRequest) (cursors.StringIterator, error) {
 		return nil, errors.New("implement me")
 	}
@@ -55,6 +62,10 @@ func NewStorageStoreMock() *StorageStoreMock {
 
 func (s *StorageStoreMock) ReadFilter(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error) {
 	return s.ReadFilterFn(ctx, req)
+}
+
+func (s *StorageStoreMock) Delete(database string, sources []influxql.Source, condition influxql.Expr) error {
+	return s.DeleteFn(database, sources, condition)
 }
 
 func (s *StorageStoreMock) ReadGroup(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error) {

--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -496,3 +496,7 @@ func (s *Store) MeasurementNames(ctx context.Context, req *MeasurementNamesReque
 func (s *Store) GetSource(db, rp string) proto.Message {
 	return &ReadSource{Database: db, RetentionPolicy: rp}
 }
+
+func (s *Store) Delete(database string, sources []influxql.Source, condition influxql.Expr) error {
+	return s.TSDBStore.DeleteSeries(database, sources, condition)
+}


### PR DESCRIPTION
Support to V2 delete api

Does not support deletion by field, only by tag value, time, and measurement.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Documentation updated or issue created: https://github.com/influxdata/docs-v2/issues/3914