### PR TITLE
fix: don't write skipped shard messages to the line protocol output destination

### DIFF
--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -340,7 +340,7 @@ func (cmd *Command) exportTSMFile(tsmFilePath string, w io.Writer) error {
 	f, err := os.Open(tsmFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(w, "skipped missing file: %s", tsmFilePath)
+			fmt.Fprintf(cmd.Stderr, "skipped missing file: %s", tsmFilePath)
 			return nil
 		}
 		return err
@@ -408,7 +408,7 @@ func (cmd *Command) exportWALFile(walFilePath string, w io.Writer, warnDelete fu
 	f, err := os.Open(walFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(w, "skipped missing file: %s", walFilePath)
+			fmt.Fprintf(cmd.Stderr, "skipped missing file: %s", walFilePath)
 			return nil
 		}
 		return err


### PR DESCRIPTION
This switches so that the message

    skipped missing file: /path/to/tsm.tsm

is written to stdErr instead of stdout (or the output file if `-out` has been provided)

(cherry picked from commit a9bf1d54c1eb77c9b5eafef9d1d3db7511ded9c8)

closes https://github.com/influxdata/influxdb/issues/23866