### PR TITLE
fix: remember shards that fail Open(), avoid repeated attempts

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -407,7 +407,7 @@ func (w *PointsWriter) writeToShard(writeCtx tsdb.WriteContext, shard *meta.Shar
 		// store has not actually created this shard, tell it to create it and
 		// retry the write
 		if err = w.TSDBStore.CreateShard(database, retentionPolicy, shard.ID, true); err != nil {
-			w.Logger.Error("Write failed creating shard", zap.Uint64("shard", shard.ID), zap.Error(err))
+			w.Logger.Warn("Write failed creating shard", zap.Uint64("shard", shard.ID), zap.Error(err))
 			atomic.AddInt64(&w.stats.WriteErr, 1)
 			return err
 		}

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -407,7 +407,7 @@ func (w *PointsWriter) writeToShard(writeCtx tsdb.WriteContext, shard *meta.Shar
 		// store has not actually created this shard, tell it to create it and
 		// retry the write
 		if err = w.TSDBStore.CreateShard(database, retentionPolicy, shard.ID, true); err != nil {
-			w.Logger.Info("Write failed", zap.Uint64("shard", shard.ID), zap.Error(err))
+			w.Logger.Error("Write failed creating shard", zap.Uint64("shard", shard.ID), zap.Error(err))
 			atomic.AddInt64(&w.stats.WriteErr, 1)
 			return err
 		}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -81,6 +81,28 @@ type StoreStatistics struct {
 	SeriesCreated int64
 }
 
+type shardErrorMap struct {
+	mu          sync.Mutex
+	shardErrors map[uint64]error
+}
+
+func (se *shardErrorMap) setShardOpenError(shardID uint64, err error) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	if err == nil {
+		delete(se.shardErrors, shardID)
+	} else {
+		se.shardErrors[shardID] = &ErrPreviousShardFail{error: fmt.Errorf("opening shard previously failed with: %w", err)}
+	}
+}
+
+func (se *shardErrorMap) shardError(shardID uint64) (error, bool) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	oldErr, hasErr := se.shardErrors[shardID]
+	return oldErr, hasErr
+}
+
 // Store manages shards and indexes for databases.
 type Store struct {
 	mu                sync.RWMutex
@@ -96,6 +118,9 @@ type Store struct {
 	// Maintains a set of shards that are in the process of deletion.
 	// This prevents new shards from being created while old ones are being deleted.
 	pendingShardDeletes map[uint64]struct{}
+
+	// Maintains a set of shards that failed to open
+	badShards shardErrorMap
 
 	// Epoch tracker helps serialize writes and deletes that may conflict. It
 	// is stored by shard.
@@ -125,6 +150,7 @@ func NewStore(path string) *Store {
 		sfiles:              make(map[string]*SeriesFile),
 		indexes:             make(map[string]interface{}),
 		pendingShardDeletes: make(map[uint64]struct{}),
+		badShards:           shardErrorMap{shardErrors: make(map[uint64]error)},
 		epochs:              make(map[uint64]*epochTracker),
 		EngineOptions:       NewEngineOptions(),
 		Logger:              logger,
@@ -449,9 +475,9 @@ func (s *Store) loadShards() error {
 					shard.CompactionDisabled = s.EngineOptions.CompactionDisabled
 					shard.WithLogger(s.baseLogger)
 
-					err = shard.Open()
+					err = s.OpenShard(shard, false)
 					if err != nil {
-						log.Info("Failed to open shard", logger.Shard(shardID), zap.Error(err))
+						log.Error("Failed to open shard", logger.Shard(shardID), zap.Error(err))
 						resC <- &res{err: fmt.Errorf("Failed to open shard: %d: %s", shardID, err)}
 						return
 					}
@@ -607,6 +633,42 @@ func (s *Store) Shard(id uint64) *Shard {
 	return sh
 }
 
+type ErrPreviousShardFail struct {
+	error
+}
+
+func (e ErrPreviousShardFail) Unwrap() error {
+	return e.error
+}
+
+func (e ErrPreviousShardFail) Is(err error) bool {
+	_, sOk := err.(ErrPreviousShardFail)
+	_, pOk := err.(*ErrPreviousShardFail)
+	return sOk || pOk
+}
+
+func (e ErrPreviousShardFail) Error() string {
+	return e.error.Error()
+}
+
+func (s *Store) OpenShard(sh *Shard, force bool) error {
+	if sh == nil {
+		return errors.New("cannot open nil shard")
+	}
+	oldErr, bad := s.badShards.shardError(sh.ID())
+	if force || !bad {
+		err := sh.Open()
+		s.badShards.setShardOpenError(sh.ID(), err)
+		return err
+	} else {
+		return oldErr
+	}
+}
+
+func (s *Store) SetShardOpenErrorForTest(shardID uint64, err error) {
+	s.badShards.setShardOpenError(shardID, err)
+}
+
 // Shards returns a list of shards by id.
 func (s *Store) Shards(ids []uint64) []*Shard {
 	s.mu.RLock()
@@ -700,7 +762,7 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64, en
 	shard.WithLogger(s.baseLogger)
 	shard.EnableOnOpen = enabled
 
-	if err := shard.Open(); err != nil {
+	if err := s.OpenShard(shard, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If a shard cannot be opened store its ID and last error.
Prevent future attempts to open during this invocation of
influxDB. This information is not persisted, however.

partial close of https://github.com/influxdata/influxdb/issues/23428

closes https://github.com/influxdata/influxdb/issues/23426

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
