### PR TITLE
feat: build binaries and Docker images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,13 @@ jobs:
   publish-packages:
     docker:
       - image: cimg/python:3.6
+    parameters:
+      # "destination" should be one of:
+      #   - releases
+      #   - nightlies
+      #   - snapshots
+      destination:
+        type: string
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -427,7 +434,7 @@ jobs:
           aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
           aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
           from:                  /tmp/workspace/artifacts
-          to:                    s3://dl.influxdata.com/influxdb/releases
+          to:                    s3://dl.influxdata.com/influxdb/<< parameters.destination >>
   build-docker:
     # need a machine executor to have a full-powered docker daemon (the `setup_remote_docker` system just provides a
     # kinda small node)
@@ -554,6 +561,10 @@ workflows:
       - publish-packages:
           # <<: *release_filter
           <<: *any_filter
+          matrix:
+            parameters:
+              # Temporary change this to releases when done with PR
+              destination: [ snapshots ]
           requires:
             - build-release
             - sign-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,6 @@ nofork_filter: &nofork_filter
 
 
 commands:
-  install_rust:
-
   rust_components:
     description: Verify installed components
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
-          for target in /tmp/workspace/artifacts/*
+          # We need this base so that we can filter it out of our checksums
+          # output and if that changes at all we only need to update it here
+          WORK_DIR="/tmp/workspace/artifacts/"
+          for target in ${WORK_DIR}*
           do
             case "${target}"
             in
@@ -402,11 +405,11 @@ jobs:
               # Since all artifacts are present, sign them here. This saves Circle
               # credits over spinning up another instance just to separate out the
               # checksum job.
-              sha256sum "${target}" >> "/tmp/workspace/artifacts/influxdb3-edge.${CIRCLE_TAG}.digests"
+              sha256sum "${target}" | sed "s#$WORK_DIR##" >> "/tmp/workspace/artifacts/influxdb3-edge.${CIRCLE_TAG}.digests"
 
               # write individual checksums
-              md5sum    "${target}" >> "${target}.md5"
-              sha256sum "${target}" >> "${target}.sha256"
+              md5sum    "${target}" | sed "s#$WORK_DIR##" >> "${target}.md5"
+              sha256sum "${target}" | sed "s#$WORK_DIR##" >> "${target}.sha256"
             fi
           done
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ jobs:
             - artifacts
   build-packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager:latest
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next:latest
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
           path: /tmp/workspace/artifacts
   publish-packages:
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.12.2
     parameters:
       # "destination" should be one of:
       #   - releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,41 @@
 
 version: 2.1
 
+orbs:
+  aws-s3:    circleci/aws-s3@2.0.0
+  terraform: circleci/terraform@2.1.0
+  rust: circleci/rust@1.6.1
+
+# Unlike when a commit is pushed to a branch, CircleCI does not automatically
+# execute a workflow when a tag is pushed to a repository. These filters
+# allow the corresponding workflow to execute on any branch or tag.
+any_filter: &any_filter
+  filters:
+    tags:
+      only: /.*/
+    branches:
+      only: /.*/
+
+release_filter: &release_filter
+  filters:
+    tags:
+      # This regex matches what is found in 'scripts/get-version' with the
+      # '[[:digit:]]' transformed into '\d'. This also excludes release
+      # candidate detection, because this filter only matches against
+      # full releases.
+      only: /^v(\d+)(?:\.(\d+))?(?:\.(\d+))?$/
+    branches:
+      ignore: /.*/
+
+nofork_filter: &nofork_filter
+  filters:
+    branches:
+      ignore: /pull\/[0-9]+/
+
+
 commands:
+  install_rust:
+
   rust_components:
     description: Verify installed components
     steps:
@@ -46,15 +80,12 @@ commands:
             rustup show
             cargo fmt --version
             cargo clippy --version
-
-  login_to_gcloud:
+  gcloud-docker-login:
     steps:
       - run:
-          name: Login to gcloud
+          name: configure-gar
           command: |
-            echo "${GCLOUD_SERVICE_ACCOUNT_KEY}" >/tmp/gcloud.json
-            gcloud auth activate-service-account "${GCLOUD_SERVICE_ACCOUNT_EMAIL}" --key-file /tmp/gcloud.json --quiet
-            rm -f /tmp/gcloud.json
+            gcloud auth activate-service-account "${GCLOUD_SERVICE_ACCOUNT_EMAIL}" --key-file <(echo "${GCLOUD_SERVICE_ACCOUNT_KEY}")
             gcloud auth configure-docker us-docker.pkg.dev
 
 jobs:
@@ -95,7 +126,7 @@ jobs:
       - run:
           name: Yamllint
           command: yamllint --config-file .circleci/yamllint.yml --strict .
-  cargo_audit:
+  cargo-audit:
     docker:
       - image: quay.io/influxdb/rust:ci
     environment:
@@ -163,7 +194,7 @@ jobs:
           command: cargo test --workspace
 
   # end to end tests with Heappy (heap profiling enabled)
-  test_heappy:
+  test-heappy:
     docker:
       - image: quay.io/influxdb/rust:ci
     resource_class: xlarge # use of a smaller executor tends crashes on link
@@ -187,11 +218,16 @@ jobs:
   #
   # Compiles a binary with the default ("dev") cargo profile from the influxdb3 source
   # using the latest ci_image (influxdb/rust) and ensures various targets compile successfully
-  build_dev:
+  # Build a dev binary.
+  build-dev:
     docker:
-      - image: quay.io/influxdb/rust:ci
-    resource_class: 2xlarge # use of a smaller executor tends crashes on link
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3:latest
+        auth:
+          username: _json_key
+          password: $CISUPPORT_GCS_AUTHORIZATION
+    resource_class: 2xlarge+ # use of a smaller executor tends crashes on link
     environment:
+      TARGET: << parameters.target >>
       # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
       CARGO_INCREMENTAL: "0"
       # Disable full debug symbol generation to speed up CI build
