### PR TITLE
fix: sql scan error on remote bucket id when replication to 1.x

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -107,11 +107,11 @@ func (r *UpdateReplicationRequest) OK() error {
 // ReplicationHTTPConfig contains all info needed by a client to make HTTP requests against the
 // remote bucket targeted by a replication.
 type ReplicationHTTPConfig struct {
-	RemoteURL            string      `db:"remote_url"`
-	RemoteToken          string      `db:"remote_api_token"`
-	RemoteOrgID          platform.ID `db:"remote_org_id"`
-	AllowInsecureTLS     bool        `db:"allow_insecure_tls"`
-	RemoteBucketID       platform.ID `db:"remote_bucket_id"`
-	RemoteBucketName     string      `db:"remote_bucket_name"`
-	DropNonRetryableData bool        `db:"drop_non_retryable_data"`
+	RemoteURL            string       `db:"remote_url"`
+	RemoteToken          string       `db:"remote_api_token"`
+	RemoteOrgID          platform.ID  `db:"remote_org_id"`
+	AllowInsecureTLS     bool         `db:"allow_insecure_tls"`
+	RemoteBucketID       *platform.ID `db:"remote_bucket_id"`
+	RemoteBucketName     string       `db:"remote_bucket_name"`
+	DropNonRetryableData bool         `db:"drop_non_retryable_data"`
 }

--- a/replications/internal/store_test.go
+++ b/replications/internal/store_test.go
@@ -46,7 +46,7 @@ var (
 		RemoteToken:      replication.RemoteID.String(),
 		RemoteOrgID:      platform.ID(888888),
 		AllowInsecureTLS: true,
-		RemoteBucketID:   *replication.RemoteBucketID,
+		RemoteBucketID:   replication.RemoteBucketID,
 	}
 	newRemoteID  = platform.ID(200)
 	newQueueSize = influxdb.MinReplicationMaxQueueSizeBytes

--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -208,9 +208,11 @@ func PostWrite(ctx context.Context, config *influxdb.ReplicationHTTPConfig, data
 	conf.HTTPClient.Timeout = timeout
 	client := api.NewAPIClient(conf).WriteApi
 
-	bucket := config.RemoteBucketID.String()
-	if config.RemoteBucketName != "" {
+	var bucket string
+	if config.RemoteBucketID == nil || config.RemoteBucketName != "" {
 		bucket = config.RemoteBucketName
+	} else {
+		bucket = config.RemoteBucketID.String()
 	}
 
 	req := client.PostWrite(ctx).

--- a/replications/service.go
+++ b/replications/service.go
@@ -170,7 +170,7 @@ func (s *service) ValidateNewReplication(ctx context.Context, request influxdb.C
 		return errLocalBucketNotFound(request.LocalBucketID, err)
 	}
 
-	config := influxdb.ReplicationHTTPConfig{RemoteBucketID: request.RemoteBucketID}
+	config := influxdb.ReplicationHTTPConfig{RemoteBucketID: &request.RemoteBucketID}
 	if err := s.store.PopulateRemoteHTTPConfig(ctx, request.RemoteID, &config); err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (s *service) ValidateUpdatedReplication(ctx context.Context, id platform.ID
 		return err
 	}
 	if request.RemoteBucketID != nil {
-		baseConfig.RemoteBucketID = *request.RemoteBucketID
+		baseConfig.RemoteBucketID = request.RemoteBucketID
 	}
 
 	if request.RemoteID != nil {

--- a/replications/service_test.go
+++ b/replications/service_test.go
@@ -94,7 +94,7 @@ var (
 		RemoteToken:      replication1.RemoteID.String(),
 		RemoteOrgID:      platform.ID(888888),
 		AllowInsecureTLS: true,
-		RemoteBucketID:   *replication1.RemoteBucketID,
+		RemoteBucketID:   replication1.RemoteBucketID,
 	}
 )
 
@@ -295,7 +295,7 @@ func TestValidateNewReplication(t *testing.T) {
 
 			mocks.bucketSvc.EXPECT().FindBucketByID(gomock.Any(), tt.req.LocalBucketID).Return(nil, tt.bucketErr)
 
-			testConfig := &influxdb.ReplicationHTTPConfig{RemoteBucketID: tt.req.RemoteBucketID}
+			testConfig := &influxdb.ReplicationHTTPConfig{RemoteBucketID: &tt.req.RemoteBucketID}
 			if tt.bucketErr == nil {
 				mocks.serviceStore.EXPECT().PopulateRemoteHTTPConfig(gomock.Any(), tt.req.RemoteID, testConfig).Return(tt.storeErr)
 			}


### PR DESCRIPTION
- Closes #23769

### Description
Fixes sql scan error on replicating data to a 1.x instance. See #23769 for detailed info on the issue and the exact error

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
