### PR TITLE
refactor: use `/query` for v1 query API endpoint

### DIFF
--- a/influxdb3/tests/server/auth.rs
+++ b/influxdb3/tests/server/auth.rs
@@ -218,8 +218,8 @@ async fn v1_password_parameter() {
         .await;
 
     let client = reqwest::Client::new();
-    let query_url = format!("{base}/api/v1/query", base = server.client_addr());
-    let write_url = format!("{base}/api/v1/write", base = server.client_addr());
+    let query_url = format!("{base}/query", base = server.client_addr());
+    let write_url = format!("{base}/write", base = server.client_addr());
     // Send requests without any authentication:
     assert_eq!(
         client

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -182,11 +182,11 @@ impl TestServer {
 
     pub async fn api_v1_query(&self, params: &[(&str, &str)]) -> Response {
         self.http_client
-            .get(format!("{base}/api/v1/query", base = self.client_addr(),))
+            .get(format!("{base}/query", base = self.client_addr(),))
             .query(params)
             .send()
             .await
-            .expect("send /api/v1/query request to server")
+            .expect("send /query request to server")
     }
 }
 

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -547,7 +547,7 @@ fn extract_v1_auth_token(req: &mut Request<Body>) -> Option<Vec<u8>> {
     req.uri()
         .path_and_query()
         .and_then(|pq| match pq.path() {
-            "/api/v1/query" | "/api/v1/write" => pq.query(),
+            "/query" | "/write" => pq.query(),
             _ => None,
         })
         .map(serde_urlencoded::from_str::<V1AuthParameters>)
@@ -805,7 +805,7 @@ where
         (Method::GET | Method::POST, "/api/v3/query_influxql") => {
             http_server.query_influxql(req).await
         }
-        (Method::GET, "/query" | "/api/v1/query") => http_server.v1_query(req).await,
+        (Method::GET, "/query") => http_server.v1_query(req).await,
         (Method::GET, "/health" | "/api/v1/health") => http_server.health(),
         (Method::GET, "/metrics") => http_server.handle_metrics(),
         (Method::GET, "/debug/pprof") => pprof_home(req).await,

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -805,7 +805,7 @@ where
         (Method::GET | Method::POST, "/api/v3/query_influxql") => {
             http_server.query_influxql(req).await
         }
-        (Method::GET, "/api/v1/query") => http_server.v1_query(req).await,
+        (Method::GET, "/query" | "/api/v1/query") => http_server.v1_query(req).await,
         (Method::GET, "/health" | "/api/v1/health") => http_server.health(),
         (Method::GET, "/metrics") => http_server.handle_metrics(),
         (Method::GET, "/debug/pprof") => pprof_home(req).await,


### PR DESCRIPTION
There is no issue for this.

After some discussion, we decided to use the `/query` endpoint to serve the v1 InfluxDB query API, instead of `/api/v1/query`. This better preserves backward compatibility and will not conflict with any naming conventions going forward.