### PR TITLE
feat: Add All or Nothing Bearer token auth support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -330,7 +330,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "lexical-core",
  "num",
  "serde",
@@ -760,9 +760,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.2"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -892,9 +892,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1194,9 +1194,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1474,7 +1474,7 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "num_cpus",
@@ -1584,7 +1584,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "hex",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "md-5",
@@ -1616,7 +1616,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 dependencies = [
  "serde",
 ]
@@ -2230,7 +2230,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -2533,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2548,7 +2548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "is-terminal",
  "itoa",
  "log",
@@ -2599,6 +2599,7 @@ dependencies = [
  "clap_blocks",
  "console-subscriber",
  "dotenvy",
+ "hex",
  "influxdb3_server",
  "influxdb3_write",
  "iox_query",
@@ -2613,6 +2614,8 @@ dependencies = [
  "panic_logging",
  "parking_lot 0.12.1",
  "parquet_file",
+ "reqwest",
+ "sha2",
  "thiserror",
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
@@ -2643,6 +2646,7 @@ dependencies = [
  "datafusion_util",
  "flate2",
  "futures",
+ "hex",
  "http",
  "hyper",
  "influxdb-line-protocol",
@@ -2663,6 +2667,7 @@ dependencies = [
  "serde_urlencoded",
  "service_common",
  "service_grpc_flight",
+ "sha2",
  "test_helpers",
  "test_helpers_end_to_end",
  "thiserror",
@@ -2954,7 +2959,7 @@ dependencies = [
  "executor",
  "futures",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "insta",
  "iox_time",
  "itertools 0.12.1",
@@ -3140,12 +3145,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -4448,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -5192,7 +5197,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "observability_deps",
  "once_cell",
  "snafu 0.8.0",
@@ -5366,7 +5371,7 @@ version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -5693,7 +5698,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "log",
  "memchr",
  "once_cell",
@@ -6120,18 +6125,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6347,11 +6352,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "99e68c159e8f5ba8a28c4eb7b0c0c190d77bb479047ca713270048145a9ad28a"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7221,9 +7226,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
 ]
@@ -7272,7 +7277,7 @@ dependencies = [
  "heck",
  "hyper",
  "hyper-rustls",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.11.0",
  "k8s-openapi",
  "kube-core",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -40,6 +40,8 @@ tokio = { version = "1.32", features = ["macros", "net", "parking_lot", "rt-mult
 tokio-util = { version = "0.7.9" }
 uuid = { version = "1", features = ["v4"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+sha2 = "0.10.8"
+hex = "0.4.3"
 
 [features]
 default = ["jemalloc_replacing_malloc"]
@@ -64,3 +66,6 @@ jemalloc_replacing_malloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 # Implicit feature selected when running under `clippy --all-features` to accept mutable exclusive features during
 # linting
 clippy = []
+
+[dev-dependencies]
+reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls"] }

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -1,0 +1,32 @@
+use sha2::Digest;
+use sha2::Sha256;
+use std::error::Error;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    cmd: SubCommand,
+}
+
+#[derive(Debug, clap::Parser)]
+pub enum SubCommand {
+    Token { token: String },
+}
+
+pub fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    match config.cmd {
+        SubCommand::Token { token } => {
+            println!(
+                "\
+                Token Input: {token}\n\
+                Hashed Output: {hashed}\n\n\
+                Start the server with `influxdb3 serve --bearer-token {hashed}`\n\n\
+                HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
+                This will grant you access to every HTTP endpoint or deny it otherwise
+            ",
+                hashed = hex::encode(&Sha256::digest(&token)[..])
+            );
+        }
+    }
+    Ok(())
+}

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -124,6 +124,10 @@ pub struct Config {
     action
     )]
     pub datafusion_config: HashMap<String, String>,
+
+    /// bearer token to be set for requests
+    #[clap(long = "bearer-token", env = "INFLUXDB3_BEARER_TOKEN", action)]
+    pub bearer_token: Option<String>,
 }
 
 #[cfg(all(not(feature = "heappy"), not(feature = "jemalloc_replacing_malloc")))]
@@ -235,7 +239,8 @@ pub async fn command(config: Config) -> Result<()> {
         trace_exporter,
         trace_header_parser,
         *config.http_bind_address,
-    );
+        config.bearer_token,
+    )?;
     let catalog = Arc::new(influxdb3_write::catalog::Catalog::new());
     let wal: Option<Arc<WalImpl>> = config
         .wal_directory

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -25,6 +25,7 @@ use trogging::{
 };
 
 mod commands {
+    pub mod create;
     pub mod serve;
 }
 
@@ -79,9 +80,12 @@ struct Config {
 }
 
 #[derive(Debug, clap::Parser)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Run the InfluxDB 3.0 server
     Serve(commands::serve::Config),
+    /// Create new resources
+    Create(commands::create::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -111,6 +115,12 @@ fn main() -> Result<(), std::io::Error> {
                     handle_init_logs(init_logs_and_tracing(&config.logging_config));
                 if let Err(e) = commands::serve::command(config).await {
                     eprintln!("Serve command failed: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::Create(config)) => {
+                if let Err(e) = commands::create::command(config) {
+                    eprintln!("Create command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3/tests/auth.rs
+++ b/influxdb3/tests/auth.rs
@@ -1,0 +1,181 @@
+use reqwest::StatusCode;
+use std::env;
+use std::process::Command;
+use std::process::Stdio;
+
+#[tokio::test]
+async fn auth() {
+    // The binary is made before testing so we have access to it
+    let bin_path = {
+        let mut bin_path = env::current_exe().unwrap();
+        bin_path.pop();
+        bin_path.pop();
+        bin_path.join("influxdb3")
+    };
+    let mut server = Command::new(bin_path)
+        .args([
+            "serve",
+            "--bearer-token",
+            "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", // foo as a sha256
+        ])
+        .stderr(Stdio::null())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("Was able to spawn a server");
+    let client = reqwest::Client::new();
+
+    // Wait for the server to come up
+    while client
+        .get("http://127.0.0.1:8181/health")
+        .bearer_auth("foo")
+        .send()
+        .await
+        .is_err()
+    {}
+
+    match client
+        .post("http://127.0.0.1:8181/api/v3/write_lp?db=foo")
+        .body("cpu,host=a val=1i 123")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::UNAUTHORIZED {
+                server.kill().unwrap();
+                panic!("status code was not unauthorized: {:#?}", resp);
+            }
+        }
+    }
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::UNAUTHORIZED {
+                server.kill().unwrap();
+                panic!("status code was not unauthorized: {:#?}", resp);
+            }
+        }
+    }
+    match client
+        .post("http://127.0.0.1:8181/api/v3/write_lp?db=foo")
+        .body("cpu,host=a val=1i 123")
+        .bearer_auth("foo")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::OK {
+                server.kill().unwrap();
+                panic!("status code was not ok: {:#?}", resp);
+            }
+        }
+    }
+
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .bearer_auth("foo")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::OK {
+                server.kill().unwrap();
+                panic!("status code was not ok: {:#?}", resp);
+            }
+        }
+    }
+
+    // Malformed Header Tests
+    // Test that there is an extra string after the token foo
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .header("Authorization", "Bearer foo whee")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::BAD_REQUEST {
+                server.kill().unwrap();
+                panic!("status code was not bad request: {:#?}", resp);
+            }
+        }
+    }
+    // Test that Bearer is not capitalized properly
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .header("Authorization", "bearer foo")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::BAD_REQUEST {
+                server.kill().unwrap();
+                panic!("status code was not bad request: {:#?}", resp);
+            }
+        }
+    }
+    // Test that there is not a token after Bearer
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .header("Authorization", "Bearer")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::BAD_REQUEST {
+                server.kill().unwrap();
+                panic!("status code was not bad request: {:#?}", resp);
+            }
+        }
+    }
+    // Test that the request is denied with a bad Authorization header
+    match client
+        .get("http://127.0.0.1:8181/api/v3/query_sql?db=foo&q=select+*+from+cpu")
+        .header("Authorizon", "Bearer foo")
+        .send()
+        .await
+    {
+        Err(e) => {
+            server.kill().unwrap();
+            panic!("request errored out: {e}");
+        }
+        Ok(resp) => {
+            if resp.status() != StatusCode::UNAUTHORIZED {
+                server.kill().unwrap();
+                panic!("status code was not unauthorized: {:#?}", resp);
+            }
+        }
+    }
+
+    server.kill().unwrap();
+}

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -49,6 +49,8 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 arrow-json = "49.0.0"
 arrow-schema = "49.0.0"
 arrow-csv = "49.0.0"
