### PR TITLE
fix: remember shards that fail Open(), avoid repeated attempts (#23437)

### DIFF
--- a/v1/coordinator/points_writer.go
+++ b/v1/coordinator/points_writer.go
@@ -441,7 +441,7 @@ func (w *PointsWriter) writeToShard(ctx context.Context, shard *meta.ShardInfo, 
 	// If we've written to shard that should exist on the current node, but the store has
 	// not actually created this shard, tell it to create it and retry the write
 	if err = w.TSDBStore.CreateShard(ctx, database, retentionPolicy, shard.ID, true); err != nil {
-		w.Logger.Info("Write failed", zap.Uint64("shard", shard.ID), zap.Error(err))
+		w.Logger.Warn("Write failed creating shard", zap.Uint64("shard", shard.ID), zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
If a shard cannot be opened, store its ID and last error.
Prevent future attempts to open during this invocation of
influxDB. This information is not persisted.

closes https://github.com/influxdata/influxdb/issues/23428
closes https://github.com/influxdata/influxdb/issues/23426

(cherry picked from commit 54ac7e54edbbb8a495d5b1be626a21b0165fb77e)

closes https://github.com/influxdata/influxdb/issues/23434
closes https://github.com/influxdata/influxdb/issues/23436

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass