### PR TITLE
build: upgrade Go to 1.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     docker:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile
       # in the edge repo, then update the version here to match.
-      - image: quay.io/influxdb/cross-builder:go1.18.1-52b299506343dfbb3f138d8a740bcfd0d97c1888
+      - image: quay.io/influxdb/cross-builder:go1.18.3-c75d304717395a43913dcc3d576d4f3545375253
     resource_class: large
   linux-amd64:
     machine:


### PR DESCRIPTION
Upgrade master to Go 1.18.3 (latest)