### PR TITLE
feat: sort and dedupe on persist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
  "iox_http",
  "iox_query",
  "iox_time",
+ "metric",
  "object_store",
  "observability_deps",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,9 +2235,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -244,6 +244,7 @@ pub async fn command(config: Config) -> Result<()> {
             wal,
             Arc::clone(&time_provider),
             config.segment_duration,
+            Arc::clone(&exec),
         )
         .await?,
     );

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -80,7 +80,7 @@ async fn api_v3_query_sql_params() {
             .post(&url)
             .json(&json!({
                 "db": "foo",
-                "q": "SELECT host, region, time, usage FROM cpu WHERE host = $host AND usage > $usage",
+                "q": "SELECT host, region, time, usage FROM cpu WHERE host = $host AND usage > $usage ORDER BY time",
                 "params": {
                     "host": "b",
                     "usage": 0.60,
@@ -118,7 +118,7 @@ async fn api_v3_query_sql_params() {
                 ("db", "foo"),
                 (
                     "q",
-                    "SELECT host, region, time, usage FROM cpu WHERE host = $host AND usage > $usage",
+                    "SELECT host, region, time, usage FROM cpu WHERE host = $host AND usage > $usage ORDER BY time",
                 ),
                 ("format", "pretty"),
                 ("params", params.as_str()),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -279,6 +279,7 @@ mod tests {
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
+                Arc::clone(&exec),
             )
             .await
             .unwrap(),
@@ -439,6 +440,7 @@ mod tests {
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
+                Arc::clone(&exec),
             )
             .await
             .unwrap(),
@@ -646,6 +648,7 @@ mod tests {
                 None::<Arc<influxdb3_write::wal::WalImpl>>,
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
+                Arc::clone(&exec),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -43,5 +43,6 @@ url.workspace = true
 [dev-dependencies]
 # Core Crates
 arrow_util.workspace = true
+metric.workspace = true
 pretty_assertions.workspace = true
 test_helpers.workspace = true

--- a/influxdb3_write/src/chunk.rs
+++ b/influxdb3_write/src/chunk.rs
@@ -42,7 +42,7 @@ impl QueryChunk for BufferChunk {
     }
 
     fn may_contain_pk_duplicates(&self) -> bool {
-        false
+        true
     }
 
     fn data(&self) -> QueryChunkData {

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -664,6 +664,7 @@ pub(crate) mod tests {
         // When we persist the data all of these duplicates should be removed
         let lp = "cpu,tag1=cupcakes bar=1 10\n\
                   cpu,tag1=cupcakes bar=1 10\n\
+                  cpu,tag1=something bar=5 10\n\
                   cpu,tag1=cupcakes bar=1 10\n\
                   mem,tag2=turtles bar=3 15\n\
                   cpu,tag1=cupcakes bar=1 10\n\
@@ -727,7 +728,7 @@ pub(crate) mod tests {
             cpu_parqet.path,
             ParquetFilePath::new_with_parititon_key("db1", "cpu", SEGMENT_KEY, 4).to_string()
         );
-        assert_eq!(cpu_parqet.row_count, 1);
+        assert_eq!(cpu_parqet.row_count, 2);
         assert_eq!(cpu_parqet.min_time, 10);
         assert_eq!(cpu_parqet.max_time, 10);
 

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -187,7 +187,7 @@ mod tests {
         let catalog = Arc::new(catalog);
         let closed_buffer_segment = open_segment.into_closed_segment(Arc::clone(&catalog));
         closed_buffer_segment
-            .persist(Arc::clone(&persister))
+            .persist(Arc::clone(&persister), crate::test_help::make_exec(), None)
             .await
             .unwrap();
 
@@ -363,7 +363,7 @@ mod tests {
         let closed_segment = Arc::new(current_segment.into_closed_segment(Arc::clone(&catalog)));
 
         closed_segment
-            .persist(Arc::clone(&persister))
+            .persist(Arc::clone(&persister), crate::test_help::make_exec(), None)
             .await
             .unwrap();
 

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -107,6 +107,7 @@ impl<W: Wal, T: TimeProvider, P: Persister> WriteBufferImpl<W, T, P> {
         wal: Option<Arc<W>>,
         time_provider: Arc<T>,
         segment_duration: SegmentDuration,
+        executor: Arc<iox_query::exec::Executor>,
     ) -> Result<Self>
     where
         P: Persister,
@@ -143,6 +144,7 @@ impl<W: Wal, T: TimeProvider, P: Persister> WriteBufferImpl<W, T, P> {
                 shutdown_rx,
                 time_provider_persister,
                 wal_perister,
+                executor,
             )
             .await;
         });
@@ -854,6 +856,7 @@ mod tests {
             Some(Arc::new(wal)),
             Arc::clone(&time_provider),
             segment_duration,
+            crate::test_help::make_exec(),
         )
         .await
         .unwrap();
@@ -903,6 +906,7 @@ mod tests {
             Some(Arc::new(wal)),
             time_provider,
             segment_duration,
+            crate::test_help::make_exec(),
         )
         .await
         .unwrap();
@@ -923,6 +927,7 @@ mod tests {
             wal.clone(),
             Arc::clone(&time_provider),
             segment_duration,
+            crate::test_help::make_exec(),
         )
         .await
         .unwrap();
@@ -999,6 +1004,7 @@ mod tests {
             wal,
             Arc::clone(&time_provider),
             segment_duration,
+            crate::test_help::make_exec(),
         )
         .await
         .unwrap();
@@ -1042,6 +1048,7 @@ mod tests {
             wal.clone(),
             Arc::clone(&time_provider),
             segment_duration,
+            crate::test_help::make_exec(),
         )
         .await
         .unwrap();

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -18,7 +18,7 @@ pub struct TableBuffer {
     pub segment_key: PartitionKey,
     timestamp_min: i64,
     timestamp_max: i64,
-    data: BTreeMap<String, Builder>,
+    pub(crate) data: BTreeMap<String, Builder>,
     row_count: usize,
 }
 
@@ -207,7 +207,7 @@ impl std::fmt::Debug for TableBuffer {
     }
 }
 
-enum Builder {
+pub enum Builder {
     Bool(BooleanBuilder),
     I64(Int64Builder),
     F64(Float64Builder),


### PR DESCRIPTION
When persisting parquet files we now will sort and dedupe on persist using the
COMPACT operation implemented in IOx Query. Note that right now we don't choose
any column to sort on and default to no column. This means that we dedupe and
sort on whatever the default behavior is for the COMPACT operation. Future
changes can figure out what columns to sort by when compacting the data.

Closes #24823