### PR TITLE
chore: stop executing nightly workflow (2.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,31 +117,6 @@ workflows:
     jobs:
       - aws_destroy_by_name
 
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only:
-                - "2.0"
-    jobs:
-      - changelog:
-          nightly: true
-      - godeps
-      - jsdeps
-      - gotest:
-          requires:
-            - godeps
-      - golint:
-          requires:
-            - godeps
-      - fluxtest:
-          requires:
-            - godeps
-      - tlstest:
-          requires:
-            - godeps
   build_and_sign_workflow:
     when:
       and:


### PR DESCRIPTION
This halts execution of the nightly workflow for InfluxDB 2.0. While the contents of `.circleci/config.yml` remains consistent over time, the CircleCI environment changes regularly (available executors, environment variables, etc). These older branches cause unnecessary workflow failures to populate the CircleCI dashboard. Presumably, but probably not importantly, these also consume a small amount of Circle tokens.