### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/annotations/service_test.go
+++ b/annotations/service_test.go
@@ -134,8 +134,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	}
 
 	t.Run("create annotations", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 
 		tests := []struct {
 			name    string
@@ -169,9 +168,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("select with filters", func(t *testing.T) {
-
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		populateAnnotationsData(t, svc)
 
 		tests := []struct {
@@ -335,8 +332,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("get by id", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		anns := populateAnnotationsData(t, svc)
 
 		tests := []struct {
@@ -383,8 +379,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 
 	t.Run("delete multiple with a filter", func(t *testing.T) {
 		t.Run("delete by stream id", func(t *testing.T) {
-			svc, clean := newTestService(t)
-			defer clean(t)
+			svc := newTestService(t)
 			populateAnnotationsData(t, svc)
 
 			ctx := context.Background()
@@ -485,8 +480,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 		})
 
 		t.Run("delete with non-id filters", func(t *testing.T) {
-			svc, clean := newTestService(t)
-			defer clean(t)
+			svc := newTestService(t)
 			populateAnnotationsData(t, svc)
 
 			tests := []struct {
@@ -590,8 +584,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					svc, clean := newTestService(t)
-					defer clean(t)
+					svc := newTestService(t)
 					populateAnnotationsData(t, svc)
 
 					err := svc.DeleteAnnotations(ctx, tt.deleteOrgID, tt.filter)
@@ -608,8 +601,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("delete a single annotation by id", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		ans := populateAnnotationsData(t, svc)
 
 		tests := []struct {
@@ -652,8 +644,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("update a single annotation by id", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		ans := populateAnnotationsData(t, svc)
 
 		updatedTime := time.Time{}.Add(time.Minute)
@@ -728,8 +719,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("deleted streams cascade to deleted annotations", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 
 		ctx := context.Background()
 		ans := populateAnnotationsData(t, svc)
@@ -762,8 +752,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 	})
 
 	t.Run("renamed streams are reflected in subsequent annotation queries", func(t *testing.T) {
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 
 		ctx := context.Background()
 		populateAnnotationsData(t, svc)
@@ -817,8 +806,7 @@ func TestAnnotationsCRUD(t *testing.T) {
 func TestStreamsCRUDSingle(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	ctx := context.Background()
 	orgID := *influxdbtesting.IDPtr(1)
@@ -907,8 +895,7 @@ func TestStreamsCRUDSingle(t *testing.T) {
 func TestStreamsCRUDMany(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	ctx := context.Background()
 
@@ -1038,10 +1025,10 @@ func assertStreamNames(t *testing.T, want []string, got []influxdb.StoredStream)
 	require.ElementsMatch(t, want, storedNames)
 }
 
-func newTestService(t *testing.T) (*Service, func(t *testing.T)) {
+func newTestService(t *testing.T) *Service {
 	t.Helper()
 
-	store, clean := sqlite.NewTestStore(t)
+	store := sqlite.NewTestStore(t)
 	ctx := context.Background()
 
 	sqliteMigrator := sqlite.NewMigrator(store, zap.NewNop())
@@ -1050,5 +1037,5 @@ func newTestService(t *testing.T) (*Service, func(t *testing.T)) {
 
 	svc := NewService(store)
 
-	return svc, clean
+	return svc
 }

--- a/bolt/bbolt_test.go
+++ b/bolt/bbolt_test.go
@@ -43,16 +43,7 @@ func newTestClient(t *testing.T) (*bolt.Client, func(), error) {
 }
 
 func TestClientOpen(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("unable to create temporary test directory %v", err)
-	}
-
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("unable to delete temporary test directory %s: %v", tempDir, err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	boltFile := filepath.Join(tempDir, "test", "bolt.db")
 

--- a/cmd/influxd/inspect/build_tsi/build_tsi_test.go
+++ b/cmd/influxd/inspect/build_tsi/build_tsi_test.go
@@ -55,8 +55,7 @@ func Test_BuildTSI_ShardID_Without_BucketID(t *testing.T) {
 }
 
 func Test_BuildTSI_Invalid_Index_Already_Exists(t *testing.T) {
-	tempDir := newTempDirectory(t, "", "build-tsi")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tempDir, "data", "12345", "autogen", "1", "index"), 0777)
 	os.MkdirAll(filepath.Join(tempDir, "wal", "12345", "autogen", "1"), 0777)
@@ -75,8 +74,7 @@ func Test_BuildTSI_Invalid_Index_Already_Exists(t *testing.T) {
 }
 
 func Test_BuildTSI_Valid(t *testing.T) {
-	tempDir := newTempDirectory(t, "", "build-tsi")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tempDir, "data", "12345", "autogen", "1"), 0777)
 	os.MkdirAll(filepath.Join(tempDir, "wal", "12345", "autogen", "1"), 0777)
@@ -119,8 +117,7 @@ func Test_BuildTSI_Valid(t *testing.T) {
 }
 
 func Test_BuildTSI_Valid_Batch_Size_Exceeded(t *testing.T) {
-	tempDir := newTempDirectory(t, "", "build-tsi")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tempDir, "data", "12345", "autogen", "1"), 0777)
 	os.MkdirAll(filepath.Join(tempDir, "wal", "12345", "autogen", "1"), 0777)
@@ -164,8 +161,7 @@ func Test_BuildTSI_Valid_Batch_Size_Exceeded(t *testing.T) {
 
 func Test_BuildTSI_Valid_Verbose(t *testing.T) {
 	// Set up temp directory structure
-	tempDir := newTempDirectory(t, "", "build-tsi")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tempDir, "data", "12345", "autogen", "1"), 0777)
 	os.MkdirAll(filepath.Join(tempDir, "wal", "12345", "autogen", "1"), 0777)
@@ -231,8 +227,7 @@ func Test_BuildTSI_Valid_Compact_Series(t *testing.T) {
 		t.Skip("mmap implementation on Windows prevents series-file from shrinking during compaction")
 	}
 
-	tempDir := newTempDirectory(t, "", "build-tsi")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tempDir, "data", "12345", "_series"), 0777)
 
@@ -393,15 +388,6 @@ func runCommand(t *testing.T, params cmdParams, outs cmdOuts) {
 			require.Contains(t, string(out), outs.expectedOut)
 		}
 	}
-}
-
-func newTempDirectory(t *testing.T, parentDir string, dirName string) string {
-	t.Helper()
-
-	dir, err := os.MkdirTemp(parentDir, dirName)
-	require.NoError(t, err)
-
-	return dir
 }
 
 func newTempTsmFile(t *testing.T, path string, values []tsm1.Value) {

--- a/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func Test_DeleteTSM_EmptyFile(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{})
-	defer os.RemoveAll(dir)
+	_, file := createTSMFile(t, tsmParams{})
 
 	runCommand(t, testParams{
 		file:      file,
@@ -23,10 +22,9 @@ func Test_DeleteTSM_EmptyFile(t *testing.T) {
 }
 
 func Test_DeleteTSM_WrongExt(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{
+	_, file := createTSMFile(t, tsmParams{
 		improperExt: true,
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:      file,
@@ -37,7 +35,6 @@ func Test_DeleteTSM_WrongExt(t *testing.T) {
 
 func Test_DeleteTSM_NotFile(t *testing.T) {
 	dir, _ := createTSMFile(t, tsmParams{})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:      dir,
@@ -47,10 +44,9 @@ func Test_DeleteTSM_NotFile(t *testing.T) {
 }
 
 func Test_DeleteTSM_SingleEntry_Valid(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{
+	_, file := createTSMFile(t, tsmParams{
 		keys: []string{"cpu"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:            file,
@@ -60,11 +56,10 @@ func Test_DeleteTSM_SingleEntry_Valid(t *testing.T) {
 }
 
 func Test_DeleteTSM_SingleEntry_Invalid(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{
+	_, file := createTSMFile(t, tsmParams{
 		invalid: true,
 		keys:    []string{"cpu"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:      file,
@@ -74,10 +69,9 @@ func Test_DeleteTSM_SingleEntry_Invalid(t *testing.T) {
 }
 
 func Test_DeleteTSM_ManyEntries_Valid(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{
+	_, file := createTSMFile(t, tsmParams{
 		keys: []string{"cpu", "foobar", "mem"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:      file,
@@ -86,11 +80,10 @@ func Test_DeleteTSM_ManyEntries_Valid(t *testing.T) {
 }
 
 func Test_DeleteTSM_ManyEntries_Invalid(t *testing.T) {
-	dir, file := createTSMFile(t, tsmParams{
+	_, file := createTSMFile(t, tsmParams{
 		invalid: true,
 		keys:    []string{"cpu", "foobar", "mem"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testParams{
 		file:      file,
@@ -154,10 +147,10 @@ type tsmParams struct {
 
 func createTSMFile(t *testing.T, params tsmParams) (string, string) {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "deletetsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	var file *os.File
+	var err error
 	if !params.improperExt {
 		file, err = os.CreateTemp(dir, "*."+tsm1.TSMFileExtension)
 	} else {

--- a/cmd/influxd/inspect/dump_tsi/dump_tsi_test.go
+++ b/cmd/influxd/inspect/dump_tsi/dump_tsi_test.go
@@ -19,9 +19,7 @@ func Test_DumpTSI_NoError(t *testing.T) {
 	cmd.SetOut(b)
 
 	// Create the temp-dir for our un-tared files to live in
-	dir, err := os.MkdirTemp("", "dumptsitest-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Untar the test data
 	file, err := os.Open("../tsi-test-data.tar.gz")

--- a/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
+++ b/cmd/influxd/inspect/dump_tsm/dump_tsm_test.go
@@ -21,8 +21,7 @@ func Test_DumpTSM_NoFile(t *testing.T) {
 }
 
 func Test_DumpTSM_EmptyFile(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{})
-	defer os.RemoveAll(dir)
+	_, file := makeTSMFile(t, tsmParams{})
 
 	runCommand(t, cmdParams{
 		file:      file,
@@ -32,10 +31,9 @@ func Test_DumpTSM_EmptyFile(t *testing.T) {
 }
 
 func Test_DumpTSM_WrongExt(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{
+	_, file := makeTSMFile(t, tsmParams{
 		wrongExt: true,
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file:      file,
@@ -46,7 +44,6 @@ func Test_DumpTSM_WrongExt(t *testing.T) {
 
 func Test_DumpTSM_NotFile(t *testing.T) {
 	dir, _ := makeTSMFile(t, tsmParams{})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file:      dir,
@@ -56,10 +53,9 @@ func Test_DumpTSM_NotFile(t *testing.T) {
 }
 
 func Test_DumpTSM_Valid(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{
+	_, file := makeTSMFile(t, tsmParams{
 		keys: []string{"cpu"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file: file,
@@ -72,11 +68,10 @@ func Test_DumpTSM_Valid(t *testing.T) {
 }
 
 func Test_DumpTSM_Invalid(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{
+	_, file := makeTSMFile(t, tsmParams{
 		invalid: true,
 		keys:    []string{"cpu"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file:      file,
@@ -86,10 +81,9 @@ func Test_DumpTSM_Invalid(t *testing.T) {
 }
 
 func Test_DumpTSM_ManyKeys(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{
+	_, file := makeTSMFile(t, tsmParams{
 		keys: []string{"cpu", "foobar", "mem"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file: file,
@@ -103,10 +97,9 @@ func Test_DumpTSM_ManyKeys(t *testing.T) {
 }
 
 func Test_DumpTSM_FilterKey(t *testing.T) {
-	dir, file := makeTSMFile(t, tsmParams{
+	_, file := makeTSMFile(t, tsmParams{
 		keys: []string{"cpu", "foobar", "mem"},
 	})
-	defer os.RemoveAll(dir)
 
 	runCommand(t, cmdParams{
 		file:   file,
@@ -187,8 +180,7 @@ type tsmParams struct {
 func makeTSMFile(t *testing.T, params tsmParams) (string, string) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "dumptsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	ext := tsm1.TSMFileExtension
 	if params.wrongExt {

--- a/cmd/influxd/inspect/report_tsi/report_tsi_test.go
+++ b/cmd/influxd/inspect/report_tsi/report_tsi_test.go
@@ -34,10 +34,7 @@ const (
 
 func Test_ReportTSI_GeneratedData(t *testing.T) {
 	shardlessPath := newTempDirectories(t, false)
-	defer os.RemoveAll(shardlessPath)
-
 	shardPath := newTempDirectories(t, true)
-	defer os.RemoveAll(shardPath)
 
 	tests := []cmdParams{
 		{
@@ -69,9 +66,7 @@ func Test_ReportTSI_GeneratedData(t *testing.T) {
 func Test_ReportTSI_TestData(t *testing.T) {
 
 	// Create temp directory for extracted test data
-	path, err := os.MkdirTemp("", "report-tsi-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Extract test data
 	file, err := os.Open("../tsi-test-data.tar.gz")
@@ -125,10 +120,9 @@ func Test_ReportTSI_TestData(t *testing.T) {
 func newTempDirectories(t *testing.T, withShards bool) string {
 	t.Helper()
 
-	dataDir, err := os.MkdirTemp("", "reporttsi")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(dataDir, bucketID, "autogen"), 0777)
+	err := os.MkdirAll(filepath.Join(dataDir, bucketID, "autogen"), 0777)
 	require.NoError(t, err)
 
 	if withShards {

--- a/cmd/influxd/inspect/report_tsm/report_tsm_test.go
+++ b/cmd/influxd/inspect/report_tsm/report_tsm_test.go
@@ -13,16 +13,15 @@ import (
 )
 
 func Test_Invalid_NotDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	runCommand(t, testInfo{
 		dir:       file.Name(),
 		expectOut: []string{"Files: 0"},
 	})
+	require.NoError(t, file.Close())
 }
 
 func Test_Invalid_EmptyDir(t *testing.T) {

--- a/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
+++ b/cmd/influxd/inspect/verify_seriesfile/verify_seriesfile_test.go
@@ -76,11 +76,10 @@ type Test struct {
 func NewTest(t *testing.T) *Test {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-seriesfile-")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	// create a series file in the directory
-	err = func() error {
+	err := func() error {
 		seriesFile := tsdb.NewSeriesFile(dir)
 		if err := seriesFile.Open(); err != nil {
 			return err
@@ -128,7 +127,6 @@ func NewTest(t *testing.T) *Test {
 		return seriesFile.Close()
 	}()
 	if err != nil {
-		os.RemoveAll(dir)
 		t.Fatal(err)
 	}
 

--- a/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
+++ b/cmd/influxd/inspect/verify_tombstone/verify_tombstone_test.go
@@ -21,12 +21,11 @@ const (
 
 // Run tests on a directory with no Tombstone files
 func TestVerifies_InvalidFileType(t *testing.T) {
-	path, err := os.MkdirTemp("", "verify-tombstone")
-	require.NoError(t, err)
+	path := t.TempDir()
 
-	_, err = os.CreateTemp(path, "verifytombstonetest*"+".txt")
+	f, err := os.CreateTemp(path, "verifytombstonetest*"+".txt")
 	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	require.NoError(t, f.Close())
 
 	verify := NewVerifyTombstoneCommand()
 	verify.SetArgs([]string{"--engine-path", path})
@@ -43,7 +42,6 @@ func TestVerifies_InvalidFileType(t *testing.T) {
 // Run tests on an empty Tombstone file (treated as v1)
 func TestVerifies_InvalidEmptyFile(t *testing.T) {
 	path, _ := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	verify := NewVerifyTombstoneCommand()
 	verify.SetArgs([]string{"--engine-path", path})
@@ -60,7 +58,6 @@ func TestVerifies_InvalidEmptyFile(t *testing.T) {
 // Runs tests on an invalid V2 Tombstone File
 func TestVerifies_InvalidV2(t *testing.T) {
 	path, file := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	WriteTombstoneHeader(t, file, v2header)
 	WriteBadData(t, file)
@@ -74,7 +71,6 @@ func TestVerifies_InvalidV2(t *testing.T) {
 
 func TestVerifies_ValidTS(t *testing.T) {
 	path, file := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	ts := tsm1.NewTombstoner(file.Name(), nil)
 	require.NoError(t, ts.Add([][]byte{[]byte("foobar")}))
@@ -90,7 +86,6 @@ func TestVerifies_ValidTS(t *testing.T) {
 // Runs tests on an invalid V3 Tombstone File
 func TestVerifies_InvalidV3(t *testing.T) {
 	path, file := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	WriteTombstoneHeader(t, file, v3header)
 	WriteBadData(t, file)
@@ -105,7 +100,6 @@ func TestVerifies_InvalidV3(t *testing.T) {
 // Runs tests on an invalid V4 Tombstone File
 func TestVerifies_InvalidV4(t *testing.T) {
 	path, file := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	WriteTombstoneHeader(t, file, v4header)
 	WriteBadData(t, file)
@@ -121,7 +115,6 @@ func TestVerifies_InvalidV4(t *testing.T) {
 // is not needed, but was part of old command.
 func TestTombstone_VeryVeryVerbose(t *testing.T) {
 	path, file := NewTempTombstone(t)
-	defer os.RemoveAll(path)
 
 	WriteTombstoneHeader(t, file, v4header)
 	WriteBadData(t, file)
@@ -136,8 +129,7 @@ func TestTombstone_VeryVeryVerbose(t *testing.T) {
 func NewTempTombstone(t *testing.T) (string, *os.File) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tombstone")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	file, err := os.CreateTemp(dir, "verifytombstonetest*"+"."+tsm1.TombstoneFileExtension)
 	require.NoError(t, err)

--- a/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
+++ b/cmd/influxd/inspect/verify_tsm/verify_tsm_test.go
@@ -69,8 +69,7 @@ func TestValidUTF8(t *testing.T) {
 func newUTFTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)
@@ -94,8 +93,7 @@ func newUTFTest(t *testing.T, withError bool) string {
 func newChecksumTest(t *testing.T, withError bool) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "verify-tsm")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	f, err := os.CreateTemp(dir, "verifytsmtest*"+"."+tsm1.TSMFileExtension)
 	require.NoError(t, err)

--- a/cmd/influxd/inspect/verify_wal/verify_wal.go
+++ b/cmd/influxd/inspect/verify_wal/verify_wal.go
@@ -109,6 +109,8 @@ func (a args) Run(cmd *cobra.Command) error {
 		}
 		totalEntriesScanned += entriesScanned
 		_ = tw.Flush()
+
+		_ = reader.Close()
 	}
 
 	// Print Summary

--- a/cmd/influxd/launcher/backup_restore_test.go
+++ b/cmd/influxd/launcher/backup_restore_test.go
@@ -2,7 +2,6 @@ package launcher_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/influxdata/influx-cli/v2/clients/backup"
@@ -18,9 +17,7 @@ func TestBackupRestore_Full(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	backupDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(backupDir)
+	backupDir := t.TempDir()
 
 	// Boot a server, write some data, and take a backup.
 	l1 := launcher.RunAndSetupNewLauncherOrFail(ctx, t, func(o *launcher.InfluxdOpts) {
@@ -83,7 +80,7 @@ func TestBackupRestore_Full(t *testing.T) {
 	l2.ResetHTTPCLient()
 
 	// Check that orgs and buckets were reset to match the original server's metadata.
-	_, err = l2.OrgService(t).FindOrganizationByID(ctx, l2.Org.ID)
+	_, err := l2.OrgService(t).FindOrganizationByID(ctx, l2.Org.ID)
 	require.Equal(t, errors.ENotFound, errors.ErrorCode(err))
 	rbkt1, err := l2.BucketService(t).FindBucket(ctx, influxdb.BucketFilter{OrganizationID: &l1.Org.ID, ID: &l1.Bucket.ID})
 	require.NoError(t, err)
@@ -116,9 +113,7 @@ func TestBackupRestore_Partial(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	backupDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(backupDir)
+	backupDir := t.TempDir()
 
 	// Boot a server, write some data, and take a backup.
 	l1 := launcher.RunAndSetupNewLauncherOrFail(ctx, t, func(o *launcher.InfluxdOpts) {

--- a/cmd/influxd/upgrade/fs_test.go
+++ b/cmd/influxd/upgrade/fs_test.go
@@ -12,13 +12,9 @@ import (
 )
 
 func TestCopyDirAndDirSize(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "tcd")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(tmpdir, "1", "1", "1"), 0700)
+	err := os.MkdirAll(filepath.Join(tmpdir, "1", "1", "1"), 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,11 +45,7 @@ func TestCopyDirAndDirSize(t *testing.T) {
 	}
 	assert.Equal(t, uint64(1600), size)
 
-	targetDir, err := os.MkdirTemp("", "tcd")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(targetDir)
+	targetDir := t.TempDir()
 	targetDir = filepath.Join(targetDir, "x")
 	err = CopyDir(tmpdir, targetDir, nil, func(path string) bool {
 		base := filepath.Base(path)

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -29,10 +29,7 @@ import (
 )
 
 func TestPathValidations(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	require.Nil(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	v1Dir := filepath.Join(tmpdir, "v1db")
 	v2Dir := filepath.Join(tmpdir, "v2db")
@@ -41,7 +38,7 @@ func TestPathValidations(t *testing.T) {
 	configsPath := filepath.Join(v2Dir, "configs")
 	enginePath := filepath.Join(v2Dir, "engine")
 
-	err = os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
+	err := os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
 	require.Nil(t, err)
 
 	sourceOpts := &optionsV1{
@@ -89,10 +86,7 @@ func TestPathValidations(t *testing.T) {
 }
 
 func TestClearTargetPaths(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	v2Dir := filepath.Join(tmpdir, "v2db")
 	boltPath := filepath.Join(v2Dir, bolt.DefaultFilename)
@@ -101,7 +95,7 @@ func TestClearTargetPaths(t *testing.T) {
 	cqPath := filepath.Join(v2Dir, "cqs")
 	configPath := filepath.Join(v2Dir, "config")
 
-	err = os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
+	err := os.MkdirAll(filepath.Join(enginePath, "db"), 0777)
 	require.NoError(t, err)
 	err = os.WriteFile(boltPath, []byte{1}, 0777)
 	require.NoError(t, err)
@@ -176,11 +170,9 @@ func TestDbURL(t *testing.T) {
 func TestUpgradeRealDB(t *testing.T) {
 	ctx := context.Background()
 
-	tmpdir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 
-	defer os.RemoveAll(tmpdir)
-	err = testutil.Unzip(filepath.Join("testdata", "v1db.zip"), tmpdir)
+	err := testutil.Unzip(filepath.Join("testdata", "v1db.zip"), tmpdir)
 	require.NoError(t, err)
 
 	v1ConfigPath := filepath.Join(tmpdir, "v1.conf")

--- a/kit/cli/viper_test.go
+++ b/kit/cli/viper_test.go
@@ -184,9 +184,7 @@ func Test_NewProgram(t *testing.T) {
 	for _, tt := range tests {
 		for _, writer := range configWriters {
 			fn := func(t *testing.T) {
-				testDir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				defer os.RemoveAll(testDir)
+				testDir := t.TempDir()
 
 				confFile, err := writer.writeFn(testDir, config)
 				require.NoError(t, err)
@@ -286,9 +284,12 @@ func writeTomlConfig(dir string, config interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer w.Close()
+
 	if err := toml.NewEncoder(w).Encode(config); err != nil {
 		return "", err
 	}
+
 	return confFile, nil
 }
 
@@ -304,9 +305,12 @@ func yamlConfigWriter(shortExt bool) configWriter {
 		if err != nil {
 			return "", err
 		}
+		defer w.Close()
+
 		if err := yaml.NewEncoder(w).Encode(config); err != nil {
 			return "", err
 		}
+
 		return confFile, nil
 	}
 }
@@ -382,9 +386,7 @@ func Test_ConfigPrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		fn := func(t *testing.T) {
-			testDir, err := os.MkdirTemp("", "")
-			require.NoError(t, err)
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 			defer setEnvVar("TEST_CONFIG_PATH", testDir)()
 
 			if tt.writeJson {
@@ -429,9 +431,7 @@ func Test_ConfigPrecedence(t *testing.T) {
 }
 
 func Test_ConfigPathDotDirectory(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	tests := []struct {
 		name string
@@ -460,7 +460,7 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 			configDir := filepath.Join(testDir, tc.dir)
 			require.NoError(t, os.Mkdir(configDir, 0700))
 
-			_, err = writeTomlConfig(configDir, config)
+			_, err := writeTomlConfig(configDir, config)
 			require.NoError(t, err)
 			defer setEnvVar("TEST_CONFIG_PATH", configDir)()
 
@@ -487,9 +487,7 @@ func Test_ConfigPathDotDirectory(t *testing.T) {
 }
 
 func Test_LoadConfigCwd(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	pwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/notebooks/service_test.go
+++ b/notebooks/service_test.go
@@ -20,8 +20,7 @@ var (
 func TestCreateAndGetNotebook(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 	ctx := context.Background()
 
 	// getting an invalid id should return an error
@@ -59,8 +58,7 @@ func TestCreateAndGetNotebook(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 	ctx := context.Background()
 
 	testCreate := &influxdb.NotebookReqBody{
@@ -108,8 +106,7 @@ func TestUpdate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 	ctx := context.Background()
 
 	// attempting to delete a non-existant notebook should return an error
@@ -145,8 +142,7 @@ func TestDelete(t *testing.T) {
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 	ctx := context.Background()
 
 	orgID := idGen.ID()
@@ -195,8 +191,8 @@ func TestList(t *testing.T) {
 	}
 }
 
-func newTestService(t *testing.T) (*Service, func(t *testing.T)) {
-	store, clean := sqlite.NewTestStore(t)
+func newTestService(t *testing.T) *Service {
+	store := sqlite.NewTestStore(t)
 	ctx := context.Background()
 
 	sqliteMigrator := sqlite.NewMigrator(store, zap.NewNop())
@@ -205,5 +201,5 @@ func newTestService(t *testing.T) (*Service, func(t *testing.T)) {
 
 	svc := NewService(store)
 
-	return svc, clean
+	return svc
 }

--- a/pkg/durablequeue/queue_test.go
+++ b/pkg/durablequeue/queue_test.go
@@ -605,11 +605,7 @@ func ReadSegment(segment *segment) string {
 }
 
 func TestSegment_repair(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hh_queue")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	examples := []struct {
 		In       *TestSegment
@@ -703,6 +699,9 @@ func TestSegment_repair(t *testing.T) {
 			example.VerifyFn = func([]byte) error { return nil }
 		}
 		segment := mustCreateSegment(example.In, dir, example.VerifyFn)
+		t.Cleanup(func() {
+			segment.close()
+		})
 
 		if got, exp := ReadSegment(segment), example.Expected.String(); got != exp {
 			t.Errorf("[example %d]\ngot: %s\nexp: %s\n\n", i+1, got, exp)

--- a/remotes/service_test.go
+++ b/remotes/service_test.go
@@ -57,8 +57,7 @@ var (
 func TestCreateAndGetConnection(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	// Getting an invalid ID should return an error.
 	got, err := svc.GetRemoteConnection(ctx, initID)
@@ -79,8 +78,7 @@ func TestCreateAndGetConnection(t *testing.T) {
 func TestUpdateAndGetConnection(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	// Updating a nonexistent ID fails.
 	updated, err := svc.UpdateRemoteConnection(ctx, initID, updateReq)
@@ -106,8 +104,7 @@ func TestUpdateAndGetConnection(t *testing.T) {
 func TestUpdateNoop(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	// Create a connection.
 	created, err := svc.CreateRemoteConnection(ctx, createReq)
@@ -128,8 +125,7 @@ func TestUpdateNoop(t *testing.T) {
 func TestDeleteConnection(t *testing.T) {
 	t.Parallel()
 
-	svc, clean := newTestService(t)
-	defer clean(t)
+	svc := newTestService(t)
 
 	// Deleting a nonexistent ID should return an error.
 	require.Equal(t, errRemoteNotFound, svc.DeleteRemoteConnection(ctx, initID))
@@ -167,8 +163,7 @@ func TestListConnections(t *testing.T) {
 	t.Run("list all", func(t *testing.T) {
 		t.Parallel()
 
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		allConns := setup(t, svc)
 
 		listed, err := svc.ListRemoteConnections(ctx, influxdb.RemoteConnectionListFilter{OrgID: connection.OrgID})
@@ -179,8 +174,7 @@ func TestListConnections(t *testing.T) {
 	t.Run("list by name", func(t *testing.T) {
 		t.Parallel()
 
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		allConns := setup(t, svc)
 
 		listed, err := svc.ListRemoteConnections(ctx, influxdb.RemoteConnectionListFilter{
@@ -194,8 +188,7 @@ func TestListConnections(t *testing.T) {
 	t.Run("list by URL", func(t *testing.T) {
 		t.Parallel()
 
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		allConns := setup(t, svc)
 
 		listed, err := svc.ListRemoteConnections(ctx, influxdb.RemoteConnectionListFilter{
@@ -209,8 +202,7 @@ func TestListConnections(t *testing.T) {
 	t.Run("list by other org ID", func(t *testing.T) {
 		t.Parallel()
 
-		svc, clean := newTestService(t)
-		defer clean(t)
+		svc := newTestService(t)
 		setup(t, svc)
 
 		listed, err := svc.ListRemoteConnections(ctx, influxdb.RemoteConnectionListFilter{OrgID: platform.ID(1000)})
@@ -219,8 +211,8 @@ func TestListConnections(t *testing.T) {
 	})
 }
 
-func newTestService(t *testing.T) (*service, func(t *testing.T)) {
-	store, clean := sqlite.NewTestStore(t)
+func newTestService(t *testing.T) *service {
+	store := sqlite.NewTestStore(t)
 	logger := zaptest.NewLogger(t)
 	sqliteMigrator := sqlite.NewMigrator(store, logger)
 	require.NoError(t, sqliteMigrator.Up(ctx, migrations.AllUp))
@@ -230,5 +222,5 @@ func newTestService(t *testing.T) (*service, func(t *testing.T)) {
 		idGenerator: mock.NewIncrementingIDGenerator(initID),
 	}
 
-	return &svc, clean
+	return &svc
 }

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -472,6 +472,9 @@ func TestSendWrite(t *testing.T) {
 	rq, ok := qm.replicationQueues[id1]
 	require.True(t, ok)
 	closeRq(rq)
+	t.Cleanup(func() {
+		require.NoError(t, rq.queue.Close())
+	})
 	go func() { <-rq.receive }() // absorb the receive to avoid testcase deadlock
 
 	// Create custom remote writer that does some expected behavior

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -736,6 +736,9 @@ func TestReplicationStartMissingQueue(t *testing.T) {
 	// Call startup function
 	err = qm.StartReplicationQueues(trackedReplications)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		shutdown(t, qm)
+	})
 
 	// Make sure queue is stored in map
 	require.NotNil(t, qm.replicationQueues[id1])

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -35,12 +35,13 @@ func TestCreateNewQueueDirExists(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(queuePath, id1.String()))
+
+	shutdown(t, qm)
 }
 
 func TestEnqueueScan(t *testing.T) {
@@ -78,9 +79,10 @@ func TestEnqueueScan(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
-			queuePath, qm := initQueueManager(t)
-			defer os.RemoveAll(filepath.Dir(queuePath))
+			_, qm := initQueueManager(t)
 
 			// Create new queue
 			err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -97,6 +99,9 @@ func TestEnqueueScan(t *testing.T) {
 			// Check queue position
 			closeRq(rq)
 			scan, err := rq.queue.NewScanner()
+			t.Cleanup(func() {
+				require.NoError(t, rq.queue.Close())
+			})
 
 			if tt.writeFuncReturn == nil {
 				require.ErrorIs(t, err, io.EOF)
@@ -115,8 +120,7 @@ func TestEnqueueScan(t *testing.T) {
 func TestCreateNewQueueDuplicateID(t *testing.T) {
 	t.Parallel()
 
-	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
+	_, qm := initQueueManager(t)
 
 	// Create a valid new queue
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -125,13 +129,14 @@ func TestCreateNewQueueDuplicateID(t *testing.T) {
 	// Try to initialize another queue with the same replication ID
 	err = qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
 	require.EqualError(t, err, "durable queue already exists for replication ID \"0000000000000001\"")
+
+	shutdown(t, qm)
 }
 
 func TestDeleteQueueDirRemoved(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create a valid new queue
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -147,8 +152,7 @@ func TestDeleteQueueDirRemoved(t *testing.T) {
 func TestDeleteQueueNonexistentID(t *testing.T) {
 	t.Parallel()
 
-	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
+	_, qm := initQueueManager(t)
 
 	// Delete nonexistent queue
 	err := qm.DeleteQueue(id1)
@@ -158,8 +162,7 @@ func TestDeleteQueueNonexistentID(t *testing.T) {
 func TestUpdateMaxQueueSizeNonexistentID(t *testing.T) {
 	t.Parallel()
 
-	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
+	_, qm := initQueueManager(t)
 
 	// Update nonexistent queue
 	err := qm.UpdateMaxQueueSize(id1, influxdb.DefaultReplicationMaxQueueSizeBytes)
@@ -170,7 +173,6 @@ func TestStartReplicationQueue(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create new queue
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -199,13 +201,14 @@ func TestStartReplicationQueue(t *testing.T) {
 	// Ensure queue is open by trying to remove, will error if open
 	err = qm.replicationQueues[id1].queue.Remove()
 	require.Errorf(t, err, "queue is open")
+
+	require.NoError(t, qm.replicationQueues[id1].queue.Close())
 }
 
 func TestStartReplicationQueuePartialDelete(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create new queue
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -233,7 +236,6 @@ func TestStartReplicationQueuesMultiple(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create queue1
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -280,13 +282,15 @@ func TestStartReplicationQueuesMultiple(t *testing.T) {
 	require.Errorf(t, err, "queue is open")
 	err = qm.replicationQueues[id2].queue.Remove()
 	require.Errorf(t, err, "queue is open")
+
+	require.NoError(t, qm.replicationQueues[id1].queue.Close())
+	require.NoError(t, qm.replicationQueues[id2].queue.Close())
 }
 
 func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create queue1
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)
@@ -325,14 +329,14 @@ func TestStartReplicationQueuesMultipleWithPartialDelete(t *testing.T) {
 	// Ensure queue1 is open by trying to remove, will error if open
 	err = qm.replicationQueues[id1].queue.Remove()
 	require.Errorf(t, err, "queue is open")
+
+	require.NoError(t, qm.replicationQueues[id1].queue.Close())
 }
 
 func initQueueManager(t *testing.T) (string, *durableQueueManager) {
 	t.Helper()
 
-	enginePath, err := os.MkdirTemp("", "engine")
-	require.NoError(t, err)
-	queuePath := filepath.Join(enginePath, "replicationq")
+	queuePath := filepath.Join(t.TempDir(), "replicationq")
 
 	logger := zaptest.NewLogger(t)
 	qm := NewDurableQueueManager(logger, queuePath, metrics.NewReplicationsMetrics(), replicationsMock.NewMockHttpConfigStore(nil))
@@ -403,9 +407,7 @@ func getTestRemoteWriter(t *testing.T, expected string) remoteWriter {
 func TestEnqueueData(t *testing.T) {
 	t.Parallel()
 
-	queuePath, err := os.MkdirTemp("", "testqueue")
-	require.NoError(t, err)
-	defer os.RemoveAll(queuePath)
+	queuePath := t.TempDir()
 
 	logger := zaptest.NewLogger(t)
 	qm := NewDurableQueueManager(logger, queuePath, metrics.NewReplicationsMetrics(), replicationsMock.NewMockHttpConfigStore(nil))
@@ -429,6 +431,9 @@ func TestEnqueueData(t *testing.T) {
 	rq, ok := qm.replicationQueues[id1]
 	require.True(t, ok)
 	closeRq(rq)
+	t.Cleanup(func() {
+		require.NoError(t, rq.queue.Close())
+	})
 	go func() { <-rq.receive }() // absorb the receive to avoid testcase deadlock
 
 	require.NoError(t, qm.EnqueueData(id1, []byte(data), 1))
@@ -460,7 +465,6 @@ func TestSendWrite(t *testing.T) {
 	}
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
@@ -547,7 +551,6 @@ func TestEnqueueData_WithMetrics(t *testing.T) {
 	t.Parallel()
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
@@ -555,6 +558,9 @@ func TestEnqueueData_WithMetrics(t *testing.T) {
 	rq, ok := qm.replicationQueues[id1]
 	require.True(t, ok)
 	closeRq(rq)
+	t.Cleanup(func() {
+		require.NoError(t, rq.queue.Close())
+	})
 
 	reg := prom.NewRegistry(zaptest.NewLogger(t))
 	reg.MustRegister(qm.metrics.PrometheusCollectors()...)
@@ -589,7 +595,6 @@ func TestEnqueueData_EnqueueFailure(t *testing.T) {
 	t.Parallel()
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
@@ -622,7 +627,6 @@ func TestGoroutineReceives(t *testing.T) {
 	t.Parallel()
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
@@ -630,6 +634,9 @@ func TestGoroutineReceives(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, rq)
 	closeRq(rq) // atypical from normal behavior, but lets us receive channels to test
+	t.Cleanup(func() {
+		require.NoError(t, rq.queue.Close())
+	})
 
 	go func() { require.NoError(t, qm.EnqueueData(id1, []byte("1234"), 1)) }()
 	select {
@@ -645,7 +652,6 @@ func TestGoroutineCloses(t *testing.T) {
 	t.Parallel()
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
 	require.DirExists(t, filepath.Join(path, id1.String()))
 
@@ -670,7 +676,9 @@ func TestGetReplications(t *testing.T) {
 	t.Parallel()
 
 	path, qm := initQueueManager(t)
-	defer os.RemoveAll(path)
+	t.Cleanup(func() {
+		shutdown(t, qm)
+	})
 
 	// Initialize 3 queues (2nd and 3rd share the same orgID and localBucket)
 	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
@@ -700,7 +708,6 @@ func TestReplicationStartMissingQueue(t *testing.T) {
 	t.Parallel()
 
 	queuePath, qm := initQueueManager(t)
-	defer os.RemoveAll(filepath.Dir(queuePath))
 
 	// Create new queue
 	err := qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0)

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -77,8 +77,7 @@ func idPointer(id int) *platform.ID {
 func TestCreateAndGetReplication(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -101,8 +100,7 @@ func TestCreateAndGetReplication(t *testing.T) {
 func TestCreateAndGetReplicationName(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -132,8 +130,7 @@ func TestCreateAndGetReplicationName(t *testing.T) {
 func TestCreateAndGetReplicationNameAndID(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -163,8 +160,7 @@ func TestCreateAndGetReplicationNameAndID(t *testing.T) {
 func TestCreateAndGetReplicationNameError(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -186,8 +182,7 @@ func TestCreateAndGetReplicationNameError(t *testing.T) {
 func TestCreateMissingRemote(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	created, err := testStore.CreateReplication(ctx, initID, createReq)
 	require.Error(t, err)
@@ -203,8 +198,7 @@ func TestCreateMissingRemote(t *testing.T) {
 func TestUpdateAndGetReplication(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 	insertRemote(t, testStore, updatedReplication.RemoteID)
@@ -228,8 +222,7 @@ func TestUpdateAndGetReplication(t *testing.T) {
 func TestUpdateResponseInfo(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 	insertRemote(t, testStore, updatedReplication.RemoteID)
@@ -260,8 +253,7 @@ func TestUpdateResponseInfo(t *testing.T) {
 func TestUpdateMissingRemote(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -285,8 +277,7 @@ func TestUpdateMissingRemote(t *testing.T) {
 func TestUpdateNoop(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -304,8 +295,7 @@ func TestUpdateNoop(t *testing.T) {
 func TestDeleteReplication(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -327,8 +317,7 @@ func TestDeleteReplication(t *testing.T) {
 func TestDeleteReplications(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	// Deleting when there is no bucket is OK.
 	_, err := testStore.DeleteBucketReplications(ctx, replication.LocalBucketID)
@@ -387,8 +376,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list all for org", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 		allRepls := setup(t, testStore)
 
 		listed, err := testStore.ListReplications(ctx, influxdb.ReplicationListFilter{OrgID: createReq.OrgID})
@@ -407,8 +395,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list all with empty filter", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 		allRepls := setup(t, testStore)
 
 		otherOrgReq := createReq
@@ -425,8 +412,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list by name", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 		allRepls := setup(t, testStore)
 
 		listed, err := testStore.ListReplications(ctx, influxdb.ReplicationListFilter{
@@ -440,8 +426,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list by remote ID", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 		allRepls := setup(t, testStore)
 
 		listed, err := testStore.ListReplications(ctx, influxdb.ReplicationListFilter{
@@ -455,8 +440,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list by bucket ID", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 		allRepls := setup(t, testStore)
 
 		listed, err := testStore.ListReplications(ctx, influxdb.ReplicationListFilter{
@@ -470,8 +454,7 @@ func TestListReplications(t *testing.T) {
 	t.Run("list by other org ID", func(t *testing.T) {
 		t.Parallel()
 
-		testStore, clean := newTestStore(t)
-		defer clean(t)
+		testStore := newTestStore(t)
 
 		listed, err := testStore.ListReplications(ctx, influxdb.ReplicationListFilter{OrgID: platform.ID(2)})
 		require.NoError(t, err)
@@ -482,8 +465,7 @@ func TestListReplications(t *testing.T) {
 func TestMigrateDownFromReplicationsWithName(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -526,7 +508,7 @@ func TestMigrateDownFromReplicationsWithName(t *testing.T) {
 }
 
 func TestMigrateUpToRemotesNullRemoteOrg(t *testing.T) {
-	sqlStore, clean := sqlite.NewTestStore(t)
+	sqlStore := sqlite.NewTestStore(t)
 	logger := zaptest.NewLogger(t)
 	sqliteMigrator := sqlite.NewMigrator(sqlStore, logger)
 	require.NoError(t, sqliteMigrator.UpUntil(ctx, 7, migrations.AllUp))
@@ -536,7 +518,6 @@ func TestMigrateUpToRemotesNullRemoteOrg(t *testing.T) {
 	require.NoError(t, err)
 
 	testStore := NewStore(sqlStore)
-	defer clean(t)
 
 	insertRemote(t, testStore, replication.RemoteID)
 
@@ -561,8 +542,7 @@ func TestMigrateUpToRemotesNullRemoteOrg(t *testing.T) {
 func TestGetFullHTTPConfig(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	// Does not exist returns the appropriate error
 	_, err := testStore.GetFullHTTPConfig(ctx, initID)
@@ -582,8 +562,7 @@ func TestGetFullHTTPConfig(t *testing.T) {
 func TestPopulateRemoteHTTPConfig(t *testing.T) {
 	t.Parallel()
 
-	testStore, clean := newTestStore(t)
-	defer clean(t)
+	testStore := newTestStore(t)
 
 	emptyConfig := &influxdb.ReplicationHTTPConfig{RemoteOrgID: idPointer(0)}
 
@@ -606,8 +585,8 @@ func TestPopulateRemoteHTTPConfig(t *testing.T) {
 	require.Equal(t, want, *target)
 }
 
-func newTestStore(t *testing.T) (*Store, func(t *testing.T)) {
-	sqlStore, clean := sqlite.NewTestStore(t)
+func newTestStore(t *testing.T) *Store {
+	sqlStore := sqlite.NewTestStore(t)
 	logger := zaptest.NewLogger(t)
 	sqliteMigrator := sqlite.NewMigrator(sqlStore, logger)
 	require.NoError(t, sqliteMigrator.Up(ctx, migrations.AllUp))
@@ -616,7 +595,7 @@ func newTestStore(t *testing.T) (*Store, func(t *testing.T)) {
 	_, err := sqlStore.DB.Exec("PRAGMA foreign_keys = ON;")
 	require.NoError(t, err)
 
-	return NewStore(sqlStore), clean
+	return NewStore(sqlStore)
 }
 
 func insertRemote(t *testing.T, store *Store, id platform.ID) {

--- a/sqlite/migrator_test.go
+++ b/sqlite/migrator_test.go
@@ -28,8 +28,7 @@ type tableInfo struct {
 func TestUp(t *testing.T) {
 	t.Parallel()
 
-	store, clean := NewTestStore(t)
-	defer clean(t)
+	store := NewTestStore(t)
 
 	upsOnlyAll, err := test_migrations.AllUp.ReadDir(".")
 	require.NoError(t, err)
@@ -69,8 +68,7 @@ func TestUpErrors(t *testing.T) {
 	t.Parallel()
 
 	t.Run("only unknown migration exists", func(t *testing.T) {
-		store, clean := NewTestStore(t)
-		defer clean(t)
+		store := NewTestStore(t)
 		ctx := context.Background()
 
 		migrator := NewMigrator(store, zaptest.NewLogger(t))
@@ -80,8 +78,7 @@ func TestUpErrors(t *testing.T) {
 	})
 
 	t.Run("known + unknown migrations exist", func(t *testing.T) {
-		store, clean := NewTestStore(t)
-		defer clean(t)
+		store := NewTestStore(t)
 		ctx := context.Background()
 
 		migrator := NewMigrator(store, zaptest.NewLogger(t))
@@ -94,8 +91,7 @@ func TestUpErrors(t *testing.T) {
 func TestUpWithBackups(t *testing.T) {
 	t.Parallel()
 
-	store, clean := NewTestStore(t)
-	defer clean(t)
+	store := NewTestStore(t)
 
 	logger := zaptest.NewLogger(t)
 	migrator := NewMigrator(store, logger)
@@ -140,8 +136,7 @@ func TestUpWithBackups(t *testing.T) {
 func TestDown(t *testing.T) {
 	t.Parallel()
 
-	store, clean := NewTestStore(t)
-	defer clean(t)
+	store := NewTestStore(t)
 
 	upsOnlyAll, err := test_migrations.AllUp.ReadDir(".")
 	require.NoError(t, err)

--- a/sqlite/sqlite_helpers.go
+++ b/sqlite/sqlite_helpers.go
@@ -1,24 +1,21 @@
 package sqlite
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
-func NewTestStore(t *testing.T) (*SqlStore, func(t *testing.T)) {
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err, "unable to create temporary test directory")
+func NewTestStore(t *testing.T) *SqlStore {
+	tempDir := t.TempDir()
 
 	s, err := NewSqlStore(tempDir+"/"+DefaultFilename, zap.NewNop())
 	require.NoError(t, err, "unable to open testing database")
 
-	cleanUpFn := func(t *testing.T) {
+	t.Cleanup(func() {
 		require.NoError(t, s.Close(), "failed to close testing database")
-		require.NoErrorf(t, os.RemoveAll(tempDir), "unable to delete temporary test directory %s", tempDir)
-	}
+	})
 
-	return s, cleanUpFn
+	return s
 }

--- a/storage/flux/table_test.go
+++ b/storage/flux/table_test.go
@@ -50,10 +50,7 @@ type StorageReader struct {
 }
 
 func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
-	rootDir, err := os.MkdirTemp("", "storage-flux-test")
-	if err != nil {
-		tb.Fatal(err)
-	}
+	rootDir := tb.TempDir()
 
 	var closers []io.Closer
 	close := func() {
@@ -62,7 +59,6 @@ func NewStorageReader(tb testing.TB, setupFn SetupFunc) *StorageReader {
 				tb.Errorf("close error: %s", err)
 			}
 		}
-		_ = os.RemoveAll(rootDir)
 	}
 
 	// Create an underlying kv store. We use the inmem version to speed

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -179,10 +179,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	// Mostly copied out of cmd/influxd/main.go.
 	logger := zaptest.NewLogger(t)
 
-	rootDir, err := os.MkdirTemp("", "task-logreaderwriter-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	rootDir := t.TempDir()
 
 	engine := storage.NewEngine(rootDir, storage.NewConfig(), storage.WithMetaClient(metaClient))
 	engine.WithLogger(logger)
@@ -194,7 +191,6 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 	defer func() {
 		if t.Failed() {
 			engine.Close()
-			os.RemoveAll(rootDir)
 		}
 	}()
 

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -541,8 +541,7 @@ func TestCache_Deduplicate_Concurrent(t *testing.T) {
 // Ensure the CacheLoader can correctly load from a single segment, even if it's corrupted.
 func TestCacheLoader_LoadSingle(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	w := NewWALSegmentWriter(f)
 
@@ -613,10 +612,15 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 // Ensure the CacheLoader can correctly load from two segments, even if one is corrupted.
 func TestCacheLoader_LoadDouble(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f1, f2 := mustTempFile(dir), mustTempFile(dir)
 	w1, w2 := NewWALSegmentWriter(f1), NewWALSegmentWriter(f2)
+	t.Cleanup(func() {
+		f1.Close()
+		f2.Close()
+		w1.close()
+		w2.close()
+	})
 
 	p1 := NewValue(1, 1.1)
 	p2 := NewValue(1, int64(1))
@@ -678,10 +682,13 @@ func TestCacheLoader_LoadDouble(t *testing.T) {
 // Ensure the CacheLoader can load deleted series
 func TestCacheLoader_LoadDeleted(t *testing.T) {
 	// Create a WAL segment.
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	w := NewWALSegmentWriter(f)
+	t.Cleanup(func() {
+		f.Close()
+		w.close()
+	})
 
 	p1 := NewValue(1, 1.0)
 	p2 := NewValue(2, 2.0)
@@ -779,14 +786,6 @@ func TestCache_Split(t *testing.T) {
 			t.Fatalf("missing key, exp %s, got %v", key, nil)
 		}
 	}
-}
-
-func mustTempDir() string {
-	dir, err := os.MkdirTemp("", "tsm1-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir
 }
 
 func mustTempFile(dir string) *os.File {

--- a/tsdb/engine/tsm1/digest_test.go
+++ b/tsdb/engine/tsm1/digest_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func TestDigest_None(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
 	}
 
-	df := MustTempFile(dir)
+	df := MustTempFile(t, dir)
 
 	files := []string{}
 	if err := tsm1.Digest(dir, files, df); err != nil {
@@ -62,7 +62,7 @@ func TestDigest_None(t *testing.T) {
 }
 
 func TestDigest_One(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -72,14 +72,14 @@ func TestDigest_One(t *testing.T) {
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a1},
 	}
-	MustWriteTSM(dir, 1, writes)
+	MustWriteTSM(t, dir, 1, writes)
 
 	files, err := filepath.Glob(filepath.Join(dir, fmt.Sprintf("*.%s", tsm1.TSMFileExtension)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	df := MustTempFile(dir)
+	df := MustTempFile(t, dir)
 
 	if err := tsm1.Digest(dir, files, df); err != nil {
 		t.Fatalf("digest error: %v", err)
@@ -125,7 +125,7 @@ func TestDigest_One(t *testing.T) {
 }
 
 func TestDigest_TimeFilter(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -135,26 +135,26 @@ func TestDigest_TimeFilter(t *testing.T) {
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a1},
 	}
-	MustWriteTSM(dir, 1, writes)
+	MustWriteTSM(t, dir, 1, writes)
 
 	a2 := tsm1.NewValue(2, 2.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a2},
 	}
-	MustWriteTSM(dir, 2, writes)
+	MustWriteTSM(t, dir, 2, writes)
 
 	a3 := tsm1.NewValue(3, 3.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a3},
 	}
-	MustWriteTSM(dir, 3, writes)
+	MustWriteTSM(t, dir, 3, writes)
 
 	files, err := filepath.Glob(filepath.Join(dir, fmt.Sprintf("*.%s", tsm1.TSMFileExtension)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	df := MustTempFile(dir)
+	df := MustTempFile(t, dir)
 
 	if err := tsm1.DigestWithOptions(dir, files, tsm1.DigestOptions{MinTime: 2, MaxTime: 2}, df); err != nil {
 		t.Fatalf("digest error: %v", err)
@@ -206,7 +206,7 @@ func TestDigest_TimeFilter(t *testing.T) {
 }
 
 func TestDigest_KeyFilter(t *testing.T) {
-	dir := MustTempDir()
+	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatalf("create data dir: %v", err)
@@ -216,26 +216,26 @@ func TestDigest_KeyFilter(t *testing.T) {
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a1},
 	}
-	MustWriteTSM(dir, 1, writes)
+	MustWriteTSM(t, dir, 1, writes)
 
 	a2 := tsm1.NewValue(2, 2.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=B#!~#value": []tsm1.Value{a2},
 	}
-	MustWriteTSM(dir, 2, writes)
+	MustWriteTSM(t, dir, 2, writes)
 
 	a3 := tsm1.NewValue(3, 3.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=C#!~#value": []tsm1.Value{a3},
 	}
-	MustWriteTSM(dir, 3, writes)
+	MustWriteTSM(t, dir, 3, writes)
 
 	files, err := filepath.Glob(filepath.Join(dir, fmt.Sprintf("*.%s", tsm1.TSMFileExtension)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	df := MustTempFile(dir)
+	df := MustTempFile(t, dir)
 
 	if err := tsm1.DigestWithOptions(dir, files, tsm1.DigestOptions{
 		MinKey: []byte("cpu,host=B#!~#value"),
@@ -284,8 +284,7 @@ func TestDigest_KeyFilter(t *testing.T) {
 
 func TestDigest_Manifest(t *testing.T) {
 	// Create temp directory to hold test files.
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	digestFile := filepath.Join(dir, tsm1.DigestFilename)
 
@@ -299,7 +298,7 @@ func TestDigest_Manifest(t *testing.T) {
 	var files []string
 	gen := 1
 	for ; gen < 4; gen++ {
-		name := MustWriteTSM(dir, gen, writes)
+		name := MustWriteTSM(t, dir, gen, writes)
 		files = append(files, name)
 	}
 
@@ -363,7 +362,7 @@ func TestDigest_Manifest(t *testing.T) {
 	}
 
 	// Write an extra tsm file that shouldn't be included in the manifest.
-	extra := MustWriteTSM(dir, gen, writes)
+	extra := MustWriteTSM(t, dir, gen, writes)
 
 	// Re-generate manifest.
 	mfest, err = tsm1.NewDigestManifest(dir, files)

--- a/tsdb/engine/tsm1/digest_writer_test.go
+++ b/tsdb/engine/tsm1/digest_writer_test.go
@@ -12,7 +12,7 @@ import (
 // Test that an error is returned if a manifest isn't the first thing written
 // to a digest.
 func TestEngine_DigestManifestNotWritten(t *testing.T) {
-	f := MustTempFile("")
+	f := MustTempFile(t, "")
 	w, err := tsm1.NewDigestWriter(f)
 	if err != nil {
 		t.Fatalf("NewDigestWriter: %v", err)
@@ -30,7 +30,7 @@ func TestEngine_DigestManifestNotWritten(t *testing.T) {
 // Test that a digest reader will skip over the manifest without error
 // if needed.
 func TestEngine_DigestReadSkipsManifest(t *testing.T) {
-	f := MustTempFile("")
+	f := MustTempFile(t, "")
 	w, err := tsm1.NewDigestWriter(f)
 	if err != nil {
 		t.Fatalf("NewDigestWriter: %v", err)
@@ -85,7 +85,7 @@ func TestEngine_DigestReadSkipsManifest(t *testing.T) {
 
 // Test that we get an error if a digest manifest is written twice.
 func TestEngine_DigestManifestDoubleWrite(t *testing.T) {
-	f := MustTempFile("")
+	f := MustTempFile(t, "")
 	w, err := tsm1.NewDigestWriter(f)
 	if err != nil {
 		t.Fatalf("NewDigestWriter: %v", err)
@@ -103,7 +103,7 @@ func TestEngine_DigestManifestDoubleWrite(t *testing.T) {
 
 // Test that we get an error if the manifest is read twice.
 func TestEngine_DigestManifestDoubleRead(t *testing.T) {
-	f := MustTempFile("")
+	f := MustTempFile(t, "")
 	w, err := tsm1.NewDigestWriter(f)
 	if err != nil {
 		t.Fatalf("NewDigestWriter: %v", err)
@@ -143,7 +143,7 @@ func TestEngine_DigestManifestDoubleRead(t *testing.T) {
 
 // Test writing and reading a digest.
 func TestEngine_DigestWriterReader(t *testing.T) {
-	f := MustTempFile("")
+	f := MustTempFile(t, "")
 	w, err := tsm1.NewDigestWriter(f)
 	if err != nil {
 		t.Fatalf("NewDigestWriter: %v", err)

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "shard_test")
-	require.NoError(t, err, "error creating temporary directory")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
@@ -41,7 +39,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 			time.Unix(int64(i), 0),
 		))
 	}
-	err = sh.WritePoints(context.Background(), points)
+	err := sh.WritePoints(context.Background(), points)
 	require.NoError(t, err)
 
 	engineInterface, err := sh.Engine()
@@ -82,10 +80,7 @@ func TestEngine_ConcurrentShardSnapshots(t *testing.T) {
 func NewSeriesFile(tb testing.TB, tmpDir string) *tsdb.SeriesFile {
 	tb.Helper()
 
-	dir, err := os.MkdirTemp(tmpDir, "tsdb-series-file-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 	f := tsdb.NewSeriesFile(dir)
 	f.Logger = zaptest.NewLogger(tb)
 	if err := f.Open(); err != nil {

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -17,9 +17,8 @@ import (
 )
 
 func TestFileStore_Read(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -28,7 +27,7 @@ func TestFileStore_Read(t *testing.T) {
 		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -54,9 +53,8 @@ func TestFileStore_Read(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -65,7 +63,7 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -74,6 +72,8 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -93,9 +93,8 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -105,7 +104,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 4.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -114,6 +113,8 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -166,9 +167,8 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -177,7 +177,7 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -187,6 +187,8 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -207,9 +209,8 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -219,7 +220,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 4.0), tsm1.NewValue(2, 7.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -229,6 +230,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -274,9 +277,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -286,7 +288,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, int64(4)), tsm1.NewValue(2, int64(7))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -296,6 +298,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -340,9 +344,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -352,7 +355,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, uint64(4)), tsm1.NewValue(2, uint64(7))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -362,6 +365,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.UnsignedValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -406,9 +411,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -418,7 +422,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, false), tsm1.NewValue(2, true)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -428,6 +432,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -472,9 +478,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 // Tests that seeking and reading all blocks that contain overlapping points does
 // not skip any blocks.
 func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -484,7 +489,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, "four"), tsm1.NewValue(2, "seven")}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -494,6 +499,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -538,9 +545,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -550,7 +556,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.2)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -559,6 +565,8 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -618,9 +626,8 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -630,7 +637,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(5))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -639,6 +646,8 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
@@ -697,9 +706,8 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -709,7 +717,7 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, uint64(5))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -718,6 +726,8 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 
 	buf := make([]tsm1.UnsignedValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
@@ -776,9 +786,8 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -788,7 +797,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, false)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -797,6 +806,8 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
@@ -855,9 +866,8 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 // Tests that blocks with a lower min time in later files are not returned
 // more than once causing unsorted results
 func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -867,7 +877,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.2")}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -876,6 +886,8 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	// Search for an entry that exists in the second file
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
@@ -932,9 +944,8 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_Middle(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -944,7 +955,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(4, 4.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -954,6 +965,8 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 3, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -990,9 +1003,8 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 }
 
 func TestFileStore_SeekToAsc_End(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1001,7 +1013,7 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1010,6 +1022,8 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 2, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1028,9 +1042,8 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1039,7 +1052,7 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1049,6 +1062,8 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1066,9 +1081,8 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1078,7 +1092,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1088,6 +1102,8 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 2, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1125,9 +1141,8 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1137,7 +1152,7 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.2)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1147,6 +1162,8 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 5, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1190,9 +1207,8 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1202,7 +1218,7 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(5))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1212,6 +1228,8 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 5, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1252,9 +1270,8 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 	}
 }
 func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1264,7 +1281,7 @@ func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, uint64(5))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1274,6 +1291,8 @@ func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.UnsignedValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 5, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1315,9 +1334,8 @@ func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1327,7 +1345,7 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, false)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1337,6 +1355,8 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 5, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1378,9 +1398,8 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1390,7 +1409,7 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.2")}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1400,6 +1419,8 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 5, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1441,9 +1462,8 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1452,7 +1472,7 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1461,6 +1481,8 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 4, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1479,9 +1501,8 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 4 files
 	data := []keyValues{
@@ -1491,7 +1512,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, 4.0), tsm1.NewValue(7, 7.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1500,6 +1521,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 10, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1576,9 +1599,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1588,7 +1610,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, int64(4)), tsm1.NewValue(10, int64(7))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1597,6 +1619,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 11, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1653,9 +1677,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1665,7 +1688,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, uint64(4)), tsm1.NewValue(10, uint64(7))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1674,6 +1697,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 
 	buf := make([]tsm1.UnsignedValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 11, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1730,9 +1755,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1742,7 +1766,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, true), tsm1.NewValue(7, false)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1751,6 +1775,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 11, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1827,9 +1853,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1839,7 +1864,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, "four"), tsm1.NewValue(7, "seven")}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1848,6 +1873,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 11, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1924,9 +1951,8 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_Middle(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -1938,7 +1964,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 		},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -1948,6 +1974,8 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 3, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2001,9 +2029,8 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 }
 
 func TestFileStore_SeekToDesc_End(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2012,7 +2039,7 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2021,6 +2048,8 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 2, false)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2039,9 +2068,8 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2050,7 +2078,7 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2063,6 +2091,8 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	expValues := []int{0, 2}
 	for _, v := range expValues {
 		values, err := c.ReadFloatBlock(&buf)
@@ -2083,9 +2113,8 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2093,7 +2122,7 @@ func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2101,11 +2130,14 @@ func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
 	// Delete part of the block in the first file.
 	r := MustOpenTSMReader(files[0])
 	r.DeleteRange([][]byte{[]byte("cpu")}, 1, 3)
+	t.Cleanup(func() { r.Close() })
 
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	expValues := []tsm1.Value{tsm1.NewValue(0, 0.0), tsm1.NewValue(2, 2.0)}
 
 	for _, exp := range expValues {
@@ -2126,9 +2158,8 @@ func TestKeyCursor_TombstoneRange_PartialFirst(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2138,7 +2169,7 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 			tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2151,6 +2182,8 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2170,9 +2203,8 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2182,7 +2214,7 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 			tsm1.NewValue(2, int64(3))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2195,6 +2227,8 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2214,9 +2248,8 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2226,7 +2259,7 @@ func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
 			tsm1.NewValue(2, uint64(3))}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2239,6 +2272,8 @@ func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
 
 	buf := make([]tsm1.UnsignedValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2258,9 +2293,8 @@ func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2270,7 +2304,7 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 			tsm1.NewValue(2, "3")}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2283,6 +2317,8 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2302,9 +2338,8 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 }
 
 func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2314,7 +2349,7 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 			tsm1.NewValue(2, true)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2327,6 +2362,8 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+	t.Cleanup(c.Close)
+
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2346,8 +2383,7 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 }
 
 func TestFileStore_Open(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2356,16 +2392,15 @@ func TestFileStore_Open(t *testing.T) {
 		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	_, err := newFileDir(dir, data...)
+	_, err := newFileDir(t, dir, data...)
 	if err != nil {
 		fatal(t, "creating test files", err)
 	}
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(t, dir)
 	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs.Close()
 
 	if got, exp := fs.Count(), 3; got != exp {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
@@ -2377,8 +2412,7 @@ func TestFileStore_Open(t *testing.T) {
 }
 
 func TestFileStore_Remove(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2387,16 +2421,15 @@ func TestFileStore_Remove(t *testing.T) {
 		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	files, err := newFileDir(dir, data...)
+	files, err := newFileDir(t, dir, data...)
 	if err != nil {
 		fatal(t, "creating test files", err)
 	}
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(t, dir)
 	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs.Close()
 
 	if got, exp := fs.Count(), 3; got != exp {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
@@ -2418,8 +2451,7 @@ func TestFileStore_Remove(t *testing.T) {
 }
 
 func TestFileStore_Replace(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2428,7 +2460,7 @@ func TestFileStore_Replace(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFileDir(dir, data...)
+	files, err := newFileDir(t, dir, data...)
 	if err != nil {
 		fatal(t, "creating test files", err)
 	}
@@ -2437,11 +2469,10 @@ func TestFileStore_Replace(t *testing.T) {
 	replacement := fmt.Sprintf("%s.%s", files[2], tsm1.TmpTSMFileExtension)
 	os.Rename(files[2], replacement)
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(t, dir)
 	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs.Close()
 
 	if got, exp := fs.Count(), 2; got != exp {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
@@ -2509,8 +2540,7 @@ func TestFileStore_Replace(t *testing.T) {
 }
 
 func TestFileStore_Open_Deleted(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2519,16 +2549,15 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	_, err := newFileDir(dir, data...)
+	_, err := newFileDir(t, dir, data...)
 	if err != nil {
 		fatal(t, "creating test files", err)
 	}
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(t, dir)
 	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs.Close()
 
 	if got, exp := len(fs.Keys()), 3; got != exp {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
@@ -2538,11 +2567,10 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 		fatal(t, "deleting", err)
 	}
 
-	fs2 := newTestFileStore(dir)
+	fs2 := newTestFileStore(t, dir)
 	if err := fs2.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs2.Close()
 
 	if got, exp := len(fs2.Keys()), 2; got != exp {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
@@ -2550,9 +2578,8 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 }
 
 func TestFileStore_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2561,7 +2588,7 @@ func TestFileStore_Delete(t *testing.T) {
 		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2584,9 +2611,8 @@ func TestFileStore_Delete(t *testing.T) {
 }
 
 func TestFileStore_Apply(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2595,7 +2621,7 @@ func TestFileStore_Apply(t *testing.T) {
 		keyValues{"mem,host=server1#!~#value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2621,8 +2647,7 @@ func TestFileStore_Apply(t *testing.T) {
 }
 
 func TestFileStore_Stats(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create 3 TSM files...
 	data := []keyValues{
@@ -2631,16 +2656,15 @@ func TestFileStore_Stats(t *testing.T) {
 		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
-	files, err := newFileDir(dir, data...)
+	files, err := newFileDir(t, dir, data...)
 	if err != nil {
 		fatal(t, "creating test files", err)
 	}
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(t, dir)
 	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
-	defer fs.Close()
 
 	stats := fs.Stats()
 	if got, exp := len(stats), 3; got != exp {
@@ -2659,7 +2683,7 @@ func TestFileStore_Stats(t *testing.T) {
 	}
 
 	// Write a new TSM file that that is not open
-	newFile := MustWriteTSM(dir, 4, map[string][]tsm1.Value{
+	newFile := MustWriteTSM(t, dir, 4, map[string][]tsm1.Value{
 		"mem": []tsm1.Value{tsm1.NewValue(0, 1.0)},
 	})
 
@@ -2684,7 +2708,7 @@ func TestFileStore_Stats(t *testing.T) {
 		t.Fatalf("Didn't find %s in stats: %v", "foo", stats)
 	}
 
-	newFile = MustWriteTSM(dir, 5, map[string][]tsm1.Value{
+	newFile = MustWriteTSM(t, dir, 5, map[string][]tsm1.Value{
 		"mem": []tsm1.Value{tsm1.NewValue(0, 1.0)},
 	})
 
@@ -2696,9 +2720,8 @@ func TestFileStore_Stats(t *testing.T) {
 }
 
 func TestFileStore_CreateSnapshot(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 
 	// Setup 3 files
 	data := []keyValues{
@@ -2707,7 +2730,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2749,8 +2772,16 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 	}
 }
 
-func newTestFileStore(dir string) *tsm1.FileStore {
-	return tsm1.NewFileStore(dir, tsdb.EngineTags{})
+// newTestFileStore returns a FileStore for testing. The FileStore is closed by
+// tb.Cleanup when the test and all its subtests complete.
+func newTestFileStore(tb testing.TB, dir string) *tsm1.FileStore {
+	fs := tsm1.NewFileStore(dir, tsdb.EngineTags{})
+
+	tb.Cleanup(func() {
+		fs.Close()
+	})
+
+	return fs
 }
 
 type mockObserver struct {
@@ -2791,9 +2822,8 @@ func TestFileStore_Observer(t *testing.T) {
 		}
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	fs := newTestFileStore(dir)
+	dir := t.TempDir()
+	fs := newTestFileStore(t, dir)
 	fs.WithObserver(m)
 
 	// Setup 3 files
@@ -2803,7 +2833,7 @@ func TestFileStore_Observer(t *testing.T) {
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(20, 3.0)}},
 	}
 
-	files, err := newFiles(dir, data...)
+	files, err := newFiles(t, dir, data...)
 	if err != nil {
 		t.Fatalf("unexpected error creating files: %v", err)
 	}
@@ -2857,12 +2887,12 @@ func TestFileStore_Observer(t *testing.T) {
 	unlinks, finishes = nil, nil
 }
 
-func newFileDir(dir string, values ...keyValues) ([]string, error) {
+func newFileDir(tb testing.TB, dir string, values ...keyValues) ([]string, error) {
 	var files []string
 
 	id := 1
 	for _, v := range values {
-		f := MustTempFile(dir)
+		f := MustTempFile(tb, dir)
 		w, err := tsm1.NewTSMWriter(f)
 		if err != nil {
 			return nil, err
@@ -2891,12 +2921,12 @@ func newFileDir(dir string, values ...keyValues) ([]string, error) {
 
 }
 
-func newFiles(dir string, values ...keyValues) ([]string, error) {
+func newFiles(tb testing.TB, dir string, values ...keyValues) ([]string, error) {
 	var files []string
 
 	id := 1
 	for _, v := range values {
-		f := MustTempFile(dir)
+		f := MustTempFile(tb, dir)
 		w, err := tsm1.NewTSMWriter(f)
 		if err != nil {
 			return nil, err
@@ -2930,19 +2960,15 @@ type keyValues struct {
 	values []tsm1.Value
 }
 
-func MustTempDir() string {
-	dir, err := os.MkdirTemp("", "tsm1-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir
-}
-
-func MustTempFile(dir string) *os.File {
+func MustTempFile(tb testing.TB, dir string) *os.File {
 	f, err := os.CreateTemp(dir, "tsm1test")
 	if err != nil {
 		panic(fmt.Sprintf("failed to create temp file: %v", err))
 	}
+	tb.Cleanup(func() {
+		f.Close()
+	})
+
 	return f
 }
 
@@ -2953,8 +2979,7 @@ func fatal(t *testing.T, msg string, err error) {
 var fsResult []tsm1.FileStat
 
 func BenchmarkFileStore_Stats(b *testing.B) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	// Create some TSM files...
 	data := make([]keyValues, 0, 1000)
@@ -2962,18 +2987,17 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 		data = append(data, keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}})
 	}
 
-	_, err := newFileDir(dir, data...)
+	_, err := newFileDir(b, dir, data...)
 	if err != nil {
 		b.Fatalf("creating benchmark files %v", err)
 	}
 
-	fs := newTestFileStore(dir)
+	fs := newTestFileStore(b, dir)
 	fs.WithLogger(zaptest.NewLogger(b))
 
 	if err := fs.Open(context.Background()); err != nil {
 		b.Fatalf("opening file store %v", err)
 	}
-	defer fs.Close()
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -238,6 +238,7 @@ func NewTSMReader(f *os.File, options ...tsmReaderOption) (*TSMReader, error) {
 
 	index, err := t.accessor.init()
 	if err != nil {
+		_ = t.accessor.close()
 		return nil, err
 	}
 

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -17,8 +17,7 @@ func fatal(t *testing.T, msg string, err error) {
 }
 
 func TestTSMReader_Type(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -47,6 +46,7 @@ func TestTSMReader_Type(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	typ, err := r.Type([]byte("cpu"))
 	if err != nil {
@@ -59,8 +59,7 @@ func TestTSMReader_Type(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_ReadAll(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -133,8 +132,7 @@ func TestTSMReader_MMAP_ReadAll(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Read(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -212,8 +210,7 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Keys(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -291,10 +288,9 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Tombstone(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
-	defer f.Close()
+	t.Cleanup(func() { f.Close() })
 
 	w, err := NewTSMWriter(f)
 	if err != nil {
@@ -323,29 +319,29 @@ func TestTSMReader_MMAP_Tombstone(t *testing.T) {
 		t.Fatalf("unexpected error open file: %v", err)
 	}
 
-	r, err := NewTSMReader(f)
+	r1, err := NewTSMReader(f)
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r1.Close() })
 
-	if err := r.Delete([][]byte{[]byte("mem")}); err != nil {
+	if err := r1.Delete([][]byte{[]byte("mem")}); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 
-	r, err = NewTSMReader(f)
+	r2, err := NewTSMReader(f)
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { r2.Close() })
 
-	if got, exp := r.KeyCount(), 1; got != exp {
+	if got, exp := r2.KeyCount(), 1; got != exp {
 		t.Fatalf("key length mismatch: got %v, exp %v", got, exp)
 	}
 }
 
 func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -409,8 +405,7 @@ func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -471,8 +466,7 @@ func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -533,8 +527,7 @@ func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -599,8 +592,7 @@ func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -652,8 +644,7 @@ func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneFullRangeMultiple(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -725,8 +716,7 @@ func TestTSMReader_MMAP_TombstoneFullRangeMultiple(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -784,8 +774,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRangesFull(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -844,8 +833,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRangesFull(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneMultipleRangesNoOverlap(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -905,8 +893,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRangesNoOverlap(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -989,8 +976,7 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 }
 
 func TestTSMReader_MMAP_Stats(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1052,8 +1038,7 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 
 // Ensure that we return an error if we try to open a non-tsm file
 func TestTSMReader_VerifiesFileType(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1184,8 +1169,7 @@ func TestDirectIndex_KeyCount(t *testing.T) {
 }
 
 func TestBlockIterator_Single(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1215,6 +1199,7 @@ func TestBlockIterator_Single(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	var count int
 	iter := r.BlockIterator()
@@ -1253,8 +1238,7 @@ func TestBlockIterator_Single(t *testing.T) {
 }
 
 func TestBlockIterator_Tombstone(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1288,6 +1272,7 @@ func TestBlockIterator_Tombstone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	iter := r.BlockIterator()
 	for iter.Next() {
@@ -1302,8 +1287,7 @@ func TestBlockIterator_Tombstone(t *testing.T) {
 }
 
 func TestBlockIterator_MultipleBlocks(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1338,6 +1322,7 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	var count int
 	expData := []Values{values1, values2}
@@ -1380,8 +1365,7 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 }
 
 func TestBlockIterator_Sorted(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1406,7 +1390,6 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	for _, k := range keys {
 		if err := w.Write([]byte(k), values[k]); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
-
 		}
 	}
 
@@ -1427,6 +1410,7 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	var count int
 	iter := r.BlockIterator()
@@ -1457,8 +1441,7 @@ func TestBlockIterator_Sorted(t *testing.T) {
 }
 
 func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1492,8 +1475,7 @@ func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
 }
 
 func TestCompacted_NotFull(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 
 	w, err := NewTSMWriter(f)
@@ -1523,6 +1505,7 @@ func TestCompacted_NotFull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	t.Cleanup(func() { r.Close() })
 
 	iter := r.BlockIterator()
 	if !iter.Next() {
@@ -1544,8 +1527,7 @@ func TestCompacted_NotFull(t *testing.T) {
 }
 
 func TestTSMReader_File_ReadAll(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1652,48 +1634,43 @@ func TestTSMReader_FuzzCrashes(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		func() {
-			dir := mustTempDir()
-			defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
-			filename := filepath.Join(dir, "x.tsm")
-			if err := os.WriteFile(filename, []byte(c), 0600); err != nil {
-				t.Fatalf("exp no error, got %s", err)
-			}
-			defer os.RemoveAll(dir)
+		filename := filepath.Join(dir, "x.tsm")
+		if err := os.WriteFile(filename, []byte(c), 0600); err != nil {
+			t.Fatalf("exp no error, got %s", err)
+		}
 
-			f, err := os.Open(filename)
-			if err != nil {
-				t.Fatalf("exp no error, got %s", err)
-			}
-			defer f.Close()
+		f, err := os.Open(filename)
+		if err != nil {
+			t.Fatalf("exp no error, got %s", err)
+		}
+		t.Cleanup(func() { f.Close() })
 
-			r, err := NewTSMReader(f)
+		r, err := NewTSMReader(f)
+		if err != nil {
+			return
+		}
+		t.Cleanup(func() { r.Close() })
+
+		iter := r.BlockIterator()
+		for iter.Next() {
+			key, _, _, _, _, _, err := iter.Read()
 			if err != nil {
 				return
 			}
-			defer r.Close()
 
-			iter := r.BlockIterator()
-			for iter.Next() {
-				key, _, _, _, _, _, err := iter.Read()
-				if err != nil {
-					return
-				}
+			_, _ = r.Type(key)
 
-				_, _ = r.Type(key)
-
-				if _, err = r.ReadAll(key); err != nil {
-					return
-				}
+			if _, err = r.ReadAll(key); err != nil {
+				return
 			}
-		}()
+		}
 	}
 }
 
 func TestTSMReader_File_Read(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1771,8 +1748,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 }
 
 func TestTSMReader_References(t *testing.T) {
-	dir := mustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	f := mustTempFile(dir)
 	defer f.Close()
 
@@ -1915,7 +1891,7 @@ func TestBatchKeyIterator_Errors(t *testing.T) {
 }
 
 func createTestTSM(t *testing.T) (dir string, name string) {
-	dir = MustTempDir()
+	dir = t.TempDir()
 	f := mustTempFile(dir)
 	name = f.Name()
 	w, err := NewTSMWriter(f)

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestTombstoner_Add(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
@@ -58,10 +57,9 @@ func TestTombstoner_Add(t *testing.T) {
 }
 
 func TestTombstoner_Add_LargeKey(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
@@ -107,10 +105,9 @@ func TestTombstoner_Add_LargeKey(t *testing.T) {
 }
 
 func TestTombstoner_Add_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
@@ -170,10 +167,9 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 }
 
 func TestTombstoner_Add_Empty(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
@@ -199,10 +195,9 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 }
 
 func TestTombstoner_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	ts.Add([][]byte{[]byte("foo")})
@@ -237,10 +232,9 @@ func TestTombstoner_Delete(t *testing.T) {
 }
 
 func TestTombstoner_ReadV1(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	if err := os.WriteFile(f.Name(), []byte("foo\n"), 0x0600); err != nil {
 		t.Fatalf("write v1 file: %v", err)
 	}
@@ -279,12 +273,10 @@ func TestTombstoner_ReadV1(t *testing.T) {
 }
 
 func TestTombstoner_ReadEmptyV1(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(t, dir)
 	f.Close()
-
 	if err := os.Rename(f.Name(), f.Name()+"."+tsm1.TombstoneFileExtension); err != nil {
 		t.Fatalf("rename tombstone failed: %v", err)
 	}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -271,6 +271,7 @@ func (l *WAL) Open() error {
 				return err
 			}
 			if _, err := fd.Seek(0, io.SeekEnd); err != nil {
+				_ = fd.Close()
 				return err
 			}
 			l.currentSegmentWriter = NewWALSegmentWriter(fd)

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -599,16 +599,25 @@ func (l *WAL) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	// Always attempt to close the segment writer. We cannot do this in once.Do
+	// because if we have already closed the WAL before and reopened it again,
+	// the next Close() call will not close the new segment writer. For example:
+	// func main() {
+	//   w.Close() -- (1)
+	//   w.Open()
+	//   w.Close() -- (2)
+	// }
+	// (2) needs to close the reopened `currentSegmentWriter` again.
+	l.traceLogger.Info("Closing WAL file", zap.String("path", l.path))
+	if l.currentSegmentWriter != nil {
+		l.sync()
+		_ = l.currentSegmentWriter.close()
+		l.currentSegmentWriter = nil
+	}
+
 	l.once.Do(func() {
 		// Close, but don't set to nil so future goroutines can still be signaled
-		l.traceLogger.Info("Closing WAL file", zap.String("path", l.path))
 		close(l.closing)
-
-		if l.currentSegmentWriter != nil {
-			l.sync()
-			l.currentSegmentWriter.close()
-			l.currentSegmentWriter = nil
-		}
 	})
 
 	return nil

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -25,8 +25,7 @@ func NewWAL(path string, maxConcurrentWrites int, maxWriteDelay time.Duration) *
 }
 
 func TestWALWriter_WriteMulti_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -69,8 +68,7 @@ func TestWALWriter_WriteMulti_Single(t *testing.T) {
 }
 
 func TestWALWriter_WriteMulti_LargeBatch(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -109,8 +107,7 @@ func TestWALWriter_WriteMulti_LargeBatch(t *testing.T) {
 }
 
 func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -157,8 +154,7 @@ func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
 }
 
 func TestWALWriter_WriteDelete_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -184,8 +180,7 @@ func TestWALWriter_WriteDelete_Single(t *testing.T) {
 }
 
 func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -236,8 +231,7 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 }
 
 func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	w := NewWAL(dir, 0, 0)
 	defer w.Close()
 	require.NoError(t, w.Open())
@@ -295,8 +289,7 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 }
 
 func TestWAL_ClosedSegments(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -326,8 +319,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 }
 
 func TestWAL_Delete(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -354,9 +346,8 @@ func TestWAL_Delete(t *testing.T) {
 }
 
 func TestWALWriter_Corrupt(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 	w := tsm1.NewWALSegmentWriter(f)
 	corruption := []byte{1, 4, 0, 0, 0}
 
@@ -401,9 +392,8 @@ func TestWALWriter_Corrupt(t *testing.T) {
 // Reproduces a `panic: runtime error: makeslice: cap out of range` when run with
 // GOARCH=386 go test -run TestWALSegmentReader_Corrupt -v ./tsdb/engine/tsm1/
 func TestWALSegmentReader_Corrupt(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
 	p4 := tsm1.NewValue(1, "string")
@@ -439,8 +429,7 @@ func TestWALSegmentReader_Corrupt(t *testing.T) {
 }
 
 func TestWALRollSegment(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
@@ -509,8 +498,7 @@ func TestWAL_DiskSize(t *testing.T) {
 		require.Equal(t, old+cur, w.DiskSizeBytes(), "total disk size")
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	w := NewWAL(dir, 0, 0)
 
@@ -543,9 +531,10 @@ func TestWAL_DiskSize(t *testing.T) {
 	}
 
 	test(w, false, false)
+	require.NoError(t, w.Close())
 
 	// reopen
-	require.NoError(t, w.Close())
+	w = NewWAL(dir, 0, 0)
 	require.NoError(t, w.Open())
 
 	test(w, false, false)
@@ -556,6 +545,8 @@ func TestWAL_DiskSize(t *testing.T) {
 	require.NoError(t, w.Remove(closedSegments))
 
 	test(w, true, false)
+
+	require.NoError(t, w.Close())
 }
 
 func TestWriteWALSegment_UnmarshalBinary_WriteWALCorrupt(t *testing.T) {
@@ -690,8 +681,7 @@ func BenchmarkWAL_WriteMulti_Concurrency(b *testing.B) {
 				points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 			}
 
-			dir := MustTempDir()
-			defer os.RemoveAll(dir)
+			dir := b.TempDir()
 
 			w := NewWAL(dir, 0, 0)
 			defer w.Close()
@@ -748,10 +738,9 @@ func BenchmarkWALSegmentWriter(b *testing.B) {
 		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(b, dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
 	write := &tsm1.WriteWALEntry{
@@ -771,10 +760,9 @@ func BenchmarkWALSegmentReader(b *testing.B) {
 		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
-	f := MustTempFile(dir)
+	f := MustTempFile(b, dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
 	write := &tsm1.WriteWALEntry{

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -531,10 +531,9 @@ func TestWAL_DiskSize(t *testing.T) {
 	}
 
 	test(w, false, false)
-	require.NoError(t, w.Close())
 
 	// reopen
-	w = NewWAL(dir, 0, 0)
+	require.NoError(t, w.Close())
 	require.NoError(t, w.Open())
 
 	test(w, false, false)

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -47,9 +47,8 @@ func TestTSMWriter_Write_NoValues(t *testing.T) {
 }
 
 func TestTSMWriter_Write_Single(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -113,9 +112,8 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 }
 
 func TestTSMWriter_Write_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -174,9 +172,8 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -242,9 +239,8 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 
 // Tests that writing keys in reverse is able to read them back.
 func TestTSMWriter_Write_SameKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -311,9 +307,8 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 // Tests that calling Read returns all the values for block matching the key
 // and timestamp
 func TestTSMWriter_Read_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -395,9 +390,8 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -429,9 +423,8 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -487,8 +480,9 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
+	defer r.Close()
 
-	f = MustTempFile(dir)
+	f = MustTempFile(t, dir)
 	w, err = tsm1.NewTSMWriter(f)
 	if err != nil {
 		t.Fatalf("unexpected error creating writer: %v", err)
@@ -516,6 +510,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error open file: %v", err)
 	}
+	defer fd.Close()
 
 	// Now create a reader to verify the written blocks matches the originally
 	// written file using Write
@@ -544,9 +539,8 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 }
 
 func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {
@@ -564,10 +558,8 @@ func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
 }
 
 func TestTSMWriter_Write_MaxKey(t *testing.T) {
-	dir := MustTempDir()
-	defer os.RemoveAll(dir)
-	f := MustTempFile(dir)
-	defer f.Close()
+	dir := t.TempDir()
+	f := MustTempFile(t, dir)
 
 	w, err := tsm1.NewTSMWriter(f)
 	if err != nil {

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -12,7 +12,7 @@ import (
 
 // Ensure fileset can return an iterator over all series in the index.
 func TestFileSet_SeriesIDIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(t, 1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -81,7 +81,7 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all series for one measurement.
 func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(t, 1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -147,7 +147,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all measurements for the index.
 func TestFileSet_MeasurementIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(t, 1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -221,7 +221,7 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all keys for one measurement.
 func TestFileSet_TagKeyIterator(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(t, 1)
 	defer idx.Close()
 
 	// Create initial set of series.

--- a/tsdb/index/tsi1/index_file_test.go
+++ b/tsdb/index/tsi1/index_file_test.go
@@ -13,7 +13,7 @@ import (
 
 // Ensure a simple index file can be built and opened.
 func TestCreateIndexFile(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f, err := CreateIndexFile(sfile.SeriesFile, []Series{
@@ -33,7 +33,7 @@ func TestCreateIndexFile(t *testing.T) {
 }
 
 func TestIndexFile_TagKeySeriesIDIterator(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f, err := CreateIndexFile(sfile.SeriesFile, []Series{
@@ -82,7 +82,7 @@ func TestIndexFile_TagKeySeriesIDIterator(t *testing.T) {
 
 // Ensure index file generation can be successfully built.
 func TestGenerateIndexFile(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	// Build generated index file.
@@ -126,7 +126,7 @@ func TestGenerateIndexFile_Uvarint(t *testing.T) {
 
 // Ensure a MeasurementHashSeries returns false when all series are tombstoned.
 func TestIndexFile_MeasurementHasSeries_Tombstoned(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f, err := CreateIndexFile(sfile.SeriesFile, []Series{
@@ -146,17 +146,17 @@ func TestIndexFile_MeasurementHasSeries_Tombstoned(t *testing.T) {
 
 func BenchmarkIndexFile_TagValueSeries(b *testing.B) {
 	b.Run("M=1,K=2,V=3", func(b *testing.B) {
-		sfile := MustOpenSeriesFile()
+		sfile := MustOpenSeriesFile(b)
 		defer sfile.Close()
 		benchmarkIndexFile_TagValueSeries(b, MustFindOrGenerateIndexFile(sfile.SeriesFile, 1, 2, 3))
 	})
 	b.Run("M=10,K=5,V=5", func(b *testing.B) {
-		sfile := MustOpenSeriesFile()
+		sfile := MustOpenSeriesFile(b)
 		defer sfile.Close()
 		benchmarkIndexFile_TagValueSeries(b, MustFindOrGenerateIndexFile(sfile.SeriesFile, 10, 5, 5))
 	})
 	b.Run("M=10,K=7,V=5", func(b *testing.B) {
-		sfile := MustOpenSeriesFile()
+		sfile := MustOpenSeriesFile(b)
 		defer sfile.Close()
 		benchmarkIndexFile_TagValueSeries(b, MustFindOrGenerateIndexFile(sfile.SeriesFile, 10, 7, 7))
 	})

--- a/tsdb/index/tsi1/index_files_test.go
+++ b/tsdb/index/tsi1/index_files_test.go
@@ -10,7 +10,7 @@ import (
 
 // Ensure multiple index files can be compacted together.
 func TestIndexFiles_WriteTo(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	// Write first file.

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -23,7 +23,7 @@ import (
 
 // Ensure log file can append series.
 func TestLogFile_AddSeriesList(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f := MustOpenLogFile(sfile.SeriesFile)
@@ -114,7 +114,7 @@ func TestLogFile_AddSeriesList(t *testing.T) {
 }
 
 func TestLogFile_SeriesStoredInOrder(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f := MustOpenLogFile(sfile.SeriesFile)
@@ -171,7 +171,7 @@ func TestLogFile_SeriesStoredInOrder(t *testing.T) {
 
 // Ensure log file can delete an existing measurement.
 func TestLogFile_DeleteMeasurement(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f := MustOpenLogFile(sfile.SeriesFile)
@@ -210,7 +210,7 @@ func TestLogFile_DeleteMeasurement(t *testing.T) {
 // Ensure log file can recover correctly.
 func TestLogFile_Open(t *testing.T) {
 	t.Run("Truncate", func(t *testing.T) {
-		sfile := MustOpenSeriesFile()
+		sfile := MustOpenSeriesFile(t)
 		defer sfile.Close()
 		seriesSet := tsdb.NewSeriesIDSet()
 
@@ -270,7 +270,7 @@ func TestLogFile_Open(t *testing.T) {
 	})
 
 	t.Run("ChecksumMismatch", func(t *testing.T) {
-		sfile := MustOpenSeriesFile()
+		sfile := MustOpenSeriesFile(t)
 		defer sfile.Close()
 		seriesSet := tsdb.NewSeriesIDSet()
 
@@ -313,7 +313,7 @@ func TestLogFile_Open(t *testing.T) {
 }
 
 func TestLogFile_MeasurementHasSeries(t *testing.T) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(t)
 	defer sfile.Close()
 
 	f := MustOpenLogFile(sfile.SeriesFile)
@@ -447,7 +447,7 @@ func GenerateLogFile(sfile *tsdb.SeriesFile, measurementN, tagN, valueN int) (*L
 }
 
 func benchmarkLogFile_AddSeries(b *testing.B, measurementN, seriesKeyN, seriesValueN int) {
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
 	b.StopTimer()
@@ -505,7 +505,7 @@ func BenchmarkLogFile_WriteTo(b *testing.B) {
 	for _, seriesN := range []int{1000, 10000, 100000, 1000000} {
 		name := fmt.Sprintf("series=%d", seriesN)
 		b.Run(name, func(b *testing.B) {
-			sfile := MustOpenSeriesFile()
+			sfile := MustOpenSeriesFile(b)
 			defer sfile.Close()
 
 			f := MustOpenLogFile(sfile.SeriesFile)
@@ -549,7 +549,7 @@ func BenchmarkLogFile_WriteTo(b *testing.B) {
 func benchmarkLogFile_MeasurementHasSeries(b *testing.B, seriesKeyN, seriesValueN int) {
 	b.StopTimer()
 
-	sfile := MustOpenSeriesFile()
+	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
 	f := MustOpenLogFile(sfile.SeriesFile)

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -511,7 +511,7 @@ func (p *Partition) prependActiveLogFile() (rErr error) {
 	// Prepend and generate new fileset but do not yet update the partition
 	newFileSet := p.fileSet.PrependLogFile(f)
 
-	errors2.Capture(&rErr, func() error {
+	defer errors2.Capture(&rErr, func() error {
 		if rErr != nil {
 			// close the new file.
 			f.Close()

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -370,9 +370,12 @@ func (p *Partition) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	var err error
+	if p.fileSet == nil {
+		return nil
+	}
 
 	// Close log files.
+	var err error
 	for _, f := range p.fileSet.files {
 		if localErr := f.Close(); localErr != nil {
 			err = localErr

--- a/tsdb/index/tsi1/sql_index_exporter_test.go
+++ b/tsdb/index/tsi1/sql_index_exporter_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSQLIndexExporter_ExportIndex(t *testing.T) {
-	idx := MustOpenIndex(1)
+	idx := MustOpenIndex(t, 1)
 	defer idx.Close()
 
 	// Add series to index.

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -255,19 +255,10 @@ func (itr *SeriesIDIterator) Next() (elem tsdb.SeriesIDElem) {
 	return elem
 }
 
-// MustTempDir returns a temporary directory. Panic on error.
-func MustTempDir() string {
-	path, err := os.MkdirTemp("", "tsi-")
-	if err != nil {
-		panic(err)
-	}
-	return path
-}
-
-// MustTempDir returns a temporary directory for a partition. Panic on error.
-func MustTempPartitionDir() string {
-	path := MustTempDir()
-	path = filepath.Join(path, "0")
+// MustTempPartitionDir returns a temporary directory for a partition. Panic on
+// error.
+func MustTempPartitionDir(tb testing.TB) string {
+	path := filepath.Join(tb.TempDir(), "0")
 	if err := os.Mkdir(path, 0777); err != nil {
 		panic(err)
 	}
@@ -287,17 +278,13 @@ type SeriesFile struct {
 }
 
 // NewSeriesFile returns a new instance of SeriesFile with a temporary file path.
-func NewSeriesFile() *SeriesFile {
-	dir, err := os.MkdirTemp("", "tsdb-series-file-")
-	if err != nil {
-		panic(err)
-	}
-	return &SeriesFile{SeriesFile: tsdb.NewSeriesFile(dir)}
+func NewSeriesFile(tb testing.TB) *SeriesFile {
+	return &SeriesFile{SeriesFile: tsdb.NewSeriesFile(tb.TempDir())}
 }
 
 // MustOpenSeriesFile returns a new, open instance of SeriesFile. Panic on error.
-func MustOpenSeriesFile() *SeriesFile {
-	f := NewSeriesFile()
+func MustOpenSeriesFile(tb testing.TB) *SeriesFile {
+	f := NewSeriesFile(tb)
 	if err := f.Open(); err != nil {
 		panic(err)
 	}
@@ -306,7 +293,6 @@ func MustOpenSeriesFile() *SeriesFile {
 
 // Close closes the log file and removes it from disk.
 func (f *SeriesFile) Close() error {
-	defer os.RemoveAll(f.Path())
 	return f.SeriesFile.Close()
 }
 

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -369,10 +369,7 @@ func MustNewIndex(tb testing.TB, index string, eopts ...EngineOption) *Index {
 		opt(&opts)
 	}
 
-	rootPath, err := os.MkdirTemp("", "influxdb-tsdb")
-	if err != nil {
-		panic(err)
-	}
+	rootPath := tb.TempDir()
 
 	seriesPath, err := os.MkdirTemp(rootPath, tsdb.SeriesFileDirectory)
 	if err != nil {

--- a/tsdb/series_index_test.go
+++ b/tsdb/series_index_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestSeriesIndex_Count(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -30,8 +29,7 @@ func TestSeriesIndex_Count(t *testing.T) {
 }
 
 func TestSeriesIndex_Delete(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -53,8 +51,7 @@ func TestSeriesIndex_Delete(t *testing.T) {
 }
 
 func TestSeriesIndex_FindIDBySeriesKey(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {
@@ -86,8 +83,7 @@ func TestSeriesIndex_FindIDBySeriesKey(t *testing.T) {
 }
 
 func TestSeriesIndex_FindOffsetByID(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	idx := tsdb.NewSeriesIndex(filepath.Join(dir, "index"))
 	if err := idx.Open(); err != nil {

--- a/tsdb/series_segment_test.go
+++ b/tsdb/series_segment_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestSeriesSegment(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	// Create a new initial segment (4mb) and initialize for writing.
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
@@ -69,8 +68,7 @@ func TestSeriesSegment(t *testing.T) {
 }
 
 func TestSeriesSegment_AppendSeriesIDs(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
 	if err != nil {
@@ -97,8 +95,7 @@ func TestSeriesSegment_AppendSeriesIDs(t *testing.T) {
 }
 
 func TestSeriesSegment_MaxSeriesID(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))
 	if err != nil {
@@ -142,8 +139,7 @@ func TestSeriesSegmentHeader(t *testing.T) {
 }
 
 func TestSeriesSegment_PartialWrite(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	// Create a new initial segment (4mb) and initialize for writing.
 	segment, err := tsdb.CreateSeriesSegment(0, filepath.Join(dir, "0000"))

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -3,7 +3,6 @@ package tsdb
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -367,10 +366,7 @@ func NewTempShard(tb testing.TB, index string) *TempShard {
 	tb.Helper()
 
 	// Create temporary path for data and WAL.
-	dir, err := os.MkdirTemp("", "influxdb-tsdb-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 
 	// Create series file.
 	sfile := NewSeriesFile(filepath.Join(dir, "db0", SeriesFileDirectory))
@@ -398,7 +394,6 @@ func NewTempShard(tb testing.TB, index string) *TempShard {
 
 // Close closes the shard and removes all underlying data.
 func (sh *TempShard) Close() error {
-	defer os.RemoveAll(sh.path)
 	sh.sfile.Close()
 	return sh.Shard.Close()
 }

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"math"
 	"os"
 	"path/filepath"
@@ -20,6 +17,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/influxdb/v2/influxql/query"
 	"github.com/influxdata/influxdb/v2/internal"
 	"github.com/influxdata/influxdb/v2/models"
@@ -33,8 +33,7 @@ import (
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -99,11 +98,12 @@ func TestShardWriteAndIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+
+	sh.Close()
 }
 
 func TestShardRebuildIndex(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -177,11 +177,12 @@ func TestShardRebuildIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+
+	sh.Close()
 }
 
 func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -192,6 +193,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 
 	sh := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
+	t.Cleanup(func() { sh.Close() })
 
 	// Calling WritePoints when the engine is not open will return
 	// ErrEngineClosed.
@@ -230,8 +232,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 }
 
 func TestWriteTimeTag(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -280,8 +281,7 @@ func TestWriteTimeTag(t *testing.T) {
 }
 
 func TestWriteTimeField(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -315,8 +315,7 @@ func TestWriteTimeField(t *testing.T) {
 }
 
 func TestShardWriteAddNewField(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -367,8 +366,7 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	if testing.Short() || runtime.GOOS == "windows" {
 		t.Skip("Skipping on short and windows")
 	}
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -455,8 +453,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -605,8 +602,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 // Ensures that when a shard is closed, it removes any series meta-data
 // from the index.
 func TestShard_Close_RemoveIndex(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 
@@ -620,6 +616,7 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 	if err := sh.Open(context.Background()); err != nil {
 		t.Fatalf("error opening shard: %s", err.Error())
 	}
+	t.Cleanup(func() { sh.Close() })
 
 	pt := models.MustNewPoint(
 		"cpu",
@@ -730,11 +727,9 @@ cpu,host=serverB,region=uswest value=25  0
 
 // Ensure a shard can create iterators for its underlying data.
 func TestShard_CreateIterator_Descending(t *testing.T) {
-	var sh *Shard
-	var itr query.Iterator
-
 	test := func(t *testing.T, index string) {
-		sh = NewShard(t, index)
+		sh := NewShard(t, index)
+		defer sh.Close()
 
 		// Calling CreateIterator when the engine is not open will return
 		// ErrEngineClosed.
@@ -757,7 +752,7 @@ cpu,host=serverB,region=uswest value=25  0
 		// Create iterator.
 		var err error
 		m = &influxql.Measurement{Name: "cpu"}
-		itr, err = sh.CreateIterator(context.Background(), m, query.IteratorOptions{
+		itr, err := sh.CreateIterator(context.Background(), m, query.IteratorOptions{
 			Expr:       influxql.MustParseExpr(`value`),
 			Aux:        []influxql.VarRef{{Val: "val2"}},
 			Dimensions: []string{"host"},
@@ -768,6 +763,7 @@ cpu,host=serverB,region=uswest value=25  0
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer itr.Close()
 		fitr := itr.(query.FloatIterator)
 
 		// Read values from iterator.
@@ -810,8 +806,6 @@ cpu,host=serverB,region=uswest value=25  0
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) { test(t, index) })
-		sh.Close()
-		itr.Close()
 	}
 }
 
@@ -962,13 +956,12 @@ cpu,secret=foo value=100 0
 }
 
 func TestShard_Disabled_WriteQuery(t *testing.T) {
-	var sh *Shard
-
 	test := func(t *testing.T, index string) {
-		sh = NewShard(t, index)
+		sh := NewShard(t, index)
 		if err := sh.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
+		defer sh.Close()
 
 		sh.SetEnabled(false)
 
@@ -980,19 +973,13 @@ func TestShard_Disabled_WriteQuery(t *testing.T) {
 		)
 
 		err := sh.WritePoints(context.Background(), []models.Point{pt})
-		if err == nil {
-			t.Fatalf("expected shard disabled error")
-		}
-		if err != tsdb.ErrShardDisabled {
-			t.Fatalf(err.Error())
+		if !errors.Is(err, tsdb.ErrShardDisabled) {
+			t.Fatalf("expected shard disabled error: %v", err.Error())
 		}
 		m := &influxql.Measurement{Name: "cpu"}
-		_, got := sh.CreateIterator(context.Background(), m, query.IteratorOptions{})
-		if err == nil {
-			t.Fatalf("expected shard disabled error")
-		}
-		if exp := tsdb.ErrShardDisabled; got != exp {
-			t.Fatalf("got %v, expected %v", got, exp)
+		_, err = sh.CreateIterator(context.Background(), m, query.IteratorOptions{})
+		if exp := tsdb.ErrShardDisabled; !errors.Is(err, exp) {
+			t.Fatalf("got %v, expected %v", err, exp)
 		}
 
 		sh.SetEnabled(true)
@@ -1002,21 +989,21 @@ func TestShard_Disabled_WriteQuery(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		m = &influxql.Measurement{Name: "cpu"}
-		if _, err = sh.CreateIterator(context.Background(), m, query.IteratorOptions{}); err != nil {
-			t.Fatalf("unexpected error: %v", got)
+		itr, err := sh.CreateIterator(context.Background(), m, query.IteratorOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		assert2.NoError(t, itr.Close())
 	}
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) { test(t, index) })
-		sh.Close()
 	}
 }
 
 func TestShard_Closed_Functions(t *testing.T) {
-	var sh *Shard
 	test := func(t *testing.T, index string) {
-		sh = NewShard(t, index)
+		sh := NewShard(t, index)
 		if err := sh.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
@@ -1523,8 +1510,7 @@ func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
 	const measurement = "cpu"
 	const fieldName = "value"
 
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	mf, err := tsdb.NewMeasurementFieldSet(path, nil)
@@ -1572,8 +1558,7 @@ func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
 }
 
 func TestMeasurementFieldSet_Corrupt(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	func() {
@@ -1621,8 +1606,7 @@ func TestMeasurementFieldSet_Corrupt(t *testing.T) {
 }
 
 func TestMeasurementFieldSet_CorruptChangeFile(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	testFields := []struct {
 		Measurement string
@@ -1707,8 +1691,7 @@ func TestMeasurementFieldSet_DeleteEmpty(t *testing.T) {
 	const measurement = "cpu"
 	const fieldName = "value"
 
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 	mf, err := tsdb.NewMeasurementFieldSet(path, nil)
@@ -1777,8 +1760,7 @@ func checkMeasurementFieldSetClose(t *testing.T, fs *tsdb.MeasurementFieldSet) {
 }
 
 func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "fields.idx")
 
@@ -1795,8 +1777,7 @@ func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
 
 func TestMeasurementFieldSet_ConcurrentSave(t *testing.T) {
 	var iterations int
-	dir, cleanup := MustTempDir()
-	defer cleanup()
+	dir := t.TempDir()
 
 	if testing.Short() {
 		iterations = 50
@@ -2075,7 +2056,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 
 	// Run the benchmark loop.
 	for n := 0; n < b.N; n++ {
-		shard, tmpDir, err := openShard(sfile)
+		shard, err := openShard(b, sfile)
 		if err != nil {
 			shard.Close()
 			b.Fatal(err)
@@ -2087,7 +2068,6 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 
 		b.StopTimer()
 		shard.Close()
-		os.RemoveAll(tmpDir)
 	}
 }
 
@@ -2111,7 +2091,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
-	shard, tmpDir, err := openShard(sfile)
+	shard, err := openShard(b, sfile)
 	defer func() {
 		_ = shard.Close()
 	}()
@@ -2136,7 +2116,6 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 		// Call the function being benchmarked.
 		chunkedWrite(shard, points)
 	}
-	os.RemoveAll(tmpDir)
 }
 
 func benchmarkWritePointsExistingSeriesFields(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
@@ -2159,7 +2138,7 @@ func benchmarkWritePointsExistingSeriesFields(b *testing.B, mCnt, tkCnt, tvCnt, 
 		_ = sfile.Close()
 	}()
 
-	shard, tmpDir, err := openShard(sfile)
+	shard, err := openShard(b, sfile)
 	defer func() {
 		_ = shard.Close()
 	}()
@@ -2184,7 +2163,6 @@ func benchmarkWritePointsExistingSeriesFields(b *testing.B, mCnt, tkCnt, tvCnt, 
 		// Call the function being benchmarked.
 		chunkedWrite(shard, points)
 	}
-	os.RemoveAll(tmpDir)
 }
 
 func benchmarkWritePointsExistingSeriesEqualBatches(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
@@ -2202,7 +2180,7 @@ func benchmarkWritePointsExistingSeriesEqualBatches(b *testing.B, mCnt, tkCnt, t
 	sfile := MustOpenSeriesFile(b)
 	defer sfile.Close()
 
-	shard, tmpDir, err := openShard(sfile)
+	shard, err := openShard(b, sfile)
 	defer func() {
 		_ = shard.Close()
 	}()
@@ -2242,18 +2220,17 @@ func benchmarkWritePointsExistingSeriesEqualBatches(b *testing.B, mCnt, tkCnt, t
 		start = end
 		end += chunkSz
 	}
-	os.RemoveAll(tmpDir)
 }
 
-func openShard(sfile *SeriesFile) (*tsdb.Shard, string, error) {
-	tmpDir, _ := os.MkdirTemp("", "shard_test")
+func openShard(tb testing.TB, sfile *SeriesFile) (*tsdb.Shard, error) {
+	tmpDir := tb.TempDir()
 	tmpShard := filepath.Join(tmpDir, "shard")
 	tmpWal := filepath.Join(tmpDir, "wal")
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = tmpWal
 	shard := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
 	err := shard.Open(context.Background())
-	return shard, tmpDir, err
+	return shard, err
 }
 
 func BenchmarkCreateIterator(b *testing.B) {
@@ -2384,10 +2361,7 @@ func NewShards(tb testing.TB, index string, n int) Shards {
 	tb.Helper()
 
 	// Create temporary path for data and WAL.
-	dir, err := os.MkdirTemp("", "influxdb-tsdb-")
-	if err != nil {
-		panic(err)
-	}
+	dir := tb.TempDir()
 
 	sfile := MustOpenSeriesFile(tb)
 
@@ -2480,14 +2454,6 @@ func (sh *Shard) MustWritePointsString(s string) {
 	if err := sh.WritePoints(context.Background(), a); err != nil {
 		panic(err)
 	}
-}
-
-func MustTempDir() (string, func()) {
-	dir, err := os.MkdirTemp("", "shard-test")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp dir: %v", err))
-	}
-	return dir, func() { os.RemoveAll(dir) }
 }
 
 type seriesIterator struct {

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -154,7 +154,7 @@ func TestStore_BadShard(t *testing.T) {
 			sh := tsdb.NewTempShard(t, idx)
 			err := s.OpenShard(context.Background(), sh.Shard, false)
 			require.NoError(t, err, "opening temp shard")
-			defer require.NoError(t, sh.Close(), "closing temporary shard")
+			require.NoError(t, sh.Close(), "closing temporary shard")
 
 			s.SetShardOpenErrorForTest(sh.ID(), errors.New(errStr))
 			err2 := s.OpenShard(context.Background(), sh.Shard, false)
@@ -164,6 +164,7 @@ func TestStore_BadShard(t *testing.T) {
 
 			// This should succeed with the force (and because opening an open shard automatically succeeds)
 			require.NoError(t, s.OpenShard(context.Background(), sh.Shard, true), "forced re-opening previously failing shard")
+			require.NoError(t, sh.Close())
 		}()
 	}
 }


### PR DESCRIPTION
A testing cleanup. 

1. Replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir`
   function from the `testing` package to create temporary directory. The
   directory created by `T.TempDir` is automatically removed when the test and
   all its subtests complete.

    ```go
    func TestFoo(t *testing.T) {
        // before
        tmpDir, err := ioutil.TempDir("", "")
        if err != nil {
            t.Fatalf("unable to create temporary test directory %v", err)
        }
        defer func() {
            if err := os.RemoveAll(tmpDir); err != nil {
                t.Fatalf("unable to delete temporary test directory %s: %v", tempDir, err)
            }
        }()

        // now
        tmpDir := t.TempDir()
    }
    ```

2. Fixes the tests where cleanups are not performed when the test finishes. Unix permits removing an open file, Windows does not. So if an `os.File` is created inside the temporary directory returned by `t.TempDir`, we need to close it otherwise the test will fail on Windows.

    ```go
    func TestFoo(t *testing.T) {
        tmpDir := t.TempDir()

        file, err := os.CreateTemp(tmpDir, "dumpwaltest*.txt")
        assert.NoError(t, err)

        // On Windows, the test will fail if `file` is not closed because
        // t.TempDir() will not be able to cleanup the temporary directory.
        //
        // Unix permits removing an open file, Windows does not.
        t.Cleanup(func() {
                file.Close()
        })
    }
    ```

Reference: https://pkg.go.dev/testing#T.TempDir

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
