### PR TITLE
chore: update to use scheduled pipeline (1.10)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,13 @@ workflows:
   nightly:
     when:
       and:
+        # This requires a pipeline trigger with a custom "workflow" parameter
+        # set to "nightly". Since we want to trigger this workflow on several
+        # branches, we cannot use the trigger name as suggested by the
+        # documentation.
+        #
+        # For more information:
+        # https://circleci.com/docs/scheduled-pipelines/
         - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
         - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ parameters:
     type: string
     default: go1.18.6-9c97f2f2903566a00bd4b00184aeca0c813adda0
 
+  workflow:
+    type: string
+    default: build
+
 commands:
   install_rust:
     steps:
@@ -342,6 +346,8 @@ release_filter: &release_filter
 workflows:
   version: 2.1
   release:
+    when:
+      equal: [ << pipeline.parameters.workflow >>, build ]
     jobs:
       - build_binaries:
           <<: *release_filter
@@ -380,6 +386,8 @@ workflows:
           <<: *release_filter
 
   on_push:
+    when:
+      equal: [ << pipeline.parameters.workflow >>, build ]
     jobs:
       - build_binaries
       - build_packages:
@@ -393,16 +401,11 @@ workflows:
       - unit_test
       - unit_test_tsi
       - unit_test_race
-  daily:
-    triggers:
-      - schedule:
-          # run weekdays at 4am -- note: use spaces, not tabs
-          cron: "0 4 * * 1-5"
-          filters:
-            branches:
-              only:
-                - "master-1.x"
-                - "1.9"
+  nightly:
+    when:
+      and:
+        - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
+        - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:
       - changelog
       - s3-publish-changelog:


### PR DESCRIPTION
CircleCI is removing "cron" workflows later this year. This preemptively switches to scheduled pipelines as to not introduce downtime when "cron" is removed.