### PR TITLE
fix: i++ after break the for loop

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -313,6 +313,7 @@ LOOP:
 						results <- &Result{
 							Err: fmt.Errorf("unable to use system source '%s': use %s instead", s.Name, command),
 						}
+						i++
 						break LOOP
 					}
 				}
@@ -324,6 +325,7 @@ LOOP:
 		newStmt, err := RewriteStatement(stmt)
 		if err != nil {
 			results <- &Result{Err: err}
+			i++
 			break
 		}
 		stmt = newStmt
@@ -334,6 +336,7 @@ LOOP:
 				if err := ctx.send(&Result{Err: err, StatementID: i}); err == ErrQueryAborted {
 					return
 				}
+				i++
 				break
 			}
 		}
@@ -362,6 +365,7 @@ LOOP:
 				return
 			}
 			// Stop after the first error.
+			i++
 			break
 		}
 
@@ -375,6 +379,7 @@ LOOP:
 		}
 
 		if interrupted {
+			i++
 			break
 		}
 	}


### PR DESCRIPTION
i++ after break the for loop, avoid always returning ErrNotExecuted in http request

- Closes #
### Required checklist
- [ OK ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ OK ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ OK ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
1. query.executeQuery function returns len(query.Statements)+1 results if breaking loop happen; such as ACTUAL_ERR(i=0), ErrNotExecuted(i=0), ErrNotExecuted(i=1), ErrNotExecuted(i=2)....
2. httpd.Handler.serveQuery uses the results of query.ExecuteQuery, and removes the first err if i equals; so ACTUAL_ERR is removed
3. client cannot acknowledge the actual err

### Context
add some "i++" codes before "break".

### Severity (delete section if not relevant)
recommend to upgrade immediately

### Note for reviewers:
Check whether the semantic commit impact other functions 
