### PR TITLE
fix: improve delete speed when a measurement is part of the predicate

### DIFF
--- a/cmd/influxd/launcher/engine.go
+++ b/cmd/influxd/launcher/engine.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxql"
+
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/kit/platform"
@@ -119,8 +121,8 @@ func (t *TemporaryEngine) SeriesCardinality(ctx context.Context, bucketID platfo
 }
 
 // DeleteBucketRangePredicate will delete a bucket from the range and predicate.
-func (t *TemporaryEngine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate) error {
-	return t.engine.DeleteBucketRangePredicate(ctx, orgID, bucketID, min, max, pred)
+func (t *TemporaryEngine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error {
+	return t.engine.DeleteBucketRangePredicate(ctx, orgID, bucketID, min, max, pred, measurement)
 }
 
 func (t *TemporaryEngine) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {

--- a/delete.go
+++ b/delete.go
@@ -3,6 +3,8 @@ package influxdb
 import (
 	"context"
 
+	"github.com/influxdata/influxql"
+
 	"github.com/influxdata/influxdb/v2/kit/platform"
 )
 
@@ -15,5 +17,5 @@ type Predicate interface {
 
 // DeleteService will delete a bucket from the range and predict.
 type DeleteService interface {
-	DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred Predicate) error
+	DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred Predicate, measurement influxql.Expr) error
 }

--- a/http/delete_handler.go
+++ b/http/delete_handler.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	http "net/http"
 	"time"
+
+	"github.com/influxdata/influxql"
 
 	"github.com/influxdata/httprouter"
 	"github.com/influxdata/influxdb/v2"
@@ -91,7 +94,7 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dr, err := decodeDeleteRequest(
+	dr, measurement, err := decodeDeleteRequest(
 		ctx, r,
 		h.OrganizationService,
 		h.BucketService,
@@ -121,7 +124,7 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.DeleteService.DeleteBucketRangePredicate(r.Context(), dr.Org.ID, dr.Bucket.ID, dr.Start, dr.Stop, dr.Predicate); err != nil {
+	if err := h.DeleteService.DeleteBucketRangePredicate(r.Context(), dr.Org.ID, dr.Bucket.ID, dr.Start, dr.Stop, dr.Predicate, measurement); err != nil {
 		h.HandleHTTPError(ctx, &errors.Error{
 			Code: errors.EInternal,
 			Op:   "http/handleDelete",
@@ -139,24 +142,71 @@ func (h *DeleteHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func decodeDeleteRequest(ctx context.Context, r *http.Request, orgSvc influxdb.OrganizationService, bucketSvc influxdb.BucketService) (*deleteRequest, error) {
+func decodeDeleteRequest(ctx context.Context, r *http.Request, orgSvc influxdb.OrganizationService, bucketSvc influxdb.BucketService) (*deleteRequest, influxql.Expr, error) {
+	jsonErr := &errors.Error{
+		Code: errors.EInvalid,
+		Msg:  "invalid request; error parsing request json",
+	}
+
 	dr := new(deleteRequest)
-	err := json.NewDecoder(r.Body).Decode(dr)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
-		return nil, &errors.Error{
-			Code: errors.EInvalid,
-			Msg:  "invalid request; error parsing request json",
-			Err:  err,
+		jsonErr.Err = err
+		return nil, nil, jsonErr
+	}
+	buffer := bytes.NewBuffer(buf)
+	err = json.NewDecoder(buffer).Decode(dr)
+	if err != nil {
+		jsonErr.Err = err
+		return nil, nil, jsonErr
+	}
+
+	var drd deleteRequestDecode
+	err = json.Unmarshal(buf, &drd)
+	if err != nil {
+		jsonErr.Err = err
+		return nil, nil, jsonErr
+	}
+	var measurementExpr influxql.Expr
+	if drd.Predicate != "" {
+		expr, err := influxql.ParseExpr(drd.Predicate)
+		if err != nil {
+			return nil, nil, &errors.Error{
+				Code: errors.EInvalid,
+				Msg:  "invalid request; error parsing predicate",
+				Err:  err,
+			}
+		}
+		measurementExpr, _, err = influxql.PartitionExpr(influxql.CloneExpr(expr), func(e influxql.Expr) (bool, error) {
+			switch e := e.(type) {
+			case *influxql.BinaryExpr:
+				switch e.Op {
+				case influxql.EQ, influxql.NEQ, influxql.EQREGEX, influxql.NEQREGEX:
+					tag, ok := e.LHS.(*influxql.VarRef)
+					if ok && tag.Val == "_measurement" {
+						return true, nil
+					}
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			return nil, nil, &errors.Error{
+				Code: errors.EInvalid,
+				Msg:  "invalid request; error parsing predicate",
+				Err:  err,
+			}
 		}
 	}
+
 	if dr.Org, err = queryOrganization(ctx, r, orgSvc); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if dr.Bucket, err = queryBucket(ctx, dr.Org.ID, r, bucketSvc); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return dr, nil
+	return dr, measurementExpr, nil
 }
 
 type deleteRequest struct {

--- a/http/delete_test.go
+++ b/http/delete_test.go
@@ -335,7 +335,7 @@ func TestDelete(t *testing.T) {
 				body: []byte(`{
 					"start":"2009-01-01T23:00:00Z",
 					"stop":"2019-11-10T01:00:00Z",
-					"predicate": "tag1=\"v1\" and (tag2=\"v2\" and tag3=\"v3\")"
+					"predicate": "_measurement=\"testing\" and tag1=\"v1\" and (tag2=\"v2\" and tag3=\"v3\")"
 				}`),
 				authorizer: &influxdb.Authorization{
 					UserID: user1ID,

--- a/mock/delete.go
+++ b/mock/delete.go
@@ -3,6 +3,8 @@ package mock
 import (
 	"context"
 
+	"github.com/influxdata/influxql"
+
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kit/platform"
 )
@@ -11,20 +13,20 @@ var _ influxdb.DeleteService = &DeleteService{}
 
 // DeleteService is a mock delete server.
 type DeleteService struct {
-	DeleteBucketRangePredicateF func(tx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate) error
+	DeleteBucketRangePredicateF func(tx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error
 }
 
 // NewDeleteService returns a mock DeleteService where its methods will return
 // zero values.
 func NewDeleteService() DeleteService {
 	return DeleteService{
-		DeleteBucketRangePredicateF: func(tx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate) error {
+		DeleteBucketRangePredicateF: func(tx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error {
 			return nil
 		},
 	}
 }
 
-//DeleteBucketRangePredicate calls DeleteBucketRangePredicateF.
-func (s DeleteService) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate) error {
-	return s.DeleteBucketRangePredicateF(ctx, orgID, bucketID, min, max, pred)
+// DeleteBucketRangePredicate calls DeleteBucketRangePredicateF.
+func (s DeleteService) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error {
+	return s.DeleteBucketRangePredicateF(ctx, orgID, bucketID, min, max, pred, measurement)
 }

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -327,7 +327,7 @@ func (e *Engine) DeleteBucket(ctx context.Context, orgID, bucketID platform.ID) 
 
 // DeleteBucketRangePredicate deletes data within a bucket from the storage engine. Any data
 // deleted must be in [min, max], and the key must match the predicate if provided.
-func (e *Engine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate) error {
+func (e *Engine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID platform.ID, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -336,7 +336,7 @@ func (e *Engine) DeleteBucketRangePredicate(ctx context.Context, orgID, bucketID
 	if e.closing == nil {
 		return ErrEngineClosed
 	}
-	return e.tsdbStore.DeleteSeriesWithPredicate(ctx, bucketID.String(), min, max, pred)
+	return e.tsdbStore.DeleteSeriesWithPredicate(ctx, bucketID.String(), min, max, pred, measurement)
 }
 
 // RLockKVStore locks the KV store as well as the engine in preparation for doing a backup.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	errors3 "github.com/influxdata/influxdb/v2/pkg/errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	errors3 "github.com/influxdata/influxdb/v2/pkg/errors"
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/influxql/query"

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1335,7 +1335,7 @@ func (s *Store) ShardRelativePath(id uint64) (string, error) {
 
 // DeleteSeries loops through the local shards and deletes the series data for
 // the passed in series keys.
-func (s *Store) DeleteSeriesWithPredicate(ctx context.Context, database string, min, max int64, pred influxdb.Predicate) error {
+func (s *Store) DeleteSeriesWithPredicate(ctx context.Context, database string, min, max int64, pred influxdb.Predicate, measurement influxql.Expr) error {
 	s.mu.RLock()
 	if s.databases[database].hasMultipleIndexTypes() {
 		s.mu.RUnlock()
@@ -1372,12 +1372,43 @@ func (s *Store) DeleteSeriesWithPredicate(ctx context.Context, database string, 
 			return err
 		}
 
+		measurementName := make([]byte, 0)
+
+		if measurement != nil {
+			if m, ok := measurement.(*influxql.BinaryExpr); ok {
+				rhs, ok := m.RHS.(*influxql.VarRef)
+				if ok {
+					measurementName = []byte(rhs.Val)
+					exists, err := sh.MeasurementExists(measurementName)
+					if err != nil {
+						return err
+					}
+					if !exists {
+						return nil
+					}
+				}
+			}
+		}
+
 		// Find matching series keys for each measurement.
 		mitr, err := index.MeasurementIterator()
 		if err != nil {
 			return err
 		}
 		defer mitr.Close()
+
+		deleteSeries := func(mm []byte) error {
+			sitr, err := index.MeasurementSeriesIDIterator(mm)
+			if err != nil {
+				return err
+			} else if sitr == nil {
+				return nil
+			}
+			defer sitr.Close()
+
+			itr := NewSeriesIteratorAdapter(sfile, NewPredicateSeriesIDIterator(sitr, sfile, pred))
+			return sh.DeleteSeriesRange(ctx, itr, min, max)
+		}
 
 		for {
 			mm, err := mitr.Next()
@@ -1387,19 +1418,14 @@ func (s *Store) DeleteSeriesWithPredicate(ctx context.Context, database string, 
 				break
 			}
 
-			if err := func() error {
-				sitr, err := index.MeasurementSeriesIDIterator(mm)
+			// If we are deleting within a measurement and have found a match, we can return after the delete.
+			if measurementName != nil && bytes.Equal(mm, measurementName) {
+				return deleteSeries(mm)
+			} else {
+				err := deleteSeries(mm)
 				if err != nil {
 					return err
-				} else if sitr == nil {
-					return nil
 				}
-				defer sitr.Close()
-
-				itr := NewSeriesIteratorAdapter(sfile, NewPredicateSeriesIDIterator(sitr, sfile, pred))
-				return sh.DeleteSeriesRange(ctx, itr, min, max)
-			}(); err != nil {
-				return err
 			}
 		}
 


### PR DESCRIPTION
- Closes #23741

### Description
The current delete statement does not take into account the measurement predicate. It will blindly loop through all the measurements in each shard and run the delete. This can be very slow on instances with a lot of measurements. This change checks for measurement existence, and if found, only runs the delete on that measurement.

### Context
The value add is faster deletes that have a measurement predicate.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
