### PR TITLE
fix: slow limits test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,8 @@ jobs:
       - checkout
       - rust_components
       - run:
-          name: cargo test --workspace --features=limits
-          command: cargo test --workspace --features=limits
+          name: cargo test --workspace
+          command: cargo test --workspace
 
   # end to end tests with Heappy (heap profiling enabled)
   test_heappy:

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -54,7 +54,6 @@ tikv-jemalloc-sys = { version = "0.5.4", optional = true, features = ["unprefixe
 
 [features]
 default = ["jemalloc_replacing_malloc", "azure", "gcp", "aws"]
-limits = []
 
 azure = ["clap_blocks/azure"] # Optional Azure Object store support
 gcp = ["clap_blocks/gcp"] # Optional GCP object store support


### PR DESCRIPTION
This commit re-enables the limits test after making a fix that has it run <1 second on my laptop vs the old behavior of >=30 seconds. It does so by constructing one single write_lp request to create 1995 tables rather than 1995 individual requests that make a table. This is far more efficient.