### PR TITLE
chore: point at latest core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arc-swap"
@@ -311,7 +311,7 @@ dependencies = [
  "futures",
  "once_cell",
  "paste",
- "prost 0.12.3",
+ "prost 0.12.4",
  "tokio",
  "tonic 0.10.2",
 ]
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "ahash",
  "arrow",
@@ -522,22 +522,22 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy",
+ "event-listener 5.3.0",
+ "event-listener-strategy 0.5.1",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a9249d1447a85f95810c620abea82e001fe58a31713fcce614caf52499f905"
+checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
 dependencies = [
  "bzip2",
  "flate2",
@@ -553,11 +553,13 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.8.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -579,18 +581,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -605,7 +607,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "backoff 0.1.0",
@@ -674,7 +676,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "observability_deps",
  "rand",
@@ -726,21 +728,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -822,15 +809,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
-
-[[package]]
-name = "bytecount"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
@@ -849,7 +830,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -886,40 +867,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "bytes",
  "dashmap",
@@ -937,12 +887,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -959,9 +910,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -969,7 +920,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1007,7 +958,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1052,7 +1003,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1064,7 +1015,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "http",
  "reqwest",
@@ -1082,12 +1033,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -1217,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
@@ -1363,7 +1314,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1387,7 +1338,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1398,7 +1349,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1417,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow-buffer",
  "bytes",
@@ -1431,7 +1382,7 @@ dependencies = [
  "once_cell",
  "ordered-float 4.2.0",
  "percent-encoding",
- "prost 0.12.3",
+ "prost 0.12.4",
  "schema",
  "serde_json",
  "sha2",
@@ -1553,8 +1504,8 @@ dependencies = [
  "datafusion-common",
  "paste",
  "sqlparser",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1683,7 +1634,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "object_store",
- "prost 0.12.3",
+ "prost 0.12.4",
 ]
 
 [[package]]
@@ -1702,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1786,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1841,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 dependencies = [
  "serde",
 ]
@@ -1856,9 +1807,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1880,15 +1831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,12 +1849,33 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -1922,14 +1885,14 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "futures",
  "libc",
@@ -1954,9 +1917,9 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "filetime"
@@ -2017,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2030,19 +1993,10 @@ dependencies = [
  "iox_query_params",
  "observability_deps",
  "once_cell",
- "prost 0.12.3",
+ "prost 0.12.4",
  "snafu 0.8.2",
  "tonic 0.10.2",
  "workspace-hack",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2147,7 +2101,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2183,16 +2137,16 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "observability_deps",
  "once_cell",
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost 0.12.3",
+ "prost 0.12.4",
  "prost-build",
- "prost-types 0.12.3",
+ "prost-types 0.12.4",
  "serde",
  "tonic 0.10.2",
  "tonic-build",
@@ -2212,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2254,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2549,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "bytes",
  "log",
@@ -2780,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2796,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2809,7 +2763,7 @@ dependencies = [
  "generated_types",
  "influxdb-line-protocol",
  "iox_query_params",
- "prost 0.12.3",
+ "prost 0.12.4",
  "rand",
  "reqwest",
  "schema",
@@ -2824,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "base64 0.22.0",
@@ -2836,7 +2790,7 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "predicate",
- "prost 0.12.3",
+ "prost 0.12.4",
  "prost-build",
  "query_functions",
  "serde",
@@ -2900,7 +2854,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "backoff 0.1.0",
@@ -2935,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "authz",
@@ -2951,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -2989,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "chrono-tz",
@@ -3022,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3037,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3048,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "authz",
@@ -3141,9 +3095,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -3293,7 +3247,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3320,15 +3274,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.6",
 ]
 
 [[package]]
@@ -3454,14 +3399,11 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3531,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3540,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3601,21 +3543,21 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2"
+checksum = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08"
 dependencies = [
  "async-lock",
  "async-trait",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener 5.3.0",
  "futures-util",
  "once_cell",
  "parking_lot",
  "quanta",
  "rustc_version",
- "skeptic",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -3636,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "murmur3"
@@ -3649,7 +3591,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3665,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "hashbrown 0.14.3",
  "influxdb-line-protocol",
@@ -3678,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3733,12 +3675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -3919,7 +3855,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "snafu 0.7.5",
@@ -3932,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3980,7 +3916,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4054,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "parquet_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -4095,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "base64 0.22.0",
@@ -4110,7 +4046,7 @@ dependencies = [
  "observability_deps",
  "parquet",
  "pbjson-types",
- "prost 0.12.3",
+ "prost 0.12.4",
  "schema",
  "snafu 0.8.2",
  "thiserror",
@@ -4154,8 +4090,8 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
 ]
 
 [[package]]
@@ -4168,18 +4104,18 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.12.3",
+ "prost 0.12.4",
  "prost-build",
  "serde",
 ]
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "serde",
 ]
 
@@ -4229,7 +4165,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4308,7 +4244,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4371,9 +4307,9 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "parking_lot",
- "prost 0.12.3",
+ "prost 0.12.4",
  "prost-build",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.4",
  "protobuf",
  "sha2",
  "smallvec",
@@ -4391,7 +4327,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "chrono",
@@ -4415,10 +4351,7 @@ checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -4449,19 +4382,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -4486,8 +4419,6 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
- "bit-set",
- "bit-vec",
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
@@ -4495,8 +4426,6 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.3",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -4512,34 +4441,33 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.4",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
  "tempfile",
- "which",
 ]
 
 [[package]]
@@ -4557,15 +4485,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4579,11 +4507,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
- "prost 0.12.3",
+ "prost 0.12.4",
 ]
 
 [[package]]
