### PR TITLE
feat: partial /v2/api/buckets support: create, delete, list, retrieve

### DIFF
--- a/internal/storage_store.go
+++ b/internal/storage_store.go
@@ -20,9 +20,10 @@ import (
 // It's currently a partial implementation as one of a store's exported methods
 // returns an unexported type.
 type StorageStoreMock struct {
-	ReadFilterFn func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error)
-	ReadGroupFn  func(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error)
-	DeleteFn     func(database string, sources []influxql.Source, condition influxql.Expr) error
+	ReadFilterFn            func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error)
+	ReadGroupFn             func(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error)
+	DeleteFn                func(database string, sources []influxql.Source, condition influxql.Expr) error
+	DeleteRetentionPolicyFn func(database string, name string) error
 
 	TagKeysFn    func(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
 	TagValuesFn  func(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
@@ -30,6 +31,10 @@ type StorageStoreMock struct {
 
 	ResultSet *StorageResultsMock
 	// TODO(edd): can't mock GroupRead as it returns an unexported type.
+}
+
+func (s *StorageStoreMock) DeleteRetentionPolicy(database, name string) error {
+	return s.DeleteRetentionPolicyFn(database, name)
 }
 
 // NewStorageStoreMock initialises a StorageStoreMock with methods that return
@@ -48,6 +53,10 @@ func NewStorageStoreMock() *StorageStoreMock {
 	}
 
 	store.DeleteFn = func(database string, sources []influxql.Source, condition influxql.Expr) error {
+		return errors.New("implement me")
+	}
+
+	store.DeleteRetentionPolicyFn = func(database string, name string) error {
 		return errors.New("implement me")
 	}
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1265,7 +1265,7 @@ func (h *Handler) serveRetrieveBucketV2(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *Handler) serveBucketListV2(w http.ResponseWriter, r *http.Request, user meta.User) {
-	const defaultLimit = 20
+	const defaultLimit = 100
 	var err error
 	var db, rp, after string
 	limit := defaultLimit

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -83,6 +83,9 @@ type Route struct {
 type QueryAuthorizer interface {
 	AuthorizeQuery(u meta.User, query *influxql.Query, database string) (query.FineAuthorizer, error)
 	AuthorizeDatabase(u meta.User, priv influxql.Privilege, database string) error
+	AuthorizeCreateDatabase(u meta.User) error
+	AuthorizeCreateRetentionPolicy(u meta.User, db string) error
+	AuthorizeDeleteRetentionPolicy(u meta.User, db string) error
 }
 
 // userQueryAuthorizer binds the QueryAuthorizer with a specific user for consumption by the query engine.
@@ -107,6 +110,9 @@ type Handler struct {
 		Authenticate(username, password string) (ui meta.User, err error)
 		User(username string) (meta.User, error)
 		AdminUserExists() bool
+		CreateDatabaseWithRetentionPolicy(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error)
+		DropRetentionPolicy(database, name string) error
+		CreateRetentionPolicy(database string, spec *meta.RetentionPolicySpec, makeDefault bool) (*meta.RetentionPolicyInfo, error)
 	}
 
 	QueryAuthorizer QueryAuthorizer
@@ -201,6 +207,22 @@ func NewHandler(c Config) *Handler {
 		Route{
 			"delete",
 			"POST", "/api/v2/delete", false, true, h.serveDeleteV2,
+		},
+		Route{
+			"buckets",
+			"POST", "/api/v2/buckets", false, true, h.serveBucketsV2,
+		},
+		Route{
+			"delete-bucket",
+			"DELETE", "/api/v2/buckets/:db/:rp", false, true, h.serveBucketDeleteV2,
+		},
+		Route{
+			"buckets",
+			"GET", "/api/v2/buckets/:db/:rp", false, true, h.serveRetrieveBucketV2,
+		},
+		Route{
+			"buckets",
+			"GET", "/api/v2/buckets", false, true, h.serveBucketListV2,
 		},
 		Route{
 			"write", // Data-ingest route.
@@ -814,7 +836,7 @@ func bucket2dbrp(bucket string) (string, string, error) {
 	// test for a slash in our bucket name.
 	switch idx := strings.IndexByte(bucket, '/'); idx {
 	case -1:
-		// if there is no slash, we're mapping bucket to the databse.
+		// if there is no slash, we're mapping bucket to the database.
 		switch db := bucket; db {
 		case "":
 			// if our "database" is an empty string, this is an error.
@@ -845,12 +867,9 @@ type DeleteBody struct {
 // policies".
 func (h *Handler) serveDeleteV2(w http.ResponseWriter, r *http.Request, user meta.User) {
 	db, rp, err := bucket2dbrp(r.URL.Query().Get("bucket"))
+
 	if err != nil {
 		h.httpError(w, fmt.Sprintf("delete - bucket: %s", err.Error()), http.StatusNotFound)
-		return
-	}
-	if db == "" {
-		h.httpError(w, "delete - database is required", http.StatusNotFound)
 		return
 	}
 
@@ -993,8 +1012,366 @@ func fixLiterals(node influxql.Node) {
 	}
 }
 
+type RetentionRule struct {
+	Type                      string `json:"type"`
+	EverySeconds              int64  `json:"everySeconds"`
+	ShardGroupDurationSeconds int64  `json:"shardGroupDurationSeconds"`
+}
+
+// BucketsBody and RetentionRule should match the 2.0 API definition.
+type BucketsBody struct {
+	Description    string          `json:"description"`
+	Name           string          `json:"name"`
+	OrgID          string          `json:"orgId"`
+	Rp             string          `json:"rp"`
+	SchemaType     string          `json:"schemaType"`
+	RetentionRules []RetentionRule `json:"retentionRules"`
+}
+
+type Bucket struct {
+	BucketsBody
+	ID                  string    `json:"id,omitempty"`
+	Type                string    `json:"type"`
+	RetentionPolicyName string    `json:"rp,omitempty"` // This to support v1 sources
+	CreatedAt           time.Time `json:"createdAt"`
+	UpdatedAt           time.Time `json:"updatedAt"`
+}
+
+func (h *Handler) serveBucketsV2(w http.ResponseWriter, r *http.Request, user meta.User) {
+	var bs []byte
+	if r.ContentLength > 0 {
+		if h.Config.MaxBodySize > 0 && r.ContentLength > int64(h.Config.MaxBodySize) {
+			h.httpError(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		// This will just be an initial hint for the reader, as the
+		// bytes.Buffer will grow as needed when ReadFrom is called
+		bs = make([]byte, 0, r.ContentLength)
+	}
+	buf := bytes.NewBuffer(bs)
+
+	_, err := buf.ReadFrom(r.Body)
+	if err != nil {
+		h.httpError(w, fmt.Sprintf("buckets - cannot read request body: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	brd := &BucketsBody{}
+	if err = json.Unmarshal(buf.Bytes(), brd); err != nil {
+		h.httpError(w, fmt.Sprintf("buckets - cannot parse request body: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+	db, rp, err := bucket2dbrp(brd.Name)
+	if err != nil {
+		h.httpError(w, fmt.Sprintf("buckets - illegal bucket name: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+	if !((brd.Rp == rp) || ((brd.Rp == "") && (rp != "")) || ((brd.Rp != "") && (rp == ""))) {
+		h.httpError(w, fmt.Sprintf("buckets - two retention policies specified: %q differs from %q", rp, brd.Rp), http.StatusBadRequest)
+		return
+	} else if rp == "" {
+		rp = brd.Rp
+
+	}
+	// We only need to validate non-empty
+	// retention policy names
+	if rp != "" && !meta.ValidName(rp) {
+		h.httpError(w, fmt.Sprintf("buckets - retention policy %q: %s", rp, meta.ErrInvalidName.Error()), http.StatusBadRequest)
+		return
+	}
+
+	var dur, sgDur time.Duration
+	if len(brd.RetentionRules) > 0 {
+		dur = time.Second * time.Duration(brd.RetentionRules[0].EverySeconds)
+		sgDur = time.Duration(brd.RetentionRules[0].ShardGroupDurationSeconds) * time.Second
+	} else {
+		dur = meta.DefaultRetentionPolicyDuration
+		// This will get set to default in normalisedShardDuration()
+		// called by CreateRetentionPolicy
+		sgDur = 0
+	}
+	rf := meta.DefaultRetentionPolicyReplicaN
+	spec := meta.RetentionPolicySpec{
+		Name:               rp,
+		Duration:           &dur,
+		ReplicaN:           &rf,
+		ShardGroupDuration: sgDur,
+	}
+	dbi := h.MetaClient.Database(db)
+
+	if h.Config.AuthEnabled {
+		if user == nil {
+			h.httpError(w, fmt.Sprintf("buckets - user is required to to create bucket %q", brd.Name), http.StatusForbidden)
+			return
+		}
+
+		if dbi == nil {
+			if err := h.QueryAuthorizer.AuthorizeCreateDatabase(user); err != nil {
+				h.httpError(w, fmt.Sprintf("buckets - %q is not authorized to create %q: %s", user.ID(), brd.Name, err.Error()), http.StatusForbidden)
+				return
+			}
+		} else {
+			if err := h.QueryAuthorizer.AuthorizeCreateRetentionPolicy(user, db); err != nil {
+				h.httpError(w, fmt.Sprintf("buckets - %q is not authorized to create %q: %s", user.ID(), brd.Name, err.Error()), http.StatusForbidden)
+				return
+			}
+		}
+	}
+
+	if dbi == nil {
+		if _, err = h.MetaClient.CreateDatabaseWithRetentionPolicy(db, &spec); err != nil {
+			h.httpError(w, fmt.Sprintf("buckets - cannot create bucket %q: %s", brd.Name, err.Error()), http.StatusBadRequest)
+			return
+		}
+	} else {
+		if _, err = h.MetaClient.CreateRetentionPolicy(db, &spec, false); err != nil {
+			h.httpError(w, fmt.Sprintf("buckets - cannot create bucket %q: %s", brd.Name, err.Error()), http.StatusBadRequest)
+			return
+		}
+	}
+}
+
+func (h *Handler) serveBucketDeleteV2(w http.ResponseWriter, r *http.Request, user meta.User) {
+	db := r.URL.Query().Get(":db")
+	rp := r.URL.Query().Get(":rp")
+	id := fmt.Sprintf("%s/%s", db, rp)
+
+	if h.Config.AuthEnabled {
+		if user == nil {
+			h.httpError(w, fmt.Sprintf("delete bucket - user is required to delete from database %q", db), http.StatusForbidden)
+			return
+		}
+
+		if err := h.QueryAuthorizer.AuthorizeDeleteRetentionPolicy(user, db); err != nil {
+			h.httpError(w, fmt.Sprintf("delete bucket - %q is not authorized to delete %q: %s", user.ID(), id, err.Error()), http.StatusForbidden)
+			return
+		}
+	}
+
+	if dbi := h.MetaClient.Database(db); dbi == nil {
+		h.httpError(w, fmt.Sprintf("delete bucket - not found: %q", id), http.StatusNotFound)
+		return
+	} else if rpi := dbi.RetentionPolicy(rp); rpi == nil {
+		h.httpError(w, fmt.Sprintf("delete bucket - not found: %q", id), http.StatusNotFound)
+		return
+	} else if err := h.Store.DeleteRetentionPolicy(db, rp); err != nil {
+		h.httpError(w, fmt.Sprintf("delete bucket %q: %s", id, err.Error()), http.StatusBadRequest)
+		return
+	} else if err := h.MetaClient.DropRetentionPolicy(db, rp); err != nil {
+		h.httpError(w, fmt.Sprintf("delete bucket %q: %s", id, err.Error()), http.StatusBadRequest)
+		return
+	}
+}
+
+func (h *Handler) serveRetrieveBucketV2(w http.ResponseWriter, r *http.Request, user meta.User) {
+	// This is the API for returning a single bucket
+	// In V1, BucketID and BucketName are the same: "db/rp"
+	db := r.URL.Query().Get(":db")
+	rp := r.URL.Query().Get(":rp")
+	if h.Config.AuthEnabled {
+		if user == nil {
+			h.httpError(w, fmt.Sprintf("retrieve bucket - user is required for database %q", db), http.StatusForbidden)
+			return
+		}
+
+		if err := h.QueryAuthorizer.AuthorizeDatabase(user, influxql.ReadPrivilege, db); err != nil {
+			h.httpError(w, fmt.Sprintf("retrieve bucket - %q is not authorized to read %q: %s", user.ID(), db, err.Error()), http.StatusForbidden)
+			return
+		}
+	}
+
+	if bucket := h.oneBucket(w, fmt.Sprintf("%s/%s", db, rp)); bucket != nil {
+		b, err := json.Marshal(bucket)
+		if err != nil {
+			h.httpError(w, fmt.Sprintf("retrieve bucket marshaling error: %s", err.Error()), http.StatusBadRequest)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			h.httpError(w, fmt.Sprintf("retrieve bucket error writing response: %s", err.Error()), http.StatusBadRequest)
+			return
+		}
+	}
+	return
+}
+
+func (h *Handler) serveBucketListV2(w http.ResponseWriter, r *http.Request, user meta.User) {
+	var err error
+	var db, rp, after string
+	limit := 20
+	offset := 0
+
+	if h.Config.AuthEnabled {
+		if user == nil {
+			h.httpError(w, "list buckets - user is required", http.StatusForbidden)
+			return
+		}
+	}
+
+	// This is the API for returning an array of buckets
+	id := r.URL.Query().Get("id")
+	name := r.URL.Query().Get("name")
+	if id != "" || name != "" {
+		if id != "" && name != "" && id != name {
+			h.httpError(w, fmt.Sprintf("list buckets: name: %q and id: %q do not match", name, id), http.StatusBadRequest)
+			return
+		} else if id != "" {
+			name = id
+		}
+		if b := h.oneBucket(w, name); b != nil {
+			sendBuckets(w, []Bucket{*b})
+		}
+		return
+	}
+
+	if after = r.URL.Query().Get("after"); after != "" {
+		db, rp, err = bucket2dbrp(after)
+		if err != nil {
+			h.httpError(w, fmt.Sprintf("list buckets invalid parameter - after=%q: %s", after, err.Error()), http.StatusNotFound)
+			return
+		}
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.ParseInt(limitStr, 10, 64); err != nil {
+			h.httpError(w, fmt.Sprintf("list buckets parameter is not an integer - limit=%q: %s", limitStr, err.Error()), http.StatusBadRequest)
+			return
+		} else {
+			limit = int(l)
+		}
+	}
+
+	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
+		if after != "" {
+			h.httpError(w, "list buckets cannot have both \"offset\" and \"after\" arguments", http.StatusBadRequest)
+			return
+		} else if o, err := strconv.ParseInt(offsetStr, 10, 64); err != nil {
+			h.httpError(w, fmt.Sprintf("list buckets parameter is not an integer - offset=%q: %s", offsetStr, err.Error()), http.StatusBadRequest)
+			return
+		} else {
+			offset = int(o)
+		}
+	}
+
+	dbIndex := 0
+	rpIndex := 0
+	dbs := h.MetaClient.Databases()
+	if after != "" {
+		if dbIndex, rpIndex = findBucketIndex(dbs, db, rp); dbIndex < 0 {
+			h.httpError(w, fmt.Sprintf("list buckets \"after\" parameter not found: %q", after), http.StatusNotFound)
+			return
+		}
+	} else if offset > 0 {
+		if dbIndex, rpIndex = findBucketOffsetIndex(dbs, offset); dbIndex < 0 {
+			// TODO (DSB): Is this the right error?
+			http.Error(w, fmt.Sprintf("list buckets offset past end of list: %d", offset), http.StatusNotFound)
+			return
+		}
+	}
+
+	buckets := make([]Bucket, 0, limit)
+
+outer:
+	for ; dbIndex < len(dbs); dbIndex++ {
+		dbi := dbs[dbIndex]
+		if h.Config.AuthEnabled {
+			if err := h.QueryAuthorizer.AuthorizeDatabase(user, influxql.ReadPrivilege, dbi.Name); err != nil {
+				continue
+			}
+		}
+		for ; rpIndex < len(dbi.RetentionPolicies); rpIndex++ {
+			if limit > 0 {
+				buckets = append(buckets, *makeBucket(&dbi.RetentionPolicies[rpIndex], dbi.Name))
+				limit--
+			} else {
+				break outer
+			}
+		}
+		rpIndex = 0
+	}
+	sendBuckets(w, buckets)
+}
+
+func (h *Handler) oneBucket(w http.ResponseWriter, name string) *Bucket {
+	db, rp, err := bucket2dbrp(name)
+	if err != nil {
+		h.httpError(w, fmt.Sprintf("bucket %q: %s", name, err.Error()), http.StatusNotFound)
+		return nil
+	} else if dbi := h.MetaClient.Database(db); dbi == nil {
+		h.httpError(w, fmt.Sprintf("bucket not found: %q", name), http.StatusNotFound)
+		return nil
+	} else if rpi := dbi.RetentionPolicy(rp); rpi == nil {
+		h.httpError(w, fmt.Sprintf("bucket not found: %q", name), http.StatusNotFound)
+		return nil
+	} else {
+		return makeBucket(rpi, db)
+	}
+}
+
+func findBucketOffsetIndex(dbs []meta.DatabaseInfo, offset int) (dbIndex int, rpIndex int) {
+	for i, dbi := range dbs {
+		if offset > len(dbi.RetentionPolicies) {
+			offset -= len(dbi.RetentionPolicies)
+		} else {
+			dbIndex = i
+			rpIndex = offset
+			return dbIndex, rpIndex
+		}
+	}
+	return -1, -1
+}
+
+func findBucketIndex(dbs []meta.DatabaseInfo, db string, rp string) (dbIndex int, rpIndex int) {
+	for di, dbi := range dbs {
+		if dbi.Name != db {
+			continue
+		} else {
+			for ri, rpi := range dbi.RetentionPolicies {
+				if rpi.Name == rp {
+					if ri < (len(dbi.RetentionPolicies) - 1) {
+						return di, ri + 1
+					} else {
+						return di + 1, 0
+					}
+				}
+			}
+		}
+	}
+	return -1, -1
+}
+
+func sendBuckets(w http.ResponseWriter, buckets []Bucket) {
+	b, err := json.Marshal(buckets)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("list buckets marshaling error: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+	if _, err := w.Write(b); err != nil {
+		http.Error(w, fmt.Sprintf("list buckets error writing response: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+}
+
+func makeBucket(rpi *meta.RetentionPolicyInfo, database string) *Bucket {
+	name := fmt.Sprintf("%s/%s", database, rpi.Name)
+	return &Bucket{
+		BucketsBody: BucketsBody{
+			Name:       name,
+			Rp:         rpi.Name,
+			SchemaType: "implicit",
+			RetentionRules: []RetentionRule{{
+				Type:                      "",
+				EverySeconds:              int64(rpi.Duration.Seconds()),
+				ShardGroupDurationSeconds: int64(rpi.ShardGroupDuration.Seconds()),
+			}},
+		},
+		RetentionPolicyName: rpi.Name,
+		ID:                  name,
+	}
+}
+
 // serveWriteV2 maps v2 write parameters to a v1 style handler.  the concepts
-// of an "org" and "bucket" are mapped to v1 "database" and "retention
+// of a "bucket" is mapped to v1 "database" and "retention
 // policies".
 func (h *Handler) serveWriteV2(w http.ResponseWriter, r *http.Request, user meta.User) {
 	precision := r.URL.Query().Get("precision")
@@ -2186,6 +2563,7 @@ func (h *Handler) recovery(inner http.Handler, name string) http.Handler {
 type Store interface {
 	ReadFilter(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error)
 	Delete(database string, sources []influxql.Source, condition influxql.Expr) error
+	DeleteRetentionPolicy(database, name string) error
 }
 
 // Response represents a list of statement results.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1075,13 +1075,12 @@ func (h *Handler) ServePostBucketsV2(w http.ResponseWriter, r *http.Request, use
 	if err != nil {
 		h.httpError(w, fmt.Sprintf("buckets - illegal bucket name: %s", err.Error()), http.StatusBadRequest)
 		return
-	}
-	if !((brd.Rp == rp) || ((brd.Rp == "") && (rp != "")) || ((brd.Rp != "") && (rp == ""))) {
+	} else if rp == "" {
+		h.httpError(w, fmt.Sprintf("buckets - illegal bucket name: %q", brd.Name), http.StatusBadRequest)
+		return
+	} else if !((brd.Rp == rp) || (brd.Rp == "")) {
 		h.httpError(w, fmt.Sprintf("buckets - two retention policies specified: %q differs from %q", rp, brd.Rp), http.StatusBadRequest)
 		return
-	} else if rp == "" {
-		rp = brd.Rp
-
 	}
 	// We only need to validate non-empty
 	// retention policy names

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -210,7 +210,7 @@ func NewHandler(c Config) *Handler {
 		},
 		Route{
 			"buckets",
-			"POST", "/api/v2/buckets", false, true, h.serveBucketsV2,
+			"POST", "/api/v2/buckets", false, true, h.ServePostBucketsV2,
 		},
 		Route{
 			"delete-bucket",
@@ -1037,7 +1037,7 @@ type Bucket struct {
 	UpdatedAt           time.Time `json:"updatedAt"`
 }
 
-func (h *Handler) serveBucketsV2(w http.ResponseWriter, r *http.Request, user meta.User) {
+func (h *Handler) ServePostBucketsV2(w http.ResponseWriter, r *http.Request, user meta.User) {
 	var bs []byte
 	if r.ContentLength > 0 {
 		if h.Config.MaxBodySize > 0 && r.ContentLength > int64(h.Config.MaxBodySize) {
@@ -1263,8 +1263,7 @@ func (h *Handler) serveBucketListV2(w http.ResponseWriter, r *http.Request, user
 		}
 	} else if offset > 0 {
 		if dbIndex, rpIndex = findBucketOffsetIndex(dbs, offset); dbIndex < 0 {
-			// TODO (DSB): Is this the right error?
-			http.Error(w, fmt.Sprintf("list buckets offset past end of list: %d", offset), http.StatusNotFound)
+			sendBuckets(w, []Bucket{})
 			return
 		}
 	}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1140,6 +1140,8 @@ func (h *Handler) ServePostCreateBucketV2(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// serveDeleteBucketV2 should do the same thing as coordinator/statement_executor.go/executeDropRetentionPolicyStatement
+// i.e., Store.DeleteRetentionPolicy and MetaClient.DropRetentionPolicy
 func (h *Handler) serveDeleteBucketV2(w http.ResponseWriter, r *http.Request, user meta.User) {
 	db := r.URL.Query().Get(":db")
 	rp := r.URL.Query().Get(":rp")

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -2027,6 +2027,12 @@ func TestHandler_ListBuckets(t *testing.T) {
 
 	tests := []*test{
 		{
+			url:    "/api/v2/buckets?after=dbOne/rpTwo_1&limit=-1",
+			status: http.StatusOK,
+			skip:   2,
+			limit:  1000000,
+		},
+		{
 			url:    "/api/v2/buckets?offset=200",
 			status: http.StatusOK,
 			skip:   100,

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -2027,6 +2027,12 @@ func TestHandler_ListBuckets(t *testing.T) {
 
 	tests := []*test{
 		{
+			url:    "/api/v2/buckets?offset=200",
+			status: http.StatusOK,
+			skip:   100,
+			limit:  20,
+		},
+		{
 			url:    "/api/v2/buckets?id=dbOne/rpTwo_1&name=NotThere/rpTwo_1",
 			status: http.StatusBadRequest,
 			skip:   1,

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -1853,6 +1853,44 @@ func TestHandler_CreateDeleteBuckets(t *testing.T) {
 
 	tests := []*test{
 		{
+			url:    "/api/v2/buckets",
+			method: postMethod,
+			body: httpd.BucketsBody{
+				BucketUpdate: httpd.BucketUpdate{
+					Name: existingDb + "/",
+					RetentionRules: []httpd.RetentionRule{
+						httpd.RetentionRule{
+							EverySeconds:              7200,
+							ShardGroupDurationSeconds: 14400,
+						},
+					},
+				},
+				Rp:         "",
+				SchemaType: "implicit",
+			},
+			status: http.StatusBadRequest,
+			errMsg: `buckets - illegal bucket name: "mydb/"`,
+		},
+		{
+			url:    "/api/v2/buckets",
+			method: postMethod,
+			body: httpd.BucketsBody{
+				BucketUpdate: httpd.BucketUpdate{
+					Name: existingDb + "//",
+					RetentionRules: []httpd.RetentionRule{
+						httpd.RetentionRule{
+							EverySeconds:              7200,
+							ShardGroupDurationSeconds: 14400,
+						},
+					},
+				},
+				Rp:         "",
+				SchemaType: "implicit",
+			},
+			status: http.StatusBadRequest,
+			errMsg: `buckets - retention policy "/": invalid name`,
+		},
+		{
 			url:    "/api/v2/buckets/" + existingDb + "/" + goodRp,
 			method: patchMethod,
 			body: httpd.BucketsBody{

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -1835,6 +1835,403 @@ func TestHandler_Delete_V2(t *testing.T) {
 	}
 }
 
+func TestHandler_CreateDeleteBuckets(t *testing.T) {
+	const existingDb = "mydb"
+	const newDb = "newDb"
+	const goodRp = "myrp"
+	const postMethod = "POST"
+	const deleteMethod = "DELETE"
+
+	type test struct {
+		url    string
+		method string
+		body   httpd.BucketsBody
+		status int
+		errMsg string
+	}
+
+	tests := []*test{
+		{
+			url:    "/api/v2/buckets/" + existingDb + "/",
+			method: deleteMethod,
+			status: http.StatusNotFound,
+		},
+		{
+			url:    "/api/v2/buckets/baddb/" + goodRp,
+			method: deleteMethod,
+			status: http.StatusNotFound,
+			errMsg: `delete bucket - not found: "baddb/myrp"`,
+		},
+		{
+			url:    "/api/v2/buckets",
+			method: postMethod,
+			body: httpd.BucketsBody{
+				Name:       newDb + "/" + goodRp,
+				Rp:         goodRp,
+				SchemaType: "implicit",
+				RetentionRules: []httpd.RetentionRule{
+					httpd.RetentionRule{
+						EverySeconds:              7200,
+						ShardGroupDurationSeconds: 14400,
+					},
+				},
+			},
+			status: http.StatusOK,
+		},
+		{
+			url:    "/api/v2/buckets/" + existingDb + "/badrp",
+			method: deleteMethod,
+			status: http.StatusNotFound,
+			errMsg: `delete bucket - not found: "mydb/badrp"`,
+		},
+		{
+			url:    "/api/v2/buckets",
+			method: postMethod,
+			body: httpd.BucketsBody{
+				Name:       existingDb + "/" + goodRp,
+				Rp:         goodRp,
+				SchemaType: "implicit",
+				RetentionRules: []httpd.RetentionRule{
+					httpd.RetentionRule{
+						EverySeconds:              7200,
+						ShardGroupDurationSeconds: 14400,
+					},
+				},
+			},
+			status: http.StatusOK,
+		},
+		{
+			url:    "/api/v2/buckets/" + existingDb + "/" + goodRp,
+			method: deleteMethod,
+			status: http.StatusOK,
+		},
+	}
+
+	createRp := func(database string, spec *meta.RetentionPolicySpec, makeDefault bool) (*meta.RetentionPolicyInfo, error) {
+		return &meta.RetentionPolicyInfo{
+			Name:               spec.Name,
+			ReplicaN:           *spec.ReplicaN,
+			Duration:           *spec.Duration,
+			ShardGroupDuration: spec.ShardGroupDuration,
+		}, nil
+	}
+
+	lookupDb := func(name string) *meta.DatabaseInfo {
+		if name == existingDb {
+			return &meta.DatabaseInfo{
+				Name:                   name,
+				DefaultRetentionPolicy: goodRp,
+				RetentionPolicies:      []meta.RetentionPolicyInfo{meta.RetentionPolicyInfo{Name: goodRp}},
+			}
+		} else {
+			return nil
+		}
+	}
+
+	dropDeleteRp := func(database, rp string) error {
+		if dbi := lookupDb(database); dbi == nil {
+			return fmt.Errorf("database not found: %q", database)
+		} else if len(dbi.RetentionPolicies) <= 0 || dbi.RetentionPolicies[0].Name != rp {
+			return fmt.Errorf("retention policy in database %q not found: %q", database, rp)
+		} else {
+			return nil
+		}
+	}
+
+	h := NewHandler(false)
+
+	h.MetaClient = &internal.MetaClientMock{
+		DatabaseFn:              lookupDb,
+		CreateRetentionPolicyFn: createRp,
+		CreateDatabaseWithRetentionPolicyFn: func(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
+			rpi, err := createRp(name, spec, true)
+			return &meta.DatabaseInfo{
+				Name:                   name,
+				DefaultRetentionPolicy: spec.Name,
+				RetentionPolicies:      []meta.RetentionPolicyInfo{*rpi},
+				ContinuousQueries:      nil,
+			}, err
+		},
+		DropRetentionPolicyFn: dropDeleteRp,
+	}
+
+	h.Store.DeleteRetentionPolicyFn = dropDeleteRp
+	h.Handler.Store = h.Store
+	h.Handler.MetaClient = h.MetaClient
+
+	var req *http.Request
+	fn := func(ct *test) {
+		w := httptest.NewRecorder()
+		if body, err := json.Marshal(&ct.body); err != nil {
+			t.Fatalf("error marshaling body: %s", err)
+		} else {
+			req = MustNewJSONRequest(ct.method, ct.url, bytes.NewReader(body))
+		}
+		h.ServeHTTP(w, req)
+		var errMsg string
+		if w.Code != ct.status {
+			t.Fatalf("error, expected %d got %d: %s", ct.status, w.Code, errMsg)
+		} else if w.Code != http.StatusOK {
+			errMsg = w.Header().Get("X-InfluxDB-Error")
+			if errMsg != ct.errMsg {
+				t.Fatalf("incorrect error message, expected: %q, got: %q", ct.errMsg, errMsg)
+			}
+		}
+	}
+	for _, ct := range tests {
+		fn(ct)
+	}
+}
+
+var testBuckets = []meta.DatabaseInfo{
+	{
+		Name:              "dbOne",
+		RetentionPolicies: []meta.RetentionPolicyInfo{{Name: "rpOne_1"}, {Name: "rpTwo_1"}, {Name: "rpThree_1"}},
+	},
+	{
+		Name:              "dbTwo",
+		RetentionPolicies: []meta.RetentionPolicyInfo{{Name: "rpOne_2"}, {Name: "rpTwo_2"}, {Name: "rpThree_2"}, {Name: "rpFour_2"}},
+	},
+	{
+		Name:              "dbThree",
+		RetentionPolicies: []meta.RetentionPolicyInfo{{Name: "rpOne_3"}},
+	},
+}
+
+func getBuckets(offset, limit int) []string {
+	i := 0
+	buckets := make([]string, 0, 8)
+
+	for _, dbi := range testBuckets {
+		for _, rpi := range dbi.RetentionPolicies {
+			if limit <= (i - offset) {
+				return buckets
+			}
+			if i >= offset {
+				buckets = append(buckets, fmt.Sprintf("%s/%s", dbi.Name, rpi.Name))
+			}
+			i++
+		}
+	}
+	return buckets
+}
+
+func TestHandler_ListBuckets(t *testing.T) {
+	type test struct {
+		url    string
+		status int
+		errMsg string
+		skip   int
+		limit  int
+	}
+
+	tests := []*test{
+		{
+			url:    "/api/v2/buckets?id=dbOne/rpTwo_1&name=NotThere/rpTwo_1",
+			status: http.StatusBadRequest,
+			skip:   1,
+			limit:  1,
+			errMsg: "list buckets: name: \"NotThere/rpTwo_1\" and id: \"dbOne/rpTwo_1\" do not match",
+		},
+		{
+			url:    "/api/v2/buckets?after=dbOne/rpTwo_1&limit=4",
+			status: http.StatusOK,
+			skip:   2,
+			limit:  4,
+		},
+		{
+			url:    "/api/v2/buckets?after=dbOne/rpThree_1",
+			status: http.StatusOK,
+			skip:   3,
+			limit:  20,
+		},
+		{
+			url:    "/api/v2/buckets?after=dbTwo/rpTwo_2",
+			status: http.StatusOK,
+			skip:   5,
+			limit:  20,
+		},
+		{
+			url:    "/api/v2/buckets?id=dbOne/rpTwo_1&name=dbOne/rpTwo_1",
+			status: http.StatusOK,
+			skip:   1,
+			limit:  1,
+		},
+		{
+			url:    "/api/v2/buckets?id=dbOne/rpTwo_1",
+			status: http.StatusOK,
+			skip:   1,
+			limit:  1,
+		},
+		{
+			url:    "/api/v2/buckets?name=dbOne/rpTwo_1",
+			status: http.StatusOK,
+			skip:   1,
+			limit:  1,
+		},
+		{
+			url:    "/api/v2/buckets?offset=3&after=dbOne/rpOne_1",
+			status: http.StatusBadRequest,
+			skip:   0,
+			limit:  20,
+			errMsg: "list buckets cannot have both \"offset\" and \"after\" arguments",
+		},
+		{
+			url:    "/api/v2/buckets?offset=3&limit=4",
+			status: http.StatusOK,
+			skip:   3,
+			limit:  4,
+		},
+		{
+			url:    "/api/v2/buckets?offset=1&limit=5",
+			status: http.StatusOK,
+			skip:   1,
+			limit:  5,
+		},
+		{
+			url:    "/api/v2/buckets",
+			status: http.StatusOK,
+			skip:   0,
+			limit:  20,
+		},
+	}
+
+	lookupDbFn := func(name string) *meta.DatabaseInfo {
+		for i := 0; i < len(testBuckets); i++ {
+			if testBuckets[i].Name == name {
+				return &testBuckets[i]
+			}
+		}
+		return nil
+	}
+
+	dbsFn := func() []meta.DatabaseInfo {
+		return testBuckets
+	}
+
+	h := NewHandler(false)
+
+	h.MetaClient = &internal.MetaClientMock{
+		DatabaseFn:  lookupDbFn,
+		DatabasesFn: dbsFn,
+	}
+
+	h.Handler.MetaClient = h.MetaClient
+
+	var req *http.Request
+	fn := func(ct *test) {
+		w := httptest.NewRecorder()
+		req = MustNewJSONRequest("GET", ct.url, nil)
+		h.ServeHTTP(w, req)
+		var errMsg string
+		if w.Code != ct.status {
+			t.Fatalf("error, expected %d got %d: %s", ct.status, w.Code, errMsg)
+		} else if w.Code != http.StatusOK {
+			errMsg = w.Header().Get("X-InfluxDB-Error")
+			if errMsg != ct.errMsg {
+				t.Fatalf("incorrect error message, expected: %q, got: %q", ct.errMsg, errMsg)
+			}
+		} else {
+			var got []httpd.Bucket
+			exp := getBuckets(ct.skip, ct.limit)
+
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshaling buckets: %s", err.Error())
+			}
+			if len(exp) != len(got) {
+				t.Fatalf("expected %d buckets returned, got %d", len(exp), len(got))
+			}
+			for i := 0; i < len(got); i++ {
+				if exp[i] != got[i].Name {
+					t.Fatalf("expected %q, got %q", exp[i], got[i].Name)
+				}
+			}
+		}
+	}
+	for _, ct := range tests {
+		fn(ct)
+	}
+}
+
+func TestHandler_RetrieveBucket(t *testing.T) {
+	type test struct {
+		url    string
+		status int
+		errMsg string
+		exp    string
+	}
+
+	tests := []*test{
+		{
+			url:    "/api/v2/buckets/dbOne//",
+			status: http.StatusNotFound,
+		},
+		{
+			url:    "/api/v2/buckets//rpTwo_1",
+			status: http.StatusNotFound,
+			errMsg: `bucket "/rpTwo_1": bucket name "/rpTwo_1" is in db/rp form but has an empty database`,
+		},
+		{
+			url:    "/api/v2/buckets/dbFive/rpTwo_1",
+			status: http.StatusNotFound,
+			errMsg: `bucket not found: "dbFive/rpTwo_1"`,
+		},
+		{
+			url:    "/api/v2/buckets/dbOne/rpTwo_1",
+			status: http.StatusOK,
+			exp:    "dbOne/rpTwo_1",
+		},
+		{
+			url:    "/api/v2/buckets/dbOne/rpOne_2",
+			status: http.StatusNotFound,
+			errMsg: `bucket not found: "dbOne/rpOne_2"`,
+		},
+	}
+	lookupDbFn := func(name string) *meta.DatabaseInfo {
+		for i := 0; i < len(testBuckets); i++ {
+			if testBuckets[i].Name == name {
+				return &testBuckets[i]
+			}
+		}
+		return nil
+	}
+
+	h := NewHandler(false)
+
+	h.MetaClient = &internal.MetaClientMock{
+		DatabaseFn: lookupDbFn,
+	}
+
+	h.Handler.MetaClient = h.MetaClient
+
+	var req *http.Request
+	fn := func(ct *test) {
+		w := httptest.NewRecorder()
+		req = MustNewJSONRequest("GET", ct.url, nil)
+		h.ServeHTTP(w, req)
+		var errMsg string
+		if w.Code != ct.status {
+			t.Fatalf("error, expected %d got %d: %s", ct.status, w.Code, errMsg)
+		} else if w.Code != http.StatusOK {
+			errMsg = w.Header().Get("X-InfluxDB-Error")
+			if errMsg != ct.errMsg {
+				t.Fatalf("incorrect error message, expected: %q, got: %q", ct.errMsg, errMsg)
+			}
+		} else {
+			var got httpd.Bucket
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshaling buckets: %s", err.Error())
+			}
+			if ct.exp != got.Name {
+				t.Fatalf("expected %q, got %q", ct.exp, got.Name)
+			}
+		}
+	}
+	for _, ct := range tests {
+		fn(ct)
+	}
+}
+
 // Ensure X-Forwarded-For header writes the correct log message.
 func TestHandler_XForwardedFor(t *testing.T) {
 	var buf bytes.Buffer
@@ -2279,7 +2676,10 @@ func (e *HandlerStatementExecutor) ExecuteStatement(ctx *query.ExecutionContext,
 
 // HandlerQueryAuthorizer is a mock implementation of Handler.QueryAuthorizer.
 type HandlerQueryAuthorizer struct {
-	AuthorizeQueryFn func(u meta.User, query *influxql.Query, database string) error
+	AuthorizeQueryFn                 func(u meta.User, query *influxql.Query, database string) error
+	AuthorizeCreateDatabaseFn        func(u meta.User) error
+	AuthorizeCreateRetentionPolicyFn func(u meta.User, db string)
+	AuthorizeDeleteRetentionPolicyFn func(u meta.User, db string) error
 }
 
 func (a *HandlerQueryAuthorizer) AuthorizeQuery(u meta.User, q *influxql.Query, database string) (query.FineAuthorizer, error) {
@@ -2287,7 +2687,19 @@ func (a *HandlerQueryAuthorizer) AuthorizeQuery(u meta.User, q *influxql.Query, 
 }
 
 func (a *HandlerQueryAuthorizer) AuthorizeDatabase(u meta.User, priv influxql.Privilege, database string) error {
-	panic("not implemented")
+	panic("AuthorizeDatabase: not implemented")
+}
+
+func (a *HandlerQueryAuthorizer) AuthorizeCreateDatabase(u meta.User) error {
+	return a.AuthorizeCreateDatabaseFn(u)
+}
+
+func (a *HandlerQueryAuthorizer) AuthorizeCreateRetentionPolicy(u meta.User, db string) error {
+	return a.AuthorizeCreateRetentionPolicy(u, db)
+}
+
+func (a *HandlerQueryAuthorizer) AuthorizeDeleteRetentionPolicy(u meta.User, db string) error {
+	return a.AuthorizeDeleteRetentionPolicyFn(u, db)
 }
 
 type HandlerPointsWriter struct {

--- a/services/meta/query_authorizer.go
+++ b/services/meta/query_authorizer.go
@@ -135,6 +135,77 @@ func (a *QueryAuthorizer) AuthorizeDatabase(u User, priv influxql.Privilege, dat
 	}
 }
 
+func (a *QueryAuthorizer) AuthorizeCreateDatabase(u User) error {
+	if u == nil {
+		return &ErrAuthorize{
+			Message: "no user provided",
+		}
+	}
+
+	switch user := u.(type) {
+	case *UserInfo:
+		if !user.Admin {
+			return &ErrAuthorize{
+				Message: fmt.Sprintf("user %q, must be an administrator to create a database", user.Name),
+			}
+		}
+		return nil
+	default:
+	}
+	return &ErrAuthorize{
+		User:    u.ID(),
+		Message: fmt.Sprintf("Internal error - incorrect oss user type %T", u),
+	}
+}
+
+func (a *QueryAuthorizer) AuthorizeCreateRetentionPolicy(u User, db string) error {
+	if u == nil {
+		return &ErrAuthorize{
+			Message: "no user provided",
+		}
+	}
+
+	switch user := u.(type) {
+	case *UserInfo:
+		if !user.Admin {
+			return &ErrAuthorize{
+				Message: fmt.Sprintf("user %q, must be an administrator to create a retention policy", user.Name),
+			}
+		}
+		return nil
+	default:
+	}
+	return &ErrAuthorize{
+		User:    u.ID(),
+		Message: fmt.Sprintf("Internal error - incorrect oss user type %T", u),
+	}
+}
+
+func (a *QueryAuthorizer) AuthorizeDeleteRetentionPolicy(u User, db string) error {
+	if u == nil {
+		return &ErrAuthorize{
+			Database: db,
+			Message:  "no user provided",
+		}
+	}
+
+	switch user := u.(type) {
+	case *UserInfo:
+		if !user.Admin {
+			return &ErrAuthorize{
+				Database: db,
+				Message:  fmt.Sprintf("user %q, must be an administrator to delete a retention policy", u.ID()),
+			}
+		}
+		return nil
+	default:
+	}
+	return &ErrAuthorize{
+		User:    u.ID(),
+		Message: fmt.Sprintf("Internal error - incorrect oss user type %T", u),
+	}
+}
+
 // ErrAuthorize represents an authorization error.
 type ErrAuthorize struct {
 	Query    *influxql.Query

--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -500,3 +500,7 @@ func (s *Store) GetSource(db, rp string) proto.Message {
 func (s *Store) Delete(database string, sources []influxql.Source, condition influxql.Expr) error {
 	return s.TSDBStore.DeleteSeries(database, sources, condition)
 }
+
+func (s *Store) DeleteRetentionPolicy(database, name string) error {
+	return s.TSDBStore.DeleteRetentionPolicy(database, name)
+}


### PR DESCRIPTION
Partial support for V2 API buckets endpoints

create, delete, list, and retrieve

This PR partially implements the /v2/api/buckets
POST for create a bucket
DELETE for deleting a bucket
GET for listing buckets
GET for retrieving one bucket

See here for details:
https://docs.influxdata.com/influxdb/cloud/api/#tag/Buckets

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Documentation updated or issue created: https://github.com/influxdata/docs-v2/issues/3961
