### PR TITLE
fix: add reporttsi to the help text (#23566)

### DIFF
--- a/cmd/influx_inspect/help/help.go
+++ b/cmd/influx_inspect/help/help.go
@@ -40,6 +40,7 @@ The commands are:
     report               displays a shard level cardinality report
     report-db            estimates cloud 2 cardinality for a database
     report-disk          displays a shard level disk usage report
+    reporttsi            reports series cardinality in one or more TSI indexes.
     verify               verifies integrity of TSM files
     verify-seriesfile    verifies integrity of the Series file
 


### PR DESCRIPTION
reporttsi was not listed as a command in the influx_inspect help text.

(cherry picked from commit 5c22d6c729ac59acbccc6a7f431ddaa8090d8bf2)

closes https://github.com/influxdata/influxdb/issues/23567