### PR TITLE
fix: downgrading to 2.3 was broken

### DIFF
--- a/cmd/influxd/downgrade/downgrade.go
+++ b/cmd/influxd/downgrade/downgrade.go
@@ -36,7 +36,7 @@ type migrationTarget struct {
 var downgradeMigrationTargets = map[string]migrationTarget{
 	"2.0": {kvMigration: 15, sqlMigration: 0},
 	"2.1": {kvMigration: 18, sqlMigration: 3},
-	"2.3": {kvMigration: 20, sqlMigration: 6},
+	"2.3": {kvMigration: 20, sqlMigration: 5},
 }
 
 func NewCommand(ctx context.Context, v *viper.Viper) (*cobra.Command, error) {


### PR DESCRIPTION
### Description
Downgrading to 2.3 was broken with a "migration not found" error. This should resolve that issue.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
