### PR TITLE
fix: do not set measurement db or rp in V2 delete

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1013,7 +1013,7 @@ func (h *Handler) serveDeleteV2(w http.ResponseWriter, r *http.Request, user met
 			case influxql.EQ:
 				tag, ok := e.LHS.(*influxql.VarRef)
 				if ok && tag.Val == measurement {
-					srcs = append(srcs, &influxql.Measurement{Database: db, RetentionPolicy: rp, Name: e.RHS.String()})
+					srcs = append(srcs, &influxql.Measurement{Name: e.RHS.String()})
 					return true, nil
 				}
 			// Not permitted in V2 API DELETE predicates


### PR DESCRIPTION
Setting the DB and RP in measurements extracted from
the predicate and used as sources causes Enterprise
/api/v2/delete to fail. The DB must explicitly be passed
to Store.Delete without being set in the measurement
struct passed as a source.

closes https://github.com/influxdata/influxdb/issues/24139