### PR TITLE
fix: rule without tags must not match any tag filter (#23782)

### DIFF
--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -344,6 +344,9 @@ func (b *Base) MatchesTags(tags []influxdb.Tag) bool {
 	if len(tags) == 0 {
 		return true
 	}
+	if len(b.TagRules) == 0 {
+		return false
+	}
 	// for each tag in NR
 	// if there exists
 	// a key value match with operator == equal in tags

--- a/notification/rule/rule_test.go
+++ b/notification/rule/rule_test.go
@@ -501,13 +501,13 @@ func TestMatchingRules(t *testing.T) {
 			exp: true,
 		},
 		{
-			name:     "Empty tag rule matches filterTags",
+			name:     "Empty tag rule does not match filterTags",
 			tagRules: []notification.TagRule{},
 			filterTags: []influxdb.Tag{
 				{Key: "a", Value: "b"},
 				{Key: "c", Value: "X"},
 			},
-			exp: true,
+			exp: false,
 		},
 		{
 			name: "Non empty tag rule matches empty filter tags",


### PR DESCRIPTION
- Closes #23782 

### Description
Per API specification, as the ultimate source of truth, when tag filter in specified in GET request as query parameter, _"Only return notification rules that "would match" statuses which contain the tag key value pairs provided."_
Current implementation also returns rules without any tags. This PR fixes it.
