### PR TITLE
feat: Add segment persist of closed buffer segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "crossbeam-channel",
  "data_types",
  "datafusion",
+ "datafusion_util",
  "futures-util",
  "influxdb-line-protocol",
  "iox_query",

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -282,18 +282,14 @@ impl<B: WriteBuffer> SchemaProvider for QueryDatabase<B> {
     }
 
     async fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
-        info!("table {}", name);
-
-        let schema = self.db_schema.get_table_schema(name).unwrap();
-
-        info!("return QueryTable");
-        let name: Arc<str> = name.into();
-        Some(Arc::new(QueryTable {
-            db_schema: Arc::clone(&self.db_schema),
-            name,
-            schema,
-            write_buffer: Arc::clone(&self.write_buffer),
-        }))
+        self.db_schema.get_table_schema(name).map(|schema| {
+            Arc::new(QueryTable {
+                db_schema: Arc::clone(&self.db_schema),
+                name: name.into(),
+                schema: schema.clone(),
+                write_buffer: Arc::clone(&self.write_buffer),
+            }) as Arc<dyn TableProvider>
+        })
     }
 
     fn table_exist(&self, name: &str) -> bool {

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -22,6 +22,7 @@ chrono = "0.4"
 crc32fast = "1.2.0"
 crossbeam-channel = "0.5.11"
 datafusion = { workspace = true }
+datafusion_util = { path = "../datafusion_util" }
 parking_lot = "0.11.1"
 parquet = { workspace = true }
 thiserror = "1.0"

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -142,10 +142,8 @@ impl DatabaseSchema {
         }
     }
 
-    pub fn get_table_schema(&self, table_name: &str) -> Option<Schema> {
-        self.tables
-            .get(table_name)
-            .map(|table| table.schema.clone())
+    pub fn get_table_schema(&self, table_name: &str) -> Option<&Schema> {
+        self.tables.get(table_name).map(|table| &table.schema)
     }
 
     pub fn get_table(&self, table_name: &str) -> Option<&TableDefinition> {

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -67,6 +67,21 @@ impl ParquetFilePath {
         ));
         Self(path)
     }
