### PR TITLE
fix: Optimize SHOW FIELD KEY CARDINALITY

### DIFF
--- a/query/statement_rewriter.go
+++ b/query/statement_rewriter.go
@@ -84,6 +84,7 @@ func rewriteShowFieldKeyCardinalityStatement(stmt *influxql.ShowFieldKeyCardinal
 		},
 		Condition:  stmt.Condition,
 		Dimensions: stmt.Dimensions,
+		OmitTime:   true,
 		Sources: influxql.Sources{
 			&influxql.SubQuery{
 				Statement: &influxql.SelectStatement{

--- a/query/statement_rewriter.go
+++ b/query/statement_rewriter.go
@@ -69,7 +69,7 @@ func rewriteShowFieldKeyCardinalityStatement(stmt *influxql.ShowFieldKeyCardinal
 
 	return &influxql.SelectStatement{
 		Fields: []*influxql.Field{
-			&influxql.Field{
+			{
 				Expr: &influxql.Call{
 					Name: "count",
 					Args: []influxql.Expr{
@@ -85,6 +85,8 @@ func rewriteShowFieldKeyCardinalityStatement(stmt *influxql.ShowFieldKeyCardinal
 		Condition:  stmt.Condition,
 		Dimensions: stmt.Dimensions,
 		OmitTime:   true,
+		Offset:     stmt.Offset,
+		Limit:      stmt.Limit,
 		Sources: influxql.Sources{
 			&influxql.SubQuery{
 				Statement: &influxql.SelectStatement{
@@ -94,8 +96,6 @@ func rewriteShowFieldKeyCardinalityStatement(stmt *influxql.ShowFieldKeyCardinal
 					}),
 					Sources:    rewriteSources(stmt.Sources, "_fieldKeys", stmt.Database),
 					Condition:  rewriteSourcesCondition(stmt.Sources, nil),
-					Offset:     stmt.Offset,
-					Limit:      stmt.Limit,
 					OmitTime:   true,
 					Dedupe:     true,
 					IsRawQuery: true,

--- a/query/statement_rewriter_test.go
+++ b/query/statement_rewriter_test.go
@@ -53,6 +53,22 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT fieldKey, fieldType FROM mydb.myrp2._fieldKeys WHERE _name =~ /c.*/`,
 		},
 		{
+			stmt: "SHOW FIELD KEY CARDINALITY",
+			s:    "SELECT count(distinct(fieldKey)) AS count FROM (SELECT fieldKey, fieldType FROM _fieldKeys WHERE _name =~ /.+/)",
+		},
+		{
+			stmt: "SHOW FIELD KEY CARDINALITY ON db0",
+			s:    "SELECT count(distinct(fieldKey)) AS count FROM (SELECT fieldKey, fieldType FROM db0.._fieldKeys WHERE _name =~ /.+/)",
+		},
+		{
+			stmt: "SHOW FIELD KEY CARDINALITY ON db0 FROM /tsm1.*/",
+			s:    "SELECT count(distinct(fieldKey)) AS count FROM (SELECT fieldKey, fieldType FROM db0.._fieldKeys WHERE _name =~ /tsm1.*/)",
+		},
+		{
+			stmt: "SHOW FIELD KEY CARDINALITY ON db0 FROM /tsm1.*/ WHERE 1 = 1",
+			s:    "SELECT count(distinct(fieldKey)) AS count FROM (SELECT fieldKey, fieldType FROM db0.._fieldKeys WHERE _name =~ /tsm1.*/) WHERE 1 = 1",
+		},
+		{
 			stmt: `SHOW SERIES`,
 			s:    `SELECT "key" FROM _series`,
 		},

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2316,6 +2316,17 @@ const (
 // NewFieldKeysIterator returns an iterator that can be iterated over to
 // retrieve field keys.
 func NewFieldKeysIterator(sh *Shard, opt query.IteratorOptions) (query.Iterator, error) {
+	const fieldKey = `fieldKey`
+	const fieldKeyType = `fieldType`
+	if len(opt.Aux) != 2 {
+		return nil, fmt.Errorf("wrong number of field arguments for Field Keys iterator. Expected 2, got %d", len(opt.Aux))
+	}
+	if opt.Aux[0].Val != fieldKey || opt.Aux[1].Val != fieldKeyType {
+		return nil,
+			fmt.Errorf("incorrect fields specified for Field Keys iterator: expected %s, got %s and expected %s, got %s",
+				fieldKey, opt.Aux[0].Val, fieldKeyType, opt.Aux[1].Val)
+	}
+
 	itr := &fieldKeysIterator{shard: sh}
 
 	index, err := sh.Index()


### PR DESCRIPTION
Use the `_fieldKeys` system iterator
 
Closes https://github.com/influxdata/influxdb/issues/23840
