### PR TITLE
chore: remove tests from fluxtest skiplist

### DIFF
--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -87,7 +87,7 @@ run_integration_tests() {
   log "Running integration tests..."
   ./fluxtest \
       -v \
-      -p "$HOME/code/flux" \
+      -p flux.zip \
       -p query/ \
       --skip "$(skipped_tests)"
 }
@@ -98,7 +98,7 @@ cleanup() {
 
 main() {
   build_test_harness
-  # download_flux_archive
+  download_flux_archive
   run_integration_tests
   cleanup
 }

--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -78,50 +78,6 @@ remove_sort_aggregate_window
 remove_sort_join
   
 # Other skipped tests
-buckets # unbounded
-columns # failing with differences
-cov # unbounded
-covariance # failing with differences
-cumulative_sum # failing with differences
-cumulative_sum_default # failing with differences
-cumulative_sum_noop # failing with differences
-difference_columns  # failing with differences
-distinct # failing with differences
-fill # failing with differences
-first # unbounded
-group # unbounded
-highestAverage # unbounded
-highestMax # unbounded
-histogram # unbounded
-histogram_quantile # failing with differences
-histogram_quantile_minvalue # failing with error
-join # unbounded
-join_missing_on_col # unbounded
-join_panic # unbounded
-key_values # unbounded
-key_values_host_name # unbounded
-keys # failing with differences
-last # unbounded
-lowestAverage # failing with differences
-map # unbounded
-max # unbounded
-min # unbounded
-pivot_mean # failing with differences
-sample # unbounded
-secrets # failing with error
-selector_preserve_time # failing with differences
-set # failing with differences
-shapeData # failing with differences
-shapeDataWithFilter # failing with differences
-shift # unbounded
-shift_negative_duration # unbounded
-state_changes_big_any_to_any # unbounded
-state_changes_big_info_to_ok # unbounded
-state_changes_big_ok_to_info # unbounded
-union # unbounded
-union_heterogeneous # unbounded
-unique # unbounded
-window_null # failing with differences
 ENDSKIPS
 )
   echo "$doc" | sed '/^[[:space:]]*$/d' | sed 's/[[:space:]]*#.*$//' | tr '\n' ',' | sed 's/,$//'
@@ -131,7 +87,7 @@ run_integration_tests() {
   log "Running integration tests..."
   ./fluxtest \
       -v \
-      -p flux.zip \
+      -p "$HOME/code/flux" \
       -p query/ \
       --skip "$(skipped_tests)"
 }
@@ -142,7 +98,7 @@ cleanup() {
 
 main() {
   build_test_harness
-  download_flux_archive
+  # download_flux_archive
   run_integration_tests
   cleanup
 }


### PR DESCRIPTION
Removes some tests from the skiplist for flux integration tests. Only removes the tests under the `Other` heading. Tests that were in the list for a specific, documented reason were left untouched.

https://github.com/influxdata/flux/pull/5065 needs to merge before this, so this PR may have to wait for a flux release before merging.
