### PR TITLE
test: remove group skips

### DIFF
--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -141,8 +141,6 @@ fill_time
 fill_int
 fill_uint
 fill_string
-group
-group_nulls
 histogram_normalize
 histogram_quantile_minvalue
 histogram_quantile

--- a/etc/test-flux.sh
+++ b/etc/test-flux.sh
@@ -160,14 +160,6 @@ label_to_string
 #   Or, needs feature flag strictNullLogicalOps
 logical_typed_null_interp
 
-# https://github.com/influxdata/influxdb/issues/23757
-# Flux acceptance tests for group |> first (and last)
-push_down_group_one_tag_first
-push_down_group_all_filter_field_first
-push_down_group_one_tag_filter_field_first
-push_down_group_one_tag_last
-push_down_group_all_filter_field_last
-push_down_group_one_tag_filter_field_last
 ENDSKIPS
 )
   echo "$doc" | sed '/^[[:space:]]*$/d' | sed 's/[[:space:]]*#.*$//' | tr '\n' ',' | sed 's/,$//'

--- a/query/stdlib/influxdata/influxdb/group_first_last_influxdb_test.flux
+++ b/query/stdlib/influxdata/influxdb/group_first_last_influxdb_test.flux
@@ -1,51 +1,447 @@
 package influxdb_test
 
 
+import "array"
+import "testing"
 import "testing/expect"
 
-testcase push_down_group_one_tag_first extends "flux/planner/group_first_last_test.group_one_tag_first" {
+// N.b. `inData` is what this is named in the testcases using extension.
+// Apparently we can't shadow the name here when extending, else we get an error
+// about reassignment.
+input =
+    array.from(
+        rows: [
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 3,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 1,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 0,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 4,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 3,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 1,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 1,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 0,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 4,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 4,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 0,
+            },
+            {
+                _field: "f0",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 4,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 0,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 0,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 0,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 0,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 4,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v0",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 3,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 3,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 2,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v0",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 1,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:30Z,
+                _value: 1,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:40Z,
+                _value: 0,
+            },
+            {
+                _field: "f1",
+                _measurement: "m0",
+                t0: "t0v1",
+                t1: "t1v1",
+                _time: 2021-07-06T23:06:50Z,
+                _value: 2,
+            },
+        ],
+    )
+        |> group(columns: ["_measurement", "_field", "t0", "t1"])
+
+// FIXME: want to extend `flux/planner/group_first_last_test.group_one_tag_first` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_one_tag_first {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v0",
+                    "t1": "t1v0",
+                    "_value": 3,
+                    _time: 2021-07-06T23:06:30Z,
+                },
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v1",
+                    "t1": "t1v0",
+                    "_value": 1,
+                    _time: 2021-07-06T23:06:30Z,
+                },
+            ],
+        )
+            |> group(columns: ["t0"])
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> group(columns: ["t0"])
+            |> first()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+// FIXME: want to extend `flux/planner/group_first_last_test.group_all_filter_field_first` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_all_filter_field_first {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v0",
+                    "t1": "t1v0",
+                    "_value": 3,
+                    _time: 2021-07-06T23:06:30Z,
+                },
+            ],
+        )
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> filter(fn: (r) => r._field == "f0")
+            |> group()
+            |> first()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+// FIXME: want to extend `flux/planner/group_first_last_test.group_one_tag_filter_field_first` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_one_tag_filter_field_first {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v0",
+                    "t1": "t1v0",
+                    "_value": 3,
+                    _time: 2021-07-06T23:06:30Z,
+                },
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v1",
+                    "t1": "t1v0",
+                    "_value": 1,
+                    _time: 2021-07-06T23:06:30Z,
+                },
+            ],
+        )
+            |> group(columns: ["t0"])
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> filter(fn: (r) => r._field == "f0")
+            |> group(columns: ["t0"])
+            |> first()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase
+push_down_group_two_tag_filter_field_first
+extends
+"flux/planner/group_first_last_test.group_two_tag_filter_field_first"
+{
     expect.planner(rules: ["PushDownGroupAggregateRule": 1])
     super()
 }
