### PR TITLE
fix: Fixes migrating when a remote already exists

### DIFF
--- a/sqlite/migrations/0008_migrate_remotes_null_remote_org.up.sql
+++ b/sqlite/migrations/0008_migrate_remotes_null_remote_org.up.sql
@@ -1,5 +1,6 @@
 -- Removes the "NOT NULL" from remote_org_id
 ALTER TABLE remotes RENAME TO _remotes_old;
+DROP INDEX idx_remote_url_per_org;
 
 CREATE TABLE remotes (
     id VARCHAR(16) NOT NULL PRIMARY KEY,
@@ -28,7 +29,6 @@ INSERT INTO remotes (
     created_at,
     updated_at
 ) SELECT * FROM _remotes_old;
-DROP TABLE _remotes_old;
 -- Create indexes on lookup patterns we expect to be common
 CREATE INDEX idx_remote_url_per_org ON remotes (org_id, remote_url);
 
@@ -76,6 +76,7 @@ INSERT INTO replications (
     updated_at
 ) SELECT * FROM _replications_old;
 DROP TABLE _replications_old;
+DROP TABLE _remotes_old;
 
 -- Create indexes on lookup patterns we expect to be common
 CREATE INDEX idx_local_bucket_id_per_org ON replications (org_id, local_bucket_id);

--- a/sqlite/migrator.go
+++ b/sqlite/migrator.go
@@ -70,6 +70,7 @@ func (m *Migrator) UpUntil(ctx context.Context, untilMigration int, source embed
 	var migrationsToDo int
 	if untilMigration < 1 {
 		migrationsToDo = len(knownMigrations[lastMigration:])
+		untilMigration = len(knownMigrations)
 	} else if untilMigration >= lastMigration {
 		migrationsToDo = len(knownMigrations[lastMigration:untilMigration])
 	} else {

--- a/sqlite/migrator.go
+++ b/sqlite/migrator.go
@@ -33,6 +33,13 @@ func (m *Migrator) SetBackupPath(path string) {
 }
 
 func (m *Migrator) Up(ctx context.Context, source embed.FS) error {
+	return m.UpUntil(ctx, -1, source)
+}
+
+// UpUntil migrates until a specific migration.
+// -1 or 0 will run all migrations, any other number will run up until that.
+// Returns no error untilMigration is less than the already run migrations.
+func (m *Migrator) UpUntil(ctx context.Context, untilMigration int, source embed.FS) error {
 	knownMigrations, err := source.ReadDir(".")
 	if err != nil {
 		return err
@@ -60,7 +67,15 @@ func (m *Migrator) Up(ctx context.Context, source embed.FS) error {
 		}
 	}
 
-	migrationsToDo := len(knownMigrations[lastMigration:])
+	var migrationsToDo int
+	if untilMigration < 1 {
+		migrationsToDo = len(knownMigrations[lastMigration:])
+	} else if untilMigration >= lastMigration {
+		migrationsToDo = len(knownMigrations[lastMigration:untilMigration])
+	} else {
+		return nil
+	}
+
 	if migrationsToDo == 0 {
 		return nil
 	}
@@ -85,7 +100,7 @@ func (m *Migrator) Up(ctx context.Context, source embed.FS) error {
 
 	m.log.Info("Bringing up metadata migrations", zap.Int("migration_count", migrationsToDo))
 
-	for _, f := range knownMigrations[lastMigration:] {
+	for _, f := range knownMigrations[lastMigration:untilMigration] {
 		n := f.Name()
 
 		m.log.Debug("Executing metadata migration", zap.String("migration_name", n))


### PR DESCRIPTION
- Closes #23867

### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Upgrading to 2.5.1 with an existing remote fails due to a foreign key constraint. This PR reorders some commands in the migration to resolve that issue.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
