### PR TITLE
fix(fluxplan): update plans for explicit successors

### DIFF
--- a/query/stdlib/influxdata/influxdb/buckets.go
+++ b/query/stdlib/influxdata/influxdb/buckets.go
@@ -152,7 +152,7 @@ func (rule LocalBucketsRule) Name() string {
 }
 
 func (rule LocalBucketsRule) Pattern() plan.Pattern {
-	return plan.Pat(influxdb.BucketsKind)
+	return plan.MultiSuccessor(influxdb.BucketsKind)
 }
 
 func (rule LocalBucketsRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {

--- a/query/stdlib/influxdata/influxdb/v1/databases.go
+++ b/query/stdlib/influxdata/influxdb/v1/databases.go
@@ -200,7 +200,7 @@ func (rule LocalDatabasesRule) Name() string {
 }
 
 func (rule LocalDatabasesRule) Pattern() plan.Pattern {
-	return plan.Pat(v1.DatabasesKind)
+	return plan.MultiSuccessor(v1.DatabasesKind)
 }
 
 func (rule LocalDatabasesRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {


### PR DESCRIPTION
Updates planner rules according to ~~influxdata/flux#4981~~ https://github.com/influxdata/flux/pull/5047 Will require a Flux update.


Describe your proposed changes here.

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Feature flagged (if modified API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
