### PR TITLE
fix: do not delete replication on remote config delete

### DIFF
--- a/remotes/transport/http.go
+++ b/remotes/transport/http.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/influxdata/influxdb/v2/kv"
 
@@ -29,6 +30,11 @@ var (
 	errBadId = &errors.Error{
 		Code: errors.EInvalid,
 		Msg:  "remote-connection ID is invalid",
+	}
+
+	errForeignKey = &errors.Error{
+		Code: errors.EInternal,
+		Msg:  "remote-connection cannot be deleted as a replication references it",
 	}
 )
 
@@ -198,7 +204,11 @@ func (h *RemoteConnectionHandler) handleDeleteRemote(w http.ResponseWriter, r *h
 	}
 
 	if err := h.remotesService.DeleteRemoteConnection(r.Context(), *id); err != nil {
-		h.api.Err(w, r, err)
+		if strings.Contains(strings.ToLower(err.Error()), "foreign key constraint failed") {
+			h.api.Err(w, r, errForeignKey)
+		} else {
+			h.api.Err(w, r, err)
+		}
 		return
 	}
 	h.api.Respond(w, r, http.StatusNoContent, nil)

--- a/sqlite/migrations/0006_migrate_replications_foreign_key.down.sql
+++ b/sqlite/migrations/0006_migrate_replications_foreign_key.down.sql
@@ -1,0 +1,33 @@
+PRAGMA foreign_keys=off;
+
+ALTER TABLE replications RENAME TO _replications_old;
+
+CREATE TABLE replications
+(
+    id                       VARCHAR(16) NOT NULL PRIMARY KEY,
+    org_id                   VARCHAR(16) NOT NULL,
+    name                     TEXT        NOT NULL,
+    description              TEXT,
+    remote_id                VARCHAR(16) NOT NULL,
+    local_bucket_id          VARCHAR(16) NOT NULL,
+    remote_bucket_id         VARCHAR(16) NOT NULL,
+    max_queue_size_bytes     INTEGER     NOT NULL,
+    max_age_seconds          INTEGER     NOT NULL,
+    latest_response_code     INTEGER,
+    latest_error_message     TEXT,
+    drop_non_retryable_data  BOOLEAN     NOT NULL,
+    created_at               TIMESTAMP   NOT NULL,
+    updated_at               TIMESTAMP   NOT NULL,
+
+    CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
+    FOREIGN KEY (remote_id) REFERENCES remotes (id) ON DELETE CASCADE
+);
+
+INSERT INTO replications SELECT * FROM _replications_old;
+DROP TABLE _replications_old;
+
+-- Create indexes on lookup patterns we expect to be common
+CREATE INDEX idx_local_bucket_id_per_org ON replications (org_id, local_bucket_id);
+CREATE INDEX idx_remote_id_per_org ON replications (org_id, remote_id);
+
+PRAGMA foreign_keys=on;

--- a/sqlite/migrations/0006_migrate_replications_foreign_key.up.sql
+++ b/sqlite/migrations/0006_migrate_replications_foreign_key.up.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys=off;
+
+-- Removes the "ON DELETE CASCADE" from the foreign key constraint
+ALTER TABLE replications RENAME TO _replications_old;
+
+CREATE TABLE replications
+(
+    id                       VARCHAR(16) NOT NULL PRIMARY KEY,
+    org_id                   VARCHAR(16) NOT NULL,
+    name                     TEXT        NOT NULL,
+    description              TEXT,
+    remote_id                VARCHAR(16) NOT NULL,
+    local_bucket_id          VARCHAR(16) NOT NULL,
+    remote_bucket_id         VARCHAR(16) NOT NULL,
+    max_queue_size_bytes     INTEGER     NOT NULL,
+    max_age_seconds          INTEGER     NOT NULL,
+    latest_response_code     INTEGER,
+    latest_error_message     TEXT,
+    drop_non_retryable_data  BOOLEAN     NOT NULL,
+    created_at               TIMESTAMP   NOT NULL,
+    updated_at               TIMESTAMP   NOT NULL,
+
+    CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
+    FOREIGN KEY (remote_id) REFERENCES remotes (id)
+);
+
+INSERT INTO replications SELECT * FROM _replications_old;
+DROP TABLE _replications_old;
+
+-- Create indexes on lookup patterns we expect to be common
+CREATE INDEX idx_local_bucket_id_per_org ON replications (org_id, local_bucket_id);
+CREATE INDEX idx_remote_id_per_org ON replications (org_id, remote_id);
+
+PRAGMA foreign_keys=on;


### PR DESCRIPTION
Closes #23491 

Fixes the above issue by no longer cascade deleting replication configs when the remote foreign key is deleted. Instead we return an error, requiring the user to delete the replication themselves first. This should "fix" the issue by not letting that situation happen. Additionally, this means that the user will not accidentally delete their replications by deleting a remote, and potentially losing data in the queue.

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [x] Tests pass