### PR TITLE
chore: update to use scheduled pipeline (2.4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,13 @@ workflows:
   nightly:
     when:
       and:
+        # This requires a pipeline trigger with a custom "workflow" parameter
+        # set to "nightly". Since we want to trigger this workflow on several
+        # branches, we cannot use the trigger name as suggested by the
+        # documentation.
+        #
+        # For more information:
+        # https://circleci.com/docs/scheduled-pipelines/
         - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
         - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ parameters:
     type: string
     default: go1.18.6-9c97f2f2903566a00bd4b00184aeca0c813adda0
 
+  workflow:
+    type: string
+    default: build
+
 executors:
   cross-builder:
     docker:
@@ -64,6 +68,8 @@ nofork_filter: &nofork_filter
 workflows:
   version: 2
   build:
+    when:
+      equal: [ << pipeline.parameters.workflow >>, build ]
     jobs:
       - test-race:
           <<: *any_filter
@@ -200,13 +206,10 @@ workflows:
       - aws-destroy-by-date
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      and:
+        - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
+        - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:
       - changelog
       - s3-publish-changelog:


### PR DESCRIPTION
CircleCI is removing "cron" workflows later this year. This preemptively switches to scheduled pipelines as to not introduce downtime when "cron" is removed.