### PR TITLE
feat: report system stats in load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,12 +2555,14 @@ dependencies = [
  "dotenvy",
  "humantime",
  "influxdb3_client",
+ "influxdb3_process",
  "observability_deps",
  "parking_lot",
  "rand",
  "secrecy",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror",
  "tokio",
  "trogging",
@@ -4435,7 +4437,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4469,7 +4471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.53",
@@ -5739,9 +5741,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.7"
+version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+checksum = "4b1a378e48fb3ce3a5cf04359c456c9c98ff689bcf1c1bc6e6a31f247686f275"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ serde_urlencoded = "0.7.0"
 sha2 = "0.10.8"
 snap = "1.0.0"
 sqlparser = "0.41.0"
+sysinfo = "0.30.8"
 thiserror = "1.0"
 tokio = { version = "1.35", features = ["full"] }
 tokio-util = "0.7.9"

--- a/influxdb3_load_generator/Cargo.toml
+++ b/influxdb3_load_generator/Cargo.toml
@@ -12,7 +12,7 @@ trogging.workspace = true
 
 # Local Deps
 influxdb3_client = { path = "../influxdb3_client" }
-influxdb3_process = { path = "../influxdb3_process" }
+influxdb3_process = { path = "../influxdb3_process", default-features = false }
 
 # crates.io Dependencies
 anyhow.workspace = true

--- a/influxdb3_load_generator/Cargo.toml
+++ b/influxdb3_load_generator/Cargo.toml
@@ -5,8 +5,6 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 # Core Crates
 observability_deps.workspace = true
@@ -14,6 +12,7 @@ trogging.workspace = true
 
 # Local Deps
 influxdb3_client = { path = "../influxdb3_client" }
+influxdb3_process = { path = "../influxdb3_process" }
 
 # crates.io Dependencies
 anyhow.workspace = true
@@ -28,6 +27,7 @@ rand.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sysinfo.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 url.workspace = true

--- a/influxdb3_load_generator/src/report.rs
+++ b/influxdb3_load_generator/src/report.rs
@@ -396,7 +396,7 @@ impl SystemStatsReporter {
             );
             let process = system
                 .process(self.pid)
-                .expect(format!("process with pid: {}", self.pid).as_str());
+                .unwrap_or_else(|| panic!("process with pid: {}", self.pid));
             let mut csv_writer = self.csv_writer.lock();
             let test_time_ms = Instant::now().duration_since(start_time).as_millis();
             csv_writer

--- a/influxdb3_load_generator/src/report.rs
+++ b/influxdb3_load_generator/src/report.rs
@@ -2,13 +2,15 @@
 
 use crate::line_protocol_generator::{WriteSummary, WriterId};
 use crate::query_generator::QuerierId;
-use anyhow::Context;
+use anyhow::{bail, Context};
 use chrono::{DateTime, Local};
+use influxdb3_process::INFLUXDB3_PROCESS_NAME;
 use parking_lot::Mutex;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs::File;
 use std::time::{Duration, Instant};
+use sysinfo::{Pid, Process, ProcessRefreshKind, System};
 // Logged reports will be flushed to the csv file on this interval
 const REPORT_FLUSH_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -216,13 +218,13 @@ pub struct QueryReporter {
 }
 
 impl QueryReporter {
-    pub fn new(csv_file: File) -> Result<Self, anyhow::Error> {
+    pub fn new(csv_file: File) -> Self {
         let csv_writer = Mutex::new(csv::Writer::from_writer(csv_file));
-        Ok(Self {
+        Self {
             state: Mutex::new(vec![]),
             csv_writer,
             shutdown: Mutex::new(false),
-        })
+        }
     }
 
     pub fn report(
@@ -278,8 +280,8 @@ impl QueryReporter {
             }
             csv_writer.flush().expect("failed to flush csv reports");
 
-            if console_stats.last_console_outptu_time.elapsed() > CONSOLE_REPORT_INTERVAL {
-                let elapsed_millis = console_stats.last_console_outptu_time.elapsed().as_millis();
+            if console_stats.last_console_output_time.elapsed() > CONSOLE_REPORT_INTERVAL {
+                let elapsed_millis = console_stats.last_console_output_time.elapsed().as_millis();
 
                 println!(
                     "success: {:.0}/s, error: {:.0}/s, rows: {:.0}/s",
@@ -315,7 +317,7 @@ struct QueryRecord {
 }
 
 struct QueryConsoleStats {
-    last_console_outptu_time: Instant,
+    last_console_output_time: Instant,
     success: usize,
     error: usize,
     rows: u64,
@@ -324,10 +326,103 @@ struct QueryConsoleStats {
 impl QueryConsoleStats {
     fn new() -> Self {
         Self {
-            last_console_outptu_time: Instant::now(),
+            last_console_output_time: Instant::now(),
             success: 0,
             error: 0,
             rows: 0,
         }
+    }
+}
+
+const SYSTEM_STATS_REPORT_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Copy, Clone, Serialize)]
+pub struct SystemStatsRecord {
+    wall_time: DateTime<Local>,
+    test_time_ms: u128,
+    cpu_usage: f32,
+    written_bytes: u64,
+    read_bytes: u64,
+    memory_bytes: u64,
+    virtual_memory_bytes: u64,
+}
+
+#[derive(Debug)]
+pub struct SystemStatsReporter {
+    pid: Pid,
+    system: Mutex<System>,
+    csv_writer: Mutex<csv::Writer<File>>,
+    shutdown: Mutex<bool>,
+}
+
+impl SystemStatsReporter {
+    pub fn new(csv_file: File) -> Result<Self, anyhow::Error> {
+        let csv_writer = Mutex::new(csv::Writer::from_writer(csv_file));
+        let mut system = System::new_all();
+        let mut processes = system
+            .processes_by_exact_name(INFLUXDB3_PROCESS_NAME)
+            .collect::<Vec<&Process>>();
+        if processes.is_empty() {
+            bail!("there is no '{}' process", INFLUXDB3_PROCESS_NAME);
+        }
+        if processes.len() > 1 {
+            bail!(
+                "ensure there is only one '{}' process running on your operating system",
+                INFLUXDB3_PROCESS_NAME
+            );
+        }
+        let pid = processes.pop().unwrap().pid();
+        // refresh the system stats for the process to initialize the baseline:
+        system.refresh_pids(&[pid]);
+        Ok(Self {
+            pid,
+            system: Mutex::new(system),
+            csv_writer,
+            shutdown: Mutex::new(false),
+        })
+    }
+
+    pub fn report_stats(&self) {
+        let start_time = Instant::now();
+
+        loop {
+            let mut system = self.system.lock();
+            system.refresh_pids_specifics(
+                &[self.pid],
+                ProcessRefreshKind::new()
+                    .with_cpu()
+                    .with_memory()
+                    .with_disk_usage(),
+            );
+            let process = system
+                .process(self.pid)
+                .expect(format!("process with pid: {}", self.pid).as_str());
+            let mut csv_writer = self.csv_writer.lock();
+            let test_time_ms = Instant::now().duration_since(start_time).as_millis();
+            csv_writer
+                .serialize(SystemStatsRecord {
+                    wall_time: Local::now(),
+                    test_time_ms,
+                    cpu_usage: process.cpu_usage(),
+                    written_bytes: process.disk_usage().written_bytes,
+                    read_bytes: process.disk_usage().read_bytes,
+                    memory_bytes: process.memory(),
+                    virtual_memory_bytes: process.virtual_memory(),
+                })
+                .expect("failed to write csv record for system stats");
+            csv_writer.flush().expect("flush system stats csv reports");
+
+            if *self.shutdown.lock() {
+                return;
+            }
+
+            std::thread::sleep(
+                sysinfo::MINIMUM_CPU_UPDATE_INTERVAL.max(SYSTEM_STATS_REPORT_INTERVAL),
+            );
+        }
+    }
+
+    pub fn shutdown(&self) {
+        *self.shutdown.lock() = true;
     }
 }

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -4,6 +4,9 @@ use iox_time::{SystemProvider, Time, TimeProvider};
 use metric::U64Gauge;
 use once_cell::sync::Lazy;
 
+/// The process name on the local OS running `influxdb3`
+pub const INFLUXDB3_PROCESS_NAME: &str = "influxdb3";
+
 #[cfg(all(not(feature = "heappy"), feature = "jemalloc_replacing_malloc"))]
 pub mod jemalloc;
 


### PR DESCRIPTION
Closes #24829

Added the mechanism to report system stats during load generation. The following stats are saved in a CSV file. Stats pertain specifically to the `influxdb3` process running on the local operating system:

- `wall_time`: timestamp of when row was written
- `test_time_ms`: time since test started
- `cpu_usage`: total CPU usage of the process, may be greater than 100 if more than one core is being used
- `written_bytes`: total bytes written to disk since last system stat refresh, i.e., since the previous row of data
- `read_bytes`: total bytes read from disk since last system stat refresh
- `memory_bytes`: total memory usage at given time
- `virtual_memory_bytes`: total virtual memory usage at given time

System stats can only be tracked when running the load generator against a local instance of `influxdb3`, i.e., one that is running on your machine.

All information is gathered using the [`sysinfo`](https://crates.io/crates/sysinfo) crate, and currently, stats are tracked at a fixed interval of every 500 ms.

## Usage

Generating system stats is done by passing the --system-stats flag to the load generator, e.g.,

```bash
influxdb3_load_generator write --builtin-spec one_mil --system-stats
```

Here is a sample of what the output CSV file looks like:
<img width="953" alt="image" src="https://github.com/influxdata/influxdb/assets/6188834/824422eb-148f-4189-8f6d-97d8e0ed0c2f">
