### PR TITLE
feat(monitor-ci/415): get oss-e2es working locally in UI repo

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -925,7 +925,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	}
 	// If we are in testing mode we allow all data to be flushed and removed.
 	if opts.Testing {
-		httpHandler = http.DebugFlush(ctx, httpHandler, m.flushers)
+		httpHandler = http.Debug(ctx, httpHandler, m.flushers)
 	}
 
 	if !opts.ReportingDisabled {

--- a/http/debug.go
+++ b/http/debug.go
@@ -2,7 +2,12 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/pkg/httpc"
+	"github.com/influxdata/influxdb/v2/tenant"
 )
 
 // Flusher flushes data from a store to reset; used for testing.
@@ -10,13 +15,39 @@ type Flusher interface {
 	Flush(ctx context.Context)
 }
 
-// DebugFlush clears all services for testing.
-func DebugFlush(ctx context.Context, next http.Handler, f Flusher) http.HandlerFunc {
+func Debug(ctx context.Context, next http.Handler, f Flusher) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/debug/flush" {
+			// DebugFlush clears all services for testing.
 			f.Flush(ctx)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/debug/provision" {
+			client, err := httpc.New(httpc.WithAddr("http://localhost:8086"))
+			onboarding := tenant.OnboardClientService{Client: client}
+			data := &influxdb.OnboardingRequest{
+				User:     "dev_user",
+				Password: "password",
+				Org:      "InfluxData",
+				Bucket:   "project",
+			}
+			res, err := onboarding.OnboardInitialUser(ctx, data)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			body, err := json.Marshal(res)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
- Part of #https://github.com/influxdata/monitor-ci/issues/415
- Where we updated our CI and local testing for UI.
- As part of that process, made [this UI PR](https://github.com/influxdata/ui/pull/6621) which now runs OSS+UI e2es locally --> if, and only if, these changes in this PR are merged.

### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
We did not have a current, documented, and testable development workflow for influxdb/oss + UI repos. This PR is one (of two PRs) which makes this possible.


### Context
Only upside. It just wasn't working before.


### Affected areas (delete section if not relevant):
Now have a `GET /debug/provision/` route accessible when `--e2e-testing` flag is used. 


### Severity (delete section if not relevant)
Impact limited to devs who co-work with UI repo updates.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
