### PR TITLE
feat: disable file:// urls when hardening enabled

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -190,8 +190,11 @@ type InfluxdOpts struct {
 
 	Viper *viper.Viper
 
+	// HardeningEnabled toggles multiple best-practice hardening options on.
 	HardeningEnabled bool
-	StrongPasswords  bool
+	// TemplateFileUrlsDisabled disables file protocol URIs in templates.
+	TemplateFileUrlsDisabled bool
+	StrongPasswords          bool
 }
 
 // NewOpts constructs options with default values.
@@ -243,8 +246,9 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		Testing:                 false,
 		TestingAlwaysAllowSetup: false,
 
-		HardeningEnabled: false,
-		StrongPasswords:  false,
+		HardeningEnabled:         false,
+		TemplateFileUrlsDisabled: false,
+		StrongPasswords:          false,
 	}
 }
 
@@ -643,9 +647,10 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 		},
 
 		// hardening options
-		// --hardening-enabled is meant to enable all hardending
+		// --hardening-enabled is meant to enable all hardening
 		// options in one go. Today it enables the IP validator for
-		// flux and pkger templates HTTP requests. In the future,
+		// flux and pkger templates HTTP requests, and disables file://
+		// protocol for pkger templates. In the future,
 		// --hardening-enabled might be used to enable other security
 		// features, at which point we can add per-feature flags so
 		// that users can either opt into all features
@@ -657,7 +662,16 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			DestP:   &o.HardeningEnabled,
 			Flag:    "hardening-enabled",
 			Default: o.HardeningEnabled,
