### PR TITLE
fix: better file permissions on new installs

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -60,7 +60,7 @@ var errShutdown = errors.New("shutdown tasks for replications durable queues fai
 func NewDurableQueueManager(log *zap.Logger, queuePath string, metrics *metrics.ReplicationsMetrics, configStore remotewrite.HttpConfigStore) *durableQueueManager {
 	replicationQueues := make(map[platform.ID]*replicationQueue)
 
-	os.MkdirAll(queuePath, 0777)
+	os.MkdirAll(queuePath, 0700)
 
 	return &durableQueueManager{
 		replicationQueues: replicationQueues,
@@ -86,7 +86,7 @@ func (qm *durableQueueManager) InitializeQueue(replicationID platform.ID, maxQue
 		qm.queuePath,
 		replicationID.String(),
 	)
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -44,10 +44,11 @@ func NewSqlStore(path string, log *zap.Logger) (*SqlStore, error) {
 	if path != InmemPath {
 		// On new installs, set the file permissions correctly
 		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-			_, err := os.OpenFile(path, os.O_CREATE, 0600)
+			f, err := os.OpenFile(path, os.O_CREATE, 0600)
 			if err != nil {
 				return nil, err
 			}
+			f.Close()
 		}
 	}
 

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -38,6 +39,16 @@ func NewSqlStore(path string, log *zap.Logger) (*SqlStore, error) {
 	s := &SqlStore{
 		log:  log,
 		path: path,
+	}
+
+	if path != InmemPath {
+		// On new installs, set the file permissions correctly
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			_, err := os.OpenFile(path, os.O_CREATE, 0600)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if err := s.openDB(); err != nil {

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -701,7 +701,7 @@ func (cl *CacheLoader) Load(cache *Cache) error {
 	var r *WALSegmentReader
 	for _, fn := range cl.files {
 		if err := func() error {
-			f, err := os.OpenFile(fn, os.O_CREATE|os.O_RDWR, 0666)
+			f, err := os.OpenFile(fn, os.O_CREATE|os.O_RDWR, 0600)
 			if err != nil {
 				return err
 			}

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1097,7 +1097,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 }
 
 func (c *Compactor) write(path string, iter KeyIterator, throttle bool, logger *zap.Logger) (err error) {
-	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0666)
+	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
 	if err != nil {
 		return errCompactionInProgress{err: err}
 	}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2974,7 +2974,7 @@ func MustTSMWriter(dir string, gen int) (tsm1.TSMWriter, string) {
 	}
 
 	var err error
-	f, err = os.OpenFile(newName, os.O_RDWR, 0666)
+	f, err = os.OpenFile(newName, os.O_RDWR, 0600)
 	if err != nil {
 		panic(fmt.Sprintf("open tsm files: %v", err))
 	}

--- a/tsdb/engine/tsm1/digest_test.go
+++ b/tsdb/engine/tsm1/digest_test.go
@@ -425,7 +425,7 @@ func TestDigest_Manifest(t *testing.T) {
 	}
 
 	// Open one of the tsm files and write data to it.
-	f, err := os.OpenFile(files[0], os.O_WRONLY|os.O_APPEND, 0666)
+	f, err := os.OpenFile(files[0], os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -292,7 +292,7 @@ func (e *Engine) Digest() (io.ReadCloser, int64, error) {
 	// so generate a new digest.
 
 	// Make sure the directory exists, in case it was deleted for some reason.
-	if err := os.MkdirAll(e.path, 0777); err != nil {
+	if err := os.MkdirAll(e.path, 0700); err != nil {
 		log.Info("Digest aborted, problem creating shard directory path", zap.Error(err))
 		return nil, 0, err
 	}
@@ -711,7 +711,7 @@ func (e *Engine) DiskSize() int64 {
 
 // Open opens and initializes the engine.
 func (e *Engine) Open(ctx context.Context) error {
-	if err := os.MkdirAll(e.path, 0777); err != nil {
+	if err := os.MkdirAll(e.path, 0700); err != nil {
 		return err
 	}
 
@@ -999,7 +999,7 @@ func (e *Engine) Export(w io.Writer, basePath string, start time.Time, end time.
 
 func (e *Engine) filterFileToBackup(r *TSMReader, fi os.FileInfo, shardRelativePath, fullPath string, start, end int64, tw *tar.Writer) error {
 	path := fullPath + ".tmp"
-	out, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0666)
+	out, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return err
 	}
@@ -1205,7 +1205,7 @@ func (e *Engine) readFileFromBackup(tr *tar.Reader, shardRelativePath string, as
 
 	tmp := fmt.Sprintf("%s.%s", filepath.Join(e.path, filename), TmpTSMFileExtension)
 	// Create new file on disk.
-	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_RDWR, 0666)
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return "", err
 	}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -382,7 +382,7 @@ func TestEngine_Backup(t *testing.T) {
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
-	os.MkdirAll(walPath, 0777)
+	os.MkdirAll(walPath, 0700)
 	defer os.RemoveAll(f.Name())
 
 	// Create a few points.
@@ -501,7 +501,7 @@ func TestEngine_Export(t *testing.T) {
 	f.Close()
 	os.Remove(f.Name())
 	walPath := filepath.Join(f.Name(), "wal")
-	os.MkdirAll(walPath, 0777)
+	os.MkdirAll(walPath, 0700)
 	defer os.RemoveAll(f.Name())
 
 	// Create a few points.
@@ -1832,7 +1832,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	// Generate temporary file.
 	dir, _ := os.MkdirTemp("", "tsm")
 	walPath := filepath.Join(dir, "wal")
-	os.MkdirAll(walPath, 0777)
+	os.MkdirAll(walPath, 0700)
 	defer os.RemoveAll(dir)
 
 	// Create a tsm1 engine.

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -582,7 +582,7 @@ func (f *FileStore) Open(ctx context.Context) error {
 			f.currentGeneration = generation + 1
 		}
 
-		file, err := os.OpenFile(fn, os.O_RDONLY, 0666)
+		file, err := os.OpenFile(fn, os.O_RDONLY, 0600)
 		if err != nil {
 			return fmt.Errorf("error opening file %s: %v", fn, err)
 		}
@@ -1237,7 +1237,7 @@ func (f *FileStore) CreateSnapshot() (string, error) {
 
 	// create the tmp directory and add the hard links. there is no longer any shared
 	// mutable state.
-	err := os.Mkdir(tmpPath, 0777)
+	err := os.Mkdir(tmpPath, 0700)
 	if err != nil {
 		return "", err
 	}

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -305,7 +305,7 @@ func (t *Tombstoner) prepareV4() error {
 	}
 
 	tmpPath := fmt.Sprintf("%s.%s", t.tombstonePath(), CompactionTempExtension)
-	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0666)
+	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -240,7 +240,7 @@ func (l *WAL) Open() error {
 	l.traceLogger.Info("tsm1 WAL starting", zap.Int("segment_size", l.SegmentSize))
 	l.traceLogger.Info("tsm1 WAL writing", zap.String("path", l.path))
 
-	if err := os.MkdirAll(l.path, 0777); err != nil {
+	if err := os.MkdirAll(l.path, 0700); err != nil {
 		return err
 	}
 
@@ -266,7 +266,7 @@ func (l *WAL) Open() error {
 			os.Remove(lastSegment)
 			segments = segments[:len(segments)-1]
 		} else {
-			fd, err := os.OpenFile(lastSegment, os.O_RDWR, 0666)
+			fd, err := os.OpenFile(lastSegment, os.O_RDWR, 0600)
 			if err != nil {
 				return err
 			}
@@ -635,7 +635,7 @@ func (l *WAL) newSegmentFile() error {
 	}
 
 	fileName := filepath.Join(l.path, fmt.Sprintf("%s%05d.%s", WALFilePrefix, l.currentSegmentID, WALFileExtension))
-	fd, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, 0666)
+	fd, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -808,7 +808,7 @@ func mustSegmentReader(t *testing.T, w *tsm1.WAL) (*os.File, *tsm1.WALSegmentRea
 
 	sort.Strings(files)
 
-	f, err := os.OpenFile(files[0], os.O_CREATE|os.O_RDWR, 0666)
+	f, err := os.OpenFile(files[0], os.O_CREATE|os.O_RDWR, 0600)
 	require.NoError(t, err)
 	return f, tsm1.NewWALSegmentReader(f)
 }

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -562,7 +562,7 @@ func NewTSMWriterWithDiskBuffer(w io.Writer) (TSMWriter, error) {
 	var index IndexWriter
 	// Make sure is a File so we can write the temp index alongside it.
 	if fw, ok := w.(syncer); ok {
-		f, err := os.OpenFile(strings.TrimSuffix(fw.Name(), ".tsm.tmp")+".idx.tmp", os.O_CREATE|os.O_RDWR|os.O_EXCL, 0666)
+		f, err := os.OpenFile(strings.TrimSuffix(fw.Name(), ".tsm.tmp")+".idx.tmp", os.O_CREATE|os.O_RDWR|os.O_EXCL, 0600)
 		if err != nil {
 			return nil, err
 		}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -262,7 +262,7 @@ func (i *Index) Open() (rErr error) {
 	}
 
 	// Ensure root exists.
-	if err := os.MkdirAll(i.path, 0777); err != nil {
+	if err := os.MkdirAll(i.path, 0700); err != nil {
 		return err
 	}
 

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -218,7 +218,7 @@ func TestIndex_OpenFail(t *testing.T) {
 	idx.Index.Close()
 	// mess up the index:
 	tslPath := path.Join(idx.Index.Path(), "3", "L0-00000001.tsl")
-	tslFile, err := os.OpenFile(tslPath, os.O_RDWR, 0666)
+	tslFile, err := os.OpenFile(tslPath, os.O_RDWR, 0600)
 	require.NoError(t, err)
 	require.NoError(t, tslFile.Truncate(0))
 	// write poisonous TSL file - first byte doesn't matter, remaining bytes are an invalid uvarint
@@ -278,7 +278,7 @@ func TestIndex_Open(t *testing.T) {
 			// Manually create a MANIFEST file for an incompatible index version.
 			// under one of the partitions.
 			partitionPath := filepath.Join(idx.Path(), "2")
-			os.MkdirAll(partitionPath, 0777)
+			os.MkdirAll(partitionPath, 0700)
 
 			mpath := filepath.Join(partitionPath, tsi1.ManifestFileName)
 			m := tsi1.NewManifest(mpath)

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -123,7 +123,7 @@ func (f *LogFile) open() error {
 	f.id, _ = ParseFilename(f.path)
 
 	// Open file for appending.
-	file, err := os.OpenFile(f.Path(), os.O_WRONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(f.Path(), os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -292,7 +292,7 @@ func TestLogFile_Open(t *testing.T) {
 		buf[len(buf)-1] = 0
 
 		// Overwrite file with corrupt entry and reopen.
-		if err := os.WriteFile(f.LogFile.Path(), buf, 0666); err != nil {
+		if err := os.WriteFile(f.LogFile.Path(), buf, 0600); err != nil {
 			t.Fatal(err)
 		} else if err := f.LogFile.Open(); err != nil {
 			t.Fatal(err)

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -167,7 +167,7 @@ func (p *Partition) Open() (rErr error) {
 	}
 
 	// Create directory if it doesn't exist.
-	if err := os.MkdirAll(p.path, 0777); err != nil {
+	if err := os.MkdirAll(p.path, 0700); err != nil {
 		return err
 	}
 
@@ -1463,7 +1463,7 @@ func (m *Manifest) Write() (int64, error) {
 
 		tmp = f.Name()
 
-		if err = f.Chmod(0666); err != nil {
+		if err = f.Chmod(0600); err != nil {
 			return fmt.Errorf("failed setting permissions on manifest file %q: %w", tmp, err)
 		}
 		if _, err = f.Write(buf); err != nil {

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -268,7 +268,7 @@ func MustTempDir() string {
 func MustTempPartitionDir() string {
 	path := MustTempDir()
 	path = filepath.Join(path, "0")
-	if err := os.Mkdir(path, 0777); err != nil {
+	if err := os.Mkdir(path, 0700); err != nil {
 		panic(err)
 	}
 	return path

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -76,7 +76,7 @@ func (f *SeriesFile) Open() error {
 	defer f.refs.Unlock()
 
 	// Create path if it doesn't exist.
-	if err := os.MkdirAll(filepath.Join(f.path), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Join(f.path), 0700); err != nil {
 		return err
 	}
 

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -337,7 +337,7 @@ func NewBrokenSeriesFile(content []byte) *SeriesFile {
 	if _, err := os.Stat(segPath); os.IsNotExist(err) {
 		panic(err)
 	}
-	err := os.WriteFile(segPath, content, 0777)
+	err := os.WriteFile(segPath, content, 0700)
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -69,7 +69,7 @@ func (p *SeriesPartition) Open() error {
 	}
 
 	// Create path if it doesn't exist.
-	if err := os.MkdirAll(filepath.Join(p.path), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Join(p.path), 0700); err != nil {
 		return err
 	}
 

--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -93,6 +93,8 @@ func CreateSeriesSegment(id uint16, path string) (*SeriesSegment, error) {
 func (s *SeriesSegment) Open() error {
 	if err := func() (err error) {
 		// Memory map file data.
+		os.Chmod(s.path, 0600)
+
 		if s.data, err = mmap.Map(s.path, int64(SeriesSegmentSize(s.id))); err != nil {
 			return err
 		}
@@ -130,7 +132,7 @@ func (s *SeriesSegment) InitForWrite() (err error) {
 	}
 
 	// Open file handler for writing & seek to end of data.
-	if s.file, err = os.OpenFile(s.path, os.O_WRONLY|os.O_CREATE, 0666); err != nil {
+	if s.file, err = os.OpenFile(s.path, os.O_WRONLY|os.O_CREATE, 0600); err != nil {
 		return err
 	} else if _, err := s.file.Seek(int64(s.size), io.SeekStart); err != nil {
 		return err

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2103,7 +2103,7 @@ func (fs *MeasurementFieldSet) writeToFile(first writeRequest) {
 	path := fs.path + ".tmp"
 
 	// Open the temp file
-	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL|os.O_SYNC, 0666)
+	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL|os.O_SYNC, 0600)
 	if err != nil {
 		return
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -1641,7 +1641,7 @@ func TestMeasurementFieldSet_InvalidFormat(t *testing.T) {
 
 	path := filepath.Join(dir, "fields.idx")
 
-	if err := os.WriteFile(path, []byte{0, 0}, 0666); err != nil {
+	if err := os.WriteFile(path, []byte{0, 0}, 0600); err != nil {
 		t.Fatalf("error writing fields.index: %v", err)
 	}
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -254,7 +254,7 @@ func (s *Store) Open(ctx context.Context) error {
 	s.Logger.Info("Using data dir", zap.String("path", s.Path()))
 
 	// Create directory.
-	if err := os.MkdirAll(s.path, 0777); err != nil {
+	if err := os.MkdirAll(s.path, 0700); err != nil {
 		return err
 	}
 
@@ -1147,7 +1147,6 @@ func (s *Store) sketchesForDatabase(dbName string, getSketches func(*Shard) (est
 //
 // Cardinality is calculated exactly by unioning all shards' bitsets of series
 // IDs. The result of this method cannot be combined with any other results.
-//
 func (s *Store) SeriesCardinality(ctx context.Context, database string) (int64, error) {
 	s.mu.RLock()
 	shards := s.filterShards(byDatabase(database))

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -440,15 +440,15 @@ func TestStore_Open(t *testing.T) {
 		s := NewStore(t, index)
 		defer s.Close()
 
-		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0", "2"), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0", "2"), 0700); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp2", "4"), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp2", "4"), 0700); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := os.MkdirAll(filepath.Join(s.Path(), "db1", "rp0", "1"), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db1", "rp0", "1"), 0700); err != nil {
 			t.Fatal(err)
 		}
 
@@ -508,7 +508,7 @@ func TestStore_Open_InvalidRetentionPolicy(t *testing.T) {
 		defer s.Close()
 
 		// Create an RP file instead of a directory.
-		if err := os.MkdirAll(filepath.Join(s.Path(), "db0"), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0"), 0700); err != nil {
 			t.Fatal(err)
 		} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0")); err != nil {
 			t.Fatal(err)
@@ -537,7 +537,7 @@ func TestStore_Open_InvalidShard(t *testing.T) {
 		defer s.Close()
 
 		// Create a non-numeric shard file.
-		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0"), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0"), 0700); err != nil {
 			t.Fatal(err)
 		} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0", "bad_shard")); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Closes https://github.com/influxdata/edge/issues/294

### Description
Creates files in new installs without world-read permission as was done before.

### Context
This is a better default practice, users can open up permissions if desired.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes


<img width="722" alt="Screen Shot 2022-08-25 at 12 35 53" src="https://user-images.githubusercontent.com/26460069/186721239-a9e16155-e176-48fe-8f19-396dd36d3dcc.png">

