### PR TITLE
chore: eliminate use of `golang.org/x/crypto/ssh/terminal` package

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -31,7 +31,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxql"
 	"github.com/peterh/liner"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // ErrBlankCommand is returned when a parsed command is empty.
@@ -81,7 +81,7 @@ func New(version string) *CommandLine {
 
 // Run executes the CLI.
 func (c *CommandLine) Run() error {
-	hasTTY := c.ForceTTY || terminal.IsTerminal(int(os.Stdin.Fd()))
+	hasTTY := c.ForceTTY || term.IsTerminal(int(os.Stdin.Fd()))
 
 	var promptForPassword bool
 	// determine if they set the password flag but provided no value

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.10
@@ -152,7 +153,6 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.47.0 // indirect


### PR DESCRIPTION
The CLI code used a single function from the `golang.org/x/crypto/ssh/terminal` package (`terminal.IsTerminal`) which is just a wrapper around the `golang.org/x/term` package's `term.IsTerminal` function. Replacing this call prevents unnecessary and non-FIPS crypto functions from being pulled into the binary.

- Closes #24035
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Replace usage of `terminal.IsTerminal` function from `golang.org/x/crypto/ssh/terminal` package with `term.IsTerminal` from the `golang.org/x/term` package. This avoids pulling in the `golang.org/x/crypto/ssh` package, which in turn pulled in otherwise unused crypto functions.

### Context
The unused crypto functions pulled in were not using BoringCrypto, and therefore should be avoided in a FIPS build to avoid issues during audit process.


### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
