### PR TITLE
build: upgrade to Go 1.18.4 (master-1.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.18.3-c75d304717395a43913dcc3d576d4f3545375253
+    default: go1.18.4-906fbe93f953b47185818364a186604209dc8da0
 
 commands:
   install_rust:


### PR DESCRIPTION
This upgrades Go to 1.18.4 to resolve security vulnerabilities within the compiler.