### PR TITLE
feat(security): set SameSite=strict on session cookie

### DIFF
--- a/kit/transport/http/middleware.go
+++ b/kit/transport/http/middleware.go
@@ -20,6 +20,18 @@ import (
 // Middleware constructor.
 type Middleware func(http.Handler) http.Handler
 
+// SetCORS configures various headers to relax CORS browser checks
+//
+// Browsers implement Cross-Origin Resource Sharing (CORS) checks to limit
+// cross-origin accesses in HTTP requests. Various CORS headers can be used to
+// relax the standard, strict browser behavior. For details on CORS, see:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+//
+// IMPORTANT: default CORS checks disallows attaching credentials (eg, session
+// cookie) with cross-origin requests (even when Access-Control-Allow-Origin is
+// set to the Origin) and we omit the 'Access-Control-Allow-Credentials' header
+// here to preserve this behavior. Omitting this header provides security
+// defense-in-depth.
 func SetCORS(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if origin := r.Header.Get("Origin"); origin != "" {

--- a/session/http_server.go
+++ b/session/http_server.go
@@ -176,21 +176,22 @@ func encodeCookieSession(w http.ResponseWriter, s *influxdb.Session) {
 	// everything is 1st party and Strict's restriction work fine.
 	//
 	// SameSite=Lax would also be safe to use (modern browser's default if
-	// unset) since it only sends the cookie with GET requests when the
-	// location bar matches the domain of the cookie and we know that our
-	// APIs do not perform state-changing actions with GET. Using
-	// SameSite=Strict helps future-proof us against that changing (ie, we
-	// add a state-changing GET API).
+	// unset) since it only sends the cookie with GET (and other safe HTTP
+	// methods like HEAD and OPTIONS as defined in RFC6264) requests when
+	// the location bar matches the domain of the cookie and we know that
+	// our APIs do not perform state-changing actions with GET and other
+	// safe methods. Using SameSite=Strict helps future-proof us against
+	// that changing (ie, we add a state-changing GET API).
 	//
 	// Note: it's generally recommended that SameSite should not be relied
 	// upon (particularly Lax) because:
 	// a) SameSite doesn't work with (cookie-less) Basic Auth. We don't
 	//    share browser session BasicAuth with accesses to to /api/... so
 	//    this isn't a problem
-	// b) SameSite=lax allows GET and some services might allow
-	//    state-changing requests via GET. Our API doesn't support
-	//    state-changing GETs and SameSite=strict doesn't allow GETs from
-	//    3rd party sites at all, so this isn't a problem
+	// b) SameSite=lax allows GET (and other safe HTTP methods) and some
+	//    services might allow state-changing requests via GET. Our API
+	//    doesn't support state-changing GETs and SameSite=strict doesn't
+	//    allow GETs from 3rd party sites at all, so this isn't a problem
 	// c) similar to 'b', some frameworks will accept HTTP methods for
 	//    other handlers. Eg, the application is designed for POST but it
 	//    will accept requests converted to the GET method. Golang does not

--- a/session/http_server_test.go
+++ b/session/http_server_test.go
@@ -58,7 +58,7 @@ func TestSessionHandler_handleSignin(t *testing.T) {
 				password: "supersecret",
 			},
 			wants: wants{
-				cookie: "influxdb-oss-session=abc123xyz; Path=/api/; Expires=Thu, 26 Sep 2030 00:00:00 GMT",
+				cookie: "influxdb-oss-session=abc123xyz; Path=/api/; Expires=Thu, 26 Sep 2030 00:00:00 GMT; SameSite=Strict",
 				code:   http.StatusNoContent,
 			},
 		},


### PR DESCRIPTION
Use `SameSite=Strict` as a hardening measure against cross-origin attacks. While browsers have been moving to default to `SameSite=Lax`, explicitly setting `SameSite` ensures that all browsers enforce it consistently. While `lax` is a reasonable hardening choice, the cookie is only required for requests to `/api/...` and we don't expect 3rd party links into `/api/...`, so this stricter setting should be safe in terms of usability. Furthermore, while our `GET` APIs are not state-changing, using 'strict' future-proofs us in case we add a state-changing `GET` API (`lax` allows cross-origin `GET` requests for increased usability for read-only requests).

Also add a comment to `SetCORS()` lack of `Access-Control-Allow-Credentials` as a reminder that its omission is intentional for defense in depth on when to attach the cookie to a request.

In addition to tests passing, I manually tested in a chrome-based browser, firefox and a webkit-based browser by:
1. logging into the UI and going to API Tokens (it works properly)
2. trying to run a CSRF to add a token (it correctly failed)
3. navigating into `/api/v2/me` from 3rd party (it is expectedly 'unauthorized' (this is a change of behavior))
4. navigating into `/orgs/<orgid./load-data/tokens` (it works properly without re-auth)