### PR TITLE
feat: Enable Obj Storage Support for Azure/GCP/S3

### DIFF
--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -49,7 +49,7 @@ tikv-jemalloc-ctl = { version = "0.5.4", optional = true }
 tikv-jemalloc-sys = { version = "0.5.4", optional = true, features = ["unprefixed_malloc_on_supported_platforms"] }
 
 [features]
-default = ["jemalloc_replacing_malloc"]
+default = ["jemalloc_replacing_malloc", "azure", "gcp", "aws"]
 
 azure = ["clap_blocks/azure"] # Optional Azure Object store support
 gcp = ["clap_blocks/gcp"] # Optional GCP object store support


### PR DESCRIPTION
In order for Edge to support other object stores besides the local file system we just needed to turn on the features in clap_blocks which handles all of the configuration needed to create an `Arc<dyn ObjectStore>` for us. We already were calling it's `make_object_store` function that did this and so it's a simple switch flip to turn it on.

Closes #24553