### PR TITLE
fix: /api/v2/delete - user nil sources field, do not set measurement db or rp

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1001,9 +1001,13 @@ func (h *Handler) serveDeleteV2(w http.ResponseWriter, r *http.Request, user met
 		return
 	}
 
-	srcs := make([]influxql.Source, 0)
 	const measurement = "_measurement"
 
+	// This has to be nil if there are no sources;
+	// an empty slice causes the Statement.String()
+	// function into adding an empty WHERE clause.
+	// And that breaks Enterprise remote query execution.
+	var srcs []influxql.Source = nil
 	// take out the _measurement = 'mymeasurement' clause to pass separately
 	// Also check for illegal operands.
 	_, remainingExpr, err := influxql.PartitionExpr(influxql.CloneExpr(cond), func(e influxql.Expr) (bool, error) {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1013,7 +1013,7 @@ func (h *Handler) serveDeleteV2(w http.ResponseWriter, r *http.Request, user met
 			case influxql.EQ:
 				tag, ok := e.LHS.(*influxql.VarRef)
 				if ok && tag.Val == measurement {
-					srcs = append(srcs, &influxql.Measurement{Database: db, RetentionPolicy: rp, Name: e.RHS.String()})
+					srcs = append(srcs, &influxql.Measurement{Name: e.RHS.String()})
 					return true, nil
 				}
 			// Not permitted in V2 API DELETE predicates


### PR DESCRIPTION
*   An empty slice in Sources causes an empty
    WHERE clause to be generated by
    Statement.String(). Use a nil in the field
    to omit the WHERE clause completely
    
    closes https://github.com/influxdata/influxdb/issues/24144
    
    (cherry picked from commit f365bb7e3a9c5e227dbf66d84adf674d3d127176)
    
    closes https://github.com/influxdata/influxdb/issues/24146

*   Setting the DB or RP in measurements extracted from
    the predicate and used as sources causes Enterprise
    /api/v2/delete to fail. The DB must explicitly be passed
    to Store.Delete without being set in the measurement
    struct passed as a source.
    
    closes https://github.com/influxdata/influxdb/issues/24139
    
    (cherry picked from commit c31e99574ffd6fad591bcf25f68c883b908ce0e3)
    
    closes https://github.com/influxdata/influxdb/issues/24140
