### PR TITLE
fix: fix `log_file` deadlock, since `sync.RWMutex` are not reentrant …

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -429,7 +429,7 @@ func (f *LogFile) TagValueIterator(name, key []byte) TagValueIterator {
 	if !ok {
 		return nil
 	}
-	return tk.TagValueIterator()
+	return tk.TagValueIteratorNoLock()
 }
 
 // DeleteTagKey adds a tombstone for a tag key to the log file.
@@ -1383,11 +1383,15 @@ func (tk *logTagKey) Deleted() bool { return tk.deleted }
 
 func (tk *logTagKey) TagValueIterator() TagValueIterator {
 	tk.f.mu.RLock()
+	defer tk.f.mu.RUnlock()
+	return tk.TagValueIteratorNoLock()
+}
+
+func (tk *logTagKey) TagValueIteratorNoLock() TagValueIterator {
 	a := make([]logTagValue, 0, len(tk.tagValues))
 	for _, v := range tk.tagValues {
 		a = append(a, v)
 	}
-	tk.f.mu.RUnlock()
 
 	return newLogTagValueIterator(a)
 }


### PR DESCRIPTION
…(#23816)

- Closes #23816 
### Required checklist
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
[#23816](https://github.com/influxdata/influxdb/issues/23816)


### Severity (delete section if not relevant)
recommend to upgrade immediately

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes


