### PR TITLE
chore: Sync and release v1.0.1 of influxdb-line-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb-line-protocol"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb-line-protocol"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytes",
  "log",

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influxdb-line-protocol"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["InfluxDB IOx Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/influxdb_line_protocol/Cargo.toml
+++ b/influxdb_line_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influxdb-line-protocol"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["InfluxDB IOx Project Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/influxdb_line_protocol/README.md
+++ b/influxdb_line_protocol/README.md
@@ -4,14 +4,14 @@
 
 This crate contains pure Rust implementations of
 
-1. A [parser](https://docs.rs/influxdb_line_protocol/latest/influxdb_line_protocol/fn.parse_lines.html) for [InfluxDB Line Protocol] developed as part of the
+1. A [parser](https://docs.rs/influxdb-line-protocol/latest/influxdb_line_protocol/fn.parse_lines.html) for [InfluxDB Line Protocol] developed as part of the
 [InfluxDB IOx] project.  This implementation is intended to be
 compatible with the [Go implementation], however, this
 implementation uses a [nom] combinator-based parser rather than
 attempting to port the imperative Go logic so there are likely
-some small diferences.
+some small differences.
 
-2. A [builder](https://docs.rs/influxdb_line_protocol/latest/influxdb_line_protocol/builder/struct.LineProtocolBuilder.html) to contruct valid [InfluxDB Line Protocol]
+2. A [builder](https://docs.rs/influxdb-line-protocol/latest/influxdb_line_protocol/builder/struct.LineProtocolBuilder.html) to construct valid [InfluxDB Line Protocol]
 
 ## Example
 

--- a/influxdb_line_protocol/RELEASE.md
+++ b/influxdb_line_protocol/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Step 1: Update `README.md` file
 
-Update the `README.md` file (copies the rustdoc comments) using the [`cargo rmde`](https://crates.io/crates/cargo-rdme) tool (install via `cargo install cargo-rdme`):
+Update the `README.md` file (copies the rustdoc comments) using the [`cargo rdme`](https://crates.io/crates/cargo-rdme) tool (install via `cargo install cargo-rdme`):
 
 ```shell
 cargo rdme

--- a/influxdb_line_protocol/src/lib.rs
+++ b/influxdb_line_protocol/src/lib.rs
@@ -55,6 +55,11 @@
 //! [Go implementation]: https://github.com/influxdata/influxdb/blob/217eddc87e14a79b01d0c22994fc139f530094a2/models/points_parser.go
 //! [InfluxDB IOx]: https://github.com/influxdata/influxdb_iox
 //! [nom]: https://crates.io/crates/nom
+
+// Note this crate is published as its own crate on crates.io but kept in this repository for
+// maintenance convenience.
+//
+// Thus this crate can't use workspace lints, so these lint configurations must be here.
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,
@@ -66,6 +71,7 @@
     clippy::dbg_macro,
     unused_crate_dependencies
 )]
+// DO NOT REMOVE these lint configurations; see note above!
 
 pub mod builder;
 pub use builder::LineProtocolBuilder;
@@ -1173,6 +1179,16 @@ mod test {
                 _ => panic!("field was not a Bool"),
             }
         }
+    }
+
+    #[test]
+    fn parse_lines_returns_all_lines_even_when_a_line_errors() {
+        let input = ",tag1=1,tag2=2 value=1 123\nm,tag1=one,tag2=2 value=1 123";
+        let vals = super::parse_lines(input).collect::<Vec<Result<_>>>();
+        assert!(matches!(
+            &vals[..],
+            &[Err(Error::MeasurementValueInvalid), Ok(_)]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
* Increase influxdb-line-protocol version
* run `cargo rdme`
* Pull changes from influxdb_iox
  * only missing: https://github.com/influxdata/influxdb_iox/commit/61082a000005cd2f88cfd3799072e3e14e3d5005

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

