### PR TITLE
fix: log the log level at startup

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -213,6 +213,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		zap.String("version", info.Version),
 		zap.String("commit", info.Commit),
 		zap.String("build_date", info.Date),
+		zap.String("log_level", opts.LogLevel.String()),
 	)
 	m.initTracing(opts)
 


### PR DESCRIPTION
Unlike the changes for 1.x, only log the log level if we are at 'info' level. We'll know we're not at 'info' if there is no `Welcome to InfluxDB` log line.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass