### PR TITLE
fix: prevent unauthorized writes in flux "to" function

### DIFF
--- a/query/stdlib/influxdata/influxdb/provider.go
+++ b/query/stdlib/influxdata/influxdb/provider.go
@@ -125,7 +125,10 @@ func (p Provider) WriterFor(ctx context.Context, conf influxdb.Config) (influxdb
 	// err will be set if we are not authorized, we don't care about the other return values.
 	_, _, err = authorizer.AuthorizeWrite(ctx, influxdb2.BucketsResourceType, bucketID, reqOrgID)
 	if err != nil {
-		return nil, err
+		return nil, &errors.Error{
+			Code: errors.EForbidden,
+			Msg:  "user not authorized to write",
+		}
 	}
 
 	return &localPointsWriter{

--- a/query/stdlib/influxdata/influxdb/provider.go
+++ b/query/stdlib/influxdata/influxdb/provider.go
@@ -12,6 +12,8 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/values"
+	influxdb2 "github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/authorizer"
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/models"
@@ -116,6 +118,12 @@ func (p Provider) WriterFor(ctx context.Context, conf influxdb.Config) (influxdb
 	}
 
 	bucketID, err := p.lookupBucketID(ctx, reqOrgID, conf.Bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	// err will be set if we are not authorized, we don't care about the other return values.
+	_, _, err = authorizer.AuthorizeWrite(ctx, influxdb2.BucketsResourceType, bucketID, reqOrgID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Closes #24075

### Context
Prevents someone with a read only token from being able to write using the `to` function in flux.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
