### PR TITLE
fix: support gzipped responses in the legacy handler

### DIFF
--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/influxdata/influxdb/v2/http/legacy"
 	"github.com/influxdata/influxdb/v2/kit/feature"
 	kithttp "github.com/influxdata/influxdb/v2/kit/transport/http"
@@ -45,12 +46,14 @@ func NewPlatformHandler(b *APIBackend, opts ...APIHandlerOptFn) *PlatformHandler
 
 	legacyBackend := newLegacyBackend(b)
 	lh := newLegacyHandler(legacyBackend, *legacy.NewHandlerConfig())
+	// legacy reponses can optionally be gzip encoded
+	gh := gziphandler.GzipHandler(lh)
 
 	return &PlatformHandler{
 		AssetHandler:  assetHandler,
 		DocsHandler:   Redoc("/api/v2/swagger.json"),
 		APIHandler:    wrappedHandler,
-		LegacyHandler: legacy.NewInflux1xAuthenticationHandler(lh, b.AuthorizerV1, b.HTTPErrorHandler),
+		LegacyHandler: legacy.NewInflux1xAuthenticationHandler(gh, b.AuthorizerV1, b.HTTPErrorHandler),
 	}
 }
 


### PR DESCRIPTION
- Closes #23805
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
This PR enables gzip compression on the legacy handler, as it was in influxdb v1.x versions.

### Context
The goal is to reduce bandwidth usage when possible.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
