### PR TITLE
fix: improve error messages opening index partitions (#23532)

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -2,6 +2,7 @@ package tsi1_test
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -295,7 +296,7 @@ func TestIndex_Open(t *testing.T) {
 			// Opening this index should return an error because the MANIFEST has an
 			// incompatible version.
 			err = idx.Open()
-			if err != tsi1.ErrIncompatibleVersion {
+			if !errors.Is(err, tsi1.ErrIncompatibleVersion) {
 				idx.Close()
 				t.Fatalf("got error %v, expected %v", err, tsi1.ErrIncompatibleVersion)
 			}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/influxdb/v2/logger"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/pkg/bytesutil"
+	errors2 "github.com/influxdata/influxdb/v2/pkg/errors"
 	"github.com/influxdata/influxdb/v2/pkg/estimator"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxql"
@@ -151,14 +152,14 @@ func (p *Partition) Open() (rErr error) {
 	p.closing = make(chan struct{})
 
 	if p.opened {
-		return errors.New("index partition already open")
+		return fmt.Errorf("index partition already open: %q", p.path)
 	}
 
 	// Validate path is correct.
 	p.id = filepath.Base(p.path)
 	_, err := strconv.Atoi(p.id)
 	if err != nil {
-		return err
+		return fmt.Errorf("poorly formed manifest file path, %q: %w", p.path, err)
 	}
 
 	// Create directory if it doesn't exist.
@@ -166,8 +167,9 @@ func (p *Partition) Open() (rErr error) {
 		return err
 	}
 
+	filename := filepath.Join(p.path, ManifestFileName)
 	// Read manifest file.
-	m, manifestSize, err := ReadManifestFile(filepath.Join(p.path, ManifestFileName))
+	m, manifestSize, err := ReadManifestFile(filename)
 	if os.IsNotExist(err) {
 		m = NewManifest(p.ManifestPath())
 	} else if err != nil {
@@ -277,12 +279,12 @@ func (p *Partition) openIndexFile(path string) (*IndexFile, error) {
 }
 
 // deleteNonManifestFiles removes all files not in the manifest.
-func (p *Partition) deleteNonManifestFiles(m *Manifest) error {
+func (p *Partition) deleteNonManifestFiles(m *Manifest) (rErr error) {
 	dir, err := os.Open(p.path)
 	if err != nil {
 		return err
 	}
-	defer dir.Close()
+	defer errors2.Capture(&rErr, dir.Close)()
 
 	fis, err := dir.Readdir(-1)
 	if err != nil {
@@ -301,7 +303,7 @@ func (p *Partition) deleteNonManifestFiles(m *Manifest) error {
 		}
 	}
 
-	return dir.Close()
+	return nil
 }
 
 func (p *Partition) buildSeriesSet() error {
@@ -1379,7 +1381,7 @@ func (m *Manifest) Validate() error {
 	// If we don't have an explicit version in the manifest file then we know
 	// it's not compatible with the latest tsi1 Index.
 	if m.Version != Version {
-		return ErrIncompatibleVersion
+		return fmt.Errorf("%q: %w", m.path, ErrIncompatibleVersion)
 	}
 	return nil
 }
@@ -1389,7 +1391,7 @@ func (m *Manifest) Validate() error {
 func (m *Manifest) Write() (int64, error) {
 	buf, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed marshaling %q: %w", m.path, err)
 	}
 	buf = append(buf, '\n')
 
@@ -1410,7 +1412,7 @@ func ReadManifestFile(path string) (*Manifest, int64, error) {
 	// Decode manifest.
 	var m Manifest
 	if err := json.Unmarshal(buf, &m); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("failed unmarshaling %q: %w", path, err)
 	}
 
 	// Set the path of the manifest.

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -1,6 +1,7 @@
 package tsi1_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,7 +62,7 @@ func TestPartition_Open(t *testing.T) {
 			// Opening this index should return an error because the MANIFEST has an
 			// incompatible version.
 			err = p.Open()
-			if err != tsi1.ErrIncompatibleVersion {
+			if !errors.Is(err, tsi1.ErrIncompatibleVersion) {
 				p.Close()
 				t.Fatalf("got error %v, expected %v", err, tsi1.ErrIncompatibleVersion)
 			}


### PR DESCRIPTION
Where possible, add the file path path to any errors
on opening, reading, (un)marshaling, or validating
the various files comprising a partition

closes https://github.com/influxdata/influxdb/issues/23506

(cherry picked from commit a2dd708a264202995d1437cb29ccaa24577ab060)

closes https://github.com/influxdata/influxdb/issues/23534

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass