### PR TITLE
feat(flux-test): update flux-test-harness for tag support

### DIFF
--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -33,40 +33,6 @@ build_test_harness() {
 
 skipped_tests() {
   doc=$(cat <<ENDSKIPS
-# Integration write tests
-integration_mqtt_pub
-integration_sqlite_write_to
-integration_vertica_write_to
-integration_mssql_write_to
-integration_mysql_write_to
-integration_mariadb_write_to
-integration_pg_write_to
-integration_hdb_write_to
-
-# Integration read tests
-integration_sqlite_read_from_seed
-integration_sqlite_read_from_nonseed
-integration_vertica_read_from_seed
-integration_vertica_read_from_nonseed
-integration_mssql_read_from_seed
-integration_mssql_read_from_nonseed
-integration_mariadb_read_from_seed
-integration_mariadb_read_from_nonseed
-integration_mysql_read_from_seed
-integration_mysql_read_from_nonseed
-integration_pg_read_from_seed
-integration_pg_read_from_nonseed
-integration_hdb_read_from_seed
-integration_hdb_read_from_nonseed
-
-# Integration injection tests
-integration_sqlite_injection
-integration_hdb_injection
-integration_pg_injection
-integration_mysql_injection
-integration_mariadb_injection
-integration_mssql_injection
-
 # Other skipped tests
 buckets # unbounded
 columns # failing with differences

--- a/internal/cmd/fluxtest-harness-influxdb/test.go
+++ b/internal/cmd/fluxtest-harness-influxdb/test.go
@@ -262,9 +262,16 @@ func main() {
 	c.Use = "fluxtest-harness-influxdb"
 	c.Flags().BoolVarP(&flags.wait, "wait", "w", false, "Wait for a kill signal before shutting down the InfluxDB test instances.")
 	if err := tryExec(c); err != nil {
-		fmt.Println(err)
+		if _, ok := err.(silentError); !ok {
+			fmt.Fprintln(c.OutOrStderr(), err)
+		}
 		os.Exit(1)
 	}
+}
+
+// silentError indicates the error should not be printed to stderr.
+type silentError interface {
+	Silent()
 }
 
 func createInfluxDBConfig(ctx context.Context, name, host, org, token string) error {


### PR DESCRIPTION
With tag support we no longer need to explicitly skip the integration
tests.

We still need to figure out what to do about the other skipped tests
but those can come later.
