### PR TITLE
fix: only the latest scraper being run

### DIFF
--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -121,12 +121,11 @@ func (s *Scheduler) doGather() {
 		s.log.Error("Cannot list targets", zap.Error(err))
 		return
 	}
-	for _, target := range targets {
-		target := target
+	for i := range targets {
 		select {
-		case s.scrapeRequest <- &target:
+		case s.scrapeRequest <- &targets[i]:
 		default:
-			s.log.Warn("Skipping scrape due to scraper backlog", zap.String("target", target.Name))
+			s.log.Warn("Skipping scrape due to scraper backlog", zap.String("target", targets[i].Name))
 		}
 	}
 }

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -122,6 +122,7 @@ func (s *Scheduler) doGather() {
 		return
 	}
 	for _, target := range targets {
+		target := target
 		select {
 		case s.scrapeRequest <- &target:
 		default:


### PR DESCRIPTION
This is due to the Golang for-loop variable problem.

- Closes #23802

### Description
Due to the for-loop variable problem, the scraper request that was pulled off the channel was always the last one in the list of scrapers. See https://github.com/golang/go/discussions/56010 for further explanation. This PR addresses that issue.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
