### PR TITLE
fix: ensure TSMBatchKeyIterator closes all TSMReaders

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -645,14 +645,12 @@ func (f *FileStore) Close() error {
 	// Let other methods access this closed object while we do the actual closing.
 	f.mu.Unlock()
 
-	for _, file := range files {
-		err := file.Close()
-		if err != nil {
-			return err
-		}
+	var errSlice []error
+	for _, tsmFile := range files {
+		errSlice = append(errSlice, tsmFile.Close())
 	}
 
-	return nil
+	return errors.Join(errSlice...)
 }
 
 func (f *FileStore) DiskSizeBytes() int64 {


### PR DESCRIPTION
Ensure that compaction does not leave TSMReaders
open when complete, and that KeyIterators are all closed.