### PR TITLE
feat: initial query load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,7 @@ name = "influxdb3_load_generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "clap",
  "csv",

--- a/influxdb3_load_generator/Cargo.toml
+++ b/influxdb3_load_generator/Cargo.toml
@@ -16,20 +16,21 @@ trogging.workspace = true
 influxdb3_client = { path = "../influxdb3_client" }
 
 # crates.io Dependencies
-serde.workspace = true
+anyhow.workspace = true
+bytes.workspace = true
+chrono.workspace = true
 clap.workspace = true
+csv.workspace = true
 dotenvy.workspace = true
 humantime.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
 secrecy.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 url.workspace = true
-rand.workspace = true
-anyhow.workspace = true
-csv.workspace = true
-parking_lot.workspace = true
-chrono.workspace = true
 
 [lints]
 workspace = true

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
-use secrecy::Secret;
+use influxdb3_client::Client;
+use secrecy::{ExposeSecret, Secret};
 use url::Url;
 
 #[derive(Debug, Parser)]
@@ -25,4 +26,31 @@ pub(crate) struct InfluxDb3Config {
     /// The token for authentication with the InfluxDB 3.0 server
     #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
     pub(crate) auth_token: Option<Secret<String>>,
+
+    /// The path to the spec file to use for this run. Or specify a name of a builtin spec to use.
+    /// If not specified, the generator will output a list of builtin specs along with help and
+    /// an example for writing your own.
+    #[clap(short = 's', long = "spec", env = "INFLUXDB3_LOAD_DATA_SPEC_PATH")]
+    pub(crate) spec_path: Option<String>,
+
+    /// The name of the builtin spec to run. Use this instead of spec_path if you want to run
+    /// one of the builtin specs as is.
+    #[clap(long = "builtin-spec", env = "INFLUXDB3_LOAD_BUILTIN_SPEC")]
+    pub(crate) builtin_spec: Option<String>,
+
+    /// The name of the builtin spec to print to stdout. This is useful for seeing the structure
+    /// of the builtin as a starting point for creating your own.
+    #[clap(long = "print-spec")]
+    pub(crate) print_spec: Option<String>,
+}
+
+pub(crate) fn create_client(
+    host_url: Url,
+    auth_token: Option<Secret<String>>,
+) -> Result<Client, influxdb3_client::Error> {
+    let mut client = Client::new(host_url)?;
+    if let Some(t) = auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+    Ok(client)
 }

--- a/influxdb3_load_generator/src/commands/query.rs
+++ b/influxdb3_load_generator/src/commands/query.rs
@@ -1,25 +1,20 @@
-use std::str::Utf8Error;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use anyhow::Context;
+use bytes::Bytes;
+use chrono::Local;
 use clap::Parser;
-use influxdb3_client::Format;
-use secrecy::ExposeSecret;
-use tokio::io;
+use influxdb3_client::Client;
+use serde_json::Value;
+use tokio::time::Instant;
 
-use super::common::InfluxDb3Config;
+use crate::{
+    query_generator::{create_queriers, Querier},
+    report::QueryReporter,
+    specification::{Format, QuerierSpec},
+};
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
-    #[error(transparent)]
-    Client(#[from] influxdb3_client::Error),
-
-    #[error("invlid UTF8 received from server: {0}")]
-    Utf8(#[from] Utf8Error),
-
-    #[error("io error: {0}")]
-    Io(#[from] io::Error),
-}
-
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+use super::common::{create_client, InfluxDb3Config};
 
 #[derive(Debug, Parser)]
 #[clap(visible_alias = "q", trailing_var_arg = true)]
@@ -27,28 +22,173 @@ pub(crate) struct Config {
     /// Common InfluxDB 3.0 config
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
+
+    /// Sampling interval for the queriers. They will perform queries at this interval and
+    /// sleep for the remainder of the interval. Queriers stagger queries by this interval divided
+    /// by the number of queriers.
+    #[clap(
+        short = 'i',
+        long = "interval",
+        env = "INFLUXDB3_QUERY_SAMPLING_INTERVAL",
+        default_value = "1s"
+    )]
+    sampling_interval: humantime::Duration,
+
+    /// Number of simultaneous queriers. Each querier will perform queries at the specified `interval`.
+    #[clap(
+        short = 'w',
+        long = "querier-count",
+        env = "INFLUXDB3_LOAD_QUERIERS",
+        default_value = "1"
+    )]
+    querier_count: usize,
+
+    /// The file that will be used to write the results of the run. If not specified, results
+    /// will be written to <spec_name>_results.csv in the current directory.
+    #[clap(
+        short = 'r',
+        long = "results",
+        env = "INFLUXDB3_QUERY_LOAD_RESULTS_FILE"
+    )]
+    results_file: Option<String>,
 }
 
-pub(crate) async fn command(config: Config) -> Result<()> {
+pub(crate) async fn command(config: Config) -> Result<(), anyhow::Error> {
     let InfluxDb3Config {
         host_url,
         database_name,
         auth_token,
-    } = config.influxdb3_config;
-    let mut client = influxdb3_client::Client::new(host_url)?;
-    if let Some(t) = auth_token {
-        client = client.with_auth_token(t.expose_secret());
+        spec_path,
+        builtin_spec,
+        print_spec,
+    }: InfluxDb3Config = config.influxdb3_config;
+
+    if spec_path.is_none() && print_spec.is_none() && builtin_spec.is_none() {
+        println!("You didn't provide a spec path.");
+        return Ok(());
     }
 
-    println!("hello from query!");
+    let built_in_specs = crate::specs::built_in_specs();
 
-    let resp_bytes = client
-        .api_v3_query_sql(database_name, "select * from foo limit 10;")
-        .format(Format::Json)
-        .send()
-        .await?;
+    // if print spec is set, print the spec and exit
+    if let Some(spec_name) = print_spec {
+        let spec = built_in_specs
+            .iter()
+            .find(|spec| spec.query_spec.name == spec_name)
+            .with_context(|| format!("Spec with name '{spec_name}' not found"))?;
+        println!("{}", spec.query_spec.to_json_string_pretty()?);
+        return Ok(());
+    }
 
-    println!("{}", std::str::from_utf8(&resp_bytes)?);
+    // if builtin spec is set, use that instead of the spec path
+    let spec = if let Some(b) = builtin_spec {
+        let builtin = built_in_specs
+            .into_iter()
+            .find(|spec| spec.query_spec.name == b)
+            .with_context(|| format!("built-in spec with name '{b}' not found"))?;
+        println!("using built-in spec: {}", builtin.query_spec.name);
+        builtin.query_spec
+    } else {
+        QuerierSpec::from_path(&spec_path.unwrap())?
+    };
+
+    // spin up the queriers
+    let queriers = create_queriers(&spec, config.querier_count)?;
+
+    // set up a results reporter and spawn a thread to flush results
+    let results_file = config
+        .results_file
+        .unwrap_or_else(|| format!("{}_query_results.csv", spec.name));
+    let query_reporter = Arc::new(QueryReporter::new(&results_file)?);
+    let reporter = Arc::clone(&query_reporter);
+    tokio::task::spawn_blocking(move || {
+        reporter.flush_reports();
+    });
+
+    // create a InfluxDB Client and spawn tasks for each querier
+    let client = create_client(host_url, auth_token)?;
+    let mut tasks = Vec::new();
+    for querier in queriers {
+        let reporter = Arc::clone(&query_reporter);
+        let sampling_interval = config.sampling_interval.into();
+        let task = tokio::spawn(run_querier(
+            querier,
+            client.clone(),
+            database_name.clone(),
+            reporter,
+            sampling_interval,
+        ));
+        tasks.push(task);
+    }
+
+    // await tasks, shutdown reporter and exit
+    for task in tasks {
+        task.await?;
+    }
+    println!("all queriers finished");
+
+    query_reporter.shutdown();
+    println!("reporter closed and results written to {}", results_file);
 
     Ok(())
+}
+
+async fn run_querier(
+    mut querier: Querier,
+    client: Client,
+    database_name: String,
+    reporter: Arc<QueryReporter>,
+    sampling_interval: Duration,
+) {
+    let mut interval = tokio::time::interval(sampling_interval);
+    loop {
+        interval.tick().await;
+        for query in &mut querier.queries {
+            let start_request = Instant::now();
+            let mut builder = client
+                .api_v3_query_sql(&database_name, query.query())
+                .format(querier.format.into());
+            for p in query.params_mut() {
+                let v = p.generate();
+                builder = builder
+                    .with_try_param(p.name(), v)
+                    .expect("expected primitive JSON value");
+            }
+            let res = builder.send().await;
+            let response_time = start_request.elapsed().as_millis() as u64;
+            let (status, rows) = match res {
+                // TODO - parse bytes to get rows returned
+                Ok(b) => (200, count_rows(b, querier.format)),
+                Err(influxdb3_client::Error::ApiError { code, message: _ }) => (code.as_u16(), 0),
+                Err(other_error) => {
+                    panic!("unexpected error while performing query: {other_error}")
+                }
+            };
+
+            reporter.report(
+                querier.querier_id,
+                status,
+                response_time,
+                rows,
+                Local::now(),
+            );
+        }
+    }
+}
+
+fn count_rows(response: Bytes, format: Format) -> u64 {
+    match format {
+        Format::Json => {
+            let v: Vec<HashMap<String, Value>> =
+                serde_json::from_slice(&response).expect("valid formatted JSON");
+            v.len().try_into().unwrap()
+        }
+        Format::Csv => {
+            let mut count = 0;
+            for _ in response.split(|c| *c == b'\n') {
+                count += 1;
+            }
+            count
+        }
+    }
 }

--- a/influxdb3_load_generator/src/line_protocol_generator.rs
+++ b/influxdb3_load_generator/src/line_protocol_generator.rs
@@ -57,12 +57,7 @@ fn create_measurement<'a>(
         Arc::from(m.as_str())
     }));
 
