### PR TITLE
feat: support FlightSQL in 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 dependencies = [
  "serde",
 ]
@@ -2632,6 +2632,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow-csv",
+ "arrow-flight",
  "arrow-json",
  "arrow-schema",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,17 +168,17 @@ checksum = "5bc25126d18a012146a888a0298f2c22e1150327bd2765fc76d710a556b2d614"
 dependencies = [
  "ahash",
  "arrow-arith",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
  "arrow-csv",
- "arrow-data 49.0.0",
- "arrow-ipc 49.0.0",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-schema",
+ "arrow-select",
  "arrow-string",
 ]
 
@@ -188,10 +188,10 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ccd45e217ffa6e53bbb0080990e77113bdd4e91ddb84e97b77649810bcf1a7"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "num",
@@ -204,27 +204,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bda9acea48b25123c08340f3a8ac361aa0f74469bb36f5ee9acf923fce23e9d"
 dependencies = [
  "ahash",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
- "half",
- "hashbrown 0.14.3",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d390feeb7f21b78ec997a4081a025baef1e2e0d6069e181939b61864c9779609"
-dependencies = [
- "ahash",
- "arrow-buffer 50.0.0",
- "arrow-data 50.0.0",
- "arrow-schema 50.0.0",
- "chrono",
  "half",
  "hashbrown 0.14.3",
  "num",
@@ -242,48 +226,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-buffer"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69615b061701bcdffbc62756bc7e85c827d5290b472b580c972ebbbf690f5aa4"
-dependencies = [
- "bytes",
- "half",
- "num",
-]
-
-[[package]]
 name = "arrow-cast"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc0368ed618d509636c1e3cc20db1281148190a78f43519487b2daf07b63b4a"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "base64",
  "chrono",
  "comfy-table",
- "half",
- "lexical-core",
- "num",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e448e5dd2f4113bf5b74a1f26531708f5edcacc77335b7066f9398f4bcf4cdef"
-dependencies = [
- "arrow-array 50.0.0",
- "arrow-buffer 50.0.0",
- "arrow-data 50.0.0",
- "arrow-schema 50.0.0",
- "arrow-select 50.0.0",
- "base64",
- "chrono",
  "half",
  "lexical-core",
  "num",
@@ -295,11 +250,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e09aa6246a1d6459b3f14baeaa49606cfdbca34435c46320e14054d244987ca"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -314,20 +269,8 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907fafe280a3874474678c1858b9ca4cb7fd83fb8034ff5b6d6376205a08c634"
 dependencies = [
- "arrow-buffer 49.0.0",
- "arrow-schema 49.0.0",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-data"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d644b91a162f3ad3135ce1184d0a31c28b816a581e08f29e8e9277a574c64e"
-dependencies = [
- "arrow-buffer 50.0.0",
- "arrow-schema 50.0.0",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -339,15 +282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624e0dcb6b5a7a06222bfd2be3f7e905ce849a6b714ec989f18cdba330c77d38"
 dependencies = [
  "arrow-arith",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
- "arrow-data 49.0.0",
- "arrow-ipc 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-schema",
+ "arrow-select",
  "arrow-string",
  "base64",
  "bytes",
@@ -360,52 +303,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-flight"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7f215461ad6346f2e4cc853e377d4e076d533e1ed78d327debe83023e3601f"
-dependencies = [
- "arrow-array 50.0.0",
- "arrow-buffer 50.0.0",
- "arrow-cast 50.0.0",
- "arrow-ipc 50.0.0",
- "arrow-schema 50.0.0",
- "base64",
- "bytes",
- "futures",
- "paste",
- "prost 0.12.3",
- "tokio",
- "tonic 0.10.2",
-]
-
-[[package]]
 name = "arrow-ipc"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79a43d6808411886b8c7d4f6f7dd477029c1e77ffffffb7923555cc6579639cd"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers",
  "lz4_flex",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dea5e79b48de6c2e04f03f62b0afea7105be7b77d134f6c5414868feefb80d"
-dependencies = [
- "arrow-array 50.0.0",
- "arrow-buffer 50.0.0",
- "arrow-cast 50.0.0",
- "arrow-data 50.0.0",
- "arrow-schema 50.0.0",
- "flatbuffers",
 ]
 
 [[package]]
@@ -414,11 +323,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82565c91fd627922ebfe2810ee4e8346841b6f9361b87505a9acea38b614fee"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.2.3",
@@ -434,11 +343,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b23b0e53c0db57c6749997fd343d4c0354c994be7eca67152dd2bdb9a3e1bb4"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "half",
  "num",
 ]
@@ -450,10 +359,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361249898d2d6d4a6eeb7484be6ac74977e48da12a4dd81a708d620cc558117a"
 dependencies = [
  "ahash",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
  "hashbrown 0.14.3",
 ]
@@ -465,36 +374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
 
 [[package]]
-name = "arrow-schema"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff3e9c01f7cd169379d269f926892d0e622a704960350d09d331be3ec9e0029"
-
-[[package]]
 name = "arrow-select"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f6208466590960efc1d2a7172bc4ff18a67d6e25c529381d7f96ddaf0dc4036"
 dependencies = [
  "ahash",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce20973c1912de6514348e064829e50947e35977bb9d7fb637dc99ea9ffd78c"
-dependencies = [
- "ahash",
- "arrow-array 50.0.0",
- "arrow-buffer 50.0.0",
- "arrow-data 50.0.0",
- "arrow-schema 50.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
 ]
 
@@ -504,11 +393,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a48149c63c11c9ff571e50ab8f017d2a7cb71037a882b42f6354ed2da9acc7"
 dependencies = [
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-data 49.0.0",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "num",
  "regex",
  "regex-syntax 0.8.2",
@@ -1528,7 +1417,7 @@ dependencies = [
 name = "data_types"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer 49.0.0",
+ "arrow-buffer",
  "assert_matches",
  "bytes",
  "chrono",
@@ -1564,9 +1453,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 49.0.0",
- "arrow-ipc 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1611,9 +1500,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "chrono",
  "half",
  "libc",
@@ -1650,7 +1539,7 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 49.0.0",
+ "arrow-array",
  "datafusion-common",
  "paste",
  "sqlparser",
@@ -1682,10 +1571,10 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
  "arrow-ord",
- "arrow-schema 49.0.0",
+ "arrow-schema",
  "base64",
  "blake2",
  "blake3",
@@ -1715,9 +1604,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-schema 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1758,7 +1647,7 @@ version = "34.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d3d27c6ebb6d25b1699e5553e7#0e53c6d816f3a9d3d27c6ebb6d25b1699e5553e7"
 dependencies = [
  "arrow",
- "arrow-schema 49.0.0",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -2083,7 +1972,7 @@ name = "flightsql"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight 49.0.0",
+ "arrow-flight",
  "arrow_util",
  "bytes",
  "datafusion",
@@ -2705,8 +2594,10 @@ dependencies = [
 name = "influxdb3"
 version = "0.1.0"
 dependencies = [
- "arrow-array 50.0.0",
- "arrow-flight 50.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-flight",
+ "arrow_util",
  "assert_cmd",
  "backtrace",
  "clap",
@@ -2719,6 +2610,7 @@ dependencies = [
  "influxdb3_client",
  "influxdb3_server",
  "influxdb3_write",
+ "influxdb_iox_client",
  "iox_query",
  "iox_time",
  "ioxd_common",
@@ -2771,9 +2663,9 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow-csv",
- "arrow-flight 49.0.0",
+ "arrow-flight",
  "arrow-json",
- "arrow-schema 49.0.0",
+ "arrow-schema",
  "async-trait",
  "authz",
  "bytes",
@@ -2875,7 +2767,7 @@ name = "influxdb_iox_client"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight 49.0.0",
+ "arrow-flight",
  "arrow_util",
  "bytes",
  "client_util",
@@ -4306,13 +4198,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af88740a842787da39b3d69ce5fbf6fce97d20211d3b299fee0a0da6430c74d4"
 dependencies = [
  "ahash",
- "arrow-array 49.0.0",
- "arrow-buffer 49.0.0",
- "arrow-cast 49.0.0",
- "arrow-data 49.0.0",
- "arrow-ipc 49.0.0",
- "arrow-schema 49.0.0",
- "arrow-select 49.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64",
  "brotli",
  "bytes",
@@ -5533,7 +5425,7 @@ name = "service_grpc_flight"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight 49.0.0",
+ "arrow-flight",
  "assert_matches",
  "async-trait",
  "authz",
@@ -6225,7 +6117,7 @@ name = "test_helpers_end_to_end"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight 49.0.0",
+ "arrow-flight",
  "arrow_util",
  "assert_cmd",
  "assert_matches",
@@ -7388,7 +7280,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "arrow",
- "arrow-ipc 49.0.0",
+ "arrow-ipc",
  "base64",
  "bitflags 2.4.2",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "parquet",
  "parquet_file",
+ "pin-project-lite",
  "schema",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,17 +168,17 @@ checksum = "5bc25126d18a012146a888a0298f2c22e1150327bd2765fc76d710a556b2d614"
 dependencies = [
  "ahash",
  "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 49.0.0",
+ "arrow-ipc 49.0.0",
  "arrow-json",
  "arrow-ord",
  "arrow-row",
- "arrow-schema",
- "arrow-select",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "arrow-string",
 ]
 
@@ -188,10 +188,10 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ccd45e217ffa6e53bbb0080990e77113bdd4e91ddb84e97b77649810bcf1a7"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "chrono",
  "half",
  "num",
@@ -204,11 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bda9acea48b25123c08340f3a8ac361aa0f74469bb36f5ee9acf923fce23e9d"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "chrono",
  "chrono-tz",
+ "half",
+ "hashbrown 0.14.3",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d390feeb7f21b78ec997a4081a025baef1e2e0d6069e181939b61864c9779609"
+dependencies = [
+ "ahash",
+ "arrow-buffer 50.0.0",
+ "arrow-data 50.0.0",
+ "arrow-schema 50.0.0",
+ "chrono",
  "half",
  "hashbrown 0.14.3",
  "num",
@@ -226,19 +242,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69615b061701bcdffbc62756bc7e85c827d5290b472b580c972ebbbf690f5aa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc0368ed618d509636c1e3cc20db1281148190a78f43519487b2daf07b63b4a"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "base64",
  "chrono",
  "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e448e5dd2f4113bf5b74a1f26531708f5edcacc77335b7066f9398f4bcf4cdef"
+dependencies = [
+ "arrow-array 50.0.0",
+ "arrow-buffer 50.0.0",
+ "arrow-data 50.0.0",
+ "arrow-schema 50.0.0",
+ "arrow-select 50.0.0",
+ "base64",
+ "chrono",
  "half",
  "lexical-core",
  "num",
@@ -250,11 +295,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e09aa6246a1d6459b3f14baeaa49606cfdbca34435c46320e14054d244987ca"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -269,8 +314,20 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907fafe280a3874474678c1858b9ca4cb7fd83fb8034ff5b6d6376205a08c634"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 49.0.0",
+ "arrow-schema 49.0.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d644b91a162f3ad3135ce1184d0a31c28b816a581e08f29e8e9277a574c64e"
+dependencies = [
+ "arrow-buffer 50.0.0",
+ "arrow-schema 50.0.0",
  "half",
  "num",
 ]
@@ -282,15 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624e0dcb6b5a7a06222bfd2be3f7e905ce849a6b714ec989f18cdba330c77d38"
 dependencies = [
  "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-ipc 49.0.0",
  "arrow-ord",
  "arrow-row",
- "arrow-schema",
- "arrow-select",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "arrow-string",
  "base64",
  "bytes",
@@ -303,18 +360,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-flight"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7f215461ad6346f2e4cc853e377d4e076d533e1ed78d327debe83023e3601f"
+dependencies = [
+ "arrow-array 50.0.0",
+ "arrow-buffer 50.0.0",
+ "arrow-cast 50.0.0",
+ "arrow-ipc 50.0.0",
+ "arrow-schema 50.0.0",
+ "base64",
+ "bytes",
+ "futures",
+ "paste",
+ "prost 0.12.3",
+ "tokio",
+ "tonic 0.10.2",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79a43d6808411886b8c7d4f6f7dd477029c1e77ffffffb7923555cc6579639cd"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "flatbuffers",
  "lz4_flex",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03dea5e79b48de6c2e04f03f62b0afea7105be7b77d134f6c5414868feefb80d"
+dependencies = [
+ "arrow-array 50.0.0",
+ "arrow-buffer 50.0.0",
+ "arrow-cast 50.0.0",
+ "arrow-data 50.0.0",
+ "arrow-schema 50.0.0",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -323,11 +414,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82565c91fd627922ebfe2810ee4e8346841b6f9361b87505a9acea38b614fee"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "chrono",
  "half",
  "indexmap 2.2.3",
@@ -343,11 +434,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b23b0e53c0db57c6749997fd343d4c0354c994be7eca67152dd2bdb9a3e1bb4"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "half",
  "num",
 ]
@@ -359,10 +450,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361249898d2d6d4a6eeb7484be6ac74977e48da12a4dd81a708d620cc558117a"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
  "half",
  "hashbrown 0.14.3",
 ]
@@ -374,16 +465,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
 
 [[package]]
+name = "arrow-schema"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff3e9c01f7cd169379d269f926892d0e622a704960350d09d331be3ec9e0029"
+
+[[package]]
 name = "arrow-select"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f6208466590960efc1d2a7172bc4ff18a67d6e25c529381d7f96ddaf0dc4036"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce20973c1912de6514348e064829e50947e35977bb9d7fb637dc99ea9ffd78c"
+dependencies = [
+ "ahash",
+ "arrow-array 50.0.0",
+ "arrow-buffer 50.0.0",
+ "arrow-data 50.0.0",
+ "arrow-schema 50.0.0",
  "num",
 ]
 
@@ -393,11 +504,11 @@ version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a48149c63c11c9ff571e50ab8f017d2a7cb71037a882b42f6354ed2da9acc7"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "num",
  "regex",
  "regex-syntax 0.8.2",
@@ -435,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
+checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
 dependencies = [
  "anstyle",
  "bstr",
@@ -1417,7 +1528,7 @@ dependencies = [
 name = "data_types"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer",
+ "arrow-buffer 49.0.0",
  "assert_matches",
  "bytes",
  "chrono",
@@ -1453,9 +1564,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-ipc 49.0.0",
+ "arrow-schema 49.0.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1500,9 +1611,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-schema 49.0.0",
  "chrono",
  "half",
  "libc",
@@ -1539,7 +1650,7 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array",
+ "arrow-array 49.0.0",
  "datafusion-common",
  "paste",
  "sqlparser",
@@ -1571,10 +1682,10 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
  "arrow-ord",
- "arrow-schema",
+ "arrow-schema 49.0.0",
  "base64",
  "blake2",
  "blake3",
@@ -1604,9 +1715,9 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d
 dependencies = [
  "ahash",
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-schema 49.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1647,7 +1758,7 @@ version = "34.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=0e53c6d816f3a9d3d27c6ebb6d25b1699e5553e7#0e53c6d816f3a9d3d27c6ebb6d25b1699e5553e7"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 49.0.0",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -1972,7 +2083,7 @@ name = "flightsql"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
+ "arrow-flight 49.0.0",
  "arrow_util",
  "bytes",
  "datafusion",
@@ -2594,12 +2705,17 @@ dependencies = [
 name = "influxdb3"
 version = "0.1.0"
 dependencies = [
+ "arrow-array 50.0.0",
+ "arrow-flight 50.0.0",
+ "assert_cmd",
  "backtrace",
  "clap",
  "clap_blocks",
  "console-subscriber",
  "dotenvy",
+ "futures",
  "hex",
+ "hyper",
  "influxdb3_client",
  "influxdb3_server",
  "influxdb3_write",
@@ -2624,6 +2740,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tokio_metrics_bridge",
+ "tonic 0.10.2",
+ "tower",
  "trace",
  "trace_exporters",
  "trogging",
@@ -2653,9 +2771,9 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow-csv",
- "arrow-flight",
+ "arrow-flight 49.0.0",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 49.0.0",
  "async-trait",
  "authz",
  "bytes",
@@ -2756,7 +2874,7 @@ name = "influxdb_iox_client"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
+ "arrow-flight 49.0.0",
  "arrow_util",
  "bytes",
  "client_util",
@@ -4187,13 +4305,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af88740a842787da39b3d69ce5fbf6fce97d20211d3b299fee0a0da6430c74d4"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-ipc 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
  "base64",
  "brotli",
  "bytes",
@@ -5414,7 +5532,7 @@ name = "service_grpc_flight"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
+ "arrow-flight 49.0.0",
  "assert_matches",
  "async-trait",
  "authz",
@@ -6106,7 +6224,7 @@ name = "test_helpers_end_to_end"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
+ "arrow-flight 49.0.0",
  "arrow_util",
  "assert_cmd",
  "assert_matches",
@@ -7269,7 +7387,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "arrow",
- "arrow-ipc",
+ "arrow-ipc 49.0.0",
  "base64",
  "bitflags 2.4.2",
  "byteorder",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -71,9 +71,13 @@ jemalloc_replacing_malloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 clippy = []
 
 [dev-dependencies]
+arrow_util = { path = "../arrow_util" }
+influxdb_iox_client = { path = "../influxdb_iox_client" }
+
 # Crates.io dependencies in alphabetical order:
-arrow-array = "50.0.0"
-arrow-flight = "50.0.0"
+arrow = { workspace = true }
+arrow-array = "49.0.0"
+arrow-flight = "49.0.0"
 assert_cmd = "2.0.14"
 futures = "0.3.28"
 hyper = "0.14"

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -71,4 +71,12 @@ jemalloc_replacing_malloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 clippy = []
 
 [dev-dependencies]
+# Crates.io dependencies in alphabetical order:
+arrow-array = "50.0.0"
+arrow-flight = "50.0.0"
+assert_cmd = "2.0.14"
+futures = "0.3.28"
+hyper = "0.14"
 reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls"] }
+tonic.workspace = true
+tower = "0.4.13"

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -35,6 +35,8 @@ pub const DEFAULT_DATA_DIRECTORY_NAME: &str = ".influxdb3";
 
 /// The default bind address for the HTTP API.
 pub const DEFAULT_HTTP_BIND_ADDR: &str = "127.0.0.1:8181";
+/// The default bind address for the gRPC FlightSQL interface
+pub const DEFAULT_GRPC_BIND_ADDR: &str = "127.0.0.1:8282";
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -84,6 +86,15 @@ pub struct Config {
     action,
     )]
     pub http_bind_address: SocketAddr,
+
+    /// The address on which InfluxDB will serve FlightSQL gRPC requests
+    #[clap(
+    long = "grpc-bind",
+    env = "INFLUXDB3_GRPC_BIND_ADDR",
+    default_value = DEFAULT_GRPC_BIND_ADDR,
+    action,
+    )]
+    pub grpc_bind_address: SocketAddr,
 
     /// Size of the RAM cache used to store data in bytes.
     ///

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -35,8 +35,6 @@ pub const DEFAULT_DATA_DIRECTORY_NAME: &str = ".influxdb3";
 
 /// The default bind address for the HTTP API.
 pub const DEFAULT_HTTP_BIND_ADDR: &str = "127.0.0.1:8181";
-/// The default bind address for the gRPC FlightSQL interface
-pub const DEFAULT_GRPC_BIND_ADDR: &str = "127.0.0.1:8282";
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -86,15 +84,6 @@ pub struct Config {
     action,
     )]
     pub http_bind_address: SocketAddr,
-
-    /// The address on which InfluxDB will serve FlightSQL gRPC requests
-    #[clap(
-    long = "grpc-bind",
-    env = "INFLUXDB3_GRPC_BIND_ADDR",
-    default_value = DEFAULT_GRPC_BIND_ADDR,
-    action,
-    )]
-    pub grpc_bind_address: SocketAddr,
 
     /// Size of the RAM cache used to store data in bytes.
     ///

--- a/influxdb3/tests/common.rs
+++ b/influxdb3/tests/common.rs
@@ -1,0 +1,86 @@
+use std::{
+    net::{SocketAddrV4, TcpListener},
+    process::{Child, Command, Stdio},
+};
+
+use arrow_flight::FlightClient;
+use assert_cmd::cargo::CommandCargoExt;
+
+pub struct TestServer {
+    bind_addr: String,
+    server_process: Child,
+    http_client: reqwest::Client,
+}
+
+impl TestServer {
+    pub async fn spawn() -> Self {
+        let bind_addr = get_bind_addr();
+        let mut command = Command::cargo_bin("influxdb3").expect("create the influxdb3 command");
+        let command = command
+            .arg("serve")
+            .args(["--http-bind", &bind_addr])
+            // TODO - other configuration can be passed through
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let server_process = command.spawn().expect("spawn the influxdb3 server process");
+
+        let server = Self {
+            bind_addr,
+            server_process,
+            http_client: reqwest::Client::new(),
+        };
+
+        server.wait_until_ready().await;
+        server
+    }
+
+    pub async fn wait_until_ready(&self) {
+        while self
+            .http_client
+            .get(format!("{base}/health", base = self.client_addr()))
+            .send()
+            .await
+            .is_err()
+        {
+            // TODO - sleep or do a count to ensure we don't loop infinitely
+        }
+    }
+
+    pub fn client_addr(&self) -> String {
+        format!("http://{addr}", addr = self.bind_addr)
+    }
+
+    pub fn kill(&mut self) {
+        self.server_process.kill().expect("kill the server process");
+    }
+
+    pub async fn flight_client(&self) -> FlightClient {
+        let channel = tonic::transport::Channel::from_shared(self.client_addr())
+            .expect("create tonic channel")
+            .connect()
+            .await
+            .expect("connect to gRPC client");
+        FlightClient::new(channel)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+fn get_bind_addr() -> String {
+    let ip = std::net::Ipv4Addr::new(127, 0, 0, 1);
+    // Port 0 will find a free port
+    let addr = SocketAddrV4::new(ip, 0).to_string();
+    // Bind to get the full address with the selected port,
+    // the TcpListener will be dropped at the end of this function
+    // and therefore the port will be free for the command to start
+    TcpListener::bind(addr)
+        .expect("bind to a socket address")
+        .local_addr()
+        .expect("get local address")
+        .to_string()
+}

--- a/influxdb3/tests/flight.rs
+++ b/influxdb3/tests/flight.rs
@@ -131,8 +131,6 @@ async fn flight() {
             &batches
         );
     }
-
-    //
 }
 
 async fn write_lp_to_db(server: &TestServer, database: &str, lp: &'static str) {

--- a/influxdb3/tests/flight.rs
+++ b/influxdb3/tests/flight.rs
@@ -1,0 +1,40 @@
+use arrow_array::RecordBatch;
+use arrow_flight::Ticket;
+use futures::TryStreamExt;
+
+use crate::common::TestServer;
+
+mod common;
+
+#[tokio::test]
+async fn flight() {
+    let server = TestServer::spawn().await;
+
+    // use the influxdb3_client to write in some data
+    {
+        let client =
+            influxdb3_client::Client::new(server.client_addr()).expect("create influxdb3 client");
+        client
+            .api_v3_write_lp("foo")
+            .body(
+                "\
+                cpu,host=s1,region=us-east usage=0.9 1\n\
+                cpu,host=s1,region=us-east usage=0.89 2\n\
+                cpu,host=21,region=us-east usage=0.85 3",
+            )
+            .send()
+            .await
+            .expect("send write_lp request");
+    }
+
+    // Use a FlightClient to communicate via FlightSQL
+    let mut client = server.flight_client().await;
+    let ticket = Ticket::new(r#"{"database":"foo","sql_query":"SELECT * FROM cpu"}"#);
+    let response = client.do_get(ticket).await.expect("send gRPC request");
+
+    // Convert the response to a RecordBatch to make assertions
+    let batches: Vec<RecordBatch> = response.try_collect().await.expect("gather record batches");
+    let record_batch = batches.first().expect("has first batch");
+
+    assert_eq!(record_batch.num_rows(), 3);
+}

--- a/influxdb3/tests/flight.rs
+++ b/influxdb3/tests/flight.rs
@@ -1,5 +1,6 @@
-use arrow_array::RecordBatch;
-use arrow_flight::Ticket;
+use arrow::record_batch::RecordBatch;
+use arrow_flight::{decode::FlightRecordBatchStream, sql::SqlInfo};
+use arrow_util::assert_batches_sorted_eq;
 use futures::TryStreamExt;
 
 use crate::common::TestServer;
@@ -11,30 +12,142 @@ async fn flight() {
     let server = TestServer::spawn().await;
 
     // use the influxdb3_client to write in some data
+    write_lp_to_db(
+        &server,
+        "foo",
+        "cpu,host=s1,region=us-east usage=0.9 1\n\
+        cpu,host=s1,region=us-east usage=0.89 2\n\
+        cpu,host=s1,region=us-east usage=0.85 3",
+    )
+    .await;
+
+    let mut client = server.flight_client("foo").await;
+
+    // Ad-hoc Query:
     {
-        let client =
-            influxdb3_client::Client::new(server.client_addr()).expect("create influxdb3 client");
-        client
-            .api_v3_write_lp("foo")
-            .body(
-                "\
-                cpu,host=s1,region=us-east usage=0.9 1\n\
-                cpu,host=s1,region=us-east usage=0.89 2\n\
-                cpu,host=21,region=us-east usage=0.85 3",
-            )
-            .send()
-            .await
-            .expect("send write_lp request");
+        let response = client.query("SELECT * FROM cpu").await.unwrap();
+
+        let batches = collect_stream(response).await;
+        assert_batches_sorted_eq!(
+            [
+                "+------+---------+--------------------------------+-------+",
+                "| host | region  | time                           | usage |",
+                "+------+---------+--------------------------------+-------+",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000001Z | 0.9   |",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000002Z | 0.89  |",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000003Z | 0.85  |",
+                "+------+---------+--------------------------------+-------+",
+            ],
+            &batches
+        );
     }
 
-    // Use a FlightClient to communicate via FlightSQL
-    let mut client = server.flight_client().await;
-    let ticket = Ticket::new(r#"{"database":"foo","sql_query":"SELECT * FROM cpu"}"#);
-    let response = client.do_get(ticket).await.expect("send gRPC request");
+    // Ad-hoc Query error:
+    {
+        let error = client
+            .query("SELECT * FROM invalid_table")
+            .await
+            .unwrap_err();
 
-    // Convert the response to a RecordBatch to make assertions
-    let batches: Vec<RecordBatch> = response.try_collect().await.expect("gather record batches");
-    let record_batch = batches.first().expect("has first batch");
+        assert!(error
+            .to_string()
+            .contains("table 'public.iox.invalid_table' not found"));
+    }
 
-    assert_eq!(record_batch.num_rows(), 3);
+    // Prepared query:
+    {
+        let handle = client.prepare("SELECT * FROM cpu".into()).await.unwrap();
+        let stream = client.execute(handle).await.unwrap();
+
+        let batches = collect_stream(stream).await;
+        assert_batches_sorted_eq!(
+            [
+                "+------+---------+--------------------------------+-------+",
+                "| host | region  | time                           | usage |",
+                "+------+---------+--------------------------------+-------+",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000001Z | 0.9   |",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000002Z | 0.89  |",
+                "| s1   | us-east | 1970-01-01T00:00:00.000000003Z | 0.85  |",
+                "+------+---------+--------------------------------+-------+",
+            ],
+            &batches
+        );
+    }
+
+    // Get SQL Infos:
+    {
+        let infos = vec![SqlInfo::FlightSqlServerName as u32];
+        let stream = client.get_sql_info(infos).await.unwrap();
+        let batches = collect_stream(stream).await;
+        assert_batches_sorted_eq!(
+            [
+                "+-----------+-----------------------------+",
+                "| info_name | value                       |",
+                "+-----------+-----------------------------+",
+                "| 0         | {string_value=InfluxDB IOx} |",
+                "+-----------+-----------------------------+",
+            ],
+            &batches
+        );
+    }
+
+    // Get Tables
+    {
+        type OptStr = std::option::Option<&'static str>;
+        let stream = client
+            .get_tables(OptStr::None, OptStr::None, OptStr::None, vec![], false)
+            .await
+            .unwrap();
+        let batches = collect_stream(stream).await;
+
+        assert_batches_sorted_eq!(
+            [
+                "+--------------+--------------------+-------------+------------+",
+                "| catalog_name | db_schema_name     | table_name  | table_type |",
+                "+--------------+--------------------+-------------+------------+",
+                "| public       | information_schema | columns     | VIEW       |",
+                "| public       | information_schema | df_settings | VIEW       |",
+                "| public       | information_schema | tables      | VIEW       |",
+                "| public       | information_schema | views       | VIEW       |",
+                "| public       | iox                | cpu         | BASE TABLE |",
+                "+--------------+--------------------+-------------+------------+",
+            ],
+            &batches
+        );
+    }
+
+    // Get Catalogs
+    {
+        let stream = client.get_catalogs().await.unwrap();
+        let batches = collect_stream(stream).await;
+        assert_batches_sorted_eq!(
+            [
+                "+--------------+",
+                "| catalog_name |",
+                "+--------------+",
+                "| public       |",
+                "+--------------+",
+            ],
+            &batches
+        );
+    }
+
+    //
+}
+
+async fn write_lp_to_db(server: &TestServer, database: &str, lp: &'static str) {
+    let client = influxdb3_client::Client::new(server.client_addr()).unwrap();
+    client
+        .api_v3_write_lp(database)
+        .body(lp)
+        .send()
+        .await
+        .unwrap();
+}
+
+async fn collect_stream(stream: FlightRecordBatchStream) -> Vec<RecordBatch> {
+    stream
+        .try_collect()
+        .await
+        .expect("gather record batch stream")
 }

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -31,10 +31,15 @@ tracker = { path = "../tracker" }
 
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-flight.workspace = true
+arrow-json = "49.0.0"
+arrow-schema = "49.0.0"
+arrow-csv = "49.0.0"
 async-trait = "0.1"
 chrono = "0.4"
 datafusion = { workspace = true }
+flate2 = "1.0.27"
 futures = "0.3.28"
+hex = "0.4.3"
 hyper = "0.14"
 parking_lot = "0.11.1"
 thiserror = "1.0"
@@ -44,14 +49,9 @@ tonic = { workspace = true }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 serde_urlencoded = "0.7.0"
-tower = "0.4.13"
-flate2 = "1.0.27"
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-arrow-json = "49.0.0"
-arrow-schema = "49.0.0"
-arrow-csv = "49.0.0"
 sha2 = "0.10.8"
-hex = "0.4.3"
+tower = "0.4.13"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 parquet.workspace = true

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -30,9 +30,10 @@ trace_http = { path = "../trace_http" }
 tracker = { path = "../tracker" }
 
 arrow = { workspace = true, features = ["prettyprint"] }
+arrow-flight.workspace = true
+async-trait = "0.1"
 chrono = "0.4"
 datafusion = { workspace = true }
-async-trait = "0.1"
 futures = "0.3.28"
 hyper = "0.14"
 parking_lot = "0.11.1"

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -42,6 +42,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 hyper = "0.14"
 parking_lot = "0.11.1"
+pin-project-lite = "0.2"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tokio-util = { version = "0.7.9" }

--- a/influxdb3_server/src/grpc.rs
+++ b/influxdb3_server/src/grpc.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use arrow_flight::flight_service_server::{
+    FlightService as Flight, FlightServiceServer as FlightServer,
+};
+use authz::Authorizer;
+use iox_query::QueryNamespaceProvider;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("tonic server error: {0}")]
+    Tonic(#[from] tonic::transport::Error),
+}
+
+pub(crate) fn make_flight_server<Q: QueryNamespaceProvider>(
+    server: Arc<Q>,
+    authz: Option<Arc<dyn Authorizer>>,
+) -> FlightServer<impl Flight> {
+    service_grpc_flight::make_server(server, authz)
+}

--- a/influxdb3_server/src/grpc.rs
+++ b/influxdb3_server/src/grpc.rs
@@ -6,12 +6,6 @@ use arrow_flight::flight_service_server::{
 use authz::Authorizer;
 use iox_query::QueryNamespaceProvider;
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("tonic server error: {0}")]
-    Tonic(#[from] tonic::transport::Error),
-}
-
 pub(crate) fn make_flight_server<Q: QueryNamespaceProvider>(
     server: Arc<Q>,
     authz: Option<Arc<dyn Authorizer>>,

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -11,7 +11,6 @@ use futures::StreamExt;
 use hyper::header::ACCEPT;
 use hyper::header::CONTENT_ENCODING;
 use hyper::http::HeaderValue;
-use hyper::server::conn::{AddrIncoming, AddrStream};
 use hyper::{Body, Method, Request, Response, StatusCode};
 use influxdb3_write::persister::TrackedMemoryArrowWriter;
 use influxdb3_write::WriteBuffer;
@@ -24,11 +23,6 @@ use std::num::NonZeroI32;
 use std::str::Utf8Error;
 use std::sync::Arc;
 use thiserror::Error;
-use tokio_util::sync::CancellationToken;
-use tower::Layer;
-use trace_http::metrics::MetricFamily;
-use trace_http::metrics::RequestMetrics;
-use trace_http::tower::TraceLayer;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -146,13 +140,11 @@ impl Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-const TRACE_SERVER_NAME: &str = "http_api";
-
 #[derive(Debug)]
 pub(crate) struct HttpApi<W, Q> {
     common_state: CommonServerState,
     write_buffer: Arc<W>,
-    query_executor: Arc<Q>,
+    pub(crate) query_executor: Arc<Q>,
     max_request_bytes: usize,
 }
 
@@ -396,42 +388,7 @@ pub(crate) struct WriteParams {
     pub(crate) db: String,
 }
 
-pub(crate) async fn serve<W: WriteBuffer, Q: QueryExecutor>(
-    http_server: Arc<HttpApi<W, Q>>,
-    shutdown: CancellationToken,
-) -> Result<()> {
-    let listener = AddrIncoming::bind(&http_server.common_state.http_addr)?;
-    println!("binding listener");
-    info!(bind_addr=%listener.local_addr(), "bound HTTP listener");
-
-    let req_metrics = RequestMetrics::new(
-        Arc::clone(&http_server.common_state.metrics),
-        MetricFamily::HttpServer,
-    );
-    let trace_layer = TraceLayer::new(
-        http_server.common_state.trace_header_parser.clone(),
-        Arc::new(req_metrics),
-        http_server.common_state.trace_collector().clone(),
-        TRACE_SERVER_NAME,
-    );
-
-    hyper::Server::builder(listener)
-        .serve(hyper::service::make_service_fn(|_conn: &AddrStream| {
-            let http_server = Arc::clone(&http_server);
-            let service = hyper::service::service_fn(move |request: Request<_>| {
-                route_request(Arc::clone(&http_server), request)
-            });
-
-            let service = trace_layer.layer(service);
-            futures::future::ready(Ok::<_, Infallible>(service))
-        }))
-        .with_graceful_shutdown(shutdown.cancelled())
-        .await?;
-
-    Ok(())
-}
-
-async fn route_request<W: WriteBuffer, Q: QueryExecutor>(
+pub(crate) async fn route_request<W: WriteBuffer, Q: QueryExecutor>(
     http_server: Arc<HttpApi<W, Q>>,
     mut req: Request<Body>,
 ) -> Result<Response<Body>, Infallible> {

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -56,9 +56,6 @@ pub enum Error {
     #[error("http error: {0}")]
     Http(#[from] http::Error),
 
-    #[error("grpc error: {0}")]
-    Grpc(#[from] grpc::Error),
-
     #[error("database not found {db_name}")]
     DatabaseNotFound { db_name: String },
 

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -206,15 +206,13 @@ where
                     })
                 }
                 // Otherwise, serve with standard REST router:
-                (Version::HTTP_10 | Version::HTTP_11 | Version::HTTP_2, _) => Either::Left({
+                _ => Either::Left({
                     let res = rest.call(req);
                     Box::pin(async move {
                         let res = res.await.map(|res| res.map(EitherBody::Http))?;
                         Ok::<_, StdError>(res)
                     })
                 }),
-                // Other HTTP Versions are not supported:
-                _ => todo!("error for non-supported HTTP version"),
             }
         });
         let service = trace_layer.layer(service);

--- a/influxdb3_server/src/service.rs
+++ b/influxdb3_server/src/service.rs
@@ -1,0 +1,211 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Future;
+use hyper::HeaderMap;
+use hyper::{body::HttpBody, Body, Request, Response};
+use pin_project_lite::pin_project;
+use tower::Service;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub(crate) fn hybrid<MakeRest, Grpc>(
+    make_rest: MakeRest,
+    grpc: Grpc,
+) -> HybridMakeService<MakeRest, Grpc> {
+    HybridMakeService { make_rest, grpc }
+}
+
+pub struct HybridMakeService<MakeRest, Grpc> {
+    make_rest: MakeRest,
+    grpc: Grpc,
+}
+
+impl<ConnInfo, MakeRest, Grpc> Service<ConnInfo> for HybridMakeService<MakeRest, Grpc>
+where
+    MakeRest: Service<ConnInfo>,
+    Grpc: Clone,
+{
+    type Response = HybridService<MakeRest::Response, Grpc>;
+    type Error = MakeRest::Error;
+    type Future = HybridMakeServiceFuture<MakeRest::Future, Grpc>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.make_rest.poll_ready(cx)
+    }
+
+    fn call(&mut self, conn_info: ConnInfo) -> Self::Future {
+        HybridMakeServiceFuture {
+            rest_future: self.make_rest.call(conn_info),
+            grpc: Some(self.grpc.clone()),
+        }
+    }
+}
+
+pin_project! {
+    pub struct HybridMakeServiceFuture<RestFuture, Grpc> {
+        #[pin]
+        rest_future: RestFuture,
+        grpc: Option<Grpc>,
+    }
+}
+
+impl<RestFuture, Rest, RestError, Grpc> Future for HybridMakeServiceFuture<RestFuture, Grpc>
+where
+    RestFuture: Future<Output = Result<Rest, RestError>>,
+{
+    type Output = Result<HybridService<Rest, Grpc>, RestError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.rest_future.poll(cx) {
+            Poll::Ready(Ok(rest)) => Poll::Ready(Ok(HybridService {
+                rest,
+                grpc: this.grpc.take().expect("future polled after execution"),
+            })),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub struct HybridService<Rest, Grpc> {
+    rest: Rest,
+    grpc: Grpc,
+}
+
+impl<Rest, Grpc, RestBody, GrpcBody> Service<Request<Body>> for HybridService<Rest, Grpc>
+where
+    Rest: Service<Request<Body>, Response = Response<RestBody>>,
+    Grpc: Service<Request<Body>, Response = Response<GrpcBody>>,
+    Rest::Error: Into<BoxError>,
+    Grpc::Error: Into<BoxError>,
+{
+    type Response = Response<HybridBody<RestBody, GrpcBody>>;
+    type Error = BoxError;
+    type Future = HybridFuture<Rest::Future, Grpc::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.rest.poll_ready(cx) {
+            Poll::Ready(Ok(())) => match self.grpc.poll_ready(cx) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Pending => Poll::Pending,
+            },
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        if req
+            .headers()
+            .get(hyper::header::CONTENT_TYPE)
+            .is_some_and(|hv| hv.as_bytes().starts_with(b"application/grpc"))
+        {
+            HybridFuture::Grpc {
+                grpc_future: self.grpc.call(req),
+            }
+        } else {
+            HybridFuture::Rest {
+                rest_future: self.rest.call(req),
+            }
+        }
+    }
+}
+
+pin_project! {
+    #[project = HybridBodyProj]
+    pub enum HybridBody<RestBody, GrpcBody> {
+        Rest {
+            #[pin]
+            rest_body: RestBody
+        },
+        Grpc {
+            #[pin]
+            grpc_body: GrpcBody
+        },
+    }
+}
+
+impl<RestBody, GrpcBody> HttpBody for HybridBody<RestBody, GrpcBody>
+where
+    RestBody: HttpBody + Send + Unpin,
+    GrpcBody: HttpBody<Data = RestBody::Data> + Send + Unpin,
+    RestBody::Error: Into<BoxError>,
+    GrpcBody::Error: Into<BoxError>,
+{
+    type Data = RestBody::Data;
+    type Error = BoxError;
+
+    fn is_end_stream(&self) -> bool {
+        match self {
+            HybridBody::Rest { rest_body } => rest_body.is_end_stream(),
+            HybridBody::Grpc { grpc_body } => grpc_body.is_end_stream(),
+        }
+    }
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        match self.project() {
+            HybridBodyProj::Rest { rest_body } => rest_body.poll_data(cx).map_err(Into::into),
+            HybridBodyProj::Grpc { grpc_body } => grpc_body.poll_data(cx).map_err(Into::into),
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        match self.project() {
+            HybridBodyProj::Rest { rest_body } => rest_body.poll_trailers(cx).map_err(Into::into),
+            HybridBodyProj::Grpc { grpc_body } => grpc_body.poll_trailers(cx).map_err(Into::into),
+        }
+    }
+}
+
+pin_project! {
+    #[project = HybridFutureProj]
+    pub enum HybridFuture<RestFuture, GrpcFuture> {
+        Rest {
+            #[pin]
+            rest_future: RestFuture,
+        },
+        Grpc {
+            #[pin]
+            grpc_future: GrpcFuture,
+        }
+    }
+}
+
+impl<RestFuture, GrpcFuture, RestBody, GrpcBody, RestError, GrpcError> Future
+    for HybridFuture<RestFuture, GrpcFuture>
+where
+    RestFuture: Future<Output = Result<Response<RestBody>, RestError>>,
+    GrpcFuture: Future<Output = Result<Response<GrpcBody>, GrpcError>>,
+    RestError: Into<BoxError>,
+    GrpcError: Into<BoxError>,
+{
+    type Output = Result<Response<HybridBody<RestBody, GrpcBody>>, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            HybridFutureProj::Rest { rest_future } => match rest_future.poll(cx) {
+                Poll::Ready(Ok(res)) => {
+                    Poll::Ready(Ok(res.map(|rest_body| HybridBody::Rest { rest_body })))
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+                Poll::Pending => Poll::Pending,
+            },
+            HybridFutureProj::Grpc { grpc_future } => match grpc_future.poll(cx) {
+                Poll::Ready(Ok(res)) => {
+                    Poll::Ready(Ok(res.map(|grpc_body| HybridBody::Grpc { grpc_body })))
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}

--- a/influxdb3_server/src/service.rs
+++ b/influxdb3_server/src/service.rs
@@ -142,8 +142,8 @@ where
 
     fn is_end_stream(&self) -> bool {
         match self {
-            HybridBody::Rest { rest_body } => rest_body.is_end_stream(),
-            HybridBody::Grpc { grpc_body } => grpc_body.is_end_stream(),
+            Self::Rest { rest_body } => rest_body.is_end_stream(),
+            Self::Grpc { grpc_body } => grpc_body.is_end_stream(),
         }
     }
 


### PR DESCRIPTION
Closes #24643

This PR adds support for FlightSQL queries via gRPC to the `influxdb3` service. It does so by ensuring the `QueryExecutor` implements the `QueryNamespaceProvider` trait, and the underlying `QueryDatabase` implements `QueryNamespace`. Satisfying those requirements allows the construction of a `FlightServiceServer` from the `service_grpc_flight` crate.

The `FlightServiceServer` is a gRPC server that can be served via `tonic` at the API surface; however, enabling this required some `tower::Service` wrangling. The `influxdb3_server/src/server.rs` module was introduced to house this code. The code there is largely inspired by [this series of blog posts](https://www.fpcomplete.com/blog/axum-hyper-tonic-tower-part1/). The objective is to serve both gRPC (via the newly introduced `tonic` server) and standard REST HTTP requests (via the existing HTTP server) on the same port.

This is accomplished by  the `HybridService` which can handle either gRPC or non-gRPC HTTP requests. The `HybridService` is wrapped in a `HybridMakeService` which allows us to serve it via `hyper::Server` on a single bind address.

End-to-end tests were added in `influxdb3/tests/flight.rs`. These cover some basic FlightSQL cases. A `common.rs` module was added that introduces some fixtures to aid in end-to-end tests in `influxdb3`.

## Follow-on work

* This PR does not implement authentication for the FlightSQL service. I have created #24681 to track work on that.
* If the test fixtures added in this PR pass review, then we may consider adopting them in the other `influxdb3` integration test (`auth.rs`)