### PR TITLE
feat: improved results directory structure for load generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ perf.svg
 perf.txt
 valgrind-out.txt
 *.pending-snap
+results/

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -54,7 +54,7 @@ pub(crate) struct InfluxDb3Config {
     /// If not specified, this will default to `results` in the current directory.
     ///
     /// Files saved here will be organized in a directory structure as follows:
-    /// ```ignore
+    /// ```text
     /// results/<s>/<c>/<write|query|system>_<time>.csv`
     /// ```
     /// where,

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -1,9 +1,13 @@
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
+use anyhow::{anyhow, bail, Context};
+use chrono::Local;
 use clap::Parser;
 use influxdb3_client::Client;
 use secrecy::{ExposeSecret, Secret};
 use url::Url;
+
+use crate::specification::{DataSpec, QuerierSpec};
 
 #[derive(Debug, Parser)]
 pub(crate) struct InfluxDb3Config {
@@ -42,8 +46,8 @@ pub(crate) struct InfluxDb3Config {
 
     /// The name of the builtin spec to print to stdout. This is useful for seeing the structure
     /// of the builtin as a starting point for creating your own.
-    #[clap(long = "print-spec")]
-    pub(crate) print_spec: Option<String>,
+    #[clap(long = "print-spec", default_value_t = false)]
+    pub(crate) print_spec: bool,
 
     /// The directory to save results to.
     ///
@@ -60,8 +64,13 @@ pub(crate) struct InfluxDb3Config {
     /// - `<write|query|system>`: results for the `write` load, `query` load, or `system` stats of the
     ///   `influxdb3` binary, respectively.
     /// - `<time>`: a timestamp of when the test started in `YYYY-MM-DD-HH-MM` format.
-    #[clap(short = 'r', long = "results-dir", env = "INFLUXDB3_LOAD_RESULTS_DIR")]
-    pub(crate) results_dir: Option<PathBuf>,
+    #[clap(
+        short = 'r',
+        long = "results-dir",
+        env = "INFLUXDB3_LOAD_RESULTS_DIR",
+        default_value = "results"
+    )]
+    pub(crate) results_dir: PathBuf,
 
     /// Provide a custom `configuration_name` for the generated results directory.
     ///
@@ -69,6 +78,205 @@ pub(crate) struct InfluxDb3Config {
     /// under test.
     #[clap(long = "config-name")]
     pub(crate) configuration_name: Option<String>,
+
+    /// Generate a system stats file in the specified `results_dir`
+    #[clap(long = "system-stats", default_value_t = false)]
+    pub(crate) system_stats: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LoadType {
+    Write,
+    Query,
+    #[allow(dead_code)]
+    Full,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct LoadConfig {
+    pub(crate) database_name: String,
+    results_dir: PathBuf,
+    print_mode: bool,
+    pub(crate) write_spec: Option<DataSpec>,
+    pub(crate) write_results_file_path: Option<String>,
+    pub(crate) write_results_file: Option<File>,
+    pub(crate) query_spec: Option<QuerierSpec>,
+    pub(crate) query_results_file_path: Option<String>,
+    pub(crate) query_results_file: Option<File>,
+    pub(crate) system_stats_file_path: Option<String>,
+    pub(crate) system_stats_file: Option<File>,
+}
+
+impl LoadConfig {
+    fn new(database_name: String, results_dir: PathBuf, print_mode: bool) -> Self {
+        Self {
+            database_name,
+            results_dir,
+            print_mode,
+            ..Default::default()
+        }
+    }
+
+    fn setup_dir(&mut self, spec_name: &str, config_name: &str) -> Result<(), anyhow::Error> {
+        if self.print_mode {
+            return Ok(());
+        }
+        self.results_dir = self.results_dir.join(format!("{spec_name}/{config_name}"));
+        std::fs::create_dir_all(&self.results_dir).with_context(|| {
+            format!(
+                "failed to initialize the results directory at '{dir:#?}'",
+                dir = self.results_dir.as_os_str()
+            )
+        })
+    }
+
+    fn setup_write(&mut self, time_str: &str, spec: DataSpec) -> Result<(), anyhow::Error> {
+        if self.print_mode {
+            println!("Write Spec:\n{}", spec.to_json_string_pretty()?);
+            return Ok(());
+        }
+        self.write_spec = Some(spec);
+        let file_path = self.results_dir.join(format!("write_{time_str}.csv"));
+        self.write_results_file_path = Some(path_buf_to_string(file_path.clone())?);
+        self.write_results_file =
+            Some(File::create_new(file_path).context("write results file already exists")?);
+        Ok(())
+    }
+
+    fn setup_query(&mut self, time_str: &str, spec: QuerierSpec) -> Result<(), anyhow::Error> {
+        if self.print_mode {
+            println!("Query Spec:\n{}", spec.to_json_string_pretty()?);
+            return Ok(());
+        }
+        self.query_spec = Some(spec);
+        let file_path = self.results_dir.join(format!("query_{time_str}.csv"));
+        self.query_results_file_path = Some(path_buf_to_string(file_path.clone())?);
+        self.query_results_file =
+            Some(File::create_new(file_path).context("query results file already exists")?);
+        Ok(())
+    }
+
+    fn setup_system(&mut self, time_str: &str) -> Result<(), anyhow::Error> {
+        let file_path = self.results_dir.join(format!("system_{time_str}.csv"));
+        self.system_stats_file_path = Some(path_buf_to_string(file_path.clone())?);
+        self.system_stats_file =
+            Some(File::create_new(file_path).context("system stats file already exists")?);
+        Ok(())
+    }
+}
+
+fn path_buf_to_string(path: PathBuf) -> Result<String, anyhow::Error> {
+    path.into_os_string()
+        .into_string()
+        .map_err(|os_str| anyhow!("write file path could not be converted to a string: {os_str:?}"))
+}
+
+impl InfluxDb3Config {
+    pub(crate) async fn initialize(
+        self,
+        load_type: LoadType,
+    ) -> Result<(Client, LoadConfig), anyhow::Error> {
+        let Self {
+            host_url,
+            database_name,
+            auth_token,
+            spec_path,
+            builtin_spec,
+            print_spec,
+            results_dir,
+            configuration_name,
+            system_stats,
+        } = self;
+
+        if spec_path.is_none() && builtin_spec.is_none() {
+            if matches!(load_type, LoadType::Write) {
+                // TODO - print help for query as well
+                crate::commands::write::print_help();
+            }
+            bail!("You did not provide a spec path or specify a built-in spec");
+        }
+
+        let built_in_specs = crate::specs::built_in_specs();
+
+        // sepcify a time string for generated results file names:
+        let time_str = format!("{}", Local::now().format("%Y-%m-%d-%H-%M"));
+
+        // initialize the influxdb3 client:
+        let client =
+            create_client(host_url, auth_token).context("unable to create influxdb3 client")?;
+
+        // use the user-specified configuration name, or pull it from the running server:
+        let config_name = if let Some(n) = configuration_name {
+            n
+        } else {
+            client
+                .ping()
+                .await
+                .context("influxdb3 server did not respond to ping request")?
+                .revision()
+                .to_owned()
+        };
+
+        // initialize the load config:
+        let mut config = LoadConfig::new(database_name, results_dir, print_spec);
+
+        // if builtin spec is set, use that instead of the spec path
+        if let Some(b) = builtin_spec {
+            let builtin = built_in_specs
+                .into_iter()
+                .find(|spec| spec.name == *b)
+                .with_context(|| {
+                    let names = crate::specs::built_in_spec_names().join(", ");
+                    format!(
+                        "built-in spec with name '{b}' not found, available built-in specs are: {names}"
+                    )
+                })?;
+            println!("using built-in spec: {}", builtin.name);
+            let spec_name = builtin.name.as_str();
+            config.setup_dir(spec_name, &config_name)?;
+            match load_type {
+                LoadType::Write => {
+                    config.setup_write(&time_str, builtin.write_spec)?;
+                }
+                LoadType::Query => {
+                    config.setup_query(&time_str, builtin.query_spec)?;
+                }
+                LoadType::Full => {
+                    config.setup_write(&time_str, builtin.write_spec)?;
+                    config.setup_query(&time_str, builtin.query_spec)?;
+                }
+            }
+        } else {
+            match load_type {
+                LoadType::Write => {
+                    let spec = DataSpec::from_path(&spec_path.unwrap())?;
+                    let spec_name = spec.name.to_owned();
+                    config.setup_dir(&spec_name, &config_name)?;
+                    config.setup_write(&time_str, spec)?;
+                }
+                LoadType::Query => {
+                    let spec = QuerierSpec::from_path(&spec_path.unwrap())?;
+                    let spec_name = spec.name.to_owned();
+                    config.setup_dir(&spec_name, &config_name)?;
+                    config.setup_query(&time_str, spec)?;
+                }
+                LoadType::Full => {
+                    bail!("can only run custom specs with the `query` or `write` load directly")
+                }
+            }
+        };
+        // if print spec is set, print the spec and exit
+        if print_spec {
+            bail!("exiting after printing spec");
+        }
+
+        // Setup the system stats file if specified
+        if system_stats {
+            config.setup_system(&time_str)?;
+        }
+
+        Ok((client, config))
+    }
 }
 
 pub(crate) fn create_client(
@@ -80,12 +288,4 @@ pub(crate) fn create_client(
         client = client.with_auth_token(t.expose_secret());
     }
     Ok(client)
-}
-
-pub(crate) async fn init_results_dir(
-    results_dir: Option<PathBuf>,
-    spec_name: &str,
-    configuration_name: Option<String>,
-) {
-    todo!();
 }

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use influxdb3_client::Client;
 use secrecy::{ExposeSecret, Secret};
@@ -42,6 +44,31 @@ pub(crate) struct InfluxDb3Config {
     /// of the builtin as a starting point for creating your own.
     #[clap(long = "print-spec")]
     pub(crate) print_spec: Option<String>,
+
+    /// The directory to save results to.
+    ///
+    /// If not specified, this will default to `results` in the current directory.
+    ///
+    /// Files saved here will be organized in a directory structure as follows:
+    /// ```ignore
+    /// results/<s>/<c>/<write|query|system>_<time>.csv`
+    /// ```
+    /// where,
+    /// - `<s>`: the name of the load gen spec, e.g., `one_mil`
+    /// - `<c>`: the provided `configuration_name`, or will default to the revision SHA of the
+    ///   `influxdb3` binary
+    /// - `<write|query|system>`: results for the `write` load, `query` load, or `system` stats of the
+    ///   `influxdb3` binary, respectively.
+    /// - `<time>`: a timestamp of when the test started in `YYYY-MM-DD-HH-MM` format.
+    #[clap(short = 'r', long = "results-dir", env = "INFLUXDB3_LOAD_RESULTS_DIR")]
+    pub(crate) results_dir: Option<PathBuf>,
+
+    /// Provide a custom `configuration_name` for the generated results directory.
+    ///
+    /// If left blank, this will default to the revision SHA of the target `influxdb3` binary
+    /// under test.
+    #[clap(long = "config-name")]
+    pub(crate) configuration_name: Option<String>,
 }
 
 pub(crate) fn create_client(
@@ -53,4 +80,12 @@ pub(crate) fn create_client(
         client = client.with_auth_token(t.expose_secret());
     }
     Ok(client)
+}
+
+pub(crate) async fn init_results_dir(
+    results_dir: Option<PathBuf>,
+    spec_name: &str,
+    configuration_name: Option<String>,
+) {
+    todo!();
 }

--- a/influxdb3_load_generator/src/main.rs
+++ b/influxdb3_load_generator/src/main.rs
@@ -94,13 +94,13 @@ fn main() -> Result<(), std::io::Error> {
             None => println!("command required, --help for help"),
             Some(Command::Query(config)) => {
                 if let Err(e) = commands::query::command(config).await {
-                    eprintln!("Query command failed: {e}");
+                    eprintln!("Query command failed: {e:?}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }
             Some(Command::Write(config)) => {
                 if let Err(e) = commands::write::command(config).await {
-                    eprintln!("Write command failed: {e}");
+                    eprintln!("Write command failed: {e:?}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3_load_generator/src/specs/example.rs
+++ b/influxdb3_load_generator/src/specs/example.rs
@@ -7,11 +7,12 @@ use crate::specification::*;
 use crate::specs::BuiltInSpec;
 
 pub(crate) fn spec() -> BuiltInSpec {
+    let name = "sample_spec".to_string();
     let description =
         r#"Example that shows the various elements of the data generator."#.to_string();
 
     let write_spec = DataSpec {
-        name: "sample_spec".to_string(),
+        name: name.to_owned(),
         measurements: vec![
             MeasurementSpec {
                 name: "some_measurement".to_string(),
@@ -118,7 +119,7 @@ pub(crate) fn spec() -> BuiltInSpec {
     };
 
     let query_spec = QuerierSpec {
-        name: "sample_spec".to_string(),
+        name: name.to_owned(),
         queries: vec![QuerySpec {
             query: "SELECT f1, i1 FROM some_measurement WHERE some_tag = $some_val".to_string(),
             params: vec![ParamSpec {
@@ -129,6 +130,7 @@ pub(crate) fn spec() -> BuiltInSpec {
     };
 
     BuiltInSpec {
+        name: name.to_owned(),
         description,
         write_spec,
         query_spec,

--- a/influxdb3_load_generator/src/specs/mod.rs
+++ b/influxdb3_load_generator/src/specs/mod.rs
@@ -11,8 +11,16 @@ pub(crate) fn built_in_specs() -> Vec<BuiltInSpec> {
     vec![example::spec(), one_mil::spec()]
 }
 
+pub(crate) fn built_in_spec_names() -> Vec<String> {
+    built_in_specs()
+        .iter()
+        .map(|b| b.name.to_string())
+        .collect()
+}
+
 /// A built-in specification for the load generator
 pub(crate) struct BuiltInSpec {
+    pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) write_spec: DataSpec,
     pub(crate) query_spec: QuerierSpec,

--- a/influxdb3_load_generator/src/specs/one_mil.rs
+++ b/influxdb3_load_generator/src/specs/one_mil.rs
@@ -53,6 +53,7 @@ pub(crate) fn spec() -> BuiltInSpec {
     };
 
     BuiltInSpec {
+        name: "one_mil".to_string(),
         description,
         write_spec,
         query_spec,

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -8,6 +8,7 @@ use arrow::array::{
 use arrow::datatypes::Int32Type;
 use arrow::record_batch::RecordBatch;
 use data_types::{PartitionKey, TimestampMinMax};
+use observability_deps::tracing::debug;
 use schema::Schema;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -47,11 +48,11 @@ impl TableBuffer {
                         self.timestamp_max = self.timestamp_max.max(v);
 
                         let b = self.data.entry(f.name).or_insert_with(|| {
-                            println!("Creating new timestamp builder");
+                            debug!("Creating new timestamp builder");
                             let mut time_builder = TimestampNanosecondBuilder::new();
                             // append nulls for all previous rows
                             for _ in 0..(row_index + self.row_count) {
-                                println!("Appending null for timestamp");
+                                debug!("Appending null for timestamp");
                                 time_builder.append_null();
                             }
                             Builder::Time(time_builder)
@@ -158,7 +159,7 @@ impl TableBuffer {
             // add nulls for any columns not present
             for (name, builder) in &mut self.data {
                 if !value_added.contains(name) {
-                    println!("Adding null for column {}", name);
+                    debug!("Adding null for column {}", name);
                     match builder {
                         Builder::Bool(b) => b.append_null(),
                         Builder::F64(b) => b.append_null(),


### PR DESCRIPTION
Closes #24831

`write` and `query` load generation runners will now automatically setup files in a results directory, using a pre-defined structure. Users of the load tool can specify a `results_dir` to save these results, or the tool will pick a `results` folder in the current directory, by default.

Results will be saved in files using the following path convention:
```
<results_dir>/<s>/<c>/<write|query|system>_<time>.csv
```
- `<results_dir>`: the specified `results_dir`, or the `results/` folder in the current directory
- `<s>`: spec name
- `<c>`: configuration name, specified by user with the `config-name` arg, or by default, will use the revision SHA of the running server
- `<write|query|system>`: which kind of results file
- `<time>`: a timestamp in the form `YYYY-MM-DD-HH-MM`

The resulting file structure will look like this:
```
results
├── one_mil
│  └── 270f721fd7
│     ├── query_2024-04-02-12-21.csv
│     ├── system_2024-04-02-12-21.csv
│     └── write_2024-04-02-12-19.csv
└── sample_spec
   ├── 270f721fd7
   │  └── write_2024-04-02-12-24.csv
   └── my-load-test
      └── write_2024-04-02-12-25.csv
```

The setup code was unified for both `write` and `query` commands, in preparation for the creation of a system stats file, as well as for the capability to run both `query` and `write` at the same time, however, those tasks remain for future PRs.