### PR TITLE
fix(flux): inject sane defaults for flux, to prevent an error

### DIFF
--- a/flux/stdlib/influxdata/influxdb/dependencies.go
+++ b/flux/stdlib/influxdata/influxdb/dependencies.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/http"
+	"github.com/influxdata/flux/dependencies/secret"
+	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/influxdb/coordinator"
 )
 
@@ -65,7 +69,16 @@ func NewDependencies(
 	authEnabled bool,
 	writer PointsWriter,
 ) (Dependencies, error) {
-	fdeps := flux.NewDefaultDependencies()
+	validator := &url.PassValidator{}
+	fdeps := dependencies.NewDefaultDependencies("")
+	fdeps.Deps = flux.Deps{
+		Deps: flux.WrappedDeps{
+			HTTPClient:        http.NewDefaultClient(validator),
+			FilesystemService: nil,
+			SecretService:     secret.EmptySecretService{},
+			URLValidator:      validator,
+		},
+	}
 	deps := Dependencies{FluxDeps: fdeps}
 	deps.StorageDeps = StorageDependencies{
 		Reader:       reader,


### PR DESCRIPTION
This is to prevent the following error
```
/ # cat broke.flux 
import "types"

host="http://127.0.0.1:8086"
token="myuser:mypass"

from(bucket: "vehicle_communication/30days", host: host, token: token)
    |> range(start: -1h)
    |> filter(fn: (r) => types.isType(v: r["_value"], type: "int"))
    |> aggregateWindow(every: 1m, fn: mean)



/ # cat broke.flux | /influx -username influx_support -type flux -password <pass>
{"error":"failed to initialize execute state: Provider.ReaderFor called on an error dependency"}

```
