### PR TITLE
Added check to startup script for systemd to detect exits on startup

### DIFF
--- a/.circleci/scripts/package/influxdb2/fs/usr/lib/influxdb/scripts/influxd-systemd-start.sh
+++ b/.circleci/scripts/package/influxdb2/fs/usr/lib/influxdb/scripts/influxd-systemd-start.sh
@@ -22,6 +22,10 @@ url="$PROTOCOL://$HOST:$PORT/ready"
 result=$(curl -k -s -o /dev/null $url -w %{http_code})
 while [ "${result:0:2}" != "20" ] && [ "${result:0:2}" != "40" ]; do
   attempts=$(($attempts+1))
+  if [ ! -f /proc/$PID ]; then
+    echo "InfluxDB exited during startup"
+    exit 1
+  fi
   echo "InfluxDB API at $url unavailable after $attempts attempts..."
   sleep 1
   result=$(curl -k -s -o /dev/null $url -w %{http_code})


### PR DESCRIPTION
- Closes #24348

### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
Adds a check for the systemd startup script that stops the unit then the database exits

### Note for reviewers:
Check the semantic commit type:
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”