### PR TITLE
fix: handle MetricSlice to Points conversion errors (#24452)

### DIFF
--- a/gather/metrics.go
+++ b/gather/metrics.go
@@ -31,14 +31,14 @@ type MetricsSlice []Metrics
 
 // Points convert the MetricsSlice to model.Points
 func (ms MetricsSlice) Points() (models.Points, error) {
-	ps := make([]models.Point, len(ms))
-	for mi, m := range ms {
+	ps := make([]models.Point, 0, len(ms))
+	for _, m := range ms {
 		point, err := models.NewPoint(m.Name, models.NewTags(m.Tags), m.Fields, m.Timestamp)
 		if err != nil {
 			return ps, err
 		}
 
-		ps[mi] = point
+		ps = append(ps, point)
 	}
 	return ps, nil
 }


### PR DESCRIPTION
Correctly handle errors in converting MetricSlice
elements into model.Points. Add a test to verify
error handling.

(cherry picked from commit 19e5c0e1b7c40f95fd9d70d51c72281d2d4b4b6b)