### PR TITLE
feat: add type conflict checker to influx_inspect (#23616)

### DIFF
--- a/cmd/influx_inspect/help/help.go
+++ b/cmd/influx_inspect/help/help.go
@@ -31,12 +31,14 @@ Usage: influx_inspect [[command] [arguments]]
 
 The commands are:
 
+    check-schema         check for conflicts in the types between shards
     deletetsm            bulk measurement deletion of raw tsm file
     dumptsi              dumps low-level details about tsi1 files
     dumptsm              dumps low-level details about tsm1 files
     export               exports raw data from a shard to line protocol
     buildtsi             generates tsi1 indexes from tsm1 data
     help                 display this help message
+    merge-schema         merge a set of schema files from the check-schema command
     report               displays a shard level cardinality report
     report-db            estimates cloud 2 cardinality for a database
     report-disk          displays a shard level disk usage report

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx_inspect/report"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/reportdisk"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/reporttsi"
+	typecheck "github.com/influxdata/influxdb/cmd/influx_inspect/type_conflicts"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/seriesfile"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/tombstone"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify/tsm"
@@ -60,7 +61,7 @@ func (m *Main) Run(args ...string) error {
 	switch name {
 	case "", "help":
 		if err := help.NewCommand().Run(args...); err != nil {
-			return fmt.Errorf("help: %s", err)
+			return fmt.Errorf("help: %w", err)
 		}
 	case "report-db":
 		name := cardinality.NewCommand()
@@ -70,12 +71,12 @@ func (m *Main) Run(args ...string) error {
 	case "deletetsm":
 		name := deletetsm.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("deletetsm: %s", err)
+			return fmt.Errorf("deletetsm: %w", err)
 		}
 	case "dumptsi":
 		name := dumptsi.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("dumptsi: %s", err)
+			return fmt.Errorf("dumptsi: %w", err)
 		}
 	case "dumptsmdev":
 		fmt.Fprintf(m.Stderr, "warning: dumptsmdev is deprecated, use dumptsm instead.\n")
@@ -83,52 +84,62 @@ func (m *Main) Run(args ...string) error {
 	case "dumptsm":
 		name := dumptsm.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("dumptsm: %s", err)
+			return fmt.Errorf("dumptsm: %w", err)
 		}
 	case "dumptsmwal":
 		name := dumptsmwal.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("dumptsmwal: %s", err)
+			return fmt.Errorf("dumptsmwal: %w", err)
 		}
 	case "export":
 		name := export.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("export: %s", err)
+			return fmt.Errorf("export: %w", err)
 		}
 	case "buildtsi":
 		name := buildtsi.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("buildtsi: %s", err)
+			return fmt.Errorf("buildtsi: %w", err)
 		}
 	case "report":
 		name := report.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("report: %s", err)
+			return fmt.Errorf("report: %w", err)
 		}
 	case "report-disk":
 		name := reportdisk.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("report: %s", err)
+			return fmt.Errorf("report: %w", err)
 		}
 	case "reporttsi":
 		name := reporttsi.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("reporttsi: %s", err)
+			return fmt.Errorf("reporttsi: %w", err)
+		}
+	case "check-schema":
+		name := typecheck.NewTypeConflictCheckerCommand()
+		if err := name.Run(args...); err != nil {
+			return fmt.Errorf("check-schema: %w", err)
+		}
+	case "merge-schema":
+		name := typecheck.NewMergeFilesCommand()
+		if err := name.Run(args...); err != nil {
+			return fmt.Errorf("resolve-conflicts: %w", err)
 		}
 	case "verify":
 		name := tsm.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("verify: %s", err)
+			return fmt.Errorf("verify: %w", err)
 		}
 	case "verify-seriesfile":
 		name := seriesfile.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("verify-seriesfile: %s", err)
+			return fmt.Errorf("verify-seriesfile: %w", err)
 		}
 	case "verify-tombstone":
 		name := tombstone.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("verify-tombstone: %s", err)
+			return fmt.Errorf("verify-tombstone: %w", err)
 		}
 	default:
 		return fmt.Errorf(`unknown command "%s"`+"\n"+`Run 'influx_inspect help' for usage`, name)

