### PR TITLE
fix(1.10): GET /api/v2/buckets properly returns wrapped response

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1082,6 +1082,10 @@ type Bucket struct {
 	UpdatedAt           time.Time `json:"updatedAt"`
 }
 
+type Buckets struct {
+	Buckets []Bucket `json:"buckets"`
+}
+
 func (h *Handler) servePostCreateBucketV2(w http.ResponseWriter, r *http.Request, user meta.User) {
 	var bs []byte
 	if r.ContentLength > 0 {
@@ -1457,7 +1461,8 @@ func findBucketIndex(dbs []meta.DatabaseInfo, db string, rp string) (dbIndex int
 }
 
 func (h *Handler) sendBuckets(w http.ResponseWriter, buckets []Bucket) {
-	b, err := json.Marshal(buckets)
+	bucketsObj := Buckets{buckets}
+	b, err := json.Marshal(bucketsObj)
 	if err != nil {
 		h.httpError(w, fmt.Sprintf("list buckets marshaling error: %s", err.Error()), http.StatusInternalServerError)
 		return

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -2212,18 +2212,18 @@ func TestHandler_ListBuckets(t *testing.T) {
 				t.Fatalf("incorrect error message, expected: %q, got: %q", ct.errMsg, errMsg)
 			}
 		} else {
-			var got []httpd.Bucket
+			var got httpd.Buckets
 			exp := getBuckets(ct.skip, ct.limit)
 
 			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 				t.Fatalf("unmarshaling buckets: %s", err.Error())
 			}
-			if len(exp) != len(got) {
-				t.Fatalf("expected %d buckets returned, got %d", len(exp), len(got))
+			if len(exp) != len(got.Buckets) {
+				t.Fatalf("expected %d buckets returned, got %d", len(exp), len(got.Buckets))
 			}
-			for i := 0; i < len(got); i++ {
-				if exp[i] != got[i].Name {
-					t.Fatalf("expected %q, got %q", exp[i], got[i].Name)
+			for i := 0; i < len(got.Buckets); i++ {
+				if exp[i] != got.Buckets[i].Name {
+					t.Fatalf("expected %q, got %q", exp[i], got.Buckets[i].Name)
 				}
 			}
 		}


### PR DESCRIPTION
- Closes #23861

### Description
GET on /api/v2/buckets  (list buckets) currently returns a JSON array, which is wrong. The response is expected to be a JSON object according to the [InfluxDB 2 swagger](https://github.com/influxdata/openapi/blob/master/contracts/oss.yml#L4140).  

.