@@ -4591,17 +4519,6 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.5.0",
- "memchr",
- "unicase",
-]
 
 [[package]]
 name = "quanta"
@@ -4621,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "chrono",
@@ -4633,12 +4550,6 @@ dependencies = [
  "snafu 0.8.2",
  "workspace-hack",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4661,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -4894,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4907,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",
@@ -4940,11 +4851,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "rustls-pki-types",
 ]
 
@@ -4966,21 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -5009,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "hashbrown 0.14.3",
@@ -5098,9 +4997,6 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "seq-macro"
@@ -5110,9 +5006,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -5145,13 +5041,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5167,9 +5063,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -5204,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "datafusion",
@@ -5216,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5231,7 +5127,7 @@ dependencies = [
  "iox_query_influxql",
  "iox_query_params",
  "observability_deps",
- "prost 0.12.3",
+ "prost 0.12.4",
  "serde",
  "serde_json",
  "service_common",
@@ -5248,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -5289,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -5323,21 +5219,6 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
 
 [[package]]
 name = "slab"
@@ -5394,7 +5275,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5467,7 +5348,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5529,7 +5410,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "either",
  "futures",
@@ -5725,30 +5606,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.58",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5761,7 +5623,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5806,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5823,9 +5685,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.8"
+version = "0.30.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1a378e48fb3ce3a5cf04359c456c9c98ff689bcf1c1bc6e6a31f247686f275"
+checksum = "87341a165d73787554941cd5ef55ad728011566fe714e987d1b976c15dbc3a83"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -5884,7 +5746,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5900,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5925,7 +5787,7 @@ dependencies = [
  "observability_deps",
  "once_cell",
  "parking_lot",
- "prost 0.12.3",
+ "prost 0.12.4",
  "rand",
  "regex",
  "reqwest",
@@ -5942,22 +5804,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6075,7 +5937,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6107,7 +5969,6 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "slab",
@@ -6118,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "metric",
  "parking_lot",
@@ -6129,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6183,7 +6044,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost 0.12.4",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile 1.0.4",
@@ -6206,7 +6067,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6216,7 +6077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
 dependencies = [
  "async-stream",
- "prost 0.12.3",
+ "prost 0.12.4",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -6228,8 +6089,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
 dependencies = [
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -6291,7 +6152,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "futures",
  "http",
@@ -6305,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6317,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "async-trait",
  "clap",
@@ -6334,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "bytes",
  "futures",
@@ -6372,7 +6233,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6431,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "futures",
  "hashbrown 0.14.3",
@@ -6466,7 +6327,7 @@ checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "clap",
  "logfmt",
@@ -6489,7 +6350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand",
  "static_assertions",
 ]
 
@@ -6510,15 +6370,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -6616,12 +6467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6694,7 +6539,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -6728,7 +6573,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6767,18 +6612,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "whoami"
@@ -6828,7 +6661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6837,7 +6670,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6855,7 +6688,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -6875,17 +6708,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -6896,9 +6730,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6908,9 +6742,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6920,9 +6754,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6932,9 +6772,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6944,9 +6784,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6956,9 +6796,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6968,9 +6808,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"
@@ -6985,22 +6825,17 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c#1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-ipc",
  "base64 0.21.7",
- "bit-set",
- "bit-vec",
  "bitflags 2.5.0",
  "byteorder",
  "bytes",
  "cc",
  "chrono",
- "clap",
- "clap_builder",
- "concurrent-queue",
  "crossbeam-epoch",
  "crossbeam-utils",
  "crypto-common",
@@ -7024,15 +6859,12 @@ dependencies = [
  "itertools 0.11.0",
  "k8s-openapi",
  "kube-core",
- "lalrpop-util",
  "libc",
- "linux-raw-sys",
  "lock_api",
  "log",
  "md-5",
  "memchr",
  "mio",
- "nix 0.28.0",
  "nom",
  "num-traits",
  "object_store",
@@ -7041,10 +6873,9 @@ dependencies = [
  "percent-encoding",
  "petgraph",
  "phf_shared",
- "predicates",
  "proptest",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "rand",
  "rand_core",
  "regex",
@@ -7052,14 +6883,11 @@ dependencies = [
  "regex-syntax 0.8.3",
  "reqwest",
  "ring",
- "rustix",
  "rustls",
  "serde",
  "serde_json",
  "sha2",
  "similar",
- "smallvec",
- "socket2",
  "spin 0.9.8",
  "sqlparser",
  "sqlx",
@@ -7069,7 +6897,7 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 1.0.109",
- "syn 2.0.58",
+ "syn 2.0.60",
  "thrift",
  "tokio",
  "tokio-stream",
@@ -7080,7 +6908,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "twox-hash",
  "unicode-bidi",
  "unicode-normalization",
  "url",
@@ -7128,7 +6955,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "ahash",
  "arrow",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "backoff 0.1.0",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "observability_deps",
  "rand",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "bytes",
  "dashmap",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "clap",
  "ed25519-dalek",
@@ -1015,7 +1015,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "http",
  "reqwest",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow-buffer",
  "bytes",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "futures",
  "libc",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "observability_deps",
  "once_cell",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "bytes",
  "log",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "base64 0.22.0",
@@ -2854,7 +2854,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "backoff 0.1.0",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "authz",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -2943,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "chrono-tz",
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "authz",
@@ -3403,7 +3403,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3591,7 +3591,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "hashbrown 0.14.3",
  "influxdb-line-protocol",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3916,7 +3916,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "parquet_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "base64 0.22.0",
@@ -4327,7 +4327,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "chrono",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "chrono",
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "hashbrown 0.14.3",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "datafusion",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -5410,7 +5410,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "either",
  "futures",
@@ -5746,7 +5746,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "metric",
  "parking_lot",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6152,7 +6152,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "futures",
  "http",
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "async-trait",
  "clap",
@@ -6195,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "bytes",
  "futures",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "futures",
  "hashbrown 0.14.3",
@@ -6327,7 +6327,7 @@ checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "clap",
  "logfmt",
@@ -6641,11 +6641,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/hakari#0e1b6e477a8f22544ac34e73f91141e8867b56ff"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=b546e7f86ee9adbff0dd3c5e687140848397604a#b546e7f86ee9adbff0dd3c5e687140848397604a"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,37 +101,37 @@ urlencoding = "1.1"
 uuid = { version = "1", features = ["v4"] }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c"}
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c", features = ["http"] }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "1d19543c8ef1fe9b3401f703cdcaba4d20db4e8c", default-features = true, features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari"}
+authz = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari", features = ["http"] }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,37 +101,37 @@ urlencoding = "1.1"
 uuid = { version = "1", features = ["v4"] }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari"}
-authz = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari", features = ["http"] }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/hakari", default-features = true, features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a"}
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a", features = ["http"] }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "b546e7f86ee9adbff0dd3c5e687140848397604a", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"


### PR DESCRIPTION
Pointing at the latest version of `influxdb3_core` after https://github.com/influxdata/influxdb3_core/pull/16.