### PR TITLE
fix: MeasurementsCardinality should not be less than 0

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1165,7 +1165,11 @@ func (s *Store) MeasurementsCardinality(ctx context.Context, database string) (i
 	if err != nil {
 		return 0, err
 	}
-	return int64(ss.Count() - ts.Count()), nil
+	mc := int64(ss.Count() - ts.Count())
+	if mc < 0 {
+		mc = 0
+	}
+	return mc, nil
 }
 
 // MeasurementsSketches returns the sketches associated with the measurement

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1242,6 +1242,21 @@ func TestStore_Sketches(t *testing.T) {
 		if got, exp := int(tsketch.Count()), tmeasurements; got-exp < -delta(tmeasurements) || got-exp > delta(tmeasurements) {
 			return fmt.Errorf("got measurement tombstone cardinality %d, expected ~%d", got, exp)
 		}
+
+		if mc, err := store.MeasurementsCardinality(context.Background(), "db"); err != nil {
+			return fmt.Errorf("unexpected error from MeasurementsCardinality: %w", err)
+		} else {
+			if mc < 0 {
+				return fmt.Errorf("MeasurementsCardinality returned < 0 (%v)", mc)
+			}
+			expMc := int64(sketch.Count() - tsketch.Count())
+			if expMc < 0 {
+				expMc = 0
+			}
+			if got, exp := int(mc), int(expMc); got-exp < -delta(exp) || got-exp > delta(exp) {
+				return fmt.Errorf("got measurement cardinality %d, expected ~%d", mc, exp)
+			}
+		}
 		return nil
 	}
 
@@ -1315,6 +1330,33 @@ func TestStore_Sketches(t *testing.T) {
 		if err := checkCardinalities(store.Store, expS, expTS, expM, expTM); err != nil {
 			return fmt.Errorf("[initial|re-open|delete|re-open] %v", err)
 		}
+
+		// Now delete the rest of the measurements.
+		// This will cause the measurement tombstones to exceed the measurement cardinality for TSI.
+		mnames, err = store.MeasurementNames(context.Background(), nil, "db", nil)
+		if err != nil {
+			return err
+		}
+
+		for _, name := range mnames {
+			if err := store.DeleteSeries(context.Background(), "db", []influxql.Source{&influxql.Measurement{Name: string(name)}}, nil); err != nil {
+				return err
+			}
+		}
+
+		// Check cardinalities. In this case, the indexes behave differently.
+		expS, expTS, expM, expTM = 80, 159, 5, 10
+		/*
+			if index == inmem.IndexName {
+				expS, expTS, expM, expTM = 80, 80, 5, 5
+			}
+		*/
+
+		// Check cardinalities - tombstones should be in
+		if err := checkCardinalities(store.Store, expS, expTS, expM, expTM); err != nil {
+			return fmt.Errorf("[initial|re-open|delete] %v", err)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Clamp the value of Store.MeasurementsCardinality so that it can not be less
than 0. This primarily shows up as a negative numMeasurements value in
/debug/vars under some circumstances.

refs #23285

(cherry picked from commit 160cf678d56e16dc3e58eb2bc83f7540bb667a8d)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

