### PR TITLE
fix: set limited permissions on package installs

### DIFF
--- a/.circleci/package/control/postinst
+++ b/.circleci/package/control/postinst
@@ -111,8 +111,8 @@ elif [[ -f /etc/debian_version ]]; then
     # Moving these lines out of this if statement would make `rmp -V` fail after installation.
     chown -R -L influxdb:influxdb $LOG_DIR
     chown -R -L influxdb:influxdb $DATA_DIR
-    chmod 755 $LOG_DIR
-    chmod 755 $DATA_DIR
+    chmod 750 $LOG_DIR
+    chmod 750 $DATA_DIR
 
     # Debian/Ubuntu logic
     if command -v systemctl &>/dev/null; then

--- a/.circleci/package/fs/usr/lib/influxdb/scripts/influxdb.service
+++ b/.circleci/package/fs/usr/lib/influxdb/scripts/influxdb.service
@@ -15,6 +15,7 @@ KillMode=control-group
 Restart=on-failure
 Type=forking
 PIDFile=/var/lib/influxdb/influxd.pid
+UMask=0027
 
 [Install]
 WantedBy=multi-user.target

--- a/.circleci/scripts/build-package
+++ b/.circleci/scripts/build-package
@@ -58,7 +58,10 @@ function run_fpm()
       --after-remove   control/postrm                      \
       `# package files`                                    \
       --chdir          fs/                                 \
-      --package        /artifacts
+      --package        /artifacts                          \
+      --directories    /var/lib/influxdb                   \
+      --rpm-defattrdir 750                                 \
+      --rpm-defattrfile 750
 
     popd
 


### PR DESCRIPTION
- Closes https://github.com/influxdata/edge/issues/294

### Description
Tightens permissions on the default install directory.
 
### Context
This is follows best practices around access controls.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
