### PR TITLE
fix: fully clean up partially opened TSI

### DIFF
--- a/pkg/mmap/mmap_unix.go
+++ b/pkg/mmap/mmap_unix.go
@@ -10,15 +10,17 @@ package mmap
 import (
 	"os"
 	"syscall"
+
+	errors2 "github.com/influxdata/influxdb/pkg/errors"
 )
 
 // Map memory-maps a file.
-func Map(path string, sz int64) ([]byte, error) {
+func Map(path string, sz int64) (data []byte, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer errors2.Capture(&err, f.Close)()
 
 	fi, err := f.Stat()
 	if err != nil {
@@ -32,7 +34,7 @@ func Map(path string, sz int64) ([]byte, error) {
 		sz = fi.Size()
 	}
 
-	data, err := syscall.Mmap(int(f.Fd()), 0, int(sz), syscall.PROT_READ, syscall.MAP_SHARED)
+	data, err = syscall.Mmap(int(f.Fd()), 0, int(sz), syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -38,13 +38,7 @@ func (fs *FileSet) bytes() int {
 
 // Close closes all the files in the file set.
 func (fs FileSet) Close() error {
-	var err error
-	for _, f := range fs.files {
-		if e := f.Close(); e != nil && err == nil {
-			err = e
-		}
-	}
-	return err
+	return Files(fs.files).Close()
 }
 
 // Retain adds a reference count to all files.
@@ -454,6 +448,16 @@ func (a Files) IDs() []int {
 		ids[i] = a[i].ID()
 	}
 	return ids
+}
+
+func (a Files) Close() error {
+	var err error
+	for _, f := range a {
+		if e := f.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
+	return err
 }
 
 // fileSetSeriesIDIterator attaches a fileset to an iterator that is released on close.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -195,6 +195,7 @@ func (p *Partition) Open() error {
 		case LogFileExt:
 			f, err := p.openLogFile(filepath.Join(p.path, filename))
 			if err != nil {
+				Files(files).Close()
 				return err
 			}
 			files = append(files, f)
@@ -208,6 +209,7 @@ func (p *Partition) Open() error {
 		case IndexFileExt:
 			f, err := p.openIndexFile(filepath.Join(p.path, filename))
 			if err != nil {
+				Files(files).Close()
 				return err
 			}
 			files = append(files, f)
@@ -242,6 +244,10 @@ func (p *Partition) Open() error {
 	go p.runPeriodicCompaction()
 
 	return nil
+}
+
+func (p *Partition) IsOpen() bool {
+	return p.opened
 }
 
 // openLogFile opens a log file and appends it to the index.


### PR DESCRIPTION
When one partition in a TSI fails to open,
all previously opened partitions should be cleaned up, and remaining partitions should not be opened

closes https://github.com/influxdata/influxdb/issues/23427

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass