### PR TITLE
feat: implement loader for persisted state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -90,9 +90,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -513,7 +513,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -524,7 +524,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -901,7 +901,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1361,7 +1361,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1385,7 +1385,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3365,7 +3365,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3530,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "logfmt"
@@ -3660,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031ec85a3f39370cc7663640077c38766fd32b03e6beb54e6e402d0454443f7f"
+checksum = "d2f6e023aa5bdf392aa06c78e4a4e6d498baab5138d0c993503350ebbc37bf1e"
 dependencies = [
  "assert-json-diff",
  "futures-core",
@@ -4110,7 +4110,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4534,7 +4534,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4677,7 +4677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4697,7 +4697,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
@@ -4769,7 +4769,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types 0.12.3",
  "regex",
- "syn 2.0.51",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -4797,7 +4797,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4946,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -5343,7 +5343,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5611,7 +5611,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5684,7 +5684,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5964,7 +5964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6009,9 +6009,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.51"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6074,9 +6074,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6164,7 +6164,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6292,7 +6292,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6456,7 +6456,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6619,7 +6619,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6974,7 +6974,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -7008,7 +7008,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7104,7 +7104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7113,7 +7113,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7131,7 +7131,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7151,17 +7151,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -7172,9 +7172,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7184,9 +7184,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7196,9 +7196,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7208,9 +7208,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7220,9 +7220,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7232,9 +7232,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7244,15 +7244,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
+checksum = "44e19b97e00a4d3db3cdb9b53c8c5f87151b5689b82cc86c2848cbdcccb2689b"
 dependencies = [
  "memchr",
 ]
@@ -7346,7 +7346,7 @@ dependencies = [
  "sqlx-sqlite",
  "strum",
  "syn 1.0.109",
- "syn 2.0.51",
+ "syn 2.0.52",
  "thrift",
  "tokio",
  "tokio-stream",
@@ -7419,7 +7419,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -123,6 +123,10 @@ pub enum Error {
     #[error("write buffer error: {0}")]
     WriteBuffer(#[from] influxdb3_write::write_buffer::Error),
 
+    /// Persister error
+    #[error("persister error: {0}")]
+    Persister(#[from] influxdb3_write::persister::Error),
+
     // ToStrError
     #[error("to str error: {0}")]
     ToStr(#[from] hyper::header::ToStrError),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -22,7 +22,7 @@ use crate::http::HttpApi;
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use hyper::service::service_fn;
-use influxdb3_write::{persister, Persister, WriteBuffer};
+use influxdb3_write::{Persister, WriteBuffer};
 use iox_query::QueryNamespaceProvider;
 use observability_deps::tracing::{error, info};
 use service::hybrid;
@@ -115,10 +115,12 @@ impl CommonServerState {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
-pub struct Server<W, Q> {
+pub struct Server<W, Q, P> {
     common_state: CommonServerState,
     http: Arc<HttpApi<W, Q>>,
+    persister: Arc<P>,
 }
 
 #[async_trait]
@@ -132,13 +134,14 @@ pub trait QueryExecutor: QueryNamespaceProvider + Debug + Send + Sync + 'static 
     ) -> Result<SendableRecordBatchStream>;
 }
 
-impl<W, Q> Server<W, Q>
+impl<W, Q, P> Server<W, Q, P>
 where
     Q: QueryExecutor,
+    P: Persister,
 {
     pub fn new(
         common_state: CommonServerState,
-        _persister: Arc<dyn Persister<Error = persister::Error>>,
+        persister: Arc<P>,
         write_buffer: Arc<W>,
         query_executor: Arc<Q>,
         max_http_request_size: usize,
@@ -150,14 +153,19 @@ where
             max_http_request_size,
         ));
 
-        Self { common_state, http }
+        Self {
+            common_state,
+            http,
+            persister,
+        }
     }
 }
 
-pub async fn serve<W, Q>(server: Server<W, Q>, shutdown: CancellationToken) -> Result<()>
+pub async fn serve<W, Q, P>(server: Server<W, Q, P>, shutdown: CancellationToken) -> Result<()>
 where
     W: WriteBuffer,
     Q: QueryExecutor,
+    P: Persister,
 {
     // TODO:
     //  1. load the persisted catalog and segments from the persister
@@ -227,7 +235,6 @@ mod tests {
     use datafusion::parquet::data_type::AsBytes;
     use hyper::{body, Body, Client, Request, Response, StatusCode};
     use influxdb3_write::persister::PersisterImpl;
-    use influxdb3_write::{persister, Persister};
     use iox_query::exec::{Executor, ExecutorConfig};
     use object_store::DynObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};
@@ -407,8 +414,7 @@ mod tests {
             metric_registry: Arc::clone(&metrics),
             mem_pool_size: usize::MAX,
         }));
-        let persister: Arc<dyn Persister<Error = persister::Error>> =
-            Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
@@ -582,8 +588,7 @@ mod tests {
             metric_registry: Arc::clone(&metrics),
             mem_pool_size: usize::MAX,
         }));
-        let persister: Arc<dyn Persister<Error = persister::Error>> =
-            Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -22,7 +22,7 @@ use crate::http::HttpApi;
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use hyper::service::service_fn;
-use influxdb3_write::{Persister, WriteBuffer};
+use influxdb3_write::{persister, Persister, WriteBuffer};
 use iox_query::QueryNamespaceProvider;
 use observability_deps::tracing::{error, info};
 use service::hybrid;
@@ -138,7 +138,7 @@ where
 {
     pub fn new(
         common_state: CommonServerState,
-        _persister: Arc<dyn Persister>,
+        _persister: Arc<dyn Persister<Error = persister::Error>>,
         write_buffer: Arc<W>,
         query_executor: Arc<Q>,
         max_http_request_size: usize,
@@ -227,7 +227,7 @@ mod tests {
     use datafusion::parquet::data_type::AsBytes;
     use hyper::{body, Body, Client, Request, Response, StatusCode};
     use influxdb3_write::persister::PersisterImpl;
-    use influxdb3_write::Persister;
+    use influxdb3_write::{persister, Persister};
     use iox_query::exec::{Executor, ExecutorConfig};
     use object_store::DynObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};
@@ -407,7 +407,8 @@ mod tests {
             metric_registry: Arc::clone(&metrics),
             mem_pool_size: usize::MAX,
         }));
-        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister: Arc<dyn Persister<Error = persister::Error>> =
+            Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
@@ -581,7 +582,8 @@ mod tests {
             metric_registry: Arc::clone(&metrics),
             mem_pool_size: usize::MAX,
         }));
