### PR TITLE
fix: notification rules with the same name

### DIFF
--- a/notification/rule/service/service_external_test.go
+++ b/notification/rule/service/service_external_test.go
@@ -451,6 +451,118 @@ all_statuses
 				},
 			},
 		},
+		{
+			name: "rule name conflict",
+			fields: NotificationRuleFields{
+				IDGenerator:   mock.NewIDGenerator(twoID, t),
+				TimeGenerator: fakeGenerator,
+				Orgs: []*influxdb.Organization{
+					{
+						Name: "org",
+						ID:   MustIDBase16(fourID),
+					},
+				},
+				Endpoints: []influxdb.NotificationEndpoint{
+					&endpoint.Slack{
+						URL: "http://localhost:7777",
+						Token: influxdb.SecretField{
+							// TODO(desa): not sure why this has to end in token, but it does
+							Key:   "020f755c3c082001-token",
+							Value: pointer.String("abc123"),
+						},
+						Base: endpoint.Base{
+							OrgID:  MustIDBase16Ptr(fourID),
+							Name:   "foo",
+							Status: influxdb.Active,
+						},
+					},
+				},
+				NotificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:          MustIDBase16(oneID),
+							Name:        "name1",
+							OwnerID:     MustIDBase16(sixID),
+							OrgID:       MustIDBase16(fourID),
+							EndpointID:  MustIDBase16(twoID),
+							RunbookLink: "runbooklink1",
+							SleepUntil:  &time3,
+							Every:       mustDuration("1h"),
+							StatusRules: []notification.StatusRule{
+								{
+									CurrentLevel: notification.Critical,
+								},
+							},
+							TagRules: []notification.TagRule{
+								{
+									Tag: influxdb.Tag{
+										Key:   "k1",
+										Value: "v1",
+									},
+									Operator: influxdb.NotEqual,
+								},
+								{
+									Tag: influxdb.Tag{
+										Key:   "k2",
+										Value: "v2",
+									},
+									Operator: influxdb.RegexEqual,
+								},
+							},
+							CRUDLog: influxdb.CRUDLog{
+								CreatedAt: timeGen1.Now(),
+								UpdatedAt: timeGen2.Now(),
+							},
+						},
+						Channel:         "channel1",
+						MessageTemplate: "msg1",
+					},
+				},
+			},
+			args: args{
+				userID: MustIDBase16(sixID),
+				notificationRule: &rule.Slack{
+					Base: rule.Base{
+						OwnerID:     MustIDBase16(sixID),
+						OrgID:       MustIDBase16(fourID),
+						Name:        "name1", // existing name
+						EndpointID:  MustIDBase16(twoID),
+						RunbookLink: "runbooklink1",
+						SleepUntil:  &time3,
+						Every:       mustDuration("1h"),
+						StatusRules: []notification.StatusRule{
+							{
+								CurrentLevel: notification.Critical,
+							},
+						},
+						TagRules: []notification.TagRule{
+							{
+								Tag: influxdb.Tag{
+									Key:   "k1",
+									Value: "v1",
+								},
+								Operator: influxdb.NotEqual,
+							},
+							{
+								Tag: influxdb.Tag{
+									Key:   "k2",
+									Value: "v2",
+								},
+								Operator: influxdb.RegexEqual,
+							},
+						},
+					},
+					Channel:         "channel1",
+					MessageTemplate: "msg1",
+				},
+			},
+			wants: wants{
+				err: &errors.Error{
+					Code: errors.EConflict,
+					Msg:  "notification rule with specified name already exists",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkger/service_models.go
+++ b/pkger/service_models.go
@@ -1180,8 +1180,9 @@ type stateRule struct {
 
 	associatedEndpoint *stateEndpoint
 
-	parserRule *notificationRule
-	existing   influxdb.NotificationRule
+	parserRule       *notificationRule
+	existing         influxdb.NotificationRule
+	existingEndpoint influxdb.NotificationEndpoint
 }
 
 func (r *stateRule) ID() platform.ID {
@@ -1212,7 +1213,7 @@ func (r *stateRule) diffRule() DiffNotificationRule {
 		New: DiffNotificationRuleValues{
 			Name:            r.parserRule.Name(),
 			Description:     r.parserRule.description,
-			EndpointName:    r.endpointTemplateName(),
+			EndpointName:    r.endpointName(),
 			EndpointID:      SafeID(r.endpointID()),
 			EndpointType:    r.endpointType(),
 			Every:           r.parserRule.every.String(),
@@ -1230,9 +1231,12 @@ func (r *stateRule) diffRule() DiffNotificationRule {
 	sum.Old = &DiffNotificationRuleValues{
 		Name:         r.existing.GetName(),
 		Description:  r.existing.GetDescription(),
-		EndpointName: r.existing.GetName(),
 		EndpointID:   SafeID(r.existing.GetEndpointID()),
 		EndpointType: r.existing.Type(),
+	}
+
+	if r.existingEndpoint != nil {
+		sum.Old.EndpointName = r.existingEndpoint.GetName()
 	}
 
 	assignBase := func(b rule.Base) {
@@ -1282,6 +1286,13 @@ func (r *stateRule) endpointID() platform.ID {
 func (r *stateRule) endpointTemplateName() string {
 	if r.associatedEndpoint != nil && r.associatedEndpoint.parserEndpoint != nil {
 		return r.associatedEndpoint.parserEndpoint.MetaName()
+	}
+	return ""
+}
+
+func (r *stateRule) endpointName() string {
+	if r.associatedEndpoint != nil && r.associatedEndpoint.parserEndpoint != nil {
+		return r.associatedEndpoint.parserEndpoint.Name()
 	}
 	return ""
 }


### PR DESCRIPTION
- Closes #23781 

### Description
API allows to create notification rules with the same name. This PR assumes that notification rules should have unique names and current behavior is a bug.

The fix includes changes in `pkger`.  With the attached template, the diff output of `influx apply --host http://localhost:8086 -f issue23781.yaml` is correct when re-demploy is attempted (this is tested in `cmd/influxd/launcher/pkger_test.go`):

```
NOTIFICATION ENDPOINTS    +add | -remove | unchanged
+-----+--------------------------------------+------------------+------------------+
| +/- |            METADATA NAME             |        ID        |  RESOURCE NAME   |
+-----+--------------------------------------+------------------+------------------+
| -   | http-none-auth-notification-endpoint | 0a4c67f718fb6000 | no auth endpoint |
+-----+--------------------------------------+------------------+------------------+
| +   | http-none-auth-notification-endpoint | 0a4c67f718fb6000 | no auth endpoint |
+-----+--------------------------------------+------------------+------------------+
|                                                   TOTAL       |        1         |
+-----+--------------------------------------+------------------+------------------+

NOTIFICATION RULES    +add | -remove | unchanged
+-----+---------------+------------------+---------------+-------------+-------+--------+------------------+------------------+---------------+
| +/- | METADATA NAME |        ID        | RESOURCE NAME | DESCRIPTION | EVERY | OFFSET |  ENDPOINT NAME   |   ENDPOINT ID    | ENDPOINT TYPE |
+-----+---------------+------------------+---------------+-------------+-------+--------+------------------+------------------+---------------+
| -   | rule-uuid     | 0a4c68d0a79ac000 | rule_0        | desc_0      | 10m0s | 30s    | no auth endpoint | 0a4c67f718fb6000 | http          |
+-----+---------------+------------------+---------------+-------------+-------+--------+------------------+------------------+---------------+
| +   | rule-uuid     | 0a4c68d0a79ac000 | rule_0        | desc_0      | 10m0s | 30s    | no auth endpoint | 0a4c67f718fb6000 | http          |
+-----+---------------+------------------+---------------+-------------+-------+--------+------------------+------------------+---------------+
|                                                                                                                 TOTAL       |       1       |
+-----+---------------+------------------+---------------+-------------+-------+--------+------------------+------------------+---------------+
```

`issue23781.yaml`
```
apiVersion: influxdata.com/v2alpha1
kind: NotificationEndpointHTTP
metadata:
  name:  http-none-auth-notification-endpoint # on export of resource created from this, will not be same name as this
spec:
  name: no auth endpoint
  type: none
  description: http none auth desc
  method: GET
  url:  https://www.example.com/endpoint/noneauth
  status: inactive
---
apiVersion: influxdata.com/v2alpha1
kind: NotificationRule
metadata:
  name:  rule-uuid
spec:
  name:  rule_0
  description: desc_0
  endpointName: http-none-auth-notification-endpoint
  every: 10m
  offset: 30s
  messageTemplate: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }"
  status: active
  statusRules:
    - currentLevel: WARN
    - currentLevel: CRIT
      previousLevel: OK
  tagRules:
    - key: k1
      value: v2
      operator: eQuAl
    - key: k1
      value: v1
      operator: eQuAl 
```
```