### PR TITLE
chore: use common semantic PR and commit message checks

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,10 @@
+---
+name: "Semantic PR and Commit Messages"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  semantic:
+    uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main


### PR DESCRIPTION
After this is merged, the old semantic checker can be disabled, and its config file removed from the repository.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