--- a/cmd/influx_inspect/type_conflicts/resolve_conflicts.go
+++ b/cmd/influx_inspect/type_conflicts/resolve_conflicts.go
@@ -1,0 +1,52 @@
+package typecheck
+
+import (
+	"errors"
+	"flag"
+)
+
+type MergeFilesCommand struct {
+	OutputFile    string
+	ConflictsFile string
+}
+
+func NewMergeFilesCommand() *MergeFilesCommand {
+	return &MergeFilesCommand{}
+}
+
+func (rc *MergeFilesCommand) Run(args ...string) error {
+	flags := flag.NewFlagSet("merge-schema", flag.ExitOnError)
+	flags.StringVar(&rc.OutputFile, "schema-file", "schema.json", "Filename for the output file")
+	flags.StringVar(&rc.ConflictsFile, "conflicts-file", "conflicts.json", "Filename conflicts data should be written to")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	return rc.mergeFiles(flags.Args())
+}
+
+func (rc *MergeFilesCommand) mergeFiles(filenames []string) error {
+	if len(filenames) < 1 {
+		return errors.New("At least 1 file must be specified")
+	}
+
+	schema, err := SchemaFromFile(filenames[0])
+	if err != nil {
+		return err
+	}
+
+	for _, filename := range filenames[1:] {
+		other, err := SchemaFromFile(filename)
+		if err != nil {
+			return err
+		}
+		schema.Merge(other)
+	}
+
+	if err := schema.WriteConflictsFile(rc.ConflictsFile); err != nil {
+		return err
+	}
+
+	return schema.WriteSchemaFile(rc.OutputFile)
+}

--- a/cmd/influx_inspect/type_conflicts/schema.go
+++ b/cmd/influx_inspect/type_conflicts/schema.go
@@ -1,0 +1,149 @@
+package typecheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	errors2 "github.com/influxdata/influxdb/pkg/errors"
+)
+
+type UniqueField struct {
+	Database    string `json:"database"`
+	Retention   string `json:"retention"`
+	Measurement string `json:"measurement"`
+	Field       string `json:"field"`
+}
+
+type FieldTypes map[string]struct{}
+type Schema map[string]FieldTypes
+
+func (ft FieldTypes) MarshalText() (text []byte, err error) {
+	s := make([]string, 0, len(ft))
+	for f := range ft {
+		s = append(s, f)
+	}
+	return []byte(fmt.Sprintf("%s", strings.Join(s, ","))), nil
+}
+
+func (ft *FieldTypes) UnmarshalText(text []byte) error {
+	if *ft == nil {
+		*ft = make(FieldTypes)
+	}
+	for _, ty := range strings.Split(string(text), ",") {
+		(*ft)[ty] = struct{}{}
+	}
+	return nil
+}
+
+func NewSchema() Schema {
+	return make(Schema)
+}
+
+func SchemaFromFile(filename string) (Schema, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open schema file %q: %w", filename, err)
+	}
+
+	s := NewSchema()
+	if err := s.Decode(f); err != nil {
+		return nil, fmt.Errorf("unable to decode schema file %q: %w", filename, err)
+	}
+	return s, nil
+}
+
+func (uf *UniqueField) String() string {
+	return fmt.Sprintf("%q.%q.%q.%q", uf.Database, uf.Retention, uf.Measurement, uf.Field)
+}
+
+func (s Schema) AddField(database, retention, measurement, field, dataType string) {
+	uf := UniqueField{
+		Database:    database,
+		Retention:   retention,
+		Measurement: measurement,
+		Field:       field,
+	}
+	s.AddFormattedField(uf.String(), dataType)
+}
+
+func (s Schema) AddFormattedField(field string, dataType string) {
+	if _, ok := s[field]; !ok {
+		s[field] = make(map[string]struct{})
+	}
+	s[field][dataType] = struct{}{}
+}
+
+func (s Schema) Merge(schema Schema) {
+	for field, types := range schema {
+		for t := range types {
+			s.AddFormattedField(field, t)
+		}
+	}
+}
+
+func (s Schema) Conflicts() Schema {
+	cs := NewSchema()
+	for field, t := range s {
+		if len(t) > 1 {
+			for ty := range t {
+				cs.AddFormattedField(field, ty)
+			}
+		}
+	}
+	return cs
+}
+
+func (s Schema) WriteSchemaFile(filename string) error {
+	if len(s) == 0 {
+		fmt.Println("No schema file generated: no valid measurements/fields found")
+		return nil
+	}
+
+	if err := s.encodeSchema(filename); err != nil {
+		return fmt.Errorf("unable to write schema file to %q: %w", filename, err)
+	}
+	fmt.Printf("Schema file written successfully to: %q\n", filename)
+	return nil
+}
+
+func (s Schema) WriteConflictsFile(filename string) error {
+	conflicts := s.Conflicts()
+	if len(conflicts) == 0 {
+		fmt.Println("No conflicts file generated: no conflicts found")
+		return nil
+	}
+
+	if err := conflicts.encodeSchema(filename); err != nil {
+		return fmt.Errorf("unable to write conflicts file to %q: %w", filename, err)
+	}
+	fmt.Printf("Conflicts file written successfully to: %q\n", filename)
+	return nil
+}
+
+func (s Schema) encodeSchema(filename string) (rErr error) {
+	schemaFile, err := os.Create(filename)
+	defer errors2.Capture(&rErr, schemaFile.Close)
+	if err != nil {
+		return fmt.Errorf("unable to create schema file: %w", err)
+	}
+	return s.Encode(schemaFile)
+}
+
+func (s Schema) Encode(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(s); err != nil {
+		return fmt.Errorf("unable to encode schema: %w", err)
+	}
+	return nil
+}
+
+func (s Schema) Decode(r io.Reader) error {
+	if err := json.NewDecoder(r).Decode(&s); err != nil {
+		return fmt.Errorf("unable to decode schema: %w", err)
+	}
+	return nil
+}

