### PR TITLE
feat: v3 write API with series key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -454,7 +454,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -470,13 +470,13 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "ahash",
  "arrow",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "backoff",
@@ -619,7 +619,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "observability_deps",
  "rand",
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -785,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -831,13 +831,13 @@ dependencies = [
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "bytes",
  "dashmap",
  "futures",
  "generated_types",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "metric",
  "observability_deps",
  "reqwest 0.11.27",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -867,9 +867,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -932,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "clap",
@@ -953,7 +953,7 @@ dependencies = [
  "humantime",
  "iox_catalog",
  "iox_time",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libc",
  "metric",
  "non-empty-string",
@@ -968,14 +968,15 @@ dependencies = [
  "trogging",
  "url",
  "uuid",
+ "versioned_file_store",
  "workspace-hack",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -985,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -997,14 +998,14 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1029,15 +1030,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1348,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1378,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1400,6 +1392,7 @@ dependencies = [
  "datafusion-functions-array",
  "datafusion-optimizer",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-sql",
  "flate2",
@@ -1429,7 +1422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1438,6 +1431,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
+ "hashbrown 0.14.5",
  "instant",
  "libc",
  "num_cpus",
@@ -1449,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "tokio",
 ]
@@ -1457,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "chrono",
@@ -1477,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1494,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -1520,9 +1514,10 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -1535,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1554,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1566,13 +1561,13 @@ dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "log",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1602,17 +1597,18 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-expr",
+ "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1645,13 +1641,26 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "chrono",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-proto-common",
+ "object_store",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "38.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
  "object_store",
  "prost 0.12.6",
 ]
@@ -1659,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1667,6 +1676,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "log",
+ "regex",
  "sqlparser",
  "strum",
 ]
@@ -1674,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1746,9 +1756,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1855,7 +1876,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "futures",
  "metric",
@@ -1909,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2066,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "observability_deps",
  "once_cell",
@@ -2284,12 +2305,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -2303,9 +2324,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "httpdate"
@@ -2321,9 +2342,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2370,7 +2391,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2399,7 +2420,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2449,6 +2470,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,12 +2595,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -2489,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "bytes",
  "log",
@@ -2517,7 +2658,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "hex",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "influxdb3_client",
  "influxdb3_process",
  "influxdb3_server",
@@ -2633,7 +2774,7 @@ dependencies = [
  "futures",
  "hex",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "influxdb-line-protocol",
  "influxdb3_process",
  "influxdb3_write",
@@ -2723,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
@@ -2739,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2767,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2823,13 +2964,14 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "backoff",
  "base64 0.22.1",
  "catalog_cache",
  "client_util",
+ "dashmap",
  "data_types",
  "futures",
  "generated_types",
@@ -2860,12 +3002,12 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "authz",
  "data_types",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "parking_lot",
  "serde",
  "serde_urlencoded",
@@ -2876,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -2892,7 +3034,7 @@ dependencies = [
  "indexmap 2.2.6",
  "iox_query_params",
  "iox_time",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "metric",
  "object_store",
  "observability_deps",
@@ -2914,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "chrono-tz 0.9.0",
@@ -2924,7 +3066,7 @@ dependencies = [
  "influxdb_influxql_parser",
  "iox_query",
  "iox_query_params",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "observability_deps",
  "once_cell",
  "predicate",
@@ -2947,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2962,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2974,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -2985,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "authz",
@@ -2997,7 +3139,7 @@ dependencies = [
  "generated_types",
  "hashbrown 0.14.5",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "metric",
  "metric_exporters",
@@ -3065,6 +3207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,7 +3245,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
 ]
 
 [[package]]
@@ -3206,6 +3357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3281,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -3297,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3306,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3364,7 +3521,7 @@ checksum = "d2f6e023aa5bdf392aa06c78e4a4e6d498baab5138d0c993503350ebbc37bf1e"
 dependencies = [
  "assert-json-diff",
  "futures-core",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rand",
  "regex",
@@ -3389,14 +3546,14 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow_util",
  "data_types",
  "hashbrown 0.14.5",
  "iox_time",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "schema",
  "snafu 0.8.3",
  "workspace-hack",
@@ -3405,11 +3562,11 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb-line-protocol",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "mutable_batch",
  "snafu 0.8.3",
  "workspace-hack",
@@ -3418,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3432,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -3596,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -3615,7 +3772,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itertools 0.12.1",
  "md-5",
  "parking_lot",
@@ -3637,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3685,7 +3842,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3710,7 +3867,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -3752,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -3973,19 +4130,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
- "chrono",
+ "async-trait",
  "data_types",
  "datafusion",
  "datafusion_util",
- "itertools 0.12.1",
+ "futures",
+ "itertools 0.13.0",
  "observability_deps",
  "query_functions",
  "schema",
- "snafu 0.8.3",
- "sqlparser",
  "workspace-hack",
 ]
 
@@ -4088,7 +4244,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4182,14 +4338,14 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "chrono",
  "datafusion",
  "once_cell",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "schema",
  "snafu 0.8.3",
  "workspace-hack",
@@ -4290,23 +4446,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4320,13 +4476,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4337,9 +4493,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -4356,7 +4512,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -4635,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -4782,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "datafusion",
@@ -4794,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4826,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -5003,11 +5159,10 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
 dependencies = [
- "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -5092,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "either",
  "futures",
@@ -5246,6 +5401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5279,9 +5440,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5323,6 +5484,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "sysinfo"
@@ -5381,7 +5553,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5401,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5416,7 +5588,7 @@ dependencies = [
  "futures-util",
  "generated_types",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "influxdb_iox_client",
  "ingester_query_grpc",
  "insta",
@@ -5569,6 +5741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5673,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "metric",
  "parking_lot",
@@ -5684,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "metric",
  "observability_deps",
@@ -5707,7 +5889,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5734,7 +5916,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5844,7 +6026,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -5858,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -5870,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "async-trait",
  "clap",
@@ -5888,14 +6070,14 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "bytes",
  "futures",
  "hashbrown 0.14.5",
  "http 0.2.12",
  "http-body 0.4.6",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "metric",
  "observability_deps",
  "parking_lot",
@@ -5985,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -6005,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "clap",
  "logfmt",
@@ -6088,9 +6270,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode_categories"
@@ -6106,9 +6288,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6128,10 +6310,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -6166,6 +6360,20 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versioned_file_store"
+version = "0.1.0"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "object_store",
+ "tokio",
+ "uuid",
+ "workspace-hack",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -6524,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94#0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -6540,7 +6748,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap_builder",
- "concurrent-queue",
  "crossbeam-utils",
  "crypto-common",
  "digest",
@@ -6558,7 +6765,7 @@ dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
  "heck 0.4.1",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "lalrpop-util",
@@ -6585,8 +6792,8 @@ dependencies = [
  "rand",
  "rand_core",
  "regex",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
  "reqwest 0.11.27",
  "ring",
  "rustix",
@@ -6602,7 +6809,6 @@ dependencies = [
  "smallvec",
  "socket2",
  "spin 0.9.8",
- "sqlparser",
  "sqlx",
  "sqlx-core",
  "sqlx-macros",
@@ -6623,8 +6829,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "twox-hash",
- "unicode-bidi",
- "unicode-normalization",
  "url",
  "uuid",
  "winapi",
@@ -6633,6 +6837,18 @@ dependencies = [
  "xz2",
  "zeroize",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xz2"
@@ -6648,6 +6864,30 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -6670,6 +6910,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6683,6 +6944,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "ahash",
  "arrow",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "backoff",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "observability_deps",
  "rand",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "bytes",
  "dashmap",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "clap",
@@ -1005,7 +1005,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1769,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1876,7 +1876,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "futures",
  "metric",
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "observability_deps",
  "once_cell",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "bytes",
  "log",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2964,7 +2964,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "authz",
@@ -3018,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3056,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "chrono-tz 0.9.0",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "authz",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3546,7 +3546,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb-line-protocol",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3842,7 +3842,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -4130,7 +4130,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "chrono",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -4938,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "datafusion",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -5247,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "either",
  "futures",
@@ -5553,7 +5553,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5855,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "metric",
  "parking_lot",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6026,7 +6026,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -6040,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "clap",
@@ -6070,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "bytes",
  "futures",
@@ -6167,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "clap",
  "logfmt",
@@ -6364,7 +6364,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "versioned_file_store"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#ac3bb3e4e07580dddfbfcaf87761c7a2d473783a"
+source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "ahash",
  "arrow",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "backoff",
@@ -628,7 +628,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "observability_deps",
  "rand",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "bytes",
  "dashmap",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "clap",
@@ -1005,7 +1005,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "ahash",
  "arrow",
@@ -1407,6 +1407,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
+ "paste",
  "pin-project-lite",
  "rand",
  "sqlparser",
@@ -1422,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "ahash",
  "arrow",
@@ -1443,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "tokio",
 ]
@@ -1451,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "chrono",
@@ -1471,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "ahash",
  "arrow",
@@ -1488,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -1514,8 +1515,9 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
+ "ahash",
  "arrow",
  "arrow-schema",
  "datafusion-common",
@@ -1530,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1549,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1567,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "ahash",
  "arrow",
@@ -1597,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1608,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "ahash",
  "arrow",
@@ -1641,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "chrono",
@@ -1656,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "chrono",
@@ -1668,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=93e58e36a906df2008addccb6712d5bd22f82d5d#93e58e36a906df2008addccb6712d5bd22f82d5d"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=e495f1f6bfa8e65f4058829912283ee98ab46318#e495f1f6bfa8e65f4058829912283ee98ab46318"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1684,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1769,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -1876,7 +1878,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "futures",
  "metric",
@@ -1930,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2087,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "observability_deps",
  "once_cell",
@@ -2324,9 +2326,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2399,18 +2401,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -2630,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "bytes",
  "log",
@@ -2864,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
@@ -2880,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2908,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "ingester_query_grpc"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2964,7 +2967,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3002,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "authz",
@@ -3018,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3056,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "chrono-tz 0.9.0",
@@ -3089,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3104,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3116,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3127,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "ioxd_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "authz",
@@ -3384,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "observability_deps",
  "tracing-subscriber",
@@ -3454,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3463,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3546,7 +3549,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "mutable_batch"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3562,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_lp"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb-line-protocol",
@@ -3575,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "mutable_batch_pb"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow_util",
  "dml",
@@ -3794,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -3842,7 +3845,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3909,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -4130,7 +4133,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4338,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "chrono",
@@ -4365,6 +4368,53 @@ checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4528,7 +4578,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -4545,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4557,7 +4607,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4566,16 +4616,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -4628,6 +4679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,6 +4725,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
@@ -4791,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -4938,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "datafusion",
@@ -4950,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4982,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_testing"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "generated_types",
  "observability_deps",
@@ -5169,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -5247,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "either",
  "futures",
@@ -5486,6 +5557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5553,7 +5630,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -5561,7 +5638,7 @@ dependencies = [
  "ordered-float 4.2.0",
  "parking_lot",
  "prometheus-parse",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5573,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "test_helpers_end_to_end"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5828,6 +5905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5855,7 +5943,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "metric",
  "parking_lot",
@@ -5866,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6026,7 +6114,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -6040,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6052,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "clap",
@@ -6070,7 +6158,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "bytes",
  "futures",
@@ -6167,7 +6255,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -6187,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "clap",
  "logfmt",
@@ -6364,7 +6452,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "versioned_file_store"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6732,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?branch=hiltontj/14-june-2024-sk-sync#256f8282c473556612c6898fb5caa9a01f37c20d"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ca040f2a6e5b6470e469825a8d35060d0199297c#ca040f2a6e5b6470e469825a8d35060d0199297c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -6809,6 +6897,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "spin 0.9.8",
+ "sqlparser",
  "sqlx",
  "sqlx-core",
  "sqlx-macros",
@@ -6992,9 +7081,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,21 +49,21 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "string"] }
 crc32fast = "1.2.0"
 crossbeam-channel = "0.5.11"
-datafusion = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
+datafusion = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "93e58e36a906df2008addccb6712d5bd22f82d5d" }
+datafusion-proto = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "93e58e36a906df2008addccb6712d5bd22f82d5d" }
 csv = "1.3.0"
 dotenvy = "0.15.7"
 flate2 = "1.0.27"
 futures = "0.3.28"
 futures-util = "0.3.30"
-hashbrown = "0.14.3"
+hashbrown = "0.14.5"
 hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"
 hyper = "0.14"
 insta = { version = "1.39", features = ["json"] }
 libc = { version = "0.2" }
-mockito = { version = "1.2.0", default-features = false }
+mockito = { version = "1.4.0", default-features = false }
 num_cpus = "1.16.0"
 object_store = "0.9.1"
 once_cell = { version = "1.18", features = ["parking_lot"] }
@@ -74,9 +74,9 @@ pbjson-build = "0.6.2"
 pbjson-types = "0.6.0"
 pin-project-lite = "0.2"
 pretty_assertions = "1.4.0"
-prost = "0.12.3"
-prost-build = "0.12.2"
-prost-types = "0.12.3"
+prost = "0.12.6"
+prost-build = "0.12.6"
+prost-types = "0.12.6"
 rand = "0.8.5"
 reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls", "stream"] }
 secrecy = "0.8.0"
@@ -86,7 +86,7 @@ serde_urlencoded = "0.7.0"
 serde_with = "3.8.1"
 sha2 = "0.10.8"
 snap = "1.0.0"
-sqlparser = "0.41.0"
+sqlparser = "0.47.0"
 sysinfo = "0.30.8"
 thiserror = "1.0"
 tokio = { version = "1.35", features = ["full"] }
@@ -102,38 +102,38 @@ urlencoding = "1.1"
 uuid = { version = "1", features = ["v4"] }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94"}
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94", features = ["http"] }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "0f5ecbd6b17f83f7ad4ba55699fc2cd3e151cf94", default-features = true, features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync"}
+authz = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync", features = ["http"] }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "string"] }
 crc32fast = "1.2.0"
 crossbeam-channel = "0.5.11"
-datafusion = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "93e58e36a906df2008addccb6712d5bd22f82d5d" }
-datafusion-proto = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "93e58e36a906df2008addccb6712d5bd22f82d5d" }
+datafusion = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "e495f1f6bfa8e65f4058829912283ee98ab46318" }
+datafusion-proto = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "e495f1f6bfa8e65f4058829912283ee98ab46318" }
 csv = "1.3.0"
 dotenvy = "0.15.7"
 flate2 = "1.0.27"
