### PR TITLE
chore: ignore Go in .github/dependabot.yml, take 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,5 @@ updates:
   # files that no longer exist. Tell dependabot to ignore "gomod"
   - package-ecosystem: "gomod"
     directory: "/"
-    ignore: "*"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Update to use the documented dependency-name: "*" methodology rather than an undocumented example.

References:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file