### PR TITLE
fix: create TSI MANIFEST files atomically

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1401,9 +1401,35 @@ func (m *Manifest) Write() (int64, error) {
 	}
 	buf = append(buf, '\n')
 
-	if err := os.WriteFile(m.path, buf, 0666); err != nil {
+	f, err := os.CreateTemp(filepath.Dir(m.path), ManifestFileName)
+
+	if err != nil {
 		return 0, err
 	}
+
+	tmp := f.Name()
+	// In correct operation, Remove() should fail because the file was renamed
+	defer os.Remove(tmp)
+	err = func() (rErr error) {
+		// Close() before rename for Windows
+		defer errors2.Capture(&rErr, f.Close)()
+		if _, err = f.Write(buf); err != nil {
+			return fmt.Errorf("failed writing temporary manifest file %q: %w", tmp, err)
+		}
+		return nil
+	}()
+	if err != nil {
+		return 0, err
+	}
+
+	if err = os.Chmod(tmp, 0666); err != nil {
+		return 0, err
+	}
+
+	if err = os.Rename(tmp, m.path); err != nil {
+		return 0, err
+	}
+
 	return int64(len(buf)), nil
 }
 


### PR DESCRIPTION
When a MANIFEST file is created in TSI, it
should be written to a temp file, then
atomically renamed, to avoid overwriting
the existing file only to fail on the
later write.

closes https://github.com/influxdata/influxdb/issues/23536

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass