### PR TITLE
fix: user name cannot be empty

### DIFF
--- a/tenant/storage_user.go
+++ b/tenant/storage_user.go
@@ -179,6 +179,10 @@ func (s *Store) CreateUser(ctx context.Context, tx kv.Tx, u *influxdb.User) erro
 		u.ID = s.IDGen.ID()
 	}
 
+	if u.Name == "" {
+		return ErrNameisEmpty
+	}
+
 	encodedID, err := u.ID.Encode()
 	if err != nil {
 		return InvalidUserIDError(err)

--- a/testing/user_service.go
+++ b/testing/user_service.go
@@ -212,11 +212,25 @@ func CreateUser(
 						return MustIDBase16(userOneID)
 					},
 				},
+				Users: []*influxdb.User{
+					{
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: influxdb.Active,
+					},
+				},
 			},
 			args: args{
 				user: &influxdb.User{},
 			},
 			wants: wants{
+				users: []*influxdb.User{
+					{
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: influxdb.Active,
+					},
+				},
 				err: &errors.Error{
 					Code: errors.EInvalid,
 					Op:   influxdb.OpCreateUser,

--- a/testing/user_service.go
+++ b/testing/user_service.go
@@ -204,6 +204,26 @@ func CreateUser(
 				},
 			},
 		},
+		{
+			name: "name cannot be empty",
+			fields: UserFields{
+				IDGenerator: &mock.IDGenerator{
+					IDFn: func() platform.ID {
+						return MustIDBase16(userOneID)
+					},
+				},
+			},
+			args: args{
+				user: &influxdb.User{},
+			},
+			wants: wants{
+				err: &errors.Error{
+					Code: errors.EInvalid,
+					Op:   influxdb.OpCreateUser,
+					Msg:  "name is empty",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Closes #23788 

### Description
When creating user via API, and name is not supplied or empty, server throws 500 Internal Server Error. This PR adds name check and returns 400 Bad Request in such case.

### Context
User should handle invalid input and return appropriate error.
