### PR TITLE
build: upgrade to go1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.17.2-f057a4596ecb3ade6e0015992e2e9d8e0220f80b
+    default: go1.18-0b1bcef254c3fba55196c070cc39c7aad58a9068
 
 commands:
   install_rust:

--- a/_tools/tmpl/main.go
+++ b/_tools/tmpl/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,7 +103,7 @@ func main() {
 }
 
 func mustReadAll(path string) []byte {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		errExit(err.Error())
 	}
@@ -164,7 +163,7 @@ func process(data interface{}, specs []pathSpec) {
 			}
 		}
 
-		ioutil.WriteFile(spec.out, generated, fileMode(spec.in))
+		os.WriteFile(spec.out, generated, fileMode(spec.in))
 	}
 }
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -406,7 +405,7 @@ func (c *Client) Write(bp BatchPoints) (*Response, error) {
 	defer resp.Body.Close()
 
 	var response Response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +451,7 @@ func (c *Client) WriteLineProtocol(data, database, retentionPolicy, precision, w
 	defer resp.Body.Close()
 
 	var response Response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -648,7 +647,7 @@ func (r *ChunkedResponse) NextResponse() (*Response, error) {
 		// A decoding error happened. This probably means the server crashed
 		// and sent a last-ditch error message to us. Ensure we have read the
 		// entirety of the connection to get any remaining error text.
-		io.Copy(ioutil.Discard, r.duplex)
+		io.Copy(io.Discard, r.duplex)
 		return nil, errors.New(strings.TrimSpace(r.buf.String()))
 	}
 	r.buf.Reset()

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -69,11 +69,8 @@ type Query struct {
 
 // SplitPath gets the path of a url
 func SplitPath(v string) (string, string) {
-	i := strings.Index(v, "/")
-	if i == -1 {
-		return v, ""
-	}
-	return v[:i] /* first */, v[i+1:] /* rest */
+	first, rest, _ := strings.Cut(v, "/")
+	return first, rest
 }
 
 // ParseConnectionString will parse a string to create a valid connection URL

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -339,7 +339,7 @@ func TestClient_BasicAuth(t *testing.T) {
 
 func TestClient_Write(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		in, err := ioutil.ReadAll(r.Body)
+		in, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		} else if have, want := strings.TrimSpace(string(in)), `m0,host=server01 v1=2,v2=2i,v3=2u,v4="foobar",v5=true 0`; have != want {
@@ -943,7 +943,7 @@ war3JNM1mGB3o2iAtuOJlFIKLpI1x+1e8pI=
 	server.StartTLS()
 	defer server.Close()
 
-	certFile, _ := ioutil.TempFile("", "influx-cert-")
+	certFile, _ := os.CreateTemp("", "influx-cert-")
 	certFile.WriteString(cert)
 	certFile.Close()
 	defer os.Remove(certFile.Name())

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -599,7 +599,7 @@ func TestClient_Concurrent_Use(t *testing.T) {
 
 func TestClient_Write(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		in, err := ioutil.ReadAll(r.Body)
+		in, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		} else if have, want := strings.TrimSpace(string(in)), `m0,host=server01 v1=2,v2=2i,v3=2u,v4="foobar",v5=true 0`; have != want {

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -186,7 +185,7 @@ func (c *CommandLine) Run() error {
 	}
 
 	if !hasTTY {
-		cmd, err := ioutil.ReadAll(os.Stdin)
+		cmd, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -103,7 +102,7 @@ func (cmd *Command) run(dataDir, walDir string) error {
 		}
 	}
 
-	fis, err := ioutil.ReadDir(dataDir)
+	fis, err := os.ReadDir(dataDir)
 	if err != nil {
 		return err
 	}
@@ -259,7 +258,7 @@ func (cmd *Command) processDatabase(dbName, dataDir, walDir string) error {
 	}
 	defer sfile.Close()
 
-	fis, err := ioutil.ReadDir(dataDir)
+	fis, err := os.ReadDir(dataDir)
 	if err != nil {
 		return err
 	}
@@ -285,7 +284,7 @@ func (cmd *Command) processDatabase(dbName, dataDir, walDir string) error {
 func (cmd *Command) processRetentionPolicy(sfile *tsdb.SeriesFile, dbName, rpName, dataDir, walDir string) error {
 	cmd.Logger.Info("Rebuilding retention policy", logger.Database(dbName), logger.RetentionPolicy(rpName))
 
-	fis, err := ioutil.ReadDir(dataDir)
+	fis, err := os.ReadDir(dataDir)
 	if err != nil {
 		return err
 	}
@@ -531,7 +530,7 @@ func IndexTSMFile(index *tsi1.Index, path string, batchSize int, log *zap.Logger
 }
 
 func collectTSMFiles(path string) ([]string, error) {
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +552,7 @@ func collectWALFiles(path string) ([]string, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, err
 	}
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/influx_inspect/deletetsm/deletetsm.go
+++ b/cmd/influx_inspect/deletetsm/deletetsm.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -50,7 +49,7 @@ func (cmd *Command) Run(args ...string) (err error) {
 	}
 
 	if !cmd.verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	// Validate measurement or sanitize flag.

--- a/cmd/influx_inspect/dumptsi/dumptsi_test.go
+++ b/cmd/influx_inspect/dumptsi/dumptsi_test.go
@@ -2,7 +2,6 @@ package dumptsi_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -19,7 +18,7 @@ func Test_DumpTSI_NoError(t *testing.T) {
 	cmd.Stdout = b
 
 	// Create the temp-dir for our un-tared files to live in
-	dir, err := ioutil.TempDir("", "dumptsitest-")
+	dir, err := os.MkdirTemp("", "dumptsitest-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/cmd/influx_inspect/dumptsm/dumptsm.go
+++ b/cmd/influx_inspect/dumptsm/dumptsm.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Command represents the program execution for "influxd dumptsm".
@@ -237,7 +239,7 @@ func (cmd *Command) dump() error {
 		if len(counts) == 0 {
 			continue
 		}
-		fmt.Printf("    %s: ", strings.Title(fieldType[i]))
+		fmt.Printf("    %s: ", cases.Title(language.Und, cases.NoLower).String(fieldType[i]))
 		for j, v := range counts {
 			fmt.Printf("\t%s: %d (%d%%) ", encDescs[i][j], v, int(float64(v)/float64(blockCount)*100))
 		}

--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -246,7 +245,7 @@ func (cmd *Command) writeDML(mw io.Writer, w io.Writer) error {
 // the actual payload of the writes -- DML and DDL.
 //
 // Typically mw and w are the same but if we'd like to, for example, filter out
-// comments and other meta data, we can pass ioutil.Discard to mw to only
+// comments and other meta data, we can pass io.Discard to mw to only
 // include the raw data that writeFull() generates.
 func (cmd *Command) writeFull(mw io.Writer, w io.Writer) error {
 	s, e := time.Unix(0, cmd.startTime).Format(time.RFC3339), time.Unix(0, cmd.endTime).Format(time.RFC3339)
@@ -294,7 +293,7 @@ func (cmd *Command) write() error {
 
 	// mw is our "meta writer" -- the io.Writer to which meta/out-of-band data
 	// like comments will be sent.  If the lponly flag is set, mw will be
-	// ioutil.Discard which effectively filters out comments and any other
+	// io.Discard which effectively filters out comments and any other
 	// non-line protocol data.
 	//
 	// Otherwise, mw is set to the same writer as the actual DDL and line
@@ -303,7 +302,7 @@ func (cmd *Command) write() error {
 	//
 	mw := w
 	if cmd.lponly {
-		mw = ioutil.Discard
+		mw = io.Discard
 	}
 
 	return cmd.writeFull(mw, w)

--- a/cmd/influx_inspect/export/export_test.go
+++ b/cmd/influx_inspect/export/export_test.go
@@ -3,7 +3,7 @@ package export
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"os"
@@ -227,8 +227,8 @@ func BenchmarkExportWALStrings_100s_250vps(b *testing.B) {
 // newCommand returns a command that discards its output and that accepts all timestamps.
 func newCommand() *Command {
 	return &Command{
-		Stderr:    ioutil.Discard,
-		Stdout:    ioutil.Discard,
+		Stderr:    io.Discard,
+		Stdout:    io.Discard,
 		startTime: math.MinInt64,
 		endTime:   math.MaxInt64,
 	}
@@ -292,7 +292,7 @@ func makeStringsCorpus(numSeries, numStringsPerSeries int) corpus {
 // It is the caller's responsibility to remove the returned temp file.
 // writeCorpusToWALFile will panic on any error that occurs.
 func writeCorpusToWALFile(c corpus) *os.File {
-	walFile, err := ioutil.TempFile("", "export_test_corpus_wal")
+	walFile, err := os.CreateTemp("", "export_test_corpus_wal")
 	if err != nil {
 		panic(err)
 	}
@@ -323,7 +323,7 @@ func writeCorpusToWALFile(c corpus) *os.File {
 // It is the caller's responsibility to remove the returned temp file.
 // writeCorpusToTSMFile will panic on any error that occurs.
 func writeCorpusToTSMFile(c corpus) *os.File {
-	tsmFile, err := ioutil.TempFile("", "export_test_corpus_tsm")
+	tsmFile, err := os.CreateTemp("", "export_test_corpus_tsm")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/influx_inspect/report/report.go
+++ b/cmd/influx_inspect/report/report.go
@@ -2,6 +2,7 @@
 package report
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -115,8 +116,7 @@ func (cmd *Command) Run(args ...string) error {
 			dbCount.Add([]byte(key))
 
 			if cmd.detailed {
-				sep := strings.Index(string(key), "#!~#")
-				seriesKey, field := key[:sep], key[sep+4:]
+				seriesKey, field, _ := bytes.Cut(key, []byte("#!~#"))
 				measurement, tags := models.ParseKey(seriesKey)
 
 				measCount := measCardinalities[measurement]

--- a/cmd/influx_inspect/verify/seriesfile/command.go
+++ b/cmd/influx_inspect/verify/seriesfile/command.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -79,7 +78,7 @@ func (cmd *Command) Run(args ...string) error {
 		return err
 	}
 
-	dbs, err := ioutil.ReadDir(cmd.dir)
+	dbs, err := os.ReadDir(cmd.dir)
 	if err != nil {
 		return err
 	}

--- a/cmd/influx_inspect/verify/seriesfile/verify.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify.go
@@ -2,7 +2,6 @@ package seriesfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -48,7 +47,7 @@ func (v Verify) VerifySeriesFile(filePath string) (valid bool, err error) {
 		}
 	}()
 
-	partitionInfos, err := ioutil.ReadDir(filePath)
+	partitionInfos, err := os.ReadDir(filePath)
 	if os.IsNotExist(err) {
 		v.Logger.Error("Series file does not exist")
 		return false, nil
@@ -120,7 +119,7 @@ func (v Verify) VerifyPartition(partitionPath string) (valid bool, err error) {
 		}
 	}()
 
-	segmentInfos, err := ioutil.ReadDir(partitionPath)
+	segmentInfos, err := os.ReadDir(partitionPath)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/influx_inspect/verify/seriesfile/verify_test.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify_test.go
@@ -3,7 +3,6 @@ package seriesfile_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,7 +70,7 @@ type Test struct {
 func NewTest(t *testing.T) *Test {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "verify-seriesfile-")
+	dir, err := os.MkdirTemp("", "verify-seriesfile-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/influx_tools/generate/exec/command.go
+++ b/cmd/influx_tools/generate/exec/command.go
@@ -369,6 +369,7 @@ fields = [
 `
 
 func (cmd *Command) printExample() error {
+	// go vet: "possible formatting directive" is intended
 	fmt.Fprint(cmd.Stdout, exampleSchema)
 	return nil
 }

--- a/cmd/influx_tools/generate/exec/command.go
+++ b/cmd/influx_tools/generate/exec/command.go
@@ -218,7 +218,7 @@ name = "cpu"
 # sample: float; where 0 < sample ≤ 1.0 (default: 0.5)
 #   sample a subset of the tag set
 #
-# sample 25% of the tags
+# sample 25%% of the tags
 #
 sample = 0.25
 
@@ -240,7 +240,7 @@ sample = 0.25
 #   generate a sequence of tag values
 #
 #       format: string
-#           a format string for the values (default: "value%s")
+#           a format string for the values (default: "value%%s")
 #       start: int (default: 0)
 #           beginning value 
 #       count: int, required
@@ -256,7 +256,7 @@ tags = [
     # example sequence tag source. The range of values are automatically 
     # prefixed with 0s
     # to ensure correct sort behavior.
-    { name = "host", source = { type = "sequence", format = "host-%s", start = 0, count = 5 } },
+    { name = "host", source = { type = "sequence", format = "host-%%s", start = 0, count = 5 } },
 
     # tags can also be sourced from a file. The path is relative to the 
     # schema.toml.
@@ -358,7 +358,7 @@ fields = [
 [[measurements]]
 name = "mem"
 tags = [
-    { name = "host",   source = { type = "sequence", format = "host-%s", start = 0, count = 5 } },
+    { name = "host",   source = { type = "sequence", format = "host-%%s", start = 0, count = 5 } },
     { name = "region", source = ["us-west-01","us-west-02","us-east"] },
 ]
 fields = [
@@ -369,7 +369,6 @@ fields = [
 `
 
 func (cmd *Command) printExample() error {
-	// go vet: "possible formatting directive" is intended
-	fmt.Fprint(cmd.Stdout, exampleSchema)
+	fmt.Fprintf(cmd.Stdout, exampleSchema)
 	return nil
 }

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -494,7 +493,7 @@ func (cmd *Command) backupMetastore() (retErr error) {
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(filepath.Join(cmd.path, filename), protoBytes, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(cmd.path, filename), protoBytes, 0644); err != nil {
 			fmt.Fprintln(cmd.Stdout, "Error.")
 			return err
 		}

--- a/cmd/influxd/backup_util/backup_util.go
+++ b/cmd/influxd/backup_util/backup_util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -144,7 +143,7 @@ func (manifest *Manifest) Save(filename string) error {
 		return fmt.Errorf("create manifest: %v", err)
 	}
 
-	return ioutil.WriteFile(filename, b, 0600)
+	return os.WriteFile(filename, b, 0600)
 }
 
 // LoadIncremental loads multiple manifest files from a given directory.

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -290,7 +289,7 @@ func (cmd *Command) unpackMeta() error {
 	}
 
 	// Write node.json back to meta dir
-	if err := ioutil.WriteFile(filepath.Join(c.Dir, "node.json"), nodeBytes, 0655); err != nil {
+	if err := os.WriteFile(filepath.Join(c.Dir, "node.json"), nodeBytes, 0655); err != nil {
 		return err
 	}
 
@@ -330,7 +329,7 @@ func (cmd *Command) updateMetaPortable() error {
 	var metaBytes []byte
 	fileName := filepath.Join(cmd.backupFilesPath, cmd.manifestMeta.FileName)
 
-	fileBytes, err := ioutil.ReadFile(fileName)
+	fileBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -225,7 +224,7 @@ func (cmd *Command) writePIDFile(path string) error {
 
 	// Retrieve the PID and write it.
 	pid := strconv.Itoa(os.Getpid())
-	if err := ioutil.WriteFile(path, []byte(pid), 0666); err != nil {
+	if err := os.WriteFile(path, []byte(pid), 0666); err != nil {
 		return fmt.Errorf("write file: %s", err)
 	}
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -266,8 +266,7 @@ Usage: influxd run [flags]
     -cpuprofile <path>
             Write CPU profiling information to a file.
     -memprofile <path>
-            Write memory usage information to a file.
-`
+            Write memory usage information to a file.`
 
 // Options represents the command line options that can be parsed.
 type Options struct {

--- a/cmd/influxd/run/command_test.go
+++ b/cmd/influxd/run/command_test.go
@@ -1,7 +1,6 @@
 package run_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestCommand_PIDFile(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "influxd-test")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "influxd-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -118,7 +117,7 @@ func NewDemoConfig() (*Config, error) {
 
 // FromTomlFile loads the config from a TOML file.
 func (c *Config) FromTomlFile(fpath string) error {
-	bs, err := ioutil.ReadFile(fpath)
+	bs, err := os.ReadFile(fpath)
 	if err != nil {
 		return err
 	}

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -3,7 +3,6 @@ package run_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -340,7 +339,7 @@ func TestConfig_InvalidSubsections(t *testing.T) {
 func TestConfig_Parse_UTF8_ByteOrderMark(t *testing.T) {
 	// Parse configuration.
 	var c run.Config
-	f, err := ioutil.TempFile("", "influxd")
+	f, err := os.CreateTemp("", "influxd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +431,7 @@ enabled = true
 func TestConfig_Parse_UTF16_ByteOrderMark(t *testing.T) {
 	// Parse configuration.
 	var c run.Config
-	f, err := ioutil.TempFile("", "influxd")
+	f, err := os.CreateTemp("", "influxd")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,7 @@ type TestRunCommand struct {
 }
 
 func NewTestRunCommand(env map[string]string) *TestRunCommand {
-	dir, err := ioutil.TempDir("", "testrun-")
+	dir, err := os.MkdirTemp("", "testrun-")
 	if err != nil {
 		panic(err)
 	}

--- a/flux/stdlib/influxdata/influxdb/operators.go
+++ b/flux/stdlib/influxdata/influxdb/operators.go
@@ -78,13 +78,7 @@ func (s *ReadRangePhysSpec) Copy() plan.ProcedureSpec {
 }
 
 func lookupDatabase(ctx context.Context, bucketName string, deps StorageDependencies, privilege influxql.Privilege) (string, string, error) {
-	var db, rp string
-	if i := strings.IndexByte(bucketName, '/'); i == -1 {
-		db = bucketName
-	} else {
-		rp = bucketName[i+1:]
-		db = bucketName[:i]
-	}
+	db, rp, _ := strings.Cut(bucketName, "/")
 	// validate and resolve db/rp
 	di := deps.MetaClient.Database(db)
 	if di == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb
 
-go 1.17
+go 1.18
 
 require (
 	collectd.org v0.3.0
@@ -12,10 +12,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8
 	github.com/go-chi/chi v4.1.0+incompatible
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/mock v1.5.0
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.7
 	github.com/influxdata/flux v0.159.0
@@ -42,7 +40,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tinylib/msgp v1.1.0
 	github.com/uber/jaeger-client-go v2.28.0+incompatible
-	github.com/willf/bitset v1.1.9 // indirect
 	github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
@@ -105,9 +102,11 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/goccy/go-json v0.7.10 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/flatbuffers v2.0.5+incompatible // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
@@ -145,6 +144,7 @@ require (
 	github.com/uber/athenadriver v1.1.4 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/vertica/vertica-sql-go v1.1.1 // indirect
+	github.com/willf/bitset v1.1.9 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect

--- a/internal/cmd/fluxtest-harness-influxdb/test.go
+++ b/internal/cmd/fluxtest-harness-influxdb/test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -154,7 +153,7 @@ func (t *testExecutor) executeWithOptions(
 		return err
 	}
 	if resp.StatusCode/100 != 2 {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("error response from flux query: %s", string(b))
 	}
 

--- a/kit/io/limited_read_closer_test.go
+++ b/kit/io/limited_read_closer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ func TestLimitedReadCloser_Exceeded(t *testing.T) {
 	b := &closer{Reader: bytes.NewBufferString("howdy")}
 	rc := NewLimitedReadCloser(b, 3)
 
-	out, err := ioutil.ReadAll(rc)
+	out, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("how"), out)
 	assert.Equal(t, ErrReadLimitExceeded, rc.Close())
@@ -25,7 +24,7 @@ func TestLimitedReadCloser_Happy(t *testing.T) {
 	b := &closer{Reader: bytes.NewBufferString("ho")}
 	rc := NewLimitedReadCloser(b, 2)
 
-	out, err := ioutil.ReadAll(rc)
+	out, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("ho"), out)
 	assert.Nil(t, err)
@@ -38,7 +37,7 @@ func TestLimitedReadCloseWithErrorAndLimitExceeded(t *testing.T) {
 	}
 	rc := NewLimitedReadCloser(b, 3)
 
-	out, err := ioutil.ReadAll(rc)
+	out, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("how"), out)
 	// LimitExceeded error trumps the close error.
@@ -53,7 +52,7 @@ func TestLimitedReadCloseWithError(t *testing.T) {
 	}
 	rc := NewLimitedReadCloser(b, 10)
 
-	out, err := ioutil.ReadAll(rc)
+	out, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("howdy"), out)
 	assert.Equal(t, closeErr, rc.Close())
@@ -67,7 +66,7 @@ func TestMultipleCloseOnlyClosesOnce(t *testing.T) {
 	}
 	rc := NewLimitedReadCloser(b, 10)
 
-	out, err := ioutil.ReadAll(rc)
+	out, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("howdy"), out)
 	assert.Equal(t, closeErr, rc.Close())

--- a/models/uint_support.go
+++ b/models/uint_support.go
@@ -1,5 +1,4 @@
 //go:build uint || uint64
-// +build uint uint64
 
 package models
 

--- a/node.go
+++ b/node.go
@@ -3,7 +3,6 @@ package influxdb
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,7 +74,7 @@ func (n *Node) Save() error {
 
 func upgradeNodeFile(path string) error {
 	oldFile := filepath.Join(path, oldNodeFile)
-	b, err := ioutil.ReadFile(oldFile)
+	b, err := os.ReadFile(oldFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -88,7 +87,7 @@ func upgradeNodeFile(path string) error {
 	}
 
 	peers := []string{}
-	pb, err := ioutil.ReadFile(filepath.Join(path, peersFilename))
+	pb, err := os.ReadFile(filepath.Join(path, peersFilename))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/deep/equal.go
+++ b/pkg/deep/equal.go
@@ -123,7 +123,7 @@ func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) boo
 			return v1.IsNil() == v2.IsNil()
 		}
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
 	case reflect.Struct:
 		for i, n := 0, v1.NumField(); i < n; i++ {

--- a/pkg/file/file_unix.go
+++ b/pkg/file/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/pkg/limiter/write_test.go
+++ b/pkg/limiter/write_test.go
@@ -3,7 +3,6 @@ package limiter_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -14,7 +13,7 @@ func TestWriter_Limited(t *testing.T) {
 	r := bytes.NewReader(bytes.Repeat([]byte{0}, 1024*1024))
 
 	limit := 512 * 1024
-	w := limiter.NewWriter(nopWriteCloser{ioutil.Discard}, limit, 10*1024*1024)
+	w := limiter.NewWriter(nopWriteCloser{io.Discard}, limit, 10*1024*1024)
 
 	start := time.Now()
 	n, err := io.Copy(w, r)

--- a/pkg/mmap/mmap_solaris.go
+++ b/pkg/mmap/mmap_solaris.go
@@ -1,5 +1,4 @@
 //go:build solaris
-// +build solaris
 
 package mmap
 

--- a/pkg/mmap/mmap_test.go
+++ b/pkg/mmap/mmap_test.go
@@ -2,7 +2,7 @@ package mmap_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/influxdata/influxdb/pkg/mmap"
@@ -14,8 +14,8 @@ func TestMap(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 
-	if exp, err := ioutil.ReadFile("mmap_test.go"); err != nil {
-		t.Fatalf("ioutil.ReadFile: %v", err)
+	if exp, err := os.ReadFile("mmap_test.go"); err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
 	} else if !bytes.Equal(data, exp) {
 		t.Fatalf("got %q\nwant %q", string(data), string(exp))
 	}

--- a/pkg/mmap/mmap_unix.go
+++ b/pkg/mmap/mmap_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd
 
 // Copyright 2015 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/services/collectd/service_test.go
+++ b/services/collectd/service_test.go
@@ -3,7 +3,6 @@ package collectd
 import (
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -61,14 +60,14 @@ func TestService_Open_TypesDBDir(t *testing.T) {
 	t.Parallel()
 
 	// Make a temp dir to write types.db into.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	// Write types.db.
-	if err := ioutil.WriteFile(path.Join(tmpDir, "types.db"), []byte(typesDBText), 0777); err != nil {
+	if err := os.WriteFile(path.Join(tmpDir, "types.db"), []byte(typesDBText), 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/services/httpd/flux.go
+++ b/services/httpd/flux.go
@@ -3,7 +3,7 @@ package httpd
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 
@@ -32,7 +32,7 @@ func decodeQueryRequest(r *http.Request) (*client.QueryRequest, error) {
 	var req client.QueryRequest
 	switch mt {
 	case "application/vnd.flux":
-		if d, err := ioutil.ReadAll(r.Body); err != nil {
+		if d, err := io.ReadAll(r.Body); err != nil {
 			return nil, err
 		} else {
 			req.Query = string(d)

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1702,11 +1702,10 @@ type credentials struct {
 }
 
 func parseToken(token string) (user, pass string, ok bool) {
-	s := strings.IndexByte(token, ':')
-	if s < 0 {
-		return
+	if t1, t2, ok := strings.Cut(token, ":"); ok {
+		return t1, t2, ok
 	}
-	return token[:s], token[s+1:], true
+	return
 }
 
 // parseCredentials parses a request and returns the authentication credentials.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -9,7 +9,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -1218,7 +1217,7 @@ func (h *Handler) servePromWrite(w http.ResponseWriter, r *http.Request, user me
 func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user meta.User) {
 	atomic.AddInt64(&h.stats.PromReadRequests, 1)
 	h.requestTracker.Add(r, user)
-	compressed, err := ioutil.ReadAll(r.Body)
+	compressed, err := io.ReadAll(r.Body)
 	if err != nil {
 		h.httpError(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/services/httpd/io_test.go
+++ b/services/httpd/io_test.go
@@ -2,7 +2,7 @@ package httpd
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -22,7 +22,7 @@ func TestTruncatedReader_Read(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			b := truncateReader(bytes.NewReader(tc.in), tc.n)
-			_, err := ioutil.ReadAll(b)
+			_, err := io.ReadAll(b)
 			if err != tc.err {
 				t.Errorf("unexpected error; got=%v, exp=%v", err, tc.err)
 			}

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -1039,7 +1038,7 @@ func (c *Client) Load() error {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -1,7 +1,6 @@
 package meta_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -1156,7 +1155,7 @@ func testTempDir(skip int) string {
 	}
 	_, prefix := path.Split(runtime.FuncForPC(pc).Name())
 	// Make a temp dir prefixed with calling function's name.
-	dir, err := ioutil.TempDir(os.TempDir(), prefix)
+	dir, err := os.MkdirTemp(os.TempDir(), prefix)
 	if err != nil {
 		panic(err)
 	}

--- a/services/snapshotter/client.go
+++ b/services/snapshotter/client.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -51,7 +50,7 @@ func (c *Client) UpdateMeta(req *Request, upStream io.Reader) (map[uint64]uint64
 		return nil, fmt.Errorf("error uploading file: err=%v, n=%d, uploadSize: %d", err, n, req.UploadSize)
 	}
 
-	resp, err := ioutil.ReadAll(conn)
+	resp, err := io.ReadAll(conn)
 	if err != nil || len(resp) == 0 {
 		return nil, fmt.Errorf("updating metadata on influxd service failed: err=%v, n=%d", err, len(resp))
 	}

--- a/services/snapshotter/service_test.go
+++ b/services/snapshotter/service_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -145,7 +144,7 @@ func TestSnapshotter_RequestShardBackup(t *testing.T) {
 	}
 
 	// Read the result.
-	out, err := ioutil.ReadAll(conn)
+	out, err := io.ReadAll(conn)
 	if err != nil {
 		t.Errorf("unexpected error reading shard backup: %s", err)
 		return
@@ -243,7 +242,7 @@ func TestSnapshotter_RequestDatabaseInfo(t *testing.T) {
 	}
 
 	// Read the result.
-	out, err := ioutil.ReadAll(conn)
+	out, err := io.ReadAll(conn)
 	if err != nil {
 		t.Errorf("unexpected error reading database info: %s", err)
 		return
@@ -297,7 +296,7 @@ func TestSnapshotter_RequestDatabaseInfo_ErrDatabaseNotFound(t *testing.T) {
 	}
 
 	// Read the result.
-	out, err := ioutil.ReadAll(conn)
+	out, err := io.ReadAll(conn)
 	if err != nil {
 		t.Errorf("unexpected error reading database info: %s", err)
 		return
@@ -362,7 +361,7 @@ func TestSnapshotter_RequestRetentionPolicyInfo(t *testing.T) {
 	}
 
 	// Read the result.
-	out, err := ioutil.ReadAll(conn)
+	out, err := io.ReadAll(conn)
 	if err != nil {
 		t.Errorf("unexpected error reading database info: %s", err)
 		return
@@ -439,7 +438,7 @@ func TestSnapshotter_InvalidRequest(t *testing.T) {
 	conn.Write([]byte(`["invalid request"]`))
 
 	// Read the result.
-	out, err := ioutil.ReadAll(conn)
+	out, err := io.ReadAll(conn)
 	if err != nil {
 		t.Errorf("unexpected error reading database info: %s", err)
 		return

--- a/services/subscriber/config_test.go
+++ b/services/subscriber/config_test.go
@@ -2,7 +2,6 @@ package subscriber_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,7 +68,7 @@ write-concurrency = 10
 }
 
 func TestConfig_ParseTLSConfigValidCerts(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "ca-certs.crt")
+	tmpfile, err := os.CreateTemp("", "ca-certs.crt")
 	if err != nil {
 		t.Fatalf("could not create temp file. error was: %v", err)
 	}

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/influxdata/influxdb/client/v2"
@@ -62,7 +62,7 @@ func createTLSConfig(caCerts string, tlsConfig *tls.Config) (*tls.Config, error)
 }
 
 func loadCaCerts(caCerts string, tlsConfig *tls.Config) (*tls.Config, error) {
-	caCert, err := ioutil.ReadFile(caCerts)
+	caCert, err := os.ReadFile(caCerts)
 	if err != nil {
 		return nil, err
 	}

--- a/services/subscriber/service_test.go
+++ b/services/subscriber/service_test.go
@@ -3,7 +3,7 @@ package subscriber_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -408,7 +408,7 @@ func TestService_WaitForDataChanged(t *testing.T) {
 		<-done
 	}))
 	nonBlockingServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
-		b, _ := ioutil.ReadAll(req.Body)
+		b, _ := io.ReadAll(req.Body)
 		receivedNonBlocking <- string(b)
 	}))
 	defer blockingServer.Close()

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -3,7 +3,6 @@ package storageflux_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -47,7 +46,7 @@ type StorageReader struct {
 }
 
 func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
-	rootDir, err := ioutil.TempDir("", "storage-flux-test")
+	rootDir, err := os.MkdirTemp("", "storage-flux-test")
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -38,7 +37,7 @@ func TestMux(t *testing.T) {
 		defer tcpListener.Close()
 
 		// Setup muxer & listeners.
-		logger := log.New(ioutil.Discard, "", 0)
+		logger := log.New(io.Discard, "", 0)
 		if testing.Verbose() {
 			logger = tcp.MuxLogger(os.Stderr)
 		}

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -22,16 +21,16 @@ func TestServer_BackupAndRestore(t *testing.T) {
 	config.Monitor.StoreEnabled = true
 	config.Monitor.StoreInterval = toml.Duration(time.Second)
 
-	fullBackupDir, _ := ioutil.TempDir("", "backup")
+	fullBackupDir, _ := os.MkdirTemp("", "backup")
 	defer os.RemoveAll(fullBackupDir)
 
-	partialBackupDir, _ := ioutil.TempDir("", "backup")
+	partialBackupDir, _ := os.MkdirTemp("", "backup")
 	defer os.RemoveAll(partialBackupDir)
 
-	portableBackupDir, _ := ioutil.TempDir("", "backup")
+	portableBackupDir, _ := os.MkdirTemp("", "backup")
 	defer os.RemoveAll(portableBackupDir)
 
-	shardBackupDir, _ := ioutil.TempDir("", "backup")
+	shardBackupDir, _ := os.MkdirTemp("", "backup")
 	defer os.RemoveAll(shardBackupDir)
 
 	db := "mydb"

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -377,7 +376,7 @@ type Config struct {
 
 // NewConfig returns the default config with temporary paths.
 func NewConfig() *Config {
-	root, err := ioutil.TempDir("", "tests-influxdb-")
+	root, err := os.MkdirTemp("", "tests-influxdb-")
 	if err != nil {
 		panic(err)
 	}
@@ -443,7 +442,7 @@ var LosAngeles = mustParseLocation("America/Los_Angeles")
 
 // MustReadAll reads r. Panic on error.
 func MustReadAll(r io.Reader) []byte {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}
@@ -622,6 +621,6 @@ func writeTestData(s Server, t *Test) error {
 func configureLogging(s Server) {
 	// Set the logger to discard unless verbose is on
 	if !verboseServerLogs {
-		s.SetLogOutput(ioutil.Discard)
+		s.SetLogOutput(io.Discard)
 	}
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -10178,7 +10177,7 @@ func TestFluxBasicEndToEnd(t *testing.T) {
 		resp, err := httpClient.Do(req)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t,
 			strings.ReplaceAll(`,result,table,organizationID,databaseName,retentionPolicy,retentionPeriod,default,bucketId
@@ -10200,7 +10199,7 @@ func TestFluxBasicEndToEnd(t *testing.T) {
 		resp, err := httpClient.Do(req)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t,
 			strings.ReplaceAll(`#datatype,string,long,string,string,string,long,boolean,string
@@ -10222,7 +10221,7 @@ func TestFluxBasicEndToEnd(t *testing.T) {
 		resp, err := httpClient.Do(req)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t,
 			strings.ReplaceAll(`,result,table,organizationID,databaseName,retentionPolicy,retentionPeriod,default,bucketId
@@ -10297,7 +10296,7 @@ func TestFluxRegressionEndToEnd(t *testing.T) {
 		resp, err := httpClient.Do(req)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t,
 			strings.ReplaceAll(`,result,table,name,id,organizationID,retentionPolicy,retentionPeriod
@@ -10620,7 +10619,7 @@ func runFluxBuiltinTest(t *testing.T, file *ast.File, u *url.URL, bucket string,
 	}
 
 	if resp.StatusCode/100 != 2 {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		t.Log("Bad response from flux:", string(b))
 		return fmt.Errorf("Bad status code %d from flux query", resp.StatusCode)
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -154,7 +154,7 @@ func applyEnvOverrides(getenv func(string) string, prefix string, spec reflect.V
 	element := spec
 	// If spec is a named type and is addressable,
 	// check the address to see if it implements encoding.TextUnmarshaler.
-	if spec.Kind() != reflect.Ptr && spec.Type().Name() != "" && spec.CanAddr() {
+	if spec.Kind() != reflect.Pointer && spec.Type().Name() != "" && spec.CanAddr() {
 		v := spec.Addr()
 		if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
 			value := getenv(prefix)
@@ -166,7 +166,7 @@ func applyEnvOverrides(getenv func(string) string, prefix string, spec reflect.V
 		}
 	}
 	// If we have a pointer, dereference it
-	if spec.Kind() == reflect.Ptr {
+	if spec.Kind() == reflect.Pointer {
 		element = spec.Elem()
 	}
 
@@ -260,7 +260,7 @@ func applyEnvOverrides(getenv func(string) string, prefix string, spec reflect.V
 			}
 
 			// If it's a sub-config, recursively apply
-			if field.Kind() == reflect.Struct || field.Kind() == reflect.Ptr ||
+			if field.Kind() == reflect.Struct || field.Kind() == reflect.Pointer ||
 				field.Kind() == reflect.Slice || field.Kind() == reflect.Array {
 				if err := applyEnvOverrides(getenv, envKey, field, fieldName); err != nil {
 					return err

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 

--- a/tsdb/engine/tsm1/array_cursor_test.go
+++ b/tsdb/engine/tsm1/array_cursor_test.go
@@ -3,7 +3,6 @@ package tsm1
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,7 +20,7 @@ type keyValues struct {
 }
 
 func MustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -29,7 +28,7 @@ func MustTempDir() string {
 }
 
 func MustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -842,7 +841,7 @@ func TestCache_Split(t *testing.T) {
 }
 
 func mustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -850,7 +849,7 @@ func mustTempDir() string {
 }
 
 func mustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -2407,7 +2406,7 @@ func (e *Engine) reloadCache() error {
 // cleanup removes all temp files and dirs that exist on disk.  This is should only be run at startup to avoid
 // removing tmp files that are still in use.
 func (e *Engine) cleanup() error {
-	allfiles, err := ioutil.ReadDir(e.path)
+	allfiles, err := os.ReadDir(e.path)
 	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -1,7 +1,6 @@
 package tsm1
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +18,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 		t.Skip("Skipping on windows")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "shard_test")
+	tmpDir, err := os.MkdirTemp("", "shard_test")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %s", err.Error())
 	}
@@ -95,7 +94,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
 func NewSeriesFile(tmpDir string) *tsdb.SeriesFile {
-	dir, err := ioutil.TempDir(tmpDir, "tsdb-series-file-")
+	dir, err := os.MkdirTemp(tmpDir, "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -380,7 +379,7 @@ func TestEngine_Backup(t *testing.T) {
 	defer sfile.Close()
 
 	// Generate temporary file.
-	f, _ := ioutil.TempFile("", "tsm")
+	f, _ := os.CreateTemp("", "tsm")
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
@@ -500,7 +499,7 @@ func TestEngine_Backup(t *testing.T) {
 
 func TestEngine_Export(t *testing.T) {
 	// Generate temporary file.
-	f, _ := ioutil.TempFile("", "tsm")
+	f, _ := os.CreateTemp("", "tsm")
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
@@ -1853,7 +1852,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	defer sfile.Close()
 
 	// Generate temporary file.
-	dir, _ := ioutil.TempDir("", "tsm")
+	dir, _ := os.MkdirTemp("", "tsm")
 	walPath := filepath.Join(dir, "wal")
 	os.MkdirAll(walPath, 0777)
 	defer os.RemoveAll(dir)
@@ -2674,7 +2673,7 @@ type Engine struct {
 
 // NewEngine returns a new instance of Engine at a temporary location.
 func NewEngine(index string) (*Engine, error) {
-	root, err := ioutil.TempDir("", "tsm1-")
+	root, err := os.MkdirTemp("", "tsm1-")
 	if err != nil {
 		panic(err)
 	}
@@ -2850,7 +2849,7 @@ type SeriesFile struct {
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
 func NewSeriesFile() *SeriesFile {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
+	dir, err := os.MkdirTemp("", "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -491,7 +490,7 @@ func (f *FileStore) Open() error {
 	}
 
 	// find the current max ID for temp directories
-	tmpfiles, err := ioutil.ReadDir(f.dir)
+	tmpfiles, err := os.ReadDir(f.dir)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -3,7 +3,6 @@ package tsm1_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2725,7 +2724,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 	}
 	t.Logf("temp file for hard links: %q", s)
 
-	tfs, e := ioutil.ReadDir(s)
+	tfs, e := os.ReadDir(s)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -2927,7 +2926,7 @@ type keyValues struct {
 }
 
 func MustTempDir() string {
-	dir, err := ioutil.TempDir("", "tsm1-test")
+	dir, err := os.MkdirTemp("", "tsm1-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}
@@ -2935,7 +2934,7 @@ func MustTempDir() string {
 }
 
 func MustTempFile(dir string) *os.File {
-	f, err := ioutil.TempFile(dir, "tsm1test")
+	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package tsm1
 

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -1660,7 +1659,7 @@ func TestTSMReader_FuzzCrashes(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			filename := filepath.Join(dir, "x.tsm")
-			if err := ioutil.WriteFile(filename, []byte(c), 0600); err != nil {
+			if err := os.WriteFile(filename, []byte(c), 0600); err != nil {
 				t.Fatalf("exp no error, got %s", err)
 			}
 			defer os.RemoveAll(dir)

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -270,7 +269,7 @@ func (t *Tombstoner) Walk(fn func(t Tombstone) error) error {
 }
 
 func (t *Tombstoner) writeTombstoneV3(tombstones []Tombstone) error {
-	tmp, err := ioutil.TempFile(filepath.Dir(t.Path), TombstoneFileExtension)
+	tmp, err := os.CreateTemp(filepath.Dir(t.Path), TombstoneFileExtension)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -2,7 +2,6 @@ package tsm1_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -242,7 +241,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	if err := ioutil.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
+	if err := os.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
 		t.Fatalf("write v1 file: %v", err)
 	}
 	f.Close()

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -75,7 +74,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 		t.Fatalf("unexpected error open file: %v", err)
 	}
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error reading: %v", err)
 	}
@@ -419,7 +418,7 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 	}
 	defer fd.Close()
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error read all: %v", err)
 	}
@@ -467,7 +466,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	}
 	defer fd.Close()
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		t.Fatalf("unexpected error read all: %v", err)
 	}
@@ -596,7 +595,7 @@ func TestTSMWriter_Sync(t *testing.T) {
 		io.Writer
 		fakeSyncer
 	}{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}
 
 	w, err := tsm1.NewTSMWriter(f)

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -2,7 +2,6 @@ package inmem_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -165,7 +164,7 @@ type seriesFileWrapper struct {
 
 // newSeriesFileWrapper returns a new instance of seriesFileWrapper with a temporary file path.
 func newSeriesFileWrapper() *seriesFileWrapper {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
+	dir, err := os.MkdirTemp("", "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -3,7 +3,6 @@ package tsi1
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1188,7 +1187,7 @@ func (i *Index) Rebuild() {}
 
 // IsIndexDir returns true if directory contains at least one partition directory.
 func IsIndexDir(path string) (bool, error) {
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if err != nil {
 		return false, err
 	}

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -3,7 +3,7 @@ package tsi1_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -261,7 +261,7 @@ func TestIndex_Open(t *testing.T) {
 			}
 
 			// Log the MANIFEST file.
-			data, err := ioutil.ReadFile(mpath)
+			data, err := os.ReadFile(mpath)
 			if err != nil {
 				panic(err)
 			}
@@ -765,7 +765,7 @@ func BenchmarkIndex_CreateSeriesListIfNotExists(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -846,7 +846,7 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -3,7 +3,6 @@ package tsi1_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -290,14 +289,14 @@ func TestLogFile_Open(t *testing.T) {
 		}
 
 		// Corrupt last entry.
-		buf, err := ioutil.ReadFile(f.LogFile.Path())
+		buf, err := os.ReadFile(f.LogFile.Path())
 		if err != nil {
 			t.Fatal(err)
 		}
 		buf[len(buf)-1] = 0
 
 		// Overwrite file with corrupt entry and reopen.
-		if err := ioutil.WriteFile(f.LogFile.Path(), buf, 0666); err != nil {
+		if err := os.WriteFile(f.LogFile.Path(), buf, 0666); err != nil {
 			t.Fatal(err)
 		} else if err := f.LogFile.Open(); err != nil {
 			t.Fatal(err)
@@ -324,7 +323,7 @@ type LogFile struct {
 
 // NewLogFile returns a new instance of LogFile with a temporary file path.
 func NewLogFile(sfile *tsdb.SeriesFile) *LogFile {
-	file, err := ioutil.TempFile("", "tsi1-log-file-")
+	file, err := os.CreateTemp("", "tsi1-log-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1390,7 +1389,7 @@ func (m *Manifest) Write() (int64, error) {
 	}
 	buf = append(buf, '\n')
 
-	if err := ioutil.WriteFile(m.path, buf, 0666); err != nil {
+	if err := os.WriteFile(m.path, buf, 0666); err != nil {
 		return 0, err
 	}
 	return int64(len(buf)), nil
@@ -1399,7 +1398,7 @@ func (m *Manifest) Write() (int64, error) {
 // ReadManifestFile reads a manifest from a file path and returns the Manifest,
 // the size of the manifest on disk, and any error if appropriate.
 func ReadManifestFile(path string) (*Manifest, int64, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -2,7 +2,6 @@ package tsi1_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +52,7 @@ func TestPartition_Open(t *testing.T) {
 			}
 
 			// Log the MANIFEST file.
-			data, err := ioutil.ReadFile(mpath)
+			data, err := os.ReadFile(mpath)
 			if err != nil {
 				panic(err)
 			}

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -2,7 +2,6 @@ package tsi1_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -258,7 +257,7 @@ func (itr *SeriesIDIterator) Next() (elem tsdb.SeriesIDElem) {
 
 // MustTempDir returns a temporary directory. Panic on error.
 func MustTempDir() string {
-	path, err := ioutil.TempDir("", "tsi-")
+	path, err := os.MkdirTemp("", "tsi-")
 	if err != nil {
 		panic(err)
 	}
@@ -289,7 +288,7 @@ type SeriesFile struct {
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
 func NewSeriesFile() *SeriesFile {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
+	dir, err := os.MkdirTemp("", "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -3,7 +3,7 @@ package tsdb_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -421,12 +421,12 @@ func MustNewIndex(index string, eopts ...EngineOption) *Index {
 		opt(&opts)
 	}
 
-	rootPath, err := ioutil.TempDir("", "influxdb-tsdb")
+	rootPath, err := os.MkdirTemp("", "influxdb-tsdb")
 	if err != nil {
 		panic(err)
 	}
 
-	seriesPath, err := ioutil.TempDir(rootPath, tsdb.SeriesFileDirectory)
+	seriesPath, err := os.MkdirTemp(rootPath, tsdb.SeriesFileDirectory)
 	if err != nil {
 		panic(err)
 	}
@@ -553,7 +553,7 @@ func BenchmarkIndexSet_TagSets(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -668,7 +668,7 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -3,7 +3,6 @@ package tsdb_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -317,7 +316,7 @@ type SeriesFile struct {
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
 func NewSeriesFile() *SeriesFile {
-	dir, err := ioutil.TempDir("", "tsdb-series-file-")
+	dir, err := os.MkdirTemp("", "tsdb-series-file-")
 	if err != nil {
 		panic(err)
 	}
@@ -334,7 +333,7 @@ func NewBrokenSeriesFile(content []byte) *SeriesFile {
 	if _, err := os.Stat(segPath); os.IsNotExist(err) {
 		panic(err)
 	}
-	err := ioutil.WriteFile(segPath, content, 0777)
+	err := os.WriteFile(segPath, content, 0777)
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -101,7 +100,7 @@ func (p *SeriesPartition) Open() error {
 }
 
 func (p *SeriesPartition) openSegments() error {
-	fis, err := ioutil.ReadDir(p.path)
+	fis, err := os.ReadDir(p.path)
 	if err != nil {
 		return err
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1945,7 +1944,7 @@ func (fs *MeasurementFieldSet) load() error {
 	}
 
 	var pb internal.MeasurementFieldSet
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		return err
 	}

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -2,7 +2,6 @@ package tsdb
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -215,7 +214,7 @@ type TempShard struct {
 // NewTempShard returns a new instance of TempShard with temp paths.
 func NewTempShard(index string) *TempShard {
 	// Create temporary path for data and WAL.
-	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
+	dir, err := os.MkdirTemp("", "influxdb-tsdb-")
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -102,7 +101,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 }
 
 func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -153,7 +152,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 }
 
 func TestMaxSeriesLimit(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "db", "rp", "1")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -237,7 +236,7 @@ func checkInt64Stat(t *testing.T, stat models.Statistic, name string, exp int64)
 }
 
 func TestShard_MaxTagValuesLimit(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "db", "rp", "1")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -293,7 +292,7 @@ func TestShard_MaxTagValuesLimit(t *testing.T) {
 }
 
 func TestWriteTimeTag(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -344,7 +343,7 @@ func TestWriteTimeTag(t *testing.T) {
 }
 
 func TestWriteTimeField(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -380,7 +379,7 @@ func TestWriteTimeField(t *testing.T) {
 }
 
 func TestShardWriteAddNewField(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -433,7 +432,7 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	if testing.Short() || runtime.GOOS == "windows" {
 		t.Skip("Skipping on short and windows")
 	}
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -522,7 +521,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -673,7 +672,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 // Ensures that when a shard is closed, it removes any series meta-data
 // from the index.
 func TestShard_Close_RemoveIndex(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -1712,7 +1711,7 @@ func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
 
 	path := filepath.Join(dir, "fields.idx")
 
-	if err := ioutil.WriteFile(path, []byte{0, 0}, 0666); err != nil {
+	if err := os.WriteFile(path, []byte{0, 0}, 0666); err != nil {
 		t.Fatalf("error writing fields.index: %v", err)
 	}
 
@@ -2132,7 +2131,7 @@ func benchmarkWritePointsExistingSeriesEqualBatches(b *testing.B, mCnt, tkCnt, t
 }
 
 func openShard(sfile *SeriesFile) (*tsdb.Shard, string, error) {
-	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 	opts := tsdb.NewEngineOptions()
@@ -2267,7 +2266,7 @@ func (sh *Shard) Close() error {
 // NewShards create several shards all sharing the same
 func NewShards(index string, n int) Shards {
 	// Create temporary path for data and WAL.
-	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
+	dir, err := os.MkdirTemp("", "influxdb-tsdb-")
 	if err != nil {
 		panic(err)
 	}
@@ -2369,7 +2368,7 @@ func (sh *Shard) MustWritePointsString(s string) {
 }
 
 func MustTempDir() (string, func()) {
-	dir, err := ioutil.TempDir("", "shard-test")
+	dir, err := os.MkdirTemp("", "shard-test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp dir: %v", err))
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -1780,10 +1780,14 @@ func testFieldMaker(t *testing.T, wg *sync.WaitGroup, mf *tsdb.MeasurementFieldS
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
 	for _, fieldName := range fieldNames {
 		if err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
-			t.Fatalf("create field error: %v", err)
+			t.Logf("create field error: %v", err)
+			t.Fail()
+			return
 		}
 		if err := mf.Save(); err != nil {
-			t.Fatalf("save error: %v", err)
+			t.Logf("save error: %v", err)
+			t.Fail()
+			return
 		}
 	}
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -343,7 +342,7 @@ func (s *Store) loadShards() error {
 	var n int
 
 	// Determine how many shards we need to open by checking the store path.
-	dbDirs, err := ioutil.ReadDir(s.path)
+	dbDirs, err := os.ReadDir(s.path)
 	if err != nil {
 		return err
 	}
@@ -373,7 +372,7 @@ func (s *Store) loadShards() error {
 		}
 
 		// Load each retention policy within the database directory.
-		rpDirs, err := ioutil.ReadDir(dbPath)
+		rpDirs, err := os.ReadDir(dbPath)
 		if err != nil {
 			return err
 		}
@@ -395,7 +394,7 @@ func (s *Store) loadShards() error {
 				continue
 			}
 
-			shardDirs, err := ioutil.ReadDir(rpPath)
+			shardDirs, err := os.ReadDir(rpPath)
 			if err != nil {
 				return err
 			}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -2464,7 +2463,7 @@ type Store struct {
 
 // NewStore returns a new instance of Store with a temporary path.
 func NewStore(index string) *Store {
-	path, err := ioutil.TempDir("", "influxdb-tsdb-")
+	path, err := os.MkdirTemp("", "influxdb-tsdb-")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Upgrades Go to 1.18.

Main changes aside from the version bump:
- `// +build ...` directives are no longer needed, only `//go:build` is used now
- `reflect.Ptr` was renamed to `reflect.Pointer` (`reflect.PtrTo()` was similarly renamed `reflect.PointerTo()`, though we had no usages of this function)
    - The old name still exists, but will be deprecated in a future release (and is non-breaking to change now)
- `strings.Title()` was deprecated, and we unfortunately have to use `cases.Title()` now which is a bit more complicated, but luckily we only used this function in one place in a CLI command output formatter
- The `io/ioutil` package was "loosely deprecated" (not formally) in Go 1.16, simply providing redirects to functions in `io` or `os` for all functions (except for one). I went ahead and updated all of these since I anticipate this to get properly deprecated eventually
    - The one changed function, being `ioutil.ReadDir()` -> `os.ReadDir()` now returns an array of `os.DirEntry` objects instead of `fs.FileInfo`, which is more efficient to do (especially considering we did not require the extra information on `FileInfo` in any cases)
- A few sections of code were moved to `bytes.Cut()` or `strings.Cut()` for slight code cleanliness
- Several new warnings came up from `go vet`, particularly around vetting of `fmt.Println` (and similar) and of goroutines in test cases


- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [x] Tests pass