### PR TITLE
refactor: add dedicated type for serializaing catalog tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1709,16 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2404,6 +2449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2472,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2431,6 +2483,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -2656,6 +2709,7 @@ dependencies = [
  "schema",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "snap",
  "test_helpers",
@@ -3483,6 +3537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +3956,12 @@ name = "platforms"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4683,6 +4749,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "service_common"
 version = "0.1.0"
 source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
@@ -5429,6 +5525,37 @@ checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrayref"
@@ -310,8 +310,8 @@ dependencies = [
  "futures",
  "once_cell",
  "paste",
- "prost 0.12.4",
- "prost-types 0.12.4",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "tokio",
  "tonic 0.11.0",
 ]
@@ -486,7 +486,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "regex",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "uuid",
  "workspace-hack",
 ]
@@ -524,9 +524,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
  "bzip2",
  "flate2",
@@ -559,7 +559,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -570,7 +570,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -595,7 +595,7 @@ dependencies = [
  "iox_time",
  "metric",
  "observability_deps",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tonic 0.11.0",
  "workspace-hack",
 ]
@@ -658,16 +658,16 @@ source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7a
 dependencies = [
  "observability_deps",
  "rand",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "workspace-hack",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
  "addr2line",
  "cc",
@@ -841,7 +841,7 @@ dependencies = [
  "metric",
  "observability_deps",
  "reqwest 0.11.27",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "tokio-util",
  "url",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -961,7 +961,7 @@ dependencies = [
  "observability_deps",
  "paste",
  "reqwest 0.11.27",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "sysinfo",
  "tokio",
  "trace_exporters",
@@ -992,7 +992,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1163,9 +1163,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -1294,7 +1294,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1328,12 +1328,12 @@ dependencies = [
  "once_cell",
  "ordered-float 4.2.0",
  "percent-encoding",
- "prost 0.12.4",
+ "prost 0.12.6",
  "schema",
  "serde_json",
  "sha2",
  "siphasher 1.0.1",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "sqlx",
  "thiserror",
  "uuid",
@@ -1618,7 +1618,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "object_store",
- "prost 0.12.4",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -1816,7 +1816,7 @@ dependencies = [
  "metric",
  "observability_deps",
  "parking_lot",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "tokio_metrics_bridge",
  "tokio_watchdog",
@@ -1834,12 +1834,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixedbitset"
@@ -1883,8 +1877,8 @@ dependencies = [
  "iox_query_params",
  "observability_deps",
  "once_cell",
- "prost 0.12.4",
- "snafu 0.8.2",
+ "prost 0.12.6",
+ "snafu 0.8.3",
  "tonic 0.11.0",
  "workspace-hack",
 ]
@@ -1991,7 +1985,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2034,9 +2028,9 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost 0.12.4",
+ "prost 0.12.6",
  "prost-build",
- "prost-types 0.12.4",
+ "prost-types 0.12.6",
  "serde",
  "tonic 0.11.0",
  "tonic-build",
@@ -2057,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2068,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -2368,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2448,7 +2442,7 @@ dependencies = [
  "log",
  "nom",
  "smallvec",
- "snafu 0.8.2",
+ "snafu 0.8.3",
 ]
 
 [[package]]
@@ -2703,7 +2697,7 @@ dependencies = [
  "generated_types",
  "influxdb-line-protocol",
  "iox_query_params",
- "prost 0.12.4",
+ "prost 0.12.6",
  "rand",
  "reqwest 0.11.27",
  "schema",
@@ -2730,11 +2724,11 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "predicate",
- "prost 0.12.4",
+ "prost 0.12.6",
  "prost-build",
  "query_functions",
  "serde",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tonic 0.11.0",
  "tonic-build",
  "workspace-hack",
@@ -2755,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2796,7 +2790,7 @@ dependencies = [
  "ring",
  "serde",
  "siphasher 1.0.1",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "sqlx",
  "sqlx-hotswap-pool",
  "thiserror",
@@ -2853,7 +2847,7 @@ dependencies = [
  "predicate",
  "query_functions",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "tokio-stream",
  "trace",
@@ -2960,7 +2954,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "service_grpc_testing",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3123,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -3289,9 +3283,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -3349,7 +3343,7 @@ dependencies = [
  "iox_time",
  "itertools 0.12.1",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "workspace-hack",
 ]
 
@@ -3362,7 +3356,7 @@ dependencies = [
  "influxdb-line-protocol",
  "itertools 0.12.1",
  "mutable_batch",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "workspace-hack",
 ]
 
@@ -3377,7 +3371,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "mutable_batch",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "workspace-hack",
 ]
 
@@ -3541,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
@@ -3639,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3712,9 +3706,9 @@ dependencies = [
  "observability_deps",
  "parquet",
  "pbjson-types",
- "prost 0.12.4",
+ "prost 0.12.6",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "thiserror",
  "thrift",
  "tokio",
@@ -3756,8 +3750,8 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost 0.12.4",
- "prost-types 0.12.4",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -3770,7 +3764,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.12.4",
+ "prost 0.12.6",
  "prost-build",
  "serde",
 ]
@@ -3855,7 +3849,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3923,7 +3917,7 @@ dependencies = [
  "observability_deps",
  "query_functions",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "sqlparser",
  "workspace-hack",
 ]
@@ -3975,14 +3969,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -4045,19 +4039,19 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.4",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
@@ -4067,10 +4061,10 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.4",
- "prost-types 0.12.4",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
- "syn 2.0.64",
+ "syn 2.0.66",
  "tempfile",
 ]
 
@@ -4089,15 +4083,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4111,11 +4105,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.4",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -4130,7 +4124,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.3",
  "schema",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "workspace-hack",
 ]
 
@@ -4581,7 +4575,7 @@ dependencies = [
  "indexmap 2.2.6",
  "observability_deps",
  "once_cell",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "workspace-hack",
 ]
 
@@ -4647,22 +4641,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4718,11 +4712,11 @@ dependencies = [
  "iox_query_influxql",
  "iox_query_params",
  "observability_deps",
- "prost 0.12.4",
+ "prost 0.12.6",
  "serde",
  "serde_json",
  "service_common",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tokio",
  "tonic 0.11.0",
  "tower_trailer",
@@ -4838,11 +4832,11 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+checksum = "418b8136fec49956eba89be7da2847ec1909df92a9ae4178b5ff0ff092c8d95e"
 dependencies = [
- "snafu-derive 0.8.2",
+ "snafu-derive 0.8.3",
 ]
 
 [[package]]
@@ -4859,14 +4853,14 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+checksum = "1a4812a669da00d17d8266a0439eddcacbc88b17f732f927e52eeb9d196f7fb5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4939,7 +4933,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5162,13 +5156,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
 dependencies = [
- "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5188,15 +5182,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5218,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5339,12 +5333,12 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "predicates",
- "prost 0.12.4",
+ "prost 0.12.6",
  "rand",
  "regex",
  "reqwest 0.11.27",
  "serde_json",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "sqlx",
  "tempfile",
  "test_helpers",
@@ -5356,22 +5350,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5463,9 +5457,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5493,13 +5487,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5616,7 +5610,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.4",
+ "prost 0.12.6",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -5639,7 +5633,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5649,7 +5643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cef6e24bc96871001a7e48e820ab240b3de2201e59b517cf52835df2f1d2350"
 dependencies = [
  "async-stream",
- "prost 0.12.4",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -5661,8 +5655,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
 dependencies = [
- "prost 0.12.4",
- "prost-types 0.12.4",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -5755,7 +5749,7 @@ dependencies = [
  "futures",
  "iox_time",
  "observability_deps",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "socket2",
  "thrift",
  "tokio",
@@ -5778,7 +5772,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "pin-project",
- "snafu 0.8.2",
+ "snafu 0.8.3",
  "tower",
  "trace",
  "workspace-hack",
@@ -5804,7 +5798,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5951,6 +5945,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6100,7 +6100,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -6134,7 +6134,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6452,8 +6452,8 @@ dependencies = [
  "petgraph",
  "phf_shared",
  "proptest",
- "prost 0.12.4",
- "prost-types 0.12.4",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "rand",
  "rand_core",
  "regex",
@@ -6484,7 +6484,7 @@ dependencies = [
  "strum",
  "subtle",
  "syn 1.0.109",
- "syn 2.0.64",
+ "syn 2.0.66",
  "thrift",
  "tokio",
  "tokio-stream",
@@ -6538,14 +6538,14 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -6558,7 +6558,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "futures-util",
  "hex",
  "influxdb-line-protocol",
+ "insta",
  "iox_catalog",
  "iox_http",
  "iox_query",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7.0"
+serde_with = "3.8.1"
 sha2 = "0.10.8"
 snap = "1.0.0"
 sqlparser = "0.41.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"
 hyper = "0.14"
+insta = { version = "1.39", features = ["json"] }
 libc = { version = "0.2" }
 mockito = { version = "1.2.0", default-features = false }
 num_cpus = "1.16.0"

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -34,6 +34,7 @@ parking_lot.workspace = true
 parquet.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 sha2.workspace = true
 snap.workspace = true
 thiserror.workspace = true

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -45,6 +45,7 @@ uuid.workspace = true
 [dev-dependencies]
 # Core Crates
 arrow_util.workspace = true
+insta.workspace = true
 metric.workspace = true
 pretty_assertions.workspace = true
 test_helpers.workspace = true

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -1,16 +1,16 @@
 //! Implementation of the Catalog that sits entirely in memory.
 
 use crate::SequenceNumber;
-use data_types::ColumnType;
+use influxdb_line_protocol::FieldValue;
 use observability_deps::tracing::info;
 use parking_lot::RwLock;
 use schema::{InfluxColumnType, InfluxFieldType, Schema, SchemaBuilder};
-use serde::de::Visitor;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
+
+mod serialize;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -48,6 +48,21 @@ pub struct Catalog {
 impl Default for Catalog {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl PartialEq for Catalog {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.read().eq(&other.inner.read())
+    }
+}
+
+impl Serialize for Catalog {
+    fn serialize<S>(&self, serializer: S) -> std::prelude::v1::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.read().serialize(serializer)
     }
 }
 
@@ -97,7 +112,7 @@ impl Catalog {
         }
 
         for table in db.tables.values() {
-            if table.columns.len() > Self::NUM_COLUMNS_PER_TABLE_LIMIT {
+            if table.num_columns() > Self::NUM_COLUMNS_PER_TABLE_LIMIT {
                 return Err(Error::TooManyColumns);
             }
         }
@@ -144,10 +159,6 @@ impl Catalog {
         self.inner.read().databases.get(name).cloned()
     }
 
-    pub fn into_inner(self) -> InnerCatalog {
-        self.inner.into_inner()
-    }
-
     pub fn sequence_number(&self) -> SequenceNumber {
         self.inner.read().sequence
     }
@@ -159,9 +170,14 @@ impl Catalog {
     pub fn list_databases(&self) -> Vec<String> {
         self.inner.read().databases.keys().cloned().collect()
     }
+
+    #[cfg(test)]
+    pub fn db_exists(&self, db_name: &str) -> bool {
+        self.inner.read().db_exists(db_name)
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Default)]
+#[derive(Debug, Eq, PartialEq, Clone, Default, Serialize, Deserialize)]
 pub struct InnerCatalog {
     /// The catalog is a map of databases with their table schemas
     databases: HashMap<String, Arc<DatabaseSchema>>,
@@ -186,7 +202,7 @@ impl InnerCatalog {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct DatabaseSchema {
     pub name: String,
     /// The database is a map of tables
@@ -218,112 +234,49 @@ impl DatabaseSchema {
     }
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TableDefinition {
     pub name: String,
-    #[serde(skip_serializing, skip_deserializing)]
     pub schema: Schema,
-    columns: BTreeMap<String, i16>,
-}
-
-struct TableDefinitionVisitor;
-
-impl<'de> Visitor<'de> for TableDefinitionVisitor {
-    type Value = TableDefinition;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("struct TableDefinition")
-    }
-
-    fn visit_map<V>(self, mut map: V) -> Result<TableDefinition, V::Error>
-    where
-        V: serde::de::MapAccess<'de>,
-    {
-        let mut name = None;
-        let mut columns = None;
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                "name" => {
-                    if name.is_some() {
-                        return Err(serde::de::Error::duplicate_field("name"));
-                    }
-                    name = Some(map.next_value::<String>()?);
-                }
-                "columns" => {
-                    if columns.is_some() {
-                        return Err(serde::de::Error::duplicate_field("columns"));
-                    }
-                    columns = Some(map.next_value::<BTreeMap<String, i16>>()?);
-                }
-                _ => {
-                    let _ = map.next_value::<serde::de::IgnoredAny>()?;
-                }
-            }
-        }
-        let name = name.ok_or_else(|| serde::de::Error::missing_field("name"))?;
-        let columns = columns.ok_or_else(|| serde::de::Error::missing_field("columns"))?;
-
-        Ok(TableDefinition::new(name, columns))
-    }
-}
-
-impl<'de> Deserialize<'de> for TableDefinition {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_map(TableDefinitionVisitor)
-    }
 }
 
 impl TableDefinition {
-    pub(crate) fn new(name: impl Into<String>, columns: BTreeMap<String, i16>) -> Self {
-        let mut schema_builder = SchemaBuilder::with_capacity(columns.len());
-        for (name, column_type) in &columns {
-            schema_builder.influx_column(
-                name,
-                column_type_to_influx_column_type(&ColumnType::try_from(*column_type).unwrap()),
-            );
+    pub(crate) fn new(
+        name: impl Into<String>,
+        columns: impl AsRef<[(String, InfluxColumnType)]>,
+    ) -> Self {
+        let mut schema_builder = SchemaBuilder::with_capacity(columns.as_ref().len());
+        for (name, column_type) in columns.as_ref() {
+            schema_builder.influx_column(name, *column_type);
         }
         let schema = schema_builder.build().unwrap();
 
         Self {
             name: name.into(),
             schema,
-            columns,
         }
     }
 
     pub(crate) fn column_exists(&self, column: &str) -> bool {
-        self.columns.contains_key(column)
+        self.schema.find_index_of(column).is_some()
     }
 
-    pub(crate) fn add_columns(&mut self, columns: Vec<(String, i16)>) {
-        for (name, column_type) in columns.into_iter() {
-            self.columns.insert(name, column_type);
-        }
-
-        let mut schema_builder = SchemaBuilder::with_capacity(self.columns.len());
-        for (name, column_type) in &self.columns {
-            schema_builder.influx_column(
-                name,
-                column_type_to_influx_column_type(&ColumnType::try_from(*column_type).unwrap()),
-            );
+    pub(crate) fn add_columns(&mut self, columns: Vec<(String, InfluxColumnType)>) {
+        let mut schema_builder = SchemaBuilder::with_capacity(columns.len());
+        for (name, column_type) in columns {
+            schema_builder.influx_column(name, column_type);
         }
         let schema = schema_builder.build().unwrap();
 
         self.schema = schema;
     }
 
-    pub(crate) fn index_columns(&self) -> Vec<String> {
-        self.columns
+    pub(crate) fn index_columns(&self) -> Vec<&str> {
+        self.schema
             .iter()
-            .filter_map(|(name, column_type)| {
-                if *column_type == ColumnType::Tag as i16 {
-                    Some(name.clone())
-                } else {
-                    None
-                }
+            .filter_map(|(col_type, field)| match col_type {
+                InfluxColumnType::Tag => Some(field.name().as_str()),
+                InfluxColumnType::Field(_) | InfluxColumnType::Timestamp => None,
             })
             .collect()
     }
@@ -333,21 +286,18 @@ impl TableDefinition {
         &self.schema
     }
 
-    #[cfg(test)]
-    pub(crate) fn columns(&self) -> &BTreeMap<String, i16> {
-        &self.columns
+    pub(crate) fn num_columns(&self) -> usize {
+        self.schema.len()
     }
 }
 
-fn column_type_to_influx_column_type(column_type: &ColumnType) -> InfluxColumnType {
-    match column_type {
-        ColumnType::I64 => InfluxColumnType::Field(InfluxFieldType::Integer),
-        ColumnType::U64 => InfluxColumnType::Field(InfluxFieldType::UInteger),
-        ColumnType::F64 => InfluxColumnType::Field(InfluxFieldType::Float),
-        ColumnType::Bool => InfluxColumnType::Field(InfluxFieldType::Boolean),
-        ColumnType::String => InfluxColumnType::Field(InfluxFieldType::String),
-        ColumnType::Time => InfluxColumnType::Timestamp,
-        ColumnType::Tag => InfluxColumnType::Tag,
+pub fn influx_column_type_from_field_value(fv: &FieldValue<'_>) -> InfluxColumnType {
+    match fv {
+        FieldValue::I64(_) => InfluxColumnType::Field(InfluxFieldType::Integer),
+        FieldValue::U64(_) => InfluxColumnType::Field(InfluxFieldType::UInteger),
+        FieldValue::F64(_) => InfluxColumnType::Field(InfluxFieldType::Float),
+        FieldValue::String(_) => InfluxColumnType::Field(InfluxFieldType::String),
+        FieldValue::Boolean(_) => InfluxColumnType::Field(InfluxFieldType::Boolean),
     }
 }
 
@@ -366,19 +316,22 @@ mod tests {
             "test".into(),
             TableDefinition::new(
                 "test",
-                BTreeMap::from([("test".to_string(), ColumnType::String as i16)]),
+                [(
+                    "test".to_string(),
+                    InfluxColumnType::Field(InfluxFieldType::String),
+                )],
             ),
         );
         let database = Arc::new(database);
         catalog
             .replace_database(SequenceNumber::new(0), database)
             .unwrap();
-        let inner = catalog.inner.read();
+        let inner = catalog.clone_inner();
 
-        let serialized = serde_json::to_string(&*inner).unwrap();
+        let serialized = serde_json::to_string(&inner).unwrap();
         let deserialized: InnerCatalog = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(*inner, deserialized);
+        assert_eq!(inner, deserialized);
     }
 
     #[test]
@@ -391,12 +344,15 @@ mod tests {
             "test".into(),
             TableDefinition::new(
                 "test",
-                BTreeMap::from([("test".to_string(), ColumnType::String as i16)]),
+                [(
+                    "test".to_string(),
+                    InfluxColumnType::Field(InfluxFieldType::String),
+                )],
             ),
         );
 
         let table = database.tables.get_mut("test").unwrap();
-        table.add_columns(vec![("test2".to_string(), ColumnType::Tag as i16)]);
+        table.add_columns(vec![("test2".to_string(), InfluxColumnType::Tag)]);
         let schema = table.schema();
         assert_eq!(
             schema.field(0).0,

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -282,7 +282,7 @@ impl TableDefinition {
             cols.insert(field.name(), col_type);
         }
         for (name, column_type) in columns.iter() {
-            cols.insert(&name, *column_type);
+            cols.insert(name, *column_type);
         }
         let mut schema_builder = SchemaBuilder::with_capacity(columns.len());
         // TODO: may need to capture some schema-level metadata, currently, this causes trouble in

--- a/influxdb3_write/src/catalog/serialize.rs
+++ b/influxdb3_write/src/catalog/serialize.rs
@@ -40,8 +40,12 @@ struct TableSnapshot<'a> {
 }
 
 /// Representation of Arrow's `DataType` for table snapshots.
+///
+/// Uses `#[non_exhaustive]` with the assumption that variants will be added as we support
+/// more Arrow data types.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 enum DataType<'a> {
     Null,
     Bool,

--- a/influxdb3_write/src/catalog/serialize.rs
+++ b/influxdb3_write/src/catalog/serialize.rs
@@ -102,9 +102,8 @@ enum InfluxType {
 /// The inner column definition for a [`TableSnapshot`]
 #[derive(Debug, Serialize, Deserialize)]
 struct ColumnDefinition<'a> {
-    /// The column name
-    name: &'a str,
     /// The column's data type
+    #[serde(borrow)]
     r#type: DataType<'a>,
     /// The columns Influx type
     influx_type: InfluxType,
@@ -122,7 +121,6 @@ impl<'a> From<&'a TableDefinition> for TableSnapshot<'a> {
                 (
                     f.name().as_str(),
                     ColumnDefinition {
-                        name: f.name(),
                         r#type: f.data_type().into(),
                         influx_type: InfluxType::Field,
                         nullable: f.is_nullable(),
@@ -134,7 +132,6 @@ impl<'a> From<&'a TableDefinition> for TableSnapshot<'a> {
             (
                 f.name().as_str(),
                 ColumnDefinition {
-                    name: f.name(),
                     r#type: f.data_type().into(),
                     influx_type: InfluxType::Tag,
                     nullable: true,
@@ -145,7 +142,6 @@ impl<'a> From<&'a TableDefinition> for TableSnapshot<'a> {
             (
                 f.name().as_str(),
                 ColumnDefinition {
-                    name: f.name(),
                     r#type: f.data_type().into(),
                     influx_type: InfluxType::Time,
                     nullable: false,
@@ -214,13 +210,13 @@ impl<'a> From<TableSnapshot<'a>> for TableDefinition {
         // TODO: may need to capture some schema-level metadata, currently, this causes trouble in
         // tests, so I am omitting this for now:
         // b.measurement(&name);
-        for (_, col) in snap.cols {
+        for (name, col) in snap.cols {
             match col.influx_type {
                 InfluxType::Tag => {
-                    b.influx_column(col.name, schema::InfluxColumnType::Tag);
+                    b.influx_column(name, schema::InfluxColumnType::Tag);
                 }
                 InfluxType::Field => {
-                    b.influx_field(col.name, col.r#type.into());
+                    b.influx_field(name, col.r#type.into());
                 }
                 InfluxType::Time => {
                     b.timestamp();

--- a/influxdb3_write/src/catalog/serialize.rs
+++ b/influxdb3_write/src/catalog/serialize.rs
@@ -1,0 +1,201 @@
+use arrow::datatypes::DataType as ArrowDataType;
+use schema::SchemaBuilder;
+use serde::{Deserialize, Serialize};
+
+use super::TableDefinition;
+
+impl Serialize for TableDefinition {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let snapshot = TableSnapshot::from(self);
+        snapshot.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TableDefinition {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        TableSnapshot::<'de>::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TableSnapshot<'a> {
+    name: &'a str,
+    cols: Vec<ColumnDefinition<'a>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum DataType<'a> {
+    Null,
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    F16,
+    F32,
+    F64,
+    Str,
+    BigStr,
+    StrView,
+    Bin,
+    BigBin,
+    BinView,
+    Time(TimeUnit, Option<&'a str>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum TimeUnit {
+    #[serde(rename = "s")]
+    Seconds,
+    #[serde(rename = "ms")]
+    Milliseconds,
+    #[serde(rename = "us")]
+    Microseconds,
+    #[serde(rename = "ns")]
+    Nanoseconds,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum InfluxType {
+    Tag,
+    Field,
+    Time,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ColumnDefinition<'a> {
+    name: &'a str,
+    r#type: DataType<'a>,
+    meta: InfluxType,
+    nullable: bool,
+}
+
+impl<'a> From<&'a TableDefinition> for TableSnapshot<'a> {
+    fn from(def: &'a TableDefinition) -> Self {
+        let name = def.name.as_str();
+        let mut cols: Vec<ColumnDefinition<'_>> = def
+            .schema()
+            .fields_iter()
+            .map(|f| ColumnDefinition {
+                name: f.name(),
+                r#type: f.data_type().into(),
+                meta: InfluxType::Field,
+                nullable: f.is_nullable(),
+            })
+            .collect();
+        cols.extend(def.schema().tags_iter().map(|f| ColumnDefinition {
+            name: f.name(),
+            r#type: f.data_type().into(),
+            meta: InfluxType::Tag,
+            nullable: true,
+        }));
+        cols.extend(def.schema().time_iter().map(|f| ColumnDefinition {
+            name: f.name(),
+            r#type: f.data_type().into(),
+            meta: InfluxType::Time,
+            nullable: false,
+        }));
+        Self { name, cols }
+    }
+}
+
+impl<'a> From<&'a ArrowDataType> for DataType<'a> {
+    fn from(arrow_type: &ArrowDataType) -> Self {
+        match arrow_type {
+            ArrowDataType::Null => Self::Null,
+            ArrowDataType::Boolean => Self::Bool,
+            ArrowDataType::Int8 => Self::I8,
+            ArrowDataType::Int16 => Self::I16,
+            ArrowDataType::Int32 => Self::I32,
+            ArrowDataType::Int64 => Self::I64,
+            ArrowDataType::UInt8 => Self::U8,
+            ArrowDataType::UInt16 => Self::U16,
+            ArrowDataType::UInt32 => Self::U32,
+            ArrowDataType::UInt64 => Self::U64,
+            ArrowDataType::Float16 => Self::F16,
+            ArrowDataType::Float32 => Self::F32,
+            ArrowDataType::Float64 => Self::F64,
+            ArrowDataType::Timestamp(_, _) => todo!(),
+            ArrowDataType::Date32 => todo!(),
+            ArrowDataType::Date64 => todo!(),
+            ArrowDataType::Time32(_) => todo!(),
+            ArrowDataType::Time64(_) => todo!(),
+            ArrowDataType::Duration(_) => todo!(),
+            ArrowDataType::Interval(_) => todo!(),
+            ArrowDataType::Binary => Self::Bin,
+            ArrowDataType::FixedSizeBinary(_) => todo!(),
+            ArrowDataType::LargeBinary => Self::BigBin,
+            ArrowDataType::BinaryView => Self::BinView,
+            ArrowDataType::Utf8 => Self::Str,
+            ArrowDataType::LargeUtf8 => Self::BigStr,
+            ArrowDataType::Utf8View => Self::StrView,
+            ArrowDataType::List(_) => todo!(),
+            ArrowDataType::ListView(_) => todo!(),
+            ArrowDataType::FixedSizeList(_, _) => todo!(),
+            ArrowDataType::LargeList(_) => todo!(),
+            ArrowDataType::LargeListView(_) => todo!(),
+            ArrowDataType::Struct(_) => todo!(),
+            ArrowDataType::Union(_, _) => todo!(),
+            ArrowDataType::Dictionary(_, _) => todo!(),
+            ArrowDataType::Decimal128(_, _) => todo!(),
+            ArrowDataType::Decimal256(_, _) => todo!(),
+            ArrowDataType::Map(_, _) => todo!(),
+            ArrowDataType::RunEndEncoded(_, _) => todo!(),
+        }
+    }
+}
+
+impl<'a> From<TableSnapshot<'a>> for TableDefinition {
+    fn from(snap: TableSnapshot<'a>) -> Self {
+        let name = snap.name.to_owned();
+        let mut b = SchemaBuilder::new();
+        b.measurement(&name);
+        for col in snap.cols {
+            match col.meta {
+                InfluxType::Tag => {
+                    b.influx_column(col.name, schema::InfluxColumnType::Tag);
+                }
+                InfluxType::Field => {
+                    b.influx_field(col.name, col.r#type.into());
+                }
+                InfluxType::Time => (),
+            }
+        }
+        b.timestamp();
+
+        let schema = b.build().expect("valid schema from snapshot");
+
+        Self { name, schema }
+    }
+}
+
+// NOTE: Ideally, we will remove the need for the InfluxFieldType, and be able
+// to use Arrow's DataType directly. If that happens, this conversion will need
+// to support the entirety of Arrow's DataType enum, which is why [`DataType`]
+// has been defined to mimic the Arrow type.
+//
+// See <https://github.com/influxdata/influxdb_iox/issues/11111>
+impl<'a> From<DataType<'a>> for schema::InfluxFieldType {
+    fn from(data_type: DataType<'a>) -> Self {
+        match data_type {
+            DataType::Bool => Self::Boolean,
+            DataType::I64 => Self::Integer,
+            DataType::U64 => Self::UInteger,
+            DataType::F64 => Self::Float,
+            DataType::Str => Self::String,
+            other => unimplemented!("unsupported data type in catalog {other:?}"),
+        }
+    }
+}

--- a/influxdb3_write/src/catalog/serialize.rs
+++ b/influxdb3_write/src/catalog/serialize.rs
@@ -25,9 +25,11 @@ impl<'de> Deserialize<'de> for TableDefinition {
     }
 }
 
+#[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 struct TableSnapshot<'a> {
     name: &'a str,
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_, _>")]
     cols: BTreeMap<&'a str, ColumnDefinition<'a>>,
 }
 

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -230,7 +230,7 @@ impl Persister for PersisterImpl {
 
     async fn persist_catalog(&self, segment_id: SegmentId, catalog: Catalog) -> Result<()> {
         let catalog_path = CatalogFilePath::new(segment_id);
-        let json = serde_json::to_vec_pretty(&catalog.into_inner())?;
+        let json = serde_json::to_vec_pretty(&catalog)?;
         self.object_store
             .put(catalog_path.as_ref(), Bytes::from(json))
             .await?;

--- a/influxdb3_write/src/snapshots/influxdb3_write__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_write/src/snapshots/influxdb3_write__catalog__tests__catalog_serialization.snap
@@ -1,0 +1,154 @@
+---
+source: influxdb3_write/src/catalog.rs
+expression: catalog
+---
+{
+  "databases": {
+    "test_db": {
+      "name": "test_db",
+      "tables": {
+        "test_table_1": {
+          "name": "test_table_1",
+          "cols": {
+            "bool_field": {
+              "type": "bool",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "f64_field": {
+              "type": "f64",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "i64_field": {
+              "type": "i64",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "string_field": {
+              "type": "str",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "tag_1": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "tag_2": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "tag_3": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "time": {
+              "type": {
+                "time": [
+                  "ns",
+                  null
+                ]
+              },
+              "influx_type": "time",
+              "nullable": false
+            },
+            "u64_field": {
+              "type": "u64",
+              "influx_type": "field",
+              "nullable": true
+            }
+          }
+        },
+        "test_table_2": {
+          "name": "test_table_2",
+          "cols": {
+            "bool_field": {
+              "type": "bool",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "f64_field": {
+              "type": "f64",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "i64_field": {
+              "type": "i64",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "string_field": {
+              "type": "str",
+              "influx_type": "field",
+              "nullable": true
+            },
+            "tag_1": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "tag_2": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "tag_3": {
+              "type": {
+                "dict": [
+                  "i32",
+                  "str"
+                ]
+              },
+              "influx_type": "tag",
+              "nullable": true
+            },
+            "time": {
+              "type": {
+                "time": [
+                  "ns",
+                  null
+                ]
+              },
+              "influx_type": "time",
+              "nullable": false
+            },
+            "u64_field": {
+              "type": "u64",
+              "influx_type": "field",
+              "nullable": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "sequence": 1
+}

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -619,7 +619,7 @@ pub(crate) mod tests {
             )
             .unwrap()
             .unwrap();
-        let expected_cpu_table = vec![
+        let expected_cpu_table = [
             "+-----+----------+--------------------------------+",
             "| bar | tag1     | time                           |",
             "+-----+----------+--------------------------------+",
@@ -627,7 +627,7 @@ pub(crate) mod tests {
             "| 2.0 | cupcakes | 1970-01-01T00:00:00.000000030Z |",
             "+-----+----------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected_cpu_table, &[cpu_table]);
+        assert_batches_eq!(expected_cpu_table, &[cpu_table]);
 
         let mem_table = open_segment
             .table_record_batch(
@@ -638,14 +638,14 @@ pub(crate) mod tests {
             )
             .unwrap()
             .unwrap();
-        let expected_mem_table = vec![
+        let expected_mem_table = [
             "+-----+--------+--------------------------------+",
             "| bar | tag2   | time                           |",
             "+-----+--------+--------------------------------+",
             "| 2.0 | snakes | 1970-01-01T00:00:00.000000020Z |",
             "+-----+--------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected_mem_table, &[mem_table]);
+        assert_batches_eq!(expected_mem_table, &[mem_table]);
     }
 
     #[tokio::test]
@@ -695,7 +695,7 @@ pub(crate) mod tests {
             )
             .unwrap()
             .unwrap();
-        let expected_cpu_table = vec![
+        let expected_cpu_table = [
             "+-----+------+------+----------+------+--------------------------------+",
             "| bar | fval | ival | tag1     | tag2 | time                           |",
             "+-----+------+------+----------+------+--------------------------------+",
@@ -706,7 +706,7 @@ pub(crate) mod tests {
             "|     | 2.1  |      |          |      | 1970-01-01T00:00:00.000000040Z |",
             "+-----+------+------+----------+------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected_cpu_table, &[cpu_table]);
+        assert_batches_eq!(expected_cpu_table, &[cpu_table]);
     }
 
     #[tokio::test]

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -10,7 +10,7 @@ use arrow::datatypes::{GenericStringType, Int32Type, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use data_types::{PartitionKey, TimestampMinMax};
 use datafusion::logical_expr::{BinaryExpr, Expr};
-use observability_deps::tracing::{debug, info};
+use observability_deps::tracing::debug;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem::size_of;
 use std::sync::Arc;
@@ -49,14 +49,12 @@ impl TableBuffer {
     }
 
     pub fn add_rows(&mut self, rows: Vec<Row>) {
-        info!(n_rows = rows.len(), "add_rows");
         let new_row_count = rows.len();
 
         for (row_index, r) in rows.into_iter().enumerate() {
             let mut value_added = HashSet::with_capacity(r.fields.len());
 
             for f in r.fields {
-                info!(row_index, field = ?f, "process field");
                 value_added.insert(f.name.clone());
 
                 match f.value {


### PR DESCRIPTION
Closes #25031

## Remove `data_types::ColumnType`

[`data_types::ColumnType`](https://github.com/influxdata/influxdb3_core/blob/0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94/data_types/src/columns.rs#L295-L307) was meant for the IOx catalog and its interweaving into the catalog and related code in monolith was not absolutely necessary. This PR removes it in favour of using the [`schema::Schema`](https://github.com/influxdata/influxdb3_core/blob/0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94/schema/src/lib.rs#L123-L149) type directly, which uses the [`InfluxColumnType`](https://github.com/influxdata/influxdb3_core/blob/0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94/schema/src/lib.rs#L613-L633).

As part of https://github.com/influxdata/influxdb/issues/24979, removing `data_types::ColumnType` will make extending the data model to more complex types less of a pain in monolith.

## Introduce dedicated types for serializing/deserializing tables in the catalog

The `InnerCatalog`, as well as its descendent `DatabaseSchema` are still serialized using serde. However, to serialize `TableDefinition`s, this PR introduces a new [`serialize.rs`](https://github.com/influxdata/influxdb/pull/25042/files#diff-9163031521f1788cd87a71558ded4071b33ca438784d1ddfce90b1cd4ef1ae81) module, which contains the [`TableSnapshot`](https://github.com/influxdata/influxdb/pull/25042/files#diff-9163031521f1788cd87a71558ded4071b33ca438784d1ddfce90b1cd4ef1ae81R28-R40) type for serializing and deserializing the `TableDefinition` for the catalog.

The objective was to remove the `columns` member from the `TableDefinition` and strictly operate on its `schema::Schema`. We would then serialize the schema directly. However, `schema::Schema` does not implement serde's traits, and although the internal Arrow `Schema` can, we do not consider those to be stable. Therefore, the `serilalize.rs` module also contains several types for representing Arrow's schema, and for mapping from our serialized format to the `schema::Schema` used in the `TableDefinition`. Using this mapping over serializing the schema directly will protect us from breaking changes to the Arrow types.

## Catalog serialization testing

* The `catalog_serialization` test was extended to exercise more variations of the `Catalog`, i.e., more column types (see [changes](https://github.com/influxdata/influxdb/pull/25042/files#diff-081d5d2f8483fca11c345ee1ff09ec193f194fb73b5c9a091e121a5ad7ef3fd7R349-R382)).
* This PR also introduces a snapshot test for the catalog, via the [`insta`](https://docs.rs/insta/latest/insta/index.html) crate, to help guard us from introducing breaking changes to the catalog (see [here](https://github.com/influxdata/influxdb/pull/25042/files#diff-081d5d2f8483fca11c345ee1ff09ec193f194fb73b5c9a091e121a5ad7ef3fd7R390)). This adds a snapshot file of the JSON serialized catalog (see [here](https://github.com/influxdata/influxdb/pull/25042/files#diff-4784737d307c252b4ccf35f77d31688eecb31d17e1b728c632cf614f1c80f30c)).
* A test was also added to verify deserialization errors when dealing with malformed catalog files (see [changes](https://github.com/influxdata/influxdb/pull/25042/files#diff-081d5d2f8483fca11c345ee1ff09ec193f194fb73b5c9a091e121a5ad7ef3fd7R400)).

## Other Changes

* Introduces the [`serde_with`](https://docs.rs/serde_with/latest/serde_with/) crate for its convenience macros to throw errors when there are duplicate map keys during deserialization (see example [here](https://github.com/influxdata/influxdb/pull/25042/files#diff-081d5d2f8483fca11c345ee1ff09ec193f194fb73b5c9a091e121a5ad7ef3fd7R207-R214)). Previously, the `TableDefinition` had a custom `Deserialize` implementation that was doing this, but this PR extends that behaviour to each level of the Catalog.