### PR TITLE
fix: writes with incorrect schema should fail

### DIFF
--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -85,6 +85,12 @@ impl WriteBufferFlusher {
         &self,
         segmented_data: Vec<ValidSegmentedData>,
     ) -> crate::write_buffer::Result<()> {
+        // Check for presence of valid segment data, otherwise, the await on the response receiver
+        // will hang below.
+        if segmented_data.is_empty() {
+            return Ok(());
+        }
+
         let (response_tx, response_rx) = oneshot::channel();
 
         self.buffer_tx

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -521,8 +521,8 @@ fn validate_line_schema<'a>(
     let table_name = line.series.measurement.as_str();
     if let Some(table_schema) = schema.get_table_schema(table_name) {
         for (field_name, field_val) in line.field_set.iter() {
-            if let Some(schema_col_type) = table_schema.field_type_by_name(&field_name) {
-                let field_col_type = column_type_from_field(&field_val);
+            if let Some(schema_col_type) = table_schema.field_type_by_name(field_name) {
+                let field_col_type = column_type_from_field(field_val);
                 if field_col_type != schema_col_type {
                     let field_name = field_name.to_string();
                     return Err(WriteLineError {

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -469,25 +469,22 @@ pub(crate) fn parse_validate_and_update_schema(
     let mut valid_parsed_and_raw_lines: Vec<(ParsedLine, &str)> = vec![];
 
     for (line_idx, maybe_line) in parse_lines(lp).enumerate() {
-        let line = match maybe_line {
+        let line = match maybe_line
+            .map_err(|e| WriteLineError {
+                // This unwrap is fine because we're moving line by line
+                // alongside the output from parse_lines
+                original_line: lp_lines.next().unwrap().to_string(),
+                line_number: line_idx + 1,
+                error_message: e.to_string(),
+            })
+            .and_then(|l| validate_line_schema(line_idx, l, schema))
+        {
             Ok(line) => line,
             Err(e) => {
                 if !accept_partial {
-                    return Err(Error::ParseError(WriteLineError {
-                        // This unwrap is fine because we're moving line by line
-                        // alongside the output from parse_lines
-                        original_line: lp_lines.next().unwrap().to_string(),
-                        line_number: line_idx + 1,
-                        error_message: e.to_string(),
-                    }));
+                    return Err(Error::ParseError(e));
                 } else {
-                    errors.push(WriteLineError {
-                        original_line: lp_lines.next().unwrap().to_string(),
-                        // This unwrap is fine because we're moving line by line
-                        // alongside the output from parse_lines
-                        line_number: line_idx + 1,
-                        error_message: e.to_string(),
-                    });
+                    errors.push(e);
                 }
                 continue;
             }
@@ -510,6 +507,40 @@ pub(crate) fn parse_validate_and_update_schema(
         result.errors = errors;
         result
     })
+}
+
+/// Validate a line of line protocol against the given schema definition
+///
+/// This is for scenarios where a write comes in for a table that exists, but may have invalid field
+/// types, based on the pre-existing schema.
+fn validate_line_schema<'a>(
+    line_number: usize,
+    line: ParsedLine<'a>,
+    schema: &DatabaseSchema,
+) -> Result<ParsedLine<'a>, WriteLineError> {
+    let table_name = line.series.measurement.as_str();
+    if let Some(table_schema) = schema.get_table_schema(table_name) {
+        for (field_name, field_val) in line.field_set.iter() {
+            if let Some(schema_col_type) = table_schema.field_type_by_name(&field_name) {
+                let field_col_type = column_type_from_field(&field_val);
+                if field_col_type != schema_col_type {
+                    let field_name = field_name.to_string();
+                    return Err(WriteLineError {
+                        original_line: line.to_string(),
+                        line_number: line_number + 1,
+                        error_message: format!(
+                            "invalid field value in line protocol for field '{field_name}' on line \
+                            {line_number}: expected type {expected}, but got {got}",
+                            expected = ColumnType::from(schema_col_type),
+                            got = field_col_type,
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(line)
 }
 
 /// Takes parsed lines, validates their schema. If new tables or columns are defined, they


### PR DESCRIPTION
### Summary of Changes

* Added a reproducer to replicate the scenario described in #25006 
* Added a step in the write path to validate fields against the existing schema, to ensure that the fields being written have the same types as the existing schema
* _Note_: this incurs an extra check against each field in each line written when `accept_partial=true`; if this degrades performance, we could introduce a parameter that turns this check off, e.g., `validate_schema`, for users that don't want schema validation.

#### Example API Response
```json
{
  "error":"partial write of line protocol occurred",
  "data":[
    {
      "original_line":"t0,t0_tag0=initTag t0_f0=0u 1715694000",
      "line_number":1,
      "error_message":"invalid field value in line protocol for field 't0_f0' on line 0: expected type i64, but got u64"
    },
    {
      "original_line":"t0,t0_tag0=initTag t0_f0=1u 1715694001",
      "line_number":2,
      "error_message":"invalid field value in line protocol for field 't0_f0' on line 1: expected type i64, but got u64"
    }
  ]
}
```

Closes #25006