### PR TITLE
refactor: use dynamic dispatch for Authorizer

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -269,15 +269,14 @@ pub async fn command(config: Config) -> Result<()> {
         .query_executor(query_executor)
         .persister(persister);
 
-    if let Some(token) = config.bearer_token.map(hex::decode).transpose()? {
-        let server = builder
+    let server = if let Some(token) = config.bearer_token.map(hex::decode).transpose()? {
+        builder
             .authorizer(Arc::new(AllOrNothingAuthorizer::new(token)))
-            .build();
-        serve(server, frontend_shutdown).await?;
+            .build()
     } else {
-        let server = builder.build();
-        serve(server, frontend_shutdown).await?;
-    }
+        builder.build()
+    };
+    serve(server, frontend_shutdown).await?;
 
     Ok(())
 }

--- a/influxdb3_server/src/builder.rs
+++ b/influxdb3_server/src/builder.rs
@@ -33,7 +33,7 @@ impl<W, Q, P> ServerBuilder<W, Q, P> {
         self
     }
 
-    pub fn authorizer(mut self, a: Arc<dyn Authorizer>) -> ServerBuilder<W, Q, P> {
+    pub fn authorizer(mut self, a: Arc<dyn Authorizer>) -> Self {
         self.authorizer = a;
         self
     }


### PR DESCRIPTION
This is a proposed change to the #24738 to use dynamic dispatch for the `Authorizer` on the `Server`.

It also removes the old `Server::new` method which is no longer used.
