### PR TITLE
feat: Add limits for InfluxDB Edge

### DIFF
--- a/influxdb3/tests/server/limits.rs
+++ b/influxdb3/tests/server/limits.rs
@@ -1,0 +1,81 @@
+use crate::TestServer;
+use hyper::StatusCode;
+use influxdb3_client::Error;
+use influxdb3_client::Precision;
+
+#[tokio::test]
+async fn limits() -> Result<(), Error> {
+    let server = TestServer::spawn().await;
+
+    // Test that a server can't have more than 5 DBs
+    for db in ["one", "two", "three", "four", "five"] {
+        server
+            .write_lp_to_db(
+                db,
+                "cpu,host=s1,region=us-east usage=0.9 1\n",
+                Precision::Nanosecond,
+            )
+            .await?;
+    }
+
+    let Err(Error::ApiError { code, .. }) = server
+        .write_lp_to_db(
+            "six",
+            "cpu,host=s1,region=us-east usage=0.9 1\n",
+            Precision::Nanosecond,
+        )
+        .await
+    else {
+        panic!("Did not error when adding 6th db");
+    };
+    assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
+
+    // Test that the server can't have more than 2000 tables
+    // First create the other needed 1995 tables
+    for table in (0..1995).map(|i| format!("cpu{i}")) {
+        server
+            .write_lp_to_db(
+                "one",
+                &format!("{table},host=s1,region=us-east usage=0.9 1\n"),
+                Precision::Nanosecond,
+            )
+            .await?;
+    }
+
+    let Err(Error::ApiError { code, .. }) = server
+        .write_lp_to_db(
+            "six",
+            "cpu2000,host=s1,region=us-east usage=0.9 1\n",
+            Precision::Nanosecond,
+        )
+        .await
+    else {
+        panic!("Did not error when adding 2001st table");
+    };
+    assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
+
+    // Test that we can't add a row 500 columns long
+    let mut lp_500 = String::from("cpu,host=foo,region=bar usage=2");
+    let mut lp_501 = String::from("cpu,host=foo,region=bar usage=2");
+    for i in 5..=500 {
+        let column = format!(",column{}=1", i);
+        lp_500.push_str(&column);
+        lp_501.push_str(&column);
+    }
+    lp_500.push_str(" 0\n");
+    lp_501.push_str(",column501=1 0\n");
+
+    server
+        .write_lp_to_db("one", &lp_500, Precision::Nanosecond)
+        .await?;
+
+    let Err(Error::ApiError { code, .. }) = server
+        .write_lp_to_db("one", &lp_501, Precision::Nanosecond)
+        .await
+    else {
+        panic!("Did not error when adding 501st column");
+    };
+    assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
+
+    Ok(())
+}

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -14,7 +14,8 @@ async fn api_v3_query_sql() {
             cpu,host=s1,region=us-east usage=0.85 3",
             Precision::Nanosecond,
         )
-        .await;
+        .await
+        .unwrap();
 
     let client = reqwest::Client::new();
 
@@ -62,7 +63,8 @@ async fn api_v3_query_influxql() {
             mem,host=s1,region=us-east usage=0.7 6",
             Precision::Nanosecond,
         )
-        .await;
+        .await
+        .unwrap();
 
     struct TestCase<'a> {
         database: Option<&'a str>,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -410,7 +410,7 @@ mod test_helpers {
         lp: &str,
     ) -> WriteBatch {
         let mut write_batch = WriteBatch::default();
-        let (seq, db) = catalog.db_or_create(db_name);
+        let (seq, db) = catalog.db_or_create(db_name).unwrap();
         let partitioner = Partitioner::new_per_day_partitioner();
         let result = parse_validate_and_update_schema(
             lp,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -353,7 +353,7 @@ pub(crate) fn parse_validate_and_update_catalog(
     accept_partial: bool,
     precision: Precision,
 ) -> Result<ValidationResult> {
-    let (sequence, db) = catalog.db_or_create(db_name);
+    let (sequence, db) = catalog.db_or_create(db_name)?;
     let mut result = parse_validate_and_update_schema(
         lp,
         &db,


### PR DESCRIPTION
This commit is the final piece for the write_lp endpoint. It adds limits to Edge such that:

- There can only be 5 Databases
- There can only be 500 Columns per Table
- There can only be 2000 Tables across all Databases

We do this by modifying the catalog code to error out whenever one of these limits would be exceeded before permanently modifying the schema. These are hard coded limits and cannot be configured by the user.

Closes #24554