### PR TITLE
feat: optimize saving changes to fields.idx (#23701)

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -719,7 +719,7 @@ func (e *Engine) Open(ctx context.Context) error {
 		return err
 	}
 
-	fields, err := tsdb.NewMeasurementFieldSet(filepath.Join(e.path, "fields.idx"))
+	fields, err := tsdb.NewMeasurementFieldSet(filepath.Join(e.path, "fields.idx"), e.logger)
 	if err != nil {
 		e.logger.Warn(fmt.Sprintf("error opening fields.idx: %v.  Rebuilding.", err))
 	}
@@ -763,15 +763,18 @@ func (e *Engine) Close() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.done = nil // Ensures that the channel will not be closed again.
-	e.fieldset.Close()
 
-	if err := e.FileStore.Close(); err != nil {
-		return err
+	var err error = nil
+	err = e.fieldset.Close()
+	if err2 := e.FileStore.Close(); err2 != nil && err == nil {
+		err = err2
 	}
 	if e.WALEnabled {
-		return e.WAL.Close()
+		if err2 := e.WAL.Close(); err2 != nil && err == nil {
+			err = err2
+		}
 	}
-	return nil
+	return err
 }
 
 // WithLogger sets the logger for the engine.
@@ -868,7 +871,7 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
 	}
 
 	// Save the field set index so we don't have to rebuild it next time
-	if err := e.fieldset.Save(); err != nil {
+	if err := e.fieldset.WriteToFile(); err != nil {
 		return err
 	}
 
@@ -1170,7 +1173,7 @@ func (e *Engine) overlay(r io.Reader, basePath string, asNew bool) error {
 			return err
 		}
 	}
-	return nil
+	return e.MeasurementFieldSet().WriteToFile()
 }
 
 // readFileFromBackup copies the next file from the archive into the shard.
@@ -1703,19 +1706,20 @@ func (e *Engine) deleteSeriesRange(ctx context.Context, seriesKeys [][]byte, min
 			ids.Add(sid)
 		}
 
-		fielsetChanged := false
+		actuallyDeleted := make([]string, 0, len(measurements))
 		for k := range measurements {
 			if dropped, err := e.index.DropMeasurementIfSeriesNotExist([]byte(k)); err != nil {
 				return err
 			} else if dropped {
-				if err := e.cleanupMeasurement([]byte(k)); err != nil {
+				if deleted, err := e.cleanupMeasurement([]byte(k)); err != nil {
 					return err
+				} else if deleted {
+					actuallyDeleted = append(actuallyDeleted, k)
 				}
-				fielsetChanged = true
 			}
 		}
-		if fielsetChanged {
-			if err := e.fieldset.Save(); err != nil {
+		if len(actuallyDeleted) > 0 {
+			if err := e.fieldset.Save(tsdb.MeasurementsToFieldChangeDeletions(actuallyDeleted)); err != nil {
 				return err
 			}
 		}
@@ -1745,7 +1749,7 @@ func (e *Engine) deleteSeriesRange(ctx context.Context, seriesKeys [][]byte, min
 	return nil
 }
 
-func (e *Engine) cleanupMeasurement(name []byte) error {
+func (e *Engine) cleanupMeasurement(name []byte) (deleted bool, err error) {
 	// A sentinel error message to cause DeleteWithLock to not delete the measurement
 	abortErr := fmt.Errorf("measurements still exist")
 
@@ -1776,10 +1780,10 @@ func (e *Engine) cleanupMeasurement(name []byte) error {
 
 	}); err != nil && err != abortErr {
 		// Something else failed, return it
-		return err
+		return false, err
 	}
 
-	return nil
+	return err != abortErr, nil
 }
 
 // DeleteMeasurement deletes a measurement and all related series.

--- a/tsdb/internal/fieldsindex.pb.go
+++ b/tsdb/internal/fieldsindex.pb.go
@@ -20,6 +20,52 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ChangeType int32
+
+const (
+	ChangeType_AddMeasurementField ChangeType = 0
+	ChangeType_DeleteMeasurement   ChangeType = 1
+)
+
+// Enum value maps for ChangeType.
+var (
+	ChangeType_name = map[int32]string{
+		0: "AddMeasurementField",
+		1: "DeleteMeasurement",
+	}
+	ChangeType_value = map[string]int32{
+		"AddMeasurementField": 0,
+		"DeleteMeasurement":   1,
+	}
+)
+
+func (x ChangeType) Enum() *ChangeType {
+	p := new(ChangeType)
+	*p = x
+	return p
+}
+
+func (x ChangeType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ChangeType) Descriptor() protoreflect.EnumDescriptor {
+	return file_internal_fieldsindex_proto_enumTypes[0].Descriptor()
+}
+
+func (ChangeType) Type() protoreflect.EnumType {
+	return &file_internal_fieldsindex_proto_enumTypes[0]
+}
+
+func (x ChangeType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ChangeType.Descriptor instead.
+func (ChangeType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_fieldsindex_proto_rawDescGZIP(), []int{0}
+}
+
 type Series struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -287,6 +333,116 @@ func (x *MeasurementFieldSet) GetMeasurements() []*MeasurementFields {
 	return nil
 }
 
+type MeasurementFieldChange struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Measurement []byte     `protobuf:"bytes,1,opt,name=Measurement,proto3" json:"Measurement,omitempty"`
+	Field       *Field     `protobuf:"bytes,2,opt,name=Field,proto3" json:"Field,omitempty"`
+	Change      ChangeType `protobuf:"varint,3,opt,name=Change,proto3,enum=tsdb.ChangeType" json:"Change,omitempty"`
+}
+
+func (x *MeasurementFieldChange) Reset() {
+	*x = MeasurementFieldChange{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_fieldsindex_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MeasurementFieldChange) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MeasurementFieldChange) ProtoMessage() {}
+
+func (x *MeasurementFieldChange) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_fieldsindex_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MeasurementFieldChange.ProtoReflect.Descriptor instead.
+func (*MeasurementFieldChange) Descriptor() ([]byte, []int) {
+	return file_internal_fieldsindex_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *MeasurementFieldChange) GetMeasurement() []byte {
+	if x != nil {
+		return x.Measurement
+	}
+	return nil
+}
+
+func (x *MeasurementFieldChange) GetField() *Field {
+	if x != nil {
+		return x.Field
+	}
+	return nil
+}
+
+func (x *MeasurementFieldChange) GetChange() ChangeType {
+	if x != nil {
+		return x.Change
+	}
+	return ChangeType_AddMeasurementField
+}
+
+type FieldChangeSet struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Changes []*MeasurementFieldChange `protobuf:"bytes,1,rep,name=Changes,proto3" json:"Changes,omitempty"`
+}
+
+func (x *FieldChangeSet) Reset() {
+	*x = FieldChangeSet{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_fieldsindex_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *FieldChangeSet) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FieldChangeSet) ProtoMessage() {}
+
+func (x *FieldChangeSet) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_fieldsindex_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FieldChangeSet.ProtoReflect.Descriptor instead.
+func (*FieldChangeSet) Descriptor() ([]byte, []int) {
+	return file_internal_fieldsindex_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *FieldChangeSet) GetChanges() []*MeasurementFieldChange {
+	if x != nil {
+		return x.Changes
+	}
+	return nil
+}
+
 var File_internal_fieldsindex_proto protoreflect.FileDescriptor
 
 var file_internal_fieldsindex_proto_rawDesc = []byte{
@@ -311,9 +467,26 @@ var file_internal_fieldsindex_proto_rawDesc = []byte{
 	0x65, 0x74, 0x12, 0x3b, 0x0a, 0x0c, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e,
 	0x74, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x74, 0x73, 0x64, 0x62, 0x2e,
 	0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x46, 0x69, 0x65, 0x6c, 0x64,
-	0x73, 0x52, 0x0c, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x42,
-	0x08, 0x5a, 0x06, 0x2e, 0x3b, 0x74, 0x73, 0x64, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x33,
+	0x73, 0x52, 0x0c, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22,
+	0x87, 0x01, 0x0a, 0x16, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x46,
+	0x69, 0x65, 0x6c, 0x64, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x20, 0x0a, 0x0b, 0x4d, 0x65,
+	0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52,
+	0x0b, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x21, 0x0a, 0x05,
+	0x46, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0b, 0x2e, 0x74, 0x73,
+	0x64, 0x62, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x52, 0x05, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x12,
+	0x28, 0x0a, 0x06, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0e, 0x32,
+	0x10, 0x2e, 0x74, 0x73, 0x64, 0x62, 0x2e, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x54, 0x79, 0x70,
+	0x65, 0x52, 0x06, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x22, 0x48, 0x0a, 0x0e, 0x46, 0x69, 0x65,
+	0x6c, 0x64, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x53, 0x65, 0x74, 0x12, 0x36, 0x0a, 0x07, 0x43,
+	0x68, 0x61, 0x6e, 0x67, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x74,
+	0x73, 0x64, 0x62, 0x2e, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x46,
+	0x69, 0x65, 0x6c, 0x64, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x07, 0x43, 0x68, 0x61, 0x6e,
+	0x67, 0x65, 0x73, 0x2a, 0x3c, 0x0a, 0x0a, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x54, 0x79, 0x70,
+	0x65, 0x12, 0x17, 0x0a, 0x13, 0x41, 0x64, 0x64, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d,
+	0x65, 0x6e, 0x74, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x44, 0x65,
+	0x6c, 0x65, 0x74, 0x65, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x10,
+	0x01, 0x42, 0x08, 0x5a, 0x06, 0x2e, 0x3b, 0x74, 0x73, 0x64, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x33,
 }
 
 var (
@@ -328,23 +501,30 @@ func file_internal_fieldsindex_proto_rawDescGZIP() []byte {
 	return file_internal_fieldsindex_proto_rawDescData
 }
 
-var file_internal_fieldsindex_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_internal_fieldsindex_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_internal_fieldsindex_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_internal_fieldsindex_proto_goTypes = []interface{}{
-	(*Series)(nil),              // 0: tsdb.Series
-	(*Tag)(nil),                 // 1: tsdb.Tag
-	(*MeasurementFields)(nil),   // 2: tsdb.MeasurementFields
-	(*Field)(nil),               // 3: tsdb.Field
-	(*MeasurementFieldSet)(nil), // 4: tsdb.MeasurementFieldSet
+	(ChangeType)(0),                // 0: tsdb.ChangeType
+	(*Series)(nil),                 // 1: tsdb.Series
+	(*Tag)(nil),                    // 2: tsdb.Tag
+	(*MeasurementFields)(nil),      // 3: tsdb.MeasurementFields
+	(*Field)(nil),                  // 4: tsdb.Field
+	(*MeasurementFieldSet)(nil),    // 5: tsdb.MeasurementFieldSet
+	(*MeasurementFieldChange)(nil), // 6: tsdb.MeasurementFieldChange
+	(*FieldChangeSet)(nil),         // 7: tsdb.FieldChangeSet
 }
 var file_internal_fieldsindex_proto_depIdxs = []int32{
-	1, // 0: tsdb.Series.Tags:type_name -> tsdb.Tag
-	3, // 1: tsdb.MeasurementFields.Fields:type_name -> tsdb.Field
-	2, // 2: tsdb.MeasurementFieldSet.Measurements:type_name -> tsdb.MeasurementFields
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 0: tsdb.Series.Tags:type_name -> tsdb.Tag
+	4, // 1: tsdb.MeasurementFields.Fields:type_name -> tsdb.Field
+	3, // 2: tsdb.MeasurementFieldSet.Measurements:type_name -> tsdb.MeasurementFields
+	4, // 3: tsdb.MeasurementFieldChange.Field:type_name -> tsdb.Field
+	0, // 4: tsdb.MeasurementFieldChange.Change:type_name -> tsdb.ChangeType
+	6, // 5: tsdb.FieldChangeSet.Changes:type_name -> tsdb.MeasurementFieldChange
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_internal_fieldsindex_proto_init() }
@@ -413,19 +593,44 @@ func file_internal_fieldsindex_proto_init() {
 				return nil
 			}
 		}
+		file_internal_fieldsindex_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MeasurementFieldChange); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_fieldsindex_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*FieldChangeSet); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_internal_fieldsindex_proto_rawDesc,
-			NumEnums:      0,
-			NumMessages:   5,
+			NumEnums:      1,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_internal_fieldsindex_proto_goTypes,
 		DependencyIndexes: file_internal_fieldsindex_proto_depIdxs,
+		EnumInfos:         file_internal_fieldsindex_proto_enumTypes,
 		MessageInfos:      file_internal_fieldsindex_proto_msgTypes,
 	}.Build()
 	File_internal_fieldsindex_proto = out.File

--- a/tsdb/internal/fieldsindex.proto
+++ b/tsdb/internal/fieldsindex.proto
@@ -32,3 +32,18 @@ message Field {
 message MeasurementFieldSet {
 	repeated MeasurementFields Measurements = 1;
 }
+
+enum ChangeType {
+  AddMeasurementField = 0;
+  DeleteMeasurement = 1;
+}
+
+message MeasurementFieldChange {
+  bytes Measurement = 1;
+  Field Field = 2;
+  ChangeType Change = 3;
+}
+
+message FieldChangeSet {
+  repeated MeasurementFieldChange Changes = 1;
+}


### PR DESCRIPTION
Instead of writing out the complete fields.idx
file when it changes, write out incremental
changes that will be applied to the file on
close and startup.

closes https://github.com/influxdata/influxdb/issues/23653

(cherry picked from commit 80c10c8c04d44afb709f7db84b5580fbb475fe3f)

closes https://github.com/influxdata/influxdb/issues/23703