### PR TITLE
WIP: fix(tsm1): shrinking the time window for merging overlapping blocks

### DIFF
--- a/tsdb/engine/tsm1/file_store.gen.go
+++ b/tsdb/engine/tsm1/file_store.gen.go
@@ -67,7 +67,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values = values.Include(minT, maxT)
@@ -130,7 +130,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values = values.Include(minT, maxT)
@@ -253,7 +253,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values = values.Include(minT, maxT)
@@ -316,7 +316,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values = values.Include(minT, maxT)
@@ -439,7 +439,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values = values.Include(minT, maxT)
@@ -502,7 +502,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values = values.Include(minT, maxT)
@@ -625,7 +625,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values = values.Include(minT, maxT)
@@ -688,7 +688,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values = values.Include(minT, maxT)
@@ -811,7 +811,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values = values.Include(minT, maxT)
@@ -874,7 +874,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values = values.Include(minT, maxT)

--- a/tsdb/engine/tsm1/file_store.gen.go.tmpl
+++ b/tsdb/engine/tsm1/file_store.gen.go.tmpl
@@ -96,7 +96,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 {{if $isArray -}}
@@ -183,7 +183,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 {{if $isArray -}}

--- a/tsdb/engine/tsm1/file_store_array.gen.go
+++ b/tsdb/engine/tsm1/file_store_array.gen.go
@@ -71,7 +71,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values.Include(minT, maxT)
@@ -133,7 +133,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values.Include(minT, maxT)
@@ -255,7 +255,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values.Include(minT, maxT)
@@ -317,7 +317,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values.Include(minT, maxT)
@@ -439,7 +439,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values.Include(minT, maxT)
@@ -501,7 +501,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values.Include(minT, maxT)
@@ -623,7 +623,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values.Include(minT, maxT)
@@ -685,7 +685,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values.Include(minT, maxT)
@@ -807,7 +807,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MaxTime > maxT {
+				if cur.entry.MaxTime < maxT {
 					maxT = cur.entry.MaxTime
 				}
 				values.Include(minT, maxT)
@@ -869,7 +869,7 @@ LOOP:
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				if cur.entry.MinTime < minT {
+				if cur.entry.MinTime > minT {
 					minT = cur.entry.MinTime
 				}
 				values.Include(minT, maxT)

--- a/tsdb/engine/tsm1/file_store_array_test.go
+++ b/tsdb/engine/tsm1/file_store_array_test.go
@@ -93,7 +93,8 @@ func TestFileStore_Array(t *testing.T) {
 			time: 0,
 			asc:  true,
 			reads: []read{
-				[]sel{{3, 0}, {0, 1}, {3, 1}},
+				[]sel{{3, 0}, {0, 1}},
+				[]sel{{3, 1}},
 				[]sel{{2, 0}},
 			},
 		},
@@ -111,9 +112,9 @@ func TestFileStore_Array(t *testing.T) {
 			time: 0,
 			asc:  true,
 			reads: []read{
-				[]sel{{2, 0}, {2, 1}, {3, 0}, {0, 1}},
+				[]sel{{2, 0}, {2, 1}},
+				[]sel{{3, 0}, {0, 1}},
 				[]sel{{1, 1}},
-				[]sel{},
 			},
 		},
 		{

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -229,6 +229,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -237,7 +238,6 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[3].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -257,9 +257,27 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	}
 
 	exp = []tsm1.Value{
-		data[2].values[0],
+		data[3].values[1],
 	}
 
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+	c.Next()
+	values, err = c.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -304,7 +322,6 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[3].values[1],
 	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -323,9 +340,27 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	}
 
 	exp = []tsm1.Value{
-		data[2].values[0],
+		data[3].values[1],
 	}
 
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -370,7 +405,6 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[3].values[1],
 	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -382,6 +416,25 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 		}
 	}
 
+	c.Next()
+	values, err = c.ReadUnsignedBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadUnsignedBlock(&buf)
 	if err != nil {
@@ -436,7 +489,6 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[3].values[1],
 	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -448,6 +500,25 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 		}
 	}
 
+	c.Next()
+	values, err = c.ReadBooleanBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadBooleanBlock(&buf)
 	if err != nil {
@@ -502,7 +573,6 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[3].values[1],
 	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -514,6 +584,25 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 		}
 	}
 
+	c.Next()
+	values, err = c.ReadStringBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadStringBlock(&buf)
 	if err != nil {
@@ -568,8 +657,6 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 	exp := []tsm1.Value{
 		data[2].values[0],
 		data[2].values[1],
-		data[3].values[0],
-		data[0].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -583,6 +670,26 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 	}
 
 	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -648,8 +755,6 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 	exp := []tsm1.Value{
 		data[2].values[0],
 		data[2].values[1],
-		data[3].values[0],
-		data[0].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -663,6 +768,25 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 	}
 
 	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadIntegerBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadIntegerBlock(&buf)
 	if err != nil {
@@ -727,8 +851,6 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 	exp := []tsm1.Value{
 		data[2].values[0],
 		data[2].values[1],
-		data[3].values[0],
-		data[0].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -742,6 +864,25 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 	}
 
 	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadUnsignedBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadUnsignedBlock(&buf)
 	if err != nil {
@@ -806,8 +947,6 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 	exp := []tsm1.Value{
 		data[2].values[0],
 		data[2].values[1],
-		data[3].values[0],
-		data[0].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -821,6 +960,25 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 	}
 
 	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadBooleanBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadBooleanBlock(&buf)
 	if err != nil {
@@ -885,8 +1043,6 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 	exp := []tsm1.Value{
 		data[2].values[0],
 		data[2].values[1],
-		data[3].values[0],
-		data[0].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -900,6 +1056,25 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 	}
 
 	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadStringBlock(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadStringBlock(&buf)
 	if err != nil {
@@ -1603,7 +1778,6 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	}
 
 	exp := []tsm1.Value{
-		data[3].values[0],
 		data[0].values[0],
 		data[0].values[1],
 		data[3].values[1],
@@ -1619,6 +1793,26 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 		}
 	}
 
+	c.Next()
+	values, err = c.ReadIntegerBlock(&buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 	c.Next()
 	values, err = c.ReadIntegerBlock(&buf)
 
@@ -1680,10 +1874,29 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 	}
 
 	exp := []tsm1.Value{
-		data[3].values[0],
 		data[0].values[0],
 		data[0].values[1],
 		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+	c.Next()
+	values, err = c.ReadUnsignedBlock(&buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {


### PR DESCRIPTION
when scanning data with overlapping blocks, the current algorithm would
maximize time window(though we do have comments mentioning it *should*
shrink the window). If we have a block with a long time window
which overlaps with many other blocks, the merging operation would be
time consuming especially with string data type.
This change simply makes the code in line with original comments by
shrinking the window to merge.

Closes #23354 