### PR TITLE
fix: fix wrong max age transformation from seconds

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -447,7 +447,7 @@ func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platfor
 	if maxAgeSeconds < 0 {
 		maxAgeTime = defaultMaxAge
 	} else {
-		maxAgeTime = time.Duration(time.Duration(maxAgeSeconds) * time.Second)
+		maxAgeTime = time.Duration(maxAgeSeconds) * time.Second
 	}
 
 	return &replicationQueue{

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -21,7 +21,7 @@ import (
 const (
 	scannerAdvanceInterval = 10 * time.Second
 	purgeInterval          = 60 * time.Second
-	defaultMaxAge          = 168 * time.Hour
+	defaultMaxAge          = 7 * 24 * time.Hour // 1 week
 )
 
 type remoteWriter interface {

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -21,7 +21,7 @@ import (
 const (
 	scannerAdvanceInterval = 10 * time.Second
 	purgeInterval          = 60 * time.Second
-	defaultMaxAge          = 168 * time.Hour / time.Second
+	defaultMaxAge          = 168 * time.Hour
 )
 
 type remoteWriter interface {
@@ -72,7 +72,7 @@ func NewDurableQueueManager(log *zap.Logger, queuePath string, metrics *metrics.
 }
 
 // InitializeQueue creates and opens a new durable queue which is associated with a replication stream.
-func (qm *durableQueueManager) InitializeQueue(replicationID platform.ID, maxQueueSizeBytes int64, orgID platform.ID, localBucketID platform.ID, maxAge int64) error {
+func (qm *durableQueueManager) InitializeQueue(replicationID platform.ID, maxQueueSizeBytes int64, orgID platform.ID, localBucketID platform.ID, maxAgeSeconds int64) error {
 	qm.mutex.Lock()
 	defer qm.mutex.Unlock()
 
@@ -112,7 +112,7 @@ func (qm *durableQueueManager) InitializeQueue(replicationID platform.ID, maxQue
 	}
 
 	// Map new durable queue and scanner to its corresponding replication stream via replication ID
-	rq := qm.newReplicationQueue(replicationID, orgID, localBucketID, newQueue, maxAge)
+	rq := qm.newReplicationQueue(replicationID, orgID, localBucketID, newQueue, maxAgeSeconds)
 	qm.replicationQueues[replicationID] = rq
 	rq.Open()
 
@@ -439,15 +439,15 @@ func (qm *durableQueueManager) EnqueueData(replicationID platform.ID, data []byt
 	return nil
 }
 
-func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platform.ID, localBucketID platform.ID, queue *durablequeue.Queue, maxAge int64) *replicationQueue {
+func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platform.ID, localBucketID platform.ID, queue *durablequeue.Queue, maxAgeSeconds int64) *replicationQueue {
 	logger := qm.logger.With(zap.String("replication_id", id.String()))
 	done := make(chan struct{})
 	// check for max age minimum
 	var maxAgeTime time.Duration
-	if maxAge < 0 {
+	if maxAgeSeconds < 0 {
 		maxAgeTime = defaultMaxAge
 	} else {
-		maxAgeTime = time.Duration(maxAge)
+		maxAgeTime = time.Duration(time.Duration(maxAgeSeconds) * time.Second)
 	}
 
 	return &replicationQueue{


### PR DESCRIPTION
- Closes https://github.com/influxdata/influxdb/issues/23681
### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
1-3 sentences describing the PR (or link to well written issue)

Creating a replication stream with maxAgeSeconds (following this guide https://docs.influxdata.com/influxdb/v2.4/write-data/replication/replicate-data/?t=API)
Creates a replication stream with max age in nanoseconds (100_000_000ns = 1s) which makes the maxAgeSeconds=604800 in the docs to be 0.6048ms instead of 168h

Related issue https://github.com/influxdata/influxdb/issues/23681

### Context
Why was this added? What value does it add? What are risks/best practices?

Converts the maxAgeSeconds to be seconds instead of nanoseconds.

### Affected areas (delete section if not relevant):
List of user-visible changes. As a user, what would I need to see in docs?
Examples:
CLI commands, subcommands, and flags
API changes
Configuration (sample config blocks)

A quick workaround was to add 100_000_000 to the value stored in maxAgeSeconds. Using this fix would make those 100_000_000 times longer.

### Severity (delete section if not relevant)
 i.e., ("recommend to upgrade immediately", "upgrade at your leisure", etc.)

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