--- a/cmd/influx_inspect/type_conflicts/schema_test.go
+++ b/cmd/influx_inspect/type_conflicts/schema_test.go
@@ -1,0 +1,78 @@
+package typecheck_test
+
+import (
+	"bytes"
+	"testing"
+
+	typecheck "github.com/influxdata/influxdb/cmd/influx_inspect/type_conflicts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema_Encoding(t *testing.T) {
+	s := typecheck.NewSchema()
+
+	b := bytes.Buffer{}
+
+	s.AddField("db1", "rp1", "foo", "v2", "float")
+	s.AddField("db1", "rp1", "foo", "v2", "bool")
+	s.AddField("db1", "rp1", "bZ", "v1", "int")
+
+	err := s.Encode(&b)
+	assert.NoError(t, err, "encode failed unexpectedly")
+	s2 := typecheck.NewSchema()
+	err = s2.Decode(&b)
+	assert.NoError(t, err, "decode failed unexpectedly")
+	assert.Len(t, s2, 2, "wrong number of fields - expected %d, got %d", 2, len(s))
+	for f1, fields1 := range s {
+		assert.Len(t,
+			s2[f1],
+			len(fields1),
+			"differing number of types for a conflicted field %s: expected %d, got %d",
+			f1,
+			len(fields1),
+			len(s2[f1]))
+	}
+}
+
+type filler struct {
+	typecheck.UniqueField
+	typ string
+}
+
+func TestSchema_Merge(t *testing.T) {
+	const expectedConflicts = 2
+	s1Fill := []filler{
+		{typecheck.UniqueField{"db1", "rp1", "m1", "f1"}, "integer"},
+		{typecheck.UniqueField{"db2", "rp1", "m1", "f1"}, "float"},
+		{typecheck.UniqueField{"db1", "rp2", "m1", "f1"}, "string"},
+		{typecheck.UniqueField{"db1", "rp1", "m2", "f1"}, "string"},
+		{typecheck.UniqueField{"db1", "rp1", "m1", "f2"}, "float"},
+		{typecheck.UniqueField{"db2", "rp2", "m2", "f2"}, "integer"},
+	}
+
+	s2Fill := []filler{
+		{typecheck.UniqueField{"db1", "rp1", "m1", "f1"}, "integer"},
+		{typecheck.UniqueField{"db2", "rp1", "m1", "f1"}, "string"},
+		{typecheck.UniqueField{"db2", "rp2", "m2", "f2"}, "float"},
+		{typecheck.UniqueField{"db1", "rp2", "m1", "f1"}, "string"},
+		{typecheck.UniqueField{"db1", "rp1", "m2", "f1"}, "string"},
+		{typecheck.UniqueField{"db1", "rp1", "m1", "f2"}, "float"},
+		{typecheck.UniqueField{"db2", "rp2", "m2", "f2"}, "integer"},
+	}
+
+	s1 := typecheck.NewSchema()
+	s2 := typecheck.NewSchema()
+	fillSchema(s1, s1Fill)
+	fillSchema(s2, s2Fill)
+
+	s1.Merge(s2)
+	conflicts := s1.Conflicts()
+
+	assert.Len(t, conflicts, expectedConflicts, "wrong number of type conflicts detected: expected %d, got %d", expectedConflicts, len(conflicts))
+}
+
+func fillSchema(s typecheck.Schema, fill []filler) {
+	for _, f := range fill {
+		s.AddFormattedField(f.String(), f.typ)
+	}
+}

