### PR TITLE
feat: replicate based on bucket name rather than id

### DIFF
--- a/cmd/influxd/downgrade/downgrade.go
+++ b/cmd/influxd/downgrade/downgrade.go
@@ -123,7 +123,7 @@ func downgrade(ctx context.Context, boltPath, sqlitePath, targetVersion string, 
 	info := influxdb.GetBuildInfo()
 
 	n, err := compareVersionStrings(targetVersion, "2.4.0")
-	if n <= 0 || err != nil {
+	if n < 0 || err != nil {
 		errStr := "if the target version is less than 2.4.0, any replications using bucket names rather than ids will be deleted"
 		log.Warn("downgrade warning", zap.String("targetVersion", errStr))
 	}

--- a/replication.go
+++ b/replication.go
@@ -27,6 +27,7 @@ type Replication struct {
 	RemoteID              platform.ID `json:"remoteID" db:"remote_id"`
 	LocalBucketID         platform.ID `json:"localBucketID" db:"local_bucket_id"`
 	RemoteBucketID        platform.ID `json:"remoteBucketID" db:"remote_bucket_id"`
+	RemoteBucketName      string      `json:"RemoteBucketName" db:"remote_bucket_name"`
 	MaxQueueSizeBytes     int64       `json:"maxQueueSizeBytes" db:"max_queue_size_bytes"`
 	CurrentQueueSizeBytes int64       `json:"currentQueueSizeBytes" db:"current_queue_size_bytes"`
 	LatestResponseCode    *int32      `json:"latestResponseCode,omitempty" db:"latest_response_code"`
@@ -65,6 +66,7 @@ type CreateReplicationRequest struct {
 	RemoteID             platform.ID `json:"remoteID"`
 	LocalBucketID        platform.ID `json:"localBucketID"`
 	RemoteBucketID       platform.ID `json:"remoteBucketID"`
+	RemoteBucketName     string      `json:"remoteBucketName"`
 	MaxQueueSizeBytes    int64       `json:"maxQueueSizeBytes,omitempty"`
 	DropNonRetryableData bool        `json:"dropNonRetryableData,omitempty"`
 	MaxAgeSeconds        int64       `json:"maxAgeSeconds,omitempty"`
@@ -84,6 +86,7 @@ type UpdateReplicationRequest struct {
 	Description          *string      `json:"description,omitempty"`
 	RemoteID             *platform.ID `json:"remoteID,omitempty"`
 	RemoteBucketID       *platform.ID `json:"remoteBucketID,omitempty"`
+	RemoteBucketName     *string      `json:"remoteBucketName,omitempty"`
 	MaxQueueSizeBytes    *int64       `json:"maxQueueSizeBytes,omitempty"`
 	DropNonRetryableData *bool        `json:"dropNonRetryableData,omitempty"`
 	MaxAgeSeconds        *int64       `json:"maxAgeSeconds,omitempty"`
@@ -109,5 +112,6 @@ type ReplicationHTTPConfig struct {
 	RemoteOrgID          platform.ID `db:"remote_org_id"`
 	AllowInsecureTLS     bool        `db:"allow_insecure_tls"`
 	RemoteBucketID       platform.ID `db:"remote_bucket_id"`
+	RemoteBucketName     string      `db:"remote_bucket_name"`
 	DropNonRetryableData bool        `db:"drop_non_retryable_data"`
 }

--- a/replication.go
+++ b/replication.go
@@ -20,20 +20,20 @@ var ErrMaxQueueSizeTooSmall = errors.Error{
 
 // Replication contains all info about a replication that should be returned to users.
 type Replication struct {
-	ID                    platform.ID `json:"id" db:"id"`
-	OrgID                 platform.ID `json:"orgID" db:"org_id"`
-	Name                  string      `json:"name" db:"name"`
-	Description           *string     `json:"description,omitempty" db:"description"`
-	RemoteID              platform.ID `json:"remoteID" db:"remote_id"`
-	LocalBucketID         platform.ID `json:"localBucketID" db:"local_bucket_id"`
-	RemoteBucketID        platform.ID `json:"remoteBucketID" db:"remote_bucket_id"`
-	RemoteBucketName      string      `json:"RemoteBucketName" db:"remote_bucket_name"`
-	MaxQueueSizeBytes     int64       `json:"maxQueueSizeBytes" db:"max_queue_size_bytes"`
-	CurrentQueueSizeBytes int64       `json:"currentQueueSizeBytes" db:"current_queue_size_bytes"`
-	LatestResponseCode    *int32      `json:"latestResponseCode,omitempty" db:"latest_response_code"`
-	LatestErrorMessage    *string     `json:"latestErrorMessage,omitempty" db:"latest_error_message"`
-	DropNonRetryableData  bool        `json:"dropNonRetryableData" db:"drop_non_retryable_data"`
-	MaxAgeSeconds         int64       `json:"maxAgeSeconds" db:"max_age_seconds"`
+	ID                    platform.ID  `json:"id" db:"id"`
+	OrgID                 platform.ID  `json:"orgID" db:"org_id"`
+	Name                  string       `json:"name" db:"name"`
+	Description           *string      `json:"description,omitempty" db:"description"`
+	RemoteID              platform.ID  `json:"remoteID" db:"remote_id"`
+	LocalBucketID         platform.ID  `json:"localBucketID" db:"local_bucket_id"`
+	RemoteBucketID        *platform.ID `json:"remoteBucketID" db:"remote_bucket_id"`
+	RemoteBucketName      string       `json:"RemoteBucketName" db:"remote_bucket_name"`
+	MaxQueueSizeBytes     int64        `json:"maxQueueSizeBytes" db:"max_queue_size_bytes"`
+	CurrentQueueSizeBytes int64        `json:"currentQueueSizeBytes" db:"current_queue_size_bytes"`
+	LatestResponseCode    *int32       `json:"latestResponseCode,omitempty" db:"latest_response_code"`
+	LatestErrorMessage    *string      `json:"latestErrorMessage,omitempty" db:"latest_error_message"`
+	DropNonRetryableData  bool         `json:"dropNonRetryableData" db:"drop_non_retryable_data"`
+	MaxAgeSeconds         int64        `json:"maxAgeSeconds" db:"max_age_seconds"`
 }
 
 // ReplicationListFilter is a selection filter for listing replications.

--- a/replications/internal/store.go
+++ b/replications/internal/store.go
@@ -104,7 +104,7 @@ func (s *Store) CreateReplication(ctx context.Context, newID platform.ID, reques
 		fields["remote_bucket_id"] = request.RemoteBucketID
 		fields["remote_bucket_name"] = ""
 	} else if request.RemoteBucketName != "" {
-		fields["remote_bucket_id"] = platform.ID(1) // 0 isn't a valid ID so we need to set some default value
+		fields["remote_bucket_id"] = nil
 		fields["remote_bucket_name"] = request.RemoteBucketName
 	} else {
 		return nil, errMissingIDName

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -491,6 +491,7 @@ func TestMigrateDownFromReplicationsWithName(t *testing.T) {
 	require.NoError(t, err)
 
 	replications, err := testStore.ListReplications(context.Background(), influxdb.ReplicationListFilter{OrgID: replication.OrgID})
+	require.NoError(t, err)
 	require.Equal(t, 2, len(replications.Replications))
 
 	logger := zaptest.NewLogger(t)

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -27,7 +27,7 @@ var (
 		Description:       &desc,
 		RemoteID:          platform.ID(100),
 		LocalBucketID:     platform.ID(1000),
-		RemoteBucketID:    platform.ID(99999),
+		RemoteBucketID:    idPointer(99999),
 		MaxQueueSizeBytes: 3 * influxdb.DefaultReplicationMaxQueueSizeBytes,
 		MaxAgeSeconds:     0,
 	}
@@ -37,7 +37,7 @@ var (
 		Description:       replication.Description,
 		RemoteID:          replication.RemoteID,
 		LocalBucketID:     replication.LocalBucketID,
-		RemoteBucketID:    replication.RemoteBucketID,
+		RemoteBucketID:    *replication.RemoteBucketID,
 		MaxQueueSizeBytes: replication.MaxQueueSizeBytes,
 		MaxAgeSeconds:     replication.MaxAgeSeconds,
 	}
@@ -46,7 +46,7 @@ var (
 		RemoteToken:      replication.RemoteID.String(),
 		RemoteOrgID:      platform.ID(888888),
 		AllowInsecureTLS: true,
-		RemoteBucketID:   replication.RemoteBucketID,
+		RemoteBucketID:   *replication.RemoteBucketID,
 	}
 	newRemoteID  = platform.ID(200)
 	newQueueSize = influxdb.MinReplicationMaxQueueSizeBytes
@@ -68,6 +68,11 @@ var (
 		MaxAgeSeconds:        replication.MaxAgeSeconds,
 	}
 )
+
+func idPointer(id int) *platform.ID {
+	p := platform.ID(id)
+	return &p
+}
 
 func TestCreateAndGetReplication(t *testing.T) {
 	t.Parallel()
@@ -111,7 +116,7 @@ func TestCreateAndGetReplicationName(t *testing.T) {
 	req.RemoteBucketName = "testbucket"
 	expected := replication
 	expected.RemoteBucketName = "testbucket"
-	expected.RemoteBucketID = platform.ID(1)
+	expected.RemoteBucketID = nil
 
 	// Create a replication, check the results.
 	created, err := testStore.CreateReplication(ctx, initID, req)
@@ -142,7 +147,7 @@ func TestCreateAndGetReplicationNameAndID(t *testing.T) {
 	req.RemoteBucketName = "testbucket"
 	expected := replication
 	expected.RemoteBucketName = ""
-	expected.RemoteBucketID = platform.ID(100)
+	expected.RemoteBucketID = idPointer(100)
 
 	// Create a replication, check the results.
 	created, err := testStore.CreateReplication(ctx, initID, req)

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -93,6 +93,91 @@ func TestCreateAndGetReplication(t *testing.T) {
 	require.Equal(t, replication, *got)
 }
 
+func TestCreateAndGetReplicationName(t *testing.T) {
+	t.Parallel()
+
+	testStore, clean := newTestStore(t)
+	defer clean(t)
+
+	insertRemote(t, testStore, replication.RemoteID)
+
+	// Getting an invalid ID should return an error.
+	got, err := testStore.GetReplication(ctx, initID)
+	require.Equal(t, errReplicationNotFound, err)
+	require.Nil(t, got)
+
+	req := createReq
+	req.RemoteBucketID = platform.ID(0)
+	req.RemoteBucketName = "testbucket"
+	expected := replication
+	expected.RemoteBucketName = "testbucket"
+	expected.RemoteBucketID = platform.ID(1)
+
+	// Create a replication, check the results.
+	created, err := testStore.CreateReplication(ctx, initID, req)
+	require.NoError(t, err)
+	require.Equal(t, expected, *created)
+
+	// Read the created replication and assert it matches the creation response.
+	got, err = testStore.GetReplication(ctx, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, expected, *got)
+}
+
+func TestCreateAndGetReplicationNameAndID(t *testing.T) {
+	t.Parallel()
+
+	testStore, clean := newTestStore(t)
+	defer clean(t)
+
+	insertRemote(t, testStore, replication.RemoteID)
+
+	// Getting an invalid ID should return an error.
+	got, err := testStore.GetReplication(ctx, initID)
+	require.Equal(t, errReplicationNotFound, err)
+	require.Nil(t, got)
+
+	req := createReq
+	req.RemoteBucketID = platform.ID(100)
+	req.RemoteBucketName = "testbucket"
+	expected := replication
+	expected.RemoteBucketName = ""
+	expected.RemoteBucketID = platform.ID(100)
+
+	// Create a replication, check the results.
+	created, err := testStore.CreateReplication(ctx, initID, req)
+	require.NoError(t, err)
+	require.Equal(t, expected, *created)
+
+	// Read the created replication and assert it matches the creation response.
+	got, err = testStore.GetReplication(ctx, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, expected, *got)
+}
+
+func TestCreateAndGetReplicationNameError(t *testing.T) {
+	t.Parallel()
+
+	testStore, clean := newTestStore(t)
+	defer clean(t)
+
+	insertRemote(t, testStore, replication.RemoteID)
+
+	// Getting an invalid ID should return an error.
+	got, err := testStore.GetReplication(ctx, initID)
+	require.Equal(t, errReplicationNotFound, err)
+	require.Nil(t, got)
+
+	req := createReq
+	req.RemoteBucketID = platform.ID(0)
+	req.RemoteBucketName = ""
+
+	// Create a replication, should fail due to missing params
+	created, err := testStore.CreateReplication(ctx, initID, req)
+	require.Equal(t, errMissingIDName, err)
+	require.Nil(t, created)
+}
+
 func TestCreateMissingRemote(t *testing.T) {
 	t.Parallel()
 

--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -208,9 +208,14 @@ func PostWrite(ctx context.Context, config *influxdb.ReplicationHTTPConfig, data
 	conf.HTTPClient.Timeout = timeout
 	client := api.NewAPIClient(conf).WriteApi
 
+	bucket := config.RemoteBucketID.String()
+	if config.RemoteBucketName != "" {
+		bucket = config.RemoteBucketName
+	}
+
 	req := client.PostWrite(ctx).
 		Org(config.RemoteOrgID.String()).
-		Bucket(config.RemoteBucketID.String()).
+		Bucket(bucket).
 		Body(data)
 
 	// Don't set the encoding header for empty bodies, like those used for validation.

--- a/replications/service.go
+++ b/replications/service.go
@@ -140,6 +140,10 @@ func (s *service) CreateReplication(ctx context.Context, request influxdb.Create
 	s.store.Lock()
 	defer s.store.Unlock()
 
+	if request.RemoteID == platform.ID(0) && request.RemoteBucketName == "" {
+		return nil, fmt.Errorf("please supply one of: remoteBucketID, remoteBucketName")
+	}
+
 	if _, err := s.bucketService.FindBucketByID(ctx, request.LocalBucketID); err != nil {
 		return nil, errLocalBucketNotFound(request.LocalBucketID, err)
 	}

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -38,7 +38,7 @@ var (
 		Description:       &desc,
 		RemoteID:          platform.ID(100),
 		LocalBucketID:     platform.ID(1000),
-		RemoteBucketID:    platform.ID(99999),
+		RemoteBucketID:    idPointer(99999),
 		MaxQueueSizeBytes: 3 * influxdb.DefaultReplicationMaxQueueSizeBytes,
 	}
 	replication2 = influxdb.Replication{
@@ -48,7 +48,7 @@ var (
 		Description:       &desc,
 		RemoteID:          platform.ID(100),
 		LocalBucketID:     platform.ID(1000),
-		RemoteBucketID:    platform.ID(99999),
+		RemoteBucketID:    idPointer(99999),
 		MaxQueueSizeBytes: 3 * influxdb.DefaultReplicationMaxQueueSizeBytes,
 	}
 	createReq = influxdb.CreateReplicationRequest{
@@ -57,7 +57,7 @@ var (
 		Description:       replication1.Description,
 		RemoteID:          replication1.RemoteID,
 		LocalBucketID:     replication1.LocalBucketID,
-		RemoteBucketID:    replication1.RemoteBucketID,
+		RemoteBucketID:    *replication1.RemoteBucketID,
 		MaxQueueSizeBytes: replication1.MaxQueueSizeBytes,
 	}
 	newRemoteID          = platform.ID(200)
@@ -94,9 +94,14 @@ var (
 		RemoteToken:      replication1.RemoteID.String(),
 		RemoteOrgID:      platform.ID(888888),
 		AllowInsecureTLS: true,
-		RemoteBucketID:   replication1.RemoteBucketID,
+		RemoteBucketID:   *replication1.RemoteBucketID,
 	}
 )
+
+func idPointer(id int) *platform.ID {
+	p := platform.ID(id)
+	return &p
+}
 
 func TestListReplications(t *testing.T) {
 	t.Parallel()

--- a/replications/transport/http_test.go
+++ b/replications/transport/http_test.go
@@ -35,7 +35,7 @@ var (
 		OrgID:             *orgID,
 		RemoteID:          *remoteID,
 		LocalBucketID:     *localBucketId,
-		RemoteBucketID:    *remoteBucketID,
+		RemoteBucketID:    remoteBucketID,
 		Name:              "example",
 		MaxQueueSizeBytes: influxdb.DefaultReplicationMaxQueueSizeBytes,
 	}
@@ -79,7 +79,7 @@ func TestReplicationHandler(t *testing.T) {
 			Name:           testReplication.Name,
 			RemoteID:       testReplication.RemoteID,
 			LocalBucketID:  testReplication.LocalBucketID,
-			RemoteBucketID: testReplication.RemoteBucketID,
+			RemoteBucketID: *testReplication.RemoteBucketID,
 		}
 
 		t.Run("with explicit queue size", func(t *testing.T) {
@@ -126,7 +126,7 @@ func TestReplicationHandler(t *testing.T) {
 			Name:           testReplication.Name,
 			RemoteID:       testReplication.RemoteID,
 			LocalBucketID:  testReplication.LocalBucketID,
-			RemoteBucketID: testReplication.RemoteBucketID,
+			RemoteBucketID: *testReplication.RemoteBucketID,
 		}
 
 		t.Run("with explicit queue size", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestReplicationHandler(t *testing.T) {
 			Name:              testReplication.Name,
 			RemoteID:          testReplication.RemoteID,
 			LocalBucketID:     testReplication.LocalBucketID,
-			RemoteBucketID:    testReplication.RemoteBucketID,
+			RemoteBucketID:    *testReplication.RemoteBucketID,
 			MaxQueueSizeBytes: influxdb.MinReplicationMaxQueueSizeBytes / 2,
 		}
 

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
@@ -22,8 +22,6 @@ CREATE TABLE replications
     FOREIGN KEY (remote_id) REFERENCES remotes (id)
 );
 
-DELETE FROM _replications_old WHERE remote_bucket_name <> '';
-
 INSERT INTO replications SELECT
     id,
     org_id,
@@ -37,7 +35,7 @@ INSERT INTO replications SELECT
     latest_response_code,
     latest_error_message,
     drop_non_retryable_data,
-    created_at,updated_at FROM _replications_old;
+    created_at,updated_at FROM _replications_old WHERE remote_bucket_name = '';
 DROP TABLE _replications_old;
 
 -- Create indexes on lookup patterns we expect to be common

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
@@ -22,6 +22,8 @@ CREATE TABLE replications
     FOREIGN KEY (remote_id) REFERENCES remotes (id)
 );
 
+DELETE FROM _replications_old WHERE remote_bucket_name <> '';
+
 INSERT INTO replications SELECT
     id,
     org_id,

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.down.sql
@@ -1,0 +1,43 @@
+-- Adds the "NOT NULL" to `remote_bucket_id` and removes `remote_bucket_name`.
+ALTER TABLE replications RENAME TO _replications_old;
+
+CREATE TABLE replications
+(
+    id                       VARCHAR(16) NOT NULL PRIMARY KEY,
+    org_id                   VARCHAR(16) NOT NULL,
+    name                     TEXT        NOT NULL,
+    description              TEXT,
+    remote_id                VARCHAR(16) NOT NULL,
+    local_bucket_id          VARCHAR(16) NOT NULL,
+    remote_bucket_id         VARCHAR(16) NOT NULL,
+    max_queue_size_bytes     INTEGER     NOT NULL,
+    max_age_seconds          INTEGER     NOT NULL,
+    latest_response_code     INTEGER,
+    latest_error_message     TEXT,
+    drop_non_retryable_data  BOOLEAN     NOT NULL,
+    created_at               TIMESTAMP   NOT NULL,
+    updated_at               TIMESTAMP   NOT NULL,
+
+    CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
+    FOREIGN KEY (remote_id) REFERENCES remotes (id)
+);
+
+INSERT INTO replications SELECT
+    id,
+    org_id,
+    name,
+    description,
+    remote_id,
+    local_bucket_id,
+    remote_bucket_id,
+    max_queue_size_bytes,
+    max_age_seconds,
+    latest_response_code,
+    latest_error_message,
+    drop_non_retryable_data,
+    created_at,updated_at FROM _replications_old;
+DROP TABLE _replications_old;
+
+-- Create indexes on lookup patterns we expect to be common
+CREATE INDEX idx_local_bucket_id_per_org ON replications (org_id, local_bucket_id);
+CREATE INDEX idx_remote_id_per_org ON replications (org_id, remote_id);

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
@@ -20,6 +20,7 @@ CREATE TABLE replications
     updated_at               TIMESTAMP   NOT NULL,
 
     CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
+    CONSTRAINT replications_one_of_id_name CHECK (remote_bucket_id IS NOT NULL AND remote_bucket_name != ''),
     FOREIGN KEY (remote_id) REFERENCES remotes (id)
 );
 

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
@@ -20,7 +20,7 @@ CREATE TABLE replications
     updated_at               TIMESTAMP   NOT NULL,
 
     CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
-    CONSTRAINT replications_one_of_id_name CHECK (remote_bucket_id IS NOT NULL AND remote_bucket_name != ''),
+    CONSTRAINT replications_one_of_id_name CHECK (remote_bucket_id IS NOT NULL OR remote_bucket_name != ''),
     FOREIGN KEY (remote_id) REFERENCES remotes (id)
 );
 

--- a/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
+++ b/sqlite/migrations/0007_migrate_replications_add_bucket_name.up.sql
@@ -1,0 +1,45 @@
+-- Removes the "NOT NULL" from `remote_bucket_id` and adds `remote_bucket_name`.
+ALTER TABLE replications RENAME TO _replications_old;
+
+CREATE TABLE replications
+(
+    id                       VARCHAR(16) NOT NULL PRIMARY KEY,
+    org_id                   VARCHAR(16) NOT NULL,
+    name                     TEXT        NOT NULL,
+    description              TEXT,
+    remote_id                VARCHAR(16) NOT NULL,
+    local_bucket_id          VARCHAR(16) NOT NULL,
+    remote_bucket_id         VARCHAR(16),
+    remote_bucket_name       TEXT DEFAULT '',
+    max_queue_size_bytes     INTEGER     NOT NULL,
+    max_age_seconds          INTEGER     NOT NULL,
+    latest_response_code     INTEGER,
+    latest_error_message     TEXT,
+    drop_non_retryable_data  BOOLEAN     NOT NULL,
+    created_at               TIMESTAMP   NOT NULL,
+    updated_at               TIMESTAMP   NOT NULL,
+
+    CONSTRAINT replications_uniq_orgid_name UNIQUE (org_id, name),
+    FOREIGN KEY (remote_id) REFERENCES remotes (id)
+);
+
+INSERT INTO replications (
+    id,
+    org_id,
+    name,
+    description,
+    remote_id,
+    local_bucket_id,
+    remote_bucket_id,
+    max_queue_size_bytes,
+    max_age_seconds,
+    latest_response_code,
+    latest_error_message,
+    drop_non_retryable_data,
+    created_at,updated_at
+) SELECT * FROM _replications_old;
+DROP TABLE _replications_old;
+
+-- Create indexes on lookup patterns we expect to be common
+CREATE INDEX idx_local_bucket_id_per_org ON replications (org_id, local_bucket_id);
+CREATE INDEX idx_remote_id_per_org ON replications (org_id, remote_id);


### PR DESCRIPTION
- This adds compatibility with 1.x replication targets

- Closes #23550
### Required checklist
- [x] openapi swagger.yml updated (if modified API) - link openapi PR https://github.com/influxdata/openapi/pull/478

### Description
Replications now support using a bucket name instead of a bucket id. This will allow replications to a 1.x instance.

### Context
The main value in this addition is full compatibility with replicating to enterprise 1.x instances.

### Affected areas (delete section if not relevant):
CLI change (add --replication-bucket flag) https://github.com/influxdata/influx-cli/pull/440
API change (add replicationBucketName to several replication routes) https://github.com/influxdata/openapi/pull/478

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
