### PR TITLE
chore: use 1.x signing key (1.9)

### DIFF
--- a/.circleci/scripts/sign-packages
+++ b/.circleci/scripts/sign-packages
@@ -8,7 +8,7 @@ cp -r /tmp/workspace/packages packages
 # CircleCI mangles environment variables with newlines. This key contians
 # escaped newlines. For `gpg` to import the key, it requires `echo -e` to
 # expand the escape sequences.
-gpg --batch --import <<<"$(echo -e "${GPG_PRIVATE_KEY}")"
+gpg --batch --import <<<"$(echo -e "${GPG_1X_PRIVATE_KEY}")"
 
 # TODO(bnpfeife): replace with code signing server
 for target in packages/*


### PR DESCRIPTION
The original code used the 2.x signing key for 1.x releases.