### PR TITLE
chore: gate `limits` test behind a feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,8 @@ jobs:
       - checkout
       - rust_components
       - run:
-          name: cargo test --workspace
-          command: cargo test --workspace
-
+          name: cargo test --workspace --features=limits
+          command: cargo test --workspace --features=limits
 
   # end to end tests with Heappy (heap profiling enabled)
   test_heappy:

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -52,6 +52,7 @@ tikv-jemalloc-sys = { version = "0.5.4", optional = true, features = ["unprefixe
 
 [features]
 default = ["jemalloc_replacing_malloc", "azure", "gcp", "aws"]
+limits = []
 
 azure = ["clap_blocks/azure"] # Optional Azure Object store support
 gcp = ["clap_blocks/gcp"] # Optional GCP object store support

--- a/influxdb3/tests/server/limits.rs
+++ b/influxdb3/tests/server/limits.rs
@@ -4,6 +4,7 @@ use influxdb3_client::Error;
 use influxdb3_client::Precision;
 
 #[tokio::test]
+#[cfg_attr(not(feature = "limits"), ignore)]
 async fn limits() -> Result<(), Error> {
     let server = TestServer::spawn().await;
 

--- a/influxdb3/tests/server/limits.rs
+++ b/influxdb3/tests/server/limits.rs
@@ -4,7 +4,10 @@ use influxdb3_client::Error;
 use influxdb3_client::Precision;
 
 #[tokio::test]
-#[cfg_attr(not(feature = "limits"), ignore)]
+#[cfg_attr(
+    not(feature = "limits"),
+    ignore = "long running test, test with 'cargo test --features=limits'"
+)]
 async fn limits() -> Result<(), Error> {
     let server = TestServer::spawn().await;
 


### PR DESCRIPTION
There is no issue for this. This puts a feature gate on the `influxdb3::server::limits` end-to-end test, as it takes some time to run locally.

The test can be run with the feature flag `limits`, e.g.,
```
cargo test --workspace --features=limits
```

CI has been updated to run tests this way.