### PR TITLE
fix: replications remote write failure can deadlock remote writer

### DIFF
--- a/cmd/influxd/launcher/replication_test.go
+++ b/cmd/influxd/launcher/replication_test.go
@@ -1,11 +1,16 @@
 package launcher_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"math/rand"
 	nethttp "net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -296,6 +301,121 @@ csv.from(csv: csvData) |> to(bucket: %q)
 	require.Equal(t, exp2, l.FluxQueryOrFail(t, l.Org, l.Auth.Token, fmt.Sprintf(qs, localBucketName)))
 	require.Equal(t, exp2, l.FluxQueryOrFail(t, l.Org, l.Auth.Token, fmt.Sprintf(qs, remote1BucketName)))
 	require.Equal(t, exp3, l.FluxQueryOrFail(t, l.Org, l.Auth.Token, fmt.Sprintf(qs, remote2BucketName)))
+}
+
+func TestReplicationStreamEndToEndRemoteFailures(t *testing.T) {
+	// Points that will be written to the local bucket when only one replication is active.
+	testPoints := []string{
+		`m,k=v1 f=100i 946684800000000000`,
+		`m,k=v2 f=200i 946684800000000000`,
+		`m,k=v3 f=300i 946684800000000000`,
+		`m,k=v4 f=400i 946684800000000000`,
+	}
+
+	// Format string to be used as a flux query to get data from a bucket.
+	qs := `from(bucket:%q) |> range(start:2000-01-01T00:00:00Z,stop:2000-01-02T00:00:00Z)`
+
+	// Data that should be in a bucket which received all the testPoints1.
+	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v1` + "\r\n" +
+		`,_result,1,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,200,f,m,v2` + "\r\n" +
+		`,_result,2,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,300,f,m,v3` + "\r\n" +
+		`,_result,3,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,400,f,m,v4` + "\r\n\r\n"
+
+	l := launcher.RunAndSetupNewLauncherOrFail(ctx, t)
+	defer l.ShutdownOrFail(t, ctx)
+	client := l.APIClient(t)
+
+	localBucketName := l.Bucket.Name
+	remoteBucketName := "remote1"
+
+	random := rand.New(rand.NewSource(1000))
+	pointsIndex := 1
+
+	// Create a proxy for use in testing. This will proxy requests to the server, and also decrement the waitGroup to
+	// allow for synchronization.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	proxyHandler := httputil.NewSingleHostReverseProxy(l.URL())
+	proxy := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Read the current point off of the request
+		body, _ := io.ReadAll(r.Body)
+		reader, _ := gzip.NewReader(bytes.NewBuffer(body))
+		unzipBody, _ := io.ReadAll(reader)
+
+		// Fix the Body on the request
+		r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+		// "Randomly" fail on remote write to test retries
+		if random.Intn(2) == 0 {
+			// Increment the index if the proper point succeeds.
+			// This is needed since the replication queue will currently send the same
+			// data several times if a failure is reached, since there is not enough
+			// data to warrant a call to scan.Advance()
+			if strings.Contains(string(unzipBody), fmt.Sprintf("v%d", pointsIndex)) {
+				pointsIndex++
+			}
+			proxyHandler.ServeHTTP(w, r)
+
+			// Decrement the waitgroup if all points have succeeded in writing
+			if pointsIndex == len(testPoints)+1 {
+				wg.Done()
+			}
+		} else {
+			w.WriteHeader(nethttp.StatusGatewayTimeout)
+		}
+	}))
+	defer proxy.Close()
+
+	// Create a "remote" connection to the launcher from itself via the test proxy.
+	remote, err := client.RemoteConnectionsApi.PostRemoteConnection(ctx).
+		RemoteConnectionCreationRequest(api.RemoteConnectionCreationRequest{
+			Name:             "self",
+			OrgID:            l.Org.ID.String(),
+			RemoteURL:        proxy.URL,
+			RemoteAPIToken:   l.Auth.Token,
+			RemoteOrgID:      l.Org.ID.String(),
+			AllowInsecureTLS: false,
+		}).Execute()
+	require.NoError(t, err)
+
+	// Create separate buckets to act as the target for remote writes
+	svc := l.BucketService(t)
+	remoteBucket := &influxdb.Bucket{
+		OrgID: l.Org.ID,
+		Name:  remoteBucketName,
+	}
+	require.NoError(t, svc.CreateBucket(ctx, remoteBucket))
+
+	// Create a replication for the first remote bucket.
+	replicationCreateReq := api.ReplicationCreationRequest{
+		Name:              "test1",
+		OrgID:             l.Org.ID.String(),
+		RemoteID:          remote.Id,
+		LocalBucketID:     l.Bucket.ID.String(),
+		RemoteBucketID:    remoteBucket.ID.String(),
+		MaxQueueSizeBytes: influxdb.DefaultReplicationMaxQueueSizeBytes,
+		MaxAgeSeconds:     influxdb.DefaultReplicationMaxAge,
+	}
+
+	_, err = client.ReplicationsApi.PostReplication(ctx).ReplicationCreationRequest(replicationCreateReq).Execute()
+	require.NoError(t, err)
+
+	// Write the first set of points to the launcher bucket. This is the local bucket in the replication.
+	wg.Add(1)
+	for _, p := range testPoints {
+		l.WritePointsOrFail(t, p)
+	}
+	wg.Wait()
+
+	// Data should now be in the local bucket and in the replication remote bucket, but not in the bucket without the
+	// replication.
+	require.Equal(t, exp, l.FluxQueryOrFail(t, l.Org, l.Auth.Token, fmt.Sprintf(qs, localBucketName)))
+	require.Equal(t, exp, l.FluxQueryOrFail(t, l.Org, l.Auth.Token, fmt.Sprintf(qs, remoteBucketName)))
 }
 
 func TestReplicationsLocalWriteAndShutdownBlocking(t *testing.T) {

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -484,7 +484,7 @@ func TestSendWrite(t *testing.T) {
 	// Send the write to the "remote" with a success
 	rq.SendWrite()
 	// Make sure the data is no longer in the queue
-	scan, err = rq.queue.NewScanner()
+	_, err = rq.queue.NewScanner()
 	require.Equal(t, io.EOF, err)
 
 	// Write second point
@@ -509,7 +509,7 @@ func TestSendWrite(t *testing.T) {
 	shouldFailThisWrite = false
 	rq.SendWrite()
 	// Make sure the data is no longer in the queue
-	scan, err = rq.queue.NewScanner()
+	_, err = rq.queue.NewScanner()
 	require.Equal(t, io.EOF, err)
 }
 

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -353,10 +353,10 @@ func shutdown(t *testing.T, qm *durableQueueManager) {
 }
 
 type testRemoteWriter struct {
-	writeFn func([]byte, int) (time.Duration, bool, error)
+	writeFn func([]byte, int) (time.Duration, error)
 }
 
-func (tw *testRemoteWriter) Write(data []byte, attempt int) (time.Duration, bool, error) {
+func (tw *testRemoteWriter) Write(data []byte, attempt int) (time.Duration, error) {
 	return tw.writeFn(data, attempt)
 }
 
@@ -364,7 +364,7 @@ func getTestRemoteWriterSequenced(t *testing.T, expected []string, returning err
 	t.Helper()
 
 	count := 0
-	writeFn := func(b []byte, attempt int) (time.Duration, bool, error) {
+	writeFn := func(b []byte, attempt int) (time.Duration, error) {
 		if count >= len(expected) {
 			t.Fatalf("count larger than expected len, %d > %d", count, len(expected))
 		}
@@ -377,7 +377,7 @@ func getTestRemoteWriterSequenced(t *testing.T, expected []string, returning err
 		if returning == nil {
 			count++
 		}
-		return time.Second, true, returning
+		return time.Second, returning
 	}
 
 	writer := &testRemoteWriter{}
@@ -391,9 +391,9 @@ func getTestRemoteWriter(t *testing.T, expected string) remoteWriter {
 	t.Helper()
 
 	writer := &testRemoteWriter{
-		writeFn: func(b []byte, i int) (time.Duration, bool, error) {
+		writeFn: func(b []byte, i int) (time.Duration, error) {
 			require.Equal(t, expected, string(b))
-			return time.Second, true, nil
+			return time.Second, nil
 		},
 	}
 
@@ -435,6 +435,82 @@ func TestEnqueueData(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, data, string(written))
+}
+
+// this test ensures that data does not get incorrectly dropped from the Queue on remote write failures
+func TestSendWrite(t *testing.T) {
+	t.Parallel()
+
+	// data points to test
+	var pointIndex int
+	points := []string{
+		"this is some data",
+		"this is also some data",
+		"this is even more data",
+	}
+
+	path, qm := initQueueManager(t)
+	defer os.RemoveAll(path)
+	require.NoError(t, qm.InitializeQueue(id1, maxQueueSizeBytes, orgID1, localBucketID1, 0))
+	require.DirExists(t, filepath.Join(path, id1.String()))
+
+	// close the scanner goroutine to test SendWrite() with more granularity
+	rq, ok := qm.replicationQueues[id1]
+	require.True(t, ok)
+	closeRq(rq)
+	go func() { <-rq.receive }() // absorb the receive to avoid testcase deadlock
+
+	// Create custom remote writer that does some expected behavior
+	// Will periodically fail to simulate a timeout
+	shouldFailThisWrite := false
+	writer := &testRemoteWriter{}
+	writer.writeFn = func(data []byte, attempt int) (time.Duration, error) {
+		require.Equal(t, []byte(points[pointIndex]), data)
+		if shouldFailThisWrite {
+			return 100, errors.New("remote timeout")
+		}
+		return 0, nil // current "success" return values
+	}
+	rq.remoteWriter = writer
+
+	// Write first point
+	require.NoError(t, qm.EnqueueData(id1, []byte(points[pointIndex]), 1))
+	// Make sure the data is in the queue
+	scan, err := rq.queue.NewScanner()
+	require.NoError(t, err)
+	require.True(t, scan.Next())
+	require.Equal(t, []byte(points[pointIndex]), scan.Bytes())
+	require.NoError(t, scan.Err())
+	// Send the write to the "remote" with a success
+	rq.SendWrite()
+	// Make sure the data is no longer in the queue
+	scan, err = rq.queue.NewScanner()
+	require.Equal(t, io.EOF, err)
+
+	// Write second point
+	pointIndex++
+	require.NoError(t, qm.EnqueueData(id1, []byte(points[pointIndex]), 1))
+	// Make sure the data is in the queue
+	scan, err = rq.queue.NewScanner()
+	require.NoError(t, err)
+	require.True(t, scan.Next())
+	require.Equal(t, []byte(points[pointIndex]), scan.Bytes())
+	require.NoError(t, scan.Err())
+	// Send the write to the "remote" with a FAILURE
+	shouldFailThisWrite = true
+	rq.SendWrite()
+	// Make sure the data is still in the queue
+	scan, err = rq.queue.NewScanner()
+	require.NoError(t, err)
+	require.True(t, scan.Next())
+	require.Equal(t, []byte(points[pointIndex]), scan.Bytes())
+	require.NoError(t, scan.Err())
+	// Send the write to the "remote" again, with a SUCCESS
+	shouldFailThisWrite = false
+	rq.SendWrite()
+	// Make sure the data is no longer in the queue
+	scan, err = rq.queue.NewScanner()
+	require.Equal(t, io.EOF, err)
 }
 
 func TestEnqueueData_WithMetrics(t *testing.T) {

--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -86,7 +86,7 @@ func NewWriter(replicationID platform.ID, store HttpConfigStore, metrics *metric
 	}
 }
 
-func (w *writer) Write(data []byte, attempts int) (backoff time.Duration, shouldRetry bool, err error) {
+func (w *writer) Write(data []byte, attempts int) (backoff time.Duration, err error) {
 	cancelOnce := &sync.Once{}
 	// Cancel any outstanding HTTP requests if the replicationQueue is closed.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -107,31 +107,31 @@ func (w *writer) Write(data []byte, attempts int) (backoff time.Duration, should
 	// Get the most recent config on every attempt, in case the user has updated the config to correct errors.
 	conf, err := w.configStore.GetFullHTTPConfig(ctx, w.replicationID)
 	if err != nil {
-		return w.backoff(attempts), true, err
+		return w.backoff(attempts), err
 	}
 
 	res, postWriteErr := PostWrite(ctx, conf, data, w.clientTimeout)
 	res, msg, ok := normalizeResponse(res, postWriteErr)
 	if !ok {
 		// bail out
-		return w.backoff(attempts), true, postWriteErr
+		return w.backoff(attempts), postWriteErr
 	}
 
 	// Update metrics and most recent error diagnostic information.
 	if err := w.configStore.UpdateResponseInfo(ctx, w.replicationID, res.StatusCode, msg); err != nil {
 		// TODO: We shouldn't fail/retry a successful remote write for not successfully writing to the config store
-		// we should log instead of returning, like:
-		// w.logger.Warn("failed to update config store with latest remote write response info", zap.Error(err))
+		// we should only log instead of returning, like:
+		w.logger.Debug("failed to update config store with latest remote write response info", zap.Error(err))
 		// Unfortunately this will mess up a lot of tests that are using UpdateResponseInfo failures as a proxy for
 		// write failures.
-		return w.backoff(attempts), true, err
+		return w.backoff(attempts), err
 	}
 
 	if postWriteErr == nil {
 		// Successful write
 		w.metrics.RemoteWriteSent(w.replicationID, len(data))
 		w.logger.Debug("remote write successful", zap.Int("attempt", attempts), zap.Int("bytes", len(data)))
-		return 0, true, nil
+		return 0, nil
 	}
 
 	w.metrics.RemoteWriteError(w.replicationID, res.StatusCode)
@@ -147,7 +147,7 @@ func (w *writer) Write(data []byte, attempts int) (backoff time.Duration, should
 			res.Body.Read(errBody)
 			w.logger.Warn("dropped data", zap.Int("bytes", len(data)), zap.String("reason", string(errBody)))
 			w.metrics.RemoteWriteDropped(w.replicationID, len(data))
-			return 0, false, nil
+			return 0, nil
 		}
 	case http.StatusTooManyRequests:
 		headerTime := w.waitTimeFromHeader(res)
@@ -161,7 +161,7 @@ func (w *writer) Write(data []byte, attempts int) (backoff time.Duration, should
 		waitTime = w.backoff(attempts)
 	}
 
-	return waitTime, true, postWriteErr
+	return waitTime, postWriteErr
 }
 
 // normalizeResponse returns a guaranteed non-nil value for *http.Response, and an extracted error message string for use

--- a/replications/remotewrite/writer_test.go
+++ b/replications/remotewrite/writer_test.go
@@ -72,9 +72,8 @@ func TestWrite(t *testing.T) {
 		w, configStore, _ := testWriter(t)
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(nil, wantErr)
-		_, shouldRetry, actualErr := w.Write([]byte{}, 1)
+		_, actualErr := w.Write([]byte{}, 1)
 		require.Equal(t, wantErr, actualErr)
-		require.True(t, shouldRetry)
 	})
 
 	t.Run("nil response from PostWrite", func(t *testing.T) {
@@ -85,9 +84,8 @@ func TestWrite(t *testing.T) {
 		w, configStore, _ := testWriter(t)
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
-		_, shouldRetry, actualErr := w.Write([]byte{}, 1)
+		_, actualErr := w.Write([]byte{}, 1)
 		require.Error(t, actualErr)
-		require.True(t, shouldRetry)
 	})
 
 	t.Run("immediate good response", func(t *testing.T) {
@@ -102,9 +100,8 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, "").Return(nil)
-		_, shouldRetry, actualErr := w.Write(testData, 0)
+		_, actualErr := w.Write(testData, 0)
 		require.NoError(t, actualErr)
-		require.True(t, shouldRetry)
 	})
 
 	t.Run("error updating response info", func(t *testing.T) {
@@ -121,9 +118,8 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, "").Return(wantErr)
-		_, shouldRetry, actualErr := w.Write(testData, 1)
+		_, actualErr := w.Write(testData, 1)
 		require.Equal(t, wantErr, actualErr)
-		require.True(t, shouldRetry)
 	})
 
 	t.Run("bad server responses that never succeed", func(t *testing.T) {
@@ -143,7 +139,7 @@ func TestWrite(t *testing.T) {
 
 				configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 				configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, status, invalidResponseCode(status).Error()).Return(nil)
-				_, _, actualErr := w.Write(testData, testAttempts)
+				_, actualErr := w.Write(testData, testAttempts)
 				require.NotNil(t, actualErr)
 				require.Contains(t, actualErr.Error(), fmt.Sprintf("invalid response code %d", status))
 			})
@@ -172,13 +168,11 @@ func TestWrite(t *testing.T) {
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(updatedConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusBadRequest, invalidResponseCode(http.StatusBadRequest).Error()).Return(nil).Times(testAttempts)
 		for i := 1; i <= testAttempts; i++ {
-			_, shouldRetry, actualErr := w.Write(testData, i)
+			_, actualErr := w.Write(testData, i)
 			if testAttempts == i {
 				require.NoError(t, actualErr)
-				require.False(t, shouldRetry)
 			} else {
 				require.Error(t, actualErr)
-				require.True(t, shouldRetry)
 			}
 		}
 	})
@@ -195,10 +189,13 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusBadRequest, gomock.Any()).Return(nil)
-		backoff, shouldRetry, actualErr := w.Write(testData, 1)
+		backoff, actualErr := w.Write(testData, 1)
 		require.Equal(t, backoff, w.backoff(1))
 		require.Equal(t, invalidResponseCode(http.StatusBadRequest), actualErr)
-		require.True(t, shouldRetry)
+	})
+
+	t.Run("", func(t *testing.T) {
+
 	})
 
 	t.Run("uses wait time from response header if present", func(t *testing.T) {
@@ -227,9 +224,8 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusTooManyRequests, invalidResponseCode(http.StatusTooManyRequests).Error()).Return(nil)
-		_, shouldRetry, actualErr := w.Write(testData, 1)
+		_, actualErr := w.Write(testData, 1)
 		require.Equal(t, invalidResponseCode(http.StatusTooManyRequests), actualErr)
-		require.True(t, shouldRetry)
 	})
 
 	t.Run("can cancel with done channel", func(t *testing.T) {
@@ -244,8 +240,66 @@ func TestWrite(t *testing.T) {
 
 		configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
 		configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusInternalServerError, invalidResponseCode(http.StatusInternalServerError).Error()).Return(nil)
-		_, _, actualErr := w.Write(testData, 1)
+		_, actualErr := w.Write(testData, 1)
 		require.Equal(t, invalidResponseCode(http.StatusInternalServerError), actualErr)
+	})
+
+	t.Run("writes resume after temporary remote disconnect", func(t *testing.T) {
+		// Attempt to write data a total of 5 times.
+		// Succeed on the first point, writing point 1. (baseline test)
+		// Fail on the second and third, then succeed on the fourth, writing point 2.
+		// Fail on the fifth, sixth and seventh, then succeed on the eighth, writing point 3.
+		attemptMap := make([]bool, 8)
+		attemptMap[0] = true
+		attemptMap[3] = true
+		attemptMap[7] = true
+		var attempt uint8
+
+		var currentWrite int
+		testWrites := []string{
+			"this is some data",
+			"this is also some data",
+			"this is even more data",
+		}
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attemptMap[attempt] {
+				gotData, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				require.Equal(t, []byte(testWrites[currentWrite]), gotData)
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				// Simulate a timeout, as if the remote connection were offline
+				w.WriteHeader(http.StatusGatewayTimeout)
+			}
+			attempt++
+		}))
+		defer svr.Close()
+
+		testConfig := &influxdb.ReplicationHTTPConfig{
+			RemoteURL: svr.URL,
+		}
+		w, configStore, _ := testWriter(t)
+
+		numAttempts := 0
+		for i := 0; i < len(testWrites); i++ {
+			currentWrite = i
+			configStore.EXPECT().GetFullHTTPConfig(gomock.Any(), testID).Return(testConfig, nil)
+			if attemptMap[attempt] {
+				// should succeed
+				configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusNoContent, gomock.Any()).Return(nil)
+				_, err := w.Write([]byte(testWrites[i]), numAttempts)
+				require.NoError(t, err)
+				numAttempts = 0
+			} else {
+				// should fail
+				configStore.EXPECT().UpdateResponseInfo(gomock.Any(), testID, http.StatusGatewayTimeout, invalidResponseCode(http.StatusGatewayTimeout).Error()).Return(nil)
+				_, err := w.Write([]byte(testWrites[i]), numAttempts)
+				require.Error(t, err)
+				numAttempts++
+				i-- // decrement so that we retry this same data point in the next loop iteration
+			}
+		}
 	})
 }
 
@@ -332,7 +386,7 @@ func TestWrite_Metrics(t *testing.T) {
 			reg.MustRegister(w.metrics.PrometheusCollectors()...)
 
 			tt.registerExpectations(t, configStore, testConfig)
-			_, _, actualErr := w.Write(tt.data, 1)
+			_, actualErr := w.Write(tt.data, 1)
 			require.Equal(t, tt.expectedErr, actualErr)
 			tt.checkMetrics(t, reg)
 		})

--- a/replications/remotewrite/writer_test.go
+++ b/replications/remotewrite/writer_test.go
@@ -194,10 +194,6 @@ func TestWrite(t *testing.T) {
 		require.Equal(t, invalidResponseCode(http.StatusBadRequest), actualErr)
 	})
 
-	t.Run("", func(t *testing.T) {
-
-	})
-
 	t.Run("uses wait time from response header if present", func(t *testing.T) {
 		numSeconds := 5
 		waitTimeFromHeader := 5 * time.Second


### PR DESCRIPTION
Closes #23397

Fixes an issue where we could get stuck on a `time.Timer#C` channel listen. If we had multiple remote write failures in a row, we would end up in a situation where the `retry.C` channel was just drained, then we call `retry.Stop()`, followed by `<-retry.C`, which would deadlock the goroutine responsible for sending remote writes.

Additionally, this PR adds several new test cases, and refactors the `remoteWriter` interface to no longer return `shouldRetry`, since it was unnecessary and unused.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
