### PR TITLE
feat: QoL improvements to the load generator and analysis tools

### DIFF
--- a/influxdb3_load_generator/analysis/app.py
+++ b/influxdb3_load_generator/analysis/app.py
@@ -30,7 +30,7 @@ def get_config_names():
         if os.path.isdir(config_path):
             run_times = set()
             for file_name in os.listdir(config_path):
-                match = re.search(r'_(\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})', file_name)
+                match = re.search(r'_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})', file_name)
                 if match:
                     run_time = match.group(1)
                     run_times.add(run_time)

--- a/influxdb3_load_generator/analysis/app.py
+++ b/influxdb3_load_generator/analysis/app.py
@@ -30,7 +30,7 @@ def get_config_names():
         if os.path.isdir(config_path):
             run_times = set()
             for file_name in os.listdir(config_path):
-                match = re.search(r'_(\d{4}-\d{2}-\d{2}-\d{2}-\d{2})', file_name)
+                match = re.search(r'_(\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})', file_name)
                 if match:
                     run_time = match.group(1)
                     run_times.add(run_time)
@@ -49,22 +49,29 @@ def get_aggregated_data():
     query_file = os.path.join(config_path, f'query_{run_time}.csv')
     system_file = os.path.join(config_path, f'system_{run_time}.csv')
 
-    if os.path.isfile(write_file) and os.path.isfile(query_file) and os.path.isfile(system_file):
-        write_data = aggregate_data(write_file, 'lines', 'latency_ms')
-        query_data = aggregate_data(query_file, 'rows', 'response_ms')
-        system_data = aggregate_system_data(system_file)
-
-        aggregated_data = {
-            'config_name': config_name,
-            'run_time': run_time,
-            'write_data': write_data,
-            'query_data': query_data,
-            'system_data': system_data
-        }
-
-        return jsonify(aggregated_data)
-    else:
+    if not os.path.isfile(write_file) and not os.path.isfile(query_file) and not os.path.isfile(system_file):
         return jsonify({'error': 'Files not found for the specified configuration and run time'})
+
+    write_data = None
+    if os.path.isfile(write_file):
+        write_data = aggregate_data(write_file, 'lines', 'latency_ms')
+    query_data = None
+    if os.path.isfile(query_file):
+        query_data = aggregate_data(query_file, 'rows', 'response_ms')
+    system_data = None
+    if os.path.isfile(system_file):
+        system_data = aggregate_system_data(system_file)
+    
+
+    aggregated_data = {
+        'config_name': config_name,
+        'run_time': run_time,
+        'write_data': write_data,
+        'query_data': query_data,
+        'system_data': system_data
+    }
+
+    return jsonify(aggregated_data)
 
 def aggregate_data(file_path, lines_field, latency_field):
     aggregated_data = []

--- a/influxdb3_load_generator/analysis/templates/index.html
+++ b/influxdb3_load_generator/analysis/templates/index.html
@@ -4,7 +4,7 @@
     <title>Benchmark Results Comparison</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
-        .graph-container {
+        #graph-container {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
             grid-template-rows: repeat(3, 1fr);
@@ -12,7 +12,7 @@
             width: 100%;
             height: 600px;
         }
-        .graph-container canvas {
+        #graph-container canvas {
             width: 100% !important;
             height: 100% !important;
         }
@@ -33,14 +33,7 @@
     <select id="config-name-2"></select>
 </div>
 <button id="compare-btn">Compare</button>
-<div class="graph-container">
-    <canvas id="lines-per-second-chart"></canvas>
-    <canvas id="write-latency-chart"></canvas>
-    <canvas id="queries-per-second-chart"></canvas>
-    <canvas id="query-latency-chart"></canvas>
-    <canvas id="cpu-usage-chart"></canvas>
-    <canvas id="memory-usage-chart"></canvas>
-</div>
+<div id="graph-container"></div>
 <script>
     const testNameSelect = document.getElementById('test-name');
     const configName1Select = document.getElementById('config-name-1');
@@ -111,18 +104,27 @@
                 const config1Data = data[0];
                 const config2Data = data[1];
 