@@ -202,83 +238,344 @@ jobs:
       # The `2xlarge` resource class that we use has 32GB RAM but also 16 CPUs. This means we have 2GB RAM per core on
       # avarage. At peak this is a bit tight, so lower the CPU count for cargo a bit.
       CARGO_BUILD_JOBS: "12"
+    parameters:
+      target:
+        type: string
     steps:
       - checkout
-      - rust_components
+      - run:
+          name: Install Target
+          command: rustup target add << parameters.target >>
       - run:
           name: Cargo build
-          command: cargo build --workspace
-      - run:
-          name: Check benches compile
-          command: cargo check --workspace --benches
-      - run:
-          name: Check extra features (like prod image)
-          command: cargo check --no-default-features --features="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,pprof"
+          command: target-env cargo build --target=<< parameters.target >> --workspace
+      - when:
+          condition:
+            not:
+              equal: [ << parameters.target >>, x86_64-pc-windows-gnu ]
+          steps:
+          - run:
+              name: Check benches compile
+              command: target-env cargo check --target=<< parameters.target >> --workspace --benches
+          - run:
+              name: Check extra features (like prod image)
+              command: target-env cargo check --target=<< parameters.target >> --no-default-features --features="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,pprof"
+      - when:
+          condition:
+            equal: [ << parameters.target >>, x86_64-pc-windows-gnu ]
+          steps:
+          - run:
+              name: Check extra features (like prod image)
+              command: target-env cargo check --target=<< parameters.target >> --no-default-features --features="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console"
 
