### PR TITLE
fix: replace unprintable and invalid characters in errors

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -740,6 +740,7 @@ func makePrintable(s string) string {
 			c++
 		} else {
 			b.WriteRune(r)
+			c = 0
 		}
 	}
 	return b.String()

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -731,27 +731,15 @@ const unPrintMaxReplRune = 3
 func makePrintable(s string) string {
 	b := strings.Builder{}
 	b.Grow(len(s))
-	for _, r := range strings.ToValidUTF8(s, string(unPrintReplRune)) {
+	c := 0
+	for _, r := range strings.ToValidUTF8(s, string(unicode.ReplacementChar)) {
 		if !unicode.IsPrint(r) || r == unicode.ReplacementChar {
-			b.WriteRune(unPrintReplRune)
+			if c < unPrintMaxReplRune {
+				b.WriteRune(unPrintReplRune)
+			}
+			c++
 		} else {
 			b.WriteRune(r)
-		}
-	}
-	return removeRepeats(b.String(), unPrintMaxReplRune, unPrintReplRune)
-}
-
-func removeRepeats(s string, m int, r rune) string {
-	b := strings.Builder{}
-	b.Grow(len(s))
-	c := 0
-	for _, cr := range s {
-		if cr != r {
-			b.WriteRune(cr)
-			c = 0
-		} else if c < m {
-			b.WriteRune(cr)
-			c++
 		}
 	}
 	return b.String()

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -23,8 +23,8 @@ func TestShard_ErrorPrinting(t *testing.T) {
 
 	badStrings := []string{
 		string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', '\t', '\n'}),
-		string([]byte{'b', 'e', 'n', 't', 'e', 's', 0, 0, 0, 0xFE, 't'}),
-		string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', 0, 0, 0, 0, 0xFE, '\t', '\n'}),
+		string([]byte{'b', 'e', 'n', 't', 'e', 's', 0, 0, 0xFE, 0, 0xFE, 't'}),
+		string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', 0, 0, 0, 0, 0xFE, '\t', '\n', '\t', '\t', '\t'}),
 	}
 
 	for _, s := range badStrings {

--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -16,7 +16,31 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/require"
 )
+
+func TestShard_ErrorPrinting(t *testing.T) {
+
+	badStrings := []string{
+		string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', '\t', '\n'}),
+		string([]byte{'b', 'e', 'n', 't', 'e', 's', 0, 0, 0, 0xFE, 't'}),
+		string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', 0, 0, 0, 0, 0xFE, '\t', '\n'}),
+	}
+
+	for _, s := range badStrings {
+		f := makePrintable(s)
+		require.True(t, models.ValidKeyToken(f))
+		c := 0
+		for _, r := range f {
+			if r == unPrintReplRune {
+				c++
+				require.LessOrEqual(t, c, unPrintMaxReplRune, "too many repeated %c", unPrintReplRune)
+			} else {
+				c = 0
+			}
+		}
+	}
+}
 
 func TestShard_MapType(t *testing.T) {
 	var sh *TempShard


### PR DESCRIPTION
Replace unprintable and invalid characters with '?'
in logged errors.  Truncate consecutive runs of them to
only 3 repeats of '?'

closes https://github.com/influxdata/influxdb/issues/23386

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
