### PR TITLE
feat: add the `full` sub-command to load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,9 +2235,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/influxdb3_load_generator/src/commands/full.rs
+++ b/influxdb3_load_generator/src/commands/full.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use clap::Parser;
+
+use crate::commands::{query::run_query_load, write::run_write_load};
+
+use super::{common::InfluxDb3Config, query::QueryConfig, write::WriteConfig};
+
+#[derive(Debug, Parser)]
+pub(crate) struct Config {
+    /// Common InfluxDB 3.0 config
+    #[clap(flatten)]
+    common: InfluxDb3Config,
+
+    /// Query-specific config
+    #[clap(flatten)]
+    query: QueryConfig,
+
+    /// Write-specific config
+    #[clap(flatten)]
+    write: WriteConfig,
+}
+
+pub(crate) async fn command(mut config: Config) -> Result<(), anyhow::Error> {
+    let (client, mut load_config) = config
+        .common
+        .initialize_full(
+            config.query.querier_spec_path.take(),
+            config.write.writer_spec_path.take(),
+        )
+        .await?;
+
+    // spawn system stats collection:
+    let stats = load_config.system_reporter()?;
+    let database_name = load_config.database_name.clone();
+
+    // setup query load:
+    let query_spec = load_config.query_spec()?;
+    let (query_results_file_path, query_reporter) = load_config.query_reporter()?;
+    let qr = Arc::clone(&query_reporter);
+    let query_client = client.clone();
+    let query_handle = tokio::spawn(async move {
+        run_query_load(
+            query_spec,
+            qr,
+            query_client,
+            database_name.clone(),
+            config.query,
+        )
+        .await
+    });
+
+    // setup write load:
+    let write_spec = load_config.write_spec()?;
+    let (write_results_file_path, write_reporter) = load_config.write_reporter()?;
+    let wr = Arc::clone(&write_reporter);
+    let write_handle = tokio::spawn(async move {
+        run_write_load(
+            write_spec,
+            wr,
+            client,
+            load_config.database_name,
+            config.write,
+        )
+        .await
+    });
+
+    let (query_task, write_task) = tokio::try_join!(query_handle, write_handle)
+        .context("failed to join query and write tasks")?;
+
+    query_task?;
+    write_task?;
+
+    write_reporter.shutdown();
+    println!("write results saved in: {write_results_file_path}");
+
+    // shutdown query reporter:
+    query_reporter.shutdown();
+    println!("query results saved in: {query_results_file_path}");
+
+    if let Some((stats_file_path, stats_reporter)) = stats {
+        println!("system stats saved in: {stats_file_path}");
+        stats_reporter.shutdown();
+    }
+
+    Ok(())
+}

--- a/influxdb3_load_generator/src/main.rs
+++ b/influxdb3_load_generator/src/main.rs
@@ -17,6 +17,7 @@ mod specs;
 
 pub mod commands {
     pub mod common;
+    pub mod full;
     pub mod query;
     pub mod write;
 }
@@ -80,6 +81,9 @@ enum Command {
 
     /// Perform a set of writes to a running InfluxDB 3.0 server
     Write(commands::write::Config),
+
+    /// Perform both writes and queries against a running InfluxDB 3.0 server
+    Full(commands::full::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -101,6 +105,12 @@ fn main() -> Result<(), std::io::Error> {
             Some(Command::Write(config)) => {
                 if let Err(e) = commands::write::command(config).await {
                     eprintln!("Write command exited: {e:?}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::Full(config)) => {
+                if let Err(e) = commands::full::command(config).await {
+                    eprintln!("Full Write/Query command exited: {e:?}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3_load_generator/src/report.rs
+++ b/influxdb3_load_generator/src/report.rs
@@ -157,7 +157,7 @@ impl WriteReporter {
                 let elapsed_millis = console_stats.last_console_output_time.elapsed().as_millis();
 
                 println!(
-                    "success: {:.0}/s, error: {:.0}/s, lines: {:.0}/s, bytes: {:.0}/s",
+                    "write: success: {:.0}/s, error: {:.0}/s, lines: {:.0}/s, bytes: {:.0}/s",
                     console_stats.success as f64 / elapsed_millis as f64 * 1000.0,
                     console_stats.error as f64 / elapsed_millis as f64 * 1000.0,
                     console_stats.lines as f64 / elapsed_millis as f64 * 1000.0,
@@ -284,7 +284,7 @@ impl QueryReporter {
                 let elapsed_millis = console_stats.last_console_output_time.elapsed().as_millis();
 
                 println!(
-                    "success: {:.0}/s, error: {:.0}/s, rows: {:.0}/s",
+                    "query: success: {:.0}/s, error: {:.0}/s, rows: {:.0}/s",
                     console_stats.success as f64 / elapsed_millis as f64 * 1000.0,
                     console_stats.error as f64 / elapsed_millis as f64 * 1000.0,
                     console_stats.rows as f64 / elapsed_millis as f64 * 1000.0,

--- a/influxdb3_load_generator/src/specification.rs
+++ b/influxdb3_load_generator/src/specification.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -14,7 +16,7 @@ pub struct DataSpec {
 }
 
 impl DataSpec {
-    pub fn from_path(path: &str) -> Result<Self, anyhow::Error> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let contents = std::fs::read_to_string(path)?;
         let res = serde_json::from_str(&contents)?;
 
@@ -164,7 +166,7 @@ impl QuerierSpec {
         serde_json::to_string_pretty(self).context("failed to serialize query spec")
     }
 
-    pub(crate) fn from_path(path: &str) -> Result<Self, anyhow::Error> {
+    pub(crate) fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let contents = std::fs::read_to_string(path)?;
         serde_json::from_str(&contents).context("unable to serialize as JSON")
     }


### PR DESCRIPTION
Closes #24832

This implements a new `full` sub-command for the `influxdb3_load_generator` binary. This will run both the `query` and `write` loads simultaneously. The required refactoring was split over a few commits, which I have described below.

---

### [`b67d1ac`](https://github.com/influxdata/influxdb/commit/b67d1ace24b794d1ab78977382a557d1972f3e65) refactor: query/write load gen arg interface

Refactored the argument interface for the `query` and `write` load generator sub-commands to make them easier to unify in a new `full` command.

In summary:
- remove the query sampling interval arg
- make short-form of `--querier-count` `q` instead of `Q`
- remove the short-form for `--query-format`
- remove `--spec-path` in favour of `--querier-spec` and `--writer-spec` for specifying spec path of the `query` and `write` loads, respectively

### [`bc9562e`](https://github.com/influxdata/influxdb/commit/bc9562e79ec5516dca7744c4d2754dbe04b93a49) refactor: split out query/write command configs

Refactored the `query` and `write` command clap configurations to make them composable for the `full` command.

### [`c33ccc1`](https://github.com/influxdata/influxdb/commit/c33ccc1184b9226a1ba830f363c13b03af29301e) refactor: expose query and write runner for composability

Refactored the `query` and `write` runners so that they can be composed into the `full` runner.

### [`e90f8cd`](https://github.com/influxdata/influxdb/commit/e90f8cd0c87646dec330619399ce6a43d9a2074a) feat: add the full load generator sub-command

Implement a new sub-command for the load generator: `full`

This runs both the `query` and `write` loads simultaneously, and exposes the unified CLI of the two commands, respectively.

## Other Changes

* [`0995eea`](https://github.com/influxdata/influxdb/commit/0995eea689e350f13aeb4ba6f3f9f730ff00c678) feat: produce error on 0s sampling interval

  Closes #24859