### PR TITLE
fix: MeasurementsCardinality should not be less than 0

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1248,7 +1248,11 @@ func (s *Store) MeasurementsCardinality(ctx context.Context, database string) (i
 	if err != nil {
 		return 0, err
 	}
-	return int64(ss.Count() - ts.Count()), nil
+	mc := int64(ss.Count() - ts.Count())
+	if mc < 0 {
+		mc = 0
+	}
+	return mc, nil
 }
 
 // MeasurementsSketches returns the sketches associated with the measurement


### PR DESCRIPTION
Clamp the value of Store.MeasurementsCardinality so that it can not be less
than 0. This primarily shows up as a negative `numMeasurements` value in
/debug/vars under some circumstances.

Closes #23285

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