+sha2 = "0.10.8"
+hex = "0.4.3"
 
 [dev-dependencies]
 parquet.workspace = true

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -9,6 +9,7 @@ use data_types::NamespaceName;
 use datafusion::execution::memory_pool::UnboundedMemoryPool;
 use futures::StreamExt;
 use hyper::header::ACCEPT;
+use hyper::header::AUTHORIZATION;
 use hyper::header::CONTENT_ENCODING;
 use hyper::http::HeaderValue;
 use hyper::server::conn::{AddrIncoming, AddrStream};
@@ -18,6 +19,8 @@ use influxdb3_write::WriteBuffer;
 use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::{debug, error, info};
 use serde::Deserialize;
+use sha2::Digest;
+use sha2::Sha256;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::num::NonZeroI32;
@@ -132,6 +135,16 @@ pub enum Error {
     // Influxdb3 Write
     #[error("serde json error: {0}")]
     Influxdb3Write(#[from] influxdb3_write::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum AuthorizationError {
+    #[error("the request was not authorized")]
+    Unauthorized,
+    #[error("the request was not in the form of 'Authorization: Bearer <token>'")]
+    MalformedRequest,
+    #[error("to str error: {0}")]
+    ToStr(#[from] hyper::header::ToStrError),
 }
 
 impl Error {
@@ -277,8 +290,8 @@ where
                 Some("text/csv") => (to_csv(batches)?, Format::Csv),
                 Some("text/plain") => (to_pretty(batches)?, Format::Pretty),
                 Some("application/json") => (to_json(batches)?, Format::Json),
+                Some("*/*") | None => (to_json(batches)?, Format::Json),
                 Some(_) => (Bytes::from("{ \"error\": \"Available mime types are: application/vnd.apache.parquet, text/csv, text/plain, and application/json\" }"), Format::Error),
-                None => (to_json(batches)?, Format::Json),
             },
             Some(format) => match format.as_str() {
                 "parquet" => (to_parquet(batches)?, Format::Parquet),
@@ -382,6 +395,46 @@ where
 
         Ok(decoded_data.into())
     }
+
+    fn authorize_request(&self, req: &mut Request<Body>) -> Result<(), AuthorizationError> {
+        // We won't need the authorization header anymore and we don't want to accidentally log it.
+        // Take it out so we can use it and not log it later by accident.
+        let auth = req.headers_mut().remove(AUTHORIZATION);
+
+        if let Some(bearer_token) = self.common_state.bearer_token() {
+            let Some(header) = &auth else {
+                return Err(AuthorizationError::Unauthorized);
+            };
+
+            // Split the header value into two parts
+            let mut header = header.to_str()?.split(' ');
+
+            // Check that the header is the 'Bearer' auth scheme
+            let bearer = header.next().ok_or(AuthorizationError::MalformedRequest)?;
+            if bearer != "Bearer" {
+                return Err(AuthorizationError::MalformedRequest);
+            }
+
+            // Get the token that we want to hash to check the request is valid
+            let token = header.next().ok_or(AuthorizationError::MalformedRequest)?;
+
+            // There should only be two parts the 'Bearer' scheme and the actual
+            // token, error otherwise
+            if header.next().is_some() {
+                return Err(AuthorizationError::MalformedRequest);
+            }
+
+            // Check that the hashed token is acceptable
+            let authorized = &Sha256::digest(token)[..] == bearer_token;
+            if !authorized {
+                return Err(AuthorizationError::Unauthorized);
+            }
+        }
+
+        req.extensions_mut()
+            .insert(AuthorizationHeaderExtension::new(auth));
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -435,12 +488,32 @@ async fn route_request<W: WriteBuffer, Q: QueryExecutor>(
     http_server: Arc<HttpApi<W, Q>>,
     mut req: Request<Body>,
 ) -> Result<Response<Body>, Infallible> {
-    let auth = { req.headers().get(hyper::header::AUTHORIZATION).cloned() };
-    req.extensions_mut()
-        .insert(AuthorizationHeaderExtension::new(auth));
-
-    // we don't need the authorization header anymore and we don't want to accidentally log it.
-    req.headers_mut().remove(hyper::header::AUTHORIZATION);
+    if let Err(e) = http_server.authorize_request(&mut req) {
+        match e {
+            AuthorizationError::Unauthorized => {
+                return Ok(Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(Body::empty())
+                    .unwrap())
+            }
+            AuthorizationError::MalformedRequest => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from("{\"error\":\
+                        \"Authorization header was malformed and should be in the form 'Authorization: Bearer <token>'\"\
+                    }"))
+                    .unwrap());
+            }
+            // We don't expect this to happen, but if the header is messed up
+            // better to handle it then not at all
+            AuthorizationError::ToStr(_) => {
+                return Ok(Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::empty())
+                    .unwrap())
+            }
+        }
+    }
     debug!(request = ?req,"Processing request");
 
     let method = req.method().clone();


### PR DESCRIPTION
This commit adds basic authorization support to Edge. Up to this point we didn't need have authorization at all and so the server would receieve and accept requests from anyone. This isn't exactly secure or ideal for a deployment and so we add a basic form of authentication.

The way this works is that a user passes in a hex encoded sha256 hash of a given token to the '--bearer-token' flag of the serve command. When the server starts with this flag it will now check a header of the form 'Authorization: Bearer <token>' by making sure it is valid in the sense that it is not malformed and that when token is hashed it matches the value passed in on the command line. The request is denied with either a 400 Bad Request if the header is malformed or a 401 Unauthorized if the hash does not match or the header is missing.

The user is provided a new subcommand of the form: 'influxdb3 create token <token>' where the output contains the command to run the server with and what the header should look like to make requests.

I can see future work including multiple tokens and rotating between them or adding new ones to a live service, but for now this shall suffice.

As part of the commit end-to-end tests are included to run the server and make requests against the HTTP API and to make sure that requests are denied for being unauthorized, accepted for having the right header, or denied for being malformed.

Also as part of this commit a small fix is included for 'Accept: */*' headers. We were not checking for them and if this header was included we were denying it instead of sending back the default payload return value.

Closes #24646