### PR TITLE
build: upgrade to Go 1.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.18.1-52b299506343dfbb3f138d8a740bcfd0d97c1888
+    default: go1.18.3-c75d304717395a43913dcc3d576d4f3545375253
 
 commands:
   install_rust:


### PR DESCRIPTION
Upgrades 1.10 to Go 1.18.3 (latest)