### PR TITLE
fix: remove controller 64bit misalignment

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -49,8 +49,8 @@ const orgLabel = "org"
 // Controller provides a central location to manage all incoming queries.
 // The controller is responsible for compiling, queueing, and executing queries.
 type Controller struct {
-	config     Config
 	lastID     uint64
+	config     Config
 	queriesMu  sync.RWMutex
 	queries    map[QueryID]*Query
 	queryQueue chan *Query


### PR DESCRIPTION
I understand 32-bit architectures are no longer officially supported, but this is a minor change.

Calling `atomic.AddUint64()` on `lastID` resulted in an alignment panic in armv7, due to it not being 64bit aligned.

Declaring it first in the struct solved it.

See https://pkg.go.dev/sync/atomic#pkg-note-BUG fore more details

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
