### PR TITLE
fix: remove breaking argument validation for _fieldKeys iterator

### DIFF
--- a/cmd/influx_tools/export/command.go
+++ b/cmd/influx_tools/export/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx_tools/internal/format/line"
 	"github.com/influxdata/influxdb/cmd/influx_tools/internal/format/text"
 	"github.com/influxdata/influxdb/cmd/influx_tools/server"
+	errors2 "github.com/influxdata/influxdb/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -105,9 +106,7 @@ func (cmd *Command) Run(args []string) (err error) {
 	case "discard":
 		wr = format.Discard
 	}
-	defer func() {
-		err = wr.Close()
-	}()
+	defer errors2.Capture(&err, wr.Close)()
 
 	if cmd.conflicts != nil {
 		wr = format.NewConflictWriter(wr, line.NewWriter(cmd.conflicts))

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2316,17 +2316,6 @@ const (
 // NewFieldKeysIterator returns an iterator that can be iterated over to
 // retrieve field keys.
 func NewFieldKeysIterator(sh *Shard, opt query.IteratorOptions) (query.Iterator, error) {
-	const fieldKey = `fieldKey`
-	const fieldKeyType = `fieldType`
-	if len(opt.Aux) != 2 {
-		return nil, fmt.Errorf("wrong number of field arguments for Field Keys iterator. Expected 2, got %d", len(opt.Aux))
-	}
-	if opt.Aux[0].Val != fieldKey || opt.Aux[1].Val != fieldKeyType {
-		return nil,
-			fmt.Errorf("incorrect fields specified for Field Keys iterator: expected %s, got %s and expected %s, got %s",
-				fieldKey, opt.Aux[0].Val, fieldKeyType, opt.Aux[1].Val)
-	}
-
 	itr := &fieldKeysIterator{shard: sh}
 
 	index, err := sh.Index()


### PR DESCRIPTION
New argument validation code for `_fieldKeys` system iterator broke Enterprise tests because it is misused all over the place. Back out the safety check. 