### PR TITLE
build: fix release workflow for 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
           <<: *any_filter
       - build:
           <<: *any_filter
-          name: build-snapshot-<< matrix.os >>-<< matrix.arch >>
+          name: build-<< matrix.os >>-<< matrix.arch >>
           build-type: snapshot
           matrix:
             parameters:
@@ -114,7 +114,7 @@ workflows:
           <<: *any_filter
           name: build-package-<< matrix.os >>-<< matrix.arch >>
           requires:
-            - build-snapshot-<< matrix.os >>-<< matrix.arch >>
+            - build-<< matrix.os >>-<< matrix.arch >>
           matrix:
             parameters:
               os:   [ linux, darwin, windows ]
@@ -125,11 +125,11 @@ workflows:
       - test-downgrade:
           <<: *any_filter
           requires:
-            - build-snapshot-linux-amd64
+            - build-linux-amd64
       - e2e-monitor-ci:
           <<: *nofork_filter
           requires:
-            - build-snapshot-linux-amd64
+            - build-linux-amd64
       - test-linux-packages:
           <<: *nofork_filter
           requires:
@@ -156,14 +156,14 @@ workflows:
       - grace-test:
           <<: *any_filter
           requires:
-            - build-snapshot-linux-amd64
+            - build-linux-amd64
       - litmus-smoke-test:
           <<: *any_filter
           requires:
-            - build-snapshot-linux-amd64
+            - build-linux-amd64
       - litmus-full-test:
           requires:
-            - build-snapshot-linux-amd64
+            - build-linux-amd64
           filters:
             branches:
               only: master
@@ -381,14 +381,32 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Get InfluxDB version
+          command: |
+            PREFIX=2.x .circleci/scripts/get-version
+      - run:
           name: Generate UI assets
           command: make generate-web-assets
       - run:
           name: Build binaries
           command: |
+            build_type="<< parameters.build-type >>"
+
+            # release builds occur from the "build" pipeline
+            if [[ ${build_type} == snapshot ]]
+            then
+              # `get-version` determines whether this is a release build. If
+              # this is a release build, ensure that the proper version is
+              # templated into the go binary.
+              if [[ ${RELEASE:-} ]]
+              then
+                build_type=release
+              fi
+            fi
+
             export GOOS=<< parameters.os >>
             export GOARCH=<< parameters.arch >>
-            ./scripts/ci/build.sh "bin/influxd_$(go env GOOS)_$(go env GOARCH)" "<< parameters.build-type >>" ./cmd/influxd
+            ./scripts/ci/build.sh "bin/influxd_$(go env GOOS)_$(go env GOARCH)" "${build_type}" ./cmd/influxd
       - store_artifacts:
           path: bin
       - persist_to_workspace:

--- a/.circleci/scripts/build-package
+++ b/.circleci/scripts/build-package
@@ -3,6 +3,20 @@ set -o errexit  \
     -o nounset  \
     -o pipefail
 
+REGEX_RELEASE_VERSION='[[:digit:]]+\.[[:digit:]]\.[[:digit:]]'
+
+if [[ ${RELEASE:-} ]]
+then
+  # This ensures that release packages are built with valid versions.
+  # Unfortunately, `fpm` is fairly permissive with what version tags
+  # it accepts. This becomes a problem when `apt` or `dpkg` is used
+  # to install the package (both have strict version requirements).
+  if ! [[ ${VERSION} =~ ^${REGEX_RELEASE_VERSION}$ ]]
+  then
+    printf 'Release version is invalid!\n' >&2 && exit 1
+  fi
+fi
+
 function run_fpm()
 {
   if [[ ${1} == rpm ]]
@@ -59,7 +73,7 @@ function run_fpm()
         ;;
       rpm)
         mv "/artifacts/influxdb2-${VERSION//-/_}-1.${ARCH}.rpm" \
-           "/artifacts/influxdb2-${VERSION//-/_}-${ARCH}.rpm"
+           "/artifacts/influxdb2-${VERSION//-/_}.${ARCH}.rpm"
         ;;
     esac
 }
@@ -89,7 +103,7 @@ build_tarfile()
     # in the root of the tarfile. The second being that this excludes
     # empty directories from the tarfile.
     find "influxdb2_${PLAT}_${ARCH}/" -type f \
-      | tar -czf "/artifacts/influxdb2_${VERSION}_${PLAT}_${ARCH}.tar.gz" -T -
+      | tar -czf "/artifacts/influxdb2-${VERSION}-${PLAT}-${ARCH}.tar.gz" -T -
 
   popd
 }

--- a/.circleci/scripts/build-package
+++ b/.circleci/scripts/build-package
@@ -3,7 +3,7 @@ set -o errexit  \
     -o nounset  \
     -o pipefail
 
-REGEX_RELEASE_VERSION='[[:digit:]]+\.[[:digit:]]\.[[:digit:]]'
+REGEX_RELEASE_VERSION='[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'
 
 if [[ ${RELEASE:-} ]]
 then

--- a/.circleci/scripts/get-version
+++ b/.circleci/scripts/get-version
@@ -31,7 +31,7 @@ TAG=$(head -n 1 <<<"$(semver_tags)")
 if [[ ${TAG:-} ]]
 then
   cat <<EOF >>"${BASH_ENV}"
-export VERSION="${TAG}"
+export VERSION="${TAG:1}"
 export RELEASE=1
 EOF
 else

--- a/.circleci/scripts/get-version
+++ b/.circleci/scripts/get-version
@@ -3,7 +3,7 @@ set -o nounset  \
     -o errexit  \
     -o pipefail
 
-REGEX_TAG='v[[:digit:]]+\.[[:digit:]]\.[[:digit:]]'
+REGEX_TAG='v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'
 
 function semver_tags()
 {


### PR DESCRIPTION
This changes the package names so that they are compatible with other scripts. It also ensures that the version is correct when generating releases.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass