### PR TITLE
feat: support v1 query API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "rand",
  "reqwest",
  "secrecy",
+ "serde_json",
  "sha2",
  "test_helpers",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
 name = "influxdb3_server"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "arrow-csv",
  "arrow-flight",
@@ -2569,6 +2570,7 @@ dependencies = [
  "pin-project-lite",
  "pretty_assertions",
  "schema",
+ "secrecy",
  "serde",
  "serde_arrow",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ prost = "0.12.3"
 prost-build = "0.12.2"
 prost-types = "0.12.3"
 rand = "0.8.5"
-reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls", "stream"] }
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_arrow = { version = "0.10", features = ["arrow-50"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+anyhow = "1.0"
 arrow = { version = "50.0.0", features = ["prettyprint", "chrono-tz"] }
 arrow-array = "50.0.0"
 arrow-buffer = "50.0.0"

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -91,6 +91,7 @@ futures.workspace = true
 hyper.workspace = true
 pretty_assertions.workspace = true
 reqwest.workspace = true
+serde_json.workspace = true
 test_helpers.workspace = true
 tonic.workspace = true
 tower.workspace = true

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -179,6 +179,15 @@ impl TestServer {
             .await
             .expect("send /api/v3/query_influxql request to server")
     }
+
+    pub async fn api_v1_query(&self, params: &[(&str, &str)]) -> Response {
+        self.http_client
+            .get(format!("{base}/api/v1/query", base = self.client_addr(),))
+            .query(params)
+            .send()
+            .await
+            .expect("send /api/v1/query request to server")
+    }
 }
 
 /// Get an available bind address on localhost

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1,6 +1,7 @@
 use crate::TestServer;
 use influxdb3_client::Precision;
 use pretty_assertions::assert_eq;
+use serde_json::{json, Value};
 
 #[tokio::test]
 async fn api_v3_query_sql() {
@@ -264,6 +265,179 @@ async fn api_v3_query_influxql() {
             .unwrap();
         println!("\n{q}", q = t.query);
         println!("{resp}");
+        assert_eq!(t.expected, resp, "query failed: {q}", q = t.query);
+    }
+}
+
+#[tokio::test]
+async fn api_v1_query() {
+    let server = TestServer::spawn().await;
+
+    server
+        .write_lp_to_db(
+            "foo",
+            "cpu,host=a usage=0.9 1\n\
+            cpu,host=a usage=0.89 2\n\
+            cpu,host=a usage=0.85 3\n\
+            mem,host=a usage=0.5 4\n\
+            mem,host=a usage=0.6 5\n\
+            mem,host=a usage=0.7 6",
+            Precision::Second,
+        )
+        .await
+        .unwrap();
+
+    struct TestCase<'a> {
+        database: Option<&'a str>,
+        epoch: Option<&'a str>,
+        query: &'a str,
+        expected: Value,
+    }
+
+    let test_cases = [
+        // Basic Query:
+        TestCase {
+            database: Some("foo"),
+            epoch: None,
+            query: "SELECT * FROM cpu",
+            expected: json!({
+              "results": [
+                {
+                  "series": [
+                    {
+                      "columns": [
+                        "time",
+                        "host",
+                        "usage"
+                      ],
+                      "name": "cpu",
+                      "values": [
+                        ["1970-01-01T00:00:01", "a", 0.9],
+                        ["1970-01-01T00:00:02", "a", 0.89],
+                        ["1970-01-01T00:00:03", "a", 0.85]
+                      ]
+                    }
+                  ],
+                  "statement_id": 0
+                }
+              ]
+            }),
+        },
+        // Basic Query with multiple measurements:
+        TestCase {
+            database: Some("foo"),
+            epoch: None,
+            query: "SELECT * FROM cpu, mem",
+            expected: json!({
+              "results": [
+                {
+                  "series": [
+                    {
+                      "columns": [
+                        "time",
+                        "host",
+                        "usage"
+                      ],
+                      "name": "mem",
+                      "values": [
+                        ["1970-01-01T00:00:04", "a", 0.5],
+                        ["1970-01-01T00:00:05", "a", 0.6],
+                        ["1970-01-01T00:00:06", "a", 0.7]
+                      ]
+                    },
+                    {
+                      "columns": [
+                        "time",
+                        "host",
+                        "usage"
+                      ],
+                      "name": "cpu",
+                      "values": [
+                        ["1970-01-01T00:00:01", "a", 0.9],
+                        ["1970-01-01T00:00:02", "a", 0.89],
+                        ["1970-01-01T00:00:03", "a", 0.85]
+                      ]
+                    }
+                  ],
+                  "statement_id": 0
+                }
+              ]
+            }),
+        },
+        // Basic Query with db in query string:
+        TestCase {
+            database: None,
+            epoch: None,
+            query: "SELECT * FROM foo.autogen.cpu",
+            expected: json!({
+              "results": [
+                {
+                  "series": [
+                    {
+                      "columns": [
+                        "time",
+                        "host",
+                        "usage"
+                      ],
+                      "name": "cpu",
+                      "values": [
+                        ["1970-01-01T00:00:01", "a", 0.9],
+                        ["1970-01-01T00:00:02", "a", 0.89],
+                        ["1970-01-01T00:00:03", "a", 0.85]
+                      ]
+                    }
+                  ],
+                  "statement_id": 0
+                }
+              ]
+            }),
+        },
+        // Basic Query epoch parameter set:
+        TestCase {
+            database: Some("foo"),
+            epoch: Some("s"),
+            query: "SELECT * FROM cpu",
+            expected: json!({
+              "results": [
+                {
+                  "series": [
+                    {
+                      "columns": [
+                        "time",
+                        "host",
+                        "usage"
+                      ],
+                      "name": "cpu",
+                      "values": [
+                        [1, "a", 0.9],
+                        [2, "a", 0.89],
+                        [3, "a", 0.85]
+                      ]
+                    }
+                  ],
+                  "statement_id": 0
+                }
+              ]
+            }),
+        },
+    ];
+
+    for t in test_cases {
+        let mut params = vec![("q", t.query)];
+        if let Some(db) = t.database {
+            params.push(("db", db));
+        }
+        if let Some(epoch) = t.epoch {
+            params.push(("epoch", epoch));
+        }
+        let resp = server
+            .api_v1_query(&params)
+            .await
+            .json::<Value>()
+            .await
+            .unwrap();
+        println!("\n{q}", q = t.query);
+        println!("{resp:#}");
         assert_eq!(t.expected, resp, "query failed: {q}", q = t.query);
     }
 }

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1,4 +1,5 @@
 use crate::TestServer;
+use futures::StreamExt;
 use influxdb3_client::Precision;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
@@ -439,5 +440,234 @@ async fn api_v1_query() {
         println!("\n{q}", q = t.query);
         println!("{resp:#}");
         assert_eq!(t.expected, resp, "query failed: {q}", q = t.query);
+    }
+}
+
+#[tokio::test]
+async fn api_v1_query_chunked() {
+    let server = TestServer::spawn().await;
+
+    server
+        .write_lp_to_db(
+            "foo",
+            "cpu,host=a usage=0.9 1\n\
+            cpu,host=a usage=0.89 2\n\
+            cpu,host=a usage=0.85 3\n\
+            mem,host=a usage=0.5 4\n\
+            mem,host=a usage=0.6 5\n\
+            mem,host=a usage=0.7 6",
+            Precision::Second,
+        )
+        .await
+        .unwrap();
+
+    struct TestCase<'a> {
+        chunk_size: Option<&'a str>,
+        query: &'a str,
+        expected: Vec<Value>,
+    }
+
+    let test_cases = [
+        // Basic Query with default chunking:
+        TestCase {
+            chunk_size: None,
+            query: "SELECT * FROM cpu",
+            expected: vec![json!({
+              "results": [
+                {
+                  "series": [
+                    {
+                      "name": "cpu",
+                      "columns": ["time","host","usage"],
+                      "values": [
+                        [1, "a", 0.9],
+                        [2, "a", 0.89],
+                        [3, "a", 0.85]
+                      ]
+                    }
+                  ],
+                  "statement_id": 0
+                }
+              ]
+            })],
+        },
+        // Basic Query with chunk size:
+        TestCase {
+            chunk_size: Some("2"),
+            query: "SELECT * FROM cpu",
+            expected: vec![
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "cpu",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [1, "a", 0.9],
+                            [2, "a", 0.89],
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "cpu",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [3, "a", 0.85]
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+            ],
+        },
+        // Query with multiple measurements and default chunking:
+        TestCase {
+            chunk_size: None,
+            query: "SELECT * FROM cpu, mem",
+            expected: vec![
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "cpu",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [1, "a", 0.9],
+                            [2, "a", 0.89],
+                            [3, "a", 0.85]
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "mem",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [4, "a", 0.5],
+                            [5, "a", 0.6],
+                            [6, "a", 0.7]
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+            ],
+        },
+        // Query with multiple measurements and chunk_size specified:
+        TestCase {
+            chunk_size: Some("2"),
+            query: "SELECT * FROM cpu, mem",
+            expected: vec![
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "cpu",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [1, "a", 0.9],
+                            [2, "a", 0.89],
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "cpu",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [3, "a", 0.85]
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "mem",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [4, "a", 0.5],
+                            [5, "a", 0.6],
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+                json!({
+                  "results": [
+                    {
+                      "series": [
+                        {
+                          "name": "mem",
+                          "columns": ["time","host","usage"],
+                          "values": [
+                            [6, "a", 0.7]
+                          ]
+                        }
+                      ],
+                      "statement_id": 0
+                    }
+                  ]
+                }),
+            ],
+        },
+    ];
+
+    for t in test_cases {
+        let mut params = vec![
+            ("db", "foo"),
+            ("q", t.query),
+            ("epoch", "s"),
+            ("chunked", "true"),
+        ];
+        if let Some(chunk_size) = t.chunk_size {
+            params.push(("chunk_size", chunk_size));
+        }
+        let stream = server.api_v1_query(&params).await.bytes_stream();
+        let values = stream
+            .map(|chunk| {
+                println!("{chunk:?}");
+                serde_json::from_slice(chunk.unwrap().as_ref()).unwrap()
+            })
+            .collect::<Vec<Value>>()
+            .await;
+        println!("\n{q}", q = t.query);
+        assert_eq!(t.expected, values, "query failed: {q}", q = t.query);
     }
 }

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -32,6 +32,7 @@ influxdb3_write = { path = "../influxdb3_write" }
 iox_query_influxql_rewrite = { path = "../iox_query_influxql_rewrite" }
 
 # crates.io Dependencies
