### PR TITLE
chore: upgrade go 1.21.9 -> 1.21.10 (1.10)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.21.9-latest
+    default: go1.21.10-latest
 
   workflow:
     type: string


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/679