### PR TITLE
fix: allow cross platform remote backups

### DIFF
--- a/cmd/influxd/backup_util/backup_util.go
+++ b/cmd/influxd/backup_util/backup_util.go
@@ -222,9 +222,12 @@ func (w *CountingWriter) BytesWritten() int64 {
 // retentionAndShardFromPath will take the shard relative path and split it into the
 // retention policy name and shard ID. The first part of the path should be the database name.
 func DBRetentionAndShardFromPath(path string) (db, retention, shard string, err error) {
-	a := strings.Split(path, string(filepath.Separator))
+	a := strings.Split(path, string('/'))
 	if len(a) != 3 {
-		return "", "", "", fmt.Errorf("expected database, retention policy, and shard id in path: %s", path)
+		a = strings.Split(path, string('\\'))
+		if len(a) != 3 {
+			return "", "", "", fmt.Errorf("expected database, retention policy, and shard id in path: %s", path)
+		}
 	}
 
 	return a[0], a[1], a[2], nil


### PR DESCRIPTION
Closes #8256

As now, in v1.x influxd backup DBRetentionAndShardFromPath() uses the local path separator, e.g. "/" on Unix. This does not work when restoring data from systems using the other one, i.e. "\" on Windows. The proposed change tries both separators before returning an error.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).