+anyhow.workspace = true
 arrow.workspace = true
 arrow-csv.workspace = true
 arrow-flight.workspace = true
@@ -49,6 +50,7 @@ hyper.workspace = true
 object_store.workspace = true
 parking_lot.workspace = true
 pin-project-lite.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_arrow.workspace = true
 serde_json.workspace = true

--- a/influxdb3_server/src/auth.rs
+++ b/influxdb3_server/src/auth.rs
@@ -26,9 +26,9 @@ impl Authorizer for AllOrNothingAuthorizer {
         debug!(?perms, "requesting permissions");
         let provided = token.as_deref().ok_or(Error::NoToken)?;
         if Sha512::digest(provided)[..] == self.token {
-            warn!("invalid token provided");
             Ok(perms.to_vec())
         } else {
+            warn!("invalid token provided");
             Err(Error::InvalidToken)
         }
     }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -10,6 +10,7 @@ use data_types::NamespaceName;
 use datafusion::error::DataFusionError;
 use datafusion::execution::memory_pool::UnboundedMemoryPool;
 use datafusion::execution::RecordBatchStream;
+use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
 use hyper::header::ACCEPT;
 use hyper::header::AUTHORIZATION;
@@ -40,6 +41,8 @@ use std::string::FromUtf8Error;
 use std::sync::Arc;
 use thiserror::Error;
 use unicode_segmentation::UnicodeSegmentation;
