### PR TITLE
build: enable nightly docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ jobs:
             - bin
 
   package-and-release:
-    executor: cross-builder
+    executor: linux-amd64
     parameters:
       build-type:
         type: string
@@ -356,9 +356,33 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - quay_login
+      - run:
+          name: Set up Docker cross-builder
+          command: |
+            # Get jq to parse binfmt output.
+            sudo apt-get update && sudo apt-get install -y jq
+
+            # Uninstall any emulators provided by the system.
+            emulators=($(docker run --rm --privileged tonistiigi/binfmt:latest | jq -r .emulators[]))
+            for e in ${emulators[@]}; do
+              docker run --rm --privileged tonistiigi/binfmt:latest --uninstall ${e}
+            done
+
+            # Install the QEMU emulators we need to cross-build.
+            docker run --rm --privileged tonistiigi/binfmt:latest --install all
+
+            # Create a new buildx context using the freshly-installed emulators.
+            docker buildx create --name cross-builder
+            docker buildx use --default cross-builder
+            docker buildx inspect --bootstrap
+
+            # Build the 1st stage of our Docker(s) on our target platforms, to flush out
+            # any problems in our emulator setup.
+            docker buildx build --target dependency-base --platform linux/amd64,linux/arm64 docker/influxd
       - run:
           name: Compute artifact version
-          command: echo "export GORELEASER_CURRENT_TAG='$(build-version.sh << parameters.build-type >>)'" >> $BASH_ENV
+          command: echo "export GORELEASER_CURRENT_TAG='$(scripts/ci/build-version.sh << parameters.build-type >>)'" >> $BASH_ENV
       - unless:
           condition:
             equal: [ release, << parameters.build-type >> ]
@@ -366,6 +390,22 @@ jobs:
             - run:
                 name: Tag commit locally to pass goreleaser validation
                 command: git tag "$GORELEASER_CURRENT_TAG"
+      - run:
+          name: Set GOPATH
+          # Machine executors use a different GOPATH from the cimg/go Docker executors.
+          command: |
+            echo 'export GOPATH=/go' >> $BASH_ENV
+            echo 'export PATH=${GOPATH}/bin:${PATH}' >> $BASH_ENV
+      - run:
+          name: Install GO 1.18
+          command: |
+            pushd "${HOME}"
+              curl -sSLO https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
+
+              sha256sum --check -- \<<<"b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334 go1.18.1.linux-amd64.tar.gz"
+
+              sudo tar xzf go1.18.1.linux-amd64.tar.gz -C /
+            popd
       - run:
           name: Import GPG key
           command: |
@@ -385,7 +425,7 @@ jobs:
             tar --extract --file=goreleaser-pro_Linux_x86_64.tar.gz goreleaser
             rm goreleaser-pro_Linux_x86_64.tar.gz
             # Move goreleaser binary out of project dir so it doesn't dirty the git state.
-            mv goreleaser /go/bin/
+            sudo mv goreleaser /usr/bin/
       - run:
           name: Run goreleaser
           command: goreleaser --debug release --config .goreleaser/<< parameters.build-type >>.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,12 @@ workflows:
                 arch: arm64
               - os: windows
                 arch: arm64
+      - changelog
       - package-and-release:
-          name: package-snapshot
-          build-type: snapshot
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
+          name: package-snapshot # should be "package-and-release-nightly"
+          build-type: nightly
           requires:
+            - changelog
             - build
       - test-downgrade:
           requires:

--- a/.goreleaser/_uploads-nightly.yml
+++ b/.goreleaser/_uploads-nightly.yml
@@ -14,3 +14,32 @@ blobs:
     folder: "platform/nightlies/master/"
     extra_files:
       - glob: ./changelog_artifacts/CHANGELOG.md
+
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "quay.io/influxdb/influxdb-amd64:nightly"
+    dockerfile: docker/influxd/Dockerfile
+    extra_files:
+      - docker/influxd/entrypoint.sh
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    use_buildx: true
+
+  - goos: linux
+    goarch: arm64
+    image_templates:
+      - "quay.io/influxdb/influxdb-arm64v8:nightly"
+    dockerfile: docker/influxd/Dockerfile
+    extra_files:
+      - docker/influxd/entrypoint.sh
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+    use_buildx: true
+
+docker_manifests:
+  - name_template: "quay.io/influxdb/influxdb:nightly"
+    image_templates:
+      - "quay.io/influxdb/influxdb-amd64:nightly"
+      - "quay.io/influxdb/influxdb-arm64v8:nightly"

--- a/scripts/ci/build-version.sh
+++ b/scripts/ci/build-version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eo pipefail
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<build-type>'
+        >&2 echo "Valid build types are 'release', 'nightly', and 'snapshot'"
+        exit 1
+    fi
+    local -r build_type=$1
+
+    local version
+    case "$build_type" in
+        release)
+            if [ -n "$CIRCLE_TAG" ]; then
+                version="$CIRCLE_TAG"
+            else
+                version=$(git describe --tags --abbrev=0 --exact-match)
+            fi
+            ;;
+        nightly)
+            version=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)+nightly.$(date +%Y.%m.%d)
+            ;;
+        snapshot)
+            version=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)+SNAPSHOT.$(git rev-parse --short HEAD)
+            ;;
+        *)
+            >&2 echo "Error: unknown build type '$build_type'"
+            >&2 echo "Valid build types are 'release', 'nightly', and 'snapshot'"
+            ;;
+    esac
+    if [ -z "$version" ]; then
+        >&2 echo "Error: couldn't compute version for build type '$build_type'"
+        exit 1
+    fi
+
+    echo "$version"
+}
+
+main ${@}


### PR DESCRIPTION
This re-enables nightly docker builds. This is based off of the nightly builds from 2.0 and 2.1. Some changes were required in order to get this working in 2.2+. The cross-builder container can no longer be used to run goreleaser. This is because goreleaser needs to build Docker containers of various architectures. The `build-version.sh` script was only available within the cross container, so it was copied here.
 
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Rebased/mergeable
- [ ] Tests pass