### PR TITLE
chore: Update Go version in instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,15 +89,15 @@ If you are going to be contributing back to InfluxDB please take a second to sig
 
 ### Installing Go
 
-InfluxDB requires Go 1.17.
+InfluxDB requires Go 1.18.
 
 At InfluxData we find `gvm`, a Go version manager, useful for installing Go.
 For instructions on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
 
 After installing gvm you can install and set the default go version by running the following:
 ```bash
-$ gvm install go1.17
-$ gvm use go1.17 --default
+$ gvm install go1.18
+$ gvm use go1.18 --default
 ```
 
 InfluxDB requires Go module support. Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed. For information about modules, please refer to the [wiki](https://github.com/golang/go/wiki/Modules).

--- a/scripts/ci/run_perftest.sh
+++ b/scripts/ci/run_perftest.sh
@@ -100,7 +100,7 @@ EOF
 
 install_go() {
   # install golang latest version
-  go_endpoint="go1.17.3.linux-amd64.tar.gz"
+  go_endpoint="go1.18.1.linux-amd64.tar.gz"
 
   wget "https://dl.google.com/go/$go_endpoint" -O "$working_dir/$go_endpoint"
   rm -rf /usr/local/go


### PR DESCRIPTION
When I followed the instructions to use Go1.17 in CONTRIBUTING.md, I got errors saying `module requires Go 1.18`.
Then I switched to Go1.18 and the build succeeded.

This PR updates hardcoded Go versions from 1.17 to 1.18. 
