### PR TITLE
fix: backport improvements to ReadTags pushdowns from 2.x

### DIFF
--- a/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
@@ -76,7 +76,8 @@ testcase read_tag_keys {
 ,,0,region
 ",
     )
-    result = testing.loadStorage(csv: input)
+    result = csv.from(csv: input)
+        |> testing.load()
         |> range(start: -100y)
         |> filter(fn: (r) => true)
         |> keys()

--- a/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
@@ -1,0 +1,157 @@
+package universe_test
+
+import "testing"
+import "testing/expect"
+import "planner"
+import "csv"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+testcase read_tag_keys {
+    expect.planner(rules: ["PushDownReadTagKeysRule": 1])
+
+    input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+
+#datatype,string,long,dateTime:RFC3339,string,string,string,string,double
+#group,false,false,false,true,true,true,true,false
+#default,_result,,,,,,,
+,result,table,_time,_measurement,region,host,_field,_value
+,,3,2018-05-22T19:53:26Z,system,us-east,host.local,load1,10
+,,3,2018-05-22T19:53:36Z,system,us-east,host.local,load1,11
+,,3,2018-05-22T19:53:46Z,system,us-east,host.local,load1,18
+,,3,2018-05-22T19:53:56Z,system,us-east,host.local,load1,19
+,,3,2018-05-22T19:54:06Z,system,us-east,host.local,load1,17
+,,3,2018-05-22T19:54:16Z,system,us-east,host.local,load1,17
+
+,,4,2018-05-22T19:53:26Z,system,us-east,host.local,load3,16
+,,4,2018-05-22T19:53:36Z,system,us-east,host.local,load3,16
+,,4,2018-05-22T19:53:46Z,system,us-east,host.local,load3,15
+,,4,2018-05-22T19:53:56Z,system,us-east,host.local,load3,19
+,,4,2018-05-22T19:54:06Z,system,us-east,host.local,load3,19
+,,4,2018-05-22T19:54:16Z,system,us-east,host.local,load3,19
+
+,,5,2018-05-22T19:53:26Z,system,us-west,host.local,load5,19
+,,5,2018-05-22T19:53:36Z,system,us-west,host.local,load5,22
+,,5,2018-05-22T19:53:46Z,system,us-west,host.local,load5,11
+,,5,2018-05-22T19:53:56Z,system,us-west,host.local,load5,12
+,,5,2018-05-22T19:54:06Z,system,us-west,host.local,load5,13
+,,5,2018-05-22T19:54:16Z,system,us-west,host.local,load5,13
+"
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,_field
+,,0,_measurement
+,,0,_start
+,,0,_stop
+,,0,host
+,,0,region
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => true)
+        |> keys()
+        |> keep(columns: ["_value"])
+        |> distinct()
+        |> sort()
+    testing.diff(want: want, got: result)
+}
+
+testcase read_tag_keys_with_predicate {
+    expect.planner(rules: ["PushDownReadTagKeysRule": 1])
+
+    input = "
+#group,false,false,false,false,true,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,_result,,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,mode,path
+,,0,2020-10-21T20:48:30Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:40Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:50Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,1,2020-10-21T20:48:30Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:40Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:50Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,2,2020-10-21T20:48:30Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:40Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:50Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,3,2020-10-21T20:48:30Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:40Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:50Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+
+#group,false,false,false,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string
+#default,_result,,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host,arch
+,,4,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,euterpe.local,amd64
+,,4,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,euterpe.local,amd64
+,,4,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,euterpe.local,amd64
+,,5,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,euterpe.local,amd64
+,,5,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,euterpe.local,amd64
+,,5,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,euterpe.local,amd64
+
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,string,string,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_field,_measurement,_time,_value,cpu,host,region
+,,6,usage_user,cpu,2020-10-21T20:48:30Z,19.30000000007567,cpu0,euterpe.local,north
+,,6,usage_user,cpu,2020-10-21T20:48:40Z,20.020020020038682,cpu0,euterpe.local,north
+,,6,usage_user,cpu,2020-10-21T20:48:50Z,18.581418581407107,cpu0,euterpe.local,north
+,,7,usage_user,cpu,2020-10-21T20:48:30Z,2.3000000000138243,cpu1,euterpe.local,north
+,,7,usage_user,cpu,2020-10-21T20:48:40Z,2.4000000000536965,cpu1,euterpe.local,north
+,,7,usage_user,cpu,2020-10-21T20:48:50Z,2.0999999999423746,cpu1,euterpe.local,north
+"
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,_field
+,,0,_measurement
+,,0,_start
+,,0,_stop
+,,0,cpu
+,,0,host
+,,0,region
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "usage_user")
+        |> keys()
+        |> keep(columns: ["_value"])
+        |> distinct()
+        |> sort()
+
+    testing.diff(want: want, got: result)
+}

--- a/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_keys_test.flux
@@ -146,7 +146,8 @@ testcase read_tag_keys_with_predicate {
 ,,0,region
 ",
     )
-    result = testing.loadStorage(csv: input)
+    result = csv.from(csv: input)
+        |> testing.load()
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "usage_user")
         |> keys()

--- a/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
@@ -72,7 +72,8 @@ testcase read_tag_values {
 ,,0,mnemosyne.local
 ",
     )
-    result = testing.loadStorage(csv: input)
+    result = csv.from(csv: input)
+        |> testing.load()
         |> range(start: 2018-01-01T00:00:00Z)
         |> filter(fn: (r) => true)
         |> keep(columns: ["host"])

--- a/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
@@ -1,0 +1,159 @@
+package universe_test
+
+import "testing"
+import "testing/expect"
+import "planner"
+import "csv"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+testcase read_tag_values {
+    expect.planner(rules: ["PushDownReadTagValuesRule": 1])
+
+    input = "
+#group,false,false,false,false,true,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,_result,,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,mode,path
+,,0,2020-10-21T20:48:30Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:40Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:50Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,1,2020-10-21T20:48:30Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:40Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:50Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,2,2020-10-21T20:48:30Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:40Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:50Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,3,2020-10-21T20:48:30Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:40Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:50Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+
+#group,false,false,false,false,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host
+,,4,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,euterpe.local
+,,4,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,euterpe.local
+,,4,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,euterpe.local
+,,5,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,euterpe.local
+,,5,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,euterpe.local
+,,5,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,euterpe.local
+
+#group,false,false,false,false,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host
+,,6,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,mnemosyne.local
+,,6,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,mnemosyne.local
+,,6,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,mnemosyne.local
+,,7,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,mnemosyne.local
+,,7,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,mnemosyne.local
+,,7,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,mnemosyne.local
+
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,string,string,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_field,_measurement,_time,_value,cpu,host,region
+,,8,usage_user,cpu,2020-10-21T20:48:30Z,19.30000000007567,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:40Z,20.020020020038682,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:50Z,18.581418581407107,cpu0,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:30Z,2.3000000000138243,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:40Z,2.4000000000536965,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:50Z,2.0999999999423746,cpu1,euterpe.local,north
+"
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,euterpe.local
+,,0,mnemosyne.local
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: 2018-01-01T00:00:00Z)
+        |> filter(fn: (r) => true)
+        |> keep(columns: ["host"])
+        |> group()
+        |> distinct(column: "host")
+        |> sort()
+
+    testing.diff(want: want, got: result)
+}
+
+testcase read_tag_values_with_predicate {
+    expect.planner(rules: ["PushDownReadTagValuesRule": 1])
+
+    input = "
+#group,false,false,false,false,true,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,_result,,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,mode,path
+,,0,2020-10-21T20:48:30Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:40Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:50Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,1,2020-10-21T20:48:30Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:40Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:50Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,2,2020-10-21T20:48:30Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:40Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:50Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,3,2020-10-21T20:48:30Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:40Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:50Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+
+#group,false,false,false,false,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host
+,,4,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,euterpe.local
+,,4,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,euterpe.local
+,,4,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,euterpe.local
+,,5,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,euterpe.local
+,,5,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,euterpe.local
+,,5,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,euterpe.local
+
+#group,false,false,false,false,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host
+,,6,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,mnemosyne.local
+,,6,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,mnemosyne.local
+,,6,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,mnemosyne.local
+,,7,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,mnemosyne.local
+,,7,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,mnemosyne.local
+,,7,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,mnemosyne.local
+
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,string,string,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_field,_measurement,_time,_value,cpu,host,region
+,,8,usage_user,cpu,2020-10-21T20:48:30Z,19.30000000007567,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:40Z,20.020020020038682,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:50Z,18.581418581407107,cpu0,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:30Z,2.3000000000138243,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:40Z,2.4000000000536965,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:50Z,2.0999999999423746,cpu1,euterpe.local,north
+"
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,euterpe.local
+",
+    )
+    result = testing.loadStorage(csv: input)
+        |> range(start: 2018-01-01T00:00:00Z)
+        |> filter(fn: (r) => r._field == "usage_user" and r._measurement == "cpu")
+        |> keep(columns: ["host"])
+        |> group()
+        |> distinct(column: "host")
+        |> sort()
+
+    testing.diff(want: want, got: result)
+}

