### PR TITLE
chore: make "flux-testing" public

### DIFF
--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	WriteTracing            bool              `toml:"write-tracing"`
 	FluxEnabled             bool              `toml:"flux-enabled"`
 	FluxLogEnabled          bool              `toml:"flux-log-enabled"`
-	FluxTesting             bool              `toml:"-"`
+	FluxTesting             bool              `toml:"flux-testing"`
 	PprofEnabled            bool              `toml:"pprof-enabled"`
 	PprofAuthEnabled        bool              `toml:"pprof-auth-enabled"`
 	DebugPprofEnabled       bool              `toml:"debug-pprof-enabled"`


### PR DESCRIPTION
The `flux-testing` option was originally hidden as it had no bearing outside of a testing context. However, hiding the option removes the ability to toggle it with environment variables. This functionality is useful for test automation.