### PR TITLE
refactor: make end argument common to query and write load generation

### DIFF
--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -83,7 +83,7 @@ pub(crate) struct InfluxDb3Config {
     /// Provide an end time to stop the load generation.
     ///
     /// This can be a human readable offset, e.g., `10m` (10 minutes), `1h` (1 hour), etc., or an
-    /// exact date-time in RFC3339 form, e.g., `2023-10-03T19:10:00-04:00`.
+    /// exact date-time in RFC3339 form, e.g., `2023-10-30T19:10:00-04:00`.
     #[clap(long = "end")]
     pub(crate) end_time: Option<FutureOffsetTime>,
 }
@@ -158,7 +158,9 @@ impl LoadConfig {
     ) -> Self {
         let end_time: Option<DateTime<Local>> = end_time.map(Into::into);
         if let Some(t) = end_time {
-            println!("Running load generation until: {t}");
+            println!("running load generation until: {t}");
+        } else {
+            println!("running load generation indefinitely");
         }
         Self {
             database_name,

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -1,7 +1,7 @@
-use std::{fs::File, path::PathBuf, sync::Arc};
+use std::{fs::File, path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, bail, Context};
-use chrono::Local;
+use chrono::{DateTime, Local};
 use clap::Parser;
 use influxdb3_client::Client;
 use secrecy::{ExposeSecret, Secret};
@@ -79,6 +79,41 @@ pub(crate) struct InfluxDb3Config {
     /// Generate a system stats file in the specified `results_dir`
     #[clap(long = "system-stats", default_value_t = false)]
     pub(crate) system_stats: bool,
+
+    /// Provide an end time to stop the load generation.
+    ///
+    /// This can be a human readable offset, e.g., `10m` (10 minutes), `1h` (1 hour), etc., or an
+    /// exact date-time in RFC3339 form, e.g., `2023-10-03T19:10:00-04:00`.
+    #[clap(long = "end")]
+    pub(crate) end_time: Option<FutureOffsetTime>,
+}
+
+/// A time in the future
+///
+/// Wraps a [`DateTime`], providing a custom [`FromStr`] implementation that parses human
+/// time input and converts it to a date-time in the future.
+#[derive(Debug, Clone, Copy)]
+pub struct FutureOffsetTime(DateTime<Local>);
+
+impl FromStr for FutureOffsetTime {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(t) = humantime::parse_rfc3339_weak(s) {
+            Ok(Self(DateTime::<Local>::from(t)))
+        } else {
+            humantime::parse_duration(s)
+                .map(|d| Local::now() + d)
+                .map(Self)
+                .with_context(|| format!("could not parse future offset time value: {s}"))
+        }
+    }
+}
+
+impl From<FutureOffsetTime> for DateTime<Local> {
+    fn from(t: FutureOffsetTime) -> Self {
+        t.0
+    }
 }
 
 /// Can run the load generation tool exclusively in either `query` or `write` mode, or
@@ -96,6 +131,8 @@ pub(crate) enum LoadType {
 pub(crate) struct LoadConfig {
     /// The target database name on the `influxdb3` server
     pub(crate) database_name: String,
+    /// The end time of the load generation run
+    pub(crate) end_time: Option<DateTime<Local>>,
     /// The directory that will store generated results files
     results_dir: PathBuf,
     /// If `true`, the configuration will initialize only to print out
@@ -113,11 +150,21 @@ pub(crate) struct LoadConfig {
 
 impl LoadConfig {
     /// Create a new [`LoadConfig`]
-    fn new(database_name: String, results_dir: PathBuf, print_mode: bool) -> Self {
+    fn new(
+        database_name: String,
+        results_dir: PathBuf,
+        end_time: Option<impl Into<DateTime<Local>>>,
+        print_mode: bool,
+    ) -> Self {
+        let end_time: Option<DateTime<Local>> = end_time.map(Into::into);
+        if let Some(t) = end_time {
+            println!("Running load generation until: {t}");
+        }
         Self {
             database_name,
             results_dir,
             print_mode,
+            end_time,
             ..Default::default()
         }
     }
@@ -297,6 +344,7 @@ impl InfluxDb3Config {
             results_dir,
             configuration_name,
             system_stats,
+            end_time,
         } = self;
 
         match (
@@ -338,7 +386,7 @@ impl InfluxDb3Config {
         };
 
         // initialize the load config:
-        let mut config = LoadConfig::new(database_name, results_dir, print_spec);
+        let mut config = LoadConfig::new(database_name, results_dir, end_time, print_spec);
 
         // if builtin spec is set, use that instead of the spec path
         if let Some(b) = builtin_spec {

--- a/influxdb3_load_generator/src/commands/write.rs
+++ b/influxdb3_load_generator/src/commands/write.rs
@@ -156,6 +156,8 @@ pub(crate) async fn run_write_load(
         "creating generators for {} concurrent writers",
         writer_count
     );
+    println!("each writer will send a write request every {sampling_interval}");
+
     let mut generators =
         create_generators(&spec, writer_count).context("failed to create generators")?;
 
@@ -288,10 +290,7 @@ async fn run_generator(
         let now = Local::now();
         if let Some(end_time) = end_time {
             if now > end_time {
-                println!(
-                    "writer {} finished writing to end time: {:?}",
-                    generator.writer_id, end_time
-                );
+                println!("writer {} completed at {}", generator.writer_id, end_time);
                 return;
             }
         }

--- a/influxdb3_load_generator/src/report.rs
+++ b/influxdb3_load_generator/src/report.rs
@@ -153,6 +153,10 @@ impl WriteReporter {
 
             csv_writer.flush().expect("failed to flush csv reports");
 
+            if *self.shutdown.lock() {
+                return;
+            }
+
             if console_stats.last_console_output_time.elapsed() > CONSOLE_REPORT_INTERVAL {
                 let elapsed_millis = console_stats.last_console_output_time.elapsed().as_millis();
 
@@ -165,10 +169,6 @@ impl WriteReporter {
                 );
 
                 console_stats = ConsoleReportStats::new();
-            }
-
-            if *self.shutdown.lock() {
-                return;
             }
 
             std::thread::sleep(REPORT_FLUSH_INTERVAL);
@@ -280,6 +280,10 @@ impl QueryReporter {
             }
             csv_writer.flush().expect("failed to flush csv reports");
 
+            if *self.shutdown.lock() {
+                return;
+            }
+
             if console_stats.last_console_output_time.elapsed() > CONSOLE_REPORT_INTERVAL {
                 let elapsed_millis = console_stats.last_console_output_time.elapsed().as_millis();
 
@@ -291,10 +295,6 @@ impl QueryReporter {
                 );
 
                 console_stats = QueryConsoleStats::new();
-            }
-
-            if *self.shutdown.lock() {
-                return;
             }
 
             std::thread::sleep(REPORT_FLUSH_INTERVAL);

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -188,7 +188,12 @@ impl TableBuffer {
         let mut cols = Vec::with_capacity(self.data.len());
         let schema = schema.as_arrow();
         for f in &schema.fields {
-            cols.push(self.data.get(f.name()).unwrap().as_arrow());
+            cols.push(
+                self.data
+                    .get(f.name())
+                    .unwrap_or_else(|| panic!("missing field in table buffer: {}", f.name()))
+                    .as_arrow(),
+            );
         }
 
         vec![RecordBatch::try_new(schema, cols).unwrap()]


### PR DESCRIPTION
Closes #24879

* make the `--end` argument common to both the `query` and `write` load generation runners, so that they will both terminate at the given future offset time.
* changed the `full` command to use `tokio::task::JoinSet` for spawning the query and write tasks.
* added a panic message in the table buffer where unwraps were causing panics (part of #24880)