### PR TITLE
test: add openapi spec validation to OSS grace tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,17 @@ jobs:
               fi
               sleep 1
             done
-      - run: docker run --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project/results:/grace/test-results/grace-results quay.io/influxdb/grace:daily
+      - run:
+          name: Run grace test driver
+          command: |
+            docker run -v ~/project/results:/grace/test-results/grace-results \
+              --env GRACE_BASE_URL="http://172.17.0.1:8086" \
+              --env GRACE_ORG_NAME="daily-org" \
+              --env GRACE_BUCKET_NAME="daily-bucket" \
+              --env GRACE_USER="daily@influxdata.com" \
+              --env GRACE_PASS="dailyPassword" \
+              --env GRACE_VALIDATE_OPENAPI=1 \
+              quay.io/influxdb/grace:latest-cd
       - store_artifacts:
           path: ~/project/results
       - store_test_results:


### PR DESCRIPTION
Add the newly supported `GRACE_VALIDATE_OPENAPI` environment variable to support the tests.

Also use a shared `latest-cd` container, instead of the `daily` container for grace.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass