### PR TITLE
chore: Update to Rust 1.77.0 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - rust_components
       - run:
           name: Install cargo-deny
-          command: cargo install cargo-deny
+          command: cargo install cargo-deny --locked
       - run:
           name: cargo-deny Checks
           command: cargo deny check -s

--- a/influxdb3/src/commands/query.rs
+++ b/influxdb3/src/commands/query.rs
@@ -131,6 +131,7 @@ pub(crate) async fn command(config: Config) -> Result<()> {
         let mut f = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(path)
             .await?;
         f.write_all_buf(&mut resp_bytes).await?;

--- a/influxdb3_write/src/wal.rs
+++ b/influxdb3_write/src/wal.rs
@@ -229,7 +229,11 @@ impl WalSegmentWriterImpl {
         }
 
         // it's a new file, initialize it with the header and get ready to start writing
-        let mut f = OpenOptions::new().write(true).create(true).open(&path)?;
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)?;
 
         f.write_all(FILE_TYPE_IDENTIFIER)?;
         let file_type_bytes_written = FILE_TYPE_IDENTIFIER.len();
@@ -266,7 +270,7 @@ impl WalSegmentWriterImpl {
         if let Some(file_info) =
             WalSegmentReaderImpl::read_segment_file_info_if_exists(path.clone())?
         {
-            let f = OpenOptions::new().write(true).append(true).open(&path)?;
+            let f = OpenOptions::new().append(true).open(&path)?;
 
             Ok(Self {
                 segment_id,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.77.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
This is a fairly quiet upgrade. The only changes are some lints around `OpenOptions` that were added to clippy between 1.75 and this version and they're small changes that either remove unecessary function calls or add a needed function call.

Release Blog Post: https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html