### PR TITLE
fix: improve virtual DBRP default handling

### DIFF
--- a/testing/dbrp_mapping.go
+++ b/testing/dbrp_mapping.go
@@ -669,7 +669,7 @@ func FindManyDBRPMappingsV2(
 						ID:              200,
 						Database:        "testdb2",
 						RetentionPolicy: "testrp2",
-						Default:         true,
+						Default:         false,
 						Virtual:         true,
 						OrganizationID:  MustIDBase16(dbrpOrg3ID),
 						BucketID:        200,
@@ -698,6 +698,7 @@ func FindManyDBRPMappingsV2(
 							// org 2
 							{ID: 300, Name: "testdb3", OrgID: MustIDBase16(dbrpOrg2ID)},
 							{ID: 400, Name: "testdb4/testrp4", OrgID: MustIDBase16(dbrpOrg2ID)},
+							{ID: 500, Name: "testdb4", OrgID: MustIDBase16(dbrpOrg2ID)},
 						}, 0, nil
 					}},
 				DBRPMappingsV2: []*influxdb.DBRPMapping{},
@@ -710,10 +711,19 @@ func FindManyDBRPMappingsV2(
 			wants: wants{
 				dbrpMappings: []*influxdb.DBRPMapping{
 					{
+						ID:              500,
+						Database:        "testdb4",
+						RetentionPolicy: "autogen",
+						Default:         true,
+						Virtual:         true,
+						OrganizationID:  MustIDBase16(dbrpOrg2ID),
+						BucketID:        500,
+					},
+					{
 						ID:              400,
 						Database:        "testdb4",
 						RetentionPolicy: "testrp4",
-						Default:         true,
+						Default:         false,
 						Virtual:         true,
 						OrganizationID:  MustIDBase16(dbrpOrg2ID),
 						BucketID:        400,
@@ -1244,7 +1254,7 @@ func FindDBRPMappingByIDV2(
 					ID:              MustIDBase16(dbrpBucketAID),
 					Database:        "testdb",
 					RetentionPolicy: "testrp",
-					Default:         true,
+					Default:         false,
 					Virtual:         true,
 					OrganizationID:  MustIDBase16(dbrpOrg3ID),
 					BucketID:        MustIDBase16(dbrpBucketAID),


### PR DESCRIPTION
This improves the virtual DBRP default handling. 
- **Before:** a virtual DBRP would be default unless there was another DBRP already set to default for a given _bucket_. 
 - **Now:** a virtual DBRP is default if all of these are true:
   -  The database name has no slashes. cc @lesam 
   (a bucket named `foo` has a default DBRP of `foo`/`autogen`, but a bucket named `foo/bar` would not be default)
   - There is no DBRP, physical or virtual, that is default with the same _database name_ for a given bucket.