### PR TITLE
fix: do not panic on cleaning up failed iterators (#21666)

### DIFF
--- a/influxql/query/iterator.go
+++ b/influxql/query/iterator.go
@@ -43,11 +43,22 @@ func (a Iterators) Stats() IteratorStats {
 }
 
 // Close closes all iterators.
-func (a Iterators) Close() error {
+// We are seeing an occasional panic in this function
+// which looks like a nil reference from one
+// itr.Close() call, thus we check for nil elements
+// in the slice a.  This is often called as error
+// clean-up, so the state of the iterators may be
+// unhappy.
+func (a Iterators) Close() (err error) {
+	err = nil
 	for _, itr := range a {
-		itr.Close()
+		if itr != nil {
+			if e := itr.Close(); e != nil && err == nil {
+				err = e
+			}
+		}
 	}
-	return nil
+	return err
 }
 
 // filterNonNil returns a slice of iterators that removes all nil iterators.


### PR DESCRIPTION
We have seen occasional panics in Iterators.Close()
when cleaning up after failed iterator creation.
This commit checks for nil on any iterator to be
closed, and now returns any errors generated by
that Close().

Closes https://github.com/influxdata/influxdb/issues/19579
Closes https://github.com/influxdata/influxdb/issues/19476

(cherry picked from commit acc4105b8c48657287ddeaed56c28fd2840dd862)

closes https://github.com/influxdata/influxdb/issues/23271

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass