### PR TITLE
feat(fluxtest): add support for flux feature flags in tests

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -456,7 +456,6 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 			ts.UserService,
 			combinedTaskService,
 			combinedTaskService,
-			executor.WithFlagger(m.flagger),
 		)
 		m.executor = executor
 		m.reg.MustRegister(executorMetrics.PrometheusCollectors()...)

--- a/query/stdlib/influxdata/influxdb/source_test.go
+++ b/query/stdlib/influxdata/influxdb/source_test.go
@@ -117,7 +117,7 @@ func TestMetrics(t *testing.T) {
 	}
 
 	deps := influxdb.Dependencies{
-		FluxDeps: dependenciestest.Default(),
+		FluxDeps: dependenciestest.DefaultWithoutFlags(),
 		StorageDeps: influxdb.StorageDependencies{
 			FromDeps: influxdb.FromDependencies{
 				Reader:             &mockReader{},

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -62,7 +62,6 @@ type executorConfig struct {
 	maxWorkers             int
 	systemBuildCompiler    CompilerBuilderFunc
 	nonSystemBuildCompiler CompilerBuilderFunc
-	flagger                feature.Flagger
 }
 
 type executorOption func(*executorConfig)
@@ -119,13 +118,6 @@ func WithNonSystemCompilerBuilder(builder CompilerBuilderFunc) executorOption {
 	}
 }
 
-// WithFlagger is an Executor option that allows us to use a feature flagger in the executor
-func WithFlagger(flagger feature.Flagger) executorOption {
-	return func(o *executorConfig) {
-		o.flagger = flagger
-	}
-}
-
 // NewExecutor creates a new task executor
 func NewExecutor(log *zap.Logger, qs query.QueryService, us PermissionService, ts taskmodel.TaskService, tcs backend.TaskControlService, opts ...executorOption) (*Executor, *ExecutorMetrics) {
 	cfg := &executorConfig{
@@ -150,7 +142,6 @@ func NewExecutor(log *zap.Logger, qs query.QueryService, us PermissionService, t
 		limitFunc:              func(*taskmodel.Task, *taskmodel.Run) error { return nil }, // noop
 		systemBuildCompiler:    cfg.systemBuildCompiler,
 		nonSystemBuildCompiler: cfg.nonSystemBuildCompiler,
-		flagger:                cfg.flagger,
 	}
 
 	e.metrics = NewExecutorMetrics(e)
@@ -188,7 +179,6 @@ type Executor struct {
 
 	nonSystemBuildCompiler CompilerBuilderFunc
 	systemBuildCompiler    CompilerBuilderFunc
-	flagger                feature.Flagger
 }
 
 // SetLimitFunc sets the limit func for this task executor


### PR DESCRIPTION
For Flux acceptance tests its now possible to enable feature flags on a per test case basis.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Feature flagged (if modified API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
