### PR TITLE
feat: include `crypto` diagnostics in `/debug/vars` output

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -2476,12 +2476,8 @@ func ossCryptoDiagnostics() map[string]interface{} {
 // parseCryptoDiagnostics converts the crypto diagnostics into an appropriate
 // format for marshaling to JSON in the /debug/vars format.
 func parseCryptoDiagnostics(d *diagnostics.Diagnostics) (map[string]interface{}, error) {
-	m := map[string]interface{}{
-		"ensureFIPS":     false,
-		"FIPS":           false,
-		"implementation": "Go",
-		"passwordHash":   "bcrypt",
-	}
+	// No defaults (eg ossCryptoDiagnostics) to avoid lying if values are missing
+	m := make(map[string]interface{})
 
 	for key := range m {
 		// Find the associated column.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -2468,7 +2468,7 @@ func ossCryptoDiagnostics() map[string]interface{} {
 	return map[string]interface{}{
 		"ensureFIPS":     false,
 		"FIPS":           false,
-		"pmplementation": "Go",
+		"implementation": "Go",
 		"passwordHash":   "bcrypt",
 	}
 }

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -2645,6 +2645,7 @@ func TestHandlerDebugVars(t *testing.T) {
 			h := NewHandler(false)
 			h.Monitor.StatisticsFn = func(_ map[string]string) ([]*monitor.Statistic, error) {
 				return stats(
+					stat("crypto", tags("FIPS", "ensureFIPS", "passwordHash", "implementation"), nil),
 					stat("database", tags("database", "foo"), nil),
 					stat("hh", tags("path", "/mnt/foo/bar"), nil),
 					stat("httpd", tags("bind", "127.0.0.1:8088", "proto", "https"), nil),
@@ -2656,7 +2657,7 @@ func TestHandlerDebugVars(t *testing.T) {
 			w := httptest.NewRecorder()
 			h.ServeHTTP(w, req)
 			got := keys(read(t, w.Body, Ignored...))
-			exp := []string{"database:foo", "hh:/mnt/foo/bar", "httpd:https:127.0.0.1:8088", "other", "shard:/mnt/foo:111"}
+			exp := []string{"crypto", "database:foo", "hh:/mnt/foo/bar", "httpd:https:127.0.0.1:8088", "other", "shard:/mnt/foo:111"}
 			if !cmp.Equal(got, exp) {
 				t.Errorf("unexpected keys; -got/+exp\n%s", cmp.Diff(got, exp))
 			}
@@ -2677,6 +2678,12 @@ func TestHandlerDebugVars(t *testing.T) {
 			h.ServeHTTP(w, req)
 			got := read(t, w.Body, Ignored...)
 			exp := map[string]interface{}{
+				"crypto": map[string]interface{}{
+					"FIPS":           false,
+					"ensureFIPS":     false,
+					"passwordHash":   "bcrypt",
+					"implementation": "Go",
+				},
 				"hh_processor": map[string]interface{}{
 					"name":   "hh_processor",
 					"tags":   map[string]interface{}{"db": "foo", "shardID": "10"},


### PR DESCRIPTION
Pulls `crypto` diagnostics and includes them in `/debug/vars` output. If no `crypto` diagnostics are available, then OSS crypto information will be shown instead.

closes: #23947

### Context
Added to enhance supportability of Enterprise releases.

### Affected areas (delete section if not relevant):
Extra `crypto` section is now included in `/debug/vars`

### Severity (delete section if not relevant)
This is blocking the Enterprise FIPS release.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
