### PR TITLE
chore: sync latest core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "ahash",
  "arrow",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "backoff",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "observability_deps",
  "rand",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "bytes",
  "dashmap",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "clap",
@@ -1004,7 +1004,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7266f0a7275b00ce4c4f4753e8c31afdefe93828101ece83a06e2ddab1dd1010"
+checksum = "611eaefca84c93e431ad82dfb848f6e05a99e25148384f45a3852b0fbe1c8086"
 dependencies = [
  "byteorder",
  "croaring-sys",
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "croaring-sys"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47112498c394a7067949ebc07ef429b7384a413cf0efcf675846a47bcd307fb"
+checksum = "ab5260027c04c33d67f405589d9c26e1e991fe062fb165f3094c9836e6c3b17f"
 dependencies = [
  "cc",
 ]
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "tokio",
 ]
@@ -1422,7 +1422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "chrono",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1459,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1519,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "chrono",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1810,17 +1810,14 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "futures",
  "metric",
  "observability_deps",
- "once_cell",
  "parking_lot",
- "pin-project",
  "snafu 0.8.2",
  "tokio",
- "tokio-util",
  "tokio_metrics_bridge",
  "tokio_watchdog",
  "workspace-hack",
@@ -1873,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2030,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "observability_deps",
  "once_cell",
@@ -2445,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "bytes",
  "log",
@@ -2676,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
@@ -2692,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2720,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2744,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.38.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
 dependencies = [
  "console",
  "lazy_static",
@@ -2776,7 +2773,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2813,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "authz",
@@ -2829,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -2867,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "chrono-tz 0.9.0",
@@ -2900,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2915,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -2926,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "authz",
@@ -3168,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3238,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3247,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3330,7 +3327,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3346,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb-line-protocol",
@@ -3359,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3572,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3620,7 +3617,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3687,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -3902,7 +3899,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "chrono",
@@ -4111,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "chrono",
@@ -4521,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-fork"
@@ -4564,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -4637,18 +4634,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4681,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "datafusion",
@@ -4693,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4725,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -4991,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "either",
  "futures",
@@ -5280,7 +5277,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5300,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5541,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "metric",
  "parking_lot",
@@ -5552,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "metric",
  "observability_deps",
@@ -5712,7 +5709,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -5726,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -5738,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "async-trait",
  "clap",
@@ -5756,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "bytes",
  "futures",
@@ -5853,7 +5850,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -5873,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "clap",
  "logfmt",
@@ -6386,7 +6383,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ab23285fe62f29a60652011b0bee9cc6ee3a899e#ab23285fe62f29a60652011b0bee9cc6ee3a899e"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "string"] }
 crc32fast = "1.2.0"
 crossbeam-channel = "0.5.11"
-datafusion = { git = "https://github.com/apache/datafusion.git", rev = "e0245296792eabdc35e83e8c5872345ff38c1fdf" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "e0245296792eabdc35e83e8c5872345ff38c1fdf" }
+datafusion = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
+datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
 csv = "1.3.0"
 dotenvy = "0.15.7"
 flate2 = "1.0.27"
@@ -100,38 +100,38 @@ urlencoding = "1.1"
 uuid = { version = "1", features = ["v4"] }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e"}
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e", features = ["http"] }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ab23285fe62f29a60652011b0bee9cc6ee3a899e", default-features = true, features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"}
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94", features = ["http"] }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"


### PR DESCRIPTION
No issue for this. This brings in changes to the `IoxSystemTable` trait to support query predicates. See https://github.com/influxdata/influxdb3_core/pull/19