### PR TITLE
feat: add instance-id flag for identifying edge nodes

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -153,6 +153,8 @@ type InfluxdOpts struct {
 	SecretStore string
 	VaultConfig vault.Config
 
+	InstanceID string
+
 	HttpBindAddress       string
 	HttpReadHeaderTimeout time.Duration
 	HttpReadTimeout       time.Duration
@@ -474,6 +476,12 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			DestP: &o.FeatureFlags,
 			Flag:  "feature-flags",
 			Desc:  "feature flag overrides",
+		},
+		{
+			DestP:   &o.InstanceID,
+			Flag:    "instance-id",
+			Default: "",
+			Desc:    "add an instance id for replications to prevent collisions and allow querying by edge node",
 		},
 
 		// storage configuration

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -365,7 +365,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	remotesServer := remotesTransport.NewInstrumentedRemotesHandler(
 		m.log.With(zap.String("handler", "remotes")), m.reg, remotesSvc)
 
-	replicationSvc, replicationsMetrics := replications.NewService(m.sqlStore, ts, pointsWriter, m.log.With(zap.String("service", "replications")), opts.EnginePath)
+	replicationSvc, replicationsMetrics := replications.NewService(m.sqlStore, ts, pointsWriter, m.log.With(zap.String("service", "replications")), opts.EnginePath, opts.InstanceID)
 	replicationServer := replicationTransport.NewInstrumentedReplicationHandler(
 		m.log.With(zap.String("handler", "replications")), m.reg, replicationSvc)
 	ts.BucketService = replications.NewBucketService(

--- a/replications/service.go
+++ b/replications/service.go
@@ -38,7 +38,7 @@ func errLocalBucketNotFound(id platform.ID, cause error) error {
 	}
 }
 
-func NewService(sqlStore *sqlite.SqlStore, bktSvc BucketService, localWriter storage.PointsWriter, log *zap.Logger, enginePath string) (*service, *metrics.ReplicationsMetrics) {
+func NewService(sqlStore *sqlite.SqlStore, bktSvc BucketService, localWriter storage.PointsWriter, log *zap.Logger, enginePath string, instanceID string) (*service, *metrics.ReplicationsMetrics) {
 	metrs := metrics.NewReplicationsMetrics()
 	store := internal.NewStore(sqlStore)
 
@@ -57,6 +57,7 @@ func NewService(sqlStore *sqlite.SqlStore, bktSvc BucketService, localWriter sto
 		),
 		maxRemoteWriteBatchSize: maxRemoteWriteBatchSize,
 		maxRemoteWritePointSize: maxRemoteWritePointSize,
+		instanceID:              instanceID,
 	}, metrs
 }
 
