### PR TITLE
fix: enable Secure when using TLS and enable HttpOnly (#24524)

### DIFF
--- a/session/http_server.go
+++ b/session/http_server.go
@@ -105,7 +105,7 @@ func (h *SessionHandler) handleSignin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	encodeCookieSession(w, s)
+	encodeCookieSession(w, s, (r != nil) && (r.TLS != nil))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -163,7 +163,7 @@ func decodeSignoutRequest(ctx context.Context, r *http.Request) (*signoutRequest
 
 const cookieSessionName = "influxdb-oss-session"
 
-func encodeCookieSession(w http.ResponseWriter, s *influxdb.Session) {
+func encodeCookieSession(w http.ResponseWriter, s *influxdb.Session, tlsEnabled bool) {
 	// We only need the session cookie for accesses to "/api/...", so limit
 	// it to that using "Path".
 	//
@@ -208,6 +208,8 @@ func encodeCookieSession(w http.ResponseWriter, s *influxdb.Session) {
 		Path:     "/api/", // since UI doesn't need it, limit cookie usage to API requests
 		Expires:  s.ExpiresAt,
 		SameSite: http.SameSiteStrictMode,
+		HttpOnly: true,
+		Secure:   tlsEnabled,
 	}
 
 	http.SetCookie(w, c)

--- a/session/http_server_test.go
+++ b/session/http_server_test.go
@@ -58,7 +58,7 @@ func TestSessionHandler_handleSignin(t *testing.T) {
 				password: "supersecret",
 			},
 			wants: wants{
-				cookie: "influxdb-oss-session=abc123xyz; Path=/api/; Expires=Thu, 26 Sep 2030 00:00:00 GMT; SameSite=Strict",
+				cookie: "influxdb-oss-session=abc123xyz; Path=/api/; Expires=Thu, 26 Sep 2030 00:00:00 GMT; HttpOnly; SameSite=Strict",
 				code:   http.StatusNoContent,
 			},
 		},


### PR DESCRIPTION
Set the HttpOnly and, when TLS is enabled,
Secure flags on cookies

closes: https://github.com/influxdata/influxdb/issues/24522

(cherry picked from commit 8e8700f14f8b45601f59cb20908ee5baa8667328)

closes https://github.com/influxdata/influxdb/issues/24523
