### PR TITLE
feat: error when creating v1 auth with a nonexistent bucket id

### DIFF
--- a/cmd/influxd/upgrade/security_test.go
+++ b/cmd/influxd/upgrade/security_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -200,6 +201,19 @@ func TestUpgradeSecurity(t *testing.T) {
 				token:    oResp.Auth.Token,
 				orgID:    oResp.Auth.OrgID,
 				userID:   oResp.Auth.UserID,
+			}
+
+			for k, v := range tc.db2ids {
+				for i, id := range v {
+					b := &influxdb.Bucket{
+						ID:    id,
+						Name:  fmt.Sprintf("%s_%d", k, id),
+						OrgID: targetOptions.orgID,
+					}
+					err := tenantSvc.CreateBucket(context.Background(), b)
+					require.NoError(t, err)
+					tc.db2ids[k][i] = b.ID
+				}
 			}
 
 			// fill in expected permissions now that we know IDs

--- a/v1/authorization/error.go
+++ b/v1/authorization/error.go
@@ -38,6 +38,13 @@ var (
 		Code: errors.EConflict,
 		Msg:  "token already exists",
 	}
+
+	// ErrBucketNotFound is used when attempting to create an authorization
+	// with a bucket id that does not exist
+	ErrBucketNotFound = &errors.Error{
+		Code: errors.ENotFound,
+		Msg:  "bucket not found when creating auth",
+	}
 )
 
 // ErrInvalidAuthIDError is used when a service was provided an invalid ID.

--- a/v1/authorization/storage_authorization.go
+++ b/v1/authorization/storage_authorization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/kv"
 	jsonp "github.com/influxdata/influxdb/v2/pkg/jsonparser"
+	"github.com/influxdata/influxdb/v2/tenant"
 )
 
 func authIndexKey(n string) []byte {
@@ -66,6 +67,17 @@ func (s *Store) CreateAuthorization(ctx context.Context, tx kv.Tx, a *influxdb.A
 			return nil
 		}
 		a.ID = id
+	}
+
+	ts := tenant.NewStore(s.kvStore)
+	for _, p := range a.Permissions {
+		if p.Resource.ID == nil {
+			continue
+		}
+		_, err := ts.GetBucket(ctx, tx, *p.Resource.ID)
+		if err == tenant.ErrBucketNotFound {
+			return ErrBucketNotFound
+		}
 	}
 
 	if err := s.uniqueAuthToken(ctx, tx, a); err != nil {

--- a/v1/authorization/storage_authorization_test.go
+++ b/v1/authorization/storage_authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
 	"github.com/influxdata/influxdb/v2/pkg/pointer"
+	"github.com/influxdata/influxdb/v2/tenant"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 )
@@ -222,6 +223,102 @@ func TestAuth(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAuthBucketNotExists(t *testing.T) {
+	store := inmem.NewKVStore()
+	if err := all.Up(context.Background(), zaptest.NewLogger(t), store); err != nil {
+		t.Fatal(err)
+	}
+
+	ts, err := NewStore(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bucketID := platform.ID(1)
+
+	tenant := tenant.NewStore(store)
+	err = tenant.Update(context.Background(), func(tx kv.Tx) error {
+		err := tenant.CreateBucket(context.Background(), tx, &influxdb.Bucket{
+			ID:    bucketID,
+			OrgID: platform.ID(10),
+			Name:  "testbucket",
+		})
+		if err != nil {
+			return err
+		}
+
+		b, err := tenant.GetBucketByName(context.Background(), tx, platform.ID(10), "testbucket")
+		if err != nil {
+			return err
+		}
+
+		bucketID = b.ID
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	perm1, err := influxdb.NewPermissionAtID(
+		bucketID,
+		influxdb.ReadAction,
+		influxdb.BucketsResourceType,
+		platform.ID(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	perm2, err := influxdb.NewPermissionAtID(
+		platform.ID(2),
+		influxdb.ReadAction,
+		influxdb.BucketsResourceType,
+		platform.ID(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ts.Update(context.Background(), func(tx kv.Tx) error {
+		err = ts.CreateAuthorization(context.Background(), tx, &influxdb.Authorization{
+			ID:     platform.ID(1),
+			Token:  "buckettoken",
+			OrgID:  platform.ID(10),
+			UserID: platform.ID(4),
+			Status: influxdb.Active,
+			Permissions: []influxdb.Permission{
+				*perm1,
+			},
+		})
+
+		return err
+	})
+
+	if err != nil {
+		t.Fatalf("Authorization creating should have succeeded [Error]: %v", err)
+	}
+
+	err = ts.Update(context.Background(), func(tx kv.Tx) error {
+		err = ts.CreateAuthorization(context.Background(), tx, &influxdb.Authorization{
+			ID:     platform.ID(1),
+			Token:  "buckettoken",
+			OrgID:  platform.ID(10),
+			UserID: platform.ID(4),
+			Status: influxdb.Active,
+			Permissions: []influxdb.Permission{
+				*perm2,
+			},
+		})
+
+		return err
+	})
+
+	if err == nil || err != ErrBucketNotFound {
+		t.Fatalf("Authorization creating should have failed with ErrBucketNotFound [Error]: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #23103 

Creating a v1 auth with an invalid bucket id was silently accepted. This could lead to an easy bug where a user would assume they had a valid auth but didn't. This PR adds proper erroring.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass