### PR TITLE
fix: handle a potential nil iterator leading to a panic

### DIFF
--- a/v1/services/storage/store.go
+++ b/v1/services/storage/store.go
@@ -543,8 +543,6 @@ func (s *Store) measurementFields(ctx context.Context, mqAttrs *metaqueryAttribu
 		Condition:  mqAttrs.pred,
 		Authorizer: query.OpenAuthorizer,
 	}
-	// This can return a nil iterator and nil err
-	// see tsdb/engine/tsm1/Engine.CreateIterator
 	iter, err := sg.CreateIterator(ctx, ms, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #23073

CreateIterator could return a nil iterator and a nil error. This could lead to several potential panics when trying to type assert the iterator or call methods on it. This should fix those cases.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [x] Tests pass