-    let max_cardinality = spec
-        .tags
-        .iter()
-        .map(|t| t.cardinality.unwrap_or(1))
-        .max()
-        .unwrap_or(1);
+    let max_cardinality = spec.max_cardinality();
     let max_cardinality = usize::div_ceil(max_cardinality, writer_count);
     let lines_per_sample = spec.lines_per_sample.unwrap_or(max_cardinality);
 

--- a/influxdb3_load_generator/src/main.rs
+++ b/influxdb3_load_generator/src/main.rs
@@ -10,6 +10,7 @@
 )]
 
 pub mod line_protocol_generator;
+pub mod query_generator;
 pub mod report;
 pub mod specification;
 mod specs;

--- a/influxdb3_load_generator/src/query_generator.rs
+++ b/influxdb3_load_generator/src/query_generator.rs
@@ -135,8 +135,8 @@ pub enum ParamValue {
 impl ParamValue {
     fn generate(&mut self) -> Value {
         match self {
-            ParamValue::Static(v) => v.clone(),
-            ParamValue::Cardinality(cv) => {
+            Self::Static(v) => v.clone(),
+            Self::Cardinality(cv) => {
                 let v = if let Some(base) = &cv.base {
                     format!("{base}{current}", current = cv.current)
                 } else {

--- a/influxdb3_load_generator/src/report.rs
+++ b/influxdb3_load_generator/src/report.rs
@@ -1,10 +1,14 @@
 //! Trackers and report generators for write and query runs
 
 use crate::line_protocol_generator::{WriteSummary, WriterId};
+use crate::query_generator::QuerierId;
 use anyhow::Context;
 use chrono::{DateTime, Local};
 use parking_lot::Mutex;
+use serde::Serialize;
 use std::collections::HashMap;
+use std::fmt::Display;
+use std::path::Path;
 use std::time::{Duration, Instant};
 // Logged reports will be flushed to the csv file on this interval
 const REPORT_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
@@ -193,4 +197,106 @@ impl ConsoleReportStats {
             bytes: 0,
         }
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct QuerierReport {
+    query_instant: Instant,
+    wall_time: DateTime<Local>,
+    response_time_ms: u64,
+    response_status: u16,
+    rows_returned: u64,
+    querier_id: QuerierId,
+}
+
+#[derive(Debug)]
+pub struct QueryReporter {
+    state: Mutex<Vec<QuerierReport>>,
+    csv_writer: Mutex<csv::Writer<std::fs::File>>,
+    shutdown: Mutex<bool>,
+}
+
+impl QueryReporter {
+    pub fn new<P: AsRef<Path> + Display>(results_file: P) -> Result<Self, anyhow::Error> {
+        let f = std::fs::File::create_new(&results_file)
+            .with_context(|| {
+            format!("results file already exists, use a different file name or delete it and re-run: {results_file}")
+        })?;
+        let csv_writer = Mutex::new(csv::Writer::from_writer(f));
+        Ok(Self {
+            state: Mutex::new(vec![]),
+            csv_writer,
+            shutdown: Mutex::new(false),
+        })
+    }
+
+    pub fn report(
+        &self,
+        querier_id: QuerierId,
+        response_status: u16,
+        response_time_ms: u64,
+        rows_returned: u64,
+        wall_time: DateTime<Local>,
+    ) {
+        let mut state = self.state.lock();
+        state.push(QuerierReport {
+            query_instant: Instant::now(),
+            wall_time,
+            response_time_ms,
+            response_status,
+            rows_returned,
+            querier_id,
+        })
+    }
+
+    pub fn flush_reports(&self) {
+        let start_time = Instant::now();
+
+        loop {
+            let reports = {
+                let mut state = self.state.lock();
+                let mut reports = Vec::with_capacity(state.len());
+                std::mem::swap(&mut reports, &mut *state);
+                reports
+            };
+
+            let mut csv_writer = self.csv_writer.lock();
+            for report in reports {
+                let test_time_ms = report.query_instant.duration_since(start_time).as_millis();
+                csv_writer
+                    .serialize(QueryRecord {
+                        test_time_ms,
+                        response_ms: report.response_time_ms,
+                        response_status: report.response_status,
+                        rows: report.rows_returned,
+                        querier_id: report.querier_id,
+                        wall_time: report.wall_time,
+                    })
+                    .expect("failed to write csv report record");
+            }
+            csv_writer.flush().expect("failed to flush csv reports");
+
+            // TODO - output console stats
+
+            if *self.shutdown.lock() {
+                return;
+            }
+
+            std::thread::sleep(REPORT_FLUSH_INTERVAL);
+        }
+    }
+
+    pub fn shutdown(&self) {
+        *self.shutdown.lock() = true;
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct QueryRecord {
+    test_time_ms: u128,
+    response_ms: u64,
+    response_status: u16,
+    rows: u64,
+    querier_id: QuerierId,
+    wall_time: DateTime<Local>,
 }

--- a/influxdb3_load_generator/src/specification.rs
+++ b/influxdb3_load_generator/src/specification.rs
@@ -146,26 +146,8 @@ pub enum FieldKind {
 pub struct QuerierSpec {
     /// The name of this spec
     pub name: String,
-    /// The output format of queries made
-    pub format: Format,
     /// The queries to run on each interval
     pub queries: Vec<QuerySpec>,
-}
-
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
-pub enum Format {
-    #[default]
-    Json,
-    Csv,
-}
-
-impl From<Format> for influxdb3_client::Format {
-    fn from(format: Format) -> Self {
-        match format {
-            Format::Json => Self::Json,
-            Format::Csv => Self::Csv,
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/influxdb3_load_generator/src/specification.rs
+++ b/influxdb3_load_generator/src/specification.rs
@@ -1,6 +1,8 @@
-use crate::line_protocol_generator::WriterId;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::line_protocol_generator::WriterId;
 
 /// The specification for the data to be generated
 #[derive(Debug, Deserialize, Serialize)]
@@ -36,17 +38,28 @@ pub struct MeasurementSpec {
     pub fields: Vec<FieldSpec>,
     /// Create this many copies of this measurement in each sample. The copy number will be
     /// appended to the measurement name to uniquely identify it.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub copies: Option<usize>,
     /// If this measurement has tags with cardinality, this is the number of lines that will
     /// be output per sample (up to the highest cardinality tag). If not specified, all unique
     /// values will be used. Cardinality is split across the number of workers, so the number
     /// of lines per sample could be less than this number.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lines_per_sample: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+impl MeasurementSpec {
+    /// Get the max cardinality accross all tags in the spec
+    pub fn max_cardinality(&self) -> usize {
+        self.tags
+            .iter()
+            .map(|t| t.cardinality.unwrap_or(1))
+            .max()
+            .unwrap_or(1)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TagSpec {
     /// the key/name of the tag
     pub key: String,
@@ -54,22 +67,22 @@ pub struct TagSpec {
     /// have this many copies of this tag in the measurement. Random values will be generated
     /// independently (i.e. copies won't share the same random value). Will add the copy number to
     /// the key of the tag to uniquely identify it.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub copies: Option<usize>,
     /// if set, appends the copy id of the tag to the value of the tag
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub append_copy_id: Option<bool>,
 
     /// output this string value for every line this tag is present
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub value: Option<String>,
 
     /// if set, appends the writer id to the value of the tag
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub append_writer_id: Option<bool>,
 
     /// will add a number to the value of the tag, with this number of unique values
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cardinality: Option<usize>,
 }
 
@@ -99,11 +112,11 @@ pub struct FieldSpec {
     /// have this many copies of this field in the measurement. Random values will be generated
     /// independently (i.e. copies won't share the same random value). Will add the copy number to
     /// the key of the field to uniquely identify it.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub copies: Option<usize>,
     /// A float between 0.0 and 1.0 that determines the probability that this field will be null.
     /// At least one field in a measurement should not have this option set.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub null_probability: Option<f64>,
 
     #[serde(flatten)]
@@ -127,6 +140,74 @@ pub enum FieldKind {
     Float(f64),
     /// generate a random float in this range for every line this field is present
     FloatRange(f64, f64),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct QuerierSpec {
+    /// The name of this spec
+    pub name: String,
+    /// The output format of queries made
+    pub format: Format,
+    /// The queries to run on each interval
+    pub queries: Vec<QuerySpec>,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+pub enum Format {
+    #[default]
+    Json,
+    Csv,
+}
+
+impl From<Format> for influxdb3_client::Format {
+    fn from(format: Format) -> Self {
+        match format {
+            Format::Json => Self::Json,
+            Format::Csv => Self::Csv,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct QuerySpec {
+    /// The literal query string to be executed
+    pub query: String,
+    /// Define parameters that will be injected into `query`
+    #[serde(default)]
+    pub params: Vec<ParamSpec>,
+}
+
+impl QuerierSpec {
+    pub(crate) fn to_json_string_pretty(&self) -> Result<String, anyhow::Error> {
+        serde_json::to_string_pretty(self).context("failed to serialize query spec")
+    }
+
+    pub(crate) fn from_path(path: &str) -> Result<Self, anyhow::Error> {
+        let contents = std::fs::read_to_string(path)?;
+        serde_json::from_str(&contents).context("unable to serialize as JSON")
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ParamSpec {
+    /// The literal parameter name
+    ///
+    /// If the parameter appears in the query as `$foo`, specify `"foo"` here.
+    pub name: String,
+    /// The parameter definition
+    #[serde(flatten)]
+    pub param: ParamKind,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "def")]
+pub enum ParamKind {
+    Static(Value),
+    Cardinality {
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        base: Option<String>,
+        cardinality: usize,
+    },
 }
 
 #[cfg(test)]

--- a/influxdb3_load_generator/src/specs/example.rs
+++ b/influxdb3_load_generator/src/specs/example.rs
@@ -1,12 +1,15 @@
 //! Spec that shows the various elements of the data generator. Gets printed to console when
 //! the generator is run without a spec specified.
 
+use serde_json::json;
+
 use crate::specification::*;
 use crate::specs::BuiltInSpec;
 
 pub(crate) fn spec() -> BuiltInSpec {
     let description =
         r#"Example that shows the various elements of the data generator."#.to_string();
+
     let write_spec = DataSpec {
         name: "sample_spec".to_string(),
         measurements: vec![
@@ -15,43 +18,33 @@ pub(crate) fn spec() -> BuiltInSpec {
                 tags: vec![
                     TagSpec {
                         key: "some_tag".to_string(),
-                        copies: None,
-                        append_copy_id: None,
                         value: Some("a-value-here".to_string()),
-                        append_writer_id: None,
-                        cardinality: None,
+                        ..Default::default()
                     },
                     TagSpec {
                         key: "random_data_tag".to_string(),
-                        copies: None,
-                        append_copy_id: None,
                         value: Some("card-val-".to_string()),
-                        append_writer_id: None,
                         cardinality: Some(2),
+                        ..Default::default()
                     },
                     TagSpec {
                         key: "higher_cardinality_data_tag".to_string(),
-                        copies: None,
-                        append_copy_id: None,
                         value: Some("card-val-".to_string()),
-                        append_writer_id: None,
                         cardinality: Some(6),
+                        ..Default::default()
                     },
                     TagSpec {
                         key: "copied_tag".to_string(),
                         copies: Some(3),
                         append_copy_id: Some(true),
                         value: Some("copy-val-".to_string()),
-                        append_writer_id: None,
-                        cardinality: None,
+                        ..Default::default()
                     },
                     TagSpec {
                         key: "writer_id".to_string(),
-                        copies: None,
-                        append_copy_id: None,
                         value: Some("writer-id-".to_string()),
                         append_writer_id: Some(true),
-                        cardinality: None,
+                        ..Default::default()
                     },
                 ],
                 fields: vec![
@@ -124,8 +117,21 @@ pub(crate) fn spec() -> BuiltInSpec {
         ],
     };
 
+    let query_spec = QuerierSpec {
+        name: "sample_spec".to_string(),
+        format: Format::Json,
+        queries: vec![QuerySpec {
+            query: "SELECT f1, i1 FROM some_measurement WHERE some_tag = $some_val".to_string(),
+            params: vec![ParamSpec {
+                name: "some_val".to_string(),
+                param: ParamKind::Static(json!("a-value-here")),
+            }],
+        }],
+    };
+
     BuiltInSpec {
         description,
         write_spec,
+        query_spec,
     }
 }

--- a/influxdb3_load_generator/src/specs/example.rs
+++ b/influxdb3_load_generator/src/specs/example.rs
@@ -119,7 +119,6 @@ pub(crate) fn spec() -> BuiltInSpec {
 
     let query_spec = QuerierSpec {
         name: "sample_spec".to_string(),
-        format: Format::Json,
         queries: vec![QuerySpec {
             query: "SELECT f1, i1 FROM some_measurement WHERE some_tag = $some_val".to_string(),
             params: vec![ParamSpec {

--- a/influxdb3_load_generator/src/specs/mod.rs
+++ b/influxdb3_load_generator/src/specs/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains the built-in specifications for the load generator.
 
-use crate::specification::DataSpec;
+use crate::specification::{DataSpec, QuerierSpec};
+
 mod example;
 mod one_mil;
 
@@ -14,4 +15,5 @@ pub(crate) fn built_in_specs() -> Vec<BuiltInSpec> {
 pub(crate) struct BuiltInSpec {
     pub(crate) description: String,
     pub(crate) write_spec: DataSpec,
+    pub(crate) query_spec: QuerierSpec,
 }

--- a/influxdb3_load_generator/src/specs/one_mil.rs
+++ b/influxdb3_load_generator/src/specs/one_mil.rs
@@ -39,7 +39,6 @@ pub(crate) fn spec() -> BuiltInSpec {
 
     let query_spec = QuerierSpec {
         name: "one_mil".to_string(),
-        format: Format::Json,
         queries: vec![QuerySpec {
             query: "SELECT int_val, float_val FROM measurement_data WHERE series_id = $sid"
                 .to_string(),

--- a/influxdb3_load_generator/src/specs/one_mil.rs
+++ b/influxdb3_load_generator/src/specs/one_mil.rs
@@ -45,7 +45,7 @@ pub(crate) fn spec() -> BuiltInSpec {
             params: vec![ParamSpec {
                 name: "sid".to_string(),
                 param: ParamKind::Cardinality {
-                    base: Some("some-value-".to_string()),
+                    base: Some("series-number-".to_string()),
                     cardinality: 1_000_000,
                 },
             }],

--- a/influxdb3_load_generator/src/specs/one_mil.rs
+++ b/influxdb3_load_generator/src/specs/one_mil.rs
@@ -7,17 +7,16 @@ pub(crate) fn spec() -> BuiltInSpec {
     let description =
         r#"1 million series in a single table use case. If you run this with -writer-count=100
            you'll get all 1M series written every sampling interval. Our primary test is interval=10s"#.to_string();
+
     let write_spec = DataSpec {
         name: "one_mil".to_string(),
         measurements: vec![MeasurementSpec {
             name: "measurement_data".to_string(),
             tags: vec![TagSpec {
                 key: "series_id".to_string(),
-                copies: None,
-                append_copy_id: None,
                 value: Some("series-number-".to_string()),
-                append_writer_id: None,
                 cardinality: Some(1_000_000),
+                ..Default::default()
             }],
             fields: vec![
                 FieldSpec {
@@ -38,8 +37,25 @@ pub(crate) fn spec() -> BuiltInSpec {
         }],
     };
 
+    let query_spec = QuerierSpec {
+        name: "one_mil".to_string(),
+        format: Format::Json,
+        queries: vec![QuerySpec {
+            query: "SELECT int_val, float_val FROM measurement_data WHERE series_id = $sid"
+                .to_string(),
+            params: vec![ParamSpec {
+                name: "sid".to_string(),
+                param: ParamKind::Cardinality {
+                    base: Some("some-value-".to_string()),
+                    cardinality: 1_000_000,
+                },
+            }],
+        }],
+    };
+
     BuiltInSpec {
         description,
         write_spec,
+        query_spec,
     }
 }


### PR DESCRIPTION
Part of #24828

This PR implements the `query` load generator. The design follows that of the existing `write` load generator.

A `QuerySpec` is defined that will be used by the `query` command to generate a set of queriers to perform queries against a running server in parallel.