### PR TITLE
fix: ErrNotExecuted err overrides the actual err

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -795,7 +795,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 			resp.Results = append(resp.Results, r)
 		} else if resp.Results[l-1].StatementID == r.StatementID {
 			if r.Err != nil {
-				resp.Results[l-1] = r
+				if resp.Results[l-1].Err == nil {
+					resp.Results[l-1] = r
+				}
 				continue
 			}
 


### PR DESCRIPTION
if err happened in 'h.QueryExecutor.ExecuteQuery', results contain N+1 items with redundant ErrNotExecuted.

- Closes #
### Required checklist
- [ OK ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ OK ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ OK ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
1. query.executeQuery function returns len(query.Statements)+1 results if breaking loop happen; such as ACTUAL_ERR(i=0), ErrNotExecuted(i=0), ErrNotExecuted(i=1), ErrNotExecuted(i=2)....
2. httpd.Handler.serveQuery uses the results of query.ExecuteQuery, and removes the first err if i equals; so ACTUAL_ERR is removed
3. client cannot acknowledge the actual err

### Context
Before overriding, check resp.Results[l-1].Err is nil.

### Severity (delete section if not relevant)
recommend to upgrade immediately

### Note for reviewers:
Check whether the semantic commit impact other functions 
