### PR TITLE
fix: allow backup of all buckets

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -26,7 +26,7 @@ func NewBucketManifestWriter(ts *tenant.Service, mc *meta.Client) BucketManifest
 // It is intended to be used to write to an HTTP response after appropriate measures have been taken
 // to ensure that the request is authorized.
 func (b BucketManifestWriter) WriteManifest(ctx context.Context, w io.Writer) error {
-	bkts, _, err := b.ts.FindBuckets(ctx, influxdb.BucketFilter{})
+	bkts, err := b.getAllBuckets(ctx)
 	if err != nil {
 		return err
 	}
@@ -58,6 +58,27 @@ func (b BucketManifestWriter) WriteManifest(ctx context.Context, w io.Writer) er
 	}
 
 	return json.NewEncoder(w).Encode(&l)
+}
+
+func (b BucketManifestWriter) getAllBuckets(ctx context.Context) ([]*influxdb.Bucket, error) {
+	var numBuckets int
+	var offset int
+	buckets := make([]*influxdb.Bucket, 0)
+
+	// Loop until we get a number of buckets back less than the max page size
+	// indicating that we have hit the last page and gotten all buckets
+	for do := true; do; do = numBuckets >= influxdb.MaxPageSize {
+		opts := influxdb.FindOptions{Offset: offset, Limit: influxdb.MaxPageSize}
+		bkts, _, err := b.ts.FindBuckets(ctx, influxdb.BucketFilter{}, opts)
+		if err != nil {
+			return nil, err
+		}
+		buckets = append(buckets, bkts...)
+		numBuckets = len(bkts)
+		offset += numBuckets
+	}
+
+	return buckets, nil
 }
 
 // retentionPolicyToManifest and the various similar functions that follow are for converting

--- a/tenant/storage_bucket.go
+++ b/tenant/storage_bucket.go
@@ -146,16 +146,10 @@ func (s *Store) ListBuckets(ctx context.Context, tx kv.Tx, filter BucketFilter, 
 		return nil, invalidBucketListRequest
 	}
 
-	// if we dont have any options it would be irresponsible to just give back all orgs in the system
 	if len(opt) == 0 {
-		opt = append(opt, influxdb.FindOptions{
-			Limit: influxdb.DefaultPageSize,
-		})
+		opt = append(opt, influxdb.FindOptions{})
 	}
 	o := opt[0]
