### PR TITLE
chore: add protoc-gen script to releng (2.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,17 @@ orbs:
   aws-s3:    circleci/aws-s3@2.0.0
   terraform: circleci/terraform@2.1.0
 
+parameters:
+  cross-container-tag:
+    type: string
+    default: go1.18.5-81cd97477f9a6c9f2db03dc56f560bf54f8da8bb
+
 executors:
   cross-builder:
     docker:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile
       # in the edge repo, then update the version here to match.
-      - image: quay.io/influxdb/cross-builder:go1.18.5-bc9c7f5b200055b18d50111c54d3aa59fc798d5f
+      - image: quay.io/influxdb/cross-builder:<< pipeline.parameters.cross-container-tag >>
     resource_class: large
   linux-amd64:
     machine:

--- a/releng/protoc-gen
+++ b/releng/protoc-gen
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+ROOT="$(realpath "${BASH_SOURCE}")" # -> <project root>/releng/protoc-gen
+ROOT="$(dirname "${ROOT}")"         # -> <project root>/releng/
+ROOT="$(dirname "${ROOT}")"         # -> <project root>/
+
+(
+  # Since this script is run outside of a docker container, it is
+  # possible that one (or more) of the following executables is
+  # not installed.
+  set -x
+  which docker
+  which sudo
+  which yq
+) 1>/dev/null
+
+CROSS_BUILDER_VERSION="$(yq -e eval '.parameters.cross-container-tag.default' "${ROOT}/.circleci/config.yml")"
+
+# Updating ownership within the container requires both the "UID" and "GID"
+# of the current user. Since the current user does not exist within the
+# container, "${USER}:" cannot be supplied to `chown`.
+USER_UID="$(id -u)"
+USER_GID="$(id -g)"
+
+read -d '' DOCKERSCRIPT <<EOF || true
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+touch /tmp/timestamp
+
+pushd /project
+
+go generate ./...
+
+# If the previous command generated a new file, it will have "root:root"
+# ownership. This becomes an annoyance to work with (i.e git complains
+# when checking out branches). To circumvent this issue, update all
+# new files to the correct ownership.
+find . -newer /tmp/timestamp -exec chown -v "${USER_UID}:${USER_GID}" "{}" \\\;
+EOF
+
+sudo docker run --rm -it -v "$(pwd):/project" "quay.io/influxdb/cross-builder:${CROSS_BUILDER_VERSION}" bash -c "${DOCKERSCRIPT}"
+

--- a/releng/protoc-gen
+++ b/releng/protoc-gen
@@ -32,9 +32,11 @@ set -o errexit \
 
 touch /tmp/timestamp
 
+git config --global --add safe.directory /project
+
 pushd /project
 
-go generate ./...
+make generate-sources
 
 # If the previous command generated a new file, it will have "root:root"
 # ownership. This becomes an annoyance to work with (i.e git complains
@@ -43,5 +45,5 @@ go generate ./...
 find . -newer /tmp/timestamp -exec chown -v "${USER_UID}:${USER_GID}" "{}" \\\;
 EOF
 
-sudo docker run --rm -it -v "$(pwd):/project" "quay.io/influxdb/cross-builder:${CROSS_BUILDER_VERSION}" bash -c "${DOCKERSCRIPT}"
+sudo docker run --rm -it -v "${ROOT}:/project" "quay.io/influxdb/cross-builder:${CROSS_BUILDER_VERSION}" bash -c "${DOCKERSCRIPT}"
 


### PR DESCRIPTION
This script generates go code using the same version of protobuf from the cross-builder.