+
+    pub fn new_with_parititon_key(
+        db_name: &str,
+        table_name: &str,
+        partition_key: &str,
+        file_number: u32,
+    ) -> Self {
+        let path = ObjPath::from(format!(
+            "dbs/{db_name}/{table_name}/{}/{:010}.{}",
+            partition_key,
+            object_store_file_stem(file_number),
+            PARQUET_FILE_EXTENSION
+        ));
+        Self(path)
+    }
 }
 
 impl Deref for ParquetFilePath {

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -318,6 +318,10 @@ impl WalSegmentWriter for WalSegmentWriterImpl {
         self.segment_id
     }
 
+    fn bytes_written(&self) -> u64 {
+        self.bytes_written as u64
+    }
+
     fn write_batch(&mut self, ops: Vec<WalOp>) -> Result<SequenceNumber> {
         self.write_batch(ops)
     }
@@ -331,6 +335,7 @@ impl WalSegmentWriter for WalSegmentWriterImpl {
 pub struct WalSegmentWriterNoopImpl {
     segment_id: SegmentId,
     sequence_number: SequenceNumber,
+    wal_ops_written: usize,
 }
 
 impl WalSegmentWriterNoopImpl {
@@ -338,6 +343,7 @@ impl WalSegmentWriterNoopImpl {
         Self {
             segment_id,
             sequence_number: SequenceNumber::new(0),
+            wal_ops_written: 0,
         }
     }
 }
@@ -347,9 +353,19 @@ impl WalSegmentWriter for WalSegmentWriterNoopImpl {
         self.segment_id
     }
 
-    fn write_batch(&mut self, _ops: Vec<WalOp>) -> Result<SequenceNumber> {
+    fn bytes_written(&self) -> u64 {
+        println!("getting bytes_written");
+        self.wal_ops_written as u64
+    }
+
+    fn write_batch(&mut self, ops: Vec<WalOp>) -> Result<SequenceNumber> {
         let sequence_number = self.sequence_number.next();
         self.sequence_number = sequence_number;
+        self.wal_ops_written += ops.len();
+        println!(
+            "write_batch called: wal_ops_written: {}",
+            self.wal_ops_written
+        );
         Ok(sequence_number)
     }
 

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -354,7 +354,6 @@ impl WalSegmentWriter for WalSegmentWriterNoopImpl {
     }
 
     fn bytes_written(&self) -> u64 {
-        println!("getting bytes_written");
         self.wal_ops_written as u64
     }
 

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -22,17 +22,24 @@ pub struct OpenBufferSegment {
     segment_writer: Box<dyn WalSegmentWriter>,
     segment_id: SegmentId,
     buffered_data: HashMap<String, DatabaseBuffer>,
+    #[allow(dead_code)]
+    starting_catalog_sequence_number: SequenceNumber,
     // TODO: This is temporarily just the number of rows in the segment. When the buffer gets refactored to use
     //       different structures, we want this to be a representation of approximate memory usage.
     segment_size: usize,
 }
 
 impl OpenBufferSegment {
-    pub fn new(segment_id: SegmentId, segment_writer: Box<dyn WalSegmentWriter>) -> Self {
+    pub fn new(
+        segment_id: SegmentId,
+        starting_catalog_sequence_number: SequenceNumber,
+        segment_writer: Box<dyn WalSegmentWriter>,
+    ) -> Self {
         Self {
             buffered_data: Default::default(),
             segment_writer,
             segment_id,
+            starting_catalog_sequence_number,
             segment_size: 0,
         }
     }
@@ -314,6 +321,7 @@ mod tests {
     fn buffers_rows() {
         let mut open_segment = OpenBufferSegment::new(
             SegmentId::new(0),
+            SequenceNumber::new(0),
             Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(0))),
         );
 

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -205,6 +205,7 @@ impl Default for PartitionBuffer {
 
 impl PartitionBuffer {
     pub fn add_rows(&mut self, rows: Vec<Row>) {
+        self.rows.reserve(rows.len());
         for row in rows {
             self.timestamp_min = self.timestamp_min.min(row.time);
             self.timestamp_max = self.timestamp_max.max(row.time);
@@ -297,8 +298,6 @@ impl PartitionBuffer {
         for f in &schema.fields {
             cols.push(columns.remove(f.name()).unwrap().into_arrow());
         }
-
-        println!("row count: {}", row_count);
 
         RecordBatch::try_new(schema, cols).unwrap()
     }

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -205,6 +205,7 @@ mod tests {
         let segment_id = SegmentId::new(3);
         let open_segment = OpenBufferSegment::new(
             segment_id,
+            SequenceNumber::new(0),
             Box::new(WalSegmentWriterNoopImpl::new(segment_id)),
         );
         let segment_state = Arc::new(RwLock::new(SegmentState::new(open_segment)));

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -102,7 +102,8 @@ impl<W: Wal> WriteBufferImpl<W> {
             .transpose()?
             .unwrap_or_else(|| Box::new(WalSegmentWriterNoopImpl::new(next_segment_id)));
 
-        let open_segment = OpenBufferSegment::new(next_segment_id, segment_writer);
+        let open_segment =
+            OpenBufferSegment::new(next_segment_id, catalog.sequence_number(), segment_writer);
         let segment_state = Arc::new(RwLock::new(SegmentState::new(open_segment)));
 
         let write_buffer_flusher = WriteBufferFlusher::new(Arc::clone(&segment_state));

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -182,7 +182,7 @@ impl<W: Wal> WriteBufferImpl<W> {
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
         let db_schema = self.catalog.db_schema(database_name).unwrap();
         let table = db_schema.tables.get(table_name).unwrap();
-        let schema = table.schema.as_ref().cloned().unwrap();
+        let schema = table.schema.clone();
 
         let table_buffer = self.clone_table_buffer(database_name, table_name).unwrap();
 
@@ -223,7 +223,7 @@ impl<W: Wal> WriteBufferImpl<W> {
     fn get_table_record_batches(&self, datbase_name: &str, table_name: &str) -> Vec<RecordBatch> {
         let db_schema = self.catalog.db_schema(datbase_name).unwrap();
         let table = db_schema.tables.get(table_name).unwrap();
-        let schema = table.schema.as_ref().cloned().unwrap();
+        let schema = table.schema.clone();
 
         let table_buffer = self.clone_table_buffer(datbase_name, table_name).unwrap();
 

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -180,11 +180,19 @@ impl<W: Wal> WriteBufferImpl<W> {
         _projection: Option<&Vec<usize>>,
         _ctx: &SessionState,
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        let db_schema = self.catalog.db_schema(database_name).unwrap();
-        let table = db_schema.tables.get(table_name).unwrap();
+        let db_schema = self
+            .catalog
+            .db_schema(database_name)
+            .ok_or_else(|| DataFusionError::Execution(format!("db {} not found", database_name)))?;
+        let table = db_schema
+            .tables
+            .get(table_name)
+            .ok_or_else(|| DataFusionError::Execution(format!("table {} not found", table_name)))?;
         let schema = table.schema.clone();
 
-        let table_buffer = self.clone_table_buffer(database_name, table_name).unwrap();
+        let table_buffer = self
+            .clone_table_buffer(database_name, table_name)
+            .unwrap_or_default();
 
         let mut chunks = Vec::with_capacity(table_buffer.partition_buffers.len());
 


### PR DESCRIPTION
This builds on #24624, which should get merged in first. 

Fixes #24573. This adds persist to `ClosedBufferSegment`, which will persist the Catalog, if it has been modified, persist all tables and partitions in the buffer as parquet files and then write the segment file.

It doesn't have retries if errors are encountered during persistence and it doesn't parallelize them, which we should do later. Logged #24657 and #24658 to track those.