-                renderGraph('lines-per-second-chart', 'Lines per Second', config1Data.write_data, config2Data.write_data, 'lines', 10000);
-                renderGraph('write-latency-chart', 'Write Latency (ms)', config1Data.write_data, config2Data.write_data, 'latency', 10000, 'median');
-                renderGraph('queries-per-second-chart', 'Queries per Second', config1Data.query_data, config2Data.query_data, 'lines', 10000);
-                renderGraph('query-latency-chart', 'Query Latency (ms)', config1Data.query_data, config2Data.query_data, 'latency', 10000, 'median');
-                renderGraph('cpu-usage-chart', 'CPU Usage (%)', config1Data.system_data, config2Data.system_data, 'cpu_usage');
-                renderGraph('memory-usage-chart', 'Memory Usage (MB)', config1Data.system_data, config2Data.system_data, 'memory_bytes');
+                if (config1Data.write_data && config2Data.write_data) {
+                    renderGraph('Lines per Second', config1Data.write_data, config2Data.write_data, 'lines', 10000);
+                    renderGraph('Write Latency (ms)', config1Data.write_data, config2Data.write_data, 'latency', 10000, 'median');
+                }
+                if (config1Data.query_data && config2Data.query_data) {
+                    renderGraph('Queries per Second', config1Data.query_data, config2Data.query_data, 'lines', 10000);
+                    renderGraph('Query Latency (ms)', config1Data.query_data, config2Data.query_data, 'latency', 10000, 'median');
+                }
+                if (config1Data.system_data && config2Data.system_data) {
+                    renderGraph('CPU Usage (%)', config1Data.system_data, config2Data.system_data, 'cpu_usage');
+                    renderGraph('Memory Usage (MB)', config1Data.system_data, config2Data.system_data, 'memory_bytes');
+                }
             });
     });
 
     // Render a graph using Chart.js
-    function renderGraph(chartId, title, config1Data, config2Data, yAxisKey, interval = 10000, aggregateFunction = 'sum') {
-        const ctx = document.getElementById(chartId).getContext('2d');
+    function renderGraph(title, config1Data, config2Data, yAxisKey, interval = 10000, aggregateFunction = 'sum') {
+        const container = document.getElementById('graph-container');
+        const canvas = document.createElement("canvas");
+        container.appendChild(canvas);
+        const ctx = canvas.getContext('2d');
 
         const labels = getXLabels(config1Data, interval);
         const config1Values = getYValues(config1Data, yAxisKey, interval, aggregateFunction);

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -369,7 +369,7 @@ impl InfluxDb3Config {
         let built_in_specs = crate::specs::built_in_specs();
 
         // sepcify a time string for generated results file names:
-        let time_str = format!("{}", Local::now().format("%Y-%m-%d-%H-%M"));
+        let time_str = format!("{}", Local::now().format("%Y-%m-%d-%H-%M-%S"));
 
         // initialize the influxdb3 client:
         let client =

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -369,7 +369,7 @@ impl InfluxDb3Config {
         let built_in_specs = crate::specs::built_in_specs();
 
         // sepcify a time string for generated results file names:
-        let time_str = format!("{}", Local::now().format("%Y-%m-%d-%H-%M-%S"));
+        let time_str = format!("{}", Local::now().format("%Y-%m-%dT%H-%M-%S"));
 
         // initialize the influxdb3 client:
         let client =


### PR DESCRIPTION
There is no issue for this.

### Changes

* Have the load generator output files with seconds in the file name, e.g., `write_<spec_name>_2024-04-12T10-11-12.csv`
  * this was so that runs could be started within a minute of each other
  * **Note**: this will likely break the tool for previously generated files that do not have this naming convention
* Have the front-end produce graphs dynamically, based on what was run, e.g., if only `query` and `system` were run, only graphs for those will be displayed. Previously, it would error if all three (`write`/`query`/`system`) were not present. Example:

<img width="420" alt="image" src="https://github.com/influxdata/influxdb/assets/6188834/fdbde0f6-23cb-4bff-ad1c-2b2e30e123f6">
