### PR TITLE
chore: generate "influxdb.${CIRCLE_TAG}.digests" for each release (1.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,15 @@ jobs:
                 rsign "${target}"
               ;;
             esac
+
+            if [ -f "${target}" ]
+            then
+              # Since all artifacts are present, sign them here. This saves Circle
+              # credits over spinning up another instance just to separate out the
+              # checksum job. Individual checksums are written by the
+              # "build_packages" script.
+              sha256sum "${target}" >> "/tmp/workspace/packages/influxdb.${CIRCLE_TAG}.digests"
+            fi
           done
       - persist_to_workspace:
           root: /tmp/workspace
@@ -407,7 +416,6 @@ workflows:
           <<: *release_filter
       - unit_test_race:
           <<: *release_filter
-
   on_push:
     when:
       equal: [ << pipeline.parameters.workflow >>, build ]


### PR DESCRIPTION
While we have the individual `.sha256` and `.md5` files, this writes a single `.digests` file for all artifacts. If required, this should decrease the amount of time it takes to audit releases.