### PR TITLE
feat: add virtual DBRP mappings based on bucket name

### DIFF
--- a/dbrp/http_server_dbrp_test.go
+++ b/dbrp/http_server_dbrp_test.go
@@ -489,7 +489,7 @@ func Test_handleDeleteDBRP(t *testing.T) {
 				BucketID:        influxdbtesting.MustIDBase16("5555f7ed2a035555"),
 				OrganizationID:  influxdbtesting.MustIDBase16("059af7ed2a034000"),
 				Database:        "mydb",
-				RetentionPolicy: "autogen",
+				RetentionPolicy: "testrp",
 				Default:         true,
 			}
 			if err := svc.Create(ctx, d); err != nil {

--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -386,7 +386,10 @@ OUTER:
 		if bucket == nil {
 			continue
 		}
-		ms = append(ms, bucketToMapping(bucket))
+		mapping := bucketToMapping(bucket)
+		if filterFunc(mapping, filter) {
+			ms = append(ms, mapping)
+		}
 	}
 
 	return ms, len(ms), nil

--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/platform"
@@ -231,9 +232,26 @@ func (s *Service) FindByID(ctx context.Context, orgID, id platform.ID) (*influxd
 		}
 		return nil
 	}); err != nil {
+		// if not found, fallback to virtual DBRP search
+		if err == ErrDBRPNotFound {
+			b, err := s.bucketSvc.FindBucketByID(ctx, id)
+			if err != nil {
+				return nil, ErrDBRPNotFound
+			}
+			return bucketToMapping(b), nil
+		}
 		return nil, err
 	}
 	return m, nil
+}
+
+// parseDBRP parses DB and RP strings out of a bucket name
+func parseDBRP(bucketName string) (string, string) {
+	db, rp, isCut := strings.Cut(bucketName, "/")
+	if isCut {
+		return db, rp
+	}
+	return bucketName, "autogen"
 }
 
 // FindMany returns a list of mappings that match filter and the total count of matching dbrp mappings.
@@ -334,8 +352,58 @@ func (s *Service) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilte
 		}
 		return nil
 	})
+	if err != nil {
+		return ms, len(ms), err
+	}
+
+	buckets, count, err := s.bucketSvc.FindBuckets(ctx, influxdb.BucketFilter{
+		ID:             filter.BucketID,
+		Name:           filter.Database,
+		OrganizationID: filter.OrgID,
+	}, opts...)
+	if (err != nil || count == 0) && filter.Database != nil && filter.RetentionPolicy != nil {
+		// if the search couldn't find a corresponding dbrp, it could be that the bucket name has a slash (like db/rp)
+		// instead of just bucket name being the database with "autogen" retention policy
+		bucketName := *filter.Database + "/" + *filter.RetentionPolicy
+		buckets, _, err = s.bucketSvc.FindBuckets(ctx, influxdb.BucketFilter{
+			ID:             filter.BucketID,
+			Name:           &bucketName,
+			OrganizationID: filter.OrgID,
+		}, opts...)
+		if err != nil {
+			return ms, len(ms), ErrInternalService(err)
+		}
+	}
+OUTER:
+	for _, bucket := range buckets {
+		// check if this virtual mapping has been overriden by a custom, physical mapping
+		for _, m := range ms {
+			if m.BucketID == bucket.ID {
+				continue OUTER
+			}
+		}
+		if bucket == nil {
+			continue
+		}
+		ms = append(ms, bucketToMapping(bucket))
+	}
 
 	return ms, len(ms), err
+}
+
+func bucketToMapping(bucket *influxdb.Bucket) *influxdb.DBRPMapping {
+	// for now, virtual DBRPs will use the same ID as their bucket to be able to find them by ID
+	dbrpID := bucket.ID
+	db, rp := parseDBRP(bucket.Name)
+	return &influxdb.DBRPMapping{
+		ID:              dbrpID,
+		Default:         true,
+		Database:        db,
+		RetentionPolicy: rp,
+		OrganizationID:  bucket.OrgID,
+		BucketID:        bucket.ID,
+		Virtual:         true,
+	}
 }
 
 // Create creates a new mapping.

--- a/dbrp/service.go
+++ b/dbrp/service.go
@@ -371,7 +371,8 @@ func (s *Service) FindMany(ctx context.Context, filter influxdb.DBRPMappingFilte
 			OrganizationID: filter.OrgID,
 		}, opts...)
 		if err != nil {
-			return ms, len(ms), ErrInternalService(err)
+			// we were unable to find any virtual mappings, so return what physical mappings we have
+			return ms, len(ms), nil
 		}
 	}
 OUTER:
@@ -388,7 +389,7 @@ OUTER:
 		ms = append(ms, bucketToMapping(bucket))
 	}
 
-	return ms, len(ms), err
+	return ms, len(ms), nil
 }
 
 func bucketToMapping(bucket *influxdb.Bucket) *influxdb.DBRPMapping {
@@ -397,7 +398,7 @@ func bucketToMapping(bucket *influxdb.Bucket) *influxdb.DBRPMapping {
 	db, rp := parseDBRP(bucket.Name)
 	return &influxdb.DBRPMapping{
 		ID:              dbrpID,
-		Default:         true,
+		Default:         false,
 		Database:        db,
 		RetentionPolicy: rp,
 		OrganizationID:  bucket.OrgID,

--- a/dbrp/service_test.go
+++ b/dbrp/service_test.go
@@ -22,6 +22,11 @@ func initDBRPMappingService(f itesting.DBRPMappingFields, t *testing.T) (influxd
 					ID:   id,
 					Name: fmt.Sprintf("bucket-%v", id),
 				}, nil
+				// if (id == )
+				// return nil, nil
+			},
+			FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+				return []*influxdb.Bucket{}, 0, nil
 			},
 		}
 	}