@@ -102,38 +102,41 @@ urlencoding = "1.1"
 uuid = { version = "1", features = ["v4"] }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync"}
-authz = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync", features = ["http"] }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", branch = "hiltontj/14-june-2024-sk-sync", default-features = true, features = ["clap"] }
+# Currently influxdb is pointed at a revision from the experimental branch
+# in influxdb3_core, hiltontj/17-june-2024-iox-sync-exp, instead of main.
+# See https://github.com/influxdata/influxdb3_core/pull/23
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c"}
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c", features = ["http"] }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+ioxd_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+test_helpers_end_to_end = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ca040f2a6e5b6470e469825a8d35060d0199297c", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"

--- a/influxdb3/tests/server/flight.rs
+++ b/influxdb3/tests/server/flight.rs
@@ -160,7 +160,9 @@ async fn flight_influxql() {
 
     let mut client = server.flight_client().await;
 
-    // Ad-hoc query, using qualified measurement name:
+    // Ad-hoc query, using qualified measurement name
+    // This is no longer supported in 3.0, see
+    // https://github.com/influxdata/influxdb_iox/pull/11254
     {
         let ticket = Ticket::new(
             r#"{
@@ -169,21 +171,9 @@ async fn flight_influxql() {
                     "query_type": "influxql"
                 }"#,
         );
-        let response = client.do_get(ticket).await.unwrap();
+        let response = client.do_get(ticket).await.unwrap_err().to_string();
 
-        let batches = collect_stream(response).await;
-        assert_batches_sorted_eq!(
-            [
-                "+------------------+--------------------------------+------+---------+-------+",
-                "| iox::measurement | time                           | host | region  | usage |",
-                "+------------------+--------------------------------+------+---------+-------+",
-                "| cpu              | 1970-01-01T00:00:00.000000001Z | s1   | us-east | 0.9   |",
-                "| cpu              | 1970-01-01T00:00:00.000000002Z | s1   | us-east | 0.89  |",
-                "| cpu              | 1970-01-01T00:00:00.000000003Z | s1   | us-east | 0.85  |",
-                "+------------------+--------------------------------+------+---------+-------+",
-            ],
-            &batches
-        );
+        assert_contains!(response, "database prefix in qualified measurement syntax");
     }
 
     // InfluxQL-specific query to show measurements:

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -179,6 +179,18 @@ impl TestServer {
             .await
     }
 
+    pub async fn api_v3_query_sql(&self, params: &[(&str, &str)]) -> Response {
+        self.http_client
+            .get(format!(
+                "{base}/api/v3/query_sql",
+                base = self.client_addr()
+            ))
+            .query(params)
+            .send()
+            .await
+            .expect("send /api/v3/query_sql request to server")
+    }
+
     pub async fn api_v3_query_influxql(&self, params: &[(&str, &str)]) -> Response {
         self.http_client
             .get(format!(

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -328,7 +328,13 @@ where
     async fn write_lp(&self, req: Request<Body>) -> Result<Response<Body>> {
         let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
         let params: WriteParams = serde_urlencoded::from_str(query)?;
-        self.write_lp_inner(params, req, false).await
+        self.write_lp_inner(params, req, false, false).await
+    }
+
+    async fn write_v3(&self, req: Request<Body>) -> Result<Response<Body>> {
+        let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
+        let params: WriteParams = serde_urlencoded::from_str(query)?;
+        self.write_lp_inner(params, req, false, true).await
     }
 
     async fn write_lp_inner(
@@ -336,6 +342,7 @@ where
         params: WriteParams,
         req: Request<Body>,
         accept_rp: bool,
+        use_v3: bool,
     ) -> Result<Response<Body>> {
         validate_db_name(&params.db, accept_rp)?;
         info!("write_lp to {}", params.db);
@@ -347,16 +354,27 @@ where
 
         let default_time = self.time_provider.now();
 
-        let result = self
-            .write_buffer
-            .write_lp(
-                database,
-                body,
-                default_time,
-                params.accept_partial,
-                params.precision,
-            )
-            .await?;
+        let result = if use_v3 {
+            self.write_buffer
+                .write_lp_v3(
+                    database,
+                    body,
+                    default_time,
+                    params.accept_partial,
+                    params.precision,
+                )
+                .await?
+        } else {
+            self.write_buffer
+                .write_lp(
+                    database,
+                    body,
+                    default_time,
+                    params.accept_partial,
+                    params.precision,
+                )
+                .await?
+        };
 
         if result.invalid_lines.is_empty() {
             Ok(Response::new(Body::empty()))
@@ -928,7 +946,7 @@ where
                 Err(e) => return Ok(legacy_write_error_to_response(e)),
             };
 
-            http_server.write_lp_inner(params, req, true).await
+            http_server.write_lp_inner(params, req, true, false).await
         }
         (Method::POST, "/api/v2/write") => {
             let params = match http_server.legacy_write_param_unifier.parse_v2(&req).await {
@@ -936,8 +954,9 @@ where
                 Err(e) => return Ok(legacy_write_error_to_response(e)),
             };
 
-            http_server.write_lp_inner(params, req, false).await
+            http_server.write_lp_inner(params, req, false, false).await
         }
+        (Method::POST, "/api/v3/write") => http_server.write_v3(req).await,
         (Method::POST, "/api/v3/write_lp") => http_server.write_lp(req).await,
         (Method::GET | Method::POST, "/api/v3/query_sql") => http_server.query_sql(req).await,
         (Method::GET | Method::POST, "/api/v3/query_influxql") => {

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -319,6 +319,10 @@ impl TableDefinition {
     pub(crate) fn field_type_by_name(&self, name: &str) -> Option<InfluxColumnType> {
         self.schema.field_type_by_name(name)
     }
+
+    pub(crate) fn is_v3(&self) -> bool {
+        self.schema.series_key().is_some()
+    }
 }
 
 pub fn influx_column_type_from_field_value(fv: &FieldValue<'_>) -> InfluxColumnType {

--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -259,9 +259,7 @@ impl TableDefinition {
         }
         let mut schema_builder = SchemaBuilder::with_capacity(columns.as_ref().len());
         let name = name.into();
-        // TODO: may need to capture some schema-level metadata, currently, this causes trouble in
-        // tests, so I am omitting this for now:
-        // schema_builder.measurement(&name);
+        schema_builder.measurement(&name);
         for (name, column_type) in ordered_columns {
             schema_builder.influx_column(name, *column_type);
         }
@@ -310,13 +308,16 @@ impl TableDefinition {
             .collect()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn schema(&self) -> &Schema {
         &self.schema
     }
 
     pub(crate) fn num_columns(&self) -> usize {
         self.schema.len()
+    }
+
+    pub(crate) fn field_type_by_name(&self, name: &str) -> Option<InfluxColumnType> {
+        self.schema.field_type_by_name(name)
     }
 }
 
@@ -333,6 +334,7 @@ pub fn influx_column_type_from_field_value(fv: &FieldValue<'_>) -> InfluxColumnT
 #[cfg(test)]
 mod tests {
     use insta::assert_json_snapshot;
+    use pretty_assertions::assert_eq;
     use test_helpers::assert_contains;
 
     use super::*;

--- a/influxdb3_write/src/catalog/serialize.rs
+++ b/influxdb3_write/src/catalog/serialize.rs
@@ -201,9 +201,7 @@ impl<'a> From<TableSnapshot<'a>> for TableDefinition {
     fn from(snap: TableSnapshot<'a>) -> Self {
         let name = snap.name.to_owned();
         let mut b = SchemaBuilder::new();
-        // TODO: may need to capture some schema-level metadata, currently, this causes trouble in
-        // tests, so I am omitting this for now:
-        // b.measurement(&name);
+        b.measurement(&name);
         for (name, col) in snap.cols {
             match col.influx_type {
                 InfluxType::Tag => {

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -618,18 +618,6 @@ mod test_helpers {
                 Precision::Nanosecond,
             );
 
-        // let mut result = parse_validate_and_update_schema(
-        //     lp,
-        //     &db,
-        //     db_name.clone(),
-        //     Time::from_timestamp_nanos(0),
-        //     SegmentDuration::new_5m(),
-        //     false,
-        //     Precision::Nanosecond,
-        //     seq,
-        // )
-        // .unwrap();
-
         write_batch.add_db_write(
             db_name,
             result.valid_segmented_data.pop().unwrap().table_batches,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -84,6 +84,16 @@ pub trait Bufferer: Debug + Send + Sync + 'static {
         precision: Precision,
     ) -> write_buffer::Result<BufferedWriteRequest>;
 
+    /// Write v3 line protocol
+    async fn write_lp_v3(
+        &self,
+        database: NamespaceName<'static>,
+        lp: &str,
+        ingest_time: Time,
+        accept_partial: bool,
+        precision: Precision,
+    ) -> write_buffer::Result<BufferedWriteRequest>;
+
     /// Returns the configured WAL, if there is one.
     fn wal(&self) -> Option<Arc<impl Wal>>;
 
@@ -453,7 +463,7 @@ pub struct BufferedWriteRequest {
     pub invalid_lines: Vec<WriteLineError>,
     pub line_count: usize,
     pub field_count: usize,
-    pub tag_count: usize,
+    pub index_count: usize,
 }
 
 /// A persisted Catalog that contains the database, table, and column schemas.

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -25,7 +25,7 @@ use data_types::TransitionPartitionId;
 use data_types::{NamespaceName, PartitionKey};
 use datafusion::logical_expr::Expr;
 use datafusion_util::stream_from_batches;
-use iox_query::chunk_statistics::create_chunk_statistics;
+use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::frontend::reorg::ReorgPlanner;
 use iox_query::QueryChunk;
 use iox_time::Time;
@@ -447,7 +447,7 @@ impl ClosedBufferSegment {
                             Some(row_count),
                             schema,
                             Some(time_min_max),
-                            None,
+                            &NoColumnRanges,
                         );
 
                         chunks.push(Arc::new(BufferChunk {

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -184,7 +184,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, "db1", lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), "db1", lp);
 
         open_segment.write_wal_ops(vec![wal_op]).unwrap();
         open_segment.buffer_writes(write_batch).unwrap();
@@ -272,7 +272,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), db_name, lp);
 
         current_segment.write_wal_ops(vec![wal_op.clone()]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
@@ -358,7 +358,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), db_name, lp);
 
         current_segment.write_wal_ops(vec![wal_op]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
@@ -386,7 +386,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), db_name, lp);
 
         let segment_writer = wal
             .new_segment_writer(next_segment_id, next_segment_range)
@@ -423,7 +423,7 @@ mod tests {
             PersistedSegment {
                 segment_id,
                 segment_wal_size_bytes: 252,
-                segment_parquet_size_bytes: 3458,
+                segment_parquet_size_bytes: 3650,
                 segment_row_count: 3,
                 segment_min_time: 10,
                 segment_max_time: 20,
@@ -438,7 +438,7 @@ mod tests {
                                     parquet_files: vec![ParquetFile {
                                         path: "dbs/db1/cpu/1970-01-01T00-00/4294967294.parquet"
                                             .to_string(),
-                                        size_bytes: 1721,
+                                        size_bytes: 1817,
                                         row_count: 1,
                                         min_time: 10,
                                         max_time: 10,
@@ -453,7 +453,7 @@ mod tests {
                                     parquet_files: vec![ParquetFile {
                                         path: "dbs/db1/mem/1970-01-01T00-00/4294967294.parquet"
                                             .to_string(),
-                                        size_bytes: 1737,
+                                        size_bytes: 1833,
                                         row_count: 2,
                                         min_time: 15,
                                         max_time: 20,
@@ -534,7 +534,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), db_name, lp);
 
         current_segment.write_wal_ops(vec![wal_op]).unwrap();
         current_segment.buffer_writes(write_batch).unwrap();
@@ -555,7 +555,7 @@ mod tests {
             precision: Precision::Nanosecond,
         });
 
-        let write_batch = lp_to_write_batch(&catalog, db_name, lp);
+        let write_batch = lp_to_write_batch(Arc::clone(&catalog), db_name, lp);
 
         let segment_writer = wal
             .new_segment_writer(next_segment_id, next_segment_range)

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -5,29 +5,26 @@ mod flusher;
 mod loader;
 mod segment_state;
 mod table_buffer;
+pub(crate) mod validator;
 
 use crate::cache::ParquetCache;
-use crate::catalog::{
-    influx_column_type_from_field_value, Catalog, DatabaseSchema, TableDefinition, TIME_COLUMN_NAME,
-};
+use crate::catalog::{Catalog, DatabaseSchema};
 use crate::chunk::ParquetChunk;
 use crate::persister::PersisterImpl;
 use crate::write_buffer::flusher::WriteBufferFlusher;
 use crate::write_buffer::loader::load_starting_state;
 use crate::write_buffer::segment_state::{run_buffer_segment_persist_and_cleanup, SegmentState};
+use crate::write_buffer::validator::WriteValidator;
 use crate::{
-    BufferedWriteRequest, Bufferer, ChunkContainer, LpWriteOp, Persister, Precision,
-    SegmentDuration, SequenceNumber, Wal, WalOp, WriteBuffer, WriteLineError,
+    BufferedWriteRequest, Bufferer, ChunkContainer, Persister, Precision, SegmentDuration,
+    SequenceNumber, Wal, WalOp, WriteBuffer, WriteLineError,
 };
 use async_trait::async_trait;
-use data_types::{
-    column_type_from_field, ChunkId, ChunkOrder, ColumnType, NamespaceName, NamespaceNameError,
-};
+use data_types::{ChunkId, ChunkOrder, ColumnType, NamespaceName, NamespaceNameError};
 use datafusion::common::DataFusionError;
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
@@ -36,12 +33,8 @@ use object_store::ObjectMeta;
 use observability_deps::tracing::{debug, error};
 use parking_lot::{Mutex, RwLock};
 use parquet_file::storage::ParquetExecInput;
-use schema::InfluxColumnType;
-use sha2::Digest;
-use sha2::Sha256;
-use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 
@@ -179,15 +172,9 @@ impl<W: Wal, T: TimeProvider> WriteBufferImpl<W, T> {
     ) -> Result<BufferedWriteRequest> {
         debug!("write_lp to {} in writebuffer", db_name);
 
-        let result = parse_validate_and_update_catalog(
-            db_name.clone(),
-            lp,
-            &self.catalog,
-            ingest_time,
-            self.segment_duration,
-            accept_partial,
-            precision,
-        )?;
+        let result = WriteValidator::initialize(db_name.clone(), self.catalog())?
+            .v1_parse_lines_and_update_schema(lp, accept_partial)?
+            .convert_lines_to_buffer(ingest_time, self.segment_duration, precision);
 
         self.write_buffer_flusher
             .write_to_open_segment(result.valid_segmented_data)
@@ -420,345 +407,6 @@ impl<W: Wal, T: TimeProvider> ChunkContainer for WriteBufferImpl<W, T> {
 
 impl<W: Wal, T: TimeProvider> WriteBuffer for WriteBufferImpl<W, T> {}
 
-/// Returns a validated result and the sequence number of the catalog before any updates were
-/// applied.
-pub(crate) fn parse_validate_and_update_catalog(
-    db_name: NamespaceName<'static>,
-    lp: &str,
-    catalog: &Catalog,
-    ingest_time: Time,
-    segment_duration: SegmentDuration,
-    accept_partial: bool,
-    precision: Precision,
-) -> Result<ValidationResult> {
-    let (sequence, db) = catalog.db_or_create(db_name.as_str())?;
-    let mut result = parse_validate_and_update_schema(
-        lp,
-        &db,
-        db_name,
-        ingest_time,
-        segment_duration,
-        accept_partial,
-        precision,
-        sequence,
-    )?;
-
-    if let Some(schema) = result.schema.take() {
-        debug!("replacing schema for {:?}", schema);
-
-        catalog.replace_database(sequence, Arc::new(schema))?;
-    }
-
-    Ok(result)
-}
-
-/// Takes &str of line protocol, parses lines, validates the schema, and inserts new columns
-/// if present. Assigns the default time to any lines that do not include a time
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn parse_validate_and_update_schema(
-    lp: &str,
-    schema: &DatabaseSchema,
-    db_name: NamespaceName<'static>,
-    ingest_time: Time,
-    segment_duration: SegmentDuration,
-    accept_partial: bool,
-    precision: Precision,
-    starting_catalog_sequence_number: SequenceNumber,
-) -> Result<ValidationResult> {
-    let mut errors = vec![];
-    let mut lp_lines = lp.lines();
-
-    let mut valid_parsed_and_raw_lines: Vec<(ParsedLine, &str)> = vec![];
-
-    for (line_idx, maybe_line) in parse_lines(lp).enumerate() {
-        let line = match maybe_line
-            .map_err(|e| WriteLineError {
-                // This unwrap is fine because we're moving line by line
-                // alongside the output from parse_lines
-                original_line: lp_lines.next().unwrap().to_string(),
-                line_number: line_idx + 1,
-                error_message: e.to_string(),
-            })
-            .and_then(|l| validate_line_schema(line_idx, l, schema))
-        {
-            Ok(line) => line,
-            Err(e) => {
-                if !accept_partial {
-                    return Err(Error::ParseError(e));
-                } else {
-                    errors.push(e);
-                }
-                continue;
-            }
-        };
-        // This unwrap is fine because we're moving line by line
-        // alongside the output from parse_lines
-        valid_parsed_and_raw_lines.push((line, lp_lines.next().unwrap()));
-    }
-
-    validate_or_insert_schema_and_partitions(
-        valid_parsed_and_raw_lines,
-        schema,
-        db_name,
-        ingest_time,
-        segment_duration,
-        precision,
-        starting_catalog_sequence_number,
-    )
-    .map(move |mut result| {
-        result.errors = errors;
-        result
-    })
-}
-
-/// Validate a line of line protocol against the given schema definition
-///
-/// This is for scenarios where a write comes in for a table that exists, but may have invalid field
-/// types, based on the pre-existing schema.
-fn validate_line_schema<'a>(
-    line_number: usize,
-    line: ParsedLine<'a>,
-    schema: &DatabaseSchema,
-) -> Result<ParsedLine<'a>, WriteLineError> {
-    let table_name = line.series.measurement.as_str();
-    if let Some(table_schema) = schema.get_table_schema(table_name) {
-        for (field_name, field_val) in line.field_set.iter() {
-            if let Some(schema_col_type) = table_schema.field_type_by_name(field_name) {
-                let field_col_type = column_type_from_field(field_val);
-                if field_col_type != schema_col_type {
-                    let field_name = field_name.to_string();
-                    return Err(WriteLineError {
-                        original_line: line.to_string(),
-                        line_number: line_number + 1,
-                        error_message: format!(
-                            "invalid field value in line protocol for field '{field_name}' on line \
-                            {line_number}: expected type {expected}, but got {got}",
-                            expected = ColumnType::from(schema_col_type),
-                            got = field_col_type,
-                        ),
-                    });
-                }
-            }
-        }
-    }
-
-    Ok(line)
-}
-
-/// Takes parsed lines, validates their schema. If new tables or columns are defined, they
-/// are passed back as a new DatabaseSchema as part of the ValidationResult. Lines are split
-/// into partitions and the validation result contains the data that can then be serialized
-/// into the WAL.
-pub(crate) fn validate_or_insert_schema_and_partitions(
-    lines: Vec<(ParsedLine<'_>, &str)>,
-    schema: &DatabaseSchema,
-    db_name: NamespaceName<'static>,
-    ingest_time: Time,
-    segment_duration: SegmentDuration,
-    precision: Precision,
-    starting_catalog_sequence_number: SequenceNumber,
-) -> Result<ValidationResult> {
-    // The (potentially updated) DatabaseSchema to return to the caller.
-    let mut schema = Cow::Borrowed(schema);
-
-    // The parsed and validated table_batches
-    let mut segment_table_batches: HashMap<Time, TableBatchMap> = HashMap::new();
-
-    let line_count = lines.len();
-    let mut field_count = 0;
-    let mut tag_count = 0;
-
-    for (line, raw_line) in lines.into_iter() {
-        field_count += line.field_set.len();
-        tag_count += line.series.tag_set.as_ref().map(|t| t.len()).unwrap_or(0);
-
-        validate_and_convert_parsed_line(
-            line,
-            raw_line,
-            &mut segment_table_batches,
-            &mut schema,
-            ingest_time,
-            segment_duration,
-            precision,
-        )?;
-    }
-
-    let schema = match schema {
-        Cow::Owned(s) => Some(s),
-        Cow::Borrowed(_) => None,
-    };
-
-    let valid_segmented_data = segment_table_batches
-        .into_iter()
-        .map(|(segment_start, table_batches)| ValidSegmentedData {
-            database_name: db_name.clone(),
-            segment_start,
-            table_batches: table_batches.table_batches,
-            wal_op: WalOp::LpWrite(LpWriteOp {
-                db_name: db_name.to_string(),
-                lp: table_batches.lines.join("\n"),
-                default_time: ingest_time.timestamp_nanos(),
-                precision,
-            }),
-            starting_catalog_sequence_number,
-        })
-        .collect();
-
-    Ok(ValidationResult {
-        schema,
-        line_count,
-        field_count,
-        tag_count,
-        errors: vec![],
-        valid_segmented_data,
-    })
-}
-
-/// Check if the table exists in the schema and update the schema if it does not
-// Because the entry API requires &mut it is not used to avoid a premature
-// clone of the Cow.
-fn validate_and_update_schema(line: &ParsedLine<'_>, schema: &mut Cow<'_, DatabaseSchema>) {
-    let table_name = line.series.measurement.as_str();
-    match schema.tables.get(table_name) {
-        Some(t) => {
-            // Collect new column definitions
-            let mut new_cols = Vec::with_capacity(line.column_count() + 1);
-            if let Some(tagset) = &line.series.tag_set {
-                for (tag_key, _) in tagset {
-                    if !t.column_exists(tag_key.as_str()) {
-                        new_cols.push((tag_key.to_string(), InfluxColumnType::Tag));
-                    }
-                }
-            }
-            for (field_name, value) in &line.field_set {
-                if !t.column_exists(field_name.as_str()) {
-                    new_cols.push((
-                        field_name.to_string(),
-                        influx_column_type_from_field_value(value),
-                    ));
-                }
-            }
-
-            if !new_cols.is_empty() {
-                let t = schema.to_mut().tables.get_mut(table_name).unwrap();
-                t.add_columns(new_cols);
-            }
-        }
-        None => {
-            let mut columns = Vec::new();
-            if let Some(tag_set) = &line.series.tag_set {
-                for (tag_key, _) in tag_set {
-                    columns.push((tag_key.to_string(), InfluxColumnType::Tag));
-                }
-            }
-            for (field_name, value) in &line.field_set {
-                columns.push((
-                    field_name.to_string(),
-                    influx_column_type_from_field_value(value),
-                ));
-            }
-
-            columns.push((TIME_COLUMN_NAME.to_string(), InfluxColumnType::Timestamp));
-
-            let table = TableDefinition::new(table_name, columns);
-
-            assert!(schema
-                .to_mut()
-                .tables
-                .insert(table_name.to_string(), table)
-                .is_none());
-        }
-    };
-}
-
-fn validate_and_convert_parsed_line<'a>(
-    line: ParsedLine<'_>,
-    raw_line: &'a str,
-    segment_table_batches: &mut HashMap<Time, TableBatchMap<'a>>,
-    schema: &mut Cow<'_, DatabaseSchema>,
-    ingest_time: Time,
-    segment_duration: SegmentDuration,
-    precision: Precision,
-) -> Result<()> {
-    validate_and_update_schema(&line, schema);
-
-    // now that we've ensured all columns exist in the schema, construct the actual row and values
-    // while validating the column types match.
-    let mut values = Vec::with_capacity(line.column_count() + 1);
-
-    // validate tags, collecting any new ones that must be inserted, or adding the values
-    if let Some(tag_set) = line.series.tag_set {
-        for (tag_key, value) in tag_set {
-            let value = Field {
-                name: tag_key.to_string(),
-                value: FieldData::Tag(value.to_string()),
-            };
-            values.push(value);
-        }
-    }
-
-    // validate fields, collecting any new ones that must be inserted, or adding values
-    for (field_name, value) in line.field_set {
-        let field_data = match value {
-            FieldValue::I64(v) => FieldData::Integer(v),
-            FieldValue::F64(v) => FieldData::Float(v),
-            FieldValue::U64(v) => FieldData::UInteger(v),
-            FieldValue::Boolean(v) => FieldData::Boolean(v),
-            FieldValue::String(v) => FieldData::String(v.to_string()),
-        };
-        let value = Field {
-            name: field_name.to_string(),
-            value: field_data,
-        };
-        values.push(value);
-    }
-
-    // set the time value
-    let time_value_nanos = line
-        .timestamp
-        .map(|ts| {
-            let multiplier = match precision {
-                Precision::Auto => match crate::guess_precision(ts) {
-                    Precision::Second => 1_000_000_000,
-                    Precision::Millisecond => 1_000_000,
-                    Precision::Microsecond => 1_000,
-                    Precision::Nanosecond => 1,
-
-                    Precision::Auto => unreachable!(),
-                },
-                Precision::Second => 1_000_000_000,
-                Precision::Millisecond => 1_000_000,
-                Precision::Microsecond => 1_000,
-                Precision::Nanosecond => 1,
-            };
-
-            ts * multiplier
-        })
-        .unwrap_or(ingest_time.timestamp_nanos());
-
-    let segment_start = segment_duration.start_time(time_value_nanos / 1_000_000_000);
-
-    values.push(Field {
-        name: TIME_COLUMN_NAME.to_string(),
-        value: FieldData::Timestamp(time_value_nanos),
-    });
-
-    let table_batch_map = segment_table_batches.entry(segment_start).or_default();
-
-    let table_batch = table_batch_map
-        .table_batches
-        .entry(line.series.measurement.to_string())
-        .or_default();
-    table_batch.rows.push(Row {
-        time: time_value_nanos,
-        fields: values,
-    });
-
-    table_batch_map.lines.push(raw_line);
-
-    Ok(())
-}
-
 #[derive(Debug, Default)]
 pub(crate) struct TableBatch {
     #[allow(dead_code)]
@@ -843,34 +491,12 @@ pub(crate) struct TableBatchMap<'a> {
     pub(crate) table_batches: HashMap<String, TableBatch>,
 }
 
-/// The 32 byte SHA256 digest of the full tag set for a line of measurement data
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct SeriesId([u8; 32]);
-
-impl std::fmt::Display for SeriesId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
-    }
-}
-
-fn default_series_sha() -> &'static [u8; 32] {
-    static DEFAULT_SERIES_ID_SHA: OnceLock<[u8; 32]> = OnceLock::new();
-    // the unwrap is safe here because the Sha256 digest will always be 32 bytes:
-    DEFAULT_SERIES_ID_SHA.get_or_init(|| Sha256::digest("")[..].try_into().unwrap())
-}
-
-impl Default for SeriesId {
-    fn default() -> Self {
-        Self(default_series_sha().to_owned())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::persister::PersisterImpl;
     use crate::wal::WalImpl;
-    use crate::{SegmentId, SequenceNumber, WalOpBatch};
+    use crate::{LpWriteOp, SegmentId, SequenceNumber, WalOpBatch};
     use arrow::record_batch::RecordBatch;
     use arrow_util::assert_batches_eq;
     use datafusion_util::config::register_iox_object_store;
@@ -881,22 +507,20 @@ mod tests {
 
     #[test]
     fn parse_lp_into_buffer() {
-        let db = Arc::new(DatabaseSchema::new("foo"));
+        let catalog = Arc::new(Catalog::new());
         let db_name = NamespaceName::new("foo").unwrap();
         let lp = "cpu,region=west user=23.2 100\nfoo f1=1i";
-        let result = parse_validate_and_update_schema(
-            lp,
-            &db,
-            db_name,
-            Time::from_timestamp_nanos(0),
-            SegmentDuration::new_5m(),
-            false,
-            Precision::Nanosecond,
-            SequenceNumber::new(0),
-        )
-        .unwrap();
+        WriteValidator::initialize(db_name, Arc::clone(&catalog))
+            .unwrap()
+            .v1_parse_lines_and_update_schema(lp, false)
+            .unwrap()
+            .convert_lines_to_buffer(
+                Time::from_timestamp_nanos(0),
+                SegmentDuration::new_5m(),
+                Precision::Nanosecond,
+            );
 
-        let db = result.schema.unwrap();
+        let db = catalog.db_schema("foo").unwrap();
 
         assert_eq!(db.tables.len(), 2);
         assert_eq!(db.tables.get("cpu").unwrap().num_columns(), 3);

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -28,7 +28,7 @@ use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
-use iox_query::chunk_statistics::create_chunk_statistics;
+use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
 use object_store::path::Path as ObjPath;
@@ -246,7 +246,7 @@ impl<W: Wal, T: TimeProvider> WriteBufferImpl<W, T> {
                 Some(parquet_file.row_count as usize),
                 &table_schema,
                 Some(parquet_file.timestamp_min_max()),
-                None,
+                &NoColumnRanges,
             );
 
             let location = ObjPath::from(parquet_file.path.clone());
@@ -295,7 +295,7 @@ impl<W: Wal, T: TimeProvider> WriteBufferImpl<W, T> {
                 Some(parquet_file.row_count as usize),
                 &table_schema,
                 Some(parquet_file.timestamp_min_max()),
-                None,
+                &NoColumnRanges,
             );
 
             let location = ObjPath::from(parquet_file.path.clone());

--- a/influxdb3_write/src/write_buffer/segment_state.rs
+++ b/influxdb3_write/src/write_buffer/segment_state.rs
@@ -574,7 +574,11 @@ mod tests {
             None,
         );
         open_segment1
-            .buffer_writes(lp_to_write_batch(&catalog, "foo", "cpu bar=1 10"))
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=1 10",
+            ))
             .unwrap();
 
         let mut open_segment2 = OpenBufferSegment::new(
@@ -591,7 +595,11 @@ mod tests {
             None,
         );
         open_segment2
-            .buffer_writes(lp_to_write_batch(&catalog, "foo", "cpu bar=2 300000000000"))
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=2 300000000000",
+            ))
             .unwrap();
 
         let mut open_segment3 = OpenBufferSegment::new(
@@ -608,7 +616,11 @@ mod tests {
             None,
         );
         open_segment3
-            .buffer_writes(lp_to_write_batch(&catalog, "foo", "cpu bar=3 700000000000"))
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=3 700000000000",
+            ))
             .unwrap();
 
         let wal = Arc::new(TestWal::default());

--- a/influxdb3_write/src/write_buffer/segment_state.rs
+++ b/influxdb3_write/src/write_buffer/segment_state.rs
@@ -15,7 +15,7 @@ use data_types::{ChunkId, ChunkOrder, TableId, TransitionPartitionId};
 use datafusion::common::DataFusionError;
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::Expr;
-use iox_query::chunk_statistics::create_chunk_statistics;
+use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
 use observability_deps::tracing::error;
@@ -148,7 +148,7 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
                     Some(row_count),
                     &schema,
                     Some(segment.segment_range().timestamp_min_max()),
-                    None,
+                    &NoColumnRanges,
                 );
 
                 chunks.push(Arc::new(BufferChunk {
@@ -187,7 +187,7 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
                     Some(row_count),
                     &schema,
                     Some(persisting_segment.segment_range.timestamp_min_max()),
-                    None,
+                    &NoColumnRanges,
                 );
 
                 chunks.push(Arc::new(BufferChunk {

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -99,6 +99,24 @@ impl TableBuffer {
                             panic!("unexpected field type");
                         }
                     }
+                    FieldData::Key(v) => {
+                        if !self.data.contains_key(&f.name) {
+                            let key_builder = StringBuilder::new();
+                            if self.row_count > 0 {
+                                panic!("series key columns must be passed in the very first write for a table");
+                            }
+                            self.data.insert(f.name.clone(), Builder::Key(key_builder));
+                        }
+                        let b = self
+                            .data
+                            .get_mut(&f.name)
+                            .expect("key builder should exist");
+                        let Builder::Key(b) = b else {
+                            panic!("unexpected field type");
+                        };
+                        self.index.add_row_if_indexed_column(b.len(), &f.name, &v);
+                        b.append_value(v);
+                    }
                     FieldData::String(v) => {
                         let b = self.data.entry(f.name).or_insert_with(|| {
                             let mut string_builder = StringBuilder::new();
@@ -188,6 +206,7 @@ impl TableBuffer {
                         Builder::U64(b) => b.append_null(),
                         Builder::String(b) => b.append_null(),
                         Builder::Tag(b) => b.append_null(),
+                        Builder::Key(b) => b.append_null(),
                         Builder::Time(b) => b.append_null(),
                     }
                 }
@@ -319,6 +338,7 @@ pub enum Builder {
     U64(UInt64Builder),
     String(StringBuilder),
     Tag(StringDictionaryBuilder<Int32Type>),
+    Key(StringBuilder),
     Time(TimestampNanosecondBuilder),
 }
 
@@ -331,6 +351,7 @@ impl Builder {
             Self::U64(b) => Arc::new(b.finish_cloned()),
             Self::String(b) => Arc::new(b.finish_cloned()),
             Self::Tag(b) => Arc::new(b.finish_cloned()),
+            Self::Key(b) => Arc::new(b.finish_cloned()),
             Self::Time(b) => Arc::new(b.finish_cloned()),
         }
     }
@@ -394,6 +415,14 @@ impl Builder {
                 }
                 Arc::new(builder.finish())
             }
+            Self::Key(b) => {
+                let b = b.finish_cloned();
+                let mut builder = StringBuilder::new();
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Arc::new(builder.finish())
+            }
             Self::Time(b) => {
                 let b = b.finish_cloned();
                 let mut builder = TimestampNanosecondBuilder::with_capacity(rows.len());
@@ -425,6 +454,11 @@ impl Builder {
             Self::Tag(b) => {
                 let b = b.finish_cloned();
                 b.keys().len() * size_of::<i32>() + b.values().get_array_memory_size()
+            }
+            Self::Key(b) => {
+                b.values_slice().len()
+                    + b.offsets_slice().len()
+                    + b.validity_slice().map(|s| s.len()).unwrap_or(0)
             }
             Self::Time(b) => size_of::<i64>() * b.capacity(),
         };

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use data_types::NamespaceName;
 use influxdb_line_protocol::{parse_lines, v3, FieldValue, ParsedLine};
 use iox_time::Time;
-use schema::{InfluxColumnType, TIME_COLUMN_NAME};
+use schema::{InfluxColumnType, InfluxFieldType, TIME_COLUMN_NAME};
 
 use crate::{
     catalog::{influx_column_type_from_field_value, Catalog, DatabaseSchema, TableDefinition},
@@ -178,10 +178,46 @@ fn validate_v3_line<'a>(
             });
         }
         let mut columns = Vec::with_capacity(line.column_count() + 1);
+        match (table_def.schema().series_key(), &line.series.series_key) {
+            (Some(s), Some(l)) => {
+                let l = l.iter().map(|sk| sk.0.as_str()).collect::<Vec<&str>>();
+                if s != l {
+                    return Err(WriteLineError {
+                        original_line: raw_line.to_string(),
+                        line_number,
+                        error_message: format!(
+                            "write to table {table_name} had the incorrect series key, \
+                            expected: [{expected}], received: [{received}]",
+                            table_name = table_def.name,
+                            expected = s.join(", "),
+                            received = l.join(", "),
+                        ),
+                    });
+                }
+            }
+            (Some(s), None) => {
+                if !s.is_empty() {
+                    return Err(WriteLineError {
+                        original_line: raw_line.to_string(),
+                        line_number,
+                        error_message: format!(
+                            "write to table {table_name} was missing a series key, the series key \
+                            contains [{key_members}]",
+                            table_name = table_def.name,
+                            key_members = s.join(", "),
+                        ),
+                    });
+                }
+            }
+            (None, _) => unreachable!(),
+        }
         if let Some(series_key) = &line.series.series_key {
             for (sk, _) in series_key.iter() {
                 if !table_def.column_exists(sk) {
-                    columns.push((sk.to_string(), InfluxColumnType::Tag));
+                    columns.push((
+                        sk.to_string(),
+                        InfluxColumnType::Field(InfluxFieldType::String),
+                    ));
                 }
             }
         }
@@ -214,9 +250,14 @@ fn validate_v3_line<'a>(
         }
     } else {
         let mut columns = Vec::new();
+        let mut key = Vec::new();
         if let Some(series_key) = &line.series.series_key {
             for (sk, _) in series_key.iter() {
-                columns.push((sk.to_string(), InfluxColumnType::Tag));
+                key.push(sk.to_string());
+                columns.push((
+                    sk.to_string(),
+                    InfluxColumnType::Field(InfluxFieldType::String),
+                ));
             }
         }
         for (field_name, field_val) in line.field_set.iter() {
@@ -225,7 +266,9 @@ fn validate_v3_line<'a>(
                 influx_column_type_from_field_value(field_val),
             ));
         }
-        let table = TableDefinition::new(table_name, columns);
+        // Always add time last on new table:
+        columns.push((TIME_COLUMN_NAME.to_string(), InfluxColumnType::Timestamp));
+        let table = TableDefinition::new(table_name, columns, Some(key));
 
         assert!(
             db_schema
@@ -316,7 +359,7 @@ fn validate_v1_line<'a>(
         }
         // Always add time last on new table:
         columns.push((TIME_COLUMN_NAME.to_string(), InfluxColumnType::Timestamp));
-        let table = TableDefinition::new(table_name, columns);
+        let table = TableDefinition::new(table_name, columns, Option::<Vec<String>>::None);
 
         assert!(
             db_schema

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -1,0 +1,390 @@
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
+
+use data_types::NamespaceName;
+use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
+use iox_time::Time;
+use schema::{InfluxColumnType, TIME_COLUMN_NAME};
+
+use crate::{
+    catalog::{influx_column_type_from_field_value, Catalog, DatabaseSchema, TableDefinition},
+    write_buffer::Result,
+    LpWriteOp, Precision, SegmentDuration, SequenceNumber, WalOp, WriteLineError,
+};
+
+use super::{Error, Field, FieldData, Row, TableBatchMap, ValidSegmentedData};
+
+pub(crate) struct WithCatalog {
+    db_name: NamespaceName<'static>,
+    catalog: Arc<Catalog>,
+    sequence: SequenceNumber,
+    db_schema: Arc<DatabaseSchema>,
+}
+
+pub(crate) struct LinesParsed<'raw, PL> {
+    catalog: WithCatalog,
+    lines: Vec<(PL, &'raw str)>,
+    errors: Vec<WriteLineError>,
+}
+
+pub(crate) struct WriteValidator<State> {
+    state: State,
+}
+
+impl WriteValidator<WithCatalog> {
+    /// Initialize the [`WriteValidator`] by getting a handle to, or creating
+    /// a handle to the [`DatabaseSchema`] for the given namespace name `db_name`.
+    pub(crate) fn initialize(
+        db_name: NamespaceName<'static>,
+        catalog: Arc<Catalog>,
+    ) -> Result<WriteValidator<WithCatalog>> {
+        let (sequence, db_schema) = catalog.db_or_create(db_name.as_str())?;
+        Ok(WriteValidator {
+            state: WithCatalog {
+                db_name,
+                catalog,
+                sequence,
+                db_schema,
+            },
+        })
+    }
+
+    /// Parse the incoming lines of line protocol using the v1 parser and update
+    /// the [`DatabaseSchema`] if:
+    ///
+    /// * A new table is being added
+    /// * New fields, or tags are being added to an existing table
+    ///
+    /// # Implementation Note
+    ///
+    /// If this function succeeds, then the catalog will receive an update, so
+    /// steps following this should be infallible.
+    pub(crate) fn v1_parse_lines_and_update_schema(
+        self,
+        lp: &str,
+        accept_partial: bool,
+    ) -> Result<WriteValidator<LinesParsed<'_, ParsedLine<'_>>>> {
+        let mut errors = vec![];
+        let mut lp_lines = lp.lines();
+        let mut lines = vec![];
+        let mut schema = Cow::Borrowed(self.state.db_schema.as_ref());
+
+        for (line_idx, maybe_line) in parse_lines(lp).enumerate() {
+            let line = match maybe_line
+                .map_err(|e| WriteLineError {
+                    // This unwrap is fine because we're moving line by line
+                    // alongside the output from parse_lines
+                    original_line: lp_lines.next().unwrap().to_string(),
+                    line_number: line_idx + 1,
+                    error_message: e.to_string(),
+                })
+                .and_then(|l| validate_v1_line(&mut schema, line_idx, l))
+            {
+                Ok(line) => line,
+                Err(e) => {
+                    if !accept_partial {
+                        return Err(Error::ParseError(e));
+                    } else {
+                        errors.push(e);
+                    }
+                    continue;
+                }
+            };
+            // This unwrap is fine because we're moving line by line
+            // alongside the output from parse_lines
+            lines.push((line, lp_lines.next().unwrap()));
+        }
+
+        // All lines are parsed and validated, so all steps after this
+        // are infallible, therefore, update the catalog if changes were
+        // made to the schema:
+        if let Cow::Owned(schema) = schema {
+            self.state
+                .catalog
+                .replace_database(self.state.sequence, Arc::new(schema))?;
+        }
+
+        Ok(WriteValidator {
+            state: LinesParsed {
+                catalog: self.state,
+                lines,
+                errors,
+            },
+        })
+    }
+}
+
+/// Validate a line of line protocol against the given schema definition
+///
+/// This is for scenarios where a write comes in for a table that exists, but may have
+/// invalid field types, based on the pre-existing schema.
+fn validate_v1_line<'a>(
+    db_schema: &mut Cow<'_, DatabaseSchema>,
+    line_number: usize,
+    line: ParsedLine<'a>,
+) -> Result<ParsedLine<'a>, WriteLineError> {
+    let table_name = line.series.measurement.as_str();
+    if let Some(table_def) = db_schema.get_table(table_name) {
+        // This table already exists, so update with any new columns if present:
+        let mut columns = Vec::with_capacity(line.column_count() + 1);
+        if let Some(tag_set) = &line.series.tag_set {
+            for (tag_key, _) in tag_set {
+                if !table_def.column_exists(tag_key) {
+                    columns.push((tag_key.to_string(), InfluxColumnType::Tag));
+                }
+            }
+        }
+        for (field_name, field_val) in line.field_set.iter() {
+            // This field already exists, so check the incoming type matches existing type:
+            if let Some(schema_col_type) = table_def.field_type_by_name(field_name) {
+                let field_col_type = influx_column_type_from_field_value(field_val);
+                if field_col_type != schema_col_type {
+                    let field_name = field_name.to_string();
+                    return Err(WriteLineError {
+                        original_line: line.to_string(),
+                        line_number: line_number + 1,
+                        error_message: format!(
+                        "invalid field value in line protocol for field '{field_name}' on line \
+                        {line_number}: expected type {expected}, but got {got}",
+                        expected = schema_col_type,
+                        got = field_col_type,
+                    ),
+                    });
+                }
+            } else {
+                columns.push((
+                    field_name.to_string(),
+                    influx_column_type_from_field_value(field_val),
+                ));
+            }
+        }
+        if !columns.is_empty() {
+            // unwrap is safe due to the surrounding if let condition:
+            let t = db_schema.to_mut().tables.get_mut(table_name).unwrap();
+            t.add_columns(columns);
+        }
+    } else {
+        // This is a new table, so build up its columns:
+        let mut columns = Vec::new();
+        if let Some(tag_set) = &line.series.tag_set {
+            for (tag_key, _) in tag_set {
+                columns.push((tag_key.to_string(), InfluxColumnType::Tag));
+            }
+        }
+        for (field_name, field_val) in &line.field_set {
+            columns.push((
+                field_name.to_string(),
+                influx_column_type_from_field_value(field_val),
+            ));
+        }
+        // Always add time last on new table:
+        columns.push((TIME_COLUMN_NAME.to_string(), InfluxColumnType::Timestamp));
+        let table = TableDefinition::new(table_name, columns);
+
+        assert!(
+            db_schema
+                .to_mut()
+                .tables
+                .insert(table_name.to_string(), table)
+                .is_none(),
+            "attempted to overwrite existing table"
+        );
+    }
+
+    Ok(line)
+}
+
+/// Result of conversion from line protocol to valid segmented data
+/// for the buffer.
+#[derive(Debug, Default)]
+pub(crate) struct ValidatedLines {
+    /// Number of lines passed in
+    pub(crate) line_count: usize,
+    /// Number of fields passed in
+    pub(crate) field_count: usize,
+    /// Number of tags passed in
+    pub(crate) tag_count: usize,
+    /// Any errors that occurred while parsing the lines
+    pub(crate) errors: Vec<WriteLineError>,
+    /// Only valid lines from what was passed in to validate, segmented based on the
+    /// timestamps of the data.
+    pub(crate) valid_segmented_data: Vec<ValidSegmentedData>,
+}
+
+impl<'raw> WriteValidator<LinesParsed<'raw, ParsedLine<'raw>>> {
+    /// Convert a set of valid parsed lines to a [`ValidatedLines`] which will
+    /// be buffered and written to the WAL, if configured.
+    ///
+    /// This involves splitting out the writes into different batches for any
+    /// segment affected by the write.
+    pub(crate) fn convert_lines_to_buffer(
+        self,
+        ingest_time: Time,
+        segment_duration: SegmentDuration,
+        precision: Precision,
+    ) -> ValidatedLines {
+        let mut segment_table_batches = HashMap::new();
+        let line_count = self.state.lines.len();
+        let mut field_count = 0;
+        let mut tag_count = 0;
+
+        for (line, raw_line) in self.state.lines.into_iter() {
+            field_count += line.field_set.len();
+            tag_count += line.series.tag_set.as_ref().map(|t| t.len()).unwrap_or(0);
+
+            convert_parsed_line(
+                line,
+                raw_line,
+                &mut segment_table_batches,
+                ingest_time,
+                segment_duration,
+                precision,
+            );
+        }
+
+        let valid_segmented_data = segment_table_batches
+            .into_iter()
+            .map(|(segment_start, table_batches)| ValidSegmentedData {
+                database_name: self.state.catalog.db_name.clone(),
+                segment_start,
+                table_batches: table_batches.table_batches,
+                wal_op: WalOp::LpWrite(LpWriteOp {
+                    db_name: self.state.catalog.db_name.to_string(),
+                    lp: table_batches.lines.join("\n"),
+                    default_time: ingest_time.timestamp_nanos(),
+                    precision,
+                }),
+                starting_catalog_sequence_number: self.state.catalog.sequence,
+            })
+            .collect();
+
+        ValidatedLines {
+            line_count,
+            field_count,
+            tag_count,
+            errors: self.state.errors,
+            valid_segmented_data,
+        }
+    }
+}
+
+fn convert_parsed_line<'a>(
+    line: ParsedLine<'_>,
+    raw_line: &'a str,
+    segment_table_batches: &mut HashMap<Time, TableBatchMap<'a>>,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
+    precision: Precision,
+) {
+    // now that we've ensured all columns exist in the schema, construct the actual row and values
+    // while validating the column types match.
+    let mut values = Vec::with_capacity(line.column_count() + 1);
+
+    // validate tags, collecting any new ones that must be inserted, or adding the values
+    if let Some(tag_set) = line.series.tag_set {
+        for (tag_key, value) in tag_set {
+            let value = Field {
+                name: tag_key.to_string(),
+                value: FieldData::Tag(value.to_string()),
+            };
+            values.push(value);
+        }
+    }
+
+    // validate fields, collecting any new ones that must be inserted, or adding values
+    for (field_name, value) in line.field_set {
+        let field_data = match value {
+            FieldValue::I64(v) => FieldData::Integer(v),
+            FieldValue::F64(v) => FieldData::Float(v),
+            FieldValue::U64(v) => FieldData::UInteger(v),
+            FieldValue::Boolean(v) => FieldData::Boolean(v),
+            FieldValue::String(v) => FieldData::String(v.to_string()),
+        };
+        let value = Field {
+            name: field_name.to_string(),
+            value: field_data,
+        };
+        values.push(value);
+    }
+
+    // set the time value
+    let time_value_nanos = line
+        .timestamp
+        .map(|ts| {
+            let multiplier = match precision {
+                Precision::Auto => match crate::guess_precision(ts) {
+                    Precision::Second => 1_000_000_000,
+                    Precision::Millisecond => 1_000_000,
+                    Precision::Microsecond => 1_000,
+                    Precision::Nanosecond => 1,
+
+                    Precision::Auto => unreachable!(),
+                },
+                Precision::Second => 1_000_000_000,
+                Precision::Millisecond => 1_000_000,
+                Precision::Microsecond => 1_000,
+                Precision::Nanosecond => 1,
+            };
+
+            ts * multiplier
+        })
+        .unwrap_or(ingest_time.timestamp_nanos());
+
+    let segment_start = segment_duration.start_time(time_value_nanos / 1_000_000_000);
+
+    values.push(Field {
+        name: TIME_COLUMN_NAME.to_string(),
+        value: FieldData::Timestamp(time_value_nanos),
+    });
+
+    let table_batch_map = segment_table_batches.entry(segment_start).or_default();
+
+    let table_batch = table_batch_map
+        .table_batches
+        .entry(line.series.measurement.to_string())
+        .or_default();
+    table_batch.rows.push(Row {
+        time: time_value_nanos,
+        fields: values,
+    });
+
+    table_batch_map.lines.push(raw_line);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use data_types::NamespaceName;
+    use iox_time::Time;
+
+    use crate::{catalog::Catalog, write_buffer::Error, Precision, SegmentDuration};
+
+    use super::WriteValidator;
+
+    #[test]
+    fn write_validator_v1() -> Result<(), Error> {
+        let namespace = NamespaceName::new("test").unwrap();
+        let catalog = Arc::new(Catalog::new());
+        let result = WriteValidator::initialize(namespace.clone(), catalog)?
+            .v1_parse_lines_and_update_schema("cpu,tag1=foo val1=\"bar\" 1234", false)?
+            .convert_lines_to_buffer(
+                Time::from_timestamp_nanos(0),
+                SegmentDuration::new_5m(),
+                Precision::Auto,
+            );
+
+        assert_eq!(result.line_count, 1);
+        assert_eq!(result.field_count, 1);
+        assert_eq!(result.tag_count, 1);
+        assert!(result.errors.is_empty());
+
+        let data = &result.valid_segmented_data[0];
+        assert_eq!(data.database_name, namespace);
+        let batch = data.table_batches.get("cpu").unwrap();
+        assert_eq!(batch.rows.len(), 1);
+
+        println!("{result:#?}");
+
+        Ok(())
+    }
+}

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use data_types::NamespaceName;
 use influxdb_line_protocol::{parse_lines, v3, FieldValue, ParsedLine};
 use iox_time::Time;
-use schema::{InfluxColumnType, InfluxFieldType, TIME_COLUMN_NAME};
+use schema::{InfluxColumnType, TIME_COLUMN_NAME};
 
 use crate::{
     catalog::{influx_column_type_from_field_value, Catalog, DatabaseSchema, TableDefinition},
@@ -214,10 +214,7 @@ fn validate_v3_line<'a>(
         if let Some(series_key) = &line.series.series_key {
             for (sk, _) in series_key.iter() {
                 if !table_def.column_exists(sk) {
-                    columns.push((
-                        sk.to_string(),
-                        InfluxColumnType::Field(InfluxFieldType::String),
-                    ));
+                    columns.push((sk.to_string(), InfluxColumnType::Tag));
                 }
             }
         }
@@ -254,10 +251,7 @@ fn validate_v3_line<'a>(
         if let Some(series_key) = &line.series.series_key {
             for (sk, _) in series_key.iter() {
                 key.push(sk.to_string());
-                columns.push((
-                    sk.to_string(),
-                    InfluxColumnType::Field(InfluxFieldType::String),
-                ));
+                columns.push((sk.to_string(), InfluxColumnType::Tag));
             }
         }
         for (field_name, field_val) in line.field_set.iter() {

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use data_types::NamespaceName;
-use influxdb_line_protocol::{parse_lines, FieldValue, ParsedLine};
+use influxdb_line_protocol::{parse_lines, v3, FieldValue, ParsedLine};
 use iox_time::Time;
 use schema::{InfluxColumnType, TIME_COLUMN_NAME};
 
@@ -44,6 +44,54 @@ impl WriteValidator<WithCatalog> {
                 catalog,
                 sequence,
                 db_schema,
+            },
+        })
+    }
+
+    pub(crate) fn v3_parse_lines_and_update_schema(
+        self,
+        lp: &str,
+        accept_partial: bool,
+    ) -> Result<WriteValidator<LinesParsed<'_, v3::ParsedLine<'_>>>> {
+        let mut errors = vec![];
+        let mut lp_lines = lp.lines().peekable();
+        let mut lines = vec![];
+        let mut schema = Cow::Borrowed(self.state.db_schema.as_ref());
+
+        for (line_idx, maybe_line) in v3::parse_lines(lp).enumerate() {
+            let line = match maybe_line
+                .map_err(|e| WriteLineError {
+                    original_line: lp_lines.next().unwrap().to_string(),
+                    line_number: line_idx + 1,
+                    error_message: e.to_string(),
+                })
+                .and_then(|l| validate_v3_line(&mut schema, line_idx, l, lp_lines.peek().unwrap()))
+            {
+                Ok(line) => line,
+                Err(e) => {
+                    if !accept_partial {
+                        return Err(Error::ParseError(e));
+                    } else {
+                        errors.push(e);
+                    }
+                    continue;
+                }
+            };
+
+            lines.push((line, lp_lines.next().unwrap()));
+        }
+
+        if let Cow::Owned(schema) = schema {
+            self.state
+                .catalog
+                .replace_database(self.state.sequence, Arc::new(schema))?;
+        }
+
+        Ok(WriteValidator {
+            state: LinesParsed {
+                catalog: self.state,
+                lines,
+                errors,
             },
         })
     }
@@ -113,10 +161,92 @@ impl WriteValidator<WithCatalog> {
     }
 }
 
+fn validate_v3_line<'a>(
+    db_schema: &mut Cow<'_, DatabaseSchema>,
+    line_number: usize,
+    line: v3::ParsedLine<'a>,
+    raw_line: &str,
+) -> Result<v3::ParsedLine<'a>, WriteLineError> {
+    let table_name = line.series.measurement.as_str();
+    if let Some(table_def) = db_schema.get_table(table_name) {
+        if !table_def.is_v3() {
+            return Err(WriteLineError {
+                original_line: raw_line.to_string(),
+                line_number,
+                error_message: "received v3 write protocol for a table that uses the v1 data model"
+                    .to_string(),
+            });
+        }
+        let mut columns = Vec::with_capacity(line.column_count() + 1);
+        if let Some(series_key) = &line.series.series_key {
+            for (sk, _) in series_key.iter() {
+                if !table_def.column_exists(sk) {
+                    columns.push((sk.to_string(), InfluxColumnType::Tag));
+                }
+            }
+        }
+        for (field_name, field_val) in line.field_set.iter() {
+            if let Some(schema_col_type) = table_def.field_type_by_name(field_name) {
+                let field_col_type = influx_column_type_from_field_value(field_val);
+                if field_col_type != schema_col_type {
+                    let field_name = field_name.to_string();
+                    return Err(WriteLineError {
+                        original_line: raw_line.to_string(),
+                        line_number: line_number + 1,
+                        error_message: format!(
+                        "invalid field value in line protocol for field '{field_name}' on line \
+                        {line_number}: expected type {expected}, but got {got}",
+                        expected = schema_col_type,
+                        got = field_col_type,
+                    ),
+                    });
+                }
+            } else {
+                columns.push((
+                    field_name.to_string(),
+                    influx_column_type_from_field_value(field_val),
+                ));
+            }
+        }
+        if !columns.is_empty() {
+            let t = db_schema.to_mut().tables.get_mut(table_name).unwrap();
+            t.add_columns(columns);
+        }
+    } else {
+        let mut columns = Vec::new();
+        if let Some(series_key) = &line.series.series_key {
+            for (sk, _) in series_key.iter() {
+                columns.push((sk.to_string(), InfluxColumnType::Tag));
+            }
+        }
+        for (field_name, field_val) in line.field_set.iter() {
+            columns.push((
+                field_name.to_string(),
+                influx_column_type_from_field_value(field_val),
+            ));
+        }
+        let table = TableDefinition::new(table_name, columns);
+
+        assert!(
+            db_schema
+                .to_mut()
+                .tables
+                .insert(table_name.to_string(), table)
+                .is_none(),
+            "attempted to overwrite existing table"
+        )
+    }
+
+    Ok(line)
+}
+
 /// Validate a line of line protocol against the given schema definition
 ///
 /// This is for scenarios where a write comes in for a table that exists, but may have
 /// invalid field types, based on the pre-existing schema.
+///
+/// An error will also be produced if the write, which is for the v1 data model, is targetting
+/// a v3 table.
 fn validate_v1_line<'a>(
     db_schema: &mut Cow<'_, DatabaseSchema>,
     line_number: usize,
@@ -124,6 +254,14 @@ fn validate_v1_line<'a>(
 ) -> Result<ParsedLine<'a>, WriteLineError> {
     let table_name = line.series.measurement.as_str();
     if let Some(table_def) = db_schema.get_table(table_name) {
+        if table_def.is_v3() {
+            return Err(WriteLineError {
+                original_line: line.to_string(),
+                line_number,
+                error_message: "received v1 write protocol for a table that uses the v3 data model"
+                    .to_string(),
+            });
+        }
         // This table already exists, so update with any new columns if present:
         let mut columns = Vec::with_capacity(line.column_count() + 1);
         if let Some(tag_set) = &line.series.tag_set {
@@ -201,8 +339,8 @@ pub(crate) struct ValidatedLines {
     pub(crate) line_count: usize,
     /// Number of fields passed in
     pub(crate) field_count: usize,
-    /// Number of tags passed in
-    pub(crate) tag_count: usize,
+    /// Number of index columns passed in, whether tags (v1) or series keys (v3)
+    pub(crate) index_count: usize,
     /// Any errors that occurred while parsing the lines
     pub(crate) errors: Vec<WriteLineError>,
     /// Only valid lines from what was passed in to validate, segmented based on the
@@ -210,7 +348,64 @@ pub(crate) struct ValidatedLines {
     pub(crate) valid_segmented_data: Vec<ValidSegmentedData>,
 }
 
-impl<'raw> WriteValidator<LinesParsed<'raw, ParsedLine<'raw>>> {
+impl<'lp> WriteValidator<LinesParsed<'lp, v3::ParsedLine<'lp>>> {
+    pub(crate) fn convert_lines_to_buffer(
+        self,
+        ingest_time: Time,
+        segment_duration: SegmentDuration,
+        precision: Precision,
+    ) -> ValidatedLines {
+        let mut segment_table_batches = HashMap::new();
+        let line_count = self.state.lines.len();
+        let mut field_count = 0;
+        let mut series_key_count = 0;
+
+        for (line, raw_line) in self.state.lines.into_iter() {
+            field_count += line.field_set.len();
+            series_key_count += line
+                .series
+                .series_key
+                .as_ref()
+                .map(|sk| sk.len())
+                .unwrap_or(0);
+
+            convert_v3_parsed_line(
+                line,
+                raw_line,
+                &mut segment_table_batches,
+                ingest_time,
+                segment_duration,
+                precision,
+            );
+        }
+
+        let valid_segmented_data = segment_table_batches
+            .into_iter()
+            .map(|(segment_start, table_batch_map)| ValidSegmentedData {
+                database_name: self.state.catalog.db_name.clone(),
+                segment_start,
+                table_batches: table_batch_map.table_batches,
+                wal_op: WalOp::LpWrite(LpWriteOp {
+                    db_name: self.state.catalog.db_name.to_string(),
+                    lp: table_batch_map.lines.join("\n"),
+                    default_time: ingest_time.timestamp_nanos(),
+                    precision,
+                }),
+                starting_catalog_sequence_number: self.state.catalog.sequence,
+            })
+            .collect();
+
+        ValidatedLines {
+            line_count,
+            field_count,
+            index_count: series_key_count,
+            errors: self.state.errors,
+            valid_segmented_data,
+        }
+    }
+}
+
+impl<'lp> WriteValidator<LinesParsed<'lp, ParsedLine<'lp>>> {
     /// Convert a set of valid parsed lines to a [`ValidatedLines`] which will
     /// be buffered and written to the WAL, if configured.
     ///
@@ -231,7 +426,7 @@ impl<'raw> WriteValidator<LinesParsed<'raw, ParsedLine<'raw>>> {
             field_count += line.field_set.len();
             tag_count += line.series.tag_set.as_ref().map(|t| t.len()).unwrap_or(0);
 
-            convert_parsed_line(
+            convert_v1_parsed_line(
                 line,
                 raw_line,
                 &mut segment_table_batches,
@@ -260,14 +455,69 @@ impl<'raw> WriteValidator<LinesParsed<'raw, ParsedLine<'raw>>> {
         ValidatedLines {
             line_count,
             field_count,
-            tag_count,
+            index_count: tag_count,
             errors: self.state.errors,
             valid_segmented_data,
         }
     }
 }
 
-fn convert_parsed_line<'a>(
+fn convert_v3_parsed_line<'a>(
+    line: v3::ParsedLine<'_>,
+    raw_line: &'a str,
+    segment_table_batches: &mut HashMap<Time, TableBatchMap<'a>>,
+    ingest_time: Time,
+    segment_duration: SegmentDuration,
+    precision: Precision,
+) {
+    // Set up row values:
+    let mut values = Vec::with_capacity(line.column_count() + 1);
+
+    // Add series key columns:
+    if let Some(series_key) = line.series.series_key {
+        for (sk, sv) in series_key.iter() {
+            values.push(Field {
+                name: sk.to_string(),
+                value: sv.into(),
+            });
+        }
+    }
+
+    // Add fields columns:
+    for (name, val) in line.field_set {
+        values.push(Field {
+            name: name.to_string(),
+            value: val.into(),
+        });
+    }
+
+    // Add time column:
+    // TODO: change the default time resolution to microseconds in v3
+    let time_value_nanos = line
+        .timestamp
+        .map(|ts| apply_precision_to_timestamp(precision, ts))
+        .unwrap_or(ingest_time.timestamp_nanos());
+    values.push(Field {
+        name: TIME_COLUMN_NAME.to_string(),
+        value: FieldData::Timestamp(time_value_nanos),
+    });
+
+    // Add the row to the table batch, creating a new entry for the segment if
+    // it does not already exist:
+    let segment_start = segment_duration.start_time(time_value_nanos / 1_000_000_000);
+    let table_batch_map = segment_table_batches.entry(segment_start).or_default();
+    let table_batch = table_batch_map
+        .table_batches
+        .entry(line.series.measurement.to_string())
+        .or_default();
+    table_batch.rows.push(Row {
+        time: time_value_nanos,
+        fields: values,
+    });
+    table_batch_map.lines.push(raw_line);
+}
+
+fn convert_v1_parsed_line<'a>(
     line: ParsedLine<'_>,
     raw_line: &'a str,
     segment_table_batches: &mut HashMap<Time, TableBatchMap<'a>>,
@@ -309,24 +559,7 @@ fn convert_parsed_line<'a>(
     // set the time value
     let time_value_nanos = line
         .timestamp
-        .map(|ts| {
-            let multiplier = match precision {
-                Precision::Auto => match crate::guess_precision(ts) {
-                    Precision::Second => 1_000_000_000,
-                    Precision::Millisecond => 1_000_000,
-                    Precision::Microsecond => 1_000,
-                    Precision::Nanosecond => 1,
-
-                    Precision::Auto => unreachable!(),
-                },
-                Precision::Second => 1_000_000_000,
-                Precision::Millisecond => 1_000_000,
-                Precision::Microsecond => 1_000,
-                Precision::Nanosecond => 1,
-            };
-
-            ts * multiplier
-        })
+        .map(|ts| apply_precision_to_timestamp(precision, ts))
         .unwrap_or(ingest_time.timestamp_nanos());
 
     let segment_start = segment_duration.start_time(time_value_nanos / 1_000_000_000);
@@ -348,6 +581,25 @@ fn convert_parsed_line<'a>(
     });
 
     table_batch_map.lines.push(raw_line);
+}
+
+fn apply_precision_to_timestamp(precision: Precision, ts: i64) -> i64 {
+    let multiplier = match precision {
+        Precision::Auto => match crate::guess_precision(ts) {
+            Precision::Second => 1_000_000_000,
+            Precision::Millisecond => 1_000_000,
+            Precision::Microsecond => 1_000,
+            Precision::Nanosecond => 1,
+
+            Precision::Auto => unreachable!(),
+        },
+        Precision::Second => 1_000_000_000,
+        Precision::Millisecond => 1_000_000,
+        Precision::Microsecond => 1_000,
+        Precision::Nanosecond => 1,
+    };
+
+    ts * multiplier
 }
 
 #[cfg(test)]
@@ -375,7 +627,7 @@ mod tests {
 
         assert_eq!(result.line_count, 1);
         assert_eq!(result.field_count, 1);
-        assert_eq!(result.tag_count, 1);
+        assert_eq!(result.index_count, 1);
         assert!(result.errors.is_empty());
 
         let data = &result.valid_segmented_data[0];


### PR DESCRIPTION
Closes #25033

## Summary

Introduce the experimental series key feature to monolith, along with the new `/api/v3/write` API which accepts the new line protocol to write to tables containing a series key.

### Series key

The series key is supported in the `schema::Schema` type by the addition of a metadata entry that stores the series key members in their correct order. Writes that are received to `v3` tables must have the same series key for every single write.

### Series key columns are `NOT NULL`

Nullability of columns is enforced in the core `schema` crate based on a column's membership in the series key. So, when building a `schema::Schema` using `schema::SchemaBuilder`, the arrow `Field`s that are injected into the schema will have `nullable` set to false for columns that are part of the series key, as well as the `time` column.

The `NOT NULL` _constraint_, if you can call it that, is enforced in the buffer (see [here](https://github.com/influxdata/influxdb/pull/25066/files#diff-d70ef3dece149f3742ff6e164af17f6601c5a7818e31b0e3b27c3f83dcd7f199R102-R119)) by ensuring there are no gaps in data buffered for series key columns.

### Series key columns are still tags

Columns in the series key are annotated as tags in the arrow schema, which for now means that they are stored as Dictionaries. This was done to avoid having to support a new column type for series key columns.

## New write API

This PR introduces the new write API, `/api/v3/write`, which accepts the new `v3` line protocol. Currently, the only part of the new line protocol proposed in https://github.com/influxdata/influxdb/issues/24979 that is supported is the series key. New data types are not yet supported for fields.

### Split write paths

To support the existing write path alongside the new write path, a new module was set up to perform validation in the `influxdb3_write` crate (`write_buffer/validator.rs`). This re-uses the existing write validation logic, and replicates it with needed changes for the new API. I refactored the validation code to use a state machine over a series of nested function calls to help distinguish the fallible validation/update steps from the infallible conversion steps.

The code in that module could potentially be refactored to reduce code duplication.