### PR TITLE
fix: Replications - Close Idle TCP Connections

### DIFF
--- a/replications/remotewrite/writer.go
+++ b/replications/remotewrite/writer.go
@@ -243,6 +243,9 @@ func PostWrite(ctx context.Context, config *influxdb.ReplicationHTTPConfig, data
 		err = invalidResponseCode(res.StatusCode)
 	}
 
+	// Close Idle connections and prevent reaching file descriptor limit
+	conf.HTTPClient.CloseIdleConnections()
+
 	// Must return the response so that the status code and headers can be inspected by the caller, even if the response
 	// was not 204.
 	return res, err


### PR DESCRIPTION
- Closes # https://github.com/influxdata/influxdb/issues/23996 
### Required checklist
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
1-3 sentences describing the PR (or link to well written issue)
Attempts to fix:  https://github.com/influxdata/influxdb/issues/23996 
Closes any Idle TCP connections after a write is called. 

### Context
Why was this added? What value does it add? What are risks/best practices?
This will prevent any reaching the OS file descriptor limit by closing any TCP connections which are idle especially when transferring large amounts of data to a remote database. 


### Severity (delete section if not relevant)
 i.e., ("recommend to upgrade immediately", "upgrade at your leisure", etc.)

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
