### PR TITLE
fix: don't allow creating an auth with instance resources

### DIFF
--- a/authorization/middleware_auth.go
+++ b/authorization/middleware_auth.go
@@ -34,6 +34,11 @@ func (s *AuthedAuthorizationService) CreateAuthorization(ctx context.Context, a 
 	if err := authorizer.VerifyPermissions(ctx, a.Permissions); err != nil {
 		return err
 	}
+	for _, v := range a.Permissions {
+		if v.Resource.Type == influxdb.InstanceResourceType {
+			return fmt.Errorf("authorizations cannot be created with the instance type, it is only used during setup")
+		}
+	}
 
 	return s.s.CreateAuthorization(ctx, a)
 }


### PR DESCRIPTION
- Closes #23668

### Description
Fail earlier and with a better error message when trying to create an auth with instance type.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