+
+mod v1;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -187,6 +190,9 @@ pub enum Error {
         from your request"
     )]
     InfluxqlDatabaseMismatch { param_db: String, query_db: String },
+
+    #[error("v1 query API error: {0}")]
+    V1Query(#[from] v1::QueryError),
 }
 
 #[derive(Debug, Error)]
@@ -364,51 +370,7 @@ where
 
         info!(?database, %query_str, ?format, "handling query_influxql");
 
-        let mut statements = rewrite::parse_statements(&query_str)?;
-
-        if statements.len() != 1 {
-            return Err(Error::InfluxqlSingleStatement);
-        }
-        let statement = statements.pop().unwrap();
-
-        let database = match (database, statement.resolve_dbrp()) {
-            (None, None) => None,
-            (None, Some(db)) | (Some(db), None) => Some(db),
-            (Some(p), Some(q)) => {
-                if p == q {
-                    Some(p)
-                } else {
-                    return Err(Error::InfluxqlDatabaseMismatch {
-                        param_db: p,
-                        query_db: q,
-                    });
-                }
-            }
-        };
-
-        let stream = if statement.statement().is_show_databases() {
-            self.query_executor.show_databases()?
-        } else if statement.statement().is_show_retention_policies() {
-            self.query_executor
-                .show_retention_policies(database.as_deref(), None)
-                .await?
-        } else {
-            let Some(database) = database else {
-                return Err(Error::InfluxqlNoDatabase);
-            };
-
-            self.query_executor
-                .query(
-                    &database,
-                    // TODO - implement an interface that takes the statement directly,
-                    // so we don't need to double down on the parsing
-                    &statement.to_statement().to_string(),
-                    QueryKind::InfluxQl,
-                    None,
-                    None,
-                )
-                .await?
-        };
+        let stream = self.query_influxql_inner(database, &query_str).await?;
 
         Response::builder()
             .status(StatusCode::OK)
@@ -525,6 +487,63 @@ where
         req.extensions_mut()
             .insert(AuthorizationHeaderExtension::new(auth));
         Ok(())
+    }
+
+    /// Inner function for performing InfluxQL queries
+    ///
+    /// This is used by both the `/api/v3/query_influxql` and `/api/v1/query`
+    /// APIs.
+    async fn query_influxql_inner(
+        &self,
+        database: Option<String>,
+        query_str: &str,
+    ) -> Result<SendableRecordBatchStream> {
+        let mut statements = rewrite::parse_statements(query_str)?;
+
+        if statements.len() != 1 {
+            return Err(Error::InfluxqlSingleStatement);
+        }
+        let statement = statements.pop().unwrap();
+
+        let database = match (database, statement.resolve_dbrp()) {
+            (None, None) => None,
+            (None, Some(db)) | (Some(db), None) => Some(db),
+            (Some(p), Some(q)) => {
+                if p == q {
+                    Some(p)
+                } else {
+                    return Err(Error::InfluxqlDatabaseMismatch {
+                        param_db: p,
+                        query_db: q,
+                    });
+                }
+            }
+        };
+
+        if statement.statement().is_show_databases() {
+            self.query_executor.show_databases()
+        } else if statement.statement().is_show_retention_policies() {
+            self.query_executor
+                .show_retention_policies(database.as_deref(), None)
+                .await
+        } else {
+            let Some(database) = database else {
+                return Err(Error::InfluxqlNoDatabase);
+            };
+
+            self.query_executor
+                .query(
+                    &database,
+                    // TODO - implement an interface that takes the statement directly,
+                    // so we don't need to double down on the parsing
+                    &statement.to_statement().to_string(),
+                    QueryKind::InfluxQl,
+                    None,
+                    None,
+                )
+                .await
+        }
+        .map_err(Into::into)
     }
 }
 
