### PR TITLE
fix: update terraform with newer version (2.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ executors:
     resource_class: large
   linux-amd64:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:current
       resource_class: large
   linux-arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
       resource_class: arm.large
   darwin:
     macos:
@@ -503,8 +503,8 @@ jobs:
           name: Install Package Dependencies
           command: |
             export DEBIAN_FRONTEND=noninteractive
-            sudo apt-get update
-            sudo apt-get install --yes \
+            sudo -E apt-get update
+            sudo -E apt-get install --yes \
               build-essential          \
               git                      \
               rpm                      \
@@ -655,7 +655,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+            - 3a:d1:7a:b7:57:d7:85:0b:76:79:85:51:38:f3:e4:67
       - terraform/validate:
           path: scripts/ci/
       - run:
@@ -711,7 +711,7 @@ jobs:
       # To ssh into aws without failing host key checks
       - add_ssh_keys:
           fingerprints:
-            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+            - 3a:d1:7a:b7:57:d7:85:0b:76:79:85:51:38:f3:e4:67
       - run:
           name: Set up AWS CLI
           command: |
@@ -749,7 +749,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
+            - 3a:d1:7a:b7:57:d7:85:0b:76:79:85:51:38:f3:e4:67
       - run:
           name: Destroy AWS instances with datestring more than a day old
           no_output_timeout: 20m
@@ -969,24 +969,18 @@ jobs:
               /tmp/workspace/artifacts/influxdb2*-arm64.deb
 
   check_package_rpm:
+    executor: linux-amd64
     parameters:
       arch:
         type: string
-    executor: linux-amd64
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: |
-            sudo snap install --classic terraform
       - add_ssh_keys:
           fingerprints:
-            - "91:0a:5b:a7:f9:46:77:f3:5d:4a:cf:d2:44:c8:2c:5a"
-      - run:
-          name: Validate RPM Package
-          command: |
-            export AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY
-            .circleci/scripts/package-validation/redhat << parameters.arch >> /tmp/workspace/artifacts/influxdb2*.<< parameters.arch >>.rpm
+            - 3a:d1:7a:b7:57:d7:85:0b:76:79:85:51:38:f3:e4:67
+      - checkout
+      - run: |
+          AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID \
+          AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY \
+          .circleci/scripts/package-validation/redhat << parameters.arch >> /tmp/workspace/artifacts/influxdb2*.<< parameters.arch >>.rpm

--- a/.circleci/scripts/package-validation/redhat
+++ b/.circleci/scripts/package-validation/redhat
@@ -63,6 +63,30 @@ trap "terraform_free \"${arch}\" \"${package}\"" \
   ERR     \
   EXIT
 
+function terraform_setup()
+{
+  # TODO(bnpfeife): remove this once the executor is updated.
+  #
+  # Unfortunately, terraform provided by the CircleCI executor is *terribly*
+  # out of date. Most Linux distributions are disabling "ssh-rsa" public key
+  # algorithms which this uses to remote into the ec2 instance . This
+  # installs the latest version of terraform.
+  #
+  # Addendum: the "terraform_version" CircleCI option is broken!
+sudo tee /etc/apt/sources.list.d/hashicorp.list <<EOF >/dev/null || true
+deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main
+EOF
+
+  curl -fL https://apt.releases.hashicorp.com/gpg | gpg --dearmor | \
+    sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
+
+  export DEBIAN_FRONTEND=noninteractive
+  sudo -E apt-get update
+  sudo -E apt-get install --yes terraform
+}
+
+terraform_setup
+
 terraform_init "${arch}" "${package}"
 
 printf 'Setup complete! Testing %s... (this takes several minutes!)' "${1}"


### PR DESCRIPTION
The terraform shipped with snap (in the older version of Ubuntu) only supported public key encryption with ssh-rsa. New versions of Linux started deprecating ssh-rsa, so this version bump is required.

Edit: While debugging this, I recreated the ssh keypair in AWS. 