--- a/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
+++ b/flux/stdlib/influxdata/influxdb/read_tag_values_test.flux
@@ -148,7 +148,8 @@ testcase read_tag_values_with_predicate {
 ,,0,euterpe.local
 ",
     )
-    result = testing.loadStorage(csv: input)
+    result = csv.from(csv: input)
+        |> testing.load()
         |> range(start: 2018-01-01T00:00:00Z)
         |> filter(fn: (r) => r._field == "usage_user" and r._measurement == "cpu")
         |> keep(columns: ["host"])

--- a/services/storage/predicate_influxql.go
+++ b/services/storage/predicate_influxql.go
@@ -111,3 +111,27 @@ func HasFieldKeyOrValue(expr influxql.Expr) (bool, bool) {
 	influxql.Walk(&refs, expr)
 	return refs.found[0], refs.found[1]
 }
+
+type hasAnyTagKeys struct {
+	found bool
+}
+
+func (v *hasAnyTagKeys) Visit(node influxql.Node) influxql.Visitor {
+	if v.found {
+		return nil
+	}
+
+	if n, ok := node.(*influxql.VarRef); ok {
+		if n.Val != fieldKey && n.Val != measurementKey && n.Val != "$" {
+			v.found = true
+			return nil
+		}
+	}
+	return v
+}
+
+func hasTagKey(expr influxql.Expr) bool {
+	v := &hasAnyTagKeys{}
+	influxql.Walk(v, expr)
+	return v.found
+}

