### PR TITLE
fix: set Dockerfile to build influxdb3 not IOx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.57
+ARG RUST_VERSION=1.75
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root
@@ -9,15 +9,15 @@ RUN apt update \
     && apt install --yes binutils build-essential pkg-config libssl-dev clang lld git protobuf-compiler \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
-# Build influxdb_iox
-COPY . /influxdb_iox
-WORKDIR /influxdb_iox
+# Build influxdb3
+COPY . /influxdb3
+WORKDIR /influxdb3
 
 ARG CARGO_INCREMENTAL=yes
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=false
 ARG PROFILE=release
 ARG FEATURES=aws,gcp,azure,jemalloc_replacing_malloc
-ARG PACKAGE=influxdb_iox
+ARG PACKAGE=influxdb3
 ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \
     CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_NET_GIT_FETCH_WITH_CLI \
     PROFILE=$PROFILE \
@@ -25,14 +25,14 @@ ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \
     PACKAGE=$PACKAGE
 
 RUN \
-  --mount=type=cache,id=influxdb_iox_rustup,sharing=locked,target=/usr/local/rustup \
-  --mount=type=cache,id=influxdb_iox_registry,sharing=locked,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=influxdb_iox_git,sharing=locked,target=/usr/local/cargo/git \
-  --mount=type=cache,id=influxdb_iox_target,sharing=locked,target=/influxdb_iox/target \
+  --mount=type=cache,id=influxdb3_rustup,sharing=locked,target=/usr/local/rustup \
+  --mount=type=cache,id=influxdb3_registry,sharing=locked,target=/usr/local/cargo/registry \
+  --mount=type=cache,id=influxdb3_git,sharing=locked,target=/usr/local/cargo/git \
+  --mount=type=cache,id=influxdb3_target,sharing=locked,target=/influxdb_iox/target \
     du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target && \
-    cargo build --target-dir /influxdb_iox/target --package="$PACKAGE" --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
+    cargo build --target-dir /influxdb3/target --package="$PACKAGE" --profile="$PROFILE" --no-default-features --features="$FEATURES" && \
     objcopy --compress-debug-sections "target/$PROFILE/$PACKAGE" && \
-    cp "/influxdb_iox/target/$PROFILE/$PACKAGE" /root/$PACKAGE && \
+    cp "/influxdb3/target/$PROFILE/$PACKAGE" /root/$PACKAGE && \
     du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git /influxdb_iox/target
 
 
@@ -41,14 +41,14 @@ FROM debian:bookworm-slim
 RUN apt update \
     && apt install --yes ca-certificates gettext-base libssl3 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log} \
-    && groupadd --gid 1500 iox \
-    && useradd --uid 1500 --gid iox --shell /bin/bash --create-home iox
+    && groupadd --gid 1500 influxdb3 \
+    && useradd --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3
 
-USER iox
+USER influxdb3
 
-RUN mkdir ~/.influxdb_iox
+RUN mkdir ~/.influxdb3
 
-ARG PACKAGE=influxdb_iox
+ARG PACKAGE=influxdb3
 ENV PACKAGE=$PACKAGE
 
 COPY --from=build "/root/$PACKAGE" "/usr/bin/$PACKAGE"
@@ -58,4 +58,4 @@ EXPOSE 8080 8082
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
-CMD ["run"]
+CMD ["serve"]


### PR DESCRIPTION
Now that we're transitioning the repo code to have influxdb3 Edge not IOx be what's here, we can update the Dockerfile to build influxdb3. This is mostly just updating which version of Rust to use, changing the command that's run when docker runs the container to serve, and changing influxdb_iox to influxdb3 everywhere in the file.

I've confirmed locally that running docker build works fine and that running the resulting file will run the `influxdb3 serve`command. This should also fix the failing build on CI which uses Docker for the release build. In the future I think this discrepancy should be fixed (what runs on main should run here), but it works for now