### PR TITLE
fix: Update the condition when reseting cursor

### DIFF
--- a/query/stdlib/influxdata/influxdb/filter_test.flux
+++ b/query/stdlib/influxdata/influxdb/filter_test.flux
@@ -39,3 +39,37 @@ testcase filter {
         |> drop(columns: ["_start", "_stop"])
     testing.diff(want, got)
 }
+
+
+input_issue_4804 = "#datatype,string,long,dateTime:RFC3339,string,string,string,boolean
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,true
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,false
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,false
+,,2,2018-05-22T19:53:26Z,system,host.local,load4,true
+"
+
+testcase flux_issue_4804 {
+    expect.planner(rules: [
+        "influxdata/influxdb.FromStorageRule": 1,
+        "PushDownRangeRule": 1,
+        "PushDownFilterRule": 1,
+    ])
+
+    want = csv.from(csv: "#datatype,string,long,dateTime:RFC3339,string,string,string,boolean
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,true
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,false
+")
+
+    got = csv.from(csv: input_issue_4804)
+        |> testing.load()
+        |> range(start: -100y)
+        |> filter(fn: (r) => ((r["_field"] == "load1" and r["_value"] == true) or (r["_field"] == "load3" and r["_value"] == false)))
+        |> drop(columns: ["_start", "_stop"])
+    testing.diff(want, got)
+}

--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -276,6 +276,8 @@ func (c *floatMultiShardArrayCursor) reset(cur cursors.FloatArrayCursor, itrs cu
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = newFloatFilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter
@@ -1155,6 +1157,8 @@ func (c *integerMultiShardArrayCursor) reset(cur cursors.IntegerArrayCursor, itr
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = newIntegerFilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter
@@ -2034,6 +2038,8 @@ func (c *unsignedMultiShardArrayCursor) reset(cur cursors.UnsignedArrayCursor, i
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = newUnsignedFilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter
@@ -2913,6 +2919,8 @@ func (c *stringMultiShardArrayCursor) reset(cur cursors.StringArrayCursor, itrs 
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = newStringFilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter
@@ -3337,6 +3345,8 @@ func (c *booleanMultiShardArrayCursor) reset(cur cursors.BooleanArrayCursor, itr
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = newBooleanFilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -223,6 +223,8 @@ func (c *{{.name}}MultiShardArrayCursor) reset(cur cursors.{{.Name}}ArrayCursor,
 	if cond != nil {
 		if c.filter == nil {
 			c.filter = new{{.Name}}FilterArrayCursor(cond)
+		} else {
+			c.filter.cond = cond
 		}
 		c.filter.reset(cur)
 		cur = c.filter


### PR DESCRIPTION
Filters that contain `or` may change between cursor resets so we must remember to update the condition in the read cursor.

```flux
|> filter(fn: (r) => ((r["_field"] == "field1" and r["_value"]==true) or (r["_field"] == "field2" and r["_value"] == false)))
```

Closes https://github.com/influxdata/flux/issues/4804


Describe your proposed changes here.
n be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