-        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister: Arc<dyn Persister<Error = persister::Error>> =
+            Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -106,7 +106,7 @@ impl Catalog {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Default)]
 pub struct InnerCatalog {
     /// The catalog is a map of databases with their table schemas
     databases: HashMap<String, Arc<DatabaseSchema>>,
@@ -119,6 +119,10 @@ impl InnerCatalog {
             databases: HashMap::new(),
             sequence: SequenceNumber::new(0),
         }
+    }
+
+    pub fn sequence_number(&self) -> SequenceNumber {
+        self.sequence
     }
 
     #[cfg(test)]

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -36,29 +36,14 @@ pub enum Error {
     #[error("database not found {db_name}")]
     DatabaseNotFound { db_name: String },
 
-    #[error("datafusion error: {0}")]
-    DataFusion(#[from] DataFusionError),
-
     #[error("object store path error: {0}")]
     ObjStorePath(#[from] object_store::path::Error),
 
     #[error("write buffer error: {0}")]
     WriteBuffer(#[from] write_buffer::Error),
 
-    #[error("serde_json error: {0}")]
-    SerdeJson(#[from] serde_json::Error),
-
-    #[error("object_store error: {0}")]
-    ObjectStore(#[from] object_store::Error),
-
-    #[error("parse int error: {0}")]
-    ParseInt(#[from] std::num::ParseIntError),
-
-    #[error("parquet error: {0}")]
-    ParquetError(#[from] parquet::errors::ParquetError),
-
-    #[error("tried to serialize a parquet file with no rows")]
-    NoRows,
+    #[error("persister error: {0}")]
+    Persister(#[from] persister::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -102,6 +87,9 @@ pub trait Bufferer: Debug + Send + Sync + 'static {
 
     /// Returns the configured WAL, if there is one.
     fn wal(&self) -> Option<Arc<impl Wal>>;
+
+    /// Returns the catalog
+    fn catalog(&self) -> Arc<catalog::Catalog>;
 }
 
 /// A segment in the buffer that corresponds to a single WAL segment file. It contains a catalog with any updates
@@ -134,7 +122,9 @@ pub trait ChunkContainer: Debug + Send + Sync + 'static {
 }
 
 /// The segment identifier, which will be monotonically increasing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct SegmentId(u32);
 pub type SegmentIdBytes = [u8; 4];
 
@@ -157,7 +147,9 @@ impl SegmentId {
 }
 
 /// The sequence number of a batch of WAL operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct SequenceNumber(u32);
 
 impl SequenceNumber {
@@ -173,22 +165,26 @@ impl SequenceNumber {
 #[async_trait]
 pub trait Persister: Debug + Send + Sync + 'static {
     /// Loads the most recently persisted catalog from object storage.
-    async fn load_catalog(&self) -> Result<Option<PersistedCatalog>>;
+    async fn load_catalog(&self) -> persister::Result<Option<PersistedCatalog>>;
 
     /// Loads the most recently persisted N segment parquet file lists from object storage.
-    async fn load_segments(&self, most_recent_n: usize) -> Result<Vec<PersistedSegment>>;
+    async fn load_segments(&self, most_recent_n: usize)
+        -> persister::Result<Vec<PersistedSegment>>;
 
     // Loads a Parquet file from ObjectStore
-    async fn load_parquet_file(&self, path: ParquetFilePath) -> crate::Result<Bytes>;
+    async fn load_parquet_file(&self, path: ParquetFilePath) -> persister::Result<Bytes>;
 
     /// Persists the catalog with the given segment ID. If this is the highest segment ID, it will
     /// be the catalog that is returned the next time `load_catalog` is called.
-    async fn persist_catalog(&self, segment_id: SegmentId, catalog: catalog::Catalog)
-        -> Result<()>;
+    async fn persist_catalog(
+        &self,
+        segment_id: SegmentId,
+        catalog: catalog::Catalog,
+    ) -> persister::Result<()>;
 
     /// Writes a single file to object storage that contains the information for the parquet files persisted
     /// for this segment.
-    async fn persist_segment(&self, persisted_segment: PersistedSegment) -> Result<()>;
+    async fn persist_segment(&self, persisted_segment: PersistedSegment) -> persister::Result<()>;
 
     // Writes a SendableRecorgBatchStream to the Parquet format and persists it
     // to Object Store at the given path. Returns the number of bytes written and the file metadata.
@@ -196,7 +192,7 @@ pub trait Persister: Debug + Send + Sync + 'static {
         &self,
         path: ParquetFilePath,
         record_batch: SendableRecordBatchStream,
-    ) -> crate::Result<(u64, FileMetaData)>;
+    ) -> persister::Result<(u64, FileMetaData)>;
 
     /// Returns the configured `ObjectStore` that data is loaded from and persisted to.
     fn object_store(&self) -> Arc<dyn object_store::ObjectStore>;
@@ -291,7 +287,7 @@ pub struct BufferedWriteRequest {
 }
 
 /// A persisted Catalog that contains the database, table, and column schemas.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct PersistedCatalog {
     /// The segment_id that this catalog was persisted with.
     pub segment_id: SegmentId,
@@ -300,7 +296,7 @@ pub struct PersistedCatalog {
 }
 
 /// The collection of Parquet files that were persisted for a segment.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PersistedSegment {
     /// The segment_id that these parquet files were persisted with.
     pub segment_id: SegmentId,
@@ -319,13 +315,13 @@ pub struct PersistedSegment {
     pub databases: HashMap<String, DatabaseTables>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct DatabaseTables {
     pub tables: HashMap<String, TableParquetFiles>,
 }
 
 /// A collection of parquet files persisted in a segment for a specific table.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TableParquetFiles {
     /// The table name.
     pub table_name: String,
@@ -336,7 +332,7 @@ pub struct TableParquetFiles {
 }
 
 /// The summary data for a persisted parquet file in a segment.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ParquetFile {
     pub path: String,
     pub size_bytes: u64,
@@ -390,5 +386,57 @@ pub(crate) fn guess_precision(timestamp: i64) -> Precision {
         // Anything else we can assume is large enough of a number that it must
         // be nanoseconds
         Precision::Nanosecond
+    }
+}
+
+#[cfg(test)]
+mod test_helpers {
+    use crate::catalog::{Catalog, DatabaseSchema};
+    use crate::write_buffer::buffer_segment::WriteBatch;
+    use crate::write_buffer::{parse_validate_and_update_schema, Partitioner, TableBatch};
+    use crate::Precision;
+    use data_types::NamespaceName;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    pub(crate) fn lp_to_write_batch(
+        catalog: &Catalog,
+        db_name: &'static str,
+        lp: &str,
+    ) -> WriteBatch {
+        let mut write_batch = WriteBatch::default();
+        let (seq, db) = catalog.db_or_create(db_name);
+        let partitioner = Partitioner::new_per_day_partitioner();
+        let result = parse_validate_and_update_schema(
+            lp,
+            &db,
+            &partitioner,
+            0,
+            false,
+            Precision::Nanosecond,
+        )
+        .unwrap();
+        if let Some(db) = result.schema {
+            catalog.replace_database(seq, Arc::new(db)).unwrap();
+        }
+        let db_name = NamespaceName::new(db_name).unwrap();
+        write_batch.add_db_write(db_name, result.table_batches);
+        write_batch
+    }
+
+    pub(crate) fn lp_to_table_batches(lp: &str, default_time: i64) -> HashMap<String, TableBatch> {
+        let db = Arc::new(DatabaseSchema::new("foo"));
+        let partitioner = Partitioner::new_per_day_partitioner();
+        let result = parse_validate_and_update_schema(
+            lp,
+            &db,
+            &partitioner,
+            default_time,
+            false,
+            Precision::Nanosecond,
+        )
+        .unwrap();
+
+        result.table_batches
     }
 }

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -106,6 +106,8 @@ impl PersisterImpl {
 
 #[async_trait]
 impl Persister for PersisterImpl {
+    type Error = Error;
+
     async fn load_catalog(&self) -> Result<Option<PersistedCatalog>> {
         let mut list = self.object_store.list(Some(&CatalogFilePath::dir()));
         let mut catalog_path: Option<ObjPath> = None;

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -180,6 +180,10 @@ impl Persister for PersisterImpl {
                 output.push(serde_json::from_slice(&bytes)?);
             }
 
+            if end == 0 {
+                break;
+            }
+
             // Get the last path in the array to use as an offset. This assumes
             // we sorted the list as we can't guarantee otherwise the order of
             // the list call to the object store.
@@ -290,145 +294,131 @@ impl<W: Write + Send> TrackedMemoryArrowWriter<W> {
 }
 
 #[cfg(test)]
-use {
-    arrow::array::Int32Array, arrow::datatypes::DataType, arrow::datatypes::Field,
-    arrow::datatypes::Schema, chrono::Utc,
-    datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder,
-    object_store::local::LocalFileSystem, std::collections::HashMap,
-};
-
-#[tokio::test]
-async fn persist_catalog() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    let catalog = Catalog::new();
-    let _ = catalog.db_or_create("my_db");
-
-    persister
-        .persist_catalog(SegmentId::new(0), catalog)
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn persist_and_load_newest_catalog() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    let catalog = Catalog::new();
-    let _ = catalog.db_or_create("my_db");
-
-    persister
-        .persist_catalog(SegmentId::new(0), catalog)
-        .await
-        .unwrap();
-
-    let catalog = Catalog::new();
-    let _ = catalog.db_or_create("my_second_db");
-
-    persister
-        .persist_catalog(SegmentId::new(1), catalog)
-        .await
-        .unwrap();
-
-    let catalog = persister
-        .load_catalog()
-        .await
-        .expect("loading the catalog did not cause an error")
-        .expect("there was a catalog to load");
-
-    assert_eq!(catalog.segment_id, SegmentId::new(1));
-    assert!(catalog.catalog.db_exists("my_second_db"));
-    assert!(!catalog.catalog.db_exists("my_db"));
-}
-
-#[tokio::test]
-async fn persist_segment_info_file() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    let info_file = PersistedSegment {
-        segment_id: SegmentId::new(0),
-        segment_wal_size_bytes: 0,
-        databases: HashMap::new(),
-        segment_min_time: 0,
-        segment_max_time: 1,
-        segment_row_count: 0,
-        segment_parquet_size_bytes: 0,
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+    use {
+        arrow::array::Int32Array, arrow::datatypes::DataType, arrow::datatypes::Field,
+        arrow::datatypes::Schema, chrono::Utc,
+        datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder,
+        object_store::local::LocalFileSystem, std::collections::HashMap,
     };
 
-    persister.persist_segment(info_file).await.unwrap();
-}
+    #[tokio::test]
+    async fn persist_catalog() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let catalog = Catalog::new();
+        let _ = catalog.db_or_create("my_db");
 
-#[tokio::test]
-async fn persist_and_load_segment_info_files() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    let info_file = PersistedSegment {
-        segment_id: SegmentId::new(0),
-        segment_wal_size_bytes: 0,
-        databases: HashMap::new(),
-        segment_min_time: 0,
-        segment_max_time: 1,
-        segment_row_count: 0,
-        segment_parquet_size_bytes: 0,
-    };
-    let info_file_2 = PersistedSegment {
-        segment_id: SegmentId::new(1),
-        segment_wal_size_bytes: 0,
-        databases: HashMap::new(),
-        segment_min_time: 0,
-        segment_max_time: 1,
-        segment_row_count: 0,
-        segment_parquet_size_bytes: 0,
-    };
-    let info_file_3 = PersistedSegment {
-        segment_id: SegmentId::new(2),
-        segment_wal_size_bytes: 0,
-        databases: HashMap::new(),
-        segment_min_time: 0,
-        segment_max_time: 1,
-        segment_row_count: 0,
-        segment_parquet_size_bytes: 0,
-    };
+        persister
+            .persist_catalog(SegmentId::new(0), catalog)
+            .await
+            .unwrap();
+    }
 
-    persister.persist_segment(info_file).await.unwrap();
-    persister.persist_segment(info_file_2).await.unwrap();
-    persister.persist_segment(info_file_3).await.unwrap();
+    #[tokio::test]
+    async fn persist_and_load_newest_catalog() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let catalog = Catalog::new();
+        let _ = catalog.db_or_create("my_db");
 
-    let segments = persister.load_segments(2).await.unwrap();
-    assert_eq!(segments.len(), 2);
-    // The most recent one is first
-    assert_eq!(segments[0].segment_id.0, 2);
-    assert_eq!(segments[1].segment_id.0, 1);
-}
+        persister
+            .persist_catalog(SegmentId::new(0), catalog)
+            .await
+            .unwrap();
 
-#[tokio::test]
-async fn persist_and_load_segment_info_files_with_fewer_than_requested() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    let info_file = PersistedSegment {
-        segment_id: SegmentId::new(0),
-        segment_wal_size_bytes: 0,
-        databases: HashMap::new(),
-        segment_min_time: 0,
-        segment_max_time: 1,
-        segment_row_count: 0,
-        segment_parquet_size_bytes: 0,
-    };
-    persister.persist_segment(info_file).await.unwrap();
-    let segments = persister.load_segments(2).await.unwrap();
-    // We asked for the most recent 2 but there should only be 1
-    assert_eq!(segments.len(), 1);
-    assert_eq!(segments[0].segment_id.0, 0);
-}
+        let catalog = Catalog::new();
+        let _ = catalog.db_or_create("my_second_db");
 
-#[tokio::test]
-/// This test makes sure that the logic for offset lists works
-async fn persist_and_load_over_9000_segment_info_files() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
-    for id in 0..9001 {
+        persister
+            .persist_catalog(SegmentId::new(1), catalog)
+            .await
+            .unwrap();
+
+        let catalog = persister
+            .load_catalog()
+            .await
+            .expect("loading the catalog did not cause an error")
+            .expect("there was a catalog to load");
+
+        assert_eq!(catalog.segment_id, SegmentId::new(1));
+        assert!(catalog.catalog.db_exists("my_second_db"));
+        assert!(!catalog.catalog.db_exists("my_db"));
+    }
+
+    #[tokio::test]
+    async fn persist_segment_info_file() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
         let info_file = PersistedSegment {
-            segment_id: SegmentId::new(id),
+            segment_id: SegmentId::new(0),
+            segment_wal_size_bytes: 0,
+            databases: HashMap::new(),
+            segment_min_time: 0,
+            segment_max_time: 1,
+            segment_row_count: 0,
+            segment_parquet_size_bytes: 0,
+        };
+
+        persister.persist_segment(info_file).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persist_and_load_segment_info_files() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let info_file = PersistedSegment {
+            segment_id: SegmentId::new(0),
+            segment_wal_size_bytes: 0,
+            databases: HashMap::new(),
+            segment_min_time: 0,
+            segment_max_time: 1,
+            segment_row_count: 0,
+            segment_parquet_size_bytes: 0,
+        };
+        let info_file_2 = PersistedSegment {
+            segment_id: SegmentId::new(1),
+            segment_wal_size_bytes: 0,
+            databases: HashMap::new(),
+            segment_min_time: 0,
+            segment_max_time: 1,
+            segment_row_count: 0,
+            segment_parquet_size_bytes: 0,
+        };
+        let info_file_3 = PersistedSegment {
+            segment_id: SegmentId::new(2),
+            segment_wal_size_bytes: 0,
+            databases: HashMap::new(),
+            segment_min_time: 0,
+            segment_max_time: 1,
+            segment_row_count: 0,
+            segment_parquet_size_bytes: 0,
+        };
+
+        persister.persist_segment(info_file).await.unwrap();
+        persister.persist_segment(info_file_2).await.unwrap();
+        persister.persist_segment(info_file_3).await.unwrap();
+
+        let segments = persister.load_segments(2).await.unwrap();
+        assert_eq!(segments.len(), 2);
+        // The most recent one is first
+        assert_eq!(segments[0].segment_id.0, 2);
+        assert_eq!(segments[1].segment_id.0, 1);
+    }
+
+    #[tokio::test]
+    async fn persist_and_load_segment_info_files_with_fewer_than_requested() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let info_file = PersistedSegment {
+            segment_id: SegmentId::new(0),
             segment_wal_size_bytes: 0,
             databases: HashMap::new(),
             segment_min_time: 0,
@@ -437,68 +427,103 @@ async fn persist_and_load_over_9000_segment_info_files() {
             segment_parquet_size_bytes: 0,
         };
         persister.persist_segment(info_file).await.unwrap();
+        let segments = persister.load_segments(2).await.unwrap();
+        // We asked for the most recent 2 but there should only be 1
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].segment_id.0, 0);
     }
-    let segments = persister.load_segments(9500).await.unwrap();
-    // We asked for the most recent 9500 so there should be 9001 of them
-    assert_eq!(segments.len(), 9001);
-    assert_eq!(segments[0].segment_id.0, 9000);
-}
 
-#[tokio::test]
-async fn get_parquet_bytes() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
+    #[tokio::test]
+    /// This test makes sure that the logic for offset lists works
+    async fn persist_and_load_over_9000_segment_info_files() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
+        for id in 0..9001 {
+            let info_file = PersistedSegment {
+                segment_id: SegmentId::new(id),
+                segment_wal_size_bytes: 0,
+                databases: HashMap::new(),
+                segment_min_time: 0,
+                segment_max_time: 1,
+                segment_row_count: 0,
+                segment_parquet_size_bytes: 0,
+            };
+            persister.persist_segment(info_file).await.unwrap();
+        }
+        let segments = persister.load_segments(9500).await.unwrap();
+        // We asked for the most recent 9500 so there should be 9001 of them
+        assert_eq!(segments.len(), 9001);
+        assert_eq!(segments[0].segment_id.0, 9000);
+    }
 
-    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-    let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
+    #[tokio::test]
+    async fn load_segments_works_with_no_segments() {
+        let store = InMemory::new();
+        let persister = PersisterImpl::new(Arc::new(store));
 
-    let id_array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-    let batch1 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
+        let segments = persister.load_segments(100).await.unwrap();
+        assert!(segments.is_empty());
+    }
 
-    let id_array = Int32Array::from(vec![6, 7, 8, 9, 10]);
-    let batch2 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
+    #[tokio::test]
+    async fn get_parquet_bytes() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
 
-    stream_builder.tx().send(Ok(batch1)).await.unwrap();
-    stream_builder.tx().send(Ok(batch2)).await.unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
 
-    let parquet = persister
-        .serialize_to_parquet(stream_builder.build())
-        .await
-        .unwrap();
+        let id_array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let batch1 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
 
-    // Assert we've written all the expected rows
-    assert_eq!(parquet.meta_data.num_rows, 10);
-}
+        let id_array = Int32Array::from(vec![6, 7, 8, 9, 10]);
+        let batch2 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
 
