### PR TITLE
fix: check that user IDs are not in use in user create

### DIFF
--- a/tenant/error_user.go
+++ b/tenant/error_user.go
@@ -46,6 +46,15 @@ func UserAlreadyExistsError(n string) *errors.Error {
 	}
 }
 
+// UserIDAlreadyExistsError is used when attempting to create a user with an ID
+// that already exists.
+func UserIDAlreadyExistsError(id string) *errors.Error {
+	return &errors.Error{
+		Code: errors.EConflict,
+		Msg:  fmt.Sprintf("user with ID %s already exists", id),
+	}
+}
+
 // UnexpectedUserBucketError is used when the error comes from an internal system.
 func UnexpectedUserBucketError(err error) *errors.Error {
 	return &errors.Error{

--- a/tenant/storage_user_test.go
+++ b/tenant/storage_user_test.go
@@ -57,6 +57,24 @@ func TestUser(t *testing.T) {
 				if !reflect.DeepEqual(users, expected) {
 					t.Fatalf("expected identical users: \n%+v\n%+v", users, expected)
 				}
+
+				// Test that identical name causes an error
+				err = store.CreateUser(context.Background(), tx, &influxdb.User{
+					ID:   platform.ID(11), // Unique ID
+					Name: "user1",         // Non-unique name
+				})
+				if err == nil {
+					t.Fatal("expected error on creating user with identical username")
+				}
+
+				// Test that identical ID causes an error
+				err = store.CreateUser(context.Background(), tx, &influxdb.User{
+					ID:   platform.ID(1), // Non-unique ID
+					Name: "user11",       // Unique name
+				})
+				if err == nil {
+					t.Fatal("expected error on creating user with identical ID")
+				}
 			},
 		},
 		{


### PR DESCRIPTION
- Closes https://github.com/influxdata/edge/issues/292

### Affected areas:
- Providing an already in-use user ID to `api/v2/users` create will now be an error, which is a behavior change. However docs do not seem to need an update from this

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
