### PR TITLE
fix: prevent world-writable MANIFEST files

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1469,7 +1469,7 @@ func (m *Manifest) Write() (int64, error) {
 
 		tmp = f.Name()
 
-		if err = f.Chmod(0666); err != nil {
+		if err = f.Chmod(0644); err != nil {
 			return fmt.Errorf("failed setting permissions on manifest file %q: %w", tmp, err)
 		}
 		if _, err = f.Write(buf); err != nil {


### PR DESCRIPTION
When a new MANIFEST file is created, set
its permissions to 644, not 666

closes https://github.com/influxdata/influxdb/issues/24233