@@ -738,6 +757,7 @@ where
         (Method::GET | Method::POST, "/api/v3/query_influxql") => {
             http_server.query_influxql(req).await
         }
+        (Method::GET, "/api/v1/query") => http_server.v1_query(req).await,
         (Method::GET, "/health") => http_server.health(),
         (Method::GET, "/metrics") => http_server.handle_metrics(),
         (Method::GET, "/debug/pprof") => pprof_home(req).await,

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -806,7 +806,7 @@ where
             http_server.query_influxql(req).await
         }
         (Method::GET, "/api/v1/query") => http_server.v1_query(req).await,
-        (Method::GET, "/health") => http_server.health(),
+        (Method::GET, "/health" | "/api/v1/health") => http_server.health(),
         (Method::GET, "/metrics") => http_server.handle_metrics(),
         (Method::GET, "/debug/pprof") => pprof_home(req).await,
         (Method::GET, "/debug/pprof/profile") => pprof_profile(req).await,

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -298,7 +299,7 @@ impl QueryResponseStream {
                         cast_with_options(column, &DataType::Int64, &CastOptions::default())
                             .unwrap()
                     } else {
-                        column.clone()
+                        Arc::clone(column)
                     },
                 )
             }))

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -54,11 +54,7 @@ where
             "handle v1 query API"
         );
 
