### PR TITLE
fix: use copy of loop variable in parallel test

### DIFF
--- a/sqlite/migrator_test.go
+++ b/sqlite/migrator_test.go
@@ -201,6 +201,7 @@ func TestScriptVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
### Description
This fixes an occurrence of a loop variable being captured in a
parallel test. With the previous code, only the last test case is
actually exercised. To work around this problem, we create a local
copy of the range variable before the parallel test, as suggested in
the Go documentation for the `testing` package:

https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks

### Context
Issue was found automatically using the `loopvarcapture` linter.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
