### PR TITLE
fix: loader error with single wal file

### DIFF
--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -70,11 +70,7 @@ impl OpenBufferSegment {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn start_time_matches(&self, t: Time) -> bool {
-        self.segment_range.start_time == t
-    }
-
+    #[cfg(test)]
     pub fn segment_id(&self) -> SegmentId {
         self.segment_id
     }


### PR DESCRIPTION
Fixes a bug where the loader would error out if there was a wal segment file for a previous segment that hand't been persisted, and a new wal file had to be created for the new open segment. This would show up as an error if you started the server and then stopped and restarted it without writing any data.