### PR TITLE
fix: removed timeout which is hit with large databases or slow servers #22803

### DIFF
--- a/.circleci/package/fs/usr/lib/influxdb/scripts/influxdb.service
+++ b/.circleci/package/fs/usr/lib/influxdb/scripts/influxdb.service
@@ -20,6 +20,7 @@ StateDirectoryMode=0750
 LogsDirectory=influxdb
 LogsDirectoryMode=0750
 UMask=0027
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #22803

Adds [TimeoutStartSec](https://www.freedesktop.org/software/systemd/man/systemd.service.html) set to infinity to ensure that the service starts up even if there is a large database and/or a slow server.  The lack of a timeout is consistent with the solution implemented in #21967 in that it loops until the service is up.  Credit to [akomlik](https://github.com/influxdata/influxdb/issues/22803#issuecomment-973090633) for suggesting this solution.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
