### PR TITLE
fix: corrrectly return 4XX errors instead of 5XX errors (#24519)

### DIFF
--- a/authorization/error.go
+++ b/authorization/error.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	errors2 "errors"
 	"fmt"
 
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
@@ -49,18 +50,18 @@ func ErrInvalidAuthIDError(err error) *errors.Error {
 	}
 }
 
-// ErrInternalServiceError is used when the error comes from an internal system.
-func ErrInternalServiceError(err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Err:  err,
-	}
-}
-
 // UnexpectedAuthIndexError is used when the error comes from an internal system.
 func UnexpectedAuthIndexError(err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Msg:  fmt.Sprintf("unexpected error retrieving auth index; Err: %v", err),
+	var e *errors.Error
+	if !errors2.As(err, &e) {
+		e = &errors.Error{
+			Msg:  fmt.Sprintf("unexpected error retrieving auth index; Err: %v", err),
+			Code: errors.EInternal,
+			Err:  err,
+		}
 	}
+	if e.Code == "" {
+		e.Code = errors.EInternal
+	}
+	return e
 }

--- a/bucket.go
+++ b/bucket.go
@@ -2,12 +2,10 @@ package influxdb
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/influxdata/influxdb/v2/kit/platform"
-	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 )
 
 const (
@@ -160,13 +158,4 @@ func (f BucketFilter) String() string {
 		parts = append(parts, "Org Name: "+*f.Org)
 	}
 	return "[" + strings.Join(parts, ", ") + "]"
-}
-
-func ErrInternalBucketServiceError(op string, err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Msg:  fmt.Sprintf("unexpected error in buckets; Err: %v", err),
-		Op:   op,
-		Err:  err,
-	}
 }

