### PR TITLE
fix: remove data directory appending for influx_inspect verify

### DIFF
--- a/cmd/influx_inspect/verify/tsm/verify.go
+++ b/cmd/influx_inspect/verify/tsm/verify.go
@@ -46,7 +46,6 @@ func (cmd *Command) Run(args ...string) error {
 		return err
 	}
 
-	dataPath := filepath.Join(path, "data")
 	tw := tabwriter.NewWriter(cmd.Stdout, 16, 8, 0, '\t', 0)
 
 	var runner verifier
@@ -55,7 +54,7 @@ func (cmd *Command) Run(args ...string) error {
 	} else {
 		runner = &verifyChecksums{}
 	}
-	err := runner.Run(tw, dataPath)
+	err := runner.Run(tw, path)
 	tw.Flush()
 	return err
 }


### PR DESCRIPTION
This removes the line that appends "/data" to the given -dir path for `influx_inspect verify`.
Since the `loadFiles` method uses `filepath.Walk`, TSM files in a /data directory will still be checked, as well as other any other TSM files in the root directory or its subdirectories.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable

Closes #22572