### PR TITLE
feat: use new package builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ jobs:
             - artifacts
   build-packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager:latest
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next:latest
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,8 +1,7 @@
 version:
-  release:
-    match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
+  - match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
     value: '{{env.CIRCLE_TAG[1:]}}'
-  default:
+  - match: '.*'
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'
 
 sources:
@@ -30,20 +29,19 @@ packages:
   - name:        influxdb3
     description: Monolithic time-series database.
     license:     MIT/Apache-2.0
+    vendor:      InfluxData
+    homepage:    https://influxdata.com
+    maintainer:
+      name:  support
+      email: support@influxdata.com
     binaries:
       - influxdb3
       - influxdb3.exe
     extras:
       - source: LICENSE-APACHE
         target: usr/share/influxdb3/LICENSE-APACHE
-
       - source: LICENSE-MIT
         target: usr/share/influxdb3/LICENSE-MIT
-
       - source: README.md
         target: usr/share/influxdb3/README.md
-    #perm_overrides:
-    #deb_recommends:
-    #conflicts:
-    #depends:
     source: .circleci/packages/influxdb3

--- a/foo
+++ b/foo
@@ -1,0 +1,1 @@
+38fd39f0659ac8406de0e8f83c64eb0a15ac0152a8198467407ddb56c2a6e684  /home/michael/1Password Emergency Kit A3-CP6WC8-team-influxdata.pdf

--- a/foo
+++ b/foo
@@ -1,1 +1,0 @@
-38fd39f0659ac8406de0e8f83c64eb0a15ac0152a8198467407ddb56c2a6e684  /home/michael/1Password Emergency Kit A3-CP6WC8-team-influxdata.pdf


### PR DESCRIPTION
This uses the new `ci-packager` container that doesn't mangle the version strings. Some modifications to `config.yaml` were required, so I pushed the image to `ci-packager-next`. When I make all other workflows using this image compatible, I'll move everything over to `ci-packager` proper.

The only thing of note is that RPMs don't accept `-` in either the `Version` or `Release` section. So I've split the version by the first encountered `-`. For instance, here's what a snapshot package results with:

```sh
$ rpm -qip influxdb3-3.0.0+snapshot-fdee5321.x86_64.rpm
Name        : influxdb3
Version     : 3.0.0+snapshot
Release     : fdee5321
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 86751347
License     : MIT/Apache-2.0
Signature   : (none)
Source RPM  : influxdb3-3.0.0+snapshot-fdee5321.src.rpm
Build Date  : Fri 26 Apr 2024 05:23:39 PM EDT
Build Host  : 3d24177ee189
Packager    : support@influxdata.com
Vendor      : InfluxData
URL         : https://influxdata.com
Summary     : Monolithic time-series database.
Description :
Monolithic time-series database.

$ dpkg -I influxdb3_3.0.0+snapshot-fdee5321_amd64.deb 
 new Debian package, version 2.0.
 size 18204752 bytes: control archive=864 bytes.
     254 bytes,     9 lines      control              
     397 bytes,     6 lines      md5sums              
      12 bytes,     1 lines   *  postinst             #!/bin/bash
     434 bytes,    22 lines   *  preinst              #!/bin/bash
 Package: influxdb3
 Version: 3.0.0+snapshot-fdee5321
 Architecture: amd64
 Maintainer: support <support@influxdata.com>
 Installed-Size: 83934
 Section: default
 Priority: optional
 Homepage: https://influxdata.com
 Description: Monolithic time-series database.
```