### PR TITLE
fix: handle replication missing queue

### DIFF
--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -379,12 +379,11 @@ func (qm *durableQueueManager) StartReplicationQueues(trackedReplications map[pl
 					qm.replicationQueues[id] = qm.newReplicationQueue(id, repl.OrgID, repl.LocalBucketID, queue, repl.MaxAgeSeconds)
 					qm.replicationQueues[id].Open()
 					qm.logger.Info("Opened replication stream", zap.String("id", id.String()), zap.String("path", queue.Dir()))
-					continue
 				}
+			} else {
+				qm.logger.Error("failed to open replication stream durable queue", zap.Error(err), zap.String("id", id.String()))
+				errOccurred = true
 			}
-			qm.logger.Error("failed to open replication stream durable queue", zap.Error(err), zap.String("id", id.String()))
-			errOccurred = true
-			continue
 		} else {
 			qm.replicationQueues[id] = qm.newReplicationQueue(id, repl.OrgID, repl.LocalBucketID, queue, repl.MaxAgeSeconds)
 			qm.replicationQueues[id].Open()

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -365,13 +365,13 @@ func (qm *durableQueueManager) StartReplicationQueues(trackedReplications map[pl
 				path := pErr.Path
 				if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 					if err := os.MkdirAll(path, 0777); err != nil {
-						qm.logger.Error("error attempting to recreate missing replication queue", zap.Error(err), zap.String("id", id.String()))
+						qm.logger.Error("error attempting to recreate missing replication queue", zap.Error(err), zap.String("id", id.String()), zap.String("path", path))
 						errOccurred = true
 						continue
 					}
 
 					if err := queue.Open(); err != nil {
-						qm.logger.Error("error attempting to open replication queue", zap.Error(err), zap.String("id", id.String()))
+						qm.logger.Error("error attempting to open replication queue", zap.Error(err), zap.String("id", id.String()), zap.String("path", path))
 						errOccurred = true
 						continue
 					}
@@ -381,7 +381,7 @@ func (qm *durableQueueManager) StartReplicationQueues(trackedReplications map[pl
 					qm.logger.Info("Opened replication stream", zap.String("id", id.String()), zap.String("path", queue.Dir()))
 				}
 			} else {
-				qm.logger.Error("failed to open replication stream durable queue", zap.Error(err), zap.String("id", id.String()))
+				qm.logger.Error("failed to open replication stream durable queue", zap.Error(err), zap.String("id", id.String()), zap.String("path", queue.Dir()))
 				errOccurred = true
 			}
 		} else {

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -720,7 +720,8 @@ func TestReplicationStartMissingQueue(t *testing.T) {
 	shutdown(t, qm)
 
 	// Delete the queue to simulate restoring from a backup
-	os.RemoveAll(filepath.Join(queuePath))
+	err = os.RemoveAll(filepath.Join(queuePath))
+	require.NoError(t, err)
 
 	// Call startup function
 	err = qm.StartReplicationQueues(trackedReplications)


### PR DESCRIPTION
- Closes #24120 


### Description
The replication queue is not included in backup/restore. Backing up and restoring an instance that has a replication requires sqlite surgery to get a running instance. This addresses that issue by creating the queue directory if it is not there.

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
