### PR TITLE
fix: add paths to tsi log and index file errors

### DIFF
--- a/models/points_test.go
+++ b/models/points_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -2228,7 +2229,7 @@ func TestNewPointsWithBytesWithCorruptData(t *testing.T) {
 
 func TestNewPointsWithShortBuffer(t *testing.T) {
 	_, err := models.NewPointFromBytes([]byte{0, 0, 0, 3, 4})
-	if err != io.ErrShortBuffer {
+	if !errors.Is(err, io.ErrShortBuffer) {
 		t.Fatalf("NewPointFromBytes: got: (%v, %v), expected: (nil, error)", p, err)
 	}
 }

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -170,15 +170,15 @@ func (f *IndexFile) Compacting() bool {
 func (f *IndexFile) UnmarshalBinary(data []byte) error {
 	// Ensure magic number exists at the beginning.
 	if len(data) < len(FileSignature) {
-		return io.ErrShortBuffer
+		return fmt.Errorf("%q: %w", f.path, io.ErrShortBuffer)
 	} else if !bytes.Equal(data[:len(FileSignature)], []byte(FileSignature)) {
-		return ErrInvalidIndexFile
+		return fmt.Errorf("%q: %w", f.path, ErrInvalidIndexFile)
 	}
 
 	// Read index file trailer.
 	t, err := ReadIndexFileTrailer(data)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q: %w", f.path, err)
 	}
 
 	// Slice series sketch data.
@@ -191,7 +191,7 @@ func (f *IndexFile) UnmarshalBinary(data []byte) error {
 
 	// Unmarshal measurement block.
 	if err := f.mblk.UnmarshalBinary(data[t.MeasurementBlock.Offset:][:t.MeasurementBlock.Size]); err != nil {
-		return err
+		return fmt.Errorf("%q: %w", f.path, err)
 	}
 
 	// Unmarshal each tag block.
@@ -208,7 +208,7 @@ func (f *IndexFile) UnmarshalBinary(data []byte) error {
 		// Unmarshal measurement block.
 		var tblk TagBlock
 		if err := tblk.UnmarshalBinary(buf); err != nil {
-			return err
+			return fmt.Errorf("%q: %w", f.path, err)
 		}
 		f.tblks[string(e.name)] = &tblk
 	}

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -226,7 +226,9 @@ func TestIndex_OpenFail(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tslFile.Close())
 	idx.Index = tsi1.NewIndex(idx.SeriesFile.SeriesFile, "db0", tsi1.WithPath(idx.Index.Path()))
-	require.EqualError(t, idx.Index.Open(), "parsing binary-encoded uint64 value failed; binary.Uvarint() returned -11")
+	err = idx.Index.Open()
+	require.Error(t, err, "expected an error on opening the index")
+	require.Contains(t, err.Error(), ".tsl\": parsing binary-encoded uint64 value failed; binary.Uvarint() returned -11")
 	// ensure each partition is closed:
 	for i := 0; i < int(idx.Index.PartitionN); i++ {
 		assert.Equal(t, idx.Index.PartitionAt(i).FileN(), 0)

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -153,10 +153,10 @@ func (f *LogFile) open() error {
 	for buf := f.data; len(buf) > 0; {
 		// Read next entry. Truncate partial writes.
 		var e LogEntry
-		if err := e.UnmarshalBinary(buf); err == io.ErrShortBuffer || err == ErrLogEntryChecksumMismatch {
+		if err := e.UnmarshalBinary(buf); errors.Is(err, io.ErrShortBuffer) || errors.Is(err, ErrLogEntryChecksumMismatch) {
 			break
 		} else if err != nil {
-			return err
+			return fmt.Errorf("%q: %w", f.path, err)
 		}
 
 		// Execute entry against in-memory index.


### PR DESCRIPTION
Add paths to various TSI errors on opening and unmarshaling files
to help poinpoint the corrupt files.

Closes https://github.com/influxdata/influxdb/issues/23556

<!-- Please DO NOT update the CHANGELOG, as this is now handled by automation. -->
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Rebased/mergeable
- [X] Tests pass
