### PR TITLE
test(label): Invalid closure capture

### DIFF
--- a/label/storage_test.go
+++ b/label/storage_test.go
@@ -221,13 +221,14 @@ func TestLabels(t *testing.T) {
 				}
 
 				if len(l) != 9 {
-					t.Fatalf("expected 2 labels, got: %d", len(l))
+					t.Fatalf("expected 9 labels, got: %d", len(l))
 				}
 			},
 		},
 	}
 
-	for _, testScenario := range tt {
+	for _, ts := range tt {
+		testScenario := ts
 		t.Run(testScenario.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Whilst working on cloud labels, I noticed that the label storage test
isn't correctly capturing the testScenario. This is because t.Parallel()
is in use, so only the "delete" scenario will only ever be tested.

The following changes fix that, by capturing the testScenario in a local
variable so that the test function can use that correctly.

As a drive-by, I fixed the error referencing the wrong expectation.

Closes #23352

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
