### PR TITLE
build: bump crossbuilder to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.18-0b1bcef254c3fba55196c070cc39c7aad58a9068
+    default: go1.18-62da560a25c021668f39bc4d10f936cef93140f9
 
 commands:
   install_rust:


### PR DESCRIPTION
Upgrades the crossbuilder version for version parity with enterprise