-        let chunk_size = if chunked {
-            chunk_size.or(Some(DEFAULT_CHUNK_SIZE))
-        } else {
-            None
-        };
+        let chunk_size = chunked.then(|| chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE));
 
         let stream = self.query_influxql_inner(database, &query).await?;
         let stream = QueryResponseStream::new(0, stream, chunk_size, pretty, epoch)

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -295,7 +295,7 @@ impl QueryResponseStream {
                 (
                     name,
                     if name == TIME_COLUMN_NAME {
-                        // unwrap is safe here because the time column can cast cheaply to Int64
+                        // unwrap should be safe here because the time column cast to Int64
                         cast_with_options(column, &DataType::Int64, &CastOptions::default())
                             .unwrap()
                     } else {

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -1,0 +1,297 @@
+use std::{
+    collections::HashMap,
+    iter,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use anyhow::Context as AnyhowContext;
+use arrow::record_batch::RecordBatch;
+use arrow_json::writer::record_batches_to_json_rows;
+use bytes::{Bytes, BytesMut};
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::{ready, Stream, StreamExt};
+use hyper::{Body, Request, Response};
+use influxdb3_write::WriteBuffer;
+use observability_deps::tracing::debug;
+use secrecy::Secret;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::QueryExecutor;
+
+use super::{Error, HttpApi, Result};
+
+const DEFAULT_CHUNK_SIZE: usize = 10_000;
+
+impl<W, Q> HttpApi<W, Q>
+where
+    W: WriteBuffer,
+    Q: QueryExecutor,
+    Error: From<<Q as QueryExecutor>::Error>,
+{
+    pub(super) async fn v1_query(&self, req: Request<Body>) -> Result<Response<Body>> {
+        // TODO - password should be validated upstream of this, and not be
+        // available here.
+        let QueryParams {
+            chunk_size,
+            chunked,
+            database,
+            epoch,
+            password,
+            pretty,
+            query,
+        } = QueryParams::from_request(&req)?;
+        debug!(
+            ?chunk_size,
+            chunked,
+            ?database,
+            query,
+            "handle v1 query API"
+        );
+
+        let chunk_size = if chunked {
+            chunk_size.or(Some(DEFAULT_CHUNK_SIZE))
+        } else {
+            None
+        };
+
+        let stream = self.query_influxql_inner(database, &query).await?;
+        let stream =
+            StatementResultStream::new(0, stream, chunk_size).map_err(QueryError::Unexpected)?;
+        let body = Body::wrap_stream(stream);
+
+        Ok(Response::builder().status(200).body(body).unwrap())
+    }
+}
+
+/// Query parameters for the v1/query API
+///
+/// The original API supports a `u` parameter, for "username", but
+/// we ignore this.
+#[derive(Debug, Deserialize)]
+struct QueryParams {
+    #[serde(default)]
+    chunked: bool,
+    chunk_size: Option<usize>,
+    #[serde(rename = "db")]
+    database: Option<String>,
+    epoch: Option<Precision>,
+    #[serde(rename = "p")]
+    password: Option<Secret<String>>,
+    #[serde(default)]
+    pretty: bool,
+    #[serde(rename = "q")]
+    query: String,
+}
+
+impl QueryParams {
+    fn from_request(req: &Request<Body>) -> Result<Self> {
+        let query = req.uri().query().ok_or(Error::MissingQueryParams)?;
+        serde_urlencoded::from_str(query).map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+enum Precision {
+    #[serde(rename = "ns")]
+    Nanoseconds,
+    #[serde(rename = "u", alias = "µ")]
+    Microseconds,
+    #[serde(rename = "ms")]
+    Milliseconds,
+    #[serde(rename = "s")]
+    Seconds,
+    #[serde(rename = "m")]
+    Minutes,
+    #[serde(rename = "h")]
+    Hours,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    #[error("unexpected query error: {0}")]
+    Unexpected(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Serialize)]
+struct QueryResponse {
+    results: Vec<StatementResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct StatementResult {
+    statement_id: usize,
+    series: Vec<Series>,
+}
+
+impl From<StatementResult> for Bytes {
+    fn from(s: StatementResult) -> Self {
+        let mut b = serde_json::to_vec(&s).unwrap();
+        b.extend_from_slice(b"\n");
+        b.into()
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Series {
+    name: String,
+    columns: Vec<String>,
+    values: Vec<Row>,
+}
+
+#[derive(Debug, Serialize)]
+struct Row(Vec<Value>);
+
+struct StatementResultStream {
+    chunk_name: Option<String>,
+    chunk_columns: Vec<String>,
+    chunk_buffer: Vec<Row>,
+    chunk_pos: usize,
+    chunk_size: usize,
+    current_batch: Option<RecordBatch>,
+    input: SendableRecordBatchStream,
+    statement_id: usize,
+}
+
+impl StatementResultStream {
+    fn new(
+        statement_id: usize,
+        input: SendableRecordBatchStream,
+        chunk_size: Option<usize>,
+    ) -> Result<Self, anyhow::Error> {
+        let chunk_buffer = chunk_size
+            .map(|size| Vec::with_capacity(size))
+            .unwrap_or_else(|| Vec::new());
+        let chunk_size = chunk_size.unwrap_or(usize::MAX);
+        let schema = input.schema();
+        debug!(?schema, "input schema");
+        let chunk_columns = schema
+            .fields()
+            .into_iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        Ok(Self {
+            chunk_name: None,
+            chunk_columns,
+            chunk_buffer,
+            chunk_pos: 0,
+            chunk_size,
+            current_batch: None,
+            input,
+            statement_id,
+        })
+    }
+
+    fn stream_batch(&mut self, batch: RecordBatch) -> Result<(), anyhow::Error> {
+        let batch_row_count = batch.num_rows();
+        let batch_offset = 0;
+        let batch_slice_length =
+            (self.chunk_size - self.chunk_pos).min(batch_row_count - batch_offset);
+        let base = self.chunk_pos;
+        debug!(?batch, %batch_offset, %batch_row_count, %batch_slice_length, %base, "stream batch");
+        let batch_slice = batch.slice(batch_offset, batch_slice_length);
+        self.chunk_pos = self.chunk_pos + batch_slice_length;
+        let json_rows = record_batches_to_json_rows(&[&batch_slice])
+            .context("failed to convert RecordBatch slice to JSON")?;
+        let column_positions =
+            self.chunk_columns
+                .iter()
+                .enumerate()
+                .fold(HashMap::new(), |mut acc, (j, name)| {
+                    acc.insert(name.to_owned(), j);
+                    acc
+                });
+        let mut name = None;
+        for json_row in json_rows {
+            let mut row: Vec<Value> = iter::repeat(Value::Null)
+                .take(column_positions.len().checked_sub(1).unwrap_or(0))
+                .collect();
+            debug!(?row, "new row");
+            json_row.into_iter().for_each(|(k, v)| {
+                debug!(key = %k, value = %v, ?column_positions, "JSON Row");
+                if k == "iox::measurement" {
+                    name.replace(v.as_str().unwrap().to_owned());
+                } else {
+                    let j = column_positions.get(&k).unwrap();
+                    row[*j - 1] = v;
+                }
+            });
+            debug!(?row, "updated row");
+            self.chunk_buffer.push(Row(row));
+        }
+        if let Some(name) = name {
+            self.chunk_name.replace(name);
+        }
+        let new_batch_offset = batch_offset + batch_slice_length;
+        if new_batch_offset < batch.num_rows() {
+            self.current_batch
+                .replace(batch.slice(new_batch_offset, batch.num_rows() - new_batch_offset));
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> StatementResult {
+        let series = vec![Series {
+            name: self.chunk_name.clone().unwrap(),
+            columns: self
+                .chunk_columns
+                .iter()
+                .filter_map(|c| {
+                    if c == "iox::measurement" {
+                        None
+                    } else {
+                        Some(c)
+                    }
+                })
+                .cloned()
+                .collect(),
+            values: self.chunk_buffer.drain(..).collect(),
+        }];
+        self.chunk_pos = 0;
+        StatementResult {
+            statement_id: self.statement_id,
+            series,
+        }
+    }
+}
+
+impl Stream for StatementResultStream {
+    type Item = Result<StatementResult, anyhow::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Check if there is any records left in the current batch, we want to stream them
+        // before polling the input stream for more...
+        if let Some(batch) = self.current_batch.take() {
+            if let Err(e) = self.stream_batch(batch) {
+                return Poll::Ready(Some(Err(e)));
+            }
+            if !self.chunk_buffer.is_empty() && self.chunk_buffer.len() == self.chunk_size {
+                return Poll::Ready(Some(Ok(self.flush())));
+            }
+        }
+        match ready!(self.input.poll_next_unpin(cx)) {
+            Some(Ok(batch)) => {
+                if let Err(e) = self.stream_batch(batch) {
+                    return Poll::Ready(Some(Err(e)));
+                }
+                if self.chunk_buffer.len() < self.chunk_size {
+                    // We don't have a full chunk yet, hold data in the buffer and continue polling:
+                    Poll::Pending
+                } else {
+                    // We have a full chunk, so flush and return it:
+                    Poll::Ready(Some(Ok(self.flush())))
+                }
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
+            None => {
+                // If the input stream is done, make sure to flush what is left in the buffer:
+                if !self.chunk_buffer.is_empty() {
+                    Poll::Ready(Some(Ok(self.flush())))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+        }
+    }
+}

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -1,20 +1,25 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     pin::Pin,
     task::{Context, Poll},
 };
 
 use anyhow::Context as AnyhowContext;
-use arrow::{compute::cast_with_options, record_batch::RecordBatch};
+use arrow::{
+    compute::{cast_with_options, CastOptions},
+    record_batch::RecordBatch,
+};
 use arrow_json::writer::record_batches_to_json_rows;
 
+use arrow_schema::DataType;
 use bytes::Bytes;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{ready, stream::Fuse, Stream, StreamExt};
 use hyper::{Body, Request, Response};
 use influxdb3_write::WriteBuffer;
 use iox_time::TimeProvider;
-use observability_deps::tracing::{self, debug, trace};
+use observability_deps::tracing::debug;
+use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, TIME_COLUMN_NAME};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -36,7 +41,6 @@ where
             chunk_size,
             chunked,
             database,
-            // TODO - support conversion to epoch times
             epoch,
             pretty,
             query,
@@ -152,12 +156,65 @@ struct Series {
 #[derive(Debug, Serialize)]
 struct Row(Vec<Value>);
 
+struct ChunkBuffer {
+    size: Option<usize>,
+    series: VecDeque<(String, Vec<Row>)>,
+}
+
+impl ChunkBuffer {
+    fn new(size: Option<usize>) -> Self {
+        Self {
+            size,
+            series: VecDeque::new(),
+        }
+    }
+
+    fn current_measurement_name(&self) -> Option<&str> {
+        self.series.front().map(|(n, _)| n.as_str())
+    }
+
+    fn push_next_measurement<S: Into<String>>(&mut self, name: S) {
+        self.series.push_front((name.into(), vec![]));
+    }
+
+    fn push_row(&mut self, row: Row) -> Result<(), anyhow::Error> {
+        self.series
+            .front_mut()
+            .context("tried to push row with no measurements buffered")?
+            .1
+            .push(row);
+        Ok(())
+    }
+
+    fn flush_measurement(&mut self) -> Option<(String, Vec<Row>)> {
+        self.series.pop_back()
+    }
+
+    fn should_flush(&self) -> bool {
+        if let (Some(size), Some(m)) = (self.size, self.series.front()) {
+            m.1.len() >= size || self.series.len() > 1
+        } else {
+            false
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.series.is_empty()
+    }
+
+    fn calculate_batch_slice_len(&self, batch_row_count: usize) -> usize {
+        if let (Some(size), Some(m)) = (self.size, self.series.front()) {
+            size.checked_sub(m.1.len())
+                .unwrap_or(batch_row_count)
+                .min(batch_row_count)
+        } else {
+            batch_row_count
+        }
+    }
+}
+
 struct QueryResponseStream {
-    chunk_name: Option<String>,
-    chunk_name_next: Option<String>,
-    chunk_buffer: Vec<Row>,
-    chunk_pos: usize,
-    chunk_size: usize,
+    buffer: ChunkBuffer,
     current_batch: Option<RecordBatch>,
     input: Fuse<SendableRecordBatchStream>,
     column_map: HashMap<String, usize>,
@@ -165,8 +222,6 @@ struct QueryResponseStream {
     pretty: bool,
     epoch: Option<Precision>,
 }
-
-const IOX_MEASUREMENT_KEY: &str = "iox::measurement";
 
 impl QueryResponseStream {
     fn new(
@@ -176,10 +231,7 @@ impl QueryResponseStream {
         pretty: bool,
         epoch: Option<Precision>,
     ) -> Result<Self, anyhow::Error> {
-        let chunk_buffer = chunk_size
-            .map(|size| Vec::with_capacity(size))
-            .unwrap_or_else(|| Vec::new());
-        let chunk_size = chunk_size.unwrap_or(usize::MAX);
+        let buffer = ChunkBuffer::new(chunk_size);
         let schema = input.schema();
         let column_map = schema
             .fields
@@ -187,7 +239,7 @@ impl QueryResponseStream {
             .map(|f| f.name().to_owned())
             .enumerate()
             .flat_map(|(i, n)| {
-                if n != IOX_MEASUREMENT_KEY && i > 0 {
+                if n != INFLUXQL_MEASUREMENT_COLUMN_NAME && i > 0 {
                     Some((n, i - 1))
                 } else {
                     None
@@ -195,11 +247,7 @@ impl QueryResponseStream {
             })
             .collect();
         Ok(Self {
-            chunk_buffer,
-            chunk_name: None,
-            chunk_name_next: None,
-            chunk_pos: 0,
-            chunk_size,
+            buffer,
             column_map,
             current_batch: None,
             input: input.fuse(),
@@ -209,25 +257,19 @@ impl QueryResponseStream {
         })
     }
 
-    #[tracing::instrument(level = "TRACE", skip_all, ret, err)]
-    fn stream_batch(&mut self, batch: RecordBatch) -> Result<bool, anyhow::Error> {
-        let batch_row_count = batch.num_rows();
-        let batch_slice_length = (self.chunk_size - self.chunk_pos).min(batch_row_count);
+    fn stream_batch(&mut self, batch: RecordBatch) -> Result<(), anyhow::Error> {
+        let batch_slice_length = self.buffer.calculate_batch_slice_len(batch.num_rows());
         let mut batch_slice = batch.slice(0, batch_slice_length);
-        self.chunk_pos = self.chunk_pos + batch_slice_length;
         if self.epoch.is_some() {
             batch_slice = RecordBatch::try_from_iter(batch_slice.schema().fields.iter().map(|f| {
                 let name = f.name();
                 let column = batch.column_by_name(name).unwrap();
                 (
                     name,
-                    if name == "time" {
-                        cast_with_options(
-                            column,
-                            &arrow_schema::DataType::Int64,
-                            &Default::default(),
-                        )
-                        .unwrap()
+                    if name == TIME_COLUMN_NAME {
+                        // unwrap is safe here because the time column can cast cheaply to Int64
+                        cast_with_options(column, &DataType::Int64, &CastOptions::default())
+                            .unwrap()
                     } else {
                         column.clone()
                     },
@@ -237,47 +279,50 @@ impl QueryResponseStream {
         }
         let json_rows = record_batches_to_json_rows(&[&batch_slice])
             .context("failed to convert RecordBatch slice to JSON")?;
-        for (i, json_row) in json_rows.into_iter().enumerate() {
+        for json_row in json_rows {
             let mut row = vec![Value::Null; self.column_map.len()];
             for (k, v) in json_row {
-                if k == IOX_MEASUREMENT_KEY && self.chunk_name.is_none() {
-                    trace!(k, ?v, "setting measurement name for first time");
-                    self.chunk_name.replace(
-                        v.as_str()
-                            .context("iox::measurement value was not a string")?
-                            .to_string(),
-                    );
-                } else if k == IOX_MEASUREMENT_KEY
-                    && self.chunk_name.as_ref().is_some_and(|n| *n != v)
+                if k == INFLUXQL_MEASUREMENT_COLUMN_NAME
+                    && self.buffer.current_measurement_name().is_none()
                 {
-                    trace!(k, ?v, "updating measurement name");
-                    // we are starting a new measurement, so we want to stop here, and flush
-                    // what is currently in the buffer for the previous measurement before
-                    // streaming from this point on
-                    self.current_batch
-                        .replace(batch.slice(i, batch.num_rows() - i));
-                    self.chunk_name_next.replace(v.as_str().unwrap().to_owned());
-                    return Ok(true);
-                } else if k == IOX_MEASUREMENT_KEY {
-                    trace!(k, ?v, "ignoring measurement name");
+                    self.buffer.push_next_measurement(
+                        v.as_str()
+                            .context("iox::measurement value was not a string")?,
+                    );
+                } else if k == INFLUXQL_MEASUREMENT_COLUMN_NAME
+                    && self
+                        .buffer
+                        .current_measurement_name()
+                        .is_some_and(|n| *n != v)
+                {
+                    // here we are starting on the next measurement, so push it into the buffer
+                    self.buffer
+                        .push_next_measurement(v.as_str().unwrap().to_owned());
+                } else if k == INFLUXQL_MEASUREMENT_COLUMN_NAME {
                     continue;
                 } else {
-                    trace!(k, ?v, "setting column value");
                     let j = self.column_map.get(&k).unwrap();
-                    row[*j] = if let (Some(precision), "time") = (self.epoch, k.as_str()) {
+                    row[*j] = if let (Some(precision), TIME_COLUMN_NAME) = (self.epoch, k.as_str())
+                    {
                         convert_ns_epoch(v, precision)?
                     } else {
                         v
                     };
                 }
             }
-            self.chunk_buffer.push(Row(row));
+            self.buffer.push_row(Row(row))?;
         }
+        debug!(
+            batch_slice_length,
+            batch_num_rows = batch.num_rows(),
+            "done streaming"
+        );
         if batch_slice_length < batch.num_rows() {
+            debug!("replacing");
             self.current_batch
                 .replace(batch.slice(batch_slice_length, batch.num_rows() - batch_slice_length));
         }
-        Ok(false)
+        Ok(())
     }
 
     fn flush(&mut self) -> Result<QueryResponse, anyhow::Error> {
@@ -285,19 +330,38 @@ impl QueryResponseStream {
         self.column_map
             .iter()
             .for_each(|(k, i)| columns[*i] = k.to_owned());
-        let name = if let Some(n) = self.chunk_name_next.take() {
-            self.chunk_name.replace(n)
-        } else {
-            self.chunk_name.clone()
-        }
-        .context("missing iox::measurement name on flush")?;
+        let (name, values) = self
+            .buffer
+            .flush_measurement()
+            .context("no values to flush")?;
         let series = vec![Series {
             name,
             columns,
-            values: self.chunk_buffer.drain(..).collect(),
+            values,
         }];
         // reset the chunk position:
-        self.chunk_pos = 0;
+        Ok(QueryResponse {
+            results: vec![StatementResponse {
+                statement_id: self.statement_id,
+                series,
+            }],
+            pretty: self.pretty,
+        })
+    }
+
+    fn flush_all(&mut self) -> Result<QueryResponse, anyhow::Error> {
+        let mut columns = vec!["".to_string(); self.column_map.len()];
+        self.column_map
+            .iter()
+            .for_each(|(k, i)| columns[*i] = k.to_owned());
+        let mut series = Vec::new();
+        while let Some((name, values)) = self.buffer.flush_measurement() {
+            series.push(Series {
+                name,
+                columns: columns.clone(),
+                values,
+            });
+        }
         Ok(QueryResponse {
             results: vec![StatementResponse {
                 statement_id: self.statement_id,
@@ -330,46 +394,41 @@ impl Stream for QueryResponseStream {
         // Check if there are any records left in the current batch, we want to buffer them
         // into the current chunk and potentially stream them before polling the input stream
         if let Some(batch) = self.current_batch.take() {
-            match self.stream_batch(batch) {
-                Ok(true) => return Poll::Ready(Some(self.flush())),
-                Ok(false) => (),
-                Err(e) => return Poll::Ready(Some(Err(e))),
+            debug!(?batch, "stream current batch");
+            if let Err(e) = self.stream_batch(batch) {
+                return Poll::Ready(Some(Err(e)));
             }
-            if !self.chunk_buffer.is_empty() && self.chunk_buffer.len() == self.chunk_size {
+            if self.buffer.should_flush() {
+                debug!("flush current batch");
                 return Poll::Ready(Some(self.flush()));
             }
         }
         match ready!(self.input.poll_next_unpin(cx)) {
             Some(Ok(batch)) => {
-                debug!(?batch, "received batch from input stream");
-                match self.stream_batch(batch) {
-                    Ok(true) => return Poll::Ready(Some(self.flush())),
-                    Ok(false) => (),
-                    Err(e) => return Poll::Ready(Some(Err(e))),
+                debug!(?batch, "stream input batch");
+                if let Err(e) = self.stream_batch(batch) {
+                    return Poll::Ready(Some(Err(e)));
                 }
-                if self.chunk_buffer.len() < self.chunk_size {
-                    debug!("chunk buffer is not full yet");
-                    // We don't have a full chunk yet, hold data in the buffer and continue polling:
+                if self.buffer.should_flush() {
+                    debug!("flush recent batch");
+                    Poll::Ready(Some(self.flush()))
+                } else {
+                    debug!("pending");
                     cx.waker().wake_by_ref();
                     Poll::Pending
-                } else {
-                    debug!("chunk buffer is ready to flush");
-                    // We have a full chunk, so flush and return it:
-                    Poll::Ready(Some(self.flush()))
                 }
             }
             Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
             None => {
-                debug!("input stream is empty");
                 // If we have data remaining in the buffer, we need to flush one more time,
                 // returning Some(...), and then when the stream gets polled again, the chunk
                 // buffer will be empty, and we return None.
                 //
                 // This is the reason the input stream is fused, because we may end up polling
                 // again after it has finished.
-                if !self.chunk_buffer.is_empty() {
+                if !self.buffer.is_empty() {
                     debug!("flushing buffer");
-                    Poll::Ready(Some(self.flush()))
+                    Poll::Ready(Some(self.flush_all()))
                 } else {
                     debug!("we are done");
                     Poll::Ready(None)

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -231,7 +231,7 @@ impl ChunkBuffer {
 }
 
 /// A wrapper around a [`SendableRecordBatchStream`] that buffers streamed
-/// [`RecordBatches`] and outputs [`QueryResponse`]s
+/// [`RecordBatch`]es and outputs [`QueryResponse`]s
 ///
 /// Can operate in `chunked` mode, in which case, the `chunk_size` provided
 /// will determine how often [`QueryResponse`]s are emitted. When not in


### PR DESCRIPTION
Part of #24740 

This PR adds support for the `/api/v1/query` API, which is meant to serve the original InfluxDB v1 query API (see [docs](https://docs.influxdata.com/influxdb/v1/tools/api/#query-http-endpoint)), to serve single statement `SELECT` and `SHOW` queries. The response, which is returned as JSON, can be chunked via the `chunked` and optional `chunk_size` parameters (_see below_). An optional `epoch` parameter can be supplied to have `time` column timestamps converted to a UNIX epoch with the given precision.

## Buffering

The response is buffered by default, but if the `chunked` parameter is not supplied, or is passed as `false`, then the entire query result will be buffered into memory before being returned in the response. This is how the original API behaves, so we are replicating that here.

When `chunked` is passed as `true`, then the response will be a stream of chunks, where each chunk is a self-contained response, with the same structure as that of the non-chunked response. Chunks are split up by the provided `chunk_size`, or by series, i.e., measurement, which ever comes first. The default chunk size is 10,000 rows.

Buffering is implemented with the `QueryResponseStream` and `ChunkBuffer` types, the former implements the `Stream` trait, which allows it to be streamed in the HTTP response directly with `hyper`'s [`Body::wrap_stream`](https://docs.rs/hyper/0.14.28/hyper/body/struct.Body.html#method.wrap_stream). The `QueryResponseStream` is a wrapper around the inner arrow `RecordBatchStream`, which buffers the streamed `RecordBatch`es according to the requested chunking parameters.

## Testing

Two new E2E tests were added to test basic query functionality and chunking behaviour, respectively. In addition, some manual testing was done to verify that the InfluxDB Grafana plugin works with this API.