-  # Compile cargo "release" profile binaries for influxdb3 & data generator
-  #
-  # Uses the latest ci_image (influxdb/rust) to build a release binary and
-  # copies it to a minimal container image based upon `rust:slim-buster`. This
-  # minimal image is then pushed to `quay.io/influxdb/influxdb3:${BRANCH}`.
-  build_release:
+  # Compile cargo "release" profile binaries for influxdb3 edge releases
+  build-release:
+    docker:
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3:latest
+        auth:
+          username: _json_key
+          password: $CISUPPORT_GCS_AUTHORIZATION
+    resource_class: 2xlarge+
+    environment:
+      TARGET: << parameters.target >>
+      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
+      CARGO_INCREMENTAL: "0"
+      # Disable full debug symbol generation to speed up CI build
+      # "1" means line tables only, which is useful for panic tracebacks.
+      CARGO_PROFILE_DEV_DEBUG: "1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      # The `2xlarge` resource class that we use has 32GB RAM but also 16 CPUs. This means we have 2GB RAM per core on
+      # avarage. At peak this is a bit tight, so lower the CPU count for cargo a bit.
+      CARGO_BUILD_JOBS: "12"
+    parameters:
+      target:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Install Target
+          command: rustup target add << parameters.target >>
+      - run:
+          name: Cargo release build
+          command: target-env cargo build --target=<< parameters.target >> --workspace --release
+          # linking might take a while and doesn't produce CLI output
+          no_output_timeout: 30m
+      - run:
+          name: tar and gzip build artifacts
+          command: |
+            mkdir -p artifacts
+            tar --ignore-failed-read -czvf "${PWD}/artifacts/influxdb3-edge_<< parameters.target >>.tar.gz" -C "${PWD}/target/<< parameters.target >>/release" influxdb3{,.exe}
+      - store_artifacts:
+          path: artifacts
+      - persist_to_workspace:
+          root: .
+          paths:
+            - artifacts
+  build-packages:
+    docker:
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager:latest
+        auth:
+          username: _json_key
+          password: $CISUPPORT_GCS_AUTHORIZATION
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: packager .circleci/packages/config.yaml
+      - persist_to_workspace:
+          root: .
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: artifacts/
+  check_package_deb_amd64:
+    machine:
+      image: ubuntu-2204:current
+      resource_class: medium
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Validate Debian Package (AMD64)
+          command: |
+            sudo .circleci/scripts/package-validation/debian \
+              /tmp/workspace/artifacts/influxdb3*amd64.deb
+  check_package_deb_arm64:
+    machine:
+      image: ubuntu-2204:current
+      resource_class: arm.medium
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Validate Debian Package (ARM64)
+          command: |
+            sudo .circleci/scripts/package-validation/debian \
+              /tmp/workspace/artifacts/influxdb3*arm64.deb
+  check_package_rpm:
+    machine:
+      image: ubuntu-2204:current
+      resource_class: arm.medium
+    parameters:
+      arch:
+        type: string
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - add_ssh_keys:
+          fingerprints:
+            - 3a:d1:7a:b7:57:d7:85:0b:76:79:85:51:38:f3:e4:67
+      - checkout
+      - run: |
+          AWS_ACCESS_KEY_ID=$TEST_AWS_ACCESS_KEY_ID \
+          AWS_SECRET_ACCESS_KEY=$TEST_AWS_SECRET_ACCESS_KEY \
+          .circleci/scripts/package-validation/redhat << parameters.arch >> /tmp/workspace/artifacts/influxdb3*.<< parameters.arch >>.rpm
+  sign-packages:
+    circleci_ip_ranges: true
+    docker:
+      - image: quay.io/influxdb/rsign:latest
+        auth:
+          username: $QUAY_RSIGN_USERNAME
+          password: $QUAY_RSIGN_PASSWORD
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - fc:7b:6e:a6:38:7c:63:5a:13:be:cb:bb:fa:33:b3:3c
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: |
+          for target in /tmp/workspace/artifacts/*
+          do
+            case "${target}"
+            in
+              # rsign is shipped on Alpine Linux which uses "busybox ash" instead
+              # of bash. ash is somewhat more posix compliant and is missing some
+              # extensions and niceties from bash.
+              *.deb|*.rpm|*.tar.gz|*.zip)
+                rsign "${target}"
+              ;;
+            esac
+
+            if [ -f "${target}" ]
+            then
+              # Since all artifacts are present, sign them here. This saves Circle
+              # credits over spinning up another instance just to separate out the
+              # checksum job.
+              sha256sum "${target}" >> "/tmp/workspace/artifacts/influxdb3-edge.${CIRCLE_TAG}.digests"
+
+              # write individual checksums
+              md5sum    "${target}" >> "${target}.md5"
+              sha256sum "${target}" >> "${target}.sha256"
+            fi
+          done
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: /tmp/workspace/artifacts
+  publish-packages:
+    docker:
+      - image: cimg/python:3.6
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - aws-s3/sync:
+          arguments:             --acl public-read
+          aws-region:            RELEASE_AWS_REGION
+          aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
+          aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
+          from:                  /tmp/workspace/artifacts
+          to:                    s3://dl.influxdata.com/influxdb/releases
+  build-docker:
     # need a machine executor to have a full-powered docker daemon (the `setup_remote_docker` system just provides a
     # kinda small node)
     machine:
       image: default
-    resource_class: 2xlarge # CPU bound, so make it fast
+    resource_class: 2xlarge+ # CPU bound, so make it fast
     steps:
       - checkout
       - run:
-          name: Cargo release build
+          name: Build the docker image
           command: |
-            COMMIT_SHA="$(git rev-parse HEAD)"
-
-            .circleci/docker_build_release.bash \
+            .circleci/scripts/docker_build_release.bash \
               "influxdb3" \
               "aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,pprof" \
-              "quay.io/influxdb/influxdb3:$COMMIT_SHA"
+              "influxdb3-edge:latest"
 
-            mkdir /tmp/images
-            docker save quay.io/influxdb/influxdb3:"$COMMIT_SHA" | gzip > /tmp/images/influxdb3.tar.gz
           # linking might take a while and doesn't produce CLI output
           no_output_timeout: 30m
-      - store_artifacts:
-          path: /tmp/images
+      - run: |
+          docker save influxdb3-edge:latest >influxdb3-edge.tar
       - persist_to_workspace:
-          root: /tmp/images
+          root: .
           paths:
-            - "*.tar.gz"
+            - influxdb3-edge.tar
+  publish-docker:
+    docker:
+      - image: cimg/gcp:2023.02
+    resource_class: medium
+    steps:
+      - checkout
+      - setup_remote_docker
+      - gcloud-docker-login
+      - attach_workspace:
+          at: .
+      - run: |
+          docker load <influxdb3-edge.tar
+          .circleci/scripts/publish.bash influxdb3-edge
 
-parameters:
-  release_branch:
-    description: "Build and push container image for non-main branch"
-    type: boolean
-    default: false
+  wait-for-docker:
+    resource_class: small
+    docker:
+      - image: busybox
+    steps:
+      - run: |
+          echo build executed successfully
+
 
 workflows:
   version: 2
-
-  # CI for all pull requests.
   ci:
-    when:
-      and:
-        - not: << pipeline.parameters.release_branch >>
     jobs:
-      - fmt
-      - lint
-      - cargo_audit
-      - test
-      - test_heappy
-      - build_dev
-      - doc
-      - build_release:
-          filters:
-            branches:
-              only: main
+      - fmt:
+          <<: *any_filter
+      - lint:
+          <<: *any_filter
+      - cargo-audit:
+          <<: *any_filter
+      - test:
+          <<: *any_filter
+      - test-heappy:
+          <<: *any_filter
+      - build-dev:
+          <<: *any_filter
+          name: build-dev-<< matrix.target >>
+          matrix:
+            parameters:
+              target:
+                - aarch64-apple-darwin
+                - aarch64-unknown-linux-gnu
+                - aarch64-unknown-linux-musl
+                - x86_64-pc-windows-gnu
+                - x86_64-unknown-linux-gnu
+                - x86_64-unknown-linux-musl
+      - doc:
+          <<: *any_filter
+      - build-release:
+          # <<: *release_filter
+          <<: *any_filter
+          name: build-release-<< matrix.target >>
+          matrix:
+            parameters:
+              target:
+                - aarch64-apple-darwin
+                - aarch64-unknown-linux-gnu
+                - aarch64-unknown-linux-musl
+                - x86_64-pc-windows-gnu
+                - x86_64-unknown-linux-gnu
+                - x86_64-unknown-linux-musl
+      - build-packages:
+          # <<: *release_filter
+          <<: *any_filter
+          requires:
+            - build-release
+      - check_package_deb_arm64:
+          # <<: *release_filter
+          <<: *any_filter
+          requires:
+            - build-packages
+      - check_package_deb_amd64:
+          # <<: *release_filter
+          <<: *any_filter
+          requires:
+            - build-packages
+      - check_package_rpm:
+          # <<: *nofork_filter
+          <<: *any_filter
+          name:
+            check_package_rpm-<< matrix.arch >>
+          matrix:
+            parameters:
+              arch: [ x86_64, aarch64 ]
+          requires:
+            - build-packages
 
-  # Force build and push of container image for non-main branch.
-  # See instructions at the top of this file
-  release_branch:
-    when: << pipeline.parameters.release_branch >>
-    jobs:
-      - build_release
+      - sign-packages:
+          # <<: *release_filter
+          <<: *any_filter
+          requires:
+            - build-packages
+            - check_package_rpm
+            - check_package_deb_arm64
+            - check_package_deb_amd64
+            - test
+      - publish-packages:
+          # <<: *release_filter
+          <<: *any_filter
+          requires:
+            - build-release
+            - sign-packages
+            - test
+            - test-heappy
+            - doc
+            - lint
+            - fmt
+            - cargo-audit
+      - build-docker:
+          <<: *any_filter
+          # <<: *release_filter
+      - publish-docker:
+          <<: *any_filter
+          # <<: *release_filter
+          requires:
+            - build-docker
+      - wait-for-docker:
+          <<: *any_filter
+          # <<: *release_filter
+          requires:
+            - build-docker
+            - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,8 +514,7 @@ workflows:
       - doc:
           <<: *any_filter
       - build-release:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           name: build-release-<< matrix.target >>
           matrix:
             parameters:
@@ -527,23 +526,19 @@ workflows:
                 - x86_64-unknown-linux-gnu
                 - x86_64-unknown-linux-musl
       - build-packages:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           requires:
             - build-release
       - check_package_deb_arm64:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           requires:
             - build-packages
       - check_package_deb_amd64:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           requires:
             - build-packages
       - check_package_rpm:
-          # <<: *nofork_filter
-          <<: *any_filter
+          <<: *nofork_filter
           name:
             check_package_rpm-<< matrix.arch >>
           matrix:
@@ -553,8 +548,7 @@ workflows:
             - build-packages
 
       - sign-packages:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           requires:
             - build-packages
             - check_package_rpm
@@ -562,12 +556,10 @@ workflows:
             - check_package_deb_amd64
             - test
       - publish-packages:
-          # <<: *release_filter
-          <<: *any_filter
+          <<: *release_filter
           matrix:
             parameters:
-              # Temporary change this to releases when done with PR
-              destination: [ snapshots ]
+              destination: [ releases ]
           requires:
             - build-release
             - sign-packages
@@ -578,16 +570,13 @@ workflows:
             - fmt
             - cargo-audit
       - build-docker:
-          <<: *any_filter
-          # <<: *release_filter
+          <<: *release_filter
       - publish-docker:
-          <<: *any_filter
-          # <<: *release_filter
+          <<: *release_filter
           requires:
             - build-docker
       - wait-for-docker:
-          <<: *any_filter
-          # <<: *release_filter
+          <<: *release_filter
           requires:
             - build-docker
             - publish-docker

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,10 +1,6 @@
-
 version:
   release:
     match: '^v[0-9]+.[0-9]+.[0-9]+'
-    value: '{{env.CIRCLE_TAG[1:]}}'
-  alpha:
-    match: '^v3.0.0-0.alpha.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
   default:
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'
@@ -47,8 +43,7 @@ packages:
       - source: README.md
         target: usr/share/influxdb3/README.md
     #perm_overrides:
-    deb_recommends:
-      - influxdb3-cli
+    #deb_recommends:
     #conflicts:
     #depends:
     source: .circleci/packages/influxdb3

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,8 +1,7 @@
 version:
-  release:
-    match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
+  - match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
     value: '{{env.CIRCLE_TAG[1:]}}'
-  default:
+  - match: '.*'
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'
 
 sources:
@@ -30,20 +29,19 @@ packages:
   - name:        influxdb3
     description: Monolithic time-series database.
     license:     MIT/Apache-2.0
+    vendor:      InfluxData
+    homepage:    https://influxdata.com
+    maintainer:
+      name:  support
+      email: support@influxdata.com
     binaries:
       - influxdb3
       - influxdb3.exe
     extras:
       - source: LICENSE-APACHE
         target: usr/share/influxdb3/LICENSE-APACHE
-
       - source: LICENSE-MIT
         target: usr/share/influxdb3/LICENSE-MIT
-
       - source: README.md
         target: usr/share/influxdb3/README.md
-    #perm_overrides:
-    #deb_recommends:
-    #conflicts:
-    #depends:
     source: .circleci/packages/influxdb3

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,0 +1,51 @@
+
+version:
+  release:
+    match: '^v[0-9]+.[0-9]+.[0-9]+'
+    value: '{{env.CIRCLE_TAG[1:]}}'
+  default:
+    value: '3.x-{{env.CIRCLE_SHA1[:8]}}'
+
+sources:
+  - binary: /tmp/workspace/artifacts/influxdb3-edge_x86_64-unknown-linux-musl.tar.gz
+    target: artifacts/
+    arch:   amd64
+    plat:   linux
+
+  - binary: /tmp/workspace/artifacts/influxdb3-edge_aarch64-unknown-linux-musl.tar.gz
+    target: artifacts/
+    arch:   arm64
+    plat:   linux
+
+  - binary: /tmp/workspace/artifacts/influxdb3-edge_aarch64-apple-darwin.tar.gz
+    target: artifacts/
+    arch:   amd64
+    plat:   darwin
+
+  - binary: /tmp/workspace/artifacts/influxdb3-edge_x86_64-pc-windows-gnu.tar.gz
+    target: artifacts/
+    arch:   amd64
+    plat:   windows
+
+packages:
+  - name:        influxdb3
+    description: Monolithic time-series database.
+    license:     MIT/Apache-2.0
+    binaries:
+      - influxdb3
+      - influxdb3.exe
+    extras:
+      - source: LICENSE-APACHE
+        target: usr/share/influxdb3/LICENSE-APACHE
+
+      - source: LICENSE-MIT
+        target: usr/share/influxdb3/LICENSE-MIT
+
+      - source: README.md
+        target: usr/share/influxdb3/README.md
+    #perm_overrides:
+    deb_recommends:
+      - influxdb3-cli
+    #conflicts:
+    #depends:
+    source: .circleci/packages/influxdb3

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -4,7 +4,7 @@ version:
     match: '^v[0-9]+.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
   alpha:
-    match: '^v3.0.0.alpha.[0-9]+.[0-9]+'
+    match: '^v3.0.0-0.alpha.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
   default:
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -3,8 +3,11 @@ version:
   release:
     match: '^v[0-9]+.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
+  alpha:
+    match: '^v3.0.0.alpha.[0-9]+.[0-9]+'
+    value: '{{env.CIRCLE_TAG[1:]}}'
   default:
-    value: '3.x-{{env.CIRCLE_SHA1[:8]}}'
+    value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'
 
 sources:
   - binary: /tmp/workspace/artifacts/influxdb3-edge_x86_64-unknown-linux-musl.tar.gz

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,6 +1,6 @@
 version:
   release:
-    match: '^v[0-9]+.[0-9]+.[0-9]+'
+    match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
     value: '{{env.CIRCLE_TAG[1:]}}'
   default:
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'

--- a/.circleci/packages/influxdb3/control/post-install
+++ b/.circleci/packages/influxdb3/control/post-install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER=influxdb3
+GROUP=influxdb3
 BIN_DIR=/usr/bin
 DATA_DIR=/var/lib/influxdb3
 LOG_DIR=/var/log/influxdb3
@@ -9,8 +11,8 @@ if [[ -f /etc/debian_version ]]; then
     # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
     # We perform ownership change only for Debian-based systems.
     # Moving these lines out of this if statement would make `rmp -V` fail after installation.
-    chown -R -L influxdb:influxdb $LOG_DIR
-    chown -R -L influxdb:influxdb $DATA_DIR
+    chown -R -L $USER:$GROUP $LOG_DIR
+    chown -R -L $USER:$GROUP $DATA_DIR
     chmod 755 $LOG_DIR
     chmod 755 $DATA_DIR
 fi

--- a/.circleci/packages/influxdb3/control/post-install
+++ b/.circleci/packages/influxdb3/control/post-install
@@ -1,18 +1,1 @@
 #!/bin/bash
-
-USER=influxdb3
-GROUP=influxdb3
-BIN_DIR=/usr/bin
-DATA_DIR=/var/lib/influxdb3
-LOG_DIR=/var/log/influxdb3
-
-# Distribution-specific logic
-if [[ -f /etc/debian_version ]]; then
-    # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
-    # We perform ownership change only for Debian-based systems.
-    # Moving these lines out of this if statement would make `rmp -V` fail after installation.
-    chown -R -L $USER:$GROUP $LOG_DIR
-    chown -R -L $USER:$GROUP $DATA_DIR
-    chmod 755 $LOG_DIR
-    chmod 755 $DATA_DIR
-fi

--- a/.circleci/packages/influxdb3/control/post-install
+++ b/.circleci/packages/influxdb3/control/post-install
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BIN_DIR=/usr/bin
+DATA_DIR=/var/lib/influxdb3
+LOG_DIR=/var/log/influxdb3
+
+# Distribution-specific logic
+if [[ -f /etc/debian_version ]]; then
+    # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
+    # We perform ownership change only for Debian-based systems.
+    # Moving these lines out of this if statement would make `rmp -V` fail after installation.
+    chown -R -L influxdb:influxdb $LOG_DIR
+    chown -R -L influxdb:influxdb $DATA_DIR
+    chmod 755 $LOG_DIR
+    chmod 755 $DATA_DIR
+fi

--- a/.circleci/packages/influxdb3/control/pre-install
+++ b/.circleci/packages/influxdb3/control/pre-install
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-DATA_DIR=/var/lib/influxdb3
 USER=influxdb3
 GROUP=influxdb3
+DATA_DIR=/var/lib/influxdb3
 LOG_DIR=/var/log/influxdb3
 
 if ! id influxdb3 &>/dev/null; then

--- a/.circleci/packages/influxdb3/control/pre-install
+++ b/.circleci/packages/influxdb3/control/pre-install
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DATA_DIR=/var/lib/influxdb3
+USER=influxdb3
+GROUP=influxdb3
+LOG_DIR=/var/log/influxdb3
+
+if ! id influxdb3 &>/dev/null; then
+    useradd --system -U -M influxdb3 -s /bin/false -d $DATA_DIR
+fi
+
+# check if DATA_DIR exists
+if [ ! -d "$DATA_DIR" ]; then
+    mkdir -p $DATA_DIR
+    chown $USER:$GROUP $DATA_DIR
+fi
+
+# check if LOG_DIR exists
+if [ ! -d "$LOG_DIR" ]; then
+    mkdir -p $LOG_DIR
+    chown $USER:$GROUP $DATA_DIR
+fi

--- a/.circleci/scripts/docker_build_release.bash
+++ b/.circleci/scripts/docker_build_release.bash
@@ -10,7 +10,7 @@ RUST_VERSION="$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)"
 COMMIT_SHA="$(git rev-parse HEAD)"
 COMMIT_TS="$(env TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd" HEAD)"
 NOW="$(date --utc --iso-8601=seconds)"
-REPO_URL="https://github.com/influxdata/influxdb_iox"
+REPO_URL="https://github.com/influxdata/influxdb"
 
 exec docker buildx build \
   --build-arg CARGO_INCREMENTAL="no" \
@@ -22,8 +22,8 @@ exec docker buildx build \
   --label org.opencontainers.image.url="$REPO_URL" \
   --label org.opencontainers.image.revision="$COMMIT_SHA" \
   --label org.opencontainers.image.vendor="InfluxData Inc." \
-  --label org.opencontainers.image.title="InfluxDB IOx, '$PACKAGE'" \
-  --label org.opencontainers.image.description="InfluxDB IOx production image for package '$PACKAGE'" \
+  --label org.opencontainers.image.title="InfluxDB3 Edge" \
+  --label org.opencontainers.image.description="InfluxDB3 Edge Image" \
   --label com.influxdata.image.commit-date="$COMMIT_TS" \
   --label com.influxdata.image.package="$PACKAGE" \
   --progress plain \

--- a/.circleci/scripts/package-validation/debian
+++ b/.circleci/scripts/package-validation/debian
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+path="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+"${path}/validate" deb "${1}"

--- a/.circleci/scripts/package-validation/redhat
+++ b/.circleci/scripts/package-validation/redhat
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+# $1 -> architecture
+# $2 -> package path
+case ${1} in
+  x86_64)  arch=x86_64 ;;
+  aarch64) arch=arm64  ;;
+esac
+
+package="$(realpath "${2}")"
+
+path="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+terraform_init() {
+  pushd "${path}/tf" &>/dev/null
+
+  # Unfortunately, CircleCI doesn't offer any RPM based machine images.
+  # This is required to test the functionality of the systemd services.
+  # (systemd doesn't run within docker containers). This will spawn a
+  # Amazon Linux instance in AWS.
+  terraform init
+  terraform apply                   \
+    -auto-approve                   \
+    -var "architecture=${1}"        \
+    -var "package_path=${2}"        \
+    -var "identifier=${CIRCLE_JOB}"
+
+  popd &>/dev/null
+}
+
+terraform_free() {
+  pushd "${path}/tf" &>/dev/null
+
+  terraform destroy                 \
+    -auto-approve                   \
+    -var "architecture=${1}"        \
+    -var "package_path=${2}"        \
+    -var "identifier=${CIRCLE_JOB}"
+
+  popd &>/dev/null
+}
+
+terraform_ip() {
+  pushd "${path}/tf" &>/dev/null
+
+  terraform output -raw node_ssh
+
+  popd &>/dev/null
+}
+
+
+# This ensures that the associated resources within AWS are released
+# upon exit or when encountering an error. This is setup before the
+# call to "terraform apply" so even partially initialized resources
+# are released.
+# shellcheck disable=SC2064
+trap "terraform_free \"${arch}\" \"${package}\"" \
+  SIGINT  \
+  SIGTERM \
+  ERR     \
+  EXIT
+
+function terraform_setup()
+{
+  # TODO(bnpfeife): remove this once the executor is updated.
+  #
+  # Unfortunately, terraform provided by the CircleCI executor is *terribly*
+  # out of date. Most Linux distributions are disabling "ssh-rsa" public key
+  # algorithms which this uses to remote into the ec2 instance . This
+  # installs the latest version of terraform.
+  #
+  # Addendum: the "terraform_version" CircleCI option is broken!
+sudo tee /etc/apt/sources.list.d/hashicorp.list <<EOF >/dev/null || true
+deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main
+EOF
+
+  curl -fL https://apt.releases.hashicorp.com/gpg | gpg --dearmor | \
+    sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
+
+  export DEBIAN_FRONTEND=noninteractive
+  sudo -E apt-get update
+  sudo -E apt-get install --yes terraform
+}
+
+terraform_setup
+
+terraform_init "${arch}" "${package}"
+
+printf 'Setup complete! Testing %s... (this takes several minutes!)' "${1}"
+
+# Since terraform *just* created this instance, the host key is not
+# known. Therefore, we'll disable StrictHostKeyChecking so ssh does
+# not wait for user input.
+ssh -o 'StrictHostKeyChecking=no' "ec2-user@$(terraform_ip)" 'sudo ./validate rpm ./influxdb3.rpm'

--- a/.circleci/scripts/package-validation/tf/main.tf
+++ b/.circleci/scripts/package-validation/tf/main.tf
@@ -1,0 +1,114 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+}
+
+variable "architecture" {
+  type = string
+}
+
+variable "identifier" {
+  type = string
+}
+
+variable "package_path" {
+  type = string
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_ami" "test_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al20*-ami-20*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name   = "architecture"
+    values = [var.architecture]
+  }
+
+  owners = ["137112412989"]
+}
+
+resource "aws_security_group" "influxdb_test_package_sg" {
+  ingress {
+    description = "Allow ssh connection"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outgoing"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "all"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "test_instance" {
+  count                  = 1
+  ami                    = data.aws_ami.test_ami.id
+  instance_type          = var.architecture == "x86_64" ? "t2.micro" : "c6g.medium"
+  key_name               = "circleci-oss-test"
+  vpc_security_group_ids = [aws_security_group.influxdb_test_package_sg.id]
+
+  tags = {
+    Name = format("circleci_%s_test_%s", var.identifier, var.architecture)
+  }
+
+  provisioner "file" {
+    source      = var.package_path
+    destination = "/home/ec2-user/influxdb3.rpm"
+
+    connection {
+      type     = "ssh"
+      user     = "ec2-user"
+      host     = self.public_dns
+      agent    = true
+    }
+  }
+
+  provisioner "file" {
+    source      = "../validate"
+    destination = "/home/ec2-user/validate"
+
+    connection {
+      type     = "ssh"
+      user     = "ec2-user"
+      host     = self.public_dns
+      agent    = true
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/ec2-user/validate",
+    ]
+
+    connection {
+      type     = "ssh"
+      user     = "ec2-user"
+      host     = self.public_dns
+      agent    = true
+    }
+  }
+}
+
+output "node_ssh" {
+  value = aws_instance.test_instance.0.public_dns
+}

--- a/.circleci/scripts/package-validation/validate
+++ b/.circleci/scripts/package-validation/validate
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+usage() {
+  cat <<'EOF'
+usage: validate [type] [path]
+
+Program:
+    This application performs sanity checks on the provided InfluxDB
+    package. InfluxDB should *not* be installed on the system before
+    running this application. This validates new installations and
+    performs specific checks relevant only to InfluxDB.
+
+Options:
+    type    Must be "deb" or "rpm". This option instructs the
+            application to use the package manager associated
+            with "type".
+    path    Path to InfluxDB package to validate.
+EOF
+}
+
+if [[ ! "${1:-}" ]] || [[ ! "${2:-}" ]]
+then
+  (usage) && exit 1
+fi
+PACKAGE_TYPE="${1}"
+PACKAGE_PATH="${2}"
+
+install_deb() {
+  # When installing the package, ensure that the latest repository listings
+  # are available. This might be required so that all dependencies resolve.
+  # Since this needs to be run by CI, we supply "noninteractive" and "-y"
+  # so no prompts stall the pipeline.
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  # "apt-get install" should be used instead of "dpkg -i", because "dpkg"
+  # does not resolve dependencies. "apt-get" requires that the package
+  # path looks like a path (either fullpath or prefixed with "./").
+  apt-get install -y binutils "$(realpath "${PACKAGE_PATH}")"
+}
+
+install_rpm() {
+  # see "install_deb" for "update"
+  yum update -y
+  yum install -y binutils
+  yum localinstall -y "$(realpath "${PACKAGE_PATH}")"
+}
+
+case ${PACKAGE_TYPE}
+in
+  deb)
+    (install_deb)
+    ;;
+  rpm)
+    (install_rpm)
+    ;;
+esac
+
+if ! which influxdb3 &>/dev/null
+then
+  printf 'ERROR: Failed to locate influxdb3 executable!\n' >&2
+  exit 2
+fi
+
+NEEDED="$(readelf -d "$(which influxdb3)" | (grep 'NEEDED' || true ))"
+
+# shellcheck disable=SC2181
+if [[ ${?} -ne 0 ]]
+then
+  cat <<'EOF'
+ERROR: readelf could not analyze the influxdb3 executable! This
+       might be the consequence of installing a package built
+       for another platform OR invalid compiler/linker flags.
+EOF
+  exit 2
+fi
+
+if [[ "${NEEDED:-}" ]]
+then
+  cat <<'EOF'
+ERROR: influxdb3 not statically linked! This may prevent all
+       platforms from running influxdb3 without installing
+       separate dependencies.
+EOF
+  exit 2
+fi
+
+printf 'Finished validating influxdb3!\n'

--- a/.circleci/scripts/publish.bash
+++ b/.circleci/scripts/publish.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+release() {
+  image_src="${1}:latest"
+  image_dst="us-docker.pkg.dev/influxdata-team-edge/influxdb3-edge/${1}:${2}"
+
+  if docker pull "${image_dst}" ; then
+    echo "docker image ${image_dst} already exists"
+    exit 0
+  fi
+  docker tag  "${image_src}" "${image_dst}"
+  docker push "${image_dst}"
+}
+
+release "${1}" "${CIRCLE_SHA1}"
+if [[ "${CIRCLE_BRANCH}" == main ]] ; then
+  release "${1}" latest
+fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,47 +78,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -210,7 +211,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "num",
 ]
 
@@ -391,7 +392,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -405,7 +406,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -480,7 +481,7 @@ dependencies = [
  "arrow",
  "chrono",
  "comfy-table",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "num-traits",
  "once_cell",
  "regex",
@@ -528,16 +529,16 @@ checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
  "event-listener 5.3.0",
- "event-listener-strategy 0.5.1",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
  "bzip2",
  "flate2",
@@ -611,7 +612,7 @@ source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff
 dependencies = [
  "async-trait",
  "backoff 0.1.0",
- "base64 0.22.0",
+ "base64 0.22.1",
  "generated_types",
  "http",
  "iox_time",
@@ -719,9 +720,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -887,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
@@ -1027,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "comfy-table"
@@ -1044,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1359,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1424,7 +1425,7 @@ dependencies = [
  "futures",
  "glob",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "log",
@@ -1483,7 +1484,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "log",
  "object_store",
  "parking_lot",
@@ -1515,7 +1516,7 @@ source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=581e74785b8
 dependencies = [
  "arrow",
  "arrow-array",
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "datafusion-common",
  "datafusion-execution",
@@ -1551,7 +1552,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "itertools 0.12.1",
  "log",
  "regex-syntax 0.8.3",
@@ -1569,7 +1570,7 @@ dependencies = [
  "arrow-ord 50.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-schema",
  "arrow-string 50.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.22.0",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1577,7 +1578,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -1611,7 +1612,7 @@ dependencies = [
  "datafusion-physical-expr",
  "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "log",
@@ -1741,7 +1742,7 @@ source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff
 dependencies = [
  "arrow_util",
  "data_types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "mutable_batch",
  "schema",
  "trace",
@@ -1881,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.0",
  "pin-project-lite",
@@ -1911,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
@@ -1929,7 +1930,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -1969,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2226,9 +2227,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2240,7 +2241,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2479,7 +2480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2523,7 +2524,7 @@ dependencies = [
  "assert_cmd",
  "authz",
  "backtrace",
- "base64 0.22.0",
+ "base64 0.22.1",
  "clap",
  "clap_blocks",
  "console-subscriber",
@@ -2637,7 +2638,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "authz",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "data_types",
@@ -2782,7 +2783,7 @@ version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "data_types",
  "datafusion",
@@ -2864,7 +2865,7 @@ dependencies = [
  "data_types",
  "futures",
  "generated_types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "http",
  "iox_time",
  "log",
@@ -2918,7 +2919,7 @@ dependencies = [
  "datafusion_util",
  "executor",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "iox_query_params",
  "iox_time",
@@ -3013,7 +3014,7 @@ dependencies = [
  "flate2",
  "futures",
  "generated_types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "heappy",
  "http",
  "hyper",
@@ -3060,6 +3061,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -3262,7 +3269,7 @@ dependencies = [
  "backoff 0.4.0",
  "derivative",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -3352,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -3387,9 +3394,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3597,7 +3604,7 @@ dependencies = [
  "arrow",
  "arrow_util",
  "data_types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "iox_time",
  "itertools 0.12.1",
  "schema",
@@ -3610,7 +3617,7 @@ name = "mutable_batch_lp"
 version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "influxdb-line-protocol",
  "itertools 0.12.1",
  "mutable_batch",
@@ -3626,7 +3633,7 @@ dependencies = [
  "arrow_util",
  "dml",
  "generated_types",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "mutable_batch",
  "schema",
  "snafu 0.8.2",
@@ -3932,9 +3939,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3942,15 +3949,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3974,7 +3981,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -4035,7 +4042,7 @@ version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "data_types",
  "datafusion",
@@ -4060,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "parse-zoneinfo"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
@@ -4116,7 +4123,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -4137,9 +4144,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4148,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4158,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4171,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -4621,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -4655,6 +4662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -4819,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -4856,7 +4872,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -4912,7 +4928,7 @@ version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "observability_deps",
  "once_cell",
@@ -4922,9 +4938,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "7f55c82c700538496bdc329bb4918a81f87cc8888811bd123cf325a0f2f8d309"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4934,14 +4950,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "83263746fe5e32097f06356968a077f96089739c927a61450efa069905eec108"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5007,9 +5023,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -5042,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5053,13 +5069,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5287,9 +5303,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6200,7 +6216,7 @@ source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff
 dependencies = [
  "bytes",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "http",
  "http-body",
  "itertools 0.12.1",
@@ -6296,7 +6312,7 @@ version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "iox_time",
  "lock_api",
  "metric",
@@ -6401,9 +6417,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode_categories"
@@ -6620,7 +6636,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "wasite",
 ]
 
@@ -6852,7 +6868,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "getrandom",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "heck 0.4.1",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,9 +152,7 @@ bare_urls = "deny"
 # This profile optimizes for runtime performance and small binary size at the expense of longer
 # build times. It's most suitable for final release builds.
 [profile.release]
-codegen-units = 16
-debug = true
-lto = "thin"
+lto = "fat"
 
 [profile.bench]
 debug = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN apt update \
     && groupadd --gid 1500 influxdb3 \
     && useradd --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3
 
+RUN mkdir /usr/local/share/influxdb3 && \
+    chown influxdb3:influxdb3 /usr/local/share/influxdb3
+
 USER influxdb3
 
 RUN mkdir ~/.influxdb3
@@ -54,7 +57,11 @@ ENV PACKAGE=$PACKAGE
 COPY --from=build "/root/$PACKAGE" "/usr/bin/$PACKAGE"
 COPY docker/entrypoint.sh /usr/bin/entrypoint.sh
 
-EXPOSE 8080 8082
+EXPOSE 8181
+
+# TODO: Make this and other env vars not specific to IOx
+ENV INFLUXDB_IOX_OBJECT_STORE=file
+ENV INFLUXDB_IOX_DB_DIR=/usr/local/share/influxdb3
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN apt update \
     && groupadd --gid 1500 influxdb3 \
     && useradd --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3
 
-RUN mkdir /usr/local/share/influxdb3 && \
-    chown influxdb3:influxdb3 /usr/local/share/influxdb3
+RUN mkdir /var/lib/influxdb3 && \
+    chown influxdb3:influxdb3 /var/lib/influxdb3
 
 USER influxdb3
 
@@ -61,7 +61,8 @@ EXPOSE 8181
 
 # TODO: Make this and other env vars not specific to IOx
 ENV INFLUXDB_IOX_OBJECT_STORE=file
-ENV INFLUXDB_IOX_DB_DIR=/usr/local/share/influxdb3
+ENV INFLUXDB_IOX_DB_DIR=/var/lib/influxdb3
+ENV LOG_FILTER=info
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 

--- a/foo
+++ b/foo
@@ -1,0 +1,1 @@
+38fd39f0659ac8406de0e8f83c64eb0a15ac0152a8198467407ddb56c2a6e684  /home/michael/1Password Emergency Kit A3-CP6WC8-team-influxdata.pdf

--- a/foo
+++ b/foo
@@ -1,1 +1,0 @@
-38fd39f0659ac8406de0e8f83c64eb0a15ac0152a8198467407ddb56c2a6e684  /home/michael/1Password Emergency Kit A3-CP6WC8-team-influxdata.pdf

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -40,7 +40,7 @@ use trogging::cli::LoggingConfig;
 pub const DEFAULT_DATA_DIRECTORY_NAME: &str = ".influxdb3";
 
 /// The default bind address for the HTTP API.
-pub const DEFAULT_HTTP_BIND_ADDR: &str = "127.0.0.1:8181";
+pub const DEFAULT_HTTP_BIND_ADDR: &str = "0.0.0.0:8181";
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -97,6 +97,7 @@ enum Command {
 }
 
 fn main() -> Result<(), std::io::Error> {
+    #[cfg(unix)]
     install_crash_handler(); // attempt to render a useful stacktrace to stderr
 
     // load all environment variables from .env before doing anything
@@ -208,6 +209,7 @@ fn load_dotenv() {
 
 // Based on ideas from
 // https://github.com/servo/servo/blob/f03ddf6c6c6e94e799ab2a3a89660aea4a01da6f/ports/servo/main.rs#L58-L79
+#[cfg(unix)]
 fn install_crash_handler() {
     unsafe {
         set_signal_handler(libc::SIGSEGV, signal_handler); // handle segfaults
@@ -216,6 +218,7 @@ fn install_crash_handler() {
     }
 }
 
+#[cfg(unix)]
 unsafe extern "C" fn signal_handler(sig: i32) {
     use backtrace::Backtrace;
     use std::process::abort;
@@ -233,6 +236,7 @@ unsafe extern "C" fn signal_handler(sig: i32) {
 }
 
 // based on https://github.com/adjivas/sig/blob/master/src/lib.rs#L34-L52
+#[cfg(unix)]
 unsafe fn set_signal_handler(signal: libc::c_int, handler: unsafe extern "C" fn(libc::c_int)) {
     use libc::{sigaction, sigfillset, sighandler_t};
     let mut sigset = std::mem::zeroed();

--- a/influxdb3_process/Cargo.toml
+++ b/influxdb3_process/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 uuid.workspace = true
 
 # Optional Dependencies
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemalloc-ctl = { version = "0.5.4", optional = true }
 tikv-jemalloc-sys = { version = "0.5.4", optional = true, features = ["unprefixed_malloc_on_supported_platforms"] }
 

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -29,7 +29,7 @@ use influxdb3_write::{Persister, WriteBuffer};
 use iox_query::QueryNamespaceProvider;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
-use observability_deps::tracing::{error, info};
+use observability_deps::tracing::error;
 use service::hybrid;
 use std::convert::Infallible;
 use std::fmt::Debug;
@@ -205,6 +205,7 @@ where
 /// This method returns if either are signalled
 #[cfg(unix)]
 pub async fn wait_for_signal() {
+    use observability_deps::tracing::info;
     use tokio::signal::unix::{signal, SignalKind};
     let mut term = signal(SignalKind::terminate()).expect("failed to register signal handler");
     let mut int = signal(SignalKind::interrupt()).expect("failed to register signal handler");


### PR DESCRIPTION
feat: build binaries and Docker images in CI 

For releases we need to have Docker images and binary images available for the
user to actually run influxdb3. These CI changes will build the binaries on a
release tag and the Docker image as well, test, sign, and publish them and make
them available for download.

Co-Authored-By: Brandon Pfeifer <bpfeifer@influxdata.com>

Closes #24773