### PR TITLE
feat: Add authenticating ID and user ID to request logging

### DIFF
--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -108,6 +108,9 @@ func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Set the Authorizer pointer for use in logging high up the call stack
+	platcontext.StoreAuthorizer(ctx, auth)
+
 	// jwt based auth is permission based rather than identity based
 	// and therefor has no associated user. if the user ID is invalid
 	// disregard the user active check

--- a/http/legacy/influx1x_authentication_handler.go
+++ b/http/legacy/influx1x_authentication_handler.go
@@ -49,6 +49,10 @@ func (h *Influx1xAuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http
 	}
 
 	auth, err := h.auth.Authorize(ctx, creds)
+
+	// Set the Authorizer pointer for use in logging high up the call stack
+	platcontext.StoreAuthorizer(ctx, auth)
+
 	if err != nil {
 		var erri *errors2.Error
 		if errors.As(err, &erri) {


### PR DESCRIPTION
To allow rudimentary security auditing of logs,
add the authenticating ID and the user ID when
possible to the request logs. When a request is
authorized for V1 or V2 API, store the authorizer
object to be used by the logger up the call stack.

closes https://github.com/influxdata/influxdb/issues/24473