### PR TITLE
fix: scraping failed when Content-Type header is not set

### DIFF
--- a/gather/prometheus.go
+++ b/gather/prometheus.go
@@ -55,7 +55,9 @@ func (p *prometheusScraper) parse(r io.Reader, header http.Header, target influx
 	now := time.Now()
 
 	mediatype, params, err := mime.ParseMediaType(header.Get("Content-Type"))
-	if err != nil {
+	if err != nil && err.Error() == "mime: no media type" {
+		mediatype = "text/plain"
+	} else if err != nil {
 		return collected, err
 	}
 	// Prepare output


### PR DESCRIPTION

- Closes #20193
### Required checklist
- [x] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [x] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
This patch will assume `Content-Type` to be text/plain for cases where it's not specified, see https://github.com/influxdata/influxdb/issues/20193

An example where this applies is on commit `2d82a9c06c3262867322519970865dbcc6e5b93b` at the time of writing for the prometheus Wireguard exporter https://github.com/MindFlavor/prometheus_wireguard_exporter/tree/2d82a9c06c3262867322519970865dbcc6e5b93b

### Context
Why was this added? What value does it add? What are risks/best practices.

This avoids having to patch every project that implements a Prometheus-style metrics endpoint to offer a `Content-Type`.

No known risks, as the error handling is still being performed for cases where the error is a different one than a lacking `Content-Type`.

### Severity
Upgrade recommended for InfluxDB users who want to use scrapers that don't provide Content-Type

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
