### PR TITLE
feat: add the ability to log queries killed by `query-timeout`

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -234,6 +234,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.QueryExecutor.TaskManager.QueryTimeout = time.Duration(c.Coordinator.QueryTimeout)
 	s.QueryExecutor.TaskManager.LogQueriesAfter = time.Duration(c.Coordinator.LogQueriesAfter)
 	s.QueryExecutor.TaskManager.MaxConcurrentQueries = c.Coordinator.MaxConcurrentQueries
+	s.QueryExecutor.TaskManager.LogTimedoutQueries = c.Coordinator.LogTimedOutQueries
 
 	// Initialize the monitor
 	s.Monitor.Version = s.buildInfo.Version
@@ -465,8 +466,10 @@ func (s *Server) Open() error {
 	s.TSDBStore.WithLogger(s.Logger)
 	if s.config.Data.QueryLogEnabled {
 		s.QueryExecutor.WithLogger(s.Logger)
-	} else if s.config.Coordinator.LogQueriesAfter > 0 {
-		// Log long-running queries even if not logging all queries
+	} else if s.config.Coordinator.LogQueriesAfter > 0 || s.config.Coordinator.LogTimedOutQueries {
+		// If we need to do any logging, add a logger.
+		// The TaskManager properly handles both of the above configs
+		// so it only logs as is appropriate.
 		s.QueryExecutor.TaskManager.Logger = s.Logger
 	}
 	s.PointsWriter.WithLogger(s.Logger)

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	MaxConcurrentQueries int           `toml:"max-concurrent-queries"`
 	QueryTimeout         toml.Duration `toml:"query-timeout"`
 	LogQueriesAfter      toml.Duration `toml:"log-queries-after"`
+	LogTimedOutQueries   bool          `toml:"log-timedout-queries"`
 	MaxSelectPointN      int           `toml:"max-select-point"`
 	MaxSelectSeriesN     int           `toml:"max-select-series"`
 	MaxSelectBucketsN    int           `toml:"max-select-buckets"`
@@ -48,6 +49,7 @@ func NewConfig() Config {
 		MaxSelectPointN:      DefaultMaxSelectPointN,
 		MaxSelectSeriesN:     DefaultMaxSelectSeriesN,
 		TerminationQueryLog:  false,
+		LogTimedOutQueries:   false,
 	}
 }
 
@@ -58,6 +60,7 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"max-concurrent-queries": c.MaxConcurrentQueries,
 		"query-timeout":          c.QueryTimeout,
 		"log-queries-after":      c.LogQueriesAfter,
+		"log-timedout-queries":   c.LogTimedOutQueries,
 		"max-select-point":       c.MaxSelectPointN,
 		"max-select-series":      c.MaxSelectSeriesN,
 		"max-select-buckets":     c.MaxSelectBucketsN,

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -185,6 +185,9 @@
   # discover slow or resource intensive queries.  Setting the value to 0 disables the slow query logging.
   # log-queries-after = "0s"
 
+  # Enables the logging of queries that are killed as a result of exceeding `query-timeout`
+  # log-timedout-queries = false
+
   # The maximum number of points a SELECT can process.  A value of 0 will make
   # the maximum point count unlimited.  This will only be checked every second so queries will not
   # be aborted immediately when hitting the limit.

--- a/query/task_manager.go
+++ b/query/task_manager.go
@@ -322,6 +322,8 @@ func (t *TaskManager) waitForQuery(qid uint64, interrupt <-chan struct{}, closin
 			t.Logger.Warn(
 				"query killed for exceeding timeout limit",
 				zap.String("query", t.queries[qid].query),
+				zap.String("database", t.queries[qid].database),
+				zap.String("timeout", prettyTime(t.QueryTimeout).String()),
 			)
 		}
 		t.queryError(qid, ErrQueryTimeoutLimitExceeded)

--- a/query/task_manager.go
+++ b/query/task_manager.go
@@ -72,6 +72,9 @@ type TaskManager struct {
 	// If zero, slow queries will never be logged.
 	LogQueriesAfter time.Duration
 
+	// If true, queries that are killed due to `query-timeout` will be logged.
+	LogTimedoutQueries bool
+
 	// Maximum number of concurrent queries.
 	MaxConcurrentQueries int
 
@@ -315,6 +318,12 @@ func (t *TaskManager) waitForQuery(qid uint64, interrupt <-chan struct{}, closin
 
 		t.queryError(qid, err)
 	case <-timerCh:
+		if t.LogTimedoutQueries {
+			t.Logger.Warn(
+				"query killed for exceeding timeout limit",
+				zap.String("query", t.queries[qid].query),
+			)
+		}
 		t.queryError(qid, ErrQueryTimeoutLimitExceeded)
 	case <-interrupt:
 		// Query was manually closed so exit the select.


### PR DESCRIPTION
- Closes https://github.com/influxdata/plutonium/issues/3886
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)

### Description
Adds a flag to log when a query is killed for exceeding the timeout.

### Context
There is no currently no easy way to see what query might be leading to a timeout.

### Affected areas (delete section if not relevant):
Adds a new config option.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
