### PR TITLE
fix: don't write skipped shard messages into the line protocol output

### DIFF
--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -340,7 +340,7 @@ func (cmd *Command) exportTSMFile(tsmFilePath string, w io.Writer) error {
 	f, err := os.Open(tsmFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(w, "skipped missing file: %s", tsmFilePath)
+			fmt.Fprintf(cmd.Stderr, "skipped missing file: %s", tsmFilePath)
 			return nil
 		}
 		return err
@@ -408,7 +408,7 @@ func (cmd *Command) exportWALFile(walFilePath string, w io.Writer, warnDelete fu
 	f, err := os.Open(walFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(w, "skipped missing file: %s", walFilePath)
+			fmt.Fprintf(cmd.Stderr, "skipped missing file: %s", walFilePath)
 			return nil
 		}
 		return err


### PR DESCRIPTION
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description

This switches so that the message

    skipped missing file: /path/to/tsm.tsm

is written to stdErr instead of stdout (or the output file if `-out` has been provided)

Without this change, when TSM or WAL files are missing, the message about them being skipped is written along with the line protocol output, which can lead to difficulties ingesting that LP back into a DB (it can be `sed`'d or `grep`'d out, but that requires additional processing).