-#[tokio::test]
-async fn persist_and_load_parquet_bytes() {
-    let local_disk = LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-    let persister = PersisterImpl::new(Arc::new(local_disk));
+        stream_builder.tx().send(Ok(batch1)).await.unwrap();
+        stream_builder.tx().send(Ok(batch2)).await.unwrap();
 
-    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-    let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
+        let parquet = persister
+            .serialize_to_parquet(stream_builder.build())
+            .await
+            .unwrap();
 
-    let id_array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-    let batch1 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
+        // Assert we've written all the expected rows
+        assert_eq!(parquet.meta_data.num_rows, 10);
+    }
 
-    let id_array = Int32Array::from(vec![6, 7, 8, 9, 10]);
-    let batch2 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
+    #[tokio::test]
+    async fn persist_and_load_parquet_bytes() {
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister = PersisterImpl::new(Arc::new(local_disk));
 
-    stream_builder.tx().send(Ok(batch1)).await.unwrap();
-    stream_builder.tx().send(Ok(batch2)).await.unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
 
-    let path = ParquetFilePath::new("db_one", "table_one", Utc::now(), 1);
-    let (bytes_written, meta) = persister
-        .persist_parquet_file(path.clone(), stream_builder.build())
-        .await
-        .unwrap();
+        let id_array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let batch1 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
 
-    // Assert we've written all the expected rows
-    assert_eq!(meta.num_rows, 10);
+        let id_array = Int32Array::from(vec![6, 7, 8, 9, 10]);
+        let batch2 = RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array)]).unwrap();
 
