### PR TITLE
chore: remove previous semantic pull request config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Describe your proposed changes here.
 <!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
 <!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
 
-- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
+- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] Rebased/mergeable
 - [ ] Tests pass
 - [ ] http/swagger.yml updated (if modified Go structs or API)

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,0 @@
-# docs: https://github.com/probot/semantic-pull-requests#configuration
-# Always validate the PR title AND all the commits
-titleAndCommits: true
-allowMergeCommits: true


### PR DESCRIPTION
The old semantic pull request service has been disabled in this repository, so remove the config file.

Also update the pull request template to reflect the current conventional commit spec.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
