### PR TITLE
feat: Add paths module to influxdb3_write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -277,7 +277,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "futures",
  "once_cell",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
 dependencies = [
  "anstyle",
  "bstr",
@@ -431,9 +431,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
  "bzip2",
  "flate2",
@@ -506,7 +506,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backoff",
- "base64 0.21.6",
+ "base64 0.21.7",
  "generated_types",
  "http",
  "iox_time",
@@ -606,9 +606,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -624,9 +624,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1386,7 +1386,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
- "base64 0.21.6",
+ "base64 0.21.7",
  "blake2",
  "blake3",
  "chrono",
@@ -1885,7 +1885,7 @@ name = "grpc-binary-logger"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.6",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "futures",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2009,7 +2009,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "byteorder",
  "flate2",
  "nom",
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -2494,7 +2494,7 @@ name = "ingester_query_grpc"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "data_types",
  "datafusion",
@@ -2850,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2961,9 +2961,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -3227,7 +3227,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -3391,7 +3391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f930c88a43b1c3f6e776dfe495b4afab89882dbc81530c632db2ed65451ebcb4"
 dependencies = [
  "async-trait",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "futures",
@@ -3573,7 +3573,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.21.6",
+ "base64 0.21.7",
  "brotli",
  "bytes",
  "chrono",
@@ -3598,7 +3598,7 @@ name = "parquet_file"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "data_types",
  "datafusion",
@@ -3672,7 +3672,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -3875,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "pprof"
@@ -3932,13 +3932,12 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -4020,7 +4019,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
@@ -4177,9 +4176,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -4187,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -4275,7 +4274,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4415,11 +4414,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4444,7 +4443,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4737,9 +4736,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
 
 [[package]]
 name = "snafu"
@@ -4953,8 +4952,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64 0.21.6",
- "bitflags 2.4.1",
+ "base64 0.21.7",
+ "bitflags 2.4.2",
  "byteorder",
  "bytes",
  "crc",
@@ -4996,8 +4995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64 0.21.6",
- "bitflags 2.4.1",
+ "base64 0.21.7",
+ "bitflags 2.4.2",
  "byteorder",
  "crc",
  "dotenvy",
@@ -5518,7 +5517,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5606,7 +5605,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5836,9 +5835,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -6021,9 +6020,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6031,9 +6030,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -6046,9 +6045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6058,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6068,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6081,9 +6080,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
@@ -6100,9 +6099,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6315,9 +6314,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]
@@ -6341,7 +6340,7 @@ dependencies = [
  "arrow-array",
  "arrow-flight",
  "arrow-string",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "byteorder",
  "bytes",
  "cc",

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("datafusion error: {0}")]
     DataFusion(#[from] DataFusionError),
 
+    #[error("object store path error: {0}")]
+    ObjStorePath(#[from] object_store::path::Error),
+
     #[error("write buffer error: {0}")]
     WriteBuffer(#[from] write_buffer::Error),
 }

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -7,6 +7,7 @@
 //! to be persisted. A new open segment will be created and new writes will be written to that segment.
 
 pub mod catalog;
+pub mod paths;
 pub mod persister;
 pub mod wal;
 pub mod write_buffer;

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -1,0 +1,128 @@
+use crate::SegmentId;
+use std::convert::AsRef;
+use std::ops::Deref;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// File extension for catalog files
+const CATALOG_FILE_EXTENSION: &str = "json";
+
+/// File extension for parquet files
+const PARQUET_FILE_EXTENSION: &str = "parquet";
+
+/// File extension for segment files
+const SEGMENT_FILE_EXTENSION: &str = "wal";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogFilePath(PathBuf);
+
+impl CatalogFilePath {
+    pub fn new(prefix: impl Into<PathBuf>, sequence_number: u64) -> Self {
+        let mut path = prefix.into();
+        path.push("catalogs");
+        path.push(format!("{sequence_number:010}"));
+        path.set_extension(CATALOG_FILE_EXTENSION);
+        Self(path)
+    }
+}
+
+impl Deref for CatalogFilePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for CatalogFilePath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParquetFilePath(PathBuf);
+
+impl ParquetFilePath {
+    pub fn new(
+        prefix: impl Into<PathBuf>,
+        db_name: &str,
+        table_name: &str,
+        year: u16,
+        month: u8,
+        day: u8,
+        file_number: usize,
+    ) -> Self {
+        let mut path = prefix.into();
+        path.push("dbs");
+        path.push(db_name);
+        path.push(table_name);
+        path.push(format!("{year}-{month:02}-{day:02}"));
+        path.push(format!("{file_number:010}"));
+        path.set_extension(PARQUET_FILE_EXTENSION);
+        Self(path)
+    }
+}
+
+impl Deref for ParquetFilePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for ParquetFilePath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentFilePath(PathBuf);
+
+impl SegmentFilePath {
+    pub fn new(prefix: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
+        let mut path = prefix.into();
+        path.push("segments");
+        path.push(format!("{:010}", segment_id.0));
+        path.set_extension(SEGMENT_FILE_EXTENSION);
+        Self(path)
+    }
+}
+
+impl Deref for SegmentFilePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for SegmentFilePath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[test]
+fn catalog_file_path_new() {
+    assert_eq!(
+        *CatalogFilePath::new("prefix/dir", 0),
+        PathBuf::from("prefix/dir/catalogs/0000000000.json").as_ref()
+    );
+}
+#[test]
+fn parquet_file_path_new() {
+    assert_eq!(
+        *ParquetFilePath::new("prefix/dir", "my_db", "my_table", 2038, 1, 19, 0),
+        PathBuf::from("prefix/dir/dbs/my_db/my_table/2038-01-19/0000000000.parquet").as_ref()
+    );
+}
+#[test]
+fn segment_file_path_new() {
+    assert_eq!(
+        *SegmentFilePath::new("prefix/dir", SegmentId::new(0)),
+        PathBuf::from("prefix/dir/segments/0000000000.wal").as_ref()
+    );
+}

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -10,8 +10,11 @@ const CATALOG_FILE_EXTENSION: &str = "json";
 /// File extension for parquet files
 const PARQUET_FILE_EXTENSION: &str = "parquet";
 
-/// File extension for segment files
-const SEGMENT_FILE_EXTENSION: &str = "wal";
+/// File extension for segment info files
+const SEGMENT_INFO_FILE_EXTENSION: &str = "info.json";
+
+/// File extension for segment wal files
+const SEGMENT_WAL_FILE_EXTENSION: &str = "wal";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogFilePath(PathBuf);
@@ -79,19 +82,19 @@ impl AsRef<Path> for ParquetFilePath {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SegmentFilePath(PathBuf);
+pub struct SegmentWalFilePath(PathBuf);
 
-impl SegmentFilePath {
-    pub fn new(prefix: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
-        let mut path = prefix.into();
+impl SegmentWalFilePath {
+    pub fn new(dir: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
+        let mut path = dir.into();
         path.push("segments");
         path.push(format!("{:010}", segment_id.0));
-        path.set_extension(SEGMENT_FILE_EXTENSION);
+        path.set_extension(SEGMENT_WAL_FILE_EXTENSION);
         Self(path)
     }
 }
 
-impl Deref for SegmentFilePath {
+impl Deref for SegmentWalFilePath {
     type Target = Path;
 
     fn deref(&self) -> &Self::Target {
@@ -99,7 +102,34 @@ impl Deref for SegmentFilePath {
     }
 }
 
-impl AsRef<Path> for SegmentFilePath {
+impl AsRef<Path> for SegmentWalFilePath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl SegmentInfoFilePath {
+    pub fn new(prefix: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
+        let mut path = prefix.into();
+        path.push("segments");
+        path.push(format!("{:010}", segment_id.0));
+        path.set_extension(SEGMENT_INFO_FILE_EXTENSION);
+        Self(path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentInfoFilePath(PathBuf);
+
+impl Deref for SegmentInfoFilePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for SegmentInfoFilePath {
     fn as_ref(&self) -> &Path {
         &self.0
     }
@@ -112,6 +142,7 @@ fn catalog_file_path_new() {
         PathBuf::from("prefix/dir/catalogs/0000000000.json").as_ref()
     );
 }
+
 #[test]
 fn parquet_file_path_new() {
     assert_eq!(
@@ -119,10 +150,19 @@ fn parquet_file_path_new() {
         PathBuf::from("prefix/dir/dbs/my_db/my_table/2038-01-19/0000000000.parquet").as_ref()
     );
 }
+
 #[test]
-fn segment_file_path_new() {
+fn segment_info_file_path_new() {
     assert_eq!(
-        *SegmentFilePath::new("prefix/dir", SegmentId::new(0)),
+        *SegmentInfoFilePath::new("prefix/dir", SegmentId::new(0)),
+        PathBuf::from("prefix/dir/segments/0000000000.info.json").as_ref()
+    );
+}
+
+#[test]
+fn segment_wal_file_path_new() {
+    assert_eq!(
+        *SegmentWalFilePath::new("prefix/dir", SegmentId::new(0)),
         PathBuf::from("prefix/dir/segments/0000000000.wal").as_ref()
     );
 }

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -58,19 +58,14 @@ impl AsRef<ObjPath> for CatalogFilePath {
 pub struct ParquetFilePath(ObjPath);
 
 impl ParquetFilePath {
-    pub fn new(
-        db_name: &str,
-        table_name: &str,
-        date: DateTime<Utc>,
-        file_number: u32,
-    ) -> crate::Result<Self> {
-        let path = ObjPath::parse(format!(
+    pub fn new(db_name: &str, table_name: &str, date: DateTime<Utc>, file_number: u32) -> Self {
+        let path = ObjPath::from(format!(
             "dbs/{db_name}/{table_name}/{}/{:010}.{}",
             date.format("%Y-%m-%d"),
             object_store_file_stem(file_number),
             PARQUET_FILE_EXTENSION
-        ))?;
-        Ok(Self(path))
+        ));
+        Self(path)
     }
 }
 
@@ -158,9 +153,23 @@ fn parquet_file_path_new() {
             "my_table",
             Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
             0
-        )
-        .unwrap(),
+        ),
         ObjPath::from("dbs/my_db/my_table/2038-01-19/4294967295.parquet")
+    );
+}
+
+#[test]
+fn parquet_file_percent_encoded() {
+    assert_eq!(
+        ParquetFilePath::new(
+            "..",
+            "..",
+            Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
+            0
+        )
+        .as_ref()
+        .as_ref(),
+        "dbs/%2E%2E/%2E%2E/2038-01-19/4294967295.parquet"
     );
 }
 

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -1,81 +1,80 @@
 use crate::SegmentId;
 use chrono::prelude::*;
+use object_store::path::Path as ObjPath;
 use std::convert::AsRef;
 use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
 
 /// File extension for catalog files
-const CATALOG_FILE_EXTENSION: &str = "json";
+pub const CATALOG_FILE_EXTENSION: &str = "json";
 
 /// File extension for parquet files
-const PARQUET_FILE_EXTENSION: &str = "parquet";
+pub const PARQUET_FILE_EXTENSION: &str = "parquet";
 
 /// File extension for segment info files
-const SEGMENT_INFO_FILE_EXTENSION: &str = "info.json";
+pub const SEGMENT_INFO_FILE_EXTENSION: &str = "info.json";
 
 /// File extension for segment wal files
-const SEGMENT_WAL_FILE_EXTENSION: &str = "wal";
+pub const SEGMENT_WAL_FILE_EXTENSION: &str = "wal";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CatalogFilePath(PathBuf);
+pub struct CatalogFilePath(ObjPath);
 
 impl CatalogFilePath {
-    pub fn new(prefix: impl Into<PathBuf>, sequence_number: u32) -> Self {
-        let mut path = prefix.into();
-        path.push("catalogs");
-        path.push(format!("{:010}", u32::MAX - sequence_number));
-        path.set_extension(CATALOG_FILE_EXTENSION);
+    pub fn new(segment_id: SegmentId) -> Self {
+        let path = ObjPath::from(format!(
+            "catalogs/{:010}.{}",
+            u32::MAX - segment_id.0,
+            CATALOG_FILE_EXTENSION
+        ));
         Self(path)
+    }
+
+    pub fn dir() -> Self {
+        Self(ObjPath::from("catalogs"))
     }
 }
 
 impl Deref for CatalogFilePath {
-    type Target = Path;
+    type Target = ObjPath;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl AsRef<Path> for CatalogFilePath {
-    fn as_ref(&self) -> &Path {
+impl AsRef<ObjPath> for CatalogFilePath {
+    fn as_ref(&self) -> &ObjPath {
         &self.0
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParquetFilePath(PathBuf);
+pub struct ParquetFilePath(ObjPath);
 
 impl ParquetFilePath {
-    pub fn new(
-        prefix: impl Into<PathBuf>,
-        db_name: &str,
-        table_name: &str,
-        date: DateTime<Utc>,
-        file_number: u32,
-    ) -> Self {
-        let mut path = prefix.into();
-        path.push("dbs");
-        path.push(db_name);
-        path.push(table_name);
-        path.push(format!("{}", date.format("%Y-%m-%d")));
-        path.push(format!("{:010}", u32::MAX - file_number));
-        path.set_extension(PARQUET_FILE_EXTENSION);
+    pub fn new(db_name: &str, table_name: &str, date: DateTime<Utc>, file_number: u32) -> Self {
+        let path = ObjPath::from(format!(
+            "dbs/{db_name}/{table_name}/{}/{:010}.{}",
+            date.format("%Y-%m-%d"),
+            u32::MAX - file_number,
+            PARQUET_FILE_EXTENSION
+        ));
         Self(path)
     }
 }
 
 impl Deref for ParquetFilePath {
-    type Target = Path;
+    type Target = ObjPath;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl AsRef<Path> for ParquetFilePath {
-    fn as_ref(&self) -> &Path {
+impl AsRef<ObjPath> for ParquetFilePath {
+    fn as_ref(&self) -> &ObjPath {
         &self.0
     }
 }
@@ -106,29 +105,30 @@ impl AsRef<Path> for SegmentWalFilePath {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentInfoFilePath(ObjPath);
+
 impl SegmentInfoFilePath {
-    pub fn new(prefix: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
-        let mut path = prefix.into();
-        path.push("segments");
-        path.push(format!("{:010}", u32::MAX - segment_id.0));
-        path.set_extension(SEGMENT_INFO_FILE_EXTENSION);
+    pub fn new(segment_id: SegmentId) -> Self {
+        let path = ObjPath::from(format!(
+            "segments/{:010}.{}",
+            u32::MAX - segment_id.0,
+            SEGMENT_INFO_FILE_EXTENSION
+        ));
         Self(path)
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SegmentInfoFilePath(PathBuf);
-
 impl Deref for SegmentInfoFilePath {
-    type Target = Path;
+    type Target = ObjPath;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl AsRef<Path> for SegmentInfoFilePath {
-    fn as_ref(&self) -> &Path {
+impl AsRef<ObjPath> for SegmentInfoFilePath {
+    fn as_ref(&self) -> &ObjPath {
         &self.0
     }
 }
@@ -136,8 +136,8 @@ impl AsRef<Path> for SegmentInfoFilePath {
 #[test]
 fn catalog_file_path_new() {
     assert_eq!(
-        *CatalogFilePath::new("prefix/dir", 0),
-        PathBuf::from("prefix/dir/catalogs/4294967295.json").as_ref()
+        *CatalogFilePath::new(SegmentId::new(0)),
+        ObjPath::from("catalogs/4294967295.json")
     );
 }
 
@@ -145,21 +145,20 @@ fn catalog_file_path_new() {
 fn parquet_file_path_new() {
     assert_eq!(
         *ParquetFilePath::new(
-            "prefix/dir",
             "my_db",
             "my_table",
             Utc.with_ymd_and_hms(2038, 01, 19, 3, 14, 7).unwrap(),
             0
         ),
-        PathBuf::from("prefix/dir/dbs/my_db/my_table/2038-01-19/4294967295.parquet").as_ref()
+        ObjPath::from("dbs/my_db/my_table/2038-01-19/4294967295.parquet")
     );
 }
 
 #[test]
 fn segment_info_file_path_new() {
     assert_eq!(
-        *SegmentInfoFilePath::new("prefix/dir", SegmentId::new(0)),
-        PathBuf::from("prefix/dir/segments/4294967295.info.json").as_ref()
+        *SegmentInfoFilePath::new(SegmentId::new(0)),
+        ObjPath::from("segments/4294967295.info.json")
     );
 }
 

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -87,7 +87,6 @@ pub struct SegmentWalFilePath(PathBuf);
 impl SegmentWalFilePath {
     pub fn new(dir: impl Into<PathBuf>, segment_id: SegmentId) -> Self {
         let mut path = dir.into();
-        path.push("segments");
         path.push(format!("{:010}", segment_id.0));
         path.set_extension(SEGMENT_WAL_FILE_EXTENSION);
         Self(path)
@@ -162,7 +161,7 @@ fn segment_info_file_path_new() {
 #[test]
 fn segment_wal_file_path_new() {
     assert_eq!(
-        *SegmentWalFilePath::new("prefix/dir", SegmentId::new(0)),
-        PathBuf::from("prefix/dir/segments/0000000000.wal").as_ref()
+        *SegmentWalFilePath::new("dir", SegmentId::new(0)),
+        PathBuf::from("dir/0000000000.wal").as_ref()
     );
 }

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -1,6 +1,7 @@
 //! This is the implementation of the `Wal` that the buffer uses to make buffered data durable
 //! on disk.
 
+use crate::paths::SegmentFilePath;
 use crate::{
     SegmentFile, SegmentId, SegmentIdBytes, SequenceNumber, Wal, WalOp, WalOpBatch,
     WalSegmentReader, WalSegmentWriter,
@@ -24,9 +25,6 @@ use thiserror::Error;
 type FileTypeIdentifier = [u8; 8];
 const FILE_TYPE_IDENTIFIER: &[u8] = b"idb3.001";
 
-/// File extension for segment files
-const SEGMENT_FILE_EXTENSION: &str = "wal";
-
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("io error: {source}")]
@@ -49,7 +47,7 @@ pub enum Error {
     #[error("invalid segment file {segment_id:?} at {path:?}: {reason}")]
     InvalidSegmentFile {
         segment_id: SegmentId,
-        path: PathBuf,
+        path: SegmentFilePath,
         reason: String,
     },
 
@@ -94,7 +92,7 @@ impl WalImpl {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
         let root = path.into();
         info!(wal_dir=?root, "Ensuring WAL directory exists");
-        std::fs::create_dir_all(&root)?;
+        std::fs::create_dir_all(&root.join("segments"))?;
 
         // ensure the directory creation is actually fsync'd so that when we create files there
         // we don't lose them (see: https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-pillai.pdf)
@@ -117,7 +115,7 @@ impl WalImpl {
     }
 
     fn segment_files(&self) -> Result<Vec<SegmentFile>> {
-        let dir = std::fs::read_dir(&self.root)?;
+        let dir = std::fs::read_dir(&self.root.join("segments"))?;
 
         let mut segment_files = Vec::new();
 
@@ -161,7 +159,7 @@ impl WalImpl {
     }
 
     fn delete_wal_segment(&self, segment_id: SegmentId) -> Result<()> {
-        let path = build_segment_path(self.root.clone(), segment_id);
+        let path = SegmentFilePath::new(self.root.clone(), segment_id);
         std::fs::remove_file(path)?;
         Ok(())
     }
@@ -197,7 +195,7 @@ pub struct WalSegmentWriterImpl {
 
 impl WalSegmentWriterImpl {
     pub fn new_or_open(root: PathBuf, segment_id: SegmentId) -> Result<Self> {
-        let path = build_segment_path(root, segment_id);
+        let path = SegmentFilePath::new(root, segment_id);
 
         // if there's already a file there, validate its header and pull the sequence number from the last entry
         if path.exists() {
@@ -223,6 +221,15 @@ impl WalSegmentWriterImpl {
                     reason: "file exists but is invalid".to_string(),
                 });
             }
+        }
+
+        let parent = path
+            .parent()
+            .expect("A SegmentFilePath should have a parent directory");
+
+        // Make sure that the segments directory with the prefix exists
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
         }
 
         // it's a new file, initialize it with the header and get ready to start writing
@@ -325,7 +332,7 @@ pub struct WalSegmentReaderImpl {
 
 impl WalSegmentReaderImpl {
     pub fn new(root: impl Into<PathBuf>, segment_id: SegmentId) -> Result<Self> {
-        let path = build_segment_path(root, segment_id);
+        let path = SegmentFilePath::new(root, segment_id);
         let f = BufReader::new(File::open(path.clone())?);
 
         let mut reader = Self { f, segment_id };
@@ -359,7 +366,7 @@ impl WalSegmentReaderImpl {
     }
 
     fn read_segment_file_info_if_exists(
-        path: PathBuf,
+        path: SegmentFilePath,
         segment_id: SegmentId,
     ) -> Result<Option<ExistingSegmentFileInfo>> {
         let f = match File::open(path.clone()) {
@@ -547,13 +554,6 @@ where
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
     }
-}
-
-fn build_segment_path(dir: impl Into<PathBuf>, id: SegmentId) -> PathBuf {
-    let mut path = dir.into();
-    path.push(format!("{:010}", id.0));
-    path.set_extension(SEGMENT_FILE_EXTENSION);
-    path
 }
 
 fn segment_id_from_file_name(name: &str) -> Result<SegmentId> {

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -92,7 +92,7 @@ impl WalImpl {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
         let root = path.into();
         info!(wal_dir=?root, "Ensuring WAL directory exists");
-        std::fs::create_dir_all(root.join("segments"))?;
+        std::fs::create_dir_all(&root)?;
 
         // ensure the directory creation is actually fsync'd so that when we create files there
         // we don't lose them (see: https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-pillai.pdf)
@@ -115,7 +115,7 @@ impl WalImpl {
     }
 
     fn segment_files(&self) -> Result<Vec<SegmentFile>> {
-        let dir = std::fs::read_dir(self.root.join("segments"))?;
+        let dir = std::fs::read_dir(&self.root)?;
 
         let mut segment_files = Vec::new();
 
@@ -221,15 +221,6 @@ impl WalSegmentWriterImpl {
                     reason: "file exists but is invalid".to_string(),
                 });
             }
-        }
-
-        let parent = path
-            .parent()
-            .expect("A SegmentWalFilePath should have a parent directory");
-
-        // Make sure that the segments directory with the prefix exists
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)?;
         }
 
         // it's a new file, initialize it with the header and get ready to start writing


### PR DESCRIPTION
This commit introduces 3 new types in the paths module for the influxdb3_write crate. They are:

- ParquetFilePath
- CatalogFilePath
- SegmentFilePath

Each of these corresponds to an object store path and also on disk path that we can use to address the needed files in a consistent way and not need to have path construction be duplicated to address these files.

These types also Deref/AsRef to the Path type so that they can be used in places that expect the type such as various std::fs methods and so that we can use methods like `exist()` without needing to implement them for each type as they are thin wrappers around PathBuf.

This commit adds some tests to make sure that the path construction works as intended and also updates the `wal.rs` file to use the new `SegmentFilePath` instead of just a `PathBuf`. Currently it assumes that the prefix is just the dir handed to it.

Closes: #24578


Note: This is just the first step as I'll need to start serializing these files to disk as part of the persistor and eventually to object store.