-
-testcase push_down_group_all_filter_field_first extends "flux/planner/group_first_last_test.group_all_filter_field_first"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }
-
-testcase push_down_group_one_tag_filter_field_first extends "flux/planner/group_first_last_test.group_one_tag_filter_field_first"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }
-
-testcase push_down_group_two_tag_filter_field_first extends "flux/planner/group_first_last_test.group_two_tag_filter_field_first"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }
 
 // Group + last tests
-testcase push_down_group_one_tag_last extends "flux/planner/group_first_last_test.group_one_tag_last" {
+// FIXME: want to extend `flux/planner/group_first_last_test.group_one_tag_last` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_one_tag_last {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f1",
+                    "t0": "t0v0",
+                    "t1": "t1v1",
+                    _time: 2021-07-06T23:06:50Z,
+                    _value: 3,
+                },
+                {
+                    _measurement: "m0",
+                    _field: "f1",
+                    "t0": "t0v1",
+                    "t1": "t1v1",
+                    _time: 2021-07-06T23:06:50Z,
+                    _value: 2,
+                },
+            ],
+        )
+            |> group(columns: ["t0"])
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> group(columns: ["t0"])
+            |> last()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+// FIXME: want to extend `flux/planner/group_first_last_test.group_all_filter_field_last` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_all_filter_field_last {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v1",
+                    "t1": "t1v1",
+                    _time: 2021-07-06T23:06:50Z,
+                    _value: 4,
+                },
+            ],
+        )
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> filter(fn: (r) => r._field == "f0")
+            |> group()
+            |> last()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+// FIXME: want to extend `flux/planner/group_first_last_test.group_one_tag_filter_field_last` but can't
+// A sort was added to allow the base case to pass in cloud, but it breaks the pushdown here.
+// For now, the body of the testcase is included here, in full, minus the sort.
+// Ref: https://github.com/influxdata/influxdb/issues/23757
+testcase push_down_group_one_tag_filter_field_last {
+    expect.planner(rules: ["PushDownGroupAggregateRule": 1])
+
+    want =
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v0",
+                    "t1": "t1v1",
+                    _time: 2021-07-06T23:06:50Z,
+                    _value: 1,
+                },
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    "t0": "t0v1",
+                    "t1": "t1v1",
+                    _time: 2021-07-06T23:06:50Z,
+                    _value: 4,
+                },
+            ],
+        )
+            |> group(columns: ["t0"])
+    got =
+        testing.load(tables: input)
+            |> range(start: -100y)
+            |> filter(fn: (r) => r._field == "f0")
+            |> group(columns: ["t0"])
+            |> last()
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase
+push_down_group_two_tag_filter_field_last
+extends
+"flux/planner/group_first_last_test.group_two_tag_filter_field_last"
+{
     expect.planner(rules: ["PushDownGroupAggregateRule": 1])
     super()
 }
-
-testcase push_down_group_all_filter_field_last extends "flux/planner/group_first_last_test.group_all_filter_field_last"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }
-
-testcase push_down_group_one_tag_filter_field_last extends "flux/planner/group_first_last_test.group_one_tag_filter_field_last"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }
-
-testcase push_down_group_two_tag_filter_field_last extends "flux/planner/group_first_last_test.group_two_tag_filter_field_last"
-{
-        expect.planner(rules: ["PushDownGroupAggregateRule": 1])
-        super()
-    }


### PR DESCRIPTION
Refs: 
- https://github.com/influxdata/flux/pull/5172
- https://github.com/influxdata/influxdb/issues/23757

### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description

In https://github.com/influxdata/flux/pull/5172 various tests which have been skipped long-term were repaired. This diff removes them from the skip list during the flux integration tests run as a part of CI here.

Some tests had a **sort** added so they'd pass in cloud, vanilla, and OSS.
This also **broke some extended testcases** here in OSS since pushdown rules
no longer match the plan.

This diff "inlines" the testcase body for each of these so we get our
coverage back, but leaves a `FIXME` to note that it would be better if we
could somehow thread the needle and retain the extension.

### Context

Adds additional coverage to the flux integration tests.

### Affected areas (delete section if not relevant):

CI, specifically test selection for fluxtest.


### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
