### PR TITLE
fix: panic index out of range for invalid series keys [Port to 2.7]

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -693,6 +693,9 @@ func (f *LogFile) execSeriesEntry(e *LogEntry) {
 
 	// Read key size.
 	_, remainder := tsdb.ReadSeriesKeyLen(seriesKey)
+	if len(remainder) == 0 {
+		return
+	}
 
 	// Read measurement name.
 	name, remainder := tsdb.ReadSeriesKeyMeasurement(remainder)

--- a/tsdb/series_cursor.go
+++ b/tsdb/series_cursor.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -112,6 +113,9 @@ func (cur *seriesCursor) Next() (*SeriesCursorRow, error) {
 		}
 
 		cur.row.Name, cur.row.Tags = ParseSeriesKey(cur.keys[cur.ofs])
+		if len(cur.row.Name) == 0 {
+			return nil, fmt.Errorf("series key was not valid: %+v", cur.keys[cur.ofs])
+		}
 		cur.ofs++
 
 		//if itr.opt.Authorizer != nil && !itr.opt.Authorizer.AuthorizeSeriesRead(itr.indexSet.Database(), name, tags) {

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -414,6 +414,9 @@ func ParseSeriesKeyInto(data []byte, dstTags models.Tags) ([]byte, models.Tags) 
 func parseSeriesKey(data []byte, dst models.Tags) ([]byte, models.Tags) {
 	var name []byte
 	_, data = ReadSeriesKeyLen(data)
+	if len(data) == 0 {
+		return nil, dst
+	}
 	name, data = ReadSeriesKeyMeasurement(data)
 	tagN, data := ReadSeriesKeyTagN(data)
 
@@ -436,17 +439,30 @@ func parseSeriesKey(data []byte, dst models.Tags) ([]byte, models.Tags) {
 
 func CompareSeriesKeys(a, b []byte) int {
 	// Handle 'nil' keys.
-	if len(a) == 0 && len(b) == 0 {
-		return 0
-	} else if len(a) == 0 {
-		return -1
-	} else if len(b) == 0 {
-		return 1
+	// Values below and equal to 1 are considered invalid for key comparisons.
+	nilKeyHandler := func(a, b int) int {
+		if a == 0 && b == 0 {
+			return 0
+		} else if a == 0 {
+			return -1
+		} else if b == 0 {
+			return 1
+		}
+		return a + b
+	}
+
+	keyValidity := nilKeyHandler(len(a), len(b))
+	if keyValidity <= 1 {
+		return keyValidity
 	}
 
 	// Read total size.
-	_, a = ReadSeriesKeyLen(a)
-	_, b = ReadSeriesKeyLen(b)
+	szA, a := ReadSeriesKeyLen(a)
+	szB, b := ReadSeriesKeyLen(b)
+	keySizeValidity := nilKeyHandler(szA, szB)
+	if keySizeValidity <= 1 {
+		return keySizeValidity
+	}
 
 	// Read names.
 	name0, a := ReadSeriesKeyMeasurement(a)


### PR DESCRIPTION
This is a cherry-pick of 6af0be9 (introduced in https://github.com/influxdata/influxdb/pull/24565) for a port the `2.7` branch.

_Original pull request comment:_

Panics can be avoided by checking the validity of the return from `ReadSeriesKeyLen`, at the moment the size check resulting from this function is entirely discarded. The contained call to [`binary.Uvarint`](https://pkg.go.dev/encoding/binary#Uvarint) contains an implicit error, depending on the returned value:

> If an error occurred, the value is 0 and the number of bytes n is <= 0

In every occurrence of `ReadSeriesKeyMeasurement`, the `ReadSeriesKeyLen` function is called prior to it, determined by glancing over the output of `rg "ReadSeriesKeyMeasurement" -B 5` across the full codebase. 

This PR refactors the flow slightly to include `ReadSeriesKeyLen` returned value checks and the appropriate action to avoid panicking when trying to access memory out of bounds, it has a knock-on effect such that the `ParseSeriesKey` function can return `nil` at another point which indicates an invalid result and the appropriate action should be taken.

Closes: https://github.com/influxdata/influxdb/issues/24598 

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
