### PR TITLE
feat: log the log level regardless of log level (#23425)

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -123,6 +123,8 @@ func (cmd *Command) Run(args ...string) error {
 	// If there was an error on startup when creating the logger, output it now.
 	if logErr != nil {
 		cmd.Logger.Error("Unable to configure logger", zap.Error(logErr))
+	} else {
+		logger.New(cmd.Stderr).Info("configured logger", zap.String("format", config.Logging.Format), zap.String("level", config.Logging.Level.String()))
 	}
 
 	// Write the PID file.


### PR DESCRIPTION
Always log the log level so we know if there's no logs because of the log level.

(cherry picked from commit febf7a927cfe543194ce0e797d7146da589a87bf)

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
