### PR TITLE
refactor: remove reference to flux.Spec in query tests

### DIFF
--- a/http/query_test.go
+++ b/http/query_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
@@ -28,13 +27,11 @@ var cmpOptions = cmp.Options{
 	cmpopts.IgnoreTypes(ast.BaseNode{}),
 	cmpopts.IgnoreUnexported(query.ProxyRequest{}),
 	cmpopts.IgnoreUnexported(query.Request{}),
-	cmpopts.IgnoreUnexported(flux.Spec{}),
 	cmpopts.EquateEmpty(),
 }
 
 func TestQueryRequest_WithDefaults(t *testing.T) {
 	type fields struct {
-		Spec    *flux.Spec
 		AST     json.RawMessage
 		Query   string
 		Type    string
@@ -192,7 +189,6 @@ func TestQueryRequest_Validate(t *testing.T) {
 func TestQueryRequest_proxyRequest(t *testing.T) {
 	type fields struct {
 		Extern  json.RawMessage
-		Spec    *flux.Spec
 		AST     json.RawMessage
 		Query   string
 		Type    string

--- a/http/source_service.go
+++ b/http/source_service.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/httprouter"
@@ -143,7 +142,6 @@ func NewSourceHandler(log *zap.Logger, b *SourceBackend) *SourceHandler {
 func decodeSourceQueryRequest(r *http.Request) (*query.ProxyRequest, error) {
 	// starts here
 	request := struct {
-		Spec           *flux.Spec  `json:"spec"`
 		Query          string      `json:"query"`
 		Type           string      `json:"type"`
 		DB             string      `json:"db"`


### PR DESCRIPTION
It appears to be dead and not used anymore.

### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Context
Why was this added? What value does it add? What are risks/best practices?

It's removing some dead code that I want to refactor in the flux library
itself.

### Affected areas (delete section if not relevant):
Should affect nothing.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes