### PR TITLE
fix: Make write_lp work for both multitenant and singletenant

### DIFF
--- a/influxdb_iox/src/commands/write.rs
+++ b/influxdb_iox/src/commands/write.rs
@@ -1,5 +1,8 @@
 use futures::{stream::BoxStream, StreamExt};
-use influxdb_iox_client::{connection::Connection, write};
+use influxdb_iox_client::{
+    connection::Connection,
+    write::{self, DatabaseName},
+};
 use observability_deps::tracing::{debug, info};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use std::{
@@ -150,8 +153,9 @@ pub async fn command(connection: Connection, config: Config) -> Result<()> {
         .with_max_concurrent_uploads(max_concurrent_uploads)
         .with_max_request_payload_size_bytes(Some(max_request_payload_size_bytes));
 
+    let database = DatabaseName::split_org_db(namespace).context(ClientSnafu)?;
     let total_bytes = client
-        .write_lp_stream(namespace, lp_stream)
+        .write_lp_stream(database, lp_stream)
         .await
         .context(ClientSnafu)?;
 

--- a/influxdb_iox_client/src/client/error.rs
+++ b/influxdb_iox_client/src/client/error.rs
@@ -68,16 +68,16 @@ pub enum Error {
     Unknown(ServerError<()>),
 
     #[error("Client specified an invalid argument: {0}")]
-    InvalidArgument(ServerError<FieldViolation>),
+    InvalidArgument(Box<ServerError<FieldViolation>>),
 
     #[error("Deadline expired before operation could complete: {0}")]
     DeadlineExceeded(ServerError<()>),
 
     #[error("{0}")]
-    NotFound(ServerError<NotFound>),
+    NotFound(Box<ServerError<NotFound>>),
 
     #[error("Some entity that we attempted to create already exists: {0}")]
-    AlreadyExists(ServerError<AlreadyExists>),
+    AlreadyExists(Box<ServerError<AlreadyExists>>),
 
     #[error("The caller does not have permission to execute the specified operation: {0}")]
     PermissionDenied(ServerError<()>),
@@ -86,7 +86,7 @@ pub enum Error {
     ResourceExhausted(ServerError<()>),
 
     #[error("The system is not in a state required for the operation's execution: {0}")]
-    FailedPrecondition(ServerError<PreconditionViolation>),
+    FailedPrecondition(Box<ServerError<PreconditionViolation>>),
 
     #[error("The operation was aborted: {0}")]
     Aborted(ServerError<()>),
@@ -122,13 +122,13 @@ impl From<tonic::Status> for Error {
             Code::Ok => Self::Client("status is not an error".into()),
             Code::Cancelled => Self::Cancelled(parse_status(s)),
             Code::Unknown => Self::Unknown(parse_status(s)),
-            Code::InvalidArgument => Self::InvalidArgument(parse_status(s)),
+            Code::InvalidArgument => Self::InvalidArgument(Box::new(parse_status(s))),
             Code::DeadlineExceeded => Self::DeadlineExceeded(parse_status(s)),
-            Code::NotFound => Self::NotFound(parse_status(s)),
-            Code::AlreadyExists => Self::AlreadyExists(parse_status(s)),
+            Code::NotFound => Self::NotFound(Box::new(parse_status(s))),
+            Code::AlreadyExists => Self::AlreadyExists(Box::new(parse_status(s))),
             Code::PermissionDenied => Self::PermissionDenied(parse_status(s)),
             Code::ResourceExhausted => Self::ResourceExhausted(parse_status(s)),
-            Code::FailedPrecondition => Self::FailedPrecondition(parse_status(s)),
+            Code::FailedPrecondition => Self::FailedPrecondition(Box::new(parse_status(s))),
             Code::Aborted => Self::Aborted(parse_status(s)),
             Code::OutOfRange => Self::OutOfRange(parse_status(s)),
             Code::Unimplemented => Self::Unimplemented(parse_status(s)),
@@ -170,13 +170,13 @@ impl Error {
         let field_name = field_name.into();
         let description = description.into();
 
-        Self::InvalidArgument(ServerError {
+        Self::InvalidArgument(Box::new(ServerError {
             message: format!("Invalid argument for '{field_name}': {description}"),
             details: Some(FieldViolation {
                 field: field_name,
                 description,
             }),
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
(cherry pick of https://github.com/influxdata/influxdb_iox/pull/9027)

----

Users of the rust influxdb client library should be able to write to InfluxDB serverless multi-tenant and InfluxDB clustered single-tenant databases.

However, the `write_lp` function was assuming that the caller encoded `<org>_<bucket>` in the namespace/database name. This encoding is an internal hack of the InfluxDB serverless iox engine. No real clients are sending requests with that encoding over the wire. This encoding is only used internally in serverless to create org scoped databases in an otherwise flat namespace of database names.

This PR makes a source-compatible changes to the `write_lp` signature that allows users to keep passing database names to `write_lp` when targeting single-tenant databases, while also allowing the user to explicitly pass an "org" + "database" combo when targeting a multi-tenant database.

This change assumes that most current users of this crate are users of the single-tenant flavour of influxdb

This change does NOT change the behaviour of the `influxdb_iox write` CLI command, which interprets the namespace parameter as "org_namespace". This is because:

1. this PR is meant to fix a user facing issue with customers wanting to use the rust client crate but not being able to write to da
2. since the influxdb_iox repo is now closed source, the write client embedded in the influxdb_iox binary is mostly useful internally by us, and it makes sense to keep it using the same names as they appear in the namespace table in the catalog. The situation may change in the future, when we provide an update influxdb CLI for end-users.

### Noise

This PR added a function the returns `Result<Foo, Error>` and clippy complained with:

```
    Checking influxdb_iox_client v0.1.0 (/Users/mkm/w/iox/influxdb_iox_client)
error: the `Err`-variant returned from this function is very large
  --> influxdb_iox_client/src/client/write.rs:44:56
   |
44 |     pub fn split_org_db(namespace: impl AsRef<str>) -> Result<Self, Error> {
   |                                                        ^^^^^^^^^^^^^^^^^^^
   |
  ::: influxdb_iox_client/src/client/error.rs:77:5
   |
77 |     NotFound(ServerError<NotFound>),
   |     ------------------------------- the largest variant contains at least 128 bytes
...
80 |     AlreadyExists(ServerError<AlreadyExists>),
   |     ----------------------------------------- the variant `AlreadyExists` contains at least 128 bytes
   |
   = help: try reducing the size of `client::error::Error`, for example by boxing large elements or replacing it with `Box<client::error::Error>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
   = note: `-D clippy::result-large-err` implied by `-D warnings`
```

I'm not sure why it accepted such a large Error enum before, wince `write_lp` also returns the Error, but anyway, I boxed a few of the nested errors 