--- a/dbrp/service_test.go
+++ b/dbrp/service_test.go
@@ -22,8 +22,6 @@ func initDBRPMappingService(f itesting.DBRPMappingFields, t *testing.T) (influxd
 					ID:   id,
 					Name: fmt.Sprintf("bucket-%v", id),
 				}, nil
-				// if (id == )
-				// return nil, nil
 			},
 			FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
 				return []*influxdb.Bucket{}, 0, nil

--- a/dbrp_mapping.go
+++ b/dbrp_mapping.go
@@ -35,6 +35,8 @@ type DBRPMapping struct {
 
 	// Default indicates if this mapping is the default for the cluster and database.
 	Default bool `json:"default"`
+	// Virtual indicates if this is a virtual mapping (tied to bucket name) or physical
+	Virtual bool `json:"virtual"`
 
 	OrganizationID platform.ID `json:"orgID"`
 	BucketID       platform.ID `json:"bucketID"`

--- a/influxql/v1tests/query_test.go
+++ b/influxql/v1tests/query_test.go
@@ -177,7 +177,7 @@ func TestServer_Query_ShowDatabases(t *testing.T) {
 		&Query{
 			name:    "show databases does not return duplicates",
 			command: "SHOW DATABASES",
-			exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["my-bucket"],["telegraf"]]}]}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["my-bucket"],["telegraf"],["_monitoring"],["_tasks"],["db"]]}]}]}`,
 		},
 	)
 

--- a/testing/dbrp_mapping.go
+++ b/testing/dbrp_mapping.go
@@ -331,7 +331,9 @@ func CreateDBRPMappingV2(
 						}
 						return nil, nil
 					},
-				},
+					FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+						return []*influxdb.Bucket{}, 0, nil
+					}},
 				DBRPMappingsV2: []*influxdb.DBRPMapping{{
 					ID:              100,
 					Database:        "database1",
@@ -989,6 +991,19 @@ func FindDBRPMappingByIDV2(
 		{
 			name: "find non existing dbrp",
 			fields: DBRPMappingFields{
+				BucketSvc: &mock.BucketService{
+					FindBucketByIDFn: func(ctx context.Context, id platform.ID) (*influxdb.Bucket, error) {
+						if id == MustIDBase16(dbrpBucketAID) {
+							return &influxdb.Bucket{ID: id}, nil
+						}
+						return nil, &errors2.Error{
+							Code: errors2.ENotFound,
+							Msg:  "bucket not found",
+						}
+					},
+					FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+						return []*influxdb.Bucket{}, 0, nil
+					}},
 				DBRPMappingsV2: []*influxdb.DBRPMapping{
 					{
 						ID:              100,
@@ -1011,6 +1026,19 @@ func FindDBRPMappingByIDV2(
 		{
 			name: "find existing dbrp but wrong orgID",
 			fields: DBRPMappingFields{
+				BucketSvc: &mock.BucketService{
+					FindBucketByIDFn: func(ctx context.Context, id platform.ID) (*influxdb.Bucket, error) {
+						if id == MustIDBase16(dbrpBucketAID) {
+							return &influxdb.Bucket{ID: id}, nil
+						}
+						return nil, &errors2.Error{
+							Code: errors2.ENotFound,
+							Msg:  "bucket not found",
+						}
+					},
+					FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+						return []*influxdb.Bucket{}, 0, nil
+					}},
 				DBRPMappingsV2: []*influxdb.DBRPMapping{
 					{
 						ID:              100,
@@ -1146,6 +1174,19 @@ func UpdateDBRPMappingV2(
 		{
 			name: "error dbrp not found",
 			fields: DBRPMappingFields{
+				BucketSvc: &mock.BucketService{
+					FindBucketByIDFn: func(ctx context.Context, id platform.ID) (*influxdb.Bucket, error) {
+						if id == MustIDBase16(dbrpBucket1ID) {
+							return &influxdb.Bucket{ID: id}, nil
+						}
+						return nil, &errors2.Error{
+							Code: errors2.ENotFound,
+							Msg:  "bucket not found",
+						}
+					},
+					FindBucketsFn: func(ctx context.Context, bf influxdb.BucketFilter, fo ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+						return []*influxdb.Bucket{}, 0, nil
+					}},
 				DBRPMappingsV2: []*influxdb.DBRPMapping{{
 					ID:              100,
 					Database:        "database1",
@@ -1631,7 +1672,7 @@ func DeleteDBRPMappingV2(
 			},
 			args: args{
 				OrgID: MustIDBase16(dbrpOrg2ID),
-				ID:    100,
+				ID:    150,
 			},
 			wants: wants{
 				dbrpMappings: []*influxdb.DBRPMapping{


### PR DESCRIPTION
- Closes #23457
### Required checklist
- [x] openapi swagger.yml updated (if modified API) - https://github.com/influxdata/openapi/pull/462

### Description
Originally, I worked on #23525 to create and update physical DBRP mappings in the bucket service wrapper. This solution meant more state needed to be preserved, required a migration, etc. Virtual mappings, on the other hand, are not written on disk (corruptible), would be changed by a bucket name change implicitly, and overall made much more sense with less code.

### Context
This makes it so users don't have to create a custom DBRP mapping every time they create a bucket.

### Affected areas:
- API changes: `DBRPMapping` gained a `Virtual` field -  https://github.com/influxdata/openapi/pull/462
- CLI commands: `influx v1 dbrp list` prints a new `Virtual` column - https://github.com/influxdata/influx-cli/pull/435
