### PR TITLE
fix: set default logging level to info

### DIFF
--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -262,6 +262,7 @@ fn init_logs_and_tracing(
     config: &trogging::cli::LoggingConfig,
 ) -> Result<TroggingGuard, trogging::Error> {
     let log_layer = trogging::Builder::new()
+        .with_default_log_filter("info")
         .with_logging_config(config)
         .build()?;
 


### PR DESCRIPTION
When running influxdb3 we did not have a default log level. As a result we couldn't even see if the program was even running. This change provides a default level unless a user supplied one is given.