-			Desc:    "enable hardening options (disallow private IPs within flux and templates HTTP requests)",
+			Desc:    "enable hardening options (disallow private IPs within flux and templates HTTP requests; disable file URLs in templates)",
+		},
+
+		// --template-file-urls-disabled prevents file protocol URIs
+		// from being used for templates.
+		{
+			DestP:   &o.TemplateFileUrlsDisabled,
+			Flag:    "template-file-urls-disabled",
+			Default: o.TemplateFileUrlsDisabled,
+			Desc:    "disable template file URLs",
 		},
 		{
 			DestP:   &o.StrongPasswords,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -752,8 +752,10 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		authedOrgSVC := authorizer.NewOrgService(b.OrganizationService)
 		authedUrmSVC := authorizer.NewURMService(b.OrgLookupService, b.UserResourceMappingService)
 		pkgerLogger := m.log.With(zap.String("service", "pkger"))
+		disableFileUrls := opts.HardeningEnabled || opts.TemplateFileUrlsDisabled
 		pkgSVC = pkger.NewService(
 			pkger.WithHTTPClient(pkger.NewDefaultHTTPClient(urlValidator)),
+			pkger.WithFileUrlsDisabled(disableFileUrls),
 			pkger.WithLogger(pkgerLogger),
 			pkger.WithStore(pkger.NewStoreKV(m.kvStore)),
 			pkger.WithBucketSVC(authorizer.NewBucketService(b.BucketService)),

--- a/pkg/fs/special.go
+++ b/pkg/fs/special.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package fs
+
+import "io/fs"
+
+// IsSpecialFSFromFileInfo determines if a file resides on a special file
+// system (e.g. /proc, /dev/, /sys) based on its fs.FileInfo.
+// The bool return value should be ignored if err is not nil.
+func IsSpecialFSFromFileInfo(st fs.FileInfo) (bool, error) {
+	return false, nil
+}

--- a/pkg/fs/special_linux.go
+++ b/pkg/fs/special_linux.go
@@ -1,0 +1,91 @@
+package fs
+
+import (
+	"errors"
+	"io/fs"
+	"math"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsSpecialFSFromFileInfo determines if a file resides on a special file
+// system (e.g. /proc, /dev/, /sys) based on its fs.FileInfo.
+// The bool return value should be ignored if err is not nil.
+func IsSpecialFSFromFileInfo(st fs.FileInfo) (bool, error) {
+	// On Linux, special file systems like /proc, /dev/, and /sys are
+	// considered unnamed devices (non-device mounts). These devices
+	// will always have a major device number of 0 per the kernels
+	// Documentation/admin-guide/devices.txt file.
+
+	getDevId := func(st fs.FileInfo) (uint64, error) {
+		st_sys_any := st.Sys()
+		if st_sys_any == nil {
+			return 0, errors.New("nil returned by fs.FileInfo.Sys")
+		}
+
+		st_sys, ok := st_sys_any.(*syscall.Stat_t)
+		if !ok {
+			return 0, errors.New("could not convert st.sys() to a *syscall.Stat_t")
+		}
+		return st_sys.Dev, nil
+	}
+
+	devId, err := getDevId(st)
+	if err != nil {
+		return false, err
+	}
+	if unix.Major(devId) != 0 {
+		// This file is definitely not on a special file system.
+		return false, nil
+	}
+
+	// We know the file is in a special file system, but we'll make an
+	// exception for tmpfs, which might be used at a variety of mount points.
+	// Since the minor IDs are assigned dynamically, we'll find the device ID
+	// for each common tmpfs mount point. If the mount point's device ID matches this st's,
+	// then it is reasonable to assume the file is in tmpfs. If the device ID
+	// does not match, then st is not located in that special file system so we
+	// can't give an exception based on that file system root. This check is still
+	// valid even if the directory we check against isn't mounted as tmpfs, because
+	// the device ID won't match so we won't grant a tmpfs exception based on it.
+	// On Linux, every tmpfs mount has a different device ID, so we need to check
+	// against all common ones that might be in use.
+	tmpfsMounts := []string{"/tmp", "/run", "/dev/shm"}
+	if tmpdir := os.TempDir(); tmpdir != "/tmp" {
+		tmpfsMounts = append(tmpfsMounts, tmpdir)
+	}
+	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
+		tmpfsMounts = append(tmpfsMounts, xdgRuntimeDir)
+	}
+	getFileDevId := func(n string) (uint64, error) {
+		fSt, err := os.Stat(n)
+		if err != nil {
+			return math.MaxUint64, err
+		}
+		fDevId, err := getDevId(fSt)
+		if err != nil {
+			return math.MaxUint64, err
+		}
+		return fDevId, nil
+	}
+	var errs []error
+	for _, fn := range tmpfsMounts {
+		// Don't stop if getFileDevId returns an error. It could
+		// be because the tmpfsMount we're checking doesn't exist,
+		// which shouldn't prevent us from checking the other
+		// potential mount points.
+		if fnDevId, err := getFileDevId(fn); err == nil {
+			if fnDevId == devId {
+				return false, nil
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			// Ignore errors for missing mount points.
+			errs = append(errs, err)
+		}
+	}
+
+	// We didn't find any a reason to give st a special file system exception.
+	return true, errors.Join(errs...)
+}

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -5,11 +5,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +29,10 @@ import (
 	"github.com/influxdata/influxdb/v2/task/taskmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestService(t *testing.T) {
@@ -60,6 +68,7 @@ func TestService(t *testing.T) {
 		}
 
 		applyOpts := []ServiceSetterFn{
+			WithFileUrlsDisabled(opt.fileUrlsDisabled),
 			WithStore(opt.store),
 			WithBucketSVC(opt.bucketSVC),
 			WithCheckSVC(opt.checkSVC),
@@ -81,6 +90,9 @@ func TestService(t *testing.T) {
 		}
 		if opt.nameGen != nil {
 			applyOpts = append(applyOpts, withNameGen(opt.nameGen))
+		}
+		if opt.logger != nil {
+			applyOpts = append(applyOpts, WithLogger(opt.logger))
 		}
 
 		return NewService(applyOpts...)
@@ -767,6 +779,365 @@ func TestService(t *testing.T) {
 					},
 				})
 			})
+		})
+	})
+
+	t.Run("DryRun - stack", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// create a valid yaml file
+		ySrc, err := os.Open("testdata/bucket.yml")
+		require.NoError(t, err)
+		validYamlFn := filepath.Join(dir, "bucket.yml")
+		yDst, err := os.Create(validYamlFn)
+		require.NoError(t, err)
+		_, err = io.Copy(yDst, ySrc)
+		require.NoError(t, err)
+		require.NoError(t, ySrc.Close())
+		require.NoError(t, yDst.Close())
+
+		// create a valid yaml file
+		jSrc, err := os.Open("testdata/bucket.json")
+		require.NoError(t, err)
+		validJsonFn := filepath.Join(dir, "bucket.json")
+		jDst, err := os.Create(validJsonFn)
+		require.NoError(t, err)
+		_, err = io.Copy(jDst, jSrc)
+		require.NoError(t, err)
+		require.NoError(t, jSrc.Close())
+		require.NoError(t, jDst.Close())
+
+		// create an invalid file
+		iSrc := strings.NewReader("this is invalid")
+		invalidFn := filepath.Join(dir, "invalid")
+		iDst, err := os.Create(invalidFn)
+		require.NoError(t, err)
+		_, err = io.Copy(iDst, iSrc)
+		require.NoError(t, err)
+		require.NoError(t, iDst.Close())
+
+		// create too big test file
+		bigFn := filepath.Join(dir, "big")
+		fb, err := os.Create(bigFn)
+		require.NoError(t, err)
+		require.NoError(t, fb.Close())
+		err = os.Truncate(bigFn, limitReadFileMaxSize+1)
+		require.NoError(t, err)
+
+		// create a symlink to /proc/cpuinfo
+		procLinkFn := filepath.Join(dir, "cpuinfo")
+		require.NoError(t, os.Symlink("/proc/cpuinfo", procLinkFn))
+
+		// create tricky symlink to /proc/cpuinfo
+		trickyProcLinkFn := filepath.Join(dir, "tricky_cpuinfo")
+		require.NoError(t, os.Symlink("/../proc/cpuinfo", trickyProcLinkFn))
+
+		now := time.Time{}.Add(10 * 24 * time.Hour)
+		testOrgID := platform.ID(33)
+		testStackID := platform.ID(3)
+
+		t.Run("file URL", func(t *testing.T) {
+			type logm struct {
+				level zapcore.Level
+				msg   string
+				err   string
+			}
+			tests := []struct {
+				name             string
+				oses             []string // list of OSes to run test on, empty means all.
+				path             string
+				fileUrlsDisabled bool
+				expErr           string
+				expLog           []logm
+			}{
+				{
+					name: "valid yaml",
+					path: validYamlFn,
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+					},
+				},
+				{
+					name: "valid json",
+					path: validJsonFn,
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+					},
+				},
+				// invalid
+				{
+					name:   "invalid yaml",
+					path:   invalidFn,
+					expErr: "file:// URL failed to parse: ",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "line 1: cannot unmarshal"},
+					},
+				},
+				// fileUrlsDisabled always shows error
+				{
+					name:             "invalid yaml with disable flag",
+					path:             validYamlFn,
+					fileUrlsDisabled: true,
+					expErr:           "invalid URL scheme",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+					},
+				},
+				{
+					name:             "nonexistent with disable flag",
+					path:             "/nonexistent",
+					fileUrlsDisabled: true,
+					expErr:           "invalid URL scheme",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+					},
+				},
+				{
+					name:             "big file with disable flag",
+					path:             bigFn,
+					fileUrlsDisabled: true,
+					expErr:           "invalid URL scheme",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+					},
+				},
+				// invalid 'extra' with generic errors
+				{
+					name:   "invalid yaml wildcard",
+					path:   invalidFn + "?.yml",
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "line 1: cannot unmarshal"},
+					},
+				},
+				{
+					name:   "directory (/tmp)",
+					path:   "/tmp",
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "not a regular file"},
+					},
+				},
+				{
+					// /proc/cpuinfo is a regular file with 0 length
+					name:   "/proc/cpuinfo",
+					path:   "/proc/cpuinfo",
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					// try fooling the parser with a tricky path
+					name:   "trick /proc path",
+					path:   "/../proc/cpuinfo",
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					// try fooling the parser with a symlink to /proc
+					name:   "symlink /proc path",
+					path:   procLinkFn,
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					// try fooling the parser with a symlink to /../proc
+					name:   "tricky symlink /proc path",
+					path:   trickyProcLinkFn,
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					name:   "/dev/core",
+					path:   "/dev/core",
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "permission denied"},
+					},
+				},
+				{
+					name:   "/dev/zero",
+					path:   "/dev/zero",
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					name:   "/dev/zero",
+					path:   "/dev/zero",
+					oses:   []string{"darwin"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "not a regular file"},
+					},
+				},
+				{
+					name:   "/sys/kernel/vmcoreinfo",
+					path:   "/sys/kernel/vmcoreinfo",
+					oses:   []string{"linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file in special file system"},
+					},
+				},
+				{
+					name:   "nonexistent (darwin|linux)",
+					path:   "/nonexistent",
+					oses:   []string{"darwin", "linux"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "open /nonexistent: no such file or directory"},
+					},
+				},
+				{
+					name:   "nonexistent (windows)",
+					path:   "/nonexistent",
+					oses:   []string{"windows"},
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "open /nonexistent: The system cannot find the file specified."},
+					},
+				},
+				{
+					name:   "big file",
+					path:   bigFn,
+					expErr: "file:// URL failed to parse",
+					expLog: []logm{
+						{level: zapcore.InfoLevel, msg: "file:// specified in call to /api/v2/templates/apply with stack"},
+						{level: zapcore.ErrorLevel, msg: "error parsing file:// specified in call to /api/v2/templates/apply with stack", err: "file too big"},
+					},
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					if len(tt.oses) > 0 {
+						osFound := false
+						for _, os := range tt.oses {
+							if runtime.GOOS == os {
+								osFound = true
+								break
+							}
+						}
+						if !osFound {
+							t.Skipf("skipping test for %q OS", runtime.GOOS)
+						}
+					}
+					testStore := &fakeStore{
+						createFn: func(ctx context.Context, stack Stack) error {
+							return nil
+						},
+						readFn: func(ctx context.Context, id platform.ID) (Stack, error) {
+							return Stack{
+								ID:    id,
+								OrgID: testOrgID,
+								Events: []StackEvent{
+									{
+										Name:         "some-file",
+										Description:  "some file with file://",
+										TemplateURLs: []string{fmt.Sprintf("file://%s", pathToURLPath(tt.path))},
+									},
+								},
+							}, nil
+						},
+					}
+
+					var logger *zap.Logger = nil
+					var core zapcore.Core
+					var sink *observer.ObservedLogs
+					ctx := context.Background()
+					core, sink = observer.New(zap.InfoLevel)
+					logger = zap.New(core)
+
+					svc := newTestService(
+						WithIDGenerator(newFakeIDGen(testStackID)),
+						WithTimeGenerator(newTimeGen(now)),
+						WithLogger(logger),
+						WithFileUrlsDisabled(tt.fileUrlsDisabled),
+						WithStore(testStore),
+					)
+
+					sc := StackCreate{
+						OrgID:        testOrgID,
+						TemplateURLs: []string{fmt.Sprintf("file://%s", pathToURLPath(tt.path))},
+					}
+					stack, err := svc.InitStack(ctx, 9000, sc)
+					require.NoError(t, err)
+
+					assert.Equal(t, testStackID, stack.ID)
+					assert.Equal(t, testOrgID, stack.OrgID)
+					assert.Equal(t, now, stack.CreatedAt)
+					assert.Equal(t, now, stack.LatestEvent().UpdatedAt)
+
+					applyOpts := []ApplyOptFn{
+						ApplyWithStackID(testStackID),
+					}
+					_, err = svc.DryRun(
+						ctx,
+						platform.ID(100),
+						0,
+						applyOpts...,
+					)
+
+					entries := sink.TakeAll() // resets to 0
+					require.Equal(t, len(tt.expLog), len(entries))
+					for idx, exp := range tt.expLog {
+						actual := entries[idx]
+						require.Equal(t, exp.msg, actual.Entry.Message)
+						require.Equal(t, exp.level, actual.Entry.Level)
+
+						// Check for correct err in log context
+						var errFound bool
+						for _, lctx := range actual.Context {
+							if lctx.Key == "err" {
+								errFound = true
+								if len(exp.err) > 0 {
+									require.Contains(t, lctx.String, exp.err)
+								} else {
+									require.Fail(t, "unexpected err in log context: %s", lctx.String)
+								}
+							}
+						}
+						// Make sure we found an err if we expected one
+						if len(exp.err) > 0 {
+							require.True(t, errFound, "err not found in log context when expected: %s", exp.err)
+						}
+					}
+
+					if tt.expErr == "" {
+						require.NoError(t, err)
+					} else {
+						require.ErrorContains(t, err, tt.expErr)
+					}
+				})
+			}
 		})
 	})
 


### PR DESCRIPTION
Stacks and templates allow specifying file:// URLs. Add command line option `--template-file-urls-disabled` to disable their use for people who don't require them.

Closes: #25068
(cherry picked from commit 9fd91a554dcb73a01847b6d3bf05309c225be6cf)
