### PR TITLE
feat: Segment the write buffer on time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecount"
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4628,9 +4628,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5663,9 +5663,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.6"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6746919caf9f2a85bff759535664c060109f21975c5ac2e8652e60102bd4d196"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -5678,20 +5678,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,6 +2611,7 @@ dependencies = [
  "influxdb-line-protocol",
  "iox_catalog",
  "iox_query",
+ "iox_time",
  "object_store",
  "observability_deps",
  "parking_lot",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -135,6 +135,16 @@ pub struct Config {
     /// bearer token to be set for requests
     #[clap(long = "bearer-token", env = "INFLUXDB3_BEARER_TOKEN", action)]
     pub bearer_token: Option<String>,
+
+    /// Duration of wal segments that are persisted to object storage. Valid values: 1m, 5m, 10m,
+    /// 15m, 30m, 1h, 2h, 4h.
+    #[clap(
+        long = "segment-duration",
+        env = "INFLUXDB3_SEGMENT_DURATION",
+        default_value = "1h",
+        action
+    )]
+    pub segment_duration: SegmentDuration,
 }
 
 #[cfg(all(not(feature = "heappy"), not(feature = "jemalloc_replacing_malloc")))]
@@ -259,7 +269,7 @@ pub async fn command(config: Config) -> Result<()> {
             Arc::clone(&persister),
             wal,
             Arc::clone(&time_provider),
-            SegmentDuration::FiveMinutes,
+            config.segment_duration,
         )
         .await?,
     );

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -258,7 +258,7 @@ pub async fn command(config: Config) -> Result<()> {
         WriteBufferImpl::new(
             Arc::clone(&persister),
             wal,
-            time_provider,
+            Arc::clone(&time_provider),
             SegmentDuration::FiveMinutes,
         )
         .await?,
@@ -276,6 +276,7 @@ pub async fn command(config: Config) -> Result<()> {
         .max_request_size(config.max_http_request_size)
         .write_buffer(write_buffer)
         .query_executor(query_executor)
+        .time_provider(time_provider)
         .persister(persister);
 
     let server = if let Some(token) = config.bearer_token.map(hex::decode).transpose()? {

--- a/influxdb3_server/src/builder.rs
+++ b/influxdb3_server/src/builder.rs
@@ -5,8 +5,9 @@ use authz::Authorizer;
 use crate::{auth::DefaultAuthorizer, http::HttpApi, CommonServerState, Server};
 
 #[derive(Debug)]
-pub struct ServerBuilder<W, Q, P> {
+pub struct ServerBuilder<W, Q, P, T> {
     common_state: CommonServerState,
+    time_provider: T,
     max_request_size: usize,
     write_buffer: W,
     query_executor: Q,
@@ -14,10 +15,11 @@ pub struct ServerBuilder<W, Q, P> {
     authorizer: Arc<dyn Authorizer>,
 }
 
-impl ServerBuilder<NoWriteBuf, NoQueryExec, NoPersister> {
+impl ServerBuilder<NoWriteBuf, NoQueryExec, NoPersister, NoTimeProvider> {
     pub fn new(common_state: CommonServerState) -> Self {
         Self {
             common_state,
+            time_provider: NoTimeProvider,
             max_request_size: usize::MAX,
             write_buffer: NoWriteBuf,
             query_executor: NoQueryExec,
@@ -27,7 +29,7 @@ impl ServerBuilder<NoWriteBuf, NoQueryExec, NoPersister> {
     }
 }
 
-impl<W, Q, P> ServerBuilder<W, Q, P> {
+impl<W, Q, P, T> ServerBuilder<W, Q, P, T> {
     pub fn max_request_size(mut self, max_request_size: usize) -> Self {
         self.max_request_size = max_request_size;
         self
@@ -51,11 +53,16 @@ pub struct WithQueryExec<Q>(Arc<Q>);
 pub struct NoPersister;
 #[derive(Debug)]
 pub struct WithPersister<P>(Arc<P>);
+#[derive(Debug)]
+pub struct NoTimeProvider;
+#[derive(Debug)]
+pub struct WithTimeProvider<T>(Arc<T>);
 
-impl<Q, P> ServerBuilder<NoWriteBuf, Q, P> {
-    pub fn write_buffer<W>(self, wb: Arc<W>) -> ServerBuilder<WithWriteBuf<W>, Q, P> {
+impl<Q, P, T> ServerBuilder<NoWriteBuf, Q, P, T> {
+    pub fn write_buffer<W>(self, wb: Arc<W>) -> ServerBuilder<WithWriteBuf<W>, Q, P, T> {
         ServerBuilder {
             common_state: self.common_state,
+            time_provider: self.time_provider,
             max_request_size: self.max_request_size,
             write_buffer: WithWriteBuf(wb),
             query_executor: self.query_executor,
@@ -65,10 +72,11 @@ impl<Q, P> ServerBuilder<NoWriteBuf, Q, P> {
     }
 }
 
-impl<W, P> ServerBuilder<W, NoQueryExec, P> {
-    pub fn query_executor<Q>(self, qe: Arc<Q>) -> ServerBuilder<W, WithQueryExec<Q>, P> {
+impl<W, P, T> ServerBuilder<W, NoQueryExec, P, T> {
+    pub fn query_executor<Q>(self, qe: Arc<Q>) -> ServerBuilder<W, WithQueryExec<Q>, P, T> {
         ServerBuilder {
             common_state: self.common_state,
+            time_provider: self.time_provider,
             max_request_size: self.max_request_size,
             write_buffer: self.write_buffer,
             query_executor: WithQueryExec(qe),
@@ -78,10 +86,11 @@ impl<W, P> ServerBuilder<W, NoQueryExec, P> {
     }
 }
 
-impl<W, Q> ServerBuilder<W, Q, NoPersister> {
-    pub fn persister<P>(self, p: Arc<P>) -> ServerBuilder<W, Q, WithPersister<P>> {
+impl<W, Q, T> ServerBuilder<W, Q, NoPersister, T> {
+    pub fn persister<P>(self, p: Arc<P>) -> ServerBuilder<W, Q, WithPersister<P>, T> {
         ServerBuilder {
             common_state: self.common_state,
+            time_provider: self.time_provider,
             max_request_size: self.max_request_size,
             write_buffer: self.write_buffer,
             query_executor: self.query_executor,
@@ -91,12 +100,29 @@ impl<W, Q> ServerBuilder<W, Q, NoPersister> {
     }
 }
 
-impl<W, Q, P> ServerBuilder<WithWriteBuf<W>, WithQueryExec<Q>, WithPersister<P>> {
-    pub fn build(self) -> Server<W, Q, P> {
+impl<W, Q, P> ServerBuilder<W, Q, P, NoTimeProvider> {
+    pub fn time_provider<T>(self, tp: Arc<T>) -> ServerBuilder<W, Q, P, WithTimeProvider<T>> {
+        ServerBuilder {
+            common_state: self.common_state,
+            time_provider: WithTimeProvider(tp),
+            max_request_size: self.max_request_size,
+            write_buffer: self.write_buffer,
+            query_executor: self.query_executor,
+            persister: self.persister,
+            authorizer: self.authorizer,
+        }
+    }
+}
+
+impl<W, Q, P, T>
+    ServerBuilder<WithWriteBuf<W>, WithQueryExec<Q>, WithPersister<P>, WithTimeProvider<T>>
+{
+    pub fn build(self) -> Server<W, Q, P, T> {
         let persister = Arc::clone(&self.persister.0);
         let authorizer = Arc::clone(&self.authorizer);
         let http = Arc::new(HttpApi::new(
             self.common_state.clone(),
+            Arc::clone(&self.time_provider.0),
             Arc::clone(&self.write_buffer.0),
             Arc::clone(&self.query_executor.0),
             self.max_request_size,

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -230,7 +230,9 @@ mod tests {
     use datafusion::parquet::data_type::AsBytes;
     use hyper::{body, Body, Client, Request, Response, StatusCode};
     use influxdb3_write::persister::PersisterImpl;
+    use influxdb3_write::SegmentDuration;
     use iox_query::exec::{Executor, ExecutorConfig};
+    use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};
     use pretty_assertions::assert_eq;
@@ -271,6 +273,8 @@ mod tests {
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
+                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                SegmentDuration::FiveMinutes,
             )
             .await
             .unwrap(),
@@ -403,6 +407,8 @@ mod tests {
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
+                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                SegmentDuration::FiveMinutes,
             )
             .await
             .unwrap(),
@@ -571,6 +577,8 @@ mod tests {
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
+                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                SegmentDuration::FiveMinutes,
             )
             .await
             .unwrap(),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -273,7 +273,7 @@ mod tests {
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
-                SegmentDuration::FiveMinutes,
+                SegmentDuration::new_5m(),
             )
             .await
             .unwrap(),
@@ -409,7 +409,7 @@ mod tests {
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
-                SegmentDuration::FiveMinutes,
+                SegmentDuration::new_5m(),
             )
             .await
             .unwrap(),
@@ -583,7 +583,7 @@ mod tests {
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
-                SegmentDuration::FiveMinutes,
+                SegmentDuration::new_5m(),
             )
             .await
             .unwrap(),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -232,6 +232,7 @@ mod tests {
     use influxdb3_write::persister::PersisterImpl;
     use influxdb3_write::SegmentDuration;
     use iox_query::exec::{Executor, ExecutorConfig};
+    use iox_time::SystemProvider;
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -27,6 +27,7 @@ use datafusion::execution::SendableRecordBatchStream;
 use hyper::service::service_fn;
 use influxdb3_write::{Persister, WriteBuffer};
 use iox_query::QueryNamespaceProvider;
+use iox_time::TimeProvider;
 use observability_deps::tracing::{error, info};
 use service::hybrid;
 use std::convert::Infallible;
@@ -113,9 +114,9 @@ impl CommonServerState {
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct Server<W, Q, P> {
+pub struct Server<W, Q, P, T> {
     common_state: CommonServerState,
-    http: Arc<HttpApi<W, Q>>,
+    http: Arc<HttpApi<W, Q, T>>,
     persister: Arc<P>,
     authorizer: Arc<dyn Authorizer>,
 }
@@ -147,26 +148,23 @@ pub enum QueryKind {
     Sql,
     InfluxQl,
 }
-
-impl<W, Q, P> Server<W, Q, P> {
+impl<W, Q, P, T> Server<W, Q, P, T> {
     pub fn authorizer(&self) -> Arc<dyn Authorizer> {
         Arc::clone(&self.authorizer)
     }
 }
 
-pub async fn serve<W, Q, P>(server: Server<W, Q, P>, shutdown: CancellationToken) -> Result<()>
+pub async fn serve<W, Q, P, T>(
+    server: Server<W, Q, P, T>,
+    shutdown: CancellationToken,
+) -> Result<()>
 where
     W: WriteBuffer,
     Q: QueryExecutor,
     http::Error: From<<Q as QueryExecutor>::Error>,
     P: Persister,
+    T: TimeProvider,
 {
-    // TODO:
-    //  1. load the persisted catalog and segments from the persister
-    //  2. load semgments into the buffer
-    //  3. persist any segments from the buffer that are closed and haven't yet been persisted
-    //  4. start serving
-
     let req_metrics = RequestMetrics::new(
         Arc::clone(&server.common_state.metrics),
         MetricFamily::HttpServer,
@@ -232,7 +230,6 @@ mod tests {
     use influxdb3_write::persister::PersisterImpl;
     use influxdb3_write::SegmentDuration;
     use iox_query::exec::{Executor, ExecutorConfig};
-    use iox_time::SystemProvider;
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};
@@ -269,12 +266,13 @@ mod tests {
             mem_pool_size: usize::MAX,
         }));
         let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
-                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                Arc::clone(&time_provider),
                 SegmentDuration::FiveMinutes,
             )
             .await
@@ -294,6 +292,7 @@ mod tests {
             .query_executor(Arc::clone(&query_executor))
             .persister(Arc::clone(&persister))
             .authorizer(Arc::new(DefaultAuthorizer))
+            .time_provider(Arc::clone(&time_provider))
             .build();
         let frontend_shutdown = CancellationToken::new();
         let shutdown = frontend_shutdown.clone();
@@ -403,12 +402,13 @@ mod tests {
             mem_pool_size: usize::MAX,
         }));
         let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
-                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                Arc::clone(&time_provider),
                 SegmentDuration::FiveMinutes,
             )
             .await
@@ -428,6 +428,7 @@ mod tests {
             .query_executor(Arc::new(query_executor))
             .persister(persister)
             .authorizer(Arc::new(DefaultAuthorizer))
+            .time_provider(Arc::clone(&time_provider))
             .build();
         let frontend_shutdown = CancellationToken::new();
         let shutdown = frontend_shutdown.clone();
@@ -573,12 +574,15 @@ mod tests {
             mem_pool_size: usize::MAX,
         }));
         let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(
+            1708473607000000000,
+        )));
 
         let write_buffer = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
-                Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                Arc::clone(&time_provider),
                 SegmentDuration::FiveMinutes,
             )
             .await
@@ -598,6 +602,7 @@ mod tests {
             .query_executor(Arc::new(query_executor))
             .persister(persister)
             .authorizer(Arc::new(DefaultAuthorizer))
+            .time_provider(Arc::clone(&time_provider))
             .build();
         let frontend_shutdown = CancellationToken::new();
         let shutdown = frontend_shutdown.clone();

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -12,6 +12,7 @@ datafusion_util.workspace = true
 influxdb-line-protocol.workspace = true
 iox_catalog.workspace = true
 iox_query.workspace = true
+iox_time.workspace = true
 observability_deps.workspace = true
 schema.workspace = true
 

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -13,7 +13,7 @@ pub mod wal;
 pub mod write_buffer;
 
 use crate::catalog::Catalog;
-use crate::paths::ParquetFilePath;
+use crate::paths::{ParquetFilePath, SegmentWalFilePath};
 use async_trait::async_trait;
 use bytes::Bytes;
 use data_types::NamespaceName;
@@ -172,7 +172,6 @@ impl SegmentDuration {
         Self(duration)
     }
 
-    /// Returns a five minute segment duration, mostly used for teesting purposes.
     pub fn new_5m() -> Self {
         Self(Duration::from_secs(300))
     }
@@ -393,6 +392,8 @@ pub trait WalSegmentReader: Debug + Send + Sync + 'static {
     fn next_batch(&mut self) -> wal::Result<Option<WalOpBatch>>;
 
     fn header(&self) -> &wal::SegmentHeader;
+
+    fn path(&self) -> &SegmentWalFilePath;
 }
 
 /// Individual WalOps get batched into the WAL asynchronously. The batch is then written to the segment file.

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -110,6 +110,12 @@ impl SegmentWalFilePath {
     }
 }
 
+impl ToString for SegmentWalFilePath {
+    fn to_string(&self) -> String {
+        self.0.to_string_lossy().into_owned()
+    }
+}
+
 impl Deref for SegmentWalFilePath {
     type Target = Path;
 

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -86,6 +86,9 @@ pub enum Error {
 
     #[error("segment start time not open: {0}")]
     SegmentStartTimeNotOpen(Time),
+
+    #[error("open segment limit reached: {0}")]
+    OpenSegmentLimitReached(usize),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -258,7 +258,7 @@ impl WalSegmentWriterImpl {
         {
             let f = OpenOptions::new().write(true).append(true).open(&path)?;
 
-            return Ok(Self {
+            Ok(Self {
                 segment_id,
                 f,
                 bytes_written: file_info
@@ -267,9 +267,9 @@ impl WalSegmentWriterImpl {
                     .expect("file length must fit in usize"),
                 sequence_number: file_info.last_sequence_number,
                 buffer: Vec::with_capacity(8 * 1204), // 8kiB initial size
-            });
+            })
         } else {
-            return Err(Error::FileDoesntExist(path.to_path_buf()));
+            Err(Error::FileDoesntExist(path.to_path_buf()))
         }
     }
 

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -63,12 +63,17 @@ impl OpenBufferSegment {
         }
     }
 
+    #[allow(dead_code)]
     pub fn start_time_matches(&self, t: Time) -> bool {
         self.segment_range.start_time == t
     }
 
     pub fn segment_id(&self) -> SegmentId {
         self.segment_id
+    }
+
+    pub fn segment_range(&self) -> &SegmentRange {
+        &self.segment_range
     }
     pub fn write_wal_ops(&mut self, write_batch: Vec<WalOp>) -> wal::Result<()> {
         self.segment_writer.write_batch(write_batch)
@@ -385,6 +390,7 @@ pub struct ClosedBufferSegment {
 
 impl ClosedBufferSegment {
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         segment_id: SegmentId,
         segment_range: SegmentRange,

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -237,7 +237,7 @@ mod tests {
         );
         let catalog = Arc::new(Catalog::new());
         let segment_state = Arc::new(RwLock::new(SegmentState::<WalImpl>::new(
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
             next_segment_id,
             Arc::clone(&catalog),
             open_segment,
@@ -253,7 +253,7 @@ mod tests {
             "cpu bar=1 10",
             &catalog,
             ingest_time,
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
             false,
             Precision::Nanosecond,
         )
@@ -269,7 +269,7 @@ mod tests {
             "cpu bar=1 20",
             &catalog,
             ingest_time,
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
             false,
             Precision::Nanosecond,
         )

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -198,13 +198,14 @@ mod tests {
     use crate::test_helpers::lp_to_table_batches;
     use crate::wal::WalSegmentWriterNoopImpl;
     use crate::write_buffer::buffer_segment::OpenBufferSegment;
-    use crate::{LpWriteOp, SegmentId};
+    use crate::{LpWriteOp, SegmentId, SegmentRange};
 
     #[tokio::test]
     async fn flushes_to_open_segment() {
         let segment_id = SegmentId::new(3);
         let open_segment = OpenBufferSegment::new(
             segment_id,
+            SegmentRange::test_range(),
             SequenceNumber::new(0),
             Box::new(WalSegmentWriterNoopImpl::new(segment_id)),
             None,
@@ -247,7 +248,6 @@ mod tests {
             .open_segment
             .table_buffer(db_name.as_str(), "cpu")
             .unwrap();
-        let partition_buffer = table_buffer.partition_buffer("1970-01-01").unwrap();
-        assert_eq!(partition_buffer.row_count(), 2);
+        assert_eq!(table_buffer.row_count(), 2);
     }
 }

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -59,7 +59,7 @@ where
         let wal_segments = wal.segment_files()?;
 
         for segment_file in wal_segments {
-            // if persisted segemnts is empty, load all segments from the wal, otherwise
+            // if persisted segments is empty, load all segments from the wal, otherwise
             // only load segments that haven't been persisted yet
             if segment_file.segment_id <= last_persisted_segment_id
                 && !persisted_segments.is_empty()

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -221,7 +221,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, "db1", lp);
 
-        open_segment.write_batch(vec![wal_op]).unwrap();
+        open_segment.write_wal_ops(vec![wal_op]).unwrap();
         open_segment.buffer_writes(write_batch).unwrap();
 
         let catalog = Arc::new(catalog);
@@ -302,7 +302,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, db_name, lp);
 
-        current_segment.write_batch(vec![wal_op.clone()]).unwrap();
+        current_segment.write_wal_ops(vec![wal_op.clone()]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
 
         let loaded_state = load_starting_state(
@@ -385,7 +385,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, db_name, lp);
 
-        current_segment.write_batch(vec![wal_op]).unwrap();
+        current_segment.write_wal_ops(vec![wal_op]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
 
         let segment_id = current_segment.segment_id();
@@ -408,7 +408,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, db_name, lp);
 
-        next_segment.write_batch(vec![wal_op]).unwrap();
+        next_segment.write_wal_ops(vec![wal_op]).unwrap();
         next_segment.buffer_writes(write_batch).unwrap();
 
         // now load up with a start time that puts us in next segment period
@@ -542,7 +542,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, db_name, lp);
 
-        current_segment.write_batch(vec![wal_op]).unwrap();
+        current_segment.write_wal_ops(vec![wal_op]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
 
         // close the current segment
@@ -559,7 +559,7 @@ mod tests {
 
         let write_batch = lp_to_write_batch(&catalog, db_name, lp);
 
-        next_segment.write_batch(vec![wal_op]).unwrap();
+        next_segment.write_wal_ops(vec![wal_op]).unwrap();
         next_segment.buffer_writes(write_batch).unwrap();
 
         // now load up with a start time that puts us in next segment period. we should now

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -40,7 +40,6 @@ where
 {
     let PersistedCatalog { catalog, .. } = persister.load_catalog().await?.unwrap_or_default();
     let catalog = Arc::new(Catalog::from_inner(catalog));
-    println!("catalog sN {:?}", catalog.sequence_number());
 
     let persisted_segments = persister.load_segments(SEGMENTS_TO_LOAD).await?;
 
@@ -78,15 +77,12 @@ where
             if segment_file.segment_id <= last_persisted_segment_id
                 && !persisted_segments.is_empty()
             {
-                println!("skipping segment {:?}", segment_file.segment_id);
                 continue;
             }
 
-            println!("loading segment {:?}", segment_file.segment_id);
             let starting_sequence_number = catalog.sequence_number();
             let segment_reader = wal.open_segment_reader(segment_file.segment_id)?;
             let segment_header = *segment_reader.header();
-            println!("segment header {:?}", segment_header);
             let buffer = load_buffer_from_segment(&catalog, segment_reader)?;
 
             let segment = OpenBufferSegment::new(
@@ -245,7 +241,7 @@ mod tests {
             persister,
             None::<Arc<crate::wal::WalImpl>>,
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -299,7 +295,7 @@ mod tests {
             Arc::clone(&persister),
             Some(Arc::clone(&wal)),
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -321,7 +317,7 @@ mod tests {
             persister,
             Some(wal),
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -384,7 +380,7 @@ mod tests {
             Arc::clone(&persister),
             Some(Arc::clone(&wal)),
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -430,7 +426,7 @@ mod tests {
             persister,
             Some(wal),
             Time::from_timestamp(6 * 60, 0).unwrap(),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -543,7 +539,7 @@ mod tests {
             Arc::clone(&persister),
             Some(Arc::clone(&wal)),
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();
@@ -585,7 +581,7 @@ mod tests {
             persister,
             Some(wal),
             Time::from_timestamp(6 * 60, 0).unwrap(),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
         )
         .await
         .unwrap();

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -846,7 +846,7 @@ mod tests {
             &db,
             db_name,
             Time::from_timestamp_nanos(0),
-            SegmentDuration::FiveMinutes,
+            SegmentDuration::new_5m(),
             false,
             Precision::Nanosecond,
         )
@@ -866,7 +866,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
-        let segment_duration = SegmentDuration::FiveMinutes;
+        let segment_duration = SegmentDuration::new_5m();
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
             Some(Arc::new(wal)),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -5,18 +5,20 @@ mod flusher;
 mod loader;
 
 use crate::catalog::{Catalog, DatabaseSchema, TableDefinition, TIME_COLUMN_NAME};
-use crate::write_buffer::buffer_segment::{ClosedBufferSegment, OpenBufferSegment, TableBuffer};
+use crate::write_buffer::buffer_segment::{
+    ClosedBufferSegment, OpenBufferSegment, TableBuffer, WriteBatch,
+};
 use crate::write_buffer::flusher::WriteBufferFlusher;
 use crate::write_buffer::loader::load_starting_state;
 use crate::{
-    BufferSegment, BufferedWriteRequest, Bufferer, ChunkContainer, LpWriteOp, Persister, Precision,
-    SegmentDuration, SegmentId, Wal, WalOp, WriteBuffer, WriteLineError,
+    wal, BufferSegment, BufferedWriteRequest, Bufferer, ChunkContainer, LpWriteOp, Persister,
+    Precision, SegmentDuration, SegmentId, Wal, WalOp, WriteBuffer, WriteLineError,
 };
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use data_types::{
-    column_type_from_field, ChunkId, ChunkOrder, ColumnType, NamespaceName, TableId,
-    TransitionPartitionId,
+    column_type_from_field, ChunkId, ChunkOrder, ColumnType, NamespaceName, NamespaceNameError,
+    TableId, TransitionPartitionId,
 };
 use datafusion::common::{DataFusionError, Statistics};
 use datafusion::execution::context::SessionState;
@@ -24,8 +26,8 @@ use datafusion::logical_expr::Expr;
 use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
 use iox_query::chunk_statistics::create_chunk_statistics;
 use iox_query::{QueryChunk, QueryChunkData};
-use iox_time::TimeProvider;
-use observability_deps::tracing::{debug, info};
+use iox_time::{Time, TimeProvider};
+use observability_deps::tracing::{debug, error, info};
 use parking_lot::RwLock;
 use schema::sort::SortKey;
 use schema::Schema;
@@ -61,6 +63,9 @@ pub enum Error {
 
     #[error("corrupt load state: {0}")]
     CorruptLoadState(String),
+
+    #[error("database name error: {0}")]
+    DatabaseNameError(#[from] NamespaceNameError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -73,20 +78,22 @@ pub struct WriteRequest<'a> {
 }
 
 #[derive(Debug)]
-pub struct WriteBufferImpl<W> {
+pub struct WriteBufferImpl<W, T> {
     catalog: Arc<Catalog>,
     segment_state: Arc<RwLock<SegmentState>>,
     #[allow(dead_code)]
     wal: Option<Arc<W>>,
     write_buffer_flusher: WriteBufferFlusher,
     segment_duration: SegmentDuration,
-    time_provider: Arc<dyn TimeProvider>,
+    #[allow(dead_code)]
+    time_provider: Arc<T>,
 }
 
 #[derive(Debug)]
 struct SegmentState {
     current_segment: OpenBufferSegment,
     next_segment: OpenBufferSegment,
+    #[allow(dead_code)]
     outside_segment: Option<OpenBufferSegment>,
     #[allow(dead_code)]
     persisting_segments: Vec<ClosedBufferSegment>,
@@ -101,13 +108,42 @@ impl SegmentState {
             persisting_segments: vec![],
         }
     }
+
+    pub(crate) fn write_ops_to_segment(
+        &mut self,
+        segment_start: Time,
+        ops: Vec<WalOp>,
+    ) -> wal::Result<()> {
+        if self.current_segment.start_time_matches(segment_start) {
+            self.current_segment.write_wal_ops(ops)
+        } else if self.next_segment.start_time_matches(segment_start) {
+            self.next_segment.write_wal_ops(ops)
+        } else {
+            error!("segment_start not open!: {:?}", segment_start);
+            Err(wal::Error::SegmentStartTimeNotOpen(segment_start))
+        }
+    }
+
+    pub(crate) fn write_batch_to_segment(
+        &mut self,
+        segment_start: Time,
+        write_batch: WriteBatch,
+    ) -> Result<()> {
+        if self.current_segment.start_time_matches(segment_start) {
+            self.current_segment.buffer_writes(write_batch)
+        } else if self.next_segment.start_time_matches(segment_start) {
+            self.next_segment.buffer_writes(write_batch)
+        } else {
+            panic!("Tried to write to a segment that is not open")
+        }
+    }
 }
 
-impl<W: Wal> WriteBufferImpl<W> {
+impl<W: Wal, T: TimeProvider> WriteBufferImpl<W, T> {
     pub async fn new<P>(
         persister: Arc<P>,
         wal: Option<Arc<W>>,
-        time_provider: Arc<dyn TimeProvider>,
+        time_provider: Arc<T>,
         segment_duration: SegmentDuration,
     ) -> Result<Self>
     where
@@ -142,30 +178,25 @@ impl<W: Wal> WriteBufferImpl<W> {
         &self,
         db_name: NamespaceName<'static>,
         lp: &str,
-        default_time: i64,
+        ingest_time: Time,
         accept_partial: bool,
         precision: Precision,
     ) -> Result<BufferedWriteRequest> {
         debug!("write_lp to {} in writebuffer", db_name);
 
         let result = parse_validate_and_update_catalog(
-            db_name.as_str(),
+            db_name.clone(),
             lp,
             &self.catalog,
-            default_time,
+            ingest_time,
+            self.segment_duration,
             accept_partial,
             precision,
         )?;
 
-        let wal_op = WalOp::LpWrite(LpWriteOp {
-            db_name: db_name.to_string(),
-            lp: result.lp_valid,
-            default_time,
-        });
-
-        let write_summary = self
+        let _ = self
             .write_buffer_flusher
-            .write_to_open_segment(db_name.clone(), result.table_batches, wal_op)
+            .write_to_open_segment(result.valid_segmented_data)
             .await?;
 
         Ok(BufferedWriteRequest {
@@ -174,9 +205,6 @@ impl<W: Wal> WriteBufferImpl<W> {
             line_count: result.line_count,
             field_count: result.field_count,
             tag_count: result.tag_count,
-            total_buffer_memory_used: write_summary.buffer_size,
-            segment_id: write_summary.segment_id,
-            sequence_number: write_summary.sequence_number,
         })
     }
 
@@ -250,16 +278,16 @@ impl<W: Wal> WriteBufferImpl<W> {
 }
 
 #[async_trait]
-impl<W: Wal> Bufferer for WriteBufferImpl<W> {
+impl<W: Wal, T: TimeProvider> Bufferer for WriteBufferImpl<W, T> {
     async fn write_lp(
         &self,
         database: NamespaceName<'static>,
         lp: &str,
-        default_time: i64,
+        ingest_time: Time,
         accept_partial: bool,
         precision: Precision,
     ) -> Result<BufferedWriteRequest> {
-        self.write_lp(database, lp, default_time, accept_partial, precision)
+        self.write_lp(database, lp, ingest_time, accept_partial, precision)
             .await
     }
 
@@ -284,7 +312,7 @@ impl<W: Wal> Bufferer for WriteBufferImpl<W> {
     }
 }
 
-impl<W: Wal> ChunkContainer for WriteBufferImpl<W> {
+impl<W: Wal, T: TimeProvider> ChunkContainer for WriteBufferImpl<W, T> {
     fn get_table_chunks(
         &self,
         database_name: &str,
@@ -297,7 +325,7 @@ impl<W: Wal> ChunkContainer for WriteBufferImpl<W> {
     }
 }
 
-impl<W: Wal> WriteBuffer for WriteBufferImpl<W> {}
+impl<W: Wal, T: TimeProvider> WriteBuffer for WriteBufferImpl<W, T> {}
 
 #[derive(Debug)]
 pub struct BufferChunk {
@@ -360,16 +388,24 @@ impl QueryChunk for BufferChunk {
 }
 
 pub(crate) fn parse_validate_and_update_catalog(
-    db_name: &str,
+    db_name: NamespaceName<'static>,
     lp: &str,
     catalog: &Catalog,
-    default_time: i64,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
     accept_partial: bool,
     precision: Precision,
 ) -> Result<ValidationResult> {
-    let (sequence, db) = catalog.db_or_create(db_name)?;
-    let mut result =
-        parse_validate_and_update_schema(lp, &db, default_time, accept_partial, precision)?;
+    let (sequence, db) = catalog.db_or_create(db_name.as_str())?;
+    let mut result = parse_validate_and_update_schema(
+        lp,
+        &db,
+        db_name,
+        ingest_time,
+        segment_duration,
+        accept_partial,
+        precision,
+    )?;
 
     if let Some(schema) = result.schema.take() {
         debug!("replacing schema for {:?}", schema);
@@ -381,18 +417,20 @@ pub(crate) fn parse_validate_and_update_catalog(
 }
 
 /// Takes &str of line protocol, parses lines, validates the schema, and inserts new columns
-/// and partitions if present. Assigns the default time to any lines that do not include a time
+/// if present. Assigns the default time to any lines that do not include a time
 pub(crate) fn parse_validate_and_update_schema(
     lp: &str,
     schema: &DatabaseSchema,
-    default_time: i64,
+    db_name: NamespaceName<'static>,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
     accept_partial: bool,
     precision: Precision,
 ) -> Result<ValidationResult> {
-    let mut lines = vec![];
     let mut errors = vec![];
-    let mut valid_lines = vec![];
     let mut lp_lines = lp.lines();
+
+    let mut valid_parsed_and_raw_lines: Vec<(ParsedLine, &str)> = vec![];
 
     for (line_idx, maybe_line) in parse_lines(lp).enumerate() {
         let line = match maybe_line {
@@ -420,17 +458,21 @@ pub(crate) fn parse_validate_and_update_schema(
         };
         // This unwrap is fine because we're moving line by line
         // alongside the output from parse_lines
-        valid_lines.push(lp_lines.next().unwrap());
-        lines.push(line);
+        valid_parsed_and_raw_lines.push((line, lp_lines.next().unwrap()));
     }
 
-    validate_or_insert_schema_and_partitions(lines, schema, default_time, precision).map(
-        move |mut result| {
-            result.lp_valid = valid_lines.join("\n");
-            result.errors = errors;
-            result
-        },
+    validate_or_insert_schema_and_partitions(
+        valid_parsed_and_raw_lines,
+        schema,
+        db_name,
+        ingest_time,
+        segment_duration,
+        precision,
     )
+    .map(move |mut result| {
+        result.errors = errors;
+        result
+    })
 }
 
 /// Takes parsed lines, validates their schema. If new tables or columns are defined, they
@@ -438,30 +480,34 @@ pub(crate) fn parse_validate_and_update_schema(
 /// into partitions and the validation result contains the data that can then be serialized
 /// into the WAL.
 pub(crate) fn validate_or_insert_schema_and_partitions(
-    lines: Vec<ParsedLine<'_>>,
+    lines: Vec<(ParsedLine<'_>, &str)>,
     schema: &DatabaseSchema,
-    default_time: i64,
+    db_name: NamespaceName<'static>,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
     precision: Precision,
 ) -> Result<ValidationResult> {
     // The (potentially updated) DatabaseSchema to return to the caller.
     let mut schema = Cow::Borrowed(schema);
 
     // The parsed and validated table_batches
-    let mut table_batches: HashMap<String, TableBatch> = HashMap::new();
+    let mut segment_table_batches: HashMap<Time, TableBatchMap> = HashMap::new();
 
     let line_count = lines.len();
     let mut field_count = 0;
     let mut tag_count = 0;
 
-    for line in lines.into_iter() {
+    for (line, raw_line) in lines.into_iter() {
         field_count += line.field_set.len();
         tag_count += line.series.tag_set.as_ref().map(|t| t.len()).unwrap_or(0);
 
         validate_and_convert_parsed_line(
             line,
-            &mut table_batches,
+            raw_line,
+            &mut segment_table_batches,
             &mut schema,
-            default_time,
+            ingest_time,
+            segment_duration,
             precision,
         )?;
     }
@@ -471,24 +517,39 @@ pub(crate) fn validate_or_insert_schema_and_partitions(
         Cow::Borrowed(_) => None,
     };
 
+    let valid_segmented_data = segment_table_batches
+        .into_iter()
+        .map(|(segment_start, table_batches)| ValidSegmentedData {
+            database_name: db_name.clone(),
+            segment_start,
+            table_batches: table_batches.table_batches,
+            wal_op: WalOp::LpWrite(LpWriteOp {
+                db_name: db_name.to_string(),
+                lp: table_batches.lines.join("\n"),
+                default_time: ingest_time.timestamp_nanos(),
+            }),
+        })
+        .collect();
+
     Ok(ValidationResult {
         schema,
-        table_batches,
         line_count,
         field_count,
         tag_count,
         errors: vec![],
-        lp_valid: String::new(),
+        valid_segmented_data,
     })
 }
 
 // &mut Cow is used to avoid a copy, so allow it
 #[allow(clippy::ptr_arg)]
-fn validate_and_convert_parsed_line(
+fn validate_and_convert_parsed_line<'a>(
     line: ParsedLine<'_>,
-    table_batches: &mut HashMap<String, TableBatch>,
+    raw_line: &'a str,
+    segment_table_batches: &mut HashMap<Time, TableBatchMap<'a>>,
     schema: &mut Cow<'_, DatabaseSchema>,
-    default_time: i64,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
     precision: Precision,
 ) -> Result<()> {
     let table_name = line.series.measurement.as_str();
@@ -574,7 +635,7 @@ fn validate_and_convert_parsed_line(
     }
 
     // set the time value
-    let time_value = line
+    let time_value_nanos = line
         .timestamp
         .map(|ts| {
             let multiplier = match precision {
@@ -594,17 +655,27 @@ fn validate_and_convert_parsed_line(
 
             ts * multiplier
         })
-        .unwrap_or(default_time);
+        .unwrap_or(ingest_time.timestamp_nanos());
+
+    let segment_start = segment_duration.start_time(time_value_nanos / 1_000_000_000);
+
     values.push(Field {
         name: TIME_COLUMN_NAME.to_string(),
-        value: FieldData::Timestamp(time_value),
+        value: FieldData::Timestamp(time_value_nanos),
     });
 
-    let table_batch = table_batches.entry(table_name.to_string()).or_default();
+    let table_batch_map = segment_table_batches.entry(segment_start).or_default();
+
+    let table_batch = table_batch_map
+        .table_batches
+        .entry(table_name.to_string())
+        .or_default();
     table_batch.rows.push(Row {
-        time: time_value,
+        time: time_value_nanos,
         fields: values,
     });
+
+    table_batch_map.lines.push(raw_line);
 
     Ok(())
 }
@@ -664,8 +735,6 @@ pub(crate) struct ValidationResult {
     /// If the namespace schema is updated with new tables or columns it will be here, which
     /// can be used to update the cache.
     pub(crate) schema: Option<DatabaseSchema>,
-    /// Map of table name to TableBatch
-    pub(crate) table_batches: HashMap<String, TableBatch>,
     /// Number of lines passed in
     pub(crate) line_count: usize,
     /// Number of fields passed in
@@ -674,8 +743,23 @@ pub(crate) struct ValidationResult {
     pub(crate) tag_count: usize,
     /// Any errors that ocurred while parsing the lines
     pub(crate) errors: Vec<crate::WriteLineError>,
-    /// Only valid lines from what was passed in to validate
-    pub(crate) lp_valid: String,
+    /// Only valid lines from what was passed in to validate, segmented based on the
+    /// timestamps of the data.
+    pub(crate) valid_segmented_data: Vec<ValidSegmentedData>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ValidSegmentedData {
+    pub(crate) database_name: NamespaceName<'static>,
+    pub(crate) segment_start: Time,
+    pub(crate) table_batches: HashMap<String, TableBatch>,
+    pub(crate) wal_op: WalOp,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TableBatchMap<'a> {
+    pub(crate) lines: Vec<&'a str>,
+    pub(crate) table_batches: HashMap<String, TableBatch>,
 }
 
 #[cfg(test)]
@@ -692,9 +776,18 @@ mod tests {
     #[test]
     fn parse_lp_into_buffer() {
         let db = Arc::new(DatabaseSchema::new("foo"));
+        let db_name = NamespaceName::new("foo").unwrap();
         let lp = "cpu,region=west user=23.2 100\nfoo f1=1i";
-        let result =
-            parse_validate_and_update_schema(lp, &db, 0, false, Precision::Nanosecond).unwrap();
+        let result = parse_validate_and_update_schema(
+            lp,
+            &db,
+            db_name,
+            Time::from_timestamp_nanos(0),
+            SegmentDuration::FiveMinutes,
+            false,
+            Precision::Nanosecond,
+        )
+        .unwrap();
 
         let db = result.schema.unwrap();
 
@@ -709,7 +802,7 @@ mod tests {
         let wal = WalImpl::new(dir.clone()).unwrap();
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
-        let time_provider: Arc<dyn TimeProvider> = Arc::new(MockProvider::new(Time::MIN));
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let segment_duration = SegmentDuration::FiveMinutes;
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
@@ -724,7 +817,7 @@ mod tests {
             .write_lp(
                 NamespaceName::new("foo").unwrap(),
                 "cpu bar=1 10",
-                123,
+                Time::from_timestamp_nanos(123),
                 false,
                 Precision::Nanosecond,
             )
@@ -733,9 +826,6 @@ mod tests {
         assert_eq!(summary.line_count, 1);
         assert_eq!(summary.field_count, 1);
         assert_eq!(summary.tag_count, 0);
-        assert_eq!(summary.total_buffer_memory_used, 1);
-        assert_eq!(summary.segment_id, SegmentId::new(1));
-        assert_eq!(summary.sequence_number, SequenceNumber::new(1));
 
         // ensure the data is in the buffer
         let actual = write_buffer.get_table_record_batches("foo", "cpu");


### PR DESCRIPTION
Closes #24706. As I was implementing that initial design, I realized that everything would be much cleaner and easier to explain if all data was simply ingested into the segment period that it falls into. However, this could potentially cause a problem if users are spraying data all over history, so it currently limits open segments that can be written to to no more than 100. I will log follow up issues for items that still need to be done.

I did this with WIP commits along the way, but the design evolved as I developed it. So it's best to just view the whole thing. If it's too much to take in, I can break it down into smaller PRs that will be easier to review. Things are pretty tied together so that could get a little tricky.

## Done in this PR
* Update WAL to work with many segments and to store segment header information at beginning of file
* Split WriteBufferImpl into segments
* Update flusher to be able to write to and flush all open segments
* Update loader to work with many segments
* Update SegmentState to work with many open segments
* Update WriteBufferImpl to return query data in a chunk for each segment
* Wire up TimeProvider in HTTP and WriteBufferImpl
* Add SegmentDuration to clap and server configuration

## TODO
* Persist segments that haven't received writes in some period of time that are no longer current or next
* Remove wal files after segment persist
* Overflow for data that goes over the open segment limit?