### PR TITLE
Main 2.x

### DIFF
--- a/cmd/influxd/inspect/type_conflicts/schema.go
+++ b/cmd/influxd/inspect/type_conflicts/schema.go
@@ -125,10 +125,10 @@ func (s Schema) WriteConflictsFile(filename string) error {
 
 func (s Schema) encodeSchema(filename string) (rErr error) {
 	schemaFile, err := os.Create(filename)
-	defer errors2.Capture(&rErr, schemaFile.Close)()
 	if err != nil {
 		return fmt.Errorf("unable to create schema file: %w", err)
 	}
+	defer errors2.Capture(&rErr, schemaFile.Close)()
 	return s.Encode(schemaFile)
 }
 

--- a/cmd/influxd/inspect/type_conflicts/schema.go
+++ b/cmd/influxd/inspect/type_conflicts/schema.go
@@ -125,7 +125,7 @@ func (s Schema) WriteConflictsFile(filename string) error {
 
 func (s Schema) encodeSchema(filename string) (rErr error) {
 	schemaFile, err := os.Create(filename)
-	defer errors2.Capture(&rErr, schemaFile.Close)
+	defer errors2.Capture(&rErr, schemaFile.Close)()
 	if err != nil {
 		return fmt.Errorf("unable to create schema file: %w", err)
 	}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -138,7 +138,7 @@ func (s *SqlStore) BackupSqlStore(ctx context.Context, w io.Writer) (rErr error)
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, dest.Close)
+	defer errors2.Capture(&rErr, dest.Close)()
 
 	if err := backup(ctx, dest, s); err != nil {
 		return err
@@ -227,7 +227,7 @@ func (s *SqlStore) RestoreSqlStore(ctx context.Context, r io.Reader) (rErr error
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, f.Close)
+	defer errors2.Capture(&rErr, f.Close)()
 
 	// Copy the contents of r to the temporary file
 	if _, err := io.Copy(f, r); err != nil {


### PR DESCRIPTION
The returned function of `errors2.Capture` needs to be called.

Closes #24366 

The wrapper function that is returned by `errors2.Capture` is not getting called by defer in a few places. This results in file descriptor resource leak. Additionally, ensure that the `File.Close` is only called if successfully created/opened.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