--- a/checks/service_external_test.go
+++ b/checks/service_external_test.go
@@ -1030,7 +1030,7 @@ func FindChecks(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, opPrefix, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1049,7 +1049,7 @@ func FindChecks(
 			}
 
 			checks, _, err := s.FindChecks(ctx, filter, tt.args.findOptions)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, t)
 
 			if diff := cmp.Diff(checks, tt.wants.checks, checkCmpOptions...); diff != "" {
 				t.Errorf("checks are different -got/+want\ndiff %s", diff)
@@ -1536,14 +1536,14 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _, opPrefix, done := init(tt.fields, t)
+			s, _, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			checkCreate := influxdb.CheckCreate{Check: tt.args.check, Status: influxdb.Active}
 
 			check, err := s.UpdateCheck(ctx, tt.args.id, checkCreate)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, t)
 
 			if diff := cmp.Diff(check, tt.wants.check, checkCmpOptions...); diff != "" {
 				t.Errorf("check is different -got/+want\ndiff %s", diff)
@@ -1731,7 +1731,7 @@ func MustIDBase16(s string) platform.ID {
 	return *id
 }
 
-func diffPlatformErrors(name string, actual, expected error, opPrefix string, t *testing.T) {
+func diffPlatformErrors(name string, actual, expected error, t *testing.T) {
 	t.Helper()
 	ErrorsEqual(t, actual, expected)
 }

--- a/dashboards/testing/dashboards.go
+++ b/dashboards/testing/dashboards.go
@@ -217,11 +217,11 @@ func CreateDashboard(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateDashboard(ctx, tt.args.dashboard)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			defer s.DeleteDashboard(ctx, tt.args.dashboard.ID)
 
@@ -397,11 +397,11 @@ func AddDashboardCell(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.AddDashboardCell(ctx, tt.args.dashboardID, tt.args.cell, platform.AddDashboardCellOptions{})
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			defer s.DeleteDashboard(ctx, tt.args.dashboardID)
 
@@ -493,12 +493,12 @@ func FindDashboardByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			dashboard, err := s.FindDashboardByID(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			if diff := cmp.Diff(dashboard, tt.wants.dashboard, dashboardCmpOptions...); diff != "" {
 				t.Errorf("dashboard is different -got/+want\ndiff %s", diff)
@@ -999,7 +999,7 @@ func FindDashboards(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx, err := feature.Annotate(context.Background(), mock.NewFlagger(map[feature.Flag]interface{}{
 				feature.EnforceOrganizationDashboardLimits(): true,
@@ -1015,7 +1015,7 @@ func FindDashboards(
 			}
 
 			dashboards, _, err := s.FindDashboards(ctx, filter, tt.args.findOptions)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			if diff := cmp.Diff(dashboards, tt.wants.dashboards, dashboardCmpOptions...); diff != "" {
 				t.Errorf("dashboards are different -got/+want\ndiff %s", diff)
@@ -1115,11 +1115,11 @@ func DeleteDashboard(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteDashboard(ctx, tt.args.ID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			filter := platform.DashboardFilter{}
 			dashboards, _, err := s.FindDashboards(ctx, filter, platform.DefaultDashboardFindOptions)
@@ -1351,7 +1351,7 @@ func UpdateDashboard(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1367,7 +1367,7 @@ func UpdateDashboard(
 			}
 
 			dashboard, err := s.UpdateDashboard(ctx, tt.args.id, upd)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			if diff := cmp.Diff(dashboard, tt.wants.dashboard, dashboardCmpOptions...); diff != "" {
 				t.Errorf("dashboard is different -got/+want\ndiff %s", diff)
@@ -1454,11 +1454,11 @@ func RemoveDashboardCell(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.RemoveDashboardCell(ctx, tt.args.dashboardID, tt.args.cellID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			defer s.DeleteDashboard(ctx, tt.args.dashboardID)
 
@@ -1662,11 +1662,11 @@ func UpdateDashboardCell(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			_, err := s.UpdateDashboardCell(ctx, tt.args.dashboardID, tt.args.cellID, tt.args.cellUpdate)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			defer s.DeleteDashboard(ctx, tt.args.dashboardID)
 
@@ -1852,11 +1852,11 @@ func ReplaceDashboardCells(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.ReplaceDashboardCells(ctx, tt.args.dashboardID, tt.args.cells)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			defer s.DeleteDashboard(ctx, tt.args.dashboardID)
 
@@ -1952,12 +1952,12 @@ func GetDashboardCellView(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			view, err := s.GetDashboardCellView(ctx, tt.args.dashboardID, tt.args.cellID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			if diff := cmp.Diff(view, tt.wants.view); diff != "" {
 				t.Errorf("dashboard cell views are different -got/+want\ndiff %s", diff)
@@ -2125,7 +2125,7 @@ func UpdateDashboardCellView(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -2139,7 +2139,7 @@ func UpdateDashboardCellView(
 			}
 
 			view, err := s.UpdateDashboardCellView(ctx, tt.args.dashboardID, tt.args.cellID, upd)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(err, tt.wants.err, t)
 
 			if diff := cmp.Diff(view, tt.wants.view); diff != "" {
 				t.Errorf("dashboard cell views are different -got/+want\ndiff %s", diff)

--- a/dashboards/testing/util.go
+++ b/dashboards/testing/util.go
@@ -9,8 +9,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 )
 
-// TODO(goller): remove opPrefix argument
-func diffPlatformErrors(name string, actual, expected error, opPrefix string, t *testing.T) {
+func diffPlatformErrors(actual, expected error, t *testing.T) {
 	t.Helper()
 	ErrorsEqual(t, actual, expected)
 }

--- a/kit/errors/errors.go
+++ b/kit/errors/errors.go
@@ -1,4 +1,4 @@
-package errors
+package errors2
 
 import (
 	"fmt"

--- a/kit/errors/list.go
+++ b/kit/errors/list.go
@@ -1,4 +1,4 @@
-package errors
+package errors2
 
 import (
 	"errors"

--- a/kit/transport/http/error_handler.go
+++ b/kit/transport/http/error_handler.go
@@ -35,7 +35,8 @@ func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.Res
 
 	code := errors2.ErrorCode(err)
 	var msg string
-	if _, ok := err.(*errors2.Error); ok {
+	var eTmp *errors2.Error
+	if ok := errors.As(err, &eTmp); ok {
 		msg = err.Error()
 	} else {
 		msg = "An internal error has occurred - check server logs"

--- a/label/error.go
+++ b/label/error.go
@@ -24,11 +24,3 @@ var (
 		Msg:  "label not found",
 	}
 )
-
-// ErrInternalServiceError is used when the error comes from an internal system.
-func ErrInternalServiceError(err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Err:  err,
-	}
-}

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -2,6 +2,7 @@ package endpoint_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/v2"
-	"github.com/influxdata/influxdb/v2/kit/errors"
 	errors2 "github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/notification/endpoint"

--- a/organization.go
+++ b/organization.go
@@ -2,7 +2,6 @@ package influxdb
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
@@ -77,13 +76,4 @@ type OrganizationFilter struct {
 	Name   *string
 	ID     *platform.ID
 	UserID *platform.ID
-}
-
-func ErrInternalOrgServiceError(op string, err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Msg:  fmt.Sprintf("unexpected error in organizations; Err: %v", err),
-		Op:   op,
-		Err:  err,
-	}
 }

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -19,6 +19,7 @@ package control
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"runtime/debug"
@@ -32,7 +33,7 @@ import (
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/runtime"
-	"github.com/influxdata/influxdb/v2/kit/errors"
+	errors3 "github.com/influxdata/influxdb/v2/kit/errors"
 	errors2 "github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/kit/prom"
 	"github.com/influxdata/influxdb/v2/kit/tracing"
@@ -154,7 +155,7 @@ func (c *Config) validate() error {
 		if c.MaxMemoryBytes != 0 {
 			// This is because we have to account for the per-query reserved memory and remove it from
 			// the max total memory. If there is not a maximum number of queries this is not possible.
-			return errors.New("Cannot limit max memory when ConcurrencyQuota is unlimited")
+			return errors.New("cannot limit max memory when ConcurrencyQuota is unlimited")
 		}
 	} else {
 		if c.QueueSize <= 0 {
@@ -183,7 +184,7 @@ type QueryID uint64
 func New(config Config, logger *zap.Logger) (*Controller, error) {
 	c, err := config.complete(logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid controller config")
+		return nil, errors3.Wrap(err, "invalid controller config")
 	}
 	metricLabelKeys := append(c.MetricLabelKeys, orgLabel)
 	if logger == nil {

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -1163,9 +1163,7 @@ func meanProcedureSpec() *universe.MeanProcedureSpec {
 	}
 }
 
-//
 // Window Aggregate Testing
-//
 func TestPushDownWindowAggregateRule(t *testing.T) {
 	rules := []plan.Rule{
 		universe.AggregateWindowRule{},
@@ -2724,9 +2722,7 @@ func TestPushDownBareAggregateRule(t *testing.T) {
 	}
 }
 
-//
 // Group Aggregate Testing
-//
 func TestPushDownGroupAggregateRule(t *testing.T) {
 	readGroupAgg := func(aggregateMethod string) *influxdb.ReadGroupPhysSpec {
 		return &influxdb.ReadGroupPhysSpec{

--- a/sqlite/migrator_test.go
+++ b/sqlite/migrator_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/influxdata/influxdb/v2/kit/errors"
 	"github.com/influxdata/influxdb/v2/kit/migration"
+	"github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/sqlite/test_migrations"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/storage/reads/aggregate_resultset.go
+++ b/storage/reads/aggregate_resultset.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/influxdata/flux/interval"
 	"github.com/influxdata/flux/values"
-	"github.com/influxdata/influxdb/v2/kit/errors"
+	errors2 "github.com/influxdata/influxdb/v2/kit/errors"
 	"github.com/influxdata/influxdb/v2/kit/tracing"
 	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/storage/reads/datatypes"
@@ -58,7 +58,7 @@ func NewWindowAggregateResultSet(ctx context.Context, req *datatypes.ReadWindowA
 	}
 
 	if nAggs := len(req.Aggregate); nAggs != 1 {
-		return nil, errors.Errorf(errors.InternalError, "attempt to create a windowAggregateResultSet with %v aggregate functions", nAggs)
+		return nil, errors2.Errorf(errors2.InternalError, "attempt to create a windowAggregateResultSet with %v aggregate functions", nAggs)
 	}
 
 	ascending := !IsLastDescendingAggregateOptimization(req)

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -4,15 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/influxdb/v2"
-	"github.com/influxdata/influxdb/v2/kit/errors"
 	"github.com/influxdata/influxdb/v2/kit/platform"
-	errors2 "github.com/influxdata/influxdb/v2/kit/platform/errors"
+	errors3 "github.com/influxdata/influxdb/v2/kit/platform/errors"
 	"github.com/influxdata/influxdb/v2/query"
 	"github.com/influxdata/influxdb/v2/storage"
 	"github.com/influxdata/influxdb/v2/task/taskmodel"
@@ -260,7 +260,7 @@ func (as *AnalyticalStorage) FindRunByID(ctx context.Context, taskID, runID plat
 	// check the taskService to see if the run is on its list
 	run, err := as.TaskService.FindRunByID(ctx, taskID, runID)
 	if err != nil {
-		if err, ok := err.(*errors2.Error); !ok || err.Msg != "run not found" {
+		if err, ok := err.(*errors3.Error); !ok || err.Msg != "run not found" {
 			return run, err
 		}
 	}
@@ -332,9 +332,9 @@ func (as *AnalyticalStorage) FindRunByID(ctx context.Context, taskID, runID plat
 	}
 
 	if len(re.runs) != 1 {
-		return nil, &errors2.Error{
+		return nil, &errors3.Error{
 			Msg:  "found multiple runs with id " + runID.String(),
-			Code: errors2.EInternal,
+			Code: errors3.EInternal,
 		}
 	}
 
@@ -344,7 +344,7 @@ func (as *AnalyticalStorage) FindRunByID(ctx context.Context, taskID, runID plat
 func (as *AnalyticalStorage) RetryRun(ctx context.Context, taskID, runID platform.ID) (*taskmodel.Run, error) {
 	run, err := as.TaskService.RetryRun(ctx, taskID, runID)
 	if err != nil {
-		if err, ok := err.(*errors2.Error); !ok || err.Msg != "run not found" {
+		if err, ok := err.(*errors3.Error); !ok || err.Msg != "run not found" {
 			return run, err
 		}
 	}

--- a/tenant/error.go
+++ b/tenant/error.go
@@ -40,14 +40,6 @@ var (
 	}
 )
 
-// ErrInternalServiceError is used when the error comes from an internal system.
-func ErrInternalServiceError(err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Err:  err,
-	}
-}
-
 type errSlice []error
 
 func (e errSlice) Error() string {

--- a/tenant/http_server_org_test.go
+++ b/tenant/http_server_org_test.go
@@ -55,5 +55,5 @@ func initHttpOrgService(f itesting.OrganizationFields, t *testing.T) (influxdb.O
 }
 
 func TestHTTPOrgService(t *testing.T) {
-	itesting.OrganizationService(initHttpOrgService, t)
+	itesting.OrganizationService(initHttpOrgService, true, t)
 }

--- a/tenant/http_server_user_test.go
+++ b/tenant/http_server_user_test.go
@@ -48,5 +48,5 @@ func initHttpUserService(f platformtesting.UserFields, t *testing.T) (platform.U
 
 func TestUserService(t *testing.T) {
 	t.Parallel()
-	platformtesting.UserService(initHttpUserService, t)
+	platformtesting.UserService(initHttpUserService, true, t)
 }

--- a/tenant/middleware_org_logging_test.go
+++ b/tenant/middleware_org_logging_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestOrganizationLoggingService(t *testing.T) {
-	influxdbtesting.OrganizationService(initBoltOrganizationLoggingService, t)
+	influxdbtesting.OrganizationService(initBoltOrganizationLoggingService, false, t)
 }
 
 func initBoltOrganizationLoggingService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {

--- a/tenant/middleware_user_logging_test.go
+++ b/tenant/middleware_user_logging_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestUserLoggingService(t *testing.T) {
-	influxdbtesting.UserService(initBoltUserLoggingService, t)
+	influxdbtesting.UserService(initBoltUserLoggingService, false, t)
 }
 
 func initBoltUserLoggingService(f influxdbtesting.UserFields, t *testing.T) (influxdb.UserService, string, func()) {

--- a/tenant/service_org_test.go
+++ b/tenant/service_org_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBoltOrganizationService(t *testing.T) {
-	influxdbtesting.OrganizationService(initBoltOrganizationService, t)
+	influxdbtesting.OrganizationService(initBoltOrganizationService, false, t)
 }
 
 func initBoltOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {

--- a/tenant/service_user_test.go
+++ b/tenant/service_user_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestBoltUserService(t *testing.T) {
-	influxdbtesting.UserService(initBoltUserService, t)
+	influxdbtesting.UserService(initBoltUserService, false, t)
 }
 
 func initBoltUserService(f influxdbtesting.UserFields, t *testing.T) (influxdb.UserService, string, func()) {

--- a/tenant/storage_bucket_test.go
+++ b/tenant/storage_bucket_test.go
@@ -2,6 +2,7 @@ package tenant_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -142,7 +143,7 @@ func TestBucket(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, expected, bucket)
 
-				if _, err := store.GetBucket(context.Background(), tx, 11); err != tenant.ErrBucketNotFound {
+				if _, err := store.GetBucket(context.Background(), tx, 11); !errors.Is(err, tenant.ErrBucketNotFound) {
 					t.Fatal("failed to get correct error when looking for non present bucket by id")
 				}
 
@@ -323,7 +324,7 @@ func TestBucket(t *testing.T) {
 			update: func(t *testing.T, store *tenant.Store, tx kv.Tx) {
 				bucket5 := "bucket5"
 				_, err := store.UpdateBucket(context.Background(), tx, thirdBucketID, influxdb.BucketUpdate{Name: &bucket5})
-				if err != tenant.ErrBucketNameNotUnique {
+				if !errors.Is(err, tenant.ErrBucketNameNotUnique) {
 					t.Fatal("failed to error on duplicate bucketname")
 				}
 
@@ -355,7 +356,7 @@ func TestBucket(t *testing.T) {
 				require.NoError(t, err)
 
 				err = store.DeleteBucket(context.Background(), tx, firstBucketID)
-				if err != tenant.ErrBucketNotFound {
+				if !errors.Is(err, tenant.ErrBucketNotFound) {
 					t.Fatal("invalid error when deleting bucket that has already been deleted", err)
 				}
 

--- a/tenant/storage_org_test.go
+++ b/tenant/storage_org_test.go
@@ -2,6 +2,7 @@ package tenant_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -121,7 +122,7 @@ func TestOrg(t *testing.T) {
 				}
 				require.Equal(t, expected, org)
 
-				if _, err := store.GetOrg(context.Background(), tx, 500); err != tenant.ErrOrgNotFound {
+				if _, err := store.GetOrg(context.Background(), tx, 500); !errors.Is(err, tenant.ErrOrgNotFound) {
 					t.Fatal("failed to get correct error when looking for invalid org by id")
 				}
 
@@ -205,7 +206,7 @@ func TestOrg(t *testing.T) {
 				require.NoError(t, err)
 
 				err = store.DeleteOrg(context.Background(), tx, firstOrgID)
-				if err != tenant.ErrOrgNotFound {
+				if !errors.Is(err, tenant.ErrOrgNotFound) {
 					t.Fatal("invalid error when deleting org that has already been deleted", err)
 				}
 

--- a/tenant/storage_user_test.go
+++ b/tenant/storage_user_test.go
@@ -2,6 +2,7 @@ package tenant_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -118,11 +119,11 @@ func TestUser(t *testing.T) {
 					t.Fatalf("expected identical user: \n%+v\n%+v", user, expected)
 				}
 
-				if _, err := store.GetUser(context.Background(), tx, 500); err != tenant.ErrUserNotFound {
+				if _, err := store.GetUser(context.Background(), tx, 500); !errors.Is(err, tenant.ErrUserNotFound) {
 					t.Fatal("failed to get correct error when looking for invalid user by id")
 				}
 
-				if _, err := store.GetUserByName(context.Background(), tx, "notauser"); err != tenant.ErrUserNotFound {
+				if _, err := store.GetUserByName(context.Background(), tx, "notauser"); !errors.Is(err, tenant.ErrUserNotFound) {
 					t.Fatal("failed to get correct error when looking for invalid user by name")
 				}
 
@@ -249,7 +250,7 @@ func TestUser(t *testing.T) {
 				}
 
 				err = store.DeleteUser(context.Background(), tx, 1)
-				if err != tenant.ErrUserNotFound {
+				if !errors.Is(err, tenant.ErrUserNotFound) {
 					t.Fatal("invalid error when deleting user that has already been deleted", err)
 				}
 

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -316,7 +316,7 @@ func CreateAuthorization(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateAuthorization(ctx, tt.args.authorization)
@@ -324,7 +324,7 @@ func CreateAuthorization(
 				t.Fatalf("expected error '%v' got '%v'", tt.wants.err, err)
 			}
 
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			defer s.DeleteAuthorization(ctx, tt.args.authorization.ID)
 
@@ -416,13 +416,13 @@ func FindAuthorizationByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			for i := range tt.fields.Authorizations {
 				authorization, err := s.FindAuthorizationByID(ctx, tt.fields.Authorizations[i].ID)
-				diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+				diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 				if diff := cmp.Diff(authorization, tt.wants.authorizations[i], authorizationCmpOptions...); diff != "" {
 					t.Errorf("authorization is different -got/+want\ndiff %s", diff)
@@ -670,12 +670,12 @@ func UpdateAuthorization(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			updatedAuth, err := s.UpdateAuthorization(ctx, tt.args.id, tt.args.upd)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if tt.wants.err == nil {
 				authorization, err := s.FindAuthorizationByID(ctx, tt.args.id)
@@ -848,12 +848,12 @@ func FindAuthorizationByToken(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			authorization, err := s.FindAuthorizationByToken(ctx, tt.args.token)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(authorization, tt.wants.authorization, authorizationCmpOptions...); diff != "" {
 				t.Errorf("authorization is different -got/+want\ndiff %s", diff)
@@ -1158,7 +1158,7 @@ func FindAuthorizations(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1177,7 +1177,7 @@ func FindAuthorizations(
 			}
 
 			authorizations, _, err := s.FindAuthorizations(ctx, filter)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 			if diff := cmp.Diff(authorizations, tt.wants.authorizations, authorizationCmpOptions...); diff != "" {
 				t.Errorf("authorizations are different -got/+want\ndiff %s", diff)
 			}
@@ -1325,11 +1325,11 @@ func DeleteAuthorization(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteAuthorization(ctx, tt.args.ID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			filter := influxdb.AuthorizationFilter{}
 			authorizations, _, err := s.FindAuthorizations(ctx, filter)

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -375,11 +375,11 @@ func CreateBucket(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateBucket(ctx, tt.args.bucket)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			// Delete only newly created buckets - ie., with a not nil ID
 			// if tt.args.bucket.ID.Valid() {
@@ -500,12 +500,12 @@ func FindBucketByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			bucket, err := s.FindBucketByID(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(bucket, tt.wants.bucket, bucketCmpOptions...); diff != "" {
 				t.Errorf("bucket is different -got/+want\ndiff %s", diff)
@@ -888,7 +888,7 @@ func FindBuckets(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -907,7 +907,7 @@ func FindBuckets(
 			}
 
 			buckets, _, err := s.FindBuckets(ctx, filter, tt.args.findOptions)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			// remove system buckets
 			filteredBuckets := []*influxdb.Bucket{}
@@ -1070,11 +1070,11 @@ func DeleteBucket(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteBucket(ctx, tt.args.ID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			filter := influxdb.BucketFilter{}
 			buckets, _, err := s.FindBuckets(ctx, filter)
@@ -1228,7 +1228,7 @@ func FindBucket(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			filter := influxdb.BucketFilter{}
@@ -1243,7 +1243,7 @@ func FindBucket(
 			}
 
 			bucket, err := s.FindBucket(ctx, filter)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(bucket, tt.wants.bucket, bucketCmpOptions...); diff != "" {
 				t.Errorf("buckets are different -got/+want\ndiff %s", diff)
@@ -1718,7 +1718,7 @@ func UpdateBucket(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -1738,7 +1738,7 @@ func UpdateBucket(
 			upd.Description = tt.args.description
 
 			bucket, err := s.UpdateBucket(ctx, tt.args.id, upd)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(bucket, tt.wants.bucket, bucketCmpOptions...); diff != "" {
 				t.Errorf("bucket is different -got/+want\ndiff %s", diff)

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -271,11 +271,11 @@ func CreateLabel(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateLabel(ctx, tt.args.label)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			defer s.DeleteLabel(ctx, tt.args.label.ID)
 
@@ -410,11 +410,11 @@ func FindLabels(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			labels, err := s.FindLabels(ctx, tt.args.filter)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(labels, tt.wants.labels, labelCmpOptions...); diff != "" {
 				t.Errorf("labels are different -got/+want\ndiff %s", diff)
@@ -488,11 +488,11 @@ func FindLabelByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			label, err := s.FindLabelByID(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(label, tt.wants.label, labelCmpOptions...); diff != "" {
 				t.Errorf("labels are different -got/+want\ndiff %s", diff)
@@ -762,11 +762,11 @@ func UpdateLabel(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			_, err := s.UpdateLabel(ctx, tt.args.labelID, tt.args.update)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
 			if err != nil {
@@ -859,11 +859,11 @@ func DeleteLabel(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteLabel(ctx, tt.args.labelID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
 			if err != nil {
@@ -949,11 +949,11 @@ func CreateLabelMapping(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateLabelMapping(ctx, tt.args.mapping)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			defer s.DeleteLabelMapping(ctx, tt.args.mapping)
 
@@ -1025,11 +1025,11 @@ func DeleteLabelMapping(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteLabelMapping(ctx, tt.args.mapping)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			labels, err := s.FindResourceLabels(ctx, tt.args.filter)
 			if err != nil {

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -300,11 +300,11 @@ func AddTarget(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.AddTarget(ctx, tt.args.target, tt.args.userID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 			defer s.RemoveTarget(ctx, tt.args.target.ID)
 
 			targets, err := s.ListTargets(ctx, influxdb.ScraperTargetFilter{})
@@ -488,11 +488,11 @@ func ListTargets(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			targets, err := s.ListTargets(ctx, tt.args.filter)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(targets, tt.wants.targets, targetCmpOptions...); diff != "" {
 				t.Errorf("targets are different -got/+want\ndiff %s", diff)
@@ -585,12 +585,12 @@ func GetTargetByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			target, err := s.GetTargetByID(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(target, tt.wants.target, targetCmpOptions...); diff != "" {
 				t.Errorf("target is different -got/+want\ndiff %s", diff)
@@ -691,11 +691,11 @@ func RemoveTarget(init func(TargetFields, *testing.T) (influxdb.ScraperTargetSto
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.RemoveTarget(ctx, tt.args.ID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			targets, err := s.ListTargets(ctx, influxdb.ScraperTargetFilter{})
 			if err != nil {
@@ -826,7 +826,7 @@ func UpdateTarget(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
@@ -836,7 +836,7 @@ func UpdateTarget(
 			}
 
 			target, err := s.UpdateTarget(ctx, upd, tt.args.userID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(target, tt.wants.target, targetCmpOptions...); diff != "" {
 				t.Errorf("scraper target is different -got/+want\ndiff %s", diff)

--- a/testing/session.go
+++ b/testing/session.go
@@ -132,11 +132,11 @@ func CreateSession(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			session, err := s.CreateSession(ctx, tt.args.user)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
 				t.Errorf("sessions are different -got/+want\ndiff %s", diff)
@@ -207,12 +207,12 @@ func FindSession(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			session, err := s.FindSession(ctx, tt.args.key)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(session, tt.wants.session, sessionCmpOptions...); diff != "" {
 				t.Errorf("session is different -got/+want\ndiff %s", diff)
@@ -270,12 +270,12 @@ func ExpireSession(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			err := s.ExpireSession(ctx, tt.args.key)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			session, err := s.FindSession(ctx, tt.args.key)
 			if err.Error() != influxdb.ErrSessionExpired && err.Error() != influxdb.ErrSessionNotFound {
@@ -413,12 +413,12 @@ func RenewSession(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 
 			err := s.RenewSession(ctx, tt.args.session, tt.args.expireAt)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			session, err := s.FindSession(ctx, tt.args.key)
 			if err != nil {

--- a/testing/source.go
+++ b/testing/source.go
@@ -91,11 +91,11 @@ func CreateSource(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.CreateSource(ctx, tt.args.source)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 			defer s.DeleteSource(ctx, tt.args.source.ID)
 
 			sources, _, err := s.FindSources(ctx, platform.FindOptions{})
@@ -174,11 +174,11 @@ func FindSourceByID(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			source, err := s.FindSourceByID(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(source, tt.wants.source, sourceCmpOptions...); diff != "" {
 				t.Errorf("sources are different -got/+want\ndiff %s", diff)
@@ -250,11 +250,11 @@ func FindSources(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			sources, _, err := s.FindSources(ctx, tt.args.opts)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(sources, tt.wants.sources, sourceCmpOptions...); diff != "" {
 				t.Errorf("sources are different -got/+want\ndiff %s", diff)
@@ -339,11 +339,11 @@ func DeleteSource(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteSource(ctx, tt.args.id)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			sources, _, err := s.FindSources(ctx, platform.FindOptions{})
 			if err != nil {

--- a/testing/util.go
+++ b/testing/util.go
@@ -46,10 +46,13 @@ func NewTestInmemStore(t *testing.T) kv.SchemaStore {
 	return s
 }
 
-// TODO(goller): remove opPrefix argument
-func diffPlatformErrors(name string, actual, expected error, opPrefix string, t *testing.T) {
+func diffPlatformErrors(name string, actual, expected error, inMemNoError, isInMem bool, t *testing.T) {
 	t.Helper()
-	ErrorsEqual(t, actual, expected)
+	if inMemNoError && isInMem {
+		ErrorsEqual(t, actual, nil)
+	} else {
+		ErrorsEqual(t, actual, expected)
+	}
 }
 
 // ErrorsEqual checks to see if the provided errors are equivalent.

--- a/testing/variable.go
+++ b/testing/variable.go
@@ -830,7 +830,7 @@ func FindVariables(init func(VariableFields, *testing.T) (influxdb.VariableServi
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, opPrefix, done := init(tt.fields, t)
+			s, _, done := init(tt.fields, t)
 			defer done()
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -842,7 +842,7 @@ func FindVariables(init func(VariableFields, *testing.T) (influxdb.VariableServi
 			}
 
 			variables, err := s.FindVariables(ctx, filter, tt.args.findOpts)
-			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
 
 			if diff := cmp.Diff(variables, tt.wants.variables, variableCmpOptions...); diff != "" {
 				t.Errorf("variables are different -got/+want\ndiff %s", diff)

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1196,7 +1196,7 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 }
 
 // Ensures that deleting series from TSM files with multiple fields removes all the
-/// series
+// / series
 func TestEngine_DeleteSeries(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -564,7 +564,7 @@ func BenchmarkIndexSet_TagSets(b *testing.B) {
 // This benchmark concurrently writes series to the index and fetches cached bitsets.
 // The idea is to emphasize the performance difference when bitset caching is on and off.
 //
-// Typical results for an i7 laptop
+// # Typical results for an i7 laptop
 //
 // BenchmarkIndex_ConcurrentWriteQuery/tsi1/queries_100000/cache-8        1	1645048376 ns/op	2215402840 B/op	 23048978 allocs/op
 // BenchmarkIndex_ConcurrentWriteQuery/tsi1/queries_100000/no_cache-8     1	22242155616 ns/op	28277544136 B/op 79620463 allocs/op

--- a/v1/authorization/error.go
+++ b/v1/authorization/error.go
@@ -56,14 +56,6 @@ func ErrInvalidAuthIDError(err error) *errors.Error {
 	}
 }
 
-// ErrInternalServiceError is used when the error comes from an internal system.
-func ErrInternalServiceError(err error) *errors.Error {
-	return &errors.Error{
-		Code: errors.EInternal,
-		Err:  err,
-	}
-}
-
 // UnexpectedAuthIndexError is used when the error comes from an internal system.
 func UnexpectedAuthIndexError(err error) *errors.Error {
 	return &errors.Error{

--- a/v1/authorization/storage_authorization.go
+++ b/v1/authorization/storage_authorization.go
@@ -3,6 +3,7 @@ package authorization
 import (
 	"context"
 	"encoding/json"
+	errors2 "errors"
 
 	"github.com/buger/jsonparser"
 	"github.com/influxdata/influxdb/v2"
@@ -75,7 +76,7 @@ func (s *Store) CreateAuthorization(ctx context.Context, tx kv.Tx, a *influxdb.A
 			continue
 		}
 		_, err := ts.GetBucket(ctx, tx, *p.Resource.ID)
-		if err == tenant.ErrBucketNotFound {
+		if errors2.Is(err, tenant.ErrBucketNotFound) {
 			return ErrBucketNotFound
 		}
 	}
@@ -132,7 +133,7 @@ func (s *Store) GetAuthorizationByID(ctx context.Context, tx kv.Tx, id platform.
 
 	b, err := tx.Bucket(authBucket)
 	if err != nil {
-		return nil, ErrInternalServiceError(err)
+		return nil, errors.ErrInternalServiceError(err)
 	}
 
 	v, err := b.Get(encodedID)
@@ -141,7 +142,7 @@ func (s *Store) GetAuthorizationByID(ctx context.Context, tx kv.Tx, id platform.
 	}
 
 	if err != nil {
-		return nil, ErrInternalServiceError(err)
+		return nil, errors.ErrInternalServiceError(err)
 	}
 
 	a := &influxdb.Authorization{}
@@ -302,11 +303,11 @@ func (s *Store) DeleteAuthorization(ctx context.Context, tx kv.Tx, id platform.I
 	}
 
 	if err := idx.Delete([]byte(a.Token)); err != nil {
-		return ErrInternalServiceError(err)
+		return errors.ErrInternalServiceError(err)
 	}
 
 	if err := b.Delete(encodedID); err != nil {
-		return ErrInternalServiceError(err)
+		return errors.ErrInternalServiceError(err)
 	}
 
 	return nil
@@ -354,7 +355,7 @@ func uniqueID(ctx context.Context, tx kv.Tx, id platform.ID) error {
 
 	b, err := tx.Bucket(authBucket)
 	if err != nil {
-		return ErrInternalServiceError(err)
+		return errors.ErrInternalServiceError(err)
 	}
 
 	_, err = b.Get(encodedID)

--- a/v1/authorization/storage_authorization_test.go
+++ b/v1/authorization/storage_authorization_test.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -307,7 +308,7 @@ func TestAuthBucketNotExists(t *testing.T) {
 		return err
 	})
 
-	if err == nil || err != ErrBucketNotFound {
+	if err == nil || !errors.Is(err, ErrBucketNotFound) {
 		t.Fatalf("Authorization creating should have failed with ErrBucketNotFound [Error]: %v", err)
 	}
 }


### PR DESCRIPTION
HTTP 5XX errors were being returned incorrectly 
from BoltDB errors that were actually bad 
requests, e.g., names that were too long for 
buckets, users, and organizations. Map 
BoltDB errors to correct Influx errors and 
return 4XX errors where appropriate. Also add 
op codes to more errors

(cherry picked from commit a3fd4898640cda951d8a61a97d9a2a14ea0a80ef

