### PR TITLE
docs(contributing): update setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.15.
+InfluxDB requires Go 1.20.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,12 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.15
-    gvm use go1.15 --default
+    # Retrieve the version in use from the go.mod file.
+    INFLUXDB_GO_VERSION=$(go mod edit -json | jq -r .Go)
+
+    # Use gvm to install the correct version
+    gvm install go${INFLUXDB_GO_VERSION}
+    gvm use go${INFLUXDB_GO_VERSION} --default
 
 Revision Control Systems
 -------------


### PR DESCRIPTION
Following the current guide led me to some errenous errors, largely because I followed the need for Go 1.15 :facepalm:

Once I checked the `go.mod` file, I noticed the mention of Go1.15 was outdated. Using 1.20 fixed my issue and I've included a small setup change to help any other weary travellers avoid my mistake, by directly installing the correct version via `gvm` using the `go.mod` file as the source of truth.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb_iox/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
