### PR TITLE
feat: enable static-pie builds (2.3)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,7 +581,7 @@ jobs:
 
   perf-test:
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:2022.04
     resource_class: small
     parameters:
       record_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     docker:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile
       # in the edge repo, then update the version here to match.
-      - image: quay.io/influxdb/cross-builder:go1.18.4-906fbe93f953b47185818364a186604209dc8da0
+      - image: quay.io/influxdb/cross-builder:go1.18.5-c1ba527d2d7854f003481f0a0aebf55524d4d986
     resource_class: large
   linux-amd64:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
       resource_class: arm.large
   darwin:
     macos:
-      xcode: 12.4.0
+      xcode: 12.5.1
       resource_class: medium
     shell: /bin/bash -eo pipefail
   windows:

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -6,10 +6,10 @@ function build_linux () {
     local cc
     case $(go env GOARCH) in
         amd64)
-            cc=musl-gcc
+            cc=$(xcc linux x86_64)
             ;;
         arm64)
-            cc=aarch64-unknown-linux-musl-gcc
+            cc=$(xcc linux aarch64)
             tags="$tags,noasm"
             ;;
         *)

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -19,17 +19,17 @@ function build_linux () {
     esac
 
     local -r extld="-fno-PIC -static -Wl,-z,stack-size=8388608"
-    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=${cc} go-test-compile \
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="${cc}" go-test-compile \
         -tags "$tags" -o "${1}/" -ldflags "-extldflags '$extld'" ./...
 }
 
 function build_mac () {
-    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=x86_64-apple-darwin18-clang go-test-compile \
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="$(xcc darwin)" go-test-compile \
         -tags sqlite_foreign_keys,sqlite_json -o "${1}/" ./...
 }
 
 function build_windows () {
-    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=x86_64-w64-mingw32-gcc go-test-compile \
+    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="$(xcc windows)" go-test-compile \
         -tags sqlite_foreign_keys,sqlite_json,timetzdata -o "${1}/" ./...
 }
 

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-declare -r LINUX_EXTLD="-fno-PIC -static -Wl,-z,stack-size=8388608"
+declare -r LINUX_EXTLD="-fno-PIC -static-pie -Wl,-z,stack-size=8388608"
 
 function main () {
     if [[ $# != 3 ]]; then
@@ -20,23 +20,26 @@ function main () {
     local -r os_arch="$(go env GOOS)_$(go env GOARCH)"
     case "$os_arch" in
         linux_amd64)
-            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=$(which xcc.sh) go build \
-                -tags assets,sqlite_foreign_keys,sqlite_json,static_build \
-                -buildmode pie \
-                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -extldflags '$LINUX_EXTLD'" \
+            export CC="$(xcc linux x86_64)"
+            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
+                -tags assets,sqlite_foreign_keys,sqlite_json,static_build,noasm \
+                -buildmode=pie \
+                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD}'" \
                 -o "$out_dir/" \
                 "$pkg"
             ;;
         linux_arm64)
-            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=$(which xcc.sh) go build \
+            export CC="$(xcc linux aarch64)"
+            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json,static_build,noasm \
-                -buildmode pie \
-                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -extldflags '$LINUX_EXTLD'" \
+                -buildmode=pie \
+                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD}'" \
                 -o "$out_dir/" \
                 "$pkg"
             ;;
         darwin_amd64)
-            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=$(which xcc.sh) go build \
+            export CC="$(xcc darwin)"
+            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json \
                 -buildmode pie \
                 -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date}" \
@@ -44,7 +47,8 @@ function main () {
                 "$pkg"
             ;;
         windows_amd64)
-            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC=$(which xcc.sh) go build \
+            export CC="$(xcc windows)"
+            CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json,timetzdata \
                 -buildmode exe \
                 -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date}" \


### PR DESCRIPTION
This updates to a new version of cross-builder with a patched version of MUSL. This version of MUSL can generate static-pie binaries as well as be used with new versions of Rust.