-	if o.Limit > influxdb.MaxPageSize || o.Limit == 0 {
-		o.Limit = influxdb.MaxPageSize
-	}
 
 	// if an organization is passed we need to use the index
 	if filter.OrganizationID != nil {
@@ -204,7 +198,7 @@ func (s *Store) ListBuckets(ctx context.Context, tx kv.Tx, filter BucketFilter, 
 			bs = append(bs, b)
 		}
 
-		if len(bs) >= o.Limit {
+		if o.Limit != 0 && len(bs) >= o.Limit {
 			break
 		}
 	}
@@ -289,7 +283,7 @@ func (s *Store) listBucketsByOrg(ctx context.Context, tx kv.Tx, orgID platform.I
 
 		bs = append(bs, b)
 
-		if len(bs) >= o.Limit {
+		if o.Limit != 0 && len(bs) >= o.Limit {
 			break
 		}
 	}

--- a/tenant/storage_bucket_test.go
+++ b/tenant/storage_bucket_test.go
@@ -83,6 +83,16 @@ func TestBucket(t *testing.T) {
 		}
 	}
 
+	over20Setup := func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+		store.BucketIDGen = mock.NewIncrementingIDGenerator(1)
+		for _, bucket := range testBuckets(24) {
+			err := store.CreateBucket(context.Background(), tx, bucket)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
 	st := []struct {
 		name    string
 		setup   func(*testing.T, *tenant.Store, kv.Tx)
@@ -181,6 +191,15 @@ func TestBucket(t *testing.T) {
 				if !reflect.DeepEqual(buckets, expected[3:]) {
 					t.Fatalf("expected identical buckets with limit: \n%+v\n%+v", buckets, expected[3:])
 				}
+			},
+		},
+		{
+			name:  "listOver20",
+			setup: over20Setup,
+			results: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+				buckets, err := store.ListBuckets(context.Background(), tx, tenant.BucketFilter{})
+				require.NoError(t, err)
+				assert.Len(t, buckets, 24)
 			},
 		},
 		{

--- a/tenant/storage_org.go
+++ b/tenant/storage_org.go
@@ -112,14 +112,9 @@ func (s *Store) GetOrgByName(ctx context.Context, tx kv.Tx, n string) (*influxdb
 func (s *Store) ListOrgs(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOptions) ([]*influxdb.Organization, error) {
 	// if we dont have any options it would be irresponsible to just give back all orgs in the system
 	if len(opt) == 0 {
-		opt = append(opt, influxdb.FindOptions{
-			Limit: influxdb.DefaultPageSize,
-		})
+		opt = append(opt, influxdb.FindOptions{})
 	}
 	o := opt[0]
-	if o.Limit > influxdb.MaxPageSize || o.Limit == 0 {
-		o.Limit = influxdb.MaxPageSize
-	}
 
 	b, err := tx.Bucket(organizationBucket)
 	if err != nil {
@@ -146,7 +141,7 @@ func (s *Store) ListOrgs(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOpti
 
 		us = append(us, u)
 
-		if len(us) >= o.Limit {
+		if o.Limit != 0 && len(us) >= o.Limit {
 			break
 		}
 	}

--- a/tenant/storage_org_test.go
+++ b/tenant/storage_org_test.go
@@ -65,6 +65,13 @@ func TestOrg(t *testing.T) {
 				require.NoError(t, store.CreateOrg(context.Background(), tx, org))
 			}
 		}
+
+		over20Setup = func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+			store.OrgIDGen = mock.NewIncrementingIDGenerator(1)
+			for _, org := range testOrgs(25) {
+				require.NoError(t, store.CreateOrg(context.Background(), tx, org))
+			}
+		}
 	)
 
 	st := []struct {
@@ -146,6 +153,18 @@ func TestOrg(t *testing.T) {
 				require.NoError(t, err)
 				assert.Len(t, orgs, 7)
 				assert.Equal(t, expected[3:], orgs)
+			},
+		},
+		{
+			name:  "listOver20",
+			setup: over20Setup,
+			results: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+				orgs, err := store.ListOrgs(context.Background(), tx)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				require.Len(t, orgs, 25)
 			},
 		},
 		{

--- a/tenant/storage_user.go
+++ b/tenant/storage_user.go
@@ -122,16 +122,10 @@ func (s *Store) GetUserByName(ctx context.Context, tx kv.Tx, n string) (*influxd
 }
 
 func (s *Store) ListUsers(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOptions) ([]*influxdb.User, error) {
-	// if we dont have any options it would be irresponsible to just give back all users in the system
 	if len(opt) == 0 {
-		opt = append(opt, influxdb.FindOptions{
-			Limit: influxdb.DefaultPageSize,
-		})
+		opt = append(opt, influxdb.FindOptions{})
 	}
 	o := opt[0]
-	if o.Limit > influxdb.MaxPageSize || o.Limit == 0 {
-		o.Limit = influxdb.MaxPageSize
-	}
 
 	b, err := tx.Bucket(userBucket)
 	if err != nil {
@@ -172,7 +166,7 @@ func (s *Store) ListUsers(ctx context.Context, tx kv.Tx, opt ...influxdb.FindOpt
 
 		us = append(us, u)
 
-		if len(us) >= o.Limit {
+		if o.Limit != 0 && len(us) >= o.Limit {
 			break
 		}
 	}

--- a/tenant/storage_user_test.go
+++ b/tenant/storage_user_test.go
@@ -27,6 +27,19 @@ func TestUser(t *testing.T) {
 		}
 	}
 
+	over20Setup := func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+		for i := 1; i <= 22; i++ {
+			err := store.CreateUser(context.Background(), tx, &influxdb.User{
+				ID:     platform.ID(i),
+				Name:   fmt.Sprintf("user%d", i),
+				Status: "active",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
 	st := []struct {
 		name    string
 		setup   func(*testing.T, *tenant.Store, kv.Tx)
@@ -162,6 +175,20 @@ func TestUser(t *testing.T) {
 				}
 				if !reflect.DeepEqual(users, expected[3:]) {
 					t.Fatalf("expected identical users with limit: \n%+v\n%+v", users, expected[3:])
+				}
+			},
+		},
+		{
+			name:  "listOver20",
+			setup: over20Setup,
+			results: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
+				users, err := store.ListUsers(context.Background(), tx)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if len(users) != 22 {
+					t.Fatalf("expected 10 users got: %d", len(users))
 				}
 			},
 		},


### PR DESCRIPTION
### Description
Fixes an issue where backups were only limited to the first 20 buckets. These changes will allow backup of all buckets.

### Context
This should help with potential data loss during backup/restore.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
