### PR TITLE
fix: replace unprintable and invalid characters in errors (#23387)

### DIFF
--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -19,6 +19,37 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+func TestShard_ErrorPrinting(t *testing.T) {
+
+	tests := []struct {
+		nSeq int
+		raw  string
+	}{
+		{1, string([]byte{'b', 'e', 'n', 't', 'e', 's', 't', '\t', '\n'})},
+		{1, string([]byte{'b', 'e', 'n', 't', 'e', 's', 0, 0, 0xFE, 0, 0xFE, 't'})},
+		{2, string([]byte{0, 0, 0, 0, 0xFE, '\t', '\n', '\t', 'b', 'e', 'n', 't', 'e', 's', 't', 0, 0, 0, 0, 0xFE, '\t', '\n', '\t', '\t', '\t'})},
+	}
+
+	for i, _ := range tests {
+		f := makePrintable(tests[i].raw)
+		require.True(t, models.ValidToken([]byte(f)))
+		c := 0
+		nSeq := 0
+		for _, r := range f {
+			if r == unPrintReplRune {
+				c++
+				if c == 1 {
+					nSeq++
+				}
+				require.LessOrEqual(t, c, unPrintMaxReplRune, "too many repeated %c", unPrintReplRune)
+			} else {
+				c = 0
+			}
+		}
+		require.Equalf(t, tests[i].nSeq, nSeq, "wrong number of elided sequences of replacement characters")
+	}
+}
+
 func TestShard_MapType(t *testing.T) {
 	var sh *TempShard
 


### PR DESCRIPTION
Replace unprintable and invalid characters with '?'
in logged errors.  Truncate consecutive runs of them to
only 3 repeats of '?'

closes https://github.com/influxdata/influxdb/issues/23386

(cherry picked from commit 0ae0bd6e2eb6eeeb97b67bc8c96ad6b158ce28f5)

closes https://github.com/influxdata/influxdb/issues/23389

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
