### PR TITLE
chore: update MacOS executor to M1 (2.6)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ executors:
       image: ubuntu-2204:current
       resource_class: arm.large
   darwin:
+    resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 12.5.1
-      resource_class: medium
+      xcode: 15.0.0
     shell: /bin/bash -eo pipefail
   windows:
     machine:
@@ -395,6 +395,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Install Rosetta
+          command: .circleci/scripts/install-rosetta
       - run:
           name: Run tests
           command: ./scripts/ci/run-prebuilt-tests.sh $(pwd)/test-bin $(pwd)/test-results

--- a/.circleci/scripts/install-rosetta
+++ b/.circleci/scripts/install-rosetta
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${MACHTYPE}" == "arm64-apple-darwin"* ]]
+then
+  /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+fi


### PR DESCRIPTION
This will prevent issues when CircleCI deprecates the x86/Intel Mac images.