### PR TITLE
fix: ensure TSMBatchKeyIterator and FileStore close all TSMReaders (#24957)

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -14,6 +14,7 @@ package tsm1
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -1630,15 +1631,14 @@ func (k *tsmBatchKeyIterator) Close() error {
 	k.values = nil
 	k.pos = nil
 	k.iterators = nil
+	var errSlice []error
 	for _, r := range k.readers {
-		if err := r.Close(); err != nil {
-			return err
-		}
+		errSlice = append(errSlice, r.Close())
 	}
-	return nil
+	return errors.Join(errSlice...)
 }
 
-// Error returns any errors encountered during iteration.
+// Err error returns any errors encountered during iteration.
 func (k *tsmBatchKeyIterator) Err() error {
 	if len(k.errs) == 0 {
 		return nil

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -679,14 +679,12 @@ func (f *FileStore) Close() error {
 	// Let other methods access this closed object while we do the actual closing.
 	f.mu.Unlock()
 
-	for _, file := range files {
-		err := file.Close()
-		if err != nil {
-			return err
-		}
+	var errSlice []error
+	for _, tsmFile := range files {
+		errSlice = append(errSlice, tsmFile.Close())
 	}
 
-	return nil
+	return errors.Join(errSlice...)
 }
 
 func (f *FileStore) DiskSizeBytes() int64 {


### PR DESCRIPTION
Do not let errors on closing
a TSMReader prevent other
closes.

(cherry picked from commit 82cbdb5478af885c79a5a7dbe78c0297599bb616)

closes https://github.com/influxdata/influxdb/issues/24961