### PR TITLE
refactor: buffer using Arrow builders

### DIFF
--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -324,6 +324,7 @@ impl TableDefinition {
         &self.schema
     }
 
+    #[cfg(test)]
     pub(crate) fn columns(&self) -> &BTreeMap<String, i16> {
         &self.columns
     }

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -302,10 +302,13 @@ impl TableDefinition {
         self.columns.contains_key(column)
     }
 
-    pub(crate) fn add_columns(&mut self, mut columns: Vec<(String, i16)>) {
-        let mut schema_builder = SchemaBuilder::with_capacity(columns.len());
-        columns.sort_by(|(a, _), (b, _)| a.cmp(b));
-        for (name, column_type) in &columns {
+    pub(crate) fn add_columns(&mut self, columns: Vec<(String, i16)>) {
+        for (name, column_type) in columns.into_iter() {
+            self.columns.insert(name, column_type);
+        }
+
+        let mut schema_builder = SchemaBuilder::with_capacity(self.columns.len());
+        for (name, column_type) in &self.columns {
             schema_builder.influx_column(
                 name,
                 column_type_to_influx_column_type(&ColumnType::try_from(*column_type).unwrap()),
@@ -313,9 +316,6 @@ impl TableDefinition {
         }
         let schema = schema_builder.build().unwrap();
 
-        for (name, column_type) in columns.into_iter() {
-            self.columns.insert(name, column_type);
-        }
         self.schema = schema;
     }
 
@@ -370,5 +370,29 @@ mod tests {
         let deserialized: InnerCatalog = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(*inner, deserialized);
+    }
+
+    #[test]
+    fn add_columns_updates_schema() {
+        let mut database = DatabaseSchema {
+            name: "test".to_string(),
+            tables: BTreeMap::new(),
+        };
+        database.tables.insert(
+            "test".into(),
+            TableDefinition::new(
+                "test",
+                BTreeMap::from([("test".to_string(), ColumnType::String as i16)]),
+            ),
+        );
+
+        let table = database.tables.get_mut("test").unwrap();
+        table.add_columns(vec![("test2".to_string(), ColumnType::Tag as i16)]);
+        let schema = table.schema();
+        assert_eq!(
+            schema.field(0).0,
+            InfluxColumnType::Field(InfluxFieldType::String)
+        );
+        assert_eq!(schema.field(1).0, InfluxColumnType::Tag);
     }
 }

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -253,13 +253,10 @@ impl BufferedData {
         table_name: &str,
         schema: &Schema,
     ) -> Option<Vec<RecordBatch>> {
-        if let Some(db_buffer) = self.database_buffers.get(db_name) {
-            if let Some(table_buffer) = db_buffer.table_buffers.get(table_name) {
-                return Some(table_buffer.record_batches(schema));
-            }
-        }
-
-        None
+        self.database_buffers
+            .get(db_name)
+            .and_then(|db_buffer| db_buffer.table_buffers.get(table_name))
+            .map(|table_buffer| table_buffer.record_batches(schema))
     }
 
     /// Verifies that the passed in buffer has the same data as this buffer

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -293,7 +293,18 @@ mod tests {
 
         assert_eq!(segment.segment_id(), segment_id);
 
-        let table_buffer = segment.table_buffer(db_name.as_str(), "cpu").unwrap();
-        assert_eq!(table_buffer.row_count(), 2);
+        let data = segment
+            .table_record_batches(
+                db_name.as_str(),
+                "cpu",
+                catalog
+                    .db_schema("db1")
+                    .unwrap()
+                    .get_table_schema("cpu")
+                    .unwrap(),
+            )
+            .unwrap();
+        let row_count = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
+        assert_eq!(row_count, 2);
     }
 }

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -290,9 +290,8 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = current_segment
-            .table_buffer(db_name, "cpu")
-            .unwrap()
-            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+            .table_record_batches(db_name, "cpu", cpu_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+-----+----------+--------------------------------+",
             "| _series_id                                                       | bar | tag1     | time                           |",
@@ -300,13 +299,12 @@ mod tests {
             "| 505f9f5fc3347ac9d6ba45f2b2c94ad53a313e456e86e61db85ba1935369b238 | 1.0 | cupcakes | 1970-01-01T00:00:00.000000010Z |",
             "+------------------------------------------------------------------+-----+----------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let mem_table = db.get_table("mem").unwrap();
         let mem_data = current_segment
-            .table_buffer(db_name, "mem")
-            .unwrap()
-            .rows_to_record_batch(&mem_table.schema, mem_table.columns());
+            .table_record_batches(db_name, "mem", mem_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+-----+---------+--------------------------------+",
             "| _series_id                                                       | bar | tag2    | time                           |",
@@ -315,7 +313,7 @@ mod tests {
             "| 5ae2bb295e8b0dec713daf0da555ecd3f2899a8967f18db799e26557029198f3 | 2.0 | snakes  | 1970-01-01T00:00:00.000000020Z |",
             "+------------------------------------------------------------------+-----+---------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[mem_data]);
+        assert_batches_eq!(&expected, &mem_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(1));
     }
@@ -465,9 +463,8 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = loaded_state.open_segments[0]
-            .table_buffer(db_name, "cpu")
-            .unwrap()
-            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+            .table_record_batches(db_name, "cpu", cpu_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+-----+----------+--------------------------------+",
             "| _series_id                                                       | bar | tag1     | time                           |",
@@ -475,13 +472,12 @@ mod tests {
             "| 505f9f5fc3347ac9d6ba45f2b2c94ad53a313e456e86e61db85ba1935369b238 | 3.0 | cupcakes | 1970-01-01T00:00:00.000000020Z |",
             "+------------------------------------------------------------------+-----+----------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let foo_table = db.get_table("foo").unwrap();
         let foo_data = loaded_state.open_segments[0]
-            .table_buffer(db_name, "foo")
-            .unwrap()
-            .rows_to_record_batch(&foo_table.schema, foo_table.columns());
+            .table_record_batches(db_name, "foo", foo_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+--------------------------------+-----+",
             "| _series_id                                                       | time                           | val |",
@@ -489,7 +485,7 @@ mod tests {
             "| e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 | 1970-01-01T00:00:00.000000123Z | 1.0 |",
             "+------------------------------------------------------------------+--------------------------------+-----+",
         ];
-        assert_batches_eq!(&expected, &[foo_data]);
+        assert_batches_eq!(&expected, &foo_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(2));
     }
@@ -584,10 +580,10 @@ mod tests {
             loaded_closed_segment.catalog_start_sequence_number,
             closed_segment.catalog_start_sequence_number
         );
-        assert_eq!(
-            loaded_closed_segment.buffered_data,
-            closed_segment.buffered_data
-        );
+
+        loaded_closed_segment
+            .buffered_data
+            .verify_matches(&closed_segment.buffered_data, &catalog);
 
         let db = loaded_state.catalog.db_schema(db_name).unwrap();
         assert_eq!(db.tables.len(), 3);
@@ -597,9 +593,8 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = loaded_state.open_segments[0]
-            .table_buffer(db_name, "cpu")
-            .unwrap()
-            .rows_to_record_batch(&cpu_table.schema, cpu_table.columns());
+            .table_record_batches(db_name, "cpu", cpu_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+-----+--------+--------------------------------+",
             "| _series_id                                                       | bar | tag1   | time                           |",
@@ -607,13 +602,12 @@ mod tests {
             "| 82a59579ecb9ae1adf113fe3a09a2ebd61aa15f92c570d26278d3f1dfe8bcbd8 | 3.0 | apples | 1970-01-01T00:00:00.000000020Z |",
             "+------------------------------------------------------------------+-----+--------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let foo_table = db.get_table("foo").unwrap();
         let foo_data = loaded_state.open_segments[0]
-            .table_buffer(db_name, "foo")
-            .unwrap()
-            .rows_to_record_batch(&foo_table.schema, foo_table.columns());
+            .table_record_batches(db_name, "foo", foo_table.schema())
+            .unwrap();
         let expected = [
             "+------------------------------------------------------------------+--------------------------------+-----+",
             "| _series_id                                                       | time                           | val |",
@@ -621,7 +615,7 @@ mod tests {
             "| e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 | 1970-01-01T00:00:00.000000123Z | 1.0 |",
             "+------------------------------------------------------------------+--------------------------------+-----+",
         ];
-        assert_batches_eq!(&expected, &[foo_data]);
+        assert_batches_eq!(&expected, &foo_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(2));
     }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod buffer_segment;
 mod flusher;
 mod loader;
 mod segment_state;
+mod table_buffer;
 
 use crate::catalog::{
     Catalog, DatabaseSchema, TableDefinition, SERIES_ID_COLUMN_NAME, TIME_COLUMN_NAME,
@@ -285,14 +286,8 @@ impl<W: Wal, T: TimeProvider, P: Persister> WriteBufferImpl<W, T, P> {
         let table = db_schema.tables.get(table_name).unwrap();
         let schema = table.schema.clone();
 
-        let table_buffers = self
-            .segment_state
-            .read()
-            .clone_table_buffers(datbase_name, table_name);
-        table_buffers
-            .into_iter()
-            .map(|table_buffer| table_buffer.rows_to_record_batch(&schema, table.columns()))
-            .collect()
+        let segment_state = self.segment_state.read();
+        segment_state.open_segments_table_record_batches(datbase_name, table_name, &schema)
     }
 }
 

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -1,0 +1,198 @@
+//! The in memory bufffer of a table that can be quickly added to and queried
+
+use crate::write_buffer::{FieldData, Row};
+use arrow::array::{
+    ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder, StringDictionaryBuilder,
+    TimestampNanosecondBuilder, UInt64Builder,
+};
+use arrow::datatypes::Int32Type;
+use arrow::record_batch::RecordBatch;
+use data_types::{PartitionKey, TimestampMinMax};
+use schema::Schema;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::vec;
+
+pub struct TableBuffer {
+    pub segment_key: PartitionKey,
+    timestamp_min: i64,
+    timestamp_max: i64,
+    data: BTreeMap<String, Builder>,
+    row_count: usize,
+}
+
+impl TableBuffer {
+    pub fn new(segment_key: PartitionKey) -> Self {
+        Self {
+            segment_key,
+            timestamp_min: i64::MAX,
+            timestamp_max: i64::MIN,
+            data: Default::default(),
+            row_count: 0,
+        }
+    }
+
+    pub fn add_rows(&mut self, rows: Vec<Row>) {
+        self.row_count += rows.len();
+
+        for r in rows {
+            let mut value_added = HashSet::with_capacity(r.fields.len());
+
+            for f in r.fields {
+                value_added.insert(f.name.clone());
+
+                match f.value {
+                    FieldData::Timestamp(v) => {
+                        self.timestamp_min = self.timestamp_min.min(v);
+                        self.timestamp_max = self.timestamp_max.max(v);
+
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::Time(TimestampNanosecondBuilder::new()));
+                        if let Builder::Time(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::Tag(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::Tag(StringDictionaryBuilder::new()));
+                        if let Builder::Tag(b) = b {
+                            b.append(v).unwrap(); // we won't overflow the 32-bit integer for this dictionary
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::String(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::String(StringBuilder::new()));
+                        if let Builder::String(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::Integer(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::I64(Int64Builder::new()));
+                        if let Builder::I64(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::UInteger(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::U64(UInt64Builder::new()));
+                        if let Builder::U64(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::Float(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::F64(Float64Builder::new()));
+                        if let Builder::F64(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                    FieldData::Boolean(v) => {
+                        let b = self
+                            .data
+                            .entry(f.name)
+                            .or_insert_with(|| Builder::Bool(BooleanBuilder::new()));
+                        if let Builder::Bool(b) = b {
+                            b.append_value(v);
+                        } else {
+                            panic!("unexpected field type");
+                        }
+                    }
+                }
+            }
+
+            // add nulls for any columns not present
+            for (name, builder) in &mut self.data {
+                if !value_added.contains(name) {
+                    match builder {
+                        Builder::Bool(b) => b.append_null(),
+                        Builder::F64(b) => b.append_null(),
+                        Builder::I64(b) => b.append_null(),
+                        Builder::U64(b) => b.append_null(),
+                        Builder::String(b) => b.append_null(),
+                        Builder::Tag(b) => b.append_null(),
+                        Builder::Time(b) => b.append_null(),
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn timestamp_min_max(&self) -> TimestampMinMax {
+        TimestampMinMax {
+            min: self.timestamp_min,
+            max: self.timestamp_max,
+        }
+    }
+
+    pub fn record_batches(&self, schema: &Schema) -> Vec<RecordBatch> {
+        // ensure the order of the columns matches their order in the Arrow schema definition
+        let mut cols = Vec::with_capacity(self.data.len());
+        let schema = schema.as_arrow();
+        for f in &schema.fields {
+            cols.push(self.data.get(f.name()).unwrap().as_arrow());
+        }
+
+        vec![RecordBatch::try_new(schema, cols).unwrap()]
+    }
+}
+
+// Debug implementation for TableBuffer
+impl std::fmt::Debug for TableBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableBuffer")
+            .field("segment_key", &self.segment_key)
+            .field("timestamp_min", &self.timestamp_min)
+            .field("timestamp_max", &self.timestamp_max)
+            .field("row_count", &self.row_count)
+            .finish()
+    }
+}
+
+enum Builder {
+    Bool(BooleanBuilder),
+    I64(Int64Builder),
+    F64(Float64Builder),
+    U64(UInt64Builder),
+    String(StringBuilder),
+    Tag(StringDictionaryBuilder<Int32Type>),
+    Time(TimestampNanosecondBuilder),
+}
+
+impl Builder {
+    fn as_arrow(&self) -> ArrayRef {
+        match self {
+            Self::Bool(b) => Arc::new(b.finish_cloned()),
+            Self::I64(b) => Arc::new(b.finish_cloned()),
+            Self::F64(b) => Arc::new(b.finish_cloned()),
+            Self::U64(b) => Arc::new(b.finish_cloned()),
+            Self::String(b) => Arc::new(b.finish_cloned()),
+            Self::Tag(b) => Arc::new(b.finish_cloned()),
+            Self::Time(b) => Arc::new(b.finish_cloned()),
+        }
+    }
+}


### PR DESCRIPTION
This updates the buffer to use Arrow builders. This significantly improves the memory footprint for data in the buffer. It also makes querying the buffer significantly faster as it no longer creates copies to query against. In earlier tests when querying against a large buffer, it would cause writes to stop while making copies. This also significantly speeds up persisting of data when segments are closed.

This also fixes a bug in the catalog where the Arrow schema wouldn't get updated when new columns were added to a table.