### PR TITLE
chore: upgrade CircleCI Mac OSX image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
       resource_class: arm.large
   darwin:
     macos:
-      xcode: 12.4.0
+      xcode: 12.5.1
       resource_class: medium
     shell: /bin/bash -eo pipefail
   windows:


### PR DESCRIPTION
It appears that the Mac OSX image we were using was deprecated by CircleCI.
