### PR TITLE
fix: update me and users routes to match cloud/documentation

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -787,6 +787,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	}
 
 	userHTTPServer := ts.NewUserHTTPHandler(m.log)
+	meHTTPServer := ts.NewMeHTTPHandler(m.log)
 	onboardHTTPServer := tenant.NewHTTPOnboardHandler(m.log, onboardSvc)
 
 	// feature flagging for new labels service
@@ -897,8 +898,8 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		http.WithResourceHandler(labelHandler),
 		http.WithResourceHandler(sessionHTTPServer.SignInResourceHandler()),
 		http.WithResourceHandler(sessionHTTPServer.SignOutResourceHandler()),
-		http.WithResourceHandler(userHTTPServer.MeResourceHandler()),
-		http.WithResourceHandler(userHTTPServer.UserResourceHandler()),
+		http.WithResourceHandler(userHTTPServer),
+		http.WithResourceHandler(meHTTPServer),
 		http.WithResourceHandler(orgHTTPServer),
 		http.WithResourceHandler(bucketHTTPServer),
 		http.WithResourceHandler(v1AuthHTTPServer),

--- a/tenant/http_server_user.go
+++ b/tenant/http_server_user.go
@@ -112,6 +112,7 @@ func (h *UserHandler) handlePutUserPassword(w http.ResponseWriter, r *http.Reque
 		h.api.Err(w, r, &errors.Error{
 			Msg: fmt.Sprintf("error decoding password reset request: %s", err),
 		})
+		return
 	}
 
 	param := chi.URLParam(r, "id")
