### PR TITLE
feat: log slow queries even without query logging (#23320)

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -458,6 +458,9 @@ func (s *Server) Open() error {
 	s.TSDBStore.WithLogger(s.Logger)
 	if s.config.Data.QueryLogEnabled {
 		s.QueryExecutor.WithLogger(s.Logger)
+	} else if s.config.Coordinator.LogQueriesAfter > 0 {
+		// Log long-running queries even if not logging all queries
+		s.QueryExecutor.TaskManager.Logger = s.Logger
 	}
 	s.PointsWriter.WithLogger(s.Logger)
 	s.Subscriber.WithLogger(s.Logger)


### PR DESCRIPTION
Log long-running queries if "log-queries-after" > 0,
even if general query logging is not enabled.

closes https://github.com/influxdata/influxdb/issues/23147

(cherry picked from commit 1c89102276ba861f5dde3428e574118715a8d3e6)

Closes https://github.com/influxdata/influxdb/issues/23337

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass