### PR TITLE
feat: add signifier to replication user agent

### DIFF
--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	userAgent = fmt.Sprintf(
-		"influxdb-oss/%s (%s) Sha/%s Date/%s",
+		"influxdb-oss-replication/%s (%s) Sha/%s Date/%s",
 		influxdb.GetBuildInfo().Version,
 		runtime.GOOS,
 		influxdb.GetBuildInfo().Commit,


### PR DESCRIPTION
Closes #23251 

Changes the user-agent to state `influxdb-oss-replication` instead of `influxdb-oss` for replication writes for easier tracking