@@ -120,6 +121,7 @@ func (h *UserHandler) handlePutUserPassword(w http.ResponseWriter, r *http.Reque
 		h.api.Err(w, r, &errors.Error{
 			Msg: "invalid user ID provided in route",
 		})
+		return
 	}
 	err = h.passwordSvc.CompareAndSetPassword(ctx, *userID, req.PasswordOld, req.PasswordNew)
 	if err != nil {
@@ -500,10 +502,12 @@ func (h *MeHandler) handleMe(w http.ResponseWriter, r *http.Request) {
 	userID, err := h.getUserID(ctx)
 	if err != nil {
 		h.api.Err(w, r, err)
+		return
 	}
 	user, err := h.userSvc.FindUserByID(ctx, *userID)
 	if err != nil {
 		h.api.Err(w, r, err)
+		return
 	}
 	h.api.Respond(w, r, http.StatusOK, newUserResponse(user))
 }
@@ -513,6 +517,7 @@ func (h *MeHandler) handlePutMePassword(w http.ResponseWriter, r *http.Request) 
 	userID, err := h.getUserID(ctx)
 	if err != nil {
 		h.api.Err(w, r, err)
+		return
 	}
 
 	req, err := decodePasswordResetRequest(r)

--- a/tenant/http_server_user.go
+++ b/tenant/http_server_user.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -67,20 +66,8 @@ func NewHTTPUserHandler(log *zap.Logger, userService influxdb.UserService, passw
 	return svr
 }
 
-type resourceHandler struct {
-	prefix string
-	*UserHandler
-}
-
-func (h *resourceHandler) Prefix() string {
-	return h.prefix
-}
-func (h *UserHandler) MeResourceHandler() *resourceHandler {
-	return &resourceHandler{prefix: prefixMe, UserHandler: h}
-}
-
-func (h *UserHandler) UserResourceHandler() *resourceHandler {
-	return &resourceHandler{prefix: prefixUsers, UserHandler: h}
+func (h *UserHandler) Prefix() string {
+	return prefixUsers
 }
 
 type passwordSetRequest struct {
@@ -117,10 +104,14 @@ func (h *UserHandler) handlePostUserPassword(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *UserHandler) putPassword(ctx context.Context, w http.ResponseWriter, r *http.Request) (username string, err error) {
+// handlePutPassword is the HTTP handler for the PUT /api/v2/users/:id/password
+func (h *UserHandler) handlePutUserPassword(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	req, err := decodePasswordResetRequest(r)
 	if err != nil {
-		return "", err
+		h.api.Err(w, r, &errors.Error{
+			Msg: fmt.Sprintf("error decoding password reset request: %s", err),
+		})
 	}
 
 	param := chi.URLParam(r, "id")
@@ -129,20 +120,8 @@ func (h *UserHandler) putPassword(ctx context.Context, w http.ResponseWriter, r 
 		h.api.Err(w, r, &errors.Error{
 			Msg: "invalid user ID provided in route",
 		})
-		return
 	}
-
 	err = h.passwordSvc.CompareAndSetPassword(ctx, *userID, req.PasswordOld, req.PasswordNew)
-	if err != nil {
-		return "", err
-	}
-	return req.Username, nil
-}
-
-// handlePutPassword is the HTTP handler for the PUT /api/v2/users/:id/password
-func (h *UserHandler) handlePutUserPassword(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	_, err := h.putPassword(ctx, w, r)
 	if err != nil {
 		h.api.Err(w, r, err)
 		return
@@ -218,27 +197,6 @@ func decodePostUserRequest(ctx context.Context, r *http.Request) (*postUserReque
 	return &postUserRequest{
 		User: b,
 	}, nil
-}
-
-// handleGetMe is the HTTP handler for the GET /api/v2/me.
-func (h *UserHandler) handleGetMe(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	a, err := icontext.GetAuthorizer(ctx)
-	if err != nil {
-		h.api.Err(w, r, err)
-		return
-	}
-
-	id := a.GetUserID()
-	user, err := h.userSvc.FindUserByID(ctx, id)
-
-	if err != nil {
-		h.api.Err(w, r, err)
-		return
-	}
-
-	h.api.Respond(w, r, http.StatusOK, newUserResponse(user))
 }
 
 // handleGetUser is the HTTP handler for the GET /api/v2/users/:id route.
@@ -388,13 +346,6 @@ func newUserResponse(u *influxdb.User) *influxdb.UserResponse {
 
 // handleGetUsers is the HTTP handler for the GET /api/v2/users route.
 func (h *UserHandler) handleGetUsers(w http.ResponseWriter, r *http.Request) {
-	// because this is a mounted path in both the /users and the /me route
-	// we can get a me request through this handler
-	if strings.Contains(r.URL.Path, prefixMe) {
-		h.handleGetMe(w, r)
-		return
-	}
-
 	ctx := r.Context()
 	req, err := decodeGetUsersRequest(ctx, r)
 	if err != nil {
@@ -494,4 +445,88 @@ func decodePatchUserRequest(ctx context.Context, r *http.Request) (*patchUserReq
 		Update: upd,
 		UserID: i,
 	}, nil
+}
+
+// MeHandler represents an HTTP API handler for /me routes.
+type MeHandler struct {
+	chi.Router
+	api         *kithttp.API
+	log         *zap.Logger
+	userSvc     influxdb.UserService
+	passwordSvc influxdb.PasswordsService
+}
+
+func (h *MeHandler) Prefix() string {
+	return prefixMe
+}
+
+func NewHTTPMeHandler(log *zap.Logger, userService influxdb.UserService, passwordService influxdb.PasswordsService) *MeHandler {
+	svr := &MeHandler{
+		api:         kithttp.NewAPI(kithttp.WithLog(log)),
+		log:         log,
+		userSvc:     userService,
+		passwordSvc: passwordService,
+	}
+
+	r := chi.NewRouter()
+	r.Use(
+		middleware.Recoverer,
+		middleware.RequestID,
+		middleware.RealIP,
+	)
+
+	// RESTy routes for "articles" resource
+	r.Route("/", func(r chi.Router) {
+		r.Get("/", svr.handleMe)
+		r.Put("/password", svr.handlePutMePassword)
+	})
+
+	svr.Router = r
+	return svr
+}
+
+func (h *MeHandler) getUserID(ctx context.Context) (*platform.ID, error) {
+	a, err := icontext.GetAuthorizer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id := a.GetUserID()
+	return &id, nil
+}
+
+func (h *MeHandler) handleMe(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := h.getUserID(ctx)
+	if err != nil {
+		h.api.Err(w, r, err)
+	}
+	user, err := h.userSvc.FindUserByID(ctx, *userID)
+	if err != nil {
+		h.api.Err(w, r, err)
+	}
+	h.api.Respond(w, r, http.StatusOK, newUserResponse(user))
+}
+
+func (h *MeHandler) handlePutMePassword(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	userID, err := h.getUserID(ctx)
+	if err != nil {
+		h.api.Err(w, r, err)
+	}
+
+	req, err := decodePasswordResetRequest(r)
+	if err != nil {
+		h.api.Err(w, r, &errors.Error{
+			Msg: fmt.Sprintf("error decoding password reset request: %s", err),
+		})
+	}
+
+	err = h.passwordSvc.CompareAndSetPassword(ctx, *userID, req.PasswordOld, req.PasswordNew)
+	if err != nil {
+		h.api.Err(w, r, err)
+		return
+	}
+	h.log.Debug("User password updated")
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/tenant/middleware_user_auth.go
+++ b/tenant/middleware_user_auth.go
@@ -108,11 +108,17 @@ func (s *AuthedPasswordService) SetPassword(ctx context.Context, userID platform
 // ComparePassword checks if the password matches the password recorded.
 // Passwords that do not match return errors.
 func (s *AuthedPasswordService) ComparePassword(ctx context.Context, userID platform.ID, password string) error {
-	panic("not implemented")
+	if _, _, err := authorizer.AuthorizeWriteResource(ctx, influxdb.UsersResourceType, userID); err != nil {
+		return err
+	}
+	return s.s.ComparePassword(ctx, userID, password)
 }
 
 // CompareAndSetPassword checks the password and if they match
 // updates to the new password.
 func (s *AuthedPasswordService) CompareAndSetPassword(ctx context.Context, userID platform.ID, old string, new string) error {
-	panic("not implemented")
+	if _, _, err := authorizer.AuthorizeWriteResource(ctx, influxdb.UsersResourceType, userID); err != nil {
+		return err
+	}
+	return s.s.CompareAndSetPassword(ctx, userID, old, new)
 }

--- a/tenant/service.go
+++ b/tenant/service.go
@@ -83,3 +83,7 @@ func (ts *Service) NewBucketHTTPHandler(log *zap.Logger, labelSvc influxdb.Label
 func (ts *Service) NewUserHTTPHandler(log *zap.Logger) *UserHandler {
 	return NewHTTPUserHandler(log.With(zap.String("handler", "user")), NewAuthedUserService(ts.UserService), NewAuthedPasswordService(ts.PasswordsService))
 }
+
+func (ts *Service) NewMeHTTPHandler(log *zap.Logger) *MeHandler {
+	return NewHTTPMeHandler(log.With(zap.String("handler", "user")), NewAuthedUserService(ts.UserService), NewAuthedPasswordService(ts.PasswordsService))
+}


### PR DESCRIPTION
- Closes #23716

### Description
There were a whole host of discrepancies between how `/me` is supposed to work and how it was actually working. This PR should bring it (and `/users`) back up to spec with the docs/cloud 2.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
