### PR TITLE
chore: Update Rust to 1.79.0

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -41,7 +41,6 @@ use sha2::Digest;
 use sha2::Sha256;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::i64;
 use std::sync::{Arc, OnceLock};
 use thiserror::Error;
 use tokio::sync::watch;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Fairly quiet update for us. The only change was around using the numeric constants now inbuilt into the primitives not the ones from `std`

https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants

Release post: https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html