--- a/cmd/influx_inspect/type_conflicts/type_conflicts.go
+++ b/cmd/influx_inspect/type_conflicts/type_conflicts.go
@@ -1,0 +1,100 @@
+package typecheck
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+type TypeConflictChecker struct {
+	Path          string
+	SchemaFile    string
+	ConflictsFile string
+}
+
+func NewTypeConflictCheckerCommand() *TypeConflictChecker {
+	return &TypeConflictChecker{}
+}
+
+func (tc *TypeConflictChecker) Run(args ...string) error {
+	flags := flag.NewFlagSet("check-schema", flag.ExitOnError)
+	flags.StringVar(&tc.Path, "path", ".", "Path under which fields.idx files are located")
+	flags.StringVar(&tc.SchemaFile, "schema-file", "schema.json", "Filename schema data should be written to")
+	flags.StringVar(&tc.ConflictsFile, "conflicts-file", "conflicts.json", "Filename conflicts data should be written to")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	// Get a set of every measurement/field/type tuple present.
+	var schema Schema
+	var err error
+	schema, err = tc.readFields()
+	if err != nil {
+		return err
+	}
+
+	if err := schema.WriteSchemaFile(tc.SchemaFile); err != nil {
+		return err
+	}
+	if err := schema.WriteConflictsFile(tc.ConflictsFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (tc *TypeConflictChecker) readFields() (Schema, error) {
+	schema := NewSchema()
+	var root string
+	fi, err := os.Stat(tc.Path)
+	if err != nil {
+		return nil, err
+	}
+	if fi.IsDir() {
+		root = tc.Path
+	} else {
+		root = path.Dir(tc.Path)
+	}
+	fileSystem := os.DirFS(".")
+	err = fs.WalkDir(fileSystem, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("error walking file: %w", err)
+		}
+		if filepath.Base(path) != "fields.idx" {
+			return nil
+		}
+		dirs := strings.Split(path, string(os.PathSeparator))
+		db := dirs[len(dirs)-4]
+		rp := dirs[len(dirs)-3]
+		fmt.Printf("Processing %s\n", path)
+
+		mfs, err := tsdb.NewMeasurementFieldSet(path)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("unable to open file %q: %w", path, err)
+		}
+		defer mfs.Close()
+
+		measurements := mfs.MeasurementNames()
+		for _, m := range measurements {
+			for f, typ := range mfs.FieldsByString(m).FieldSet() {
+				schema.AddField(db, rp, m, f, typ.String())
+			}
+		}
+
+		return nil
+	})
+
+	return schema, err
+}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1715,6 +1715,20 @@ func (fs *MeasurementFieldSet) Fields(name []byte) *MeasurementFields {
 	return mf
 }
 
+// MeasurementNames returns the names of all the measurements in the field set in
+// lexicographic order.
+func (fs *MeasurementFieldSet) MeasurementNames() []string {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	names := make([]string, 0, len(fs.fields))
+	for name := range fs.fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // FieldsByString returns fields for a measurment by name.
 func (fs *MeasurementFieldSet) FieldsByString(name string) *MeasurementFields {
 	fs.mu.RLock()


### PR DESCRIPTION
adds two commands "check-schema" and
"merge-schema" to influx_inspect.
These test for field type conflicts
in all fields.idx beneath a directory
and merges the derived schemas if
"check-schema" has been run multiple
times on different directories

(cherry picked from commit 84c4f676b040ce8d197977c99a82e6566d4096ce)

Port of https://github.com/influxdata/influxdb/pull/23616 

Doc:
https://github.com/influxdata/docs-v2/issues/4324