-    let bytes = persister.load_parquet_file(path).await.unwrap();
+        stream_builder.tx().send(Ok(batch1)).await.unwrap();
+        stream_builder.tx().send(Ok(batch2)).await.unwrap();
 
-    // Assert that we have a file of bytes > 0
-    assert!(!bytes.is_empty());
-    assert_eq!(bytes.len() as u64, bytes_written);
+        let path = ParquetFilePath::new("db_one", "table_one", Utc::now(), 1);
+        let (bytes_written, meta) = persister
+            .persist_parquet_file(path.clone(), stream_builder.build())
+            .await
+            .unwrap();
+
+        // Assert we've written all the expected rows
+        assert_eq!(meta.num_rows, 10);
+
+        let bytes = persister.load_parquet_file(path).await.unwrap();
+
+        // Assert that we have a file of bytes > 0
+        assert!(!bytes.is_empty());
+        assert_eq!(bytes.len() as u64, bytes_written);
+    }
 }

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -5,10 +5,10 @@
 use crate::catalog::Catalog;
 use crate::paths::ParquetFilePath;
 use crate::write_buffer::flusher::BufferedWriteResult;
-use crate::write_buffer::{FieldData, Row, TableBatch};
+use crate::write_buffer::{parse_validate_and_update_catalog, FieldData, Row, TableBatch};
 use crate::{
-    wal, write_buffer::Result, DatabaseTables, ParquetFile, PersistedSegment, Persister, SegmentId,
-    SequenceNumber, TableParquetFiles, WalOp, WalSegmentWriter,
+    wal, write_buffer::Result, DatabaseTables, ParquetFile, PersistedSegment, Persister, Precision,
+    SegmentId, SequenceNumber, TableParquetFiles, WalOp, WalSegmentReader, WalSegmentWriter,
 };
 use arrow::array::{
     ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder, StringDictionaryBuilder,
@@ -27,7 +27,7 @@ use tokio::sync::oneshot;
 pub struct OpenBufferSegment {
     segment_writer: Box<dyn WalSegmentWriter>,
     segment_id: SegmentId,
-    buffered_data: HashMap<String, DatabaseBuffer>,
+    buffered_data: BufferedData,
     #[allow(dead_code)]
     starting_catalog_sequence_number: SequenceNumber,
     // TODO: This is temporarily just the number of rows in the segment. When the buffer gets refactored to use
@@ -40,13 +40,16 @@ impl OpenBufferSegment {
         segment_id: SegmentId,
         starting_catalog_sequence_number: SequenceNumber,
         segment_writer: Box<dyn WalSegmentWriter>,
+        buffered_data: Option<(BufferedData, usize)>,
     ) -> Self {
+        let (buffered_data, segment_size) = buffered_data.unwrap_or_default();
+
         Self {
-            buffered_data: Default::default(),
             segment_writer,
             segment_id,
             starting_catalog_sequence_number,
-            segment_size: 0,
+            segment_size,
+            buffered_data,
         }
     }
 
@@ -59,6 +62,7 @@ impl OpenBufferSegment {
 
     pub fn table_buffer(&self, db_name: &str, table_name: &str) -> Option<TableBuffer> {
         self.buffered_data
+            .database_buffers
             .get(db_name)
             .and_then(|db_buffer| db_buffer.table_buffers.get(table_name).cloned())
     }
@@ -66,7 +70,11 @@ impl OpenBufferSegment {
     /// Adds the batch into the in memory buffer. Returns the number of rows in the segment after the write.
     pub(crate) fn buffer_writes(&mut self, write_batch: WriteBatch) -> Result<usize> {
         for (db_name, db_batch) in write_batch.database_batches {
-            let db_buffer = self.buffered_data.entry(db_name.to_string()).or_default();
+            let db_buffer = self
+                .buffered_data
+                .database_buffers
+                .entry(db_name.to_string())
+                .or_default();
 
             for (table_name, table_batch) in db_batch.table_batches {
                 let table_buffer = db_buffer.table_buffers.entry(table_name).or_default();
@@ -100,6 +108,58 @@ impl OpenBufferSegment {
             catalog,
         )
     }
+}
+
+pub(crate) fn load_buffer_from_segment(
+    catalog: &Catalog,
+    mut segment_reader: Box<dyn WalSegmentReader>,
+) -> Result<(BufferedData, usize)> {
+    let mut segment_size = 0;
+    let mut buffered_data = BufferedData::default();
+
+    while let Some(batch) = segment_reader.next_batch()? {
+        for wal_op in batch.ops {
+            println!("wal_op: {:?}", wal_op);
+            match wal_op {
+                WalOp::LpWrite(write) => {
+                    let validated_write = parse_validate_and_update_catalog(
+                        &write.db_name,
+                        &write.lp,
+                        catalog,
+                        write.default_time,
+                        false,
+                        Precision::Nanosecond,
+                    )?;
+                    println!("validated_write: {:?}", validated_write);
+                    let db_buffer = buffered_data
+                        .database_buffers
+                        .entry(write.db_name)
+                        .or_default();
+
+                    for (table_name, table_batch) in validated_write.table_batches {
+                        let table_buffer = db_buffer.table_buffers.entry(table_name).or_default();
+
+                        for (partition_key, partition_batch) in table_batch.partition_batches {
+                            let partition_buffer = table_buffer
+                                .partition_buffers
+                                .entry(partition_key)
+                                .or_default();
+
+                            // TODO: for now we'll just have the number of rows represent the segment size. The entire
+                            //       buffer is going to get refactored to use different structures, so this will change.
+                            segment_size += partition_batch.rows.len();
+
+                            println!("partition_batch: {:?}", partition_batch);
+
+                            partition_buffer.add_rows(partition_batch.rows);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((buffered_data, segment_size))
 }
 
 #[derive(Debug, Default)]
@@ -169,12 +229,17 @@ pub struct WriteSummary {
     pub buffer_size: usize,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct BufferedData {
+    database_buffers: HashMap<String, DatabaseBuffer>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
 struct DatabaseBuffer {
     table_buffers: HashMap<String, TableBuffer>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct TableBuffer {
     pub partition_buffers: HashMap<String, PartitionBuffer>,
 }
@@ -186,7 +251,7 @@ impl TableBuffer {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PartitionBuffer {
     rows: Vec<Row>,
     timestamp_min: i64,
@@ -330,11 +395,11 @@ impl Builder {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct ClosedBufferSegment {
-    segment_id: SegmentId,
-    catalog_start_sequence_number: SequenceNumber,
-    catalog_end_sequence_number: SequenceNumber,
+    pub segment_id: SegmentId,
+    pub catalog_start_sequence_number: SequenceNumber,
+    pub catalog_end_sequence_number: SequenceNumber,
     segment_writer: Box<dyn WalSegmentWriter>,
-    buffered_data: HashMap<String, DatabaseBuffer>,
+    pub buffered_data: BufferedData,
     catalog: Arc<Catalog>,
 }
 
@@ -345,7 +410,7 @@ impl ClosedBufferSegment {
         catalog_start_sequence_number: SequenceNumber,
         catalog_end_sequence_number: SequenceNumber,
         segment_writer: Box<dyn WalSegmentWriter>,
-        buffered_data: HashMap<String, DatabaseBuffer>,
+        buffered_data: BufferedData,
         catalog: Arc<Catalog>,
     ) -> Self {
         Self {
@@ -375,7 +440,7 @@ impl ClosedBufferSegment {
         let mut segment_max_time = i64::MIN;
 
         // persist every partition buffer
-        for (db_name, db_buffer) in &self.buffered_data {
+        for (db_name, db_buffer) in &self.buffered_data.database_buffers {
             let mut database_tables = DatabaseTables::default();
 
             if let Some(db_schema) = self.catalog.db_schema(db_name) {
@@ -452,11 +517,9 @@ impl ClosedBufferSegment {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::{lp_to_table_batches, lp_to_write_batch};
     use crate::wal::WalSegmentWriterNoopImpl;
-    use crate::write_buffer::tests::lp_to_table_batches;
-    use crate::write_buffer::{parse_validate_and_update_schema, Partitioner};
-    use crate::Precision;
-    use crate::{LpWriteOp, PersistedCatalog};
+    use crate::{persister, LpWriteOp, PersistedCatalog};
     use bytes::Bytes;
     use datafusion::execution::SendableRecordBatchStream;
     use object_store::ObjectStore;
@@ -470,6 +533,7 @@ mod tests {
             SegmentId::new(0),
             SequenceNumber::new(0),
             Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(0))),
+            None,
         );
 
         let db_name: NamespaceName<'static> = NamespaceName::new("db1").unwrap();
@@ -503,7 +567,7 @@ mod tests {
         let segment_id = SegmentId::new(4);
         let segment_writer = Box::new(WalSegmentWriterNoopImpl::new(segment_id));
         let mut open_segment =
-            OpenBufferSegment::new(segment_id, SequenceNumber::new(0), segment_writer);
+            OpenBufferSegment::new(segment_id, SequenceNumber::new(0), segment_writer, None);
 
         let catalog = Catalog::new();
 
@@ -597,7 +661,7 @@ mod tests {
             &self,
             _segment_id: SegmentId,
             catalog: Catalog,
-        ) -> crate::Result<()> {
+        ) -> persister::Result<()> {
             self.state.lock().catalog = Some(catalog);
             Ok(())
         }
@@ -606,13 +670,13 @@ mod tests {
             &self,
             path: ParquetFilePath,
             _data: SendableRecordBatchStream,
-        ) -> crate::Result<(u64, FileMetaData)> {
+        ) -> persister::Result<(u64, FileMetaData)> {
             self.state.lock().parquet_files.push(path);
             let meta = FileMetaData::new(1, vec![], 1, vec![], None, None, None, None, None);
             Ok((1, meta))
         }
 
-        async fn persist_segment(&self, segment: PersistedSegment) -> crate::Result<()> {
+        async fn persist_segment(&self, segment: PersistedSegment) -> persister::Result<()> {
             self.state.lock().segment = Some(segment);
             Ok(())
         }
@@ -621,44 +685,23 @@ mod tests {
             self as &dyn Any
         }
 
-        async fn load_catalog(&self) -> crate::Result<Option<PersistedCatalog>> {
+        async fn load_catalog(&self) -> persister::Result<Option<PersistedCatalog>> {
             todo!()
         }
 
         async fn load_segments(
             &self,
             _most_recent_n: usize,
-        ) -> crate::Result<Vec<PersistedSegment>> {
+        ) -> persister::Result<Vec<PersistedSegment>> {
             todo!()
         }
 
-        async fn load_parquet_file(&self, _path: ParquetFilePath) -> crate::Result<Bytes> {
+        async fn load_parquet_file(&self, _path: ParquetFilePath) -> persister::Result<Bytes> {
             todo!()
         }
 
         fn object_store(&self) -> Arc<dyn ObjectStore> {
             todo!()
         }
-    }
-
-    fn lp_to_write_batch(catalog: &Catalog, db_name: &'static str, lp: &str) -> WriteBatch {
-        let mut write_batch = WriteBatch::default();
-        let (seq, db) = catalog.db_or_create(db_name);
-        let partitioner = Partitioner::new_per_day_partitioner();
-        let result = parse_validate_and_update_schema(
-            lp,
-            &db,
-            &partitioner,
-            0,
-            false,
-            Precision::Nanosecond,
-        )
-        .unwrap();
-        if let Some(db) = result.schema {
-            catalog.replace_database(seq, Arc::new(db)).unwrap();
-        }
-        let db_name = NamespaceName::new(db_name).unwrap();
-        write_batch.add_db_write(db_name, result.table_batches);
-        write_batch
     }
 }

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -195,9 +195,9 @@ fn run_io_flush(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::lp_to_table_batches;
     use crate::wal::WalSegmentWriterNoopImpl;
     use crate::write_buffer::buffer_segment::OpenBufferSegment;
-    use crate::write_buffer::tests::lp_to_table_batches;
     use crate::{LpWriteOp, SegmentId};
 
     #[tokio::test]
@@ -207,6 +207,7 @@ mod tests {
             segment_id,
             SequenceNumber::new(0),
             Box::new(WalSegmentWriterNoopImpl::new(segment_id)),
+            None,
         );
         let segment_state = Arc::new(RwLock::new(SegmentState::new(open_segment)));
         let flusher = WriteBufferFlusher::new(Arc::clone(&segment_state));

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -1,0 +1,526 @@
+//! This module contains logic to load the initial server state from the persister and wal
+//! if configured.
+
+use crate::catalog::Catalog;
+use crate::wal::WalSegmentWriterNoopImpl;
+use crate::write_buffer::{
+    buffer_segment::{load_buffer_from_segment, ClosedBufferSegment, OpenBufferSegment},
+    Result,
+};
+use crate::Wal;
+use crate::{PersistedCatalog, PersistedSegment, Persister, SegmentId};
+use std::sync::Arc;
+
+const SEGMENTS_TO_LOAD: usize = 1000;
+
+/// The state loaded and initialized from the persister and wal.
+#[derive(Debug)]
+pub struct LoadedState {
+    pub catalog: Arc<Catalog>,
+    pub open_segment: OpenBufferSegment,
+    pub persisting_buffer_segments: Vec<ClosedBufferSegment>,
+    pub persisted_segments: Vec<PersistedSegment>,
+}
+
+pub async fn load_starting_state<W: Wal>(
+    persister: Arc<dyn Persister>,
+    wal: Option<Arc<W>>,
+) -> Result<LoadedState> {
+    let PersistedCatalog { catalog, .. } = persister.load_catalog().await?.unwrap_or_default();
+    let catalog = Arc::new(Catalog::from_inner(catalog));
+
+    let persisted_segments = persister.load_segments(SEGMENTS_TO_LOAD).await?;
+
+    let last_persisted_segment_id = persisted_segments
+        .last()
+        .map(|s| s.segment_id)
+        .unwrap_or(SegmentId::new(0));
+    let mut open_segment_id = last_persisted_segment_id.next();
+    let mut persisting_buffer_segments = Vec::new();
+
+    let open_segment = if let Some(wal) = wal {
+        // read any segments that don't show up in the list of persisted segments
+
+        // first load up any segments from the wal that haven't been persisted yet, except for the
+        // last one, which is the open segment.
+        let wal_segments = wal.segment_files()?;
+        if !wal_segments.is_empty() {
+            // update the segment_id of the open segment to be for the last wal file
+            open_segment_id = wal_segments.last().unwrap().segment_id;
+
+            for segment_file in wal_segments.iter().take(wal_segments.len() - 1) {
+                // if persisted segemnts is empty, load all segments from the wal, otherwise
+                // only load segments that haven't been persisted yet
+                if segment_file.segment_id >= last_persisted_segment_id
+                    && !persisted_segments.is_empty()
+                {
+                    continue;
+                }
+
+                let segment_reader = wal.open_segment_reader(segment_file.segment_id)?;
+                let starting_sequence_number = catalog.sequence_number();
+                let buffer = load_buffer_from_segment(&catalog, segment_reader)?;
+
+                let segment = OpenBufferSegment::new(
+                    segment_file.segment_id,
+                    starting_sequence_number,
+                    Box::new(WalSegmentWriterNoopImpl::new(segment_file.segment_id)),
+                    Some(buffer),
+                );
+                let closed_segment = segment.into_closed_segment(Arc::clone(&catalog));
+                persisting_buffer_segments.push(closed_segment);
+            }
+        }
+
+        // read the last segment into an open segment
+        let segment_reader = match wal.open_segment_reader(open_segment_id) {
+            Ok(reader) => Some(reader),
+            Err(crate::wal::Error::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                None
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let buffered = match segment_reader {
+            Some(reader) => Some(load_buffer_from_segment(&catalog, reader)?),
+            None => None,
+        };
+        let segment_writer = wal.open_segment_writer(open_segment_id)?;
+        OpenBufferSegment::new(
+            open_segment_id,
+            catalog.sequence_number(),
+            segment_writer,
+            buffered,
+        )
+    } else {
+        OpenBufferSegment::new(
+            open_segment_id,
+            catalog.sequence_number(),
+            Box::new(WalSegmentWriterNoopImpl::new(open_segment_id)),
+            None,
+        )
+    };
+
+    Ok(LoadedState {
+        catalog,
+        open_segment,
+        persisting_buffer_segments,
+        persisted_segments,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persister::PersisterImpl;
+    use crate::test_helpers::lp_to_write_batch;
+    use crate::wal::{WalImpl, WalSegmentWriterNoopImpl};
+    use crate::{DatabaseTables, LpWriteOp, ParquetFile, SequenceNumber, TableParquetFiles, WalOp};
+    use arrow_util::assert_batches_eq;
+    use object_store::memory::InMemory;
+    use object_store::ObjectStore;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn loads_without_wal() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+
+        let segment_id = SegmentId::new(4);
+        let segment_writer = Box::new(WalSegmentWriterNoopImpl::new(segment_id));
+        let mut open_segment =
+            OpenBufferSegment::new(segment_id, SequenceNumber::new(0), segment_writer, None);
+
+        let catalog = Catalog::new();
+
+        let lp = "cpu,tag1=cupcakes bar=1 10\nmem,tag2=turtles bar=3 15\nmem,tag2=snakes bar=2 20";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: "db1".to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, "db1", lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let catalog = Arc::new(catalog);
+        let closed_buffer_segment = open_segment.into_closed_segment(Arc::clone(&catalog));
+        closed_buffer_segment
+            .persist(Arc::clone(&persister))
+            .await
+            .unwrap();
+
+        let loaded_state = load_starting_state(persister, None::<Arc<crate::wal::WalImpl>>)
+            .await
+            .unwrap();
+        let expected_catalog = catalog.clone_inner();
+        let loaded_catalog = loaded_state.catalog.clone_inner();
+
+        assert_eq!(expected_catalog, loaded_catalog);
+        // the open segment it creates should be the next value in line
+        assert_eq!(loaded_state.open_segment.segment_id(), SegmentId::new(5));
+        let persisted_segment = loaded_state.persisted_segments.first().unwrap();
+        assert_eq!(persisted_segment.segment_id, segment_id);
+        assert_eq!(persisted_segment.segment_row_count, 3);
+
+        let tables_persisted = persisted_segment.databases.get("db1").unwrap();
+        assert_eq!(
+            tables_persisted
+                .tables
+                .get("cpu")
+                .unwrap()
+                .parquet_files
+                .len(),
+            1
+        );
+        assert_eq!(
+            tables_persisted
+                .tables
+                .get("mem")
+                .unwrap()
+                .parquet_files
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn loads_with_no_persisted_segments_and_wal() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let dir = test_helpers::tmp_dir().unwrap().into_path();
+        let wal = Arc::new(WalImpl::new(dir.clone()).unwrap());
+        let db_name = "db1";
+
+        let LoadedState {
+            catalog,
+            mut open_segment,
+            ..
+        } = load_starting_state(Arc::clone(&persister), Some(Arc::clone(&wal)))
+            .await
+            .unwrap();
+
+        let lp = "cpu,tag1=cupcakes bar=1 10\nmem,tag2=turtles bar=3 15\nmem,tag2=snakes bar=2 20";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: db_name.to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let loaded_state = load_starting_state(persister, Some(wal)).await.unwrap();
+
+        assert!(loaded_state.persisting_buffer_segments.is_empty());
+        assert!(loaded_state.persisted_segments.is_empty());
+        let db = loaded_state.catalog.db_schema(db_name).unwrap();
+        assert_eq!(db.tables.len(), 2);
+        assert!(db.tables.contains_key("cpu"));
+        assert!(db.tables.contains_key("mem"));
+
+        let cpu_table = db.get_table("cpu").unwrap();
+        let cpu_data = open_segment
+            .table_buffer(db_name, "cpu")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+        let expected = vec![
+            "+-----+----------+--------------------------------+",
+            "| bar | tag1     | time                           |",
+            "+-----+----------+--------------------------------+",
+            "| 1.0 | cupcakes | 1970-01-01T00:00:00.000000010Z |",
+            "+-----+----------+--------------------------------+",
+        ];
+        assert_batches_eq!(&expected, &[cpu_data]);
+
+        let mem_table = db.get_table("mem").unwrap();
+        let mem_data = open_segment
+            .table_buffer(db_name, "mem")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&mem_table.schema, mem_table.columns());
+        let expected = vec![
+            "+-----+---------+--------------------------------+",
+            "| bar | tag2    | time                           |",
+            "+-----+---------+--------------------------------+",
+            "| 3.0 | turtles | 1970-01-01T00:00:00.000000015Z |",
+            "| 2.0 | snakes  | 1970-01-01T00:00:00.000000020Z |",
+            "+-----+---------+--------------------------------+",
+        ];
+        assert_batches_eq!(&expected, &[mem_data]);
+    }
+
+    #[tokio::test]
+    async fn loads_with_persisted_segments_and_wal() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let dir = test_helpers::tmp_dir().unwrap().into_path();
+        let wal = Arc::new(WalImpl::new(dir.clone()).unwrap());
+        let db_name = "db1";
+
+        let LoadedState {
+            catalog,
+            mut open_segment,
+            ..
+        } = load_starting_state(Arc::clone(&persister), Some(Arc::clone(&wal)))
+            .await
+            .unwrap();
+
+        let lp = "cpu,tag1=cupcakes bar=1 10\nmem,tag2=turtles bar=3 15\nmem,tag2=snakes bar=2 20";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: db_name.to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let segment_id = open_segment.segment_id();
+        let next_segment_id = open_segment.segment_id().next();
+
+        open_segment
+            .into_closed_segment(Arc::clone(&catalog))
+            .persist(Arc::clone(&persister))
+            .await
+            .unwrap();
+
+        let mut open_segment = OpenBufferSegment::new(
+            next_segment_id,
+            catalog.sequence_number(),
+            wal.open_segment_writer(next_segment_id).unwrap(),
+            None,
+        );
+
+        let lp = "cpu,tag1=cupcakes bar=3 20\nfoo val=1 123";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: db_name.to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let loaded_state = load_starting_state(persister, Some(wal)).await.unwrap();
+
+        assert!(loaded_state.persisting_buffer_segments.is_empty());
+        assert_eq!(
+            loaded_state.persisted_segments[0],
+            PersistedSegment {
+                segment_id,
+                segment_wal_size_bytes: 201,
+                segment_parquet_size_bytes: 3398,
+                segment_row_count: 3,
+                segment_min_time: 10,
+                segment_max_time: 20,
+                databases: HashMap::from([(
+                    "db1".to_string(),
+                    DatabaseTables {
+                        tables: HashMap::from([
+                            (
+                                "cpu".to_string(),
+                                TableParquetFiles {
+                                    table_name: "cpu".to_string(),
+                                    parquet_files: vec![ParquetFile {
+                                        path: "dbs/db1/cpu/1970-01-01/4294967294.parquet"
+                                            .to_string(),
+                                        size_bytes: 1690,
+                                        row_count: 1,
+                                        min_time: 10,
+                                        max_time: 10,
+                                    }],
+                                    sort_key: vec![],
+                                }
+                            ),
+                            (
+                                "mem".to_string(),
+                                TableParquetFiles {
+                                    table_name: "mem".to_string(),
+                                    parquet_files: vec![ParquetFile {
+                                        path: "dbs/db1/mem/1970-01-01/4294967294.parquet"
+                                            .to_string(),
+                                        size_bytes: 1708,
+                                        row_count: 2,
+                                        min_time: 15,
+                                        max_time: 20,
+                                    }],
+                                    sort_key: vec![],
+                                }
+                            )
+                        ])
+                    }
+                )])
+            }
+        );
+        let db = loaded_state.catalog.db_schema(db_name).unwrap();
+        assert_eq!(db.tables.len(), 3);
+        assert!(db.tables.contains_key("cpu"));
+        assert!(db.tables.contains_key("mem"));
+        assert!(db.tables.contains_key("foo"));
+
+        let cpu_table = db.get_table("cpu").unwrap();
+        let cpu_data = open_segment
+            .table_buffer(db_name, "cpu")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+        let expected = vec![
+            "+-----+----------+--------------------------------+",
+            "| bar | tag1     | time                           |",
+            "+-----+----------+--------------------------------+",
+            "| 3.0 | cupcakes | 1970-01-01T00:00:00.000000020Z |",
+            "+-----+----------+--------------------------------+",
+        ];
+        assert_batches_eq!(&expected, &[cpu_data]);
+
+        let foo_table = db.get_table("foo").unwrap();
+        let foo_data = open_segment
+            .table_buffer(db_name, "foo")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&foo_table.schema, foo_table.columns());
+        let expected = vec![
+            "+--------------------------------+-----+",
+            "| time                           | val |",
+            "+--------------------------------+-----+",
+            "| 1970-01-01T00:00:00.000000123Z | 1.0 |",
+            "+--------------------------------+-----+",
+        ];
+        assert_batches_eq!(&expected, &[foo_data]);
+    }
+
+    #[tokio::test]
+    async fn loads_with_persisting() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let dir = test_helpers::tmp_dir().unwrap().into_path();
+        let wal = Arc::new(WalImpl::new(dir.clone()).unwrap());
+        let db_name = "db1";
+
+        let LoadedState {
+            catalog,
+            mut open_segment,
+            ..
+        } = load_starting_state(Arc::clone(&persister), Some(Arc::clone(&wal)))
+            .await
+            .unwrap();
+
+        let lp = "cpu,tag1=cupcakes bar=1 10\nmem,tag2=turtles bar=3 15\nmem,tag2=snakes bar=2 20";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: db_name.to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let next_segment_id = open_segment.segment_id().next();
+
+        let closed_segment = open_segment.into_closed_segment(Arc::clone(&catalog));
+
+        let mut open_segment = OpenBufferSegment::new(
+            next_segment_id,
+            catalog.sequence_number(),
+            wal.open_segment_writer(next_segment_id).unwrap(),
+            None,
+        );
+
+        let lp = "cpu,tag1=apples bar=3 20\nfoo val=1 123";
+
+        let wal_op = WalOp::LpWrite(LpWriteOp {
+            db_name: db_name.to_string(),
+            lp: lp.to_string(),
+            default_time: 0,
+        });
+
+        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+
+        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.buffer_writes(write_batch).unwrap();
+
+        let loaded_state = load_starting_state(persister, Some(wal)).await.unwrap();
+
+        assert_eq!(loaded_state.persisting_buffer_segments.len(), 1);
+        let loaded_closed_segment = &loaded_state.persisting_buffer_segments[0];
+        assert_eq!(loaded_closed_segment.segment_id, closed_segment.segment_id);
+        assert_eq!(
+            loaded_closed_segment.catalog_end_sequence_number,
+            closed_segment.catalog_end_sequence_number
+        );
+        assert_eq!(
+            loaded_closed_segment.catalog_start_sequence_number,
+            closed_segment.catalog_start_sequence_number
+        );
+        assert_eq!(
+            loaded_closed_segment.buffered_data,
+            closed_segment.buffered_data
+        );
+
+        let db = loaded_state.catalog.db_schema(db_name).unwrap();
+        assert_eq!(db.tables.len(), 3);
+        assert!(db.tables.contains_key("cpu"));
+        assert!(db.tables.contains_key("mem"));
+        assert!(db.tables.contains_key("foo"));
+
+        let cpu_table = db.get_table("cpu").unwrap();
+        let cpu_data = open_segment
+            .table_buffer(db_name, "cpu")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+        let expected = vec![
+            "+-----+--------+--------------------------------+",
+            "| bar | tag1   | time                           |",
+            "+-----+--------+--------------------------------+",
+            "| 3.0 | apples | 1970-01-01T00:00:00.000000020Z |",
+            "+-----+--------+--------------------------------+",
+        ];
+        assert_batches_eq!(&expected, &[cpu_data]);
+
+        let foo_table = db.get_table("foo").unwrap();
+        let foo_data = open_segment
+            .table_buffer(db_name, "foo")
+            .unwrap()
+            .partition_buffers
+            .get("1970-01-01")
+            .unwrap()
+            .rows_to_record_batch(&foo_table.schema, foo_table.columns());
+        let expected = vec![
+            "+--------------------------------+-----+",
+            "| time                           | val |",
+            "+--------------------------------+-----+",
+            "| 1970-01-01T00:00:00.000000123Z | 1.0 |",
+            "+--------------------------------+-----+",
+        ];
+        assert_batches_eq!(&expected, &[foo_data]);
+    }
+}

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -1,15 +1,16 @@
 //! Implementation of an in-memory buffer for writes that persists data into a wal if it is configured.
 
-mod buffer_segment;
+pub(crate) mod buffer_segment;
 mod flusher;
+mod loader;
 
 use crate::catalog::{Catalog, DatabaseSchema, TableDefinition, TIME_COLUMN_NAME};
-use crate::wal::WalSegmentWriterNoopImpl;
 use crate::write_buffer::buffer_segment::{ClosedBufferSegment, OpenBufferSegment, TableBuffer};
 use crate::write_buffer::flusher::WriteBufferFlusher;
+use crate::write_buffer::loader::load_starting_state;
 use crate::{
-    BufferSegment, BufferedWriteRequest, Bufferer, ChunkContainer, LpWriteOp, Precision, SegmentId,
-    Wal, WalOp, WriteBuffer, WriteLineError,
+    BufferSegment, BufferedWriteRequest, Bufferer, ChunkContainer, LpWriteOp, Persister, Precision,
+    SegmentId, Wal, WalOp, WriteBuffer, WriteLineError,
 };
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -54,6 +55,9 @@ pub enum Error {
 
     #[error("error from buffer segment: {0}")]
     BufferSegmentError(String),
+
+    #[error("error from persister: {0}")]
+    PersisterError(#[from] crate::persister::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -91,29 +95,22 @@ impl SegmentState {
 }
 
 impl<W: Wal> WriteBufferImpl<W> {
-    pub fn new(
-        catalog: Arc<Catalog>,
-        wal: Option<Arc<W>>,
-        next_segment_id: SegmentId,
-    ) -> Result<Self> {
-        let segment_writer = wal
-            .as_ref()
-            .map(|w| w.open_segment_writer(next_segment_id))
-            .transpose()?
-            .unwrap_or_else(|| Box::new(WalSegmentWriterNoopImpl::new(next_segment_id)));
-
-        let open_segment =
-            OpenBufferSegment::new(next_segment_id, catalog.sequence_number(), segment_writer);
-        let segment_state = Arc::new(RwLock::new(SegmentState::new(open_segment)));
+    pub async fn new(persister: Arc<dyn Persister>, wal: Option<Arc<W>>) -> Result<Self> {
+        let loaded_state = load_starting_state(persister, wal.clone()).await?;
+        let segment_state = Arc::new(RwLock::new(SegmentState::new(loaded_state.open_segment)));
 
         let write_buffer_flusher = WriteBufferFlusher::new(Arc::clone(&segment_state));
 
         Ok(Self {
-            catalog,
+            catalog: loaded_state.catalog,
             segment_state,
             wal,
             write_buffer_flusher,
         })
+    }
+
+    pub fn catalog(&self) -> Arc<Catalog> {
+        Arc::clone(&self.catalog)
     }
 
     async fn write_lp(
@@ -126,9 +123,10 @@ impl<W: Wal> WriteBufferImpl<W> {
     ) -> Result<BufferedWriteRequest> {
         debug!("write_lp to {} in writebuffer", db_name);
 
-        let result = self.parse_validate_and_update_schema(
-            db_name.clone(),
+        let result = parse_validate_and_update_catalog(
+            db_name.as_str(),
             lp,
+            &self.catalog,
             default_time,
             accept_partial,
             precision,
@@ -155,33 +153,6 @@ impl<W: Wal> WriteBufferImpl<W> {
             segment_id: write_summary.segment_id,
             sequence_number: write_summary.sequence_number,
         })
-    }
-
-    fn parse_validate_and_update_schema(
-        &self,
-        db_name: NamespaceName<'static>,
-        lp: &str,
-        default_time: i64,
-        accept_partial: bool,
-        precision: Precision,
-    ) -> Result<ValidationResult> {
-        let (sequence, db) = self.catalog.db_or_create(db_name.as_str());
-        let mut result = parse_validate_and_update_schema(
-            lp,
-            &db,
-            &Partitioner::new_per_day_partitioner(),
-            default_time,
-            accept_partial,
-            precision,
-        )?;
-
-        if let Some(schema) = result.schema.take() {
-            debug!("replacing schema for {:?}", schema);
-
-            self.catalog.replace_database(sequence, Arc::new(schema))?;
-        }
-
-        Ok(result)
     }
 
     fn get_table_chunks(
@@ -287,6 +258,10 @@ impl<W: Wal> Bufferer for WriteBufferImpl<W> {
     fn wal(&self) -> Option<Arc<impl Wal>> {
         self.wal.clone()
     }
+
+    fn catalog(&self) -> Arc<Catalog> {
+        self.catalog()
+    }
 }
 
 impl<W: Wal> ChunkContainer for WriteBufferImpl<W> {
@@ -365,6 +340,33 @@ impl QueryChunk for BufferChunk {
 }
 
 const YEAR_MONTH_DAY_TIME_FORMAT: &str = "%Y-%m-%d";
+
+pub(crate) fn parse_validate_and_update_catalog(
+    db_name: &str,
+    lp: &str,
+    catalog: &Catalog,
+    default_time: i64,
+    accept_partial: bool,
+    precision: Precision,
+) -> Result<ValidationResult> {
+    let (sequence, db) = catalog.db_or_create(db_name);
+    let mut result = parse_validate_and_update_schema(
+        lp,
+        &db,
+        &Partitioner::new_per_day_partitioner(),
+        default_time,
+        accept_partial,
+        precision,
+    )?;
+
+    if let Some(schema) = result.schema.take() {
+        debug!("replacing schema for {:?}", schema);
+
+        catalog.replace_database(sequence, Arc::new(schema))?;
+    }
+
+    Ok(result)
+}
 
 /// Takes &str of line protocol, parses lines, validates the schema, and inserts new columns
 /// and partitions if present. Assigns the default time to any lines that do not include a time
@@ -619,13 +621,13 @@ pub(crate) struct PartitionBatch {
     pub(crate) rows: Vec<Row>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Row {
     pub(crate) time: i64,
     pub(crate) fields: Vec<Field>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Field {
     pub(crate) name: String,
     pub(crate) value: FieldData,
@@ -641,6 +643,23 @@ pub(crate) enum FieldData {
     Float(f64),
     Boolean(bool),
 }
+
+impl PartialEq for FieldData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (FieldData::Timestamp(a), FieldData::Timestamp(b)) => a == b,
+            (FieldData::Tag(a), FieldData::Tag(b)) => a == b,
+            (FieldData::String(a), FieldData::String(b)) => a == b,
+            (FieldData::Integer(a), FieldData::Integer(b)) => a == b,
+            (FieldData::UInteger(a), FieldData::UInteger(b)) => a == b,
+            (FieldData::Float(a), FieldData::Float(b)) => a == b,
+            (FieldData::Boolean(a), FieldData::Boolean(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for FieldData {}
 
 /// Result of the validation. If the NamespaceSchema or PartitionMap were updated, they will be
 /// in the result.
@@ -696,9 +715,12 @@ impl Partitioner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persister::PersisterImpl;
     use crate::wal::WalImpl;
     use crate::{SequenceNumber, WalOpBatch};
     use arrow_util::assert_batches_eq;
+    use object_store::memory::InMemory;
+    use object_store::ObjectStore;
 
     #[test]
     fn parse_lp_into_buffer() {
@@ -715,7 +737,6 @@ mod tests {
         )
         .unwrap();
 
-        println!("result: {:#?}", result);
         let db = result.schema.unwrap();
 
         assert_eq!(db.tables.len(), 2);
@@ -727,9 +748,11 @@ mod tests {
     async fn buffers_and_persists_to_wal() {
         let dir = test_helpers::tmp_dir().unwrap().into_path();
         let wal = WalImpl::new(dir.clone()).unwrap();
-        let catalog = Arc::new(Catalog::new());
-        let write_buffer =
-            WriteBufferImpl::new(catalog, Some(Arc::new(wal)), SegmentId::new(0)).unwrap();
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let persister: Arc<dyn Persister> = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let write_buffer = WriteBufferImpl::new(Arc::clone(&persister), Some(Arc::new(wal)))
+            .await
+            .unwrap();
 
         let summary = write_buffer
             .write_lp(
@@ -745,7 +768,7 @@ mod tests {
         assert_eq!(summary.field_count, 1);
         assert_eq!(summary.tag_count, 0);
         assert_eq!(summary.total_buffer_memory_used, 1);
-        assert_eq!(summary.segment_id, SegmentId::new(0));
+        assert_eq!(summary.segment_id, SegmentId::new(1));
         assert_eq!(summary.sequence_number, SequenceNumber::new(1));
 
         // ensure the data is in the buffer
@@ -761,7 +784,7 @@ mod tests {
 
         // ensure the data is in the wal
         let wal = WalImpl::new(dir).unwrap();
-        let mut reader = wal.open_segment_reader(SegmentId::new(0)).unwrap();
+        let mut reader = wal.open_segment_reader(SegmentId::new(1)).unwrap();
         let batch = reader.next_batch().unwrap().unwrap();
         let expected_batch = WalOpBatch {
             sequence_number: SequenceNumber::new(1),
@@ -772,21 +795,12 @@ mod tests {
             })],
         };
         assert_eq!(batch, expected_batch);
-    }
 
-    pub(crate) fn lp_to_table_batches(lp: &str, default_time: i64) -> HashMap<String, TableBatch> {
-        let db = Arc::new(DatabaseSchema::new("foo"));
-        let partitioner = Partitioner::new_per_day_partitioner();
-        let result = parse_validate_and_update_schema(
-            lp,
-            &db,
-            &partitioner,
-            default_time,
-            false,
-            Precision::Nanosecond,
-        )
-        .unwrap();
-
-        result.table_batches
+        // ensure we load state from the persister
+        let write_buffer = WriteBufferImpl::new(persister, Some(Arc::new(wal)))
+            .await
+            .unwrap();
+        let actual = write_buffer.get_table_record_batches("foo", "cpu");
+        assert_batches_eq!(&expected, &actual);
     }
 }


### PR DESCRIPTION
* This implements a loader for the write buffer. It loads the catalog and the buffer from the WAL.   
* Move Persister errors into their own type now that the write buffer load could return errors from the persister.
* Moved persister tests into tests block
* Fixes a bug where the persister would throw an error if attempting to load segments when none had been persisted.
    
This doesn't yet rotate segments or trigger persistence of newly closed segments, which will be addressed in a future PR.

Fixes #24572
