### PR TITLE
fix: improve error messages opening index partitions

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -2,6 +2,7 @@ package tsi1_test
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -295,7 +296,7 @@ func TestIndex_Open(t *testing.T) {
 			// Opening this index should return an error because the MANIFEST has an
 			// incompatible version.
 			err = idx.Open()
-			if err != tsi1.ErrIncompatibleVersion {
+			if !errors.Is(err, tsi1.ErrIncompatibleVersion) {
 				idx.Close()
 				t.Fatalf("got error %v, expected %v", err, tsi1.ErrIncompatibleVersion)
 			}

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -1,6 +1,7 @@
 package tsi1_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,7 +62,7 @@ func TestPartition_Open(t *testing.T) {
 			// Opening this index should return an error because the MANIFEST has an
 			// incompatible version.
 			err = p.Open()
-			if err != tsi1.ErrIncompatibleVersion {
+			if !errors.Is(err, tsi1.ErrIncompatibleVersion) {
 				p.Close()
 				t.Fatalf("got error %v, expected %v", err, tsi1.ErrIncompatibleVersion)
 			}


### PR DESCRIPTION
Where possible, add the file path path to any errors
on opening, reading, (un)marshaling, or validating
the various files comprising a partition

closes https://github.com/influxdata/influxdb/issues/23506

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass