### PR TITLE
fix: CircleCI image deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
     # need a machine executor to have a full-powered docker daemon (the `setup_remote_docker` system just provides a
     # kinda small node)
     machine:
-      image: ubuntu-2004:2022.04.2
+      image: default
     resource_class: 2xlarge # CPU bound, so make it fast
     steps:
       - checkout


### PR DESCRIPTION
I ran the changes on this branch to make sure CI would pass when merged to main and it will:

https://app.circleci.com/pipelines/github/influxdata/influxdb/38009/workflows/ce0c7c6d-fc6b-4ecd-aa47-60a344fc90aa/jobs/355115