### PR TITLE
fix: restore in-memory Manifest on write error

### DIFF
--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -269,7 +269,7 @@ func (i *Index) Open() (rErr error) {
 	// Initialize index partitions.
 	i.partitions = make([]*Partition, i.PartitionN)
 	for j := 0; j < len(i.partitions); j++ {
-		p := NewPartition(i, i.sfile, filepath.Join(i.path, fmt.Sprint(j)))
+		p := NewPartition(i.sfile, filepath.Join(i.path, fmt.Sprint(j)))
 		p.MaxLogFileSize = i.maxLogFileSize
 		p.MaxLogFileAge = i.maxLogFileAge
 		p.nosync = i.disableFsync

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -139,13 +139,13 @@ func TestPartition_Compact_Write_Fail(t *testing.T) {
 		fileN := p.FileN()
 		p.Compact()
 		if (1 + fileN) != p.FileN() {
-			t.Fatalf("manifest write succeeded: expected more than %d files, got %d files", fileN, p.FileN())
+			t.Fatalf("manifest write in compaction should have succeeded, but number of files did not change correctly: expected %d files, got %d files", fileN+1, p.FileN())
 		}
 		p.SetManifestPathForTest(badManifestPath)
 		fileN = p.FileN()
 		p.Compact()
 		if fileN != p.FileN() {
-			t.Fatalf("manifest write failed: expected %d files, got %d files", fileN, p.FileN())
+			t.Fatalf("manifest write should have failed the compaction, but number of files changed: expected %d files, got %d files", fileN, p.FileN())
 		}
 	})
 }

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -112,13 +112,13 @@ func TestPartition_PrependLogFile_Write_Fail(t *testing.T) {
 		fileN := p.FileN()
 		p.CheckLogFile()
 		if fileN >= p.FileN() {
-			t.Fatalf("manifest write succeeded: expected more than %d files, got %d files", fileN, p.FileN())
+			t.Fatalf("manifest write prepending log file should have succeeded but number of files did not change correctly: expected more than %d files, got %d files", fileN, p.FileN())
 		}
 		p.SetManifestPathForTest(badManifestPath)
 		fileN = p.FileN()
 		p.CheckLogFile()
 		if fileN != p.FileN() {
-			t.Fatalf("manifest write failed: expected %d files, got %d files", fileN, p.FileN())
+			t.Fatalf("manifest write prepending log file should have failed, but number of files changed: expected %d files, got %d files", fileN, p.FileN())
 		}
 	})
 }


### PR DESCRIPTION
Do not update the `FileSet` or `activeLogFile` field in the in-memory 
Partition structure if the Manifest file is not correctly saved to
the disk.

closes https://github.com/influxdata/influxdb/issues/23553