### PR TITLE
fix: incorrect error message concatenation

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2127,8 +2127,8 @@ func marshalFieldChanges(changeSet ...FieldChanges) ([]byte, error) {
 			for _, f := range fc {
 				fields = append(fields, fmt.Sprintf("%q.%q", f.Measurement, f.Field.Name))
 			}
-			return nil, fmt.Errorf("failed marshaling new fields - %s: %w", strings.Join(fields, ", "), err)
 		}
+		return nil, fmt.Errorf("failed marshaling new fields - %s: %w", strings.Join(fields, ", "), err)
 	}
 	return b, nil
 }


### PR DESCRIPTION
One line move in an error message concatenation.  Caught by `lint` in the master branch.