### PR TITLE
feat: Change Bearer Auth Token to use random bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "parking_lot",
  "parquet_file",
  "pretty_assertions",
+ "rand",
  "reqwest",
  "secrecy",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ pretty_assertions = "1.4.0"
 prost = "0.12.3"
 prost-build = "0.12.2"
 prost-types = "0.12.3"
+rand = "0.8.5"
 reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls"] }
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -35,6 +35,7 @@ libc.workspace = true
 num_cpus.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
+rand.workspace = true
 secrecy.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -1,5 +1,7 @@
+use rand::rngs::OsRng;
+use rand::RngCore;
 use sha2::Digest;
-use sha2::Sha256;
+use sha2::Sha512;
 use std::error::Error;
 
 #[derive(Debug, clap::Parser)]
@@ -10,25 +12,28 @@ pub struct Config {
 
 #[derive(Debug, clap::Parser)]
 pub enum SubCommand {
-    Token { token: String },
+    Token,
 }
 
 pub fn command(config: Config) -> Result<(), Box<dyn Error>> {
     match config.cmd {
-        SubCommand::Token { token } => {
-            if token.is_empty() {
-                return Err("Token argument must not be empty".into());
-            }
-
+        SubCommand::Token => {
+            let token = {
+                let mut token = String::from("apiv3_");
+                let mut key = [0u8; 64];
+                OsRng.fill_bytes(&mut key);
+                token.push_str(&hex::encode(key));
+                token
+            };
             println!(
                 "\
-                Token Input: {token}\n\
-                Hashed Output: {hashed}\n\n\
+                Token: {token}\n\
+                Hashed Token: {hashed}\n\n\
                 Start the server with `influxdb3 serve --bearer-token {hashed}`\n\n\
                 HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
                 This will grant you access to every HTTP endpoint or deny it otherwise
             ",
-                hashed = hex::encode(&Sha256::digest(&token)[..])
+                hashed = hex::encode(&Sha512::digest(&token)[..])
             );
         }
     }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -30,7 +30,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 use sha2::Digest;
-use sha2::Sha256;
+use sha2::Sha512;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::num::NonZeroI32;
@@ -512,7 +512,7 @@ where
             }
 
             // Check that the hashed token is acceptable
-            let authorized = &Sha256::digest(token)[..] == bearer_token;
+            let authorized = &Sha512::digest(token)[..] == bearer_token;
             if !authorized {
                 return Err(AuthorizationError::Unauthorized);
             }


### PR DESCRIPTION
This changes the 'influxdb3 create token' command so that it will just automatically generate a completely random token prepended with 'apiv3_' that is then fed into a Sha512 algorithm instead of Sha256. The user can no longer pass in a token to be turned into the proper output.

This also changes the server code to handle the change to Sha512 as well.

Closes #24704

@hiltontj note these changes don't do anything for #24649