--- a/services/storage/series_cursor_test.go
+++ b/services/storage/series_cursor_test.go
@@ -10,10 +10,7 @@ import (
 
 func exprEqual(x, y influxql.Expr) bool {
 	if x == nil {
-		if y == nil {
-			return true
-		}
-		return false
+		return y == nil
 	}
 
 	if y == nil {

--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/storage/reads"
@@ -277,6 +279,48 @@ func (s *Store) WindowAggregate(ctx context.Context, req *datatypes.ReadWindowAg
 	return s.WindowAggregateLimit(ctx, req, nil)
 }
 
+type MetaqueryAttributes struct {
+	db, rp     string
+	start, end int64
+	pred       influxql.Expr
+}
+
+func (s *Store) tagKeysWithFieldPredicate(ctx context.Context, mqAttrs *MetaqueryAttributes, shardIDs []uint64) (cursors.StringIterator, error) {
+	var cur reads.SeriesCursor
+	if ic, err := newIndexSeriesCursorInfluxQLPred(ctx, mqAttrs.pred, s.TSDBStore.Shards(shardIDs)); err != nil {
+		return nil, err
+	} else if ic == nil {
+		return cursors.EmptyStringIterator, nil
+	} else {
+		cur = ic
+	}
+	m := make(map[string]struct{})
+	rs := reads.NewFilteredResultSet(ctx, mqAttrs.start, mqAttrs.end, cur)
+	for rs.Next() {
+		func() {
+			c := rs.Cursor()
+			if c == nil {
+				// no data for series key + field combination
+				return
+			}
+			defer c.Close()
+			if cursorHasData(c) {
+				tags := rs.Tags()
+				for i := range tags {
+					m[string(tags[i].Key)] = struct{}{}
+				}
+			}
+		}()
+	}
+
+	arr := make([]string, 0, len(m))
+	for tag := range m {
+		arr = append(arr, tag)
+	}
+	sort.Strings(arr)
+	return cursors.NewStringSliceIterator(arr), nil
+}
+
 func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error) {
 	if req.TagsSource == nil {
 		return nil, errors.New("missing read source")
@@ -287,17 +331,17 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 		return nil, err
 	}
 
-	database, rp, start, end, err := s.validateArgs(source.Database, source.RetentionPolicy, req.Range.GetStart(), req.Range.GetEnd())
+	db, rp, start, end, err := s.validateArgs(source.Database, source.RetentionPolicy, req.Range.GetStart(), req.Range.GetEnd())
 	if err != nil {
 		return nil, err
 	}
 
-	shardIDs, err := s.findShardIDs(database, rp, false, start, end)
+	shardIDs, err := s.findShardIDs(db, rp, false, start, end)
 	if err != nil {
 		return nil, err
 	}
 	if len(shardIDs) == 0 {
-		return cursors.NewStringSliceIterator(nil), nil
+		return cursors.EmptyStringIterator, nil
 	}
 
 	var expr influxql.Expr
@@ -311,6 +355,16 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 		if found := reads.HasFieldValueKey(expr); found {
 			return nil, errors.New("field values unsupported")
 		}
+		if found := reads.ExprHasKey(expr, fieldKey); found {
+			mqAttrs := &MetaqueryAttributes{
+				db:    db,
+				rp:    rp,
+				start: start,
+				end:   end,
+				pred:  expr,
+			}
+			return s.tagKeysWithFieldPredicate(ctx, mqAttrs, shardIDs)
+		}
 		expr = influxql.Reduce(influxql.CloneExpr(expr), nil)
 		if reads.IsTrueBooleanLiteral(expr) {
 			expr = nil
@@ -321,7 +375,7 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 	auth := query.OpenAuthorizer
 	keys, err := s.TSDBStore.TagKeys(ctx, auth, shardIDs, expr)
 	if err != nil {
-		return nil, err
+		return cursors.EmptyStringIterator, err
 	}
 
 	m := map[string]bool{
@@ -343,16 +397,6 @@ func (s *Store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cur
 }
 
 func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error) {
-	if tagKey, ok := measurementRemap[req.TagKey]; ok {
-		switch tagKey {
-		case "_name":
-			return s.MeasurementNames(ctx, &MeasurementNamesRequest{
-				MeasurementsSource: req.TagsSource,
-				Predicate:          req.Predicate,
-			})
-		}
-	}
-
 	if req.TagsSource == nil {
 		return nil, errors.New("missing read source")
 	}
@@ -362,34 +406,67 @@ func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 		return nil, err
 	}
 
-	database, rp, start, end, err := s.validateArgs(source.Database, source.RetentionPolicy, req.Range.GetStart(), req.Range.GetEnd())
+	db, rp, start, end, err := s.validateArgs(source.Database, source.RetentionPolicy, req.Range.GetStart(), req.Range.GetEnd())
 	if err != nil {
 		return nil, err
 	}
 
-	shardIDs, err := s.findShardIDs(database, rp, false, start, end)
-	if err != nil {
-		return nil, err
-	}
-	if len(shardIDs) == 0 {
-		return cursors.NewStringSliceIterator(nil), nil
-	}
-
-	var expr influxql.Expr
+	var influxqlPred influxql.Expr
 	if root := req.Predicate.GetRoot(); root != nil {
 		var err error
-		expr, err = reads.NodeToExpr(root, measurementRemap)
+		influxqlPred, err = reads.NodeToExpr(root, measurementRemap)
 		if err != nil {
 			return nil, err
 		}
 
-		if found := reads.HasFieldValueKey(expr); found {
+		if found := reads.HasFieldValueKey(influxqlPred); found {
 			return nil, errors.New("field values unsupported")
 		}
-		expr = influxql.Reduce(influxql.CloneExpr(expr), nil)
-		if reads.IsTrueBooleanLiteral(expr) {
-			expr = nil
+		influxqlPred = influxql.Reduce(influxql.CloneExpr(influxqlPred), nil)
+		if reads.IsTrueBooleanLiteral(influxqlPred) {
+			influxqlPred = nil
 		}
+	}
+
+	mqAttrs := &MetaqueryAttributes{
+		db:    db,
+		rp:    rp,
+		start: start,
+		end:   end,
+		pred:  influxqlPred,
+	}
+
+	tagKey, ok := measurementRemap[req.TagKey]
+	if !ok {
+		tagKey = req.TagKey
+	}
+
+	// Getting values of _measurement or _field are handled specially
+	switch tagKey {
+	case "_name":
+		return s.MeasurementNames(ctx, mqAttrs)
+	case "_field":
+		return s.measurementFields(ctx, mqAttrs)
+	}
+
+	return s.tagValues(ctx, mqAttrs, tagKey)
+}
+
+func (s *Store) tagValues(ctx context.Context, mqAttrs *MetaqueryAttributes, tagKey string) (cursors.StringIterator, error) {
+	// If there are any references to _field, we need to use the slow path
+	// since we cannot rely on the index alone.
+	if mqAttrs.pred != nil {
+		if hasFieldKey := reads.ExprHasKey(mqAttrs.pred, fieldKey); hasFieldKey {
+			return s.tagValuesSlow(ctx, mqAttrs, tagKey)
+		}
+	}
+
+	shardIDs, err := s.findShardIDs(mqAttrs.db, mqAttrs.rp, false, mqAttrs.start, mqAttrs.end)
+	if err != nil {
+		return nil, err
+	}
+	if len(shardIDs) == 0 {
+		return cursors.EmptyStringIterator, nil
 	}
 
 	tagKeyExpr := &influxql.BinaryExpr{
@@ -398,35 +475,34 @@ func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 			Val: "_tagKey",
 		},
 		RHS: &influxql.StringLiteral{
-			Val: req.TagKey,
+			Val: tagKey,
 		},
 	}
-	if expr != nil {
-		expr = &influxql.BinaryExpr{
+
+	if mqAttrs.pred != nil {
+		mqAttrs.pred = &influxql.BinaryExpr{
 			Op:  influxql.AND,
 			LHS: tagKeyExpr,
 			RHS: &influxql.ParenExpr{
-				Expr: expr,
+				Expr: mqAttrs.pred,
 			},
 		}
 	} else {
-		expr = tagKeyExpr
+		mqAttrs.pred = tagKeyExpr
 	}
 
 	// TODO(jsternberg): Use a real authorizer.
 	auth := query.OpenAuthorizer
-	values, err := s.TSDBStore.TagValues(ctx, auth, shardIDs, expr)
+	values, err := s.TSDBStore.TagValues(ctx, auth, shardIDs, mqAttrs.pred)
 	if err != nil {
 		return nil, err
 	}
-
 	m := make(map[string]struct{})
 	for _, kvs := range values {
 		for _, kv := range kvs.Values {
 			m[kv.Value] = struct{}{}
 		}
 	}
-
 	names := make([]string, 0, len(m))
 	for name := range m {
 		names = append(names, name)
@@ -435,47 +511,19 @@ func (s *Store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 	return cursors.NewStringSliceIterator(names), nil
 }
 
-type MeasurementNamesRequest struct {
-	MeasurementsSource *anypb.Any
-	Predicate          *datatypes.Predicate
-}
-
-func (s *Store) MeasurementNames(ctx context.Context, req *MeasurementNamesRequest) (cursors.StringIterator, error) {
-	if req.MeasurementsSource == nil {
-		return nil, errors.New("missing read source")
-	}
-
-	source, err := GetReadSource(req.MeasurementsSource)
-	if err != nil {
-		return nil, err
-	}
-
-	database, _, _, _, err := s.validateArgs(source.Database, source.RetentionPolicy, -1, -1)
-	if err != nil {
-		return nil, err
-	}
-
-	var expr influxql.Expr
-	if root := req.Predicate.GetRoot(); root != nil {
-		var err error
-		expr, err = reads.NodeToExpr(root, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		if found := reads.HasFieldValueKey(expr); found {
-			return nil, errors.New("field values unsupported")
-		}
-		expr = influxql.Reduce(influxql.CloneExpr(expr), nil)
-		if reads.IsTrueBooleanLiteral(expr) {
-			expr = nil
+func (s *Store) MeasurementNames(ctx context.Context, mqAttrs *MetaqueryAttributes) (cursors.StringIterator, error) {
+	if mqAttrs.pred != nil {
+		if hasFieldKey := reads.ExprHasKey(mqAttrs.pred, fieldKey); hasFieldKey {
+			// If there is a predicate on _field, we cannot use the index
+			// to filter out unwanted measurement names. Use a slower
+			// block scan instead.
+			return s.tagValuesSlow(ctx, mqAttrs, measurementKey)
 		}
 	}
 
 	// TODO(jsternberg): Use a real authorizer.
 	auth := query.OpenAuthorizer
-	// NOTE: this preserves the existing flux behaviour of ignoring the retention policy here
-	values, err := s.TSDBStore.MeasurementNames(ctx, auth, database, "", expr)
+	values, err := s.TSDBStore.MeasurementNames(ctx, auth, mqAttrs.db, "", mqAttrs.pred)
 	if err != nil {
 		return nil, err
 	}
@@ -495,6 +543,135 @@ func (s *Store) MeasurementNames(ctx context.Context, req *MeasurementNamesReque
 
 func (s *Store) GetSource(db, rp string) proto.Message {
 	return &ReadSource{Database: db, RetentionPolicy: rp}
+}
+
+func (s *Store) measurementFields(ctx context.Context, mqAttrs *MetaqueryAttributes) (cursors.StringIterator, error) {
+	if mqAttrs.pred != nil {
+		if hasFieldKey := reads.ExprHasKey(mqAttrs.pred, fieldKey); hasFieldKey {
+			return s.tagValuesSlow(ctx, mqAttrs, fieldKey)
+		}
+
+		// If there predicates on anything besides _measurement, we can't
+		// use the index and need to use the slow path.
+		if hasTagKey(mqAttrs.pred) {
+			return s.tagValuesSlow(ctx, mqAttrs, fieldKey)
+		}
+	}
+
+	shardIDs, err := s.findShardIDs(mqAttrs.db, mqAttrs.rp, false, mqAttrs.start, mqAttrs.end)
+	if err != nil {
+		return nil, err
+	}
+	if len(shardIDs) == 0 {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	sg := s.TSDBStore.ShardGroup(shardIDs)
+	ms := &influxql.Measurement{
+		Database:        mqAttrs.db,
+		RetentionPolicy: mqAttrs.rp,
+		SystemIterator:  "_fieldKeys",
+	}
+	opts := query.IteratorOptions{
+		Condition:  mqAttrs.pred,
+		Authorizer: query.OpenAuthorizer,
+	}
+	iter, err := sg.CreateIterator(ctx, ms, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var fieldNames []string
+	fitr := iter.(query.FloatIterator)
+	for p, _ := fitr.Next(); p != nil; p, _ = fitr.Next() {
+		if len(p.Aux) >= 1 {
+			fieldNames = append(fieldNames, p.Aux[0].(string))
+		}
+	}
+
+	sort.Strings(fieldNames)
+	fieldNames = slices.MergeSortedStrings(fieldNames)
+
+	return cursors.NewStringSliceIterator(fieldNames), nil
+}
+
+func cursorHasData(c cursors.Cursor) bool {
+	var l int
+	switch typedCur := c.(type) {
+	case cursors.IntegerArrayCursor:
+		ia := typedCur.Next()
+		l = ia.Len()
+	case cursors.FloatArrayCursor:
+		ia := typedCur.Next()
+		l = ia.Len()
+	case cursors.UnsignedArrayCursor:
+		ia := typedCur.Next()
+		l = ia.Len()
+	case cursors.BooleanArrayCursor:
+		ia := typedCur.Next()
+		l = ia.Len()
+	case cursors.StringArrayCursor:
+		ia := typedCur.Next()
+		l = ia.Len()
+	default:
+		panic(fmt.Sprintf("unreachable: %T", typedCur))
+	}
+	return l != 0
+}
+
+// tagValuesSlow will determine the tag values for the given tagKey.
+// It's generally faster to use tagValues, measurementFields or
+// MeasurementNames, but those methods will only use the index and metadata
+// stored in the shard. Because fields are not themselves indexed, we have no way
+// of correlating fields to tag values, so we sometimes need to consult tsm to
+// provide an accurate answer.
+func (s *Store) tagValuesSlow(ctx context.Context, mqAttrs *MetaqueryAttributes, tagKey string) (cursors.StringIterator, error) {
+	shardIDs, err := s.findShardIDs(mqAttrs.db, mqAttrs.rp, false, mqAttrs.start, mqAttrs.end)
+	if err != nil {
+		return nil, err
+	}
+	if len(shardIDs) == 0 {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	var cur reads.SeriesCursor
+	if ic, err := newIndexSeriesCursorInfluxQLPred(ctx, mqAttrs.pred, s.TSDBStore.Shards(shardIDs)); err != nil {
+		return nil, err
+	} else if ic == nil {
+		return cursors.EmptyStringIterator, nil
+	} else {
+		cur = ic
+	}
+	m := make(map[string]struct{})
+
+	rs := reads.NewFilteredResultSet(ctx, mqAttrs.start, mqAttrs.end, cur)
+	for rs.Next() {
+		func() {
+			c := rs.Cursor()
+			if c == nil {
+				// no data for series key + field combination?
+				// It seems that even when there is no data for this series key + field
+				// combo that the cursor may be not nil. We need to
+				// request invoke an array cursor to be sure.
+				// This is the reason for the call to cursorHasData below.
+				return
+			}
+			defer c.Close()
+
+			if cursorHasData(c) {
+				f := rs.Tags().Get([]byte(tagKey))
+				m[string(f)] = struct{}{}
+			}
+		}()
+	}
+
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return cursors.NewStringSliceIterator(names), nil
 }
 
 func (s *Store) Delete(database string, sources []influxql.Source, condition influxql.Expr) error {

--- a/storage/reads/influxql_predicate.go
+++ b/storage/reads/influxql_predicate.go
@@ -267,8 +267,12 @@ func (v *hasRefs) Visit(node influxql.Node) influxql.Visitor {
 	return v
 }
 
-func HasFieldValueKey(expr influxql.Expr) bool {
-	refs := hasRefs{refs: []string{fieldRef}, found: make([]bool, 1)}
+func ExprHasKey(expr influxql.Expr, key string) bool {
+	refs := hasRefs{refs: []string{key}, found: make([]bool, 1)}
 	influxql.Walk(&refs, expr)
 	return refs.found[0]
+}
+
+func HasFieldValueKey(expr influxql.Expr) bool {
+	return ExprHasKey(expr, fieldRef)
 }


### PR DESCRIPTION
Continuation of #21160, which was a backport of #19856 and #19894.

The backport of #19856 updates the `tagKeys` and `tagValues` methods of the `Store` interface to return the answers that Flux is used to, by properly filtering on `_field` when such a predicate is present. These methods are frequently used by the UI query builder to describe the shape of the users data. This primarily fixed #19794 for 2.x, which contains good examples of the issue, but also fixed #19806, a related issue

The backport of #19894 returns `nil` instead of an empty iterator, and callers expect a non-nil result set for any non-error return, which fixed https://github.com/influxdata/flux/issues/3300 for 2.x

This work was originally shelved due to complications regarding Enterprise compatibility. As it stands now, this work is identical to where #21160 was left off, though I expect that this will have to be adjusted significantly to make work for what we need. Some aspects of the wire-format has changed, so we may want to undo those portions of it, or be prepared to handle it carefully