@@ -104,6 +105,7 @@ type service struct {
 	log                     *zap.Logger
 	maxRemoteWriteBatchSize int
 	maxRemoteWritePointSize int
+	instanceID              string
 }
 
 func (s *service) ListReplications(ctx context.Context, filter influxdb.ReplicationListFilter) (*influxdb.Replications, error) {
@@ -315,6 +317,12 @@ func (s *service) WritePoints(ctx context.Context, orgID platform.ID, bucketID p
 	// If there are no registered replications, all we need to do is a local write.
 	if len(replications) == 0 {
 		return s.localWriter.WritePoints(ctx, orgID, bucketID, points)
+	}
+
+	if s.instanceID != "" {
+		for i := range points {
+			points[i].AddTag("instance-id", s.instanceID)
+		}
 	}
 
 	// Concurrently...

--- a/replications/service.go
+++ b/replications/service.go
@@ -321,7 +321,7 @@ func (s *service) WritePoints(ctx context.Context, orgID platform.ID, bucketID p
 
 	if s.instanceID != "" {
 		for i := range points {
-			points[i].AddTag("instance-id", s.instanceID)
+			points[i].AddTag("_instance_id", s.instanceID)
 		}
 	}
 

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -794,14 +794,14 @@ disk,host=C value=1.3 1000000000`)
 	require.NoError(t, err)
 
 	expectedPoints, err := models.ParsePointsString(`
-cpu,host=0,instance-id=hello-edge value=1.1 6000000000
-cpu,host=A,instance-id=hello-edge value=1.2 2000000000
-cpu,host=A,instance-id=hello-edge value=1.3 3000000000
-cpu,host=B,instance-id=hello-edge value=1.3 4000000000
-cpu,host=B,instance-id=hello-edge value=1.3 5000000000
-cpu,host=C,instance-id=hello-edge value=1.3 1000000000
-mem,host=C,instance-id=hello-edge value=1.3 1000000000
-disk,host=C,instance-id=hello-edge value=1.3 1000000000`)
+cpu,host=0,_instance_id=hello-edge value=1.1 6000000000
+cpu,host=A,_instance_id=hello-edge value=1.2 2000000000
+cpu,host=A,_instance_id=hello-edge value=1.3 3000000000
+cpu,host=B,_instance_id=hello-edge value=1.3 4000000000
+cpu,host=B,_instance_id=hello-edge value=1.3 5000000000
+cpu,host=C,_instance_id=hello-edge value=1.3 1000000000
+mem,host=C,_instance_id=hello-edge value=1.3 1000000000
+disk,host=C,_instance_id=hello-edge value=1.3 1000000000`)
 	require.NoError(t, err)
 
 	// Points should successfully write to local TSM.

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -771,6 +771,57 @@ disk,host=C value=1.3 1000000000`)
 	}
 }
 
+func TestWritePointsInstanceID(t *testing.T) {
+	t.Parallel()
+
+	svc, mocks := newTestService(t)
+	svc.instanceID = "hello-edge"
+	replications := make([]platform.ID, 2)
+	replications[0] = replication1.ID
+	replications[1] = replication2.ID
+
+	mocks.durableQueueManager.EXPECT().GetReplications(orgID, id1).Return(replications)
+
+	writePoints, err := models.ParsePointsString(`
+cpu,host=0 value=1.1 6000000000
+cpu,host=A value=1.2 2000000000
+cpu,host=A value=1.3 3000000000
+cpu,host=B value=1.3 4000000000
+cpu,host=B value=1.3 5000000000
+cpu,host=C value=1.3 1000000000
+mem,host=C value=1.3 1000000000
+disk,host=C value=1.3 1000000000`)
+	require.NoError(t, err)
+
+	expectedPoints, err := models.ParsePointsString(`
+cpu,host=0,instance-id=hello-edge value=1.1 6000000000
+cpu,host=A,instance-id=hello-edge value=1.2 2000000000
+cpu,host=A,instance-id=hello-edge value=1.3 3000000000
+cpu,host=B,instance-id=hello-edge value=1.3 4000000000
+cpu,host=B,instance-id=hello-edge value=1.3 5000000000
+cpu,host=C,instance-id=hello-edge value=1.3 1000000000
+mem,host=C,instance-id=hello-edge value=1.3 1000000000
+disk,host=C,instance-id=hello-edge value=1.3 1000000000`)
+	require.NoError(t, err)
+
+	// Points should successfully write to local TSM.
+	mocks.pointWriter.EXPECT().WritePoints(gomock.Any(), orgID, id1, writePoints).Return(nil)
+
+	// Points should successfully be enqueued in the 2 replications associated with the local bucket.
+	for _, id := range replications {
+		mocks.durableQueueManager.EXPECT().
+			EnqueueData(id, gomock.Any(), len(writePoints)).
+			DoAndReturn(func(_ platform.ID, data []byte, numPoints int) error {
+				require.Equal(t, len(writePoints), numPoints)
+				checkCompressedData(t, data, expectedPoints)
+				return nil
+			})
+	}
+
+	require.NoError(t, svc.WritePoints(ctx, orgID, id1, writePoints))
+
+}
+
 func TestWritePoints_LocalFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #23360 

This flag identifies edge nodes during replication and prevents collisions if 2 edge nodes write the same measurement,tagset

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass

