### PR TITLE
feat: track buffer memory usage and persist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,16 +1263,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1755,17 +1754,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -2473,124 +2461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,14 +2468,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3360,12 +3228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,9 +3360,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -4111,12 +3973,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "powerfmt"
@@ -5472,12 +5328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5561,17 +5411,6 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "sysinfo"
@@ -5815,16 +5654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -6376,9 +6205,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6396,18 +6225,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -6928,18 +6745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6953,30 +6758,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -6999,27 +6780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7033,28 +6793,6 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -167,6 +167,16 @@ pub struct Config {
         action
     )]
     pub query_log_size: usize,
+
+    // TODO - make this default to 70% of available memory:
+    /// The size limit of the open segments in the write buffer.
+    #[clap(
+        long = "buffer-mem-limit-mb",
+        env = "INFLUXDB3_BUFFER_MEM_LIMIT_MB",
+        default_value = "5000",
+        action
+    )]
+    pub buffer_mem_limit_mb: usize,
 }
 
 /// If `p` does not exist, try to create it as a directory.
@@ -276,6 +286,7 @@ pub async fn command(config: Config) -> Result<()> {
             Arc::clone(&time_provider),
             config.segment_duration,
             Arc::clone(&exec),
+            config.buffer_mem_limit_mb,
         )
         .await?,
     );

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -279,6 +279,7 @@ mod tests {
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
                 Arc::clone(&exec),
+                10000,
             )
             .await
             .unwrap(),
@@ -439,6 +440,7 @@ mod tests {
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
                 Arc::clone(&exec),
+                10000,
             )
             .await
             .unwrap(),
@@ -646,6 +648,7 @@ mod tests {
                 Arc::clone(&time_provider),
                 SegmentDuration::new_5m(),
                 Arc::clone(&exec),
+                10000,
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -434,6 +434,7 @@ pub struct WalOpBatch {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum WalOp {
     LpWrite(LpWriteOp),
+    ParquetWrite(ParquetWriteOp),
 }
 
 /// A write of 1 or more lines of line protocol to a single database. The default time is set by the server at the
@@ -444,6 +445,18 @@ pub struct LpWriteOp {
     pub lp: String,
     pub default_time: i64,
     pub precision: Precision,
+}
+
+/// A Parquet file that has been persisted to object storage ahead of a segment being closed.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ParquetWriteOp {
+    pub db_name: String,
+    pub table_name: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub row_count: u64,
+    pub min_time: i64,
+    pub max_time: i64,
 }
 
 /// A single write request can have many lines in it. A writer can request to accept all lines that are valid, while

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -58,11 +58,18 @@ impl AsRef<ObjPath> for CatalogFilePath {
 pub struct ParquetFilePath(ObjPath);
 
 impl ParquetFilePath {
-    pub fn new(db_name: &str, table_name: &str, date: DateTime<Utc>, file_number: u32) -> Self {
+    pub fn new(
+        db_name: &str,
+        table_name: &str,
+        date: DateTime<Utc>,
+        segment_id: SegmentId,
+        file_number: u32,
+    ) -> Self {
         let path = ObjPath::from(format!(
-            "dbs/{db_name}/{table_name}/{}/{:010}.{}",
+            "dbs/{db_name}/{table_name}/{}/{:010}/{}.{}",
             date.format("%Y-%m-%d"),
-            object_store_file_stem(file_number),
+            object_store_file_stem(segment_id.0),
+            file_number,
             PARQUET_FILE_EXTENSION
         ));
         Self(path)
@@ -76,7 +83,7 @@ impl ParquetFilePath {
         file_number: u32,
     ) -> Self {
         let path = ObjPath::from(format!(
-            "dbs/{db_name}/{table_name}/{}/{:010}_{}.{}",
+            "dbs/{db_name}/{table_name}/{}/{:010}/{}.{}",
             partition_key,
             object_store_file_stem(segment_id.0),
             file_number,
@@ -179,9 +186,10 @@ fn parquet_file_path_new() {
             "my_db",
             "my_table",
             Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
+            SegmentId::new(0),
             0
         ),
-        ObjPath::from("dbs/my_db/my_table/2038-01-19/4294967295.parquet")
+        ObjPath::from("dbs/my_db/my_table/2038-01-19/4294967295/0.parquet")
     );
 }
 
@@ -192,11 +200,12 @@ fn parquet_file_percent_encoded() {
             "..",
             "..",
             Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
+            SegmentId::new(0),
             0
         )
         .as_ref()
         .as_ref(),
-        "dbs/%2E%2E/%2E%2E/2038-01-19/4294967295.parquet"
+        "dbs/%2E%2E/%2E%2E/2038-01-19/4294967295/0.parquet"
     );
 }
 

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -72,12 +72,14 @@ impl ParquetFilePath {
         db_name: &str,
         table_name: &str,
         partition_key: &str,
+        segment_id: SegmentId,
         file_number: u32,
     ) -> Self {
         let path = ObjPath::from(format!(
-            "dbs/{db_name}/{table_name}/{}/{:010}.{}",
+            "dbs/{db_name}/{table_name}/{}/{:010}_{}.{}",
             partition_key,
-            object_store_file_stem(file_number),
+            object_store_file_stem(segment_id.0),
+            file_number,
             PARQUET_FILE_EXTENSION
         ));
         Self(path)

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -542,7 +542,7 @@ mod tests {
         stream_builder.tx().send(Ok(batch1)).await.unwrap();
         stream_builder.tx().send(Ok(batch2)).await.unwrap();
 
-        let path = ParquetFilePath::new("db_one", "table_one", Utc::now(), 1);
+        let path = ParquetFilePath::new("db_one", "table_one", Utc::now(), SegmentId::new(1), 1);
         let (bytes_written, meta) = persister
             .persist_parquet_file(path.clone(), stream_builder.build())
             .await

--- a/influxdb3_write/src/write_buffer/buffer_segment.rs
+++ b/influxdb3_write/src/write_buffer/buffer_segment.rs
@@ -135,8 +135,8 @@ impl OpenBufferSegment {
 
         let persist_batch = match table_buffer.split(schema.as_arrow()) {
             Ok(b) => b,
-            Err(e) => {
-                error!(%e, "Error splitting table buffer for persistence");
+            Err(error) => {
+                error!(%error, "Error splitting table buffer for persistence");
                 return None;
             }
         };

--- a/influxdb3_write/src/write_buffer/flusher.rs
+++ b/influxdb3_write/src/write_buffer/flusher.rs
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(segment.segment_id(), segment_id);
 
         let data = segment
-            .table_record_batch(
+            .table_record_batches(
                 db_name.as_str(),
                 "cpu",
                 catalog
@@ -314,6 +314,6 @@ mod tests {
             )
             .unwrap()
             .unwrap();
-        assert_eq!(data.num_rows(), 2);
+        assert_eq!(data[0].num_rows(), 2);
     }
 }

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -296,7 +296,7 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = current_segment
-            .table_record_batch(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -306,11 +306,11 @@ mod tests {
             "| 1.0 | cupcakes | 1970-01-01T00:00:00.000000010Z |",
             "+-----+----------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let mem_table = db.get_table("mem").unwrap();
         let mem_data = current_segment
-            .table_record_batch(db_name, "mem", mem_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "mem", mem_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -321,7 +321,7 @@ mod tests {
             "| 2.0 | snakes  | 1970-01-01T00:00:00.000000020Z |",
             "+-----+---------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[mem_data]);
+        assert_batches_eq!(&expected, &mem_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(1));
     }
@@ -436,7 +436,7 @@ mod tests {
                                 TableParquetFiles {
                                     table_name: "cpu".to_string(),
                                     parquet_files: vec![ParquetFile {
-                                        path: "dbs/db1/cpu/1970-01-01T00-00/4294967294.parquet"
+                                        path: "dbs/db1/cpu/1970-01-01T00-00/4294967294_1.parquet"
                                             .to_string(),
                                         size_bytes: 1817,
                                         row_count: 1,
@@ -451,7 +451,7 @@ mod tests {
                                 TableParquetFiles {
                                     table_name: "mem".to_string(),
                                     parquet_files: vec![ParquetFile {
-                                        path: "dbs/db1/mem/1970-01-01T00-00/4294967294.parquet"
+                                        path: "dbs/db1/mem/1970-01-01T00-00/4294967294_1.parquet"
                                             .to_string(),
                                         size_bytes: 1833,
                                         row_count: 2,
@@ -474,7 +474,7 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = loaded_state.open_segments[0]
-            .table_record_batch(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -484,11 +484,11 @@ mod tests {
             "| 3.0 | cupcakes | 1970-01-01T00:00:00.000000020Z |",
             "+-----+----------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let foo_table = db.get_table("foo").unwrap();
         let foo_data = loaded_state.open_segments[0]
-            .table_record_batch(db_name, "foo", foo_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "foo", foo_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -498,7 +498,7 @@ mod tests {
             "| 1970-01-01T00:00:00.000000123Z | 1.0 |",
             "+--------------------------------+-----+",
         ];
-        assert_batches_eq!(&expected, &[foo_data]);
+        assert_batches_eq!(&expected, &foo_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(2));
     }
@@ -609,7 +609,7 @@ mod tests {
 
         let cpu_table = db.get_table("cpu").unwrap();
         let cpu_data = loaded_state.open_segments[0]
-            .table_record_batch(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "cpu", cpu_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -619,11 +619,11 @@ mod tests {
             "| 3.0 | apples | 1970-01-01T00:00:00.000000020Z |",
             "+-----+--------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected, &[cpu_data]);
+        assert_batches_eq!(&expected, &cpu_data);
 
         let foo_table = db.get_table("foo").unwrap();
         let foo_data = loaded_state.open_segments[0]
-            .table_record_batch(db_name, "foo", foo_table.schema().as_arrow(), &[])
+            .table_record_batches(db_name, "foo", foo_table.schema().as_arrow(), &[])
             .unwrap()
             .unwrap();
         let expected = [
@@ -633,7 +633,7 @@ mod tests {
             "| 1970-01-01T00:00:00.000000123Z | 1.0 |",
             "+--------------------------------+-----+",
         ];
-        assert_batches_eq!(&expected, &[foo_data]);
+        assert_batches_eq!(&expected, &foo_data);
 
         assert_eq!(loaded_state.last_segment_id, SegmentId::new(2));
     }

--- a/influxdb3_write/src/write_buffer/loader.rs
+++ b/influxdb3_write/src/write_buffer/loader.rs
@@ -436,7 +436,7 @@ mod tests {
                                 TableParquetFiles {
                                     table_name: "cpu".to_string(),
                                     parquet_files: vec![ParquetFile {
-                                        path: "dbs/db1/cpu/1970-01-01T00-00/4294967294_1.parquet"
+                                        path: "dbs/db1/cpu/1970-01-01T00-00/4294967294/1.parquet"
                                             .to_string(),
                                         size_bytes: 1817,
                                         row_count: 1,
@@ -451,7 +451,7 @@ mod tests {
                                 TableParquetFiles {
                                     table_name: "mem".to_string(),
                                     parquet_files: vec![ParquetFile {
-                                        path: "dbs/db1/mem/1970-01-01T00-00/4294967294_1.parquet"
+                                        path: "dbs/db1/mem/1970-01-01T00-00/4294967294/1.parquet"
                                             .to_string(),
                                         size_bytes: 1833,
                                         row_count: 2,

--- a/influxdb3_write/src/write_buffer/persister.rs
+++ b/influxdb3_write/src/write_buffer/persister.rs
@@ -1,0 +1,940 @@
+//! This module contains the logic for persisting buffer segments when closed and persisting
+//! individual tables in advance of closing a buffer segment based on memory limits.
+
+use crate::catalog::TIME_COLUMN_NAME;
+use crate::chunk::BufferChunk;
+use crate::paths::ParquetFilePath;
+use crate::write_buffer::buffer_segment::{ClosedBufferSegment, SegmentSizes};
+use crate::write_buffer::segment_state::SegmentState;
+use crate::{persister, write_buffer, ParquetFile, Persister, SegmentDuration, SegmentId, Wal};
+use arrow::array::TimestampNanosecondArray;
+use arrow::record_batch::RecordBatch;
+use data_types::{
+    ChunkId, ChunkOrder, PartitionKey, TableId, TimestampMinMax, TransitionPartitionId,
+};
+use datafusion_util::stream_from_batches;
+use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
+use iox_query::frontend::reorg::ReorgPlanner;
+use iox_query::QueryChunk;
+use iox_time::TimeProvider;
+use observability_deps::tracing::{error, info};
+use parking_lot::RwLock;
+use parquet::format::FileMetaData;
+use schema::sort::SortKey;
+use schema::Schema;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::watch;
+use tokio::time::MissedTickBehavior;
+
+#[cfg(test)]
+const PERSISTER_CHECK_INTERVAL: Duration = Duration::from_millis(10);
+
+#[cfg(not(test))]
+const PERSISTER_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+pub(crate) async fn run_buffer_segment_persist_and_cleanup<P, T, W>(
+    persister: Arc<P>,
+    segment_state: Arc<RwLock<SegmentState<T, W>>>,
+    mut shutdown_rx: watch::Receiver<()>,
+    time_provider: Arc<T>,
+    wal: Option<Arc<W>>,
+    executor: Arc<iox_query::exec::Executor>,
+) where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    T: TimeProvider,
+    W: Wal,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                break;
+            }
+            _ = tokio::time::sleep(PERSISTER_CHECK_INTERVAL) => {
+                if let Err(e) = persist_and_cleanup_ready_segments(Arc::clone(&persister), Arc::clone(&segment_state), Arc::clone(&time_provider), wal.clone(), Arc::clone(&executor)).await {
+                    error!("Error persisting and cleaning up segments: {}", e);
+                }
+            }
+        }
+    }
+}
+
+async fn persist_and_cleanup_ready_segments<P, T, W>(
+    persister: Arc<P>,
+    segment_state: Arc<RwLock<SegmentState<T, W>>>,
+    time_provider: Arc<T>,
+    wal: Option<Arc<W>>,
+    executor: Arc<iox_query::exec::Executor>,
+) -> Result<(), crate::Error>
+where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    T: TimeProvider,
+    W: Wal,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    // this loop is where persistence happens so if anything is in persisting,
+    // it's either been dropped or remaining from a restart, so clear those out first.
+    let persisting_segments = {
+        let segment_state = segment_state.read();
+        segment_state.persisting_segments()
+    };
+
+    for segment in persisting_segments {
+        persist_closed_segment_and_cleanup(
+            segment,
+            Arc::clone(&persister),
+            Arc::clone(&segment_state),
+            wal.clone(),
+            Arc::clone(&executor),
+        )
+        .await
+        .unwrap()
+    }
+
+    // check for open segments to persist
+    let current_time = time_provider.now();
+    let segments_to_persist = {
+        let segment_state = segment_state.read();
+        segment_state.segments_to_persist(current_time)
+    };
+
+    // close and persist each one in turn
+    for segment_start in segments_to_persist {
+        let closed_segment = {
+            let mut segment_state = segment_state.write();
+            segment_state.close_segment(segment_start)
+        };
+
+        if let Some(closed_segment) = closed_segment {
+            persist_closed_segment_and_cleanup(
+                closed_segment,
+                Arc::clone(&persister),
+                Arc::clone(&segment_state),
+                wal.clone(),
+                Arc::clone(&executor),
+            )
+            .await
+            .unwrap()
+        }
+    }
+
+    Ok(())
+}
+
+// Performs the following:
+// 1. persist the segment to the object store
+// 2. remove the segment from the persisting_segments map and add it to the persisted_segments map
+// 3. remove the wal segment file
+async fn persist_closed_segment_and_cleanup<P, T, W>(
+    closed_segment: Arc<ClosedBufferSegment>,
+    persister: Arc<P>,
+    segment_state: Arc<RwLock<SegmentState<T, W>>>,
+    wal: Option<Arc<W>>,
+    executor: Arc<iox_query::exec::Executor>,
+) -> Result<(), crate::Error>
+where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    T: TimeProvider,
+    W: Wal,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    let closed_segment_start_time = closed_segment.segment_range.start_time;
+    let closed_segment_id = closed_segment.segment_id;
+    let persisted_segment = closed_segment.persist(persister, executor, None).await?;
+
+    {
+        let mut segment_state = segment_state.write();
+        segment_state.mark_segment_as_persisted(closed_segment_start_time, persisted_segment);
+    }
+
+    if let Some(wal) = wal {
+        wal.delete_wal_segment(closed_segment_id)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+const BUFFER_SIZE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+#[cfg(not(test))]
+const BUFFER_SIZE_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Periodically checks the buffer size and persists segments or tables to free up memory if the
+/// buffer size is over the limit.
+pub(crate) async fn run_buffer_size_check_and_persist<P, T, W>(
+    persister: Arc<P>,
+    segment_state: Arc<RwLock<SegmentState<T, W>>>,
+    mut shutdown_rx: watch::Receiver<()>,
+    executor: Arc<iox_query::exec::Executor>,
+    buffer_limit_mb: usize,
+) where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    T: TimeProvider,
+    W: Wal,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    let mut interval = tokio::time::interval(BUFFER_SIZE_CHECK_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    let mut buffer_sizes = BufferSizeRingBuffer::new(10);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                break;
+            }
+            _ = interval.tick() => {
+                check_buffer_size_and_persist(Arc::clone(&persister), Arc::clone(&segment_state), Arc::clone(&executor), &mut buffer_sizes, buffer_limit_mb).await;
+            }
+        }
+    }
+}
+
+// Performs the following:
+// 1. Get the total of all open segments
+// 2. Compute the growth rate based on the buffer size from the last 10 measurements
+// 3. If the growth rate and the current size will put the buffer over the limit in the next 5
+//    minutes, persist the oldest cold segment, or persist the largest tables in the open segments
+//    until we get under a size that will not exceed the limit in the next 5 minutes.
+async fn check_buffer_size_and_persist<P, T, W>(
+    persister: Arc<P>,
+    segment_state: Arc<RwLock<SegmentState<T, W>>>,
+    executor: Arc<iox_query::exec::Executor>,
+    buffer_sizes: &mut BufferSizeRingBuffer,
+    buffer_limit_mb: usize,
+) where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    T: TimeProvider,
+    W: Wal,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    let mut segment_sizes = {
+        let segment_state = segment_state.read();
+        segment_state.open_segments_sizes()
+    };
+    let buffer_size = segment_sizes.iter().map(|s| s.size()).sum::<usize>();
+
+    buffer_sizes.push(buffer_size, Instant::now());
+
+    let mut size_to_shed = buffer_sizes.size_to_shed(buffer_limit_mb);
+
+    while let Some(target) = next_to_persist(size_to_shed, &mut segment_sizes) {
+        match target {
+            PersistTarget::SegmentToClose(segment) => {
+                // close the segment and let the regular segment persist checker pick it up
+                info!(
+                    "Closing segment early to free memory {:?} {}",
+                    segment.segment_id, segment.segment_start_time
+                );
+                let mut state = segment_state.write();
+
+                if state.close_segment(segment.segment_start_time).is_none() {
+                    error!(
+                        "Segment {:?} {} not found in open segments",
+                        segment.segment_id, segment.segment_start_time
+                    );
+                }
+
+                size_to_shed -= segment.size();
+            }
+            PersistTarget::Table(table) => {
+                info!(
+                    "Persisting table {} in database {} in segment {:?} to free memory",
+                    table.table_name, table.database_name, table.segment_id
+                );
+
+                let data_to_persist = {
+                    let mut state = segment_state.write();
+                    state.split_table_for_persistence(
+                        table.segment_id,
+                        &table.database_name,
+                        &table.table_name,
+                    )
+                };
+
+                if let Some((path, batch)) = data_to_persist {
+                    let (min_time, max_time) = min_max_time_from_batch(&batch);
+
+                    let schema =
+                        Schema::try_from(batch.schema()).expect("schema should always be valid");
+                    let sort_key = SortKey::from(
+                        schema
+                            .primary_key()
+                            .iter()
+                            .map(|k| k.to_string())
+                            .collect::<Vec<String>>(),
+                    );
+
+                    let path_string = path.to_string();
+                    let (size_bytes, meta) = sort_dedupe_persist(
+                        &table.table_name,
+                        path,
+                        batch,
+                        &schema,
+                        TimestampMinMax::new(min_time, max_time),
+                        &table.segment_key,
+                        sort_key,
+                        Arc::clone(&persister),
+                        Arc::clone(&executor),
+                    )
+                    .await;
+
+                    let parquet_file = ParquetFile {
+                        path: path_string,
+                        size_bytes,
+                        row_count: meta.num_rows as u64,
+                        min_time,
+                        max_time,
+                    };
+
+                    // grab a lock on segment state and insert the parquet file in the list of files while clearing out the persisting data from the buffer
+                    if let Err(e) = segment_state.write().clear_persisting_table_buffer(
+                        parquet_file,
+                        table.segment_id,
+                        &table.database_name,
+                        &table.table_name,
+                    ) {
+                        // if there's an error here, it just means there was a problem logging this in the WAL. The data has already been persisted so it's safe.
+                        error!("Error clearing persisted table buffer: {}", e);
+                    }
+                }
+                size_to_shed -= table.size_bytes;
+            }
+        }
+    }
+}
+
+fn min_max_time_from_batch(batch: &RecordBatch) -> (i64, i64) {
+    batch
+        .column_by_name(TIME_COLUMN_NAME)
+        .map(|c| {
+            let times = c
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("time column was an unexpected type")
+                .values()
+                .inner()
+                .typed_data();
+            let mut min_timestamp = i64::MAX;
+            let mut max_timestamp = i64::MIN;
+            for t in times {
+                min_timestamp = min_timestamp.min(*t);
+                max_timestamp = max_timestamp.max(*t);
+            }
+            (min_timestamp, max_timestamp)
+        })
+        .unwrap_or_else(|| (i64::MAX, i64::MIN))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn sort_dedupe_persist<P>(
+    table_name: &str,
+    path: ParquetFilePath,
+    batch: RecordBatch,
+    schema: &Schema,
+    time_min_max: TimestampMinMax,
+    segment_key: &PartitionKey,
+    sort_key: SortKey,
+    persister: Arc<P>,
+    executor: Arc<iox_query::exec::Executor>,
+) -> (u64, FileMetaData)
+where
+    P: Persister,
+    persister::Error: From<<P as Persister>::Error>,
+    write_buffer::Error: From<<P as Persister>::Error>,
+{
+    // Dedupe and sort using the COMPACT query built into
+    // iox_query
+    let row_count = batch.num_rows();
+
+    let chunk_stats =
+        create_chunk_statistics(Some(row_count), schema, Some(time_min_max), &NoColumnRanges);
+
+    let chunks: Vec<Arc<dyn QueryChunk>> = vec![Arc::new(BufferChunk {
+        batches: vec![batch],
+        schema: schema.clone(),
+        stats: Arc::new(chunk_stats),
+        partition_id: TransitionPartitionId::new(TableId::new(0), segment_key),
+        sort_key: None,
+        id: ChunkId::new(),
+        chunk_order: ChunkOrder::new(1),
+    })];
+
+    let ctx = executor.new_context();
+
+    let logical_plan = ReorgPlanner::new()
+        .compact_plan(Arc::from(table_name), schema, chunks, sort_key)
+        .unwrap();
+
+    // Build physical plan
+    let physical_plan = ctx.create_physical_plan(&logical_plan).await.unwrap();
+
+    // Execute the plan and return compacted record batches
+    let data = ctx.collect(physical_plan).await.unwrap();
+
+    // keep attempting to persist forever. If we can't reach the object store, we'll stop accepting
+    // writes elsewhere in the system, so we need to keep trying to persist.
+    loop {
+        let batch_stream = stream_from_batches(schema.as_arrow(), data.clone());
+
+        match persister
+            .persist_parquet_file(path.clone(), batch_stream)
+            .await
+        {
+            Ok((size_bytes, meta)) => {
+                info!("Persisted parquet file: {}", path.to_string());
+                return (size_bytes, meta);
+            }
+            Err(_) => {
+                error!("Error persisting parquet file: (TODO: figure out why we can't output the error), sleeping and retrying...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+// The interval from the last write to a segment at which to close the segment if the buffer size
+// check indicates that we need to free up space.
+const SEGMENT_CLOSE_INTERVAL: Duration = Duration::from_secs(60);
+
+// The interval in the future to see if our growth rate will cause us to exceed the buffer limit
+const GROWTH_RATE_INTERVAL: Duration = Duration::from_secs(300);
+
+// Returns the next thing to persist based on the buffer growth rate. Can be:
+// * None
+// * Close a segment
+// * Specific table in a specific segment
+fn next_to_persist(
+    size_to_shed: usize,
+    segment_sizes: &mut Vec<SegmentSizes>,
+) -> Option<PersistTarget> {
+    if size_to_shed == 0 {
+        return None;
+    }
+
+    // first check is to return the oldest cold segment
+    let mut oldest_cold_index_and_elapsed = None;
+    for (index, segment_size) in segment_sizes.iter().enumerate() {
+        if segment_is_cold(
+            segment_size.last_write_time.elapsed(),
+            segment_size.segment_duration,
+        ) {
+            match oldest_cold_index_and_elapsed {
+                Some((oldest_index, oldest_elapsed)) => {
+                    if oldest_elapsed < segment_size.last_write_time.elapsed() {
+                        oldest_cold_index_and_elapsed = Some((oldest_index, oldest_elapsed))
+                    }
+                }
+                None => {
+                    oldest_cold_index_and_elapsed =
+                        Some((index, segment_size.last_write_time.elapsed()))
+                }
+            };
+        }
+    }
+
+    // If we have a segment, remove this segment from the list so that if we have to call in here
+    // again to clear up more space, it won't be considered again. Then return the info.
+    if let Some((index, _)) = oldest_cold_index_and_elapsed {
+        let segment = segment_sizes.remove(index);
+        return Some(PersistTarget::SegmentToClose(segment));
+    }
+
+    // if no segment is cold, return the largest table
+    let max_segment_db_table = {
+        let mut max_segment_db_table = None;
+
+        for (index, segment_size) in segment_sizes.iter_mut().enumerate() {
+            for (db, db_sizes) in &segment_size.database_buffer_sizes {
+                for (table, size) in &db_sizes.table_sizes {
+                    match max_segment_db_table {
+                        Some((_, _, _, max_size)) => {
+                            if max_size < *size {
+                                max_segment_db_table = Some((index, db, table, *size))
+                            }
+                        }
+                        None => max_segment_db_table = Some((index, db, table, *size)),
+                    };
+                }
+            }
+        }
+
+        max_segment_db_table
+            .map(|(index, db, table, size)| (index, db.to_string(), table.to_string(), size))
+    };
+
+    // If we have a table, remove it from the segment so that if we have to call in here again to
+    // clear up more space, it won't be considered again. Then return the info.
+    if let Some((index, db, table, size)) = max_segment_db_table {
+        let segment = segment_sizes.get_mut(index).unwrap();
+        segment
+            .database_buffer_sizes
+            .get_mut(&db)
+            .unwrap()
+            .table_sizes
+            .remove(&table);
+        return Some(PersistTarget::Table(TableToPersist {
+            segment_id: segment.segment_id,
+            segment_key: segment.segment_key.clone(),
+            database_name: db,
+            table_name: table,
+            size_bytes: size,
+        }));
+    }
+
+    None
+}
+
+fn segment_is_cold(since_last_write: Duration, segment_duration: SegmentDuration) -> bool {
+    since_last_write > segment_duration.as_duration() / 2
+        || since_last_write > SEGMENT_CLOSE_INTERVAL
+}
+
+#[derive(Debug)]
+enum PersistTarget {
+    SegmentToClose(SegmentSizes),
+    Table(TableToPersist),
+}
+
+#[derive(Debug)]
+struct TableToPersist {
+    segment_id: SegmentId,
+    segment_key: PartitionKey,
+    database_name: String,
+    table_name: String,
+    size_bytes: usize,
+}
+
+// Ring buffer to keep buffer sizes and predict when the buffer might exceed the limit
+#[derive(Debug)]
+struct BufferSizeRingBuffer {
+    buffer: VecDeque<BufferSize>,
+}
+
+#[derive(Debug, Copy, Clone)]
+struct BufferSize {
+    size: usize,
+    time: Instant,
+}
+
+impl BufferSizeRingBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            buffer: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    fn push(&mut self, value: usize, time: Instant) {
+        if self.buffer.len() == self.buffer.capacity() {
+            self.buffer.pop_front();
+        }
+
+        self.buffer.push_back(BufferSize { size: value, time });
+    }
+
+    // Returns the growth rate of the buffer size in bytes per minute for each measurement
+    // compared to the most recent measurement
+    fn per_minute_growth_rates(&self) -> Vec<usize> {
+        if self.buffer.len() < 2 {
+            return vec![];
+        }
+
+        let latest = self.buffer.back().unwrap();
+
+        self.buffer
+            .iter()
+            .take(self.buffer.len() - 1)
+            .map(|measurement| {
+                let duration = latest.time.duration_since(measurement.time);
+                let minutes = duration.as_secs_f64() / 60.0;
+                let growth = latest.size as f64 - measurement.size as f64;
+                (growth / minutes) as usize
+            })
+            .collect()
+    }
+
+    // The size in bytes to shed from the write buffer in order to get the projected size under the
+    // limit in the next 5 minutes
+    fn size_to_shed(&self, limit_mb: usize) -> usize {
+        if limit_mb == 0 {
+            return 0;
+        }
+
+        let minutes_forward = (GROWTH_RATE_INTERVAL.as_secs() / 60) as usize;
+        let last_buffer_size = self.buffer.back().map(|s| s.size).unwrap_or(0);
+
+        let mut max_shed = 0;
+
+        for growth_per_minute in self.per_minute_growth_rates() {
+            let projected_size_mb =
+                (growth_per_minute * minutes_forward + last_buffer_size) / 1024 / 1024;
+
+            if projected_size_mb > limit_mb {
+                max_shed = max_shed.max(projected_size_mb - limit_mb)
+            }
+        }
+
+        max_shed * 1024 * 1024
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::Catalog;
+    use crate::persister::PersisterImpl;
+    use crate::test_helpers::lp_to_write_batch;
+    use crate::wal::WalSegmentWriterNoopImpl;
+    use crate::write_buffer::buffer_segment::tests::TestPersister;
+    use crate::write_buffer::buffer_segment::OpenBufferSegment;
+    use crate::{
+        wal, SegmentDuration, SegmentFile, SegmentId, SegmentRange, WalSegmentReader,
+        WalSegmentWriter,
+    };
+    use arrow_util::assert_batches_eq;
+    use datafusion_util::config::register_iox_object_store;
+    use iox_time::{MockProvider, Time};
+    use object_store::local::LocalFileSystem;
+    use parking_lot::Mutex;
+    use std::any::Any;
+
+    #[tokio::test]
+    async fn persist_and_cleanup_ready_segments_handles_persisting_and_rotates_old() {
+        let catalog = Arc::new(Catalog::new());
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let segment_duration = SegmentDuration::new_5m();
+        let first_segment_range = SegmentRange::from_time_and_duration(
+            Time::from_timestamp_nanos(0),
+            segment_duration,
+            false,
+        );
+
+        let mut open_segment1 = OpenBufferSegment::new(
+            Arc::clone(&catalog),
+            SegmentId::new(1),
+            first_segment_range,
+            time_provider.now(),
+            catalog.sequence_number(),
+            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(1))),
+            None,
+        );
+        open_segment1
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=1 10",
+            ))
+            .unwrap();
+
+        let mut open_segment2 = OpenBufferSegment::new(
+            Arc::clone(&catalog),
+            SegmentId::new(2),
+            SegmentRange::from_time_and_duration(
+                Time::from_timestamp(300, 0).unwrap(),
+                segment_duration,
+                false,
+            ),
+            time_provider.now(),
+            catalog.sequence_number(),
+            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(2))),
+            None,
+        );
+        open_segment2
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=2 300000000000",
+            ))
+            .unwrap();
+
+        let mut open_segment3 = OpenBufferSegment::new(
+            Arc::clone(&catalog),
+            SegmentId::new(3),
+            SegmentRange::from_time_and_duration(
+                Time::from_timestamp(600, 0).unwrap(),
+                segment_duration,
+                false,
+            ),
+            time_provider.now(),
+            catalog.sequence_number(),
+            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(3))),
+            None,
+        );
+        open_segment3
+            .buffer_writes(lp_to_write_batch(
+                Arc::clone(&catalog),
+                "foo",
+                "cpu bar=3 700000000000",
+            ))
+            .unwrap();
+
+        let wal = Arc::new(TestWal::default());
+
+        let segment_state: SegmentState<MockProvider, TestWal> = SegmentState::new(
+            SegmentDuration::new_5m(),
+            SegmentId::new(4),
+            Arc::clone(&catalog),
+            Arc::clone(&time_provider),
+            vec![open_segment2, open_segment3],
+            vec![open_segment1.into_closed_segment(Arc::clone(&catalog))],
+            vec![],
+            Some(Arc::clone(&wal)),
+        );
+        let segment_state = Arc::new(RwLock::new(segment_state));
+
+        let persister = Arc::new(TestPersister::default());
+
+        time_provider.set(Time::from_timestamp(900, 0).unwrap());
+
+        persist_and_cleanup_ready_segments(
+            Arc::clone(&persister),
+            Arc::clone(&segment_state),
+            Arc::clone(&time_provider),
+            Some(Arc::clone(&wal)),
+            crate::test_help::make_exec(),
+        )
+        .await
+        .unwrap();
+
+        let persisted_state = persister
+            .as_any()
+            .downcast_ref::<TestPersister>()
+            .unwrap()
+            .state
+            .lock();
+
+        assert_eq!(persisted_state.catalog.len(), 1);
+        assert_eq!(persisted_state.segments.len(), 2);
+        assert_eq!(persisted_state.parquet_files.len(), 2);
+
+        let wal_state = wal.as_any().downcast_ref::<TestWal>().unwrap();
+        let deleted_segments = wal_state.deleted_wal_segments.lock().clone();
+
+        assert_eq!(deleted_segments, vec![SegmentId::new(1), SegmentId::new(2)]);
+    }
+
+    #[tokio::test]
+    async fn test_check_buffer_size_and_persist() {
+        let catalog = Arc::new(Catalog::new());
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let segment_duration = SegmentDuration::new_5m();
+        let first_segment_range = SegmentRange::from_time_and_duration(
+            Time::from_timestamp_nanos(0),
+            segment_duration,
+            false,
+        );
+
+        let mut open_segment = OpenBufferSegment::new(
+            Arc::clone(&catalog),
+            SegmentId::new(1),
+            first_segment_range,
+            time_provider.now(),
+            catalog.sequence_number(),
+            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(1))),
+            None,
+        );
+        for x in 0..10 {
+            open_segment
+                .buffer_writes(lp_to_write_batch(
+                    Arc::clone(&catalog),
+                    "foo",
+                    format!("cpu bar={} {}", x, x).as_str(),
+                ))
+                .unwrap();
+        }
+
+        let wal = Arc::new(TestWal::default());
+
+        let segment_state: SegmentState<MockProvider, TestWal> = SegmentState::new(
+            SegmentDuration::new_5m(),
+            SegmentId::new(4),
+            Arc::clone(&catalog),
+            Arc::clone(&time_provider),
+            vec![open_segment],
+            vec![],
+            vec![],
+            Some(Arc::clone(&wal)),
+        );
+        let segment_state = Arc::new(RwLock::new(segment_state));
+
+        let local_disk =
+            LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
+        let persister: Arc<PersisterImpl> = Arc::new(PersisterImpl::new(Arc::new(local_disk)));
+
+        time_provider.set(Time::from_timestamp(900, 0).unwrap());
+
+        let mut buffer_sizes = BufferSizeRingBuffer::new(2);
+        buffer_sizes.push(0, Instant::now());
+
+        check_buffer_size_and_persist(
+            Arc::clone(&persister),
+            Arc::clone(&segment_state),
+            crate::test_help::make_exec(),
+            &mut buffer_sizes,
+            1,
+        )
+        .await;
+
+        let db_schema = catalog.db_schema("foo").unwrap();
+        let table_schema = db_schema.get_table_schema("cpu").unwrap();
+        let non_persisted_data =
+            segment_state
+                .read()
+                .open_segments_table_record_batches("foo", "cpu", table_schema);
+
+        let expected = vec![
+            "+-----+--------------------------------+",
+            "| bar | time                           |",
+            "+-----+--------------------------------+",
+            "| 9.0 | 1970-01-01T00:00:00.000000009Z |",
+            "+-----+--------------------------------+",
+        ];
+        assert_batches_eq!(expected, &non_persisted_data);
+
+        let exec = crate::test_help::make_exec();
+        let session_context = exec.new_context();
+        let runtime_env = session_context.inner().runtime_env();
+        register_iox_object_store(runtime_env, "influxdb3", persister.object_store());
+        let ctx = session_context.inner().state();
+
+        let chunks = segment_state
+            .read()
+            .get_table_chunks(
+                Arc::clone(&db_schema),
+                "cpu",
+                &[],
+                None,
+                persister.object_store_url(),
+                persister.object_store(),
+                &ctx,
+            )
+            .unwrap();
+
+        let mut batches = vec![];
+        for chunk in chunks {
+            let chunk = chunk
+                .data()
+                .read_to_batches(chunk.schema(), session_context.inner())
+                .await;
+            batches.extend(chunk);
+        }
+
+        let expected = vec![
+            "+-----+--------------------------------+",
+            "| bar | time                           |",
+            "+-----+--------------------------------+",
+            "| 0.0 | 1970-01-01T00:00:00Z           |",
+            "| 1.0 | 1970-01-01T00:00:00.000000001Z |",
+            "| 2.0 | 1970-01-01T00:00:00.000000002Z |",
+            "| 3.0 | 1970-01-01T00:00:00.000000003Z |",
+            "| 4.0 | 1970-01-01T00:00:00.000000004Z |",
+            "| 5.0 | 1970-01-01T00:00:00.000000005Z |",
+            "| 6.0 | 1970-01-01T00:00:00.000000006Z |",
+            "| 7.0 | 1970-01-01T00:00:00.000000007Z |",
+            "| 8.0 | 1970-01-01T00:00:00.000000008Z |",
+            "| 9.0 | 1970-01-01T00:00:00.000000009Z |",
+            "+-----+--------------------------------+",
+        ];
+        assert_batches_eq!(expected, &batches);
+
+        // now close out the segment and validate that two parquet files are in the segment info file
+        let closed_segment = segment_state
+            .write()
+            .close_segment(first_segment_range.start_time)
+            .unwrap();
+        let persisted = closed_segment
+            .persist(Arc::clone(&persister), exec, None)
+            .await
+            .unwrap();
+        segment_state
+            .write()
+            .mark_segment_as_persisted(first_segment_range.start_time, persisted);
+        let segments = persister.load_segments(10).await.unwrap();
+        assert_eq!(segments.len(), 1);
+        let segment = segments.first().unwrap();
+        assert_eq!(segment.segment_row_count, 10);
+        let db = segment.databases.get("foo").unwrap();
+        let table = db.tables.get("cpu").unwrap();
+        assert_eq!(table.parquet_files.len(), 2);
+        assert_eq!(table.parquet_files[0].row_count, 9);
+        assert_eq!(table.parquet_files[0].min_time, 0);
+        assert_eq!(table.parquet_files[0].max_time, 8);
+        assert_eq!(table.parquet_files[1].row_count, 1);
+        assert_eq!(table.parquet_files[1].min_time, 9);
+        assert_eq!(table.parquet_files[1].max_time, 9);
+    }
+
+    #[test]
+    fn buffer_size_ring_buffer() {
+        let mut buffer = BufferSizeRingBuffer::new(3);
+        let start = Instant::now();
+        buffer.push(1024 * 1024, start);
+        assert!(buffer.per_minute_growth_rates().is_empty());
+        assert_eq!(buffer.size_to_shed(0), 0);
+
+        buffer.push(1024 * 1024 * 100, start + Duration::from_secs(60));
+        assert!(*buffer.per_minute_growth_rates().first().unwrap() > 1024 * 1024);
+        assert_eq!(buffer.size_to_shed(10000), 0);
+        assert_eq!(buffer.size_to_shed(400), 204472320);
+
+        buffer.push(1024 * 1024 * 200, start + Duration::from_secs(120));
+        buffer.push(1024 * 1024, start + Duration::from_secs(180));
+        buffer.push(1024 * 1024 * 300, start + Duration::from_secs(240));
+
+        let rates = buffer.per_minute_growth_rates();
+        let expected = vec![52428800, 313524224];
+        assert_eq!(rates, expected);
+        assert_eq!(buffer.size_to_shed(10000), 0);
+        assert_eq!(buffer.size_to_shed(400), 1462763520);
+    }
+
+    #[derive(Debug, Default)]
+    struct TestWal {
+        deleted_wal_segments: Mutex<Vec<SegmentId>>,
+    }
+
+    impl Wal for TestWal {
+        fn new_segment_writer(
+            &self,
+            _segment_id: SegmentId,
+            _range: SegmentRange,
+        ) -> wal::Result<Box<dyn WalSegmentWriter>> {
+            todo!()
+        }
+
+        fn open_segment_writer(
+            &self,
+            _segment_id: SegmentId,
+        ) -> wal::Result<Box<dyn WalSegmentWriter>> {
+            todo!()
+        }
+
+        fn open_segment_reader(
+            &self,
+            _segment_id: SegmentId,
+        ) -> wal::Result<Box<dyn WalSegmentReader>> {
+            todo!()
+        }
+
+        fn segment_files(&self) -> wal::Result<Vec<SegmentFile>> {
+            todo!()
+        }
+
+        fn delete_wal_segment(&self, segment_id: SegmentId) -> wal::Result<()> {
+            self.deleted_wal_segments.lock().push(segment_id);
+            Ok(())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self as &dyn Any
+        }
+    }
+}

--- a/influxdb3_write/src/write_buffer/persister.rs
+++ b/influxdb3_write/src/write_buffer/persister.rs
@@ -91,8 +91,7 @@ where
             wal.clone(),
             Arc::clone(&executor),
         )
-        .await
-        .unwrap()
+        .await?
     }
 
     // check for open segments to persist
@@ -117,8 +116,7 @@ where
                 wal.clone(),
                 Arc::clone(&executor),
             )
-            .await
-            .unwrap()
+            .await?
         }
     }
 
@@ -540,8 +538,8 @@ impl BufferSizeRingBuffer {
         self.buffer.push_back(BufferSize { size: value, time });
     }
 
-    // Returns the growth rate of the buffer size in bytes per minute for each measurement
-    // compared to the most recent measurement
+    /// Returns the growth rate of the buffer size in bytes per minute for each measurement
+    /// compared to the most recent measurement
     fn per_minute_growth_rates(&self) -> Vec<usize> {
         if self.buffer.len() < 2 {
             return vec![];
@@ -561,8 +559,8 @@ impl BufferSizeRingBuffer {
             .collect()
     }
 
-    // The size in bytes to shed from the write buffer in order to get the projected size under the
-    // limit in the next 5 minutes
+    /// The size in bytes to shed from the write buffer in order to get the projected size under the
+    /// limit in the next 5 minutes
     fn size_to_shed(&self, limit_mb: usize) -> usize {
         if limit_mb == 0 {
             return 0;

--- a/influxdb3_write/src/write_buffer/segment_state.rs
+++ b/influxdb3_write/src/write_buffer/segment_state.rs
@@ -2,30 +2,32 @@
 
 use crate::catalog::{Catalog, DatabaseSchema};
 use crate::chunk::BufferChunk;
+use crate::paths::ParquetFilePath;
 use crate::wal::WalSegmentWriterNoopImpl;
-use crate::write_buffer::buffer_segment::{ClosedBufferSegment, OpenBufferSegment, WriteBatch};
+use crate::write_buffer::buffer_segment::{
+    ClosedBufferSegment, OpenBufferSegment, SegmentSizes, WriteBatch,
+};
+use crate::write_buffer::parquet_chunk_from_file;
 use crate::{
-    persister, wal, write_buffer, ParquetFile, PersistedSegment, Persister, SegmentDuration,
-    SegmentId, SegmentRange, SequenceNumber, Wal, WalOp,
+    wal, write_buffer, ParquetFile, PersistedSegment, SegmentDuration, SegmentId, SegmentRange,
+    SequenceNumber, Wal, WalOp,
 };
 use arrow::datatypes::SchemaRef;
-#[cfg(test)]
 use arrow::record_batch::RecordBatch;
 use data_types::{ChunkId, ChunkOrder, TableId, TransitionPartitionId};
 use datafusion::common::DataFusionError;
 use datafusion::execution::context::SessionState;
+use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::Expr;
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
+use object_store::ObjectStore;
 use observability_deps::tracing::error;
-use parking_lot::RwLock;
 #[cfg(test)]
 use schema::Schema;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::watch;
 
 // The maximum number of open segments that can be open at any one time. Each one of these will
 // have an open wal file and a buffer segment in memory.
@@ -109,12 +111,15 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
         segment.buffer_writes(write_batch)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn get_table_chunks(
         &self,
         db_schema: Arc<DatabaseSchema>,
         table_name: &str,
         filters: &[Expr],
         projection: Option<&Vec<usize>>,
+        object_store_url: ObjectStoreUrl,
+        object_store: Arc<dyn ObjectStore>,
         _ctx: &SessionState,
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
         let table = db_schema
@@ -133,16 +138,37 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
         let mut chunks: Vec<Arc<dyn QueryChunk>> = vec![];
 
         for segment in self.segments.values() {
-            if let Some(batch) = segment.table_record_batch(
+            // output the older persisted stuff first
+            if let Some(table_paruqet_files) =
+                segment.table_persisted_parquet_files(&db_schema.name, table_name)
+            {
+                for parquet_file in &table_paruqet_files.parquet_files {
+                    let parquet_chunk = parquet_chunk_from_file(
+                        parquet_file,
+                        &schema,
+                        object_store_url.clone(),
+                        Arc::clone(&object_store),
+                        chunks
+                            .len()
+                            .try_into()
+                            .expect("should never have this many chunks"),
+                    );
+
+                    chunks.push(Arc::new(parquet_chunk));
+                }
+            }
+
+            // now add the in-memory stuff
+            if let Some(batches) = segment.table_record_batches(
                 &db_schema.name,
                 table_name,
                 Arc::clone(&arrow_schema),
                 filters,
             ) {
-                let batch = batch.map_err(|e| {
+                let batches = batches.map_err(|e| {
                     DataFusionError::Execution(format!("error getting batches {}", e))
                 })?;
-                let row_count = batch.num_rows();
+                let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
                 let chunk_stats = create_chunk_statistics(
                     Some(row_count),
@@ -152,7 +178,7 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
                 );
 
                 chunks.push(Arc::new(BufferChunk {
-                    batches: vec![batch],
+                    batches,
                     schema: schema.clone(),
                     stats: Arc::new(chunk_stats),
                     partition_id: TransitionPartitionId::new(
@@ -172,16 +198,16 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
         }
 
         for persisting_segment in self.persisting_segments.values() {
-            if let Some(batch) = persisting_segment.buffered_data.table_record_batches(
+            if let Some(batches) = persisting_segment.buffered_data.table_record_batches(
                 &db_schema.name,
                 table_name,
                 Arc::clone(&arrow_schema),
                 filters,
             ) {
-                let batch = batch.map_err(|e| {
+                let batches = batches.map_err(|e| {
                     DataFusionError::Execution(format!("error getting batches {}", e))
                 })?;
-                let row_count = batch.num_rows();
+                let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
                 let chunk_stats = create_chunk_statistics(
                     Some(row_count),
@@ -191,7 +217,7 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
                 );
 
                 chunks.push(Arc::new(BufferChunk {
-                    batches: vec![batch],
+                    batches,
                     schema: schema.clone(),
                     stats: Arc::new(chunk_stats),
                     partition_id: TransitionPartitionId::new(
@@ -231,6 +257,43 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
         parquet_files
     }
 
+    pub(crate) fn split_table_for_persistence(
+        &mut self,
+        segment_id: SegmentId,
+        database_name: &str,
+        table_name: &str,
+    ) -> Option<(ParquetFilePath, RecordBatch)> {
+        let db_schema = self.catalog.db_schema(database_name)?;
+        let table_schema = db_schema.get_table_schema(table_name)?;
+
+        let segment = self
+            .segments
+            .values_mut()
+            .find(|segment| segment.segment_id() == segment_id)?;
+        segment.split_table_for_persistence(database_name, table_name, table_schema)
+    }
+
+    pub(crate) fn clear_persisting_table_buffer(
+        &mut self,
+        parquet_file: ParquetFile,
+        segment_id: SegmentId,
+        database_name: &str,
+        table_name: &str,
+    ) -> write_buffer::Result<()> {
+        if let Some(segment) = self
+            .segments
+            .values_mut()
+            .find(|segment| segment.segment_id() == segment_id)
+        {
+            segment.clear_persisting_table_buffer(parquet_file, database_name, table_name)
+        } else {
+            error!("Failed to find segment with id {:?}", segment_id);
+            // caller can't call back in with the same id and get any different result, so log
+            // and say it's ok.
+            Ok(())
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn persisted_segments(&self) -> Vec<Arc<PersistedSegment>> {
         self.persisted_segments.values().cloned().collect()
@@ -250,9 +313,9 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
     ) -> Vec<RecordBatch> {
         self.segments
             .values()
-            .map(|segment| {
+            .flat_map(|segment| {
                 segment
-                    .table_record_batch(db_name, table_name, schema.as_arrow(), &[])
+                    .table_record_batches(db_name, table_name, schema.as_arrow(), &[])
                     .unwrap()
                     .unwrap()
             })
@@ -268,7 +331,7 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
     // criteria (in time ascending order):
     // 1. The segment is not in the current time or next time
     // 2. The segment has been open for longer than half the segment duration
-    fn segments_to_persist(&self, current_time: Time) -> Vec<Time> {
+    pub(crate) fn segments_to_persist(&self, current_time: Time) -> Vec<Time> {
         let mut segments_to_persist = vec![];
 
         for (start_time, segment) in &self.segments {
@@ -281,7 +344,14 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
         segments_to_persist
     }
 
-    fn close_segment(&mut self, segment_start: Time) -> Option<Arc<ClosedBufferSegment>> {
+    pub(crate) fn persisting_segments(&self) -> Vec<Arc<ClosedBufferSegment>> {
+        self.persisting_segments.values().cloned().collect()
+    }
+
+    pub(crate) fn close_segment(
+        &mut self,
+        segment_start: Time,
+    ) -> Option<Arc<ClosedBufferSegment>> {
         self.segments.remove(&segment_start).map(|segment| {
             let closed_segment = Arc::new(segment.into_closed_segment(Arc::clone(&self.catalog)));
 
@@ -290,6 +360,16 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
 
             closed_segment
         })
+    }
+
+    pub(crate) fn mark_segment_as_persisted(
+        &mut self,
+        segment_start: Time,
+        persisted_segment: PersistedSegment,
+    ) {
+        self.persisting_segments.remove(&segment_start);
+        self.persisted_segments
+            .insert(segment_start, Arc::new(persisted_segment));
     }
 
     // return the segment with this start time or open up a new one if it isn't currently open.
@@ -327,159 +407,22 @@ impl<T: TimeProvider, W: Wal> SegmentState<T, W> {
 
         Ok(self.segments.get_mut(&time).unwrap())
     }
-}
 
-#[cfg(test)]
-const PERSISTER_CHECK_INTERVAL: Duration = Duration::from_millis(10);
-
-#[cfg(not(test))]
-const PERSISTER_CHECK_INTERVAL: Duration = Duration::from_secs(1);
-
-pub(crate) async fn run_buffer_segment_persist_and_cleanup<P, T, W>(
-    persister: Arc<P>,
-    segment_state: Arc<RwLock<SegmentState<T, W>>>,
-    mut shutdown_rx: watch::Receiver<()>,
-    time_provider: Arc<T>,
-    wal: Option<Arc<W>>,
-    executor: Arc<iox_query::exec::Executor>,
-) where
-    P: Persister,
-    persister::Error: From<<P as Persister>::Error>,
-    T: TimeProvider,
-    W: Wal,
-    write_buffer::Error: From<<P as Persister>::Error>,
-{
-    loop {
-        tokio::select! {
-            _ = shutdown_rx.changed() => {
-                break;
-            }
-            _ = tokio::time::sleep(PERSISTER_CHECK_INTERVAL) => {
-                if let Err(e) = persist_and_cleanup_ready_segments(Arc::clone(&persister), Arc::clone(&segment_state), Arc::clone(&time_provider), wal.clone(), Arc::clone(&executor)).await {
-                    error!("Error persisting and cleaning up segments: {}", e);
-                }
-            }
-        }
-    }
-}
-
-async fn persist_and_cleanup_ready_segments<P, T, W>(
-    persister: Arc<P>,
-    segment_state: Arc<RwLock<SegmentState<T, W>>>,
-    time_provider: Arc<T>,
-    wal: Option<Arc<W>>,
-    executor: Arc<iox_query::exec::Executor>,
-) -> Result<(), crate::Error>
-where
-    P: Persister,
-    persister::Error: From<<P as Persister>::Error>,
-    T: TimeProvider,
-    W: Wal,
-    write_buffer::Error: From<<P as Persister>::Error>,
-{
-    // this loop is where persistence happens so if anything is in persisting,
-    // it's either been dropped or remaining from a restart, so clear those out first.
-    let persisting_segments = {
-        let segment_state = segment_state.read();
-        segment_state
-            .persisting_segments
+    // Returns the details of open segments with their last write time and their individual table
+    // buffer sizes.
+    pub(crate) fn open_segments_sizes(&self) -> Vec<SegmentSizes> {
+        self.segments
             .values()
-            .cloned()
-            .collect::<Vec<_>>()
-    };
-
-    for segment in persisting_segments {
-        persist_closed_segment_and_cleanup(
-            segment,
-            Arc::clone(&persister),
-            Arc::clone(&segment_state),
-            wal.clone(),
-            Arc::clone(&executor),
-        )
-        .await
-        .unwrap()
+            .map(|segment| segment.sizes())
+            .collect()
     }
-
-    // check for open segments to persist
-    let current_time = time_provider.now();
-    let segments_to_persist = {
-        let segment_state = segment_state.read();
-        segment_state.segments_to_persist(current_time)
-    };
-
-    // close and persist each one in turn
-    for segment_start in segments_to_persist {
-        let closed_segment = {
-            let mut segment_state = segment_state.write();
-            segment_state.close_segment(segment_start)
-        };
-
-        if let Some(closed_segment) = closed_segment {
-            persist_closed_segment_and_cleanup(
-                closed_segment,
-                Arc::clone(&persister),
-                Arc::clone(&segment_state),
-                wal.clone(),
-                Arc::clone(&executor),
-            )
-            .await
-            .unwrap()
-        }
-    }
-
-    Ok(())
-}
-
-// Performs the following:
-// 1. persist the segment to the object store
-// 2. remove the segment from the persisting_segments map and add it to the persisted_segments map
-// 3. remove the wal segment file
-async fn persist_closed_segment_and_cleanup<P, T, W>(
-    closed_segment: Arc<ClosedBufferSegment>,
-    persister: Arc<P>,
-    segment_state: Arc<RwLock<SegmentState<T, W>>>,
-    wal: Option<Arc<W>>,
-    executor: Arc<iox_query::exec::Executor>,
-) -> Result<(), crate::Error>
-where
-    P: Persister,
-    persister::Error: From<<P as Persister>::Error>,
-    T: TimeProvider,
-    W: Wal,
-    write_buffer::Error: From<<P as Persister>::Error>,
-{
-    let closed_segment_start_time = closed_segment.segment_range.start_time;
-    let closed_segment_id = closed_segment.segment_id;
-    let persisted_segment = closed_segment.persist(persister, executor, None).await?;
-
-    {
-        let mut segment_state = segment_state.write();
-        segment_state
-            .persisting_segments
-            .remove(&closed_segment_start_time);
-        segment_state
-            .persisted_segments
-            .insert(closed_segment_start_time, Arc::new(persisted_segment));
-    }
-
-    if let Some(wal) = wal {
-        wal.delete_wal_segment(closed_segment_id)?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::lp_to_write_batch;
     use crate::wal::WalImpl;
-    use crate::{SegmentFile, WalSegmentReader, WalSegmentWriter};
     use iox_time::MockProvider;
-    use parking_lot::Mutex;
-    use std::any::Any;
-    use std::fmt::Debug;
-    use write_buffer::buffer_segment::tests::TestPersister;
 
     #[test]
     fn segments_to_persist_sorts_oldest_first() {
@@ -551,162 +494,5 @@ mod tests {
                 Time::from_timestamp(300, 0).unwrap()
             ]
         );
-    }
-
-    #[tokio::test]
-    async fn persist_and_cleanup_ready_segments_handles_persisting_and_rotates_old() {
-        let catalog = Arc::new(Catalog::new());
-        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
-        let segment_duration = SegmentDuration::new_5m();
-        let first_segment_range = SegmentRange::from_time_and_duration(
-            Time::from_timestamp_nanos(0),
-            segment_duration,
-            false,
-        );
-
-        let mut open_segment1 = OpenBufferSegment::new(
-            Arc::clone(&catalog),
-            SegmentId::new(1),
-            first_segment_range,
-            time_provider.now(),
-            catalog.sequence_number(),
-            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(1))),
-            None,
-        );
-        open_segment1
-            .buffer_writes(lp_to_write_batch(
-                Arc::clone(&catalog),
-                "foo",
-                "cpu bar=1 10",
-            ))
-            .unwrap();
-
-        let mut open_segment2 = OpenBufferSegment::new(
-            Arc::clone(&catalog),
-            SegmentId::new(2),
-            SegmentRange::from_time_and_duration(
-                Time::from_timestamp(300, 0).unwrap(),
-                segment_duration,
-                false,
-            ),
-            time_provider.now(),
-            catalog.sequence_number(),
-            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(2))),
-            None,
-        );
-        open_segment2
-            .buffer_writes(lp_to_write_batch(
-                Arc::clone(&catalog),
-                "foo",
-                "cpu bar=2 300000000000",
-            ))
-            .unwrap();
-
-        let mut open_segment3 = OpenBufferSegment::new(
-            Arc::clone(&catalog),
-            SegmentId::new(3),
-            SegmentRange::from_time_and_duration(
-                Time::from_timestamp(600, 0).unwrap(),
-                segment_duration,
-                false,
-            ),
-            time_provider.now(),
-            catalog.sequence_number(),
-            Box::new(WalSegmentWriterNoopImpl::new(SegmentId::new(3))),
-            None,
-        );
-        open_segment3
-            .buffer_writes(lp_to_write_batch(
-                Arc::clone(&catalog),
-                "foo",
-                "cpu bar=3 700000000000",
-            ))
-            .unwrap();
-
-        let wal = Arc::new(TestWal::default());
-
-        let segment_state: SegmentState<MockProvider, TestWal> = SegmentState::new(
-            SegmentDuration::new_5m(),
-            SegmentId::new(4),
-            Arc::clone(&catalog),
-            Arc::clone(&time_provider),
-            vec![open_segment2, open_segment3],
-            vec![open_segment1.into_closed_segment(Arc::clone(&catalog))],
-            vec![],
-            Some(Arc::clone(&wal)),
-        );
-        let segment_state = Arc::new(RwLock::new(segment_state));
-
-        let persister = Arc::new(TestPersister::default());
-
-        time_provider.set(Time::from_timestamp(900, 0).unwrap());
-
-        persist_and_cleanup_ready_segments(
-            Arc::clone(&persister),
-            Arc::clone(&segment_state),
-            Arc::clone(&time_provider),
-            Some(Arc::clone(&wal)),
-            crate::test_help::make_exec(),
-        )
-        .await
-        .unwrap();
-
-        let persisted_state = persister
-            .as_any()
-            .downcast_ref::<TestPersister>()
-            .unwrap()
-            .state
-            .lock();
-
-        assert_eq!(persisted_state.catalog.len(), 1);
-        assert_eq!(persisted_state.segments.len(), 2);
-        assert_eq!(persisted_state.parquet_files.len(), 2);
-
-        let wal_state = wal.as_any().downcast_ref::<TestWal>().unwrap();
-        let deleted_segments = wal_state.deleted_wal_segments.lock().clone();
-
-        assert_eq!(deleted_segments, vec![SegmentId::new(1), SegmentId::new(2)]);
-    }
-
-    #[derive(Debug, Default)]
-    struct TestWal {
-        deleted_wal_segments: Mutex<Vec<SegmentId>>,
-    }
-
-    impl Wal for TestWal {
-        fn new_segment_writer(
-            &self,
-            _segment_id: SegmentId,
-            _range: SegmentRange,
-        ) -> wal::Result<Box<dyn WalSegmentWriter>> {
-            todo!()
-        }
-
-        fn open_segment_writer(
-            &self,
-            _segment_id: SegmentId,
-        ) -> wal::Result<Box<dyn WalSegmentWriter>> {
-            todo!()
-        }
-
-        fn open_segment_reader(
-            &self,
-            _segment_id: SegmentId,
-        ) -> wal::Result<Box<dyn WalSegmentReader>> {
-            todo!()
-        }
-
-        fn segment_files(&self) -> wal::Result<Vec<SegmentFile>> {
-            todo!()
-        }
-
-        fn delete_wal_segment(&self, segment_id: SegmentId) -> wal::Result<()> {
-            self.deleted_wal_segments.lock().push(segment_id);
-            Ok(())
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self as &dyn Any
-        }
     }
 }

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -453,7 +453,7 @@ impl BufferIndex {
                 if old_index.columns.contains_key(c) {
                     let mut column: HashMap<String, Vec<usize>> = HashMap::new();
                     match b {
-                        Builder::Tag(b) => {
+                        Builder::Tag(b) | Builder::Key(b) => {
                             let b = b.finish_cloned();
                             let bv = b.values();
                             let bva: &StringArray =

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -1,17 +1,19 @@
 //! The in memory buffer of a table that can be quickly added to and queried
 
+use crate::catalog::TIME_COLUMN_NAME;
 use crate::write_buffer::{FieldData, Row};
 use arrow::array::{
-    Array, ArrayBuilder, ArrayRef, BooleanBuilder, Float64Builder, GenericByteDictionaryBuilder,
-    Int64Builder, StringArray, StringBuilder, StringDictionaryBuilder, TimestampNanosecondBuilder,
-    UInt64Builder,
+    Array, ArrayBuilder, ArrayRef, BooleanArray, BooleanBuilder, Float64Builder,
+    GenericByteDictionaryBuilder, Int64Builder, StringArray, StringBuilder,
+    StringDictionaryBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
+use arrow::compute::filter_record_batch;
 use arrow::datatypes::{GenericStringType, Int32Type, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use data_types::{PartitionKey, TimestampMinMax};
 use datafusion::logical_expr::{BinaryExpr, Expr};
-use observability_deps::tracing::debug;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use observability_deps::tracing::{debug, error};
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::mem::size_of;
 use std::sync::Arc;
 use thiserror::Error;
@@ -29,26 +31,123 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct TableBuffer {
     pub segment_key: PartitionKey,
-    timestamp_min: i64,
-    timestamp_max: i64,
-    pub(crate) data: BTreeMap<String, Builder>,
-    row_count: usize,
-    index: BufferIndex,
+    // tracker for the next file number to use for parquet data persisted from this buffer
+    file_number: u32,
+    mutable_table_chunk: MutableTableChunk,
+    persisting_record_batch: Option<RecordBatch>,
 }
 
 impl TableBuffer {
     pub fn new(segment_key: PartitionKey, index_columns: &[&str]) -> Self {
         Self {
             segment_key,
-            timestamp_min: i64::MAX,
-            timestamp_max: i64::MIN,
-            data: Default::default(),
-            row_count: 0,
-            index: BufferIndex::new(index_columns),
+            persisting_record_batch: None,
+            file_number: 1,
+            mutable_table_chunk: MutableTableChunk {
+                timestamp_min: i64::MAX,
+                timestamp_max: i64::MIN,
+                data: Default::default(),
+                row_count: 0,
+                index: BufferIndex::new(index_columns),
+            },
         }
     }
 
     pub fn add_rows(&mut self, rows: Vec<Row>) {
+        self.mutable_table_chunk.add_rows(rows);
+    }
+
+    pub fn timestamp_min_max(&self) -> TimestampMinMax {
+        TimestampMinMax {
+            min: self.mutable_table_chunk.timestamp_min,
+            max: self.mutable_table_chunk.timestamp_max,
+        }
+    }
+
+    pub fn record_batches(&self, schema: SchemaRef, filter: &[Expr]) -> Result<Vec<RecordBatch>> {
+        match self.persisting_record_batch {
+            Some(ref rb) => {
+                let newest = self
+                    .mutable_table_chunk
+                    .record_batch(schema.clone(), filter)?;
+                let cols: std::result::Result<Vec<_>, _> = schema
+                    .fields()
+                    .iter()
+                    .map(|f| {
+                        let col = rb
+                            .column_by_name(f.name())
+                            .ok_or(Error::FieldNotFound(f.name().to_string()));
+                        col.cloned()
+                    })
+                    .collect();
+                let cols = cols?;
+                let rb = RecordBatch::try_new(schema, cols)?;
+                Ok(vec![rb, newest])
+            }
+            None => {
+                let rb = self.mutable_table_chunk.record_batch(schema, filter)?;
+                Ok(vec![rb])
+            }
+        }
+    }
+
+    /// Returns an estimate of the size of this table buffer based on the data and index sizes.
+    pub fn computed_size(&self) -> usize {
+        let mut size = size_of::<Self>();
+        for (k, v) in &self.mutable_table_chunk.data {
+            size += k.len() + size_of::<String>() + v.size();
+        }
+        size += self.mutable_table_chunk.index._size();
+        size
+    }
+
+    /// Splits the table into 90% old and 10% new data and returns a RecordBatch of the old
+    pub fn split(&mut self, schema: SchemaRef) -> Result<PersistBatch> {
+        let (old_data, new_data) = self.mutable_table_chunk.split(schema)?;
+        self.mutable_table_chunk = new_data;
+        self.persisting_record_batch = Some(old_data.clone());
+        let file_number = self.file_number;
+        self.file_number += 1;
+        Ok(PersistBatch {
+            file_number,
+            record_batch: old_data,
+        })
+    }
+
+    pub fn clear_persisting_data(&mut self) {
+        self.persisting_record_batch = None;
+    }
+}
+
+/// A batch of data to be persisted to object storage ahead of a segment getting closed
+#[derive(Debug)]
+pub(crate) struct PersistBatch {
+    pub file_number: u32,
+    pub record_batch: RecordBatch,
+}
+
+// Debug implementation for TableBuffer
+impl std::fmt::Debug for TableBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableBuffer")
+            .field("segment_key", &self.segment_key)
+            .field("timestamp_min", &self.mutable_table_chunk.timestamp_min)
+            .field("timestamp_max", &self.mutable_table_chunk.timestamp_max)
+            .field("row_count", &self.mutable_table_chunk.row_count)
+            .finish()
+    }
+}
+
+struct MutableTableChunk {
+    timestamp_min: i64,
+    timestamp_max: i64,
+    data: BTreeMap<String, Builder>,
+    row_count: usize,
+    index: BufferIndex,
+}
+
+impl MutableTableChunk {
+    fn add_rows(&mut self, rows: Vec<Row>) {
         let new_row_count = rows.len();
 
         for (row_index, r) in rows.into_iter().enumerate() {
@@ -216,14 +315,7 @@ impl TableBuffer {
         self.row_count += new_row_count;
     }
 
-    pub fn timestamp_min_max(&self) -> TimestampMinMax {
-        TimestampMinMax {
-            min: self.timestamp_min,
-            max: self.timestamp_max,
-        }
-    }
-
-    pub fn record_batch(&self, schema: SchemaRef, filter: &[Expr]) -> Result<RecordBatch> {
+    fn record_batch(&self, schema: SchemaRef, filter: &[Expr]) -> Result<RecordBatch> {
         let row_ids = self.index.get_rows_from_index_for_filter(filter);
 
         let mut cols = Vec::with_capacity(schema.fields().len());
@@ -252,23 +344,86 @@ impl TableBuffer {
         Ok(RecordBatch::try_new(schema, cols)?)
     }
 
-    /// Returns an estimate of the size of this table buffer based on the data and index sizes.
-    #[cfg(test)]
-    pub fn _computed_size(&self) -> usize {
-        let mut size = size_of::<Self>();
-        for (k, v) in &self.data {
-            size += k.len() + size_of::<String>() + v._size();
+    pub fn split(&self, schema: SchemaRef) -> Result<(RecordBatch, MutableTableChunk)> {
+        // find the timestamp that splits the data into 90% old and 10% new
+        let max_count = self.row_count / 10;
+
+        let time_column = self
+            .data
+            .get(TIME_COLUMN_NAME)
+            .ok_or_else(|| Error::FieldNotFound(TIME_COLUMN_NAME.to_string()))?;
+        let time_column = match time_column {
+            Builder::Time(b) => b,
+            _ => panic!("unexpected field type"),
+        };
+
+        let mut heap = BinaryHeap::with_capacity(max_count);
+
+        for t in time_column.values_slice() {
+            if heap.len() < max_count {
+                heap.push(*t);
+            } else if let Some(&top) = heap.peek() {
+                if *t > top {
+                    heap.pop();
+                    heap.push(*t);
+                }
+            }
         }
-        size += self.index._size();
-        size
+
+        let newest_time = heap.peek().copied().unwrap_or_default();
+
+        // create a vec that indicates if the row is old (true) or new (false)
+        let filter_vec: BooleanArray = time_column
+            .values_slice()
+            .iter()
+            .map(|t| *t < newest_time)
+            .collect::<Vec<bool>>()
+            .into();
+        let old_data = filter_record_batch(&self.record_batch(schema, &[])?, &filter_vec)?;
+
+        // create a vec with the indexes of the rows to put into a new mutable table chunk
+        let mut new_rows = Vec::with_capacity(max_count);
+        for (i, t) in filter_vec.values().iter().enumerate() {
+            if !t {
+                new_rows.push(i);
+            }
+        }
+
+        // construct new data from the new rows
+        let data: BTreeMap<String, Builder> = self
+            .data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.new_from_rows(&new_rows)))
+            .collect();
+        let (timestamp_min, timestamp_max) = data
+            .values()
+            .find_map(|v| match v {
+                Builder::Time(b) => {
+                    let min_time = b.values_slice().iter().min().unwrap();
+                    let max_time = b.values_slice().iter().max().unwrap();
+                    Some((*min_time, *max_time))
+                }
+                _ => None,
+            })
+            .unwrap_or_default();
+        let index = BufferIndex::new_from_data(&data, &self.index);
+
+        let new_data = MutableTableChunk {
+            timestamp_min,
+            timestamp_max,
+            data,
+            row_count: new_rows.len(),
+            index,
+        };
+
+        Ok((old_data, new_data))
     }
 }
 
 // Debug implementation for TableBuffer
-impl std::fmt::Debug for TableBuffer {
+impl std::fmt::Debug for MutableTableChunk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TableBuffer")
-            .field("segment_key", &self.segment_key)
+        f.debug_struct("MutableTableChunk")
             .field("timestamp_min", &self.timestamp_min)
             .field("timestamp_max", &self.timestamp_max)
             .field("row_count", &self.row_count)
@@ -288,6 +443,44 @@ impl BufferIndex {
             .iter()
             .map(|c| (c.to_string(), HashMap::new()))
             .collect();
+        Self { columns }
+    }
+
+    fn new_from_data(data: &BTreeMap<String, Builder>, old_index: &BufferIndex) -> Self {
+        let columns = data
+            .iter()
+            .filter_map(|(c, b)| {
+                if old_index.columns.contains_key(c) {
+                    let mut column: HashMap<String, Vec<usize>> = HashMap::new();
+                    match b {
+                        Builder::Tag(b) => {
+                            let b = b.finish_cloned();
+                            let bv = b.values();
+                            let bva: &StringArray =
+                                bv.as_any().downcast_ref::<StringArray>().unwrap();
+                            for (i, v) in b.keys().iter().enumerate() {
+                                if let Some(v) = v {
+                                    let tag_val = bva.value(v as usize);
+                                    if let Some(vec) = column.get_mut(tag_val) {
+                                        vec.push(i);
+                                    } else {
+                                        column.insert(tag_val.to_string(), vec![i]);
+                                    }
+                                }
+                            }
+                            Some((c.clone(), column))
+                        }
+                        _ => {
+                            error!("unsupported index colun type: {}", b.column_type());
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         Self { columns }
     }
 
@@ -356,6 +549,93 @@ impl Builder {
             Self::Tag(b) => Arc::new(b.finish_cloned()),
             Self::Key(b) => Arc::new(b.finish_cloned()),
             Self::Time(b) => Arc::new(b.finish_cloned()),
+        }
+    }
+
+    fn new_from_rows(&self, rows: &[usize]) -> Self {
+        match self {
+            Self::Bool(b) => {
+                let b = b.finish_cloned();
+                let mut builder = BooleanBuilder::with_capacity(rows.len());
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::Bool(builder)
+            }
+            Self::I64(b) => {
+                let b = b.finish_cloned();
+                let mut builder = Int64Builder::with_capacity(rows.len());
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::I64(builder)
+            }
+            Self::F64(b) => {
+                let b = b.finish_cloned();
+                let mut builder = Float64Builder::with_capacity(rows.len());
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::F64(builder)
+            }
+            Self::U64(b) => {
+                let b = b.finish_cloned();
+                let mut builder = UInt64Builder::with_capacity(rows.len());
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::U64(builder)
+            }
+            Self::String(b) => {
+                let b = b.finish_cloned();
+                let mut builder = StringBuilder::new();
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::String(builder)
+            }
+            Self::Tag(b) => {
+                let b = b.finish_cloned();
+                let bv = b.values();
+                let bva: &StringArray = bv.as_any().downcast_ref::<StringArray>().unwrap();
+
+                let mut builder: GenericByteDictionaryBuilder<Int32Type, GenericStringType<i32>> =
+                    StringDictionaryBuilder::new();
+                for row in rows {
+                    let val = b.key(*row).unwrap();
+                    let tag_val = bva.value(val);
+
+                    builder
+                        .append(tag_val)
+                        .expect("shouldn't be able to overflow 32 bit dictionary");
+                }
+                Self::Tag(builder)
+            }
+            Self::Key(b) => {
+                let b = b.finish_cloned();
+                let bv = b.values();
+                let bva: &StringArray = bv.as_any().downcast_ref::<StringArray>().unwrap();
+
+                let mut builder: GenericByteDictionaryBuilder<Int32Type, GenericStringType<i32>> =
+                    StringDictionaryBuilder::new();
+                for row in rows {
+                    let val = b.key(*row).unwrap();
+                    let tag_val = bva.value(val);
+
+                    builder
+                        .append(tag_val)
+                        .expect("shouldn't be able to overflow 32 bit dictionary");
+                }
+                Self::Key(builder)
+            }
+            Self::Time(b) => {
+                let b = b.finish_cloned();
+                let mut builder = TimestampNanosecondBuilder::with_capacity(rows.len());
+                for row in rows {
+                    builder.append_value(b.value(*row));
+                }
+                Self::Time(builder)
+            }
         }
     }
 
@@ -429,7 +709,7 @@ impl Builder {
         }
     }
 
-    fn _size(&self) -> usize {
+    fn size(&self) -> usize {
         let data_size = match self {
             Self::Bool(b) => b.capacity() + b.validity_slice().map(|s| s.len()).unwrap_or(0),
             Self::I64(b) => {
@@ -453,6 +733,19 @@ impl Builder {
             Self::Time(b) => size_of::<i64>() * b.capacity(),
         };
         size_of::<Self>() + data_size
+    }
+
+    fn column_type(&self) -> &str {
+        match self {
+            Self::Bool(_) => "bool",
+            Self::I64(_) => "i64",
+            Self::F64(_) => "f64",
+            Self::U64(_) => "u64",
+            Self::String(_) => "string",
+            Self::Tag(_) => "tag",
+            Self::Key(_) => "key",
+            Self::Time(_) => "time",
+        }
     }
 }
 
@@ -541,13 +834,14 @@ mod tests {
             )))),
         })];
         let a_rows = table_buffer
+            .mutable_table_chunk
             .index
             .get_rows_from_index_for_filter(filter)
             .unwrap();
         assert_eq!(a_rows, &[0, 2]);
 
         let a = table_buffer
-            .record_batch(schema.as_arrow(), filter)
+            .record_batches(schema.as_arrow(), filter)
             .unwrap();
         let expected_a = vec![
             "+-----+-------+--------------------------------+",
@@ -557,7 +851,7 @@ mod tests {
             "| a   | 3     | 1970-01-01T00:00:00.000000003Z |",
             "+-----+-------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected_a, &[a]);
+        assert_batches_eq!(&expected_a, &a);
 
         let filter = &[Expr::BinaryExpr(BinaryExpr {
             left: Box::new(Expr::Column(Column {
@@ -571,13 +865,14 @@ mod tests {
         })];
 
         let b_rows = table_buffer
+            .mutable_table_chunk
             .index
             .get_rows_from_index_for_filter(filter)
             .unwrap();
         assert_eq!(b_rows, &[1]);
 
         let b = table_buffer
-            .record_batch(schema.as_arrow(), filter)
+            .record_batches(schema.as_arrow(), filter)
             .unwrap();
         let expected_b = vec![
             "+-----+-------+--------------------------------+",
@@ -586,7 +881,7 @@ mod tests {
             "| b   | 2     | 1970-01-01T00:00:00.000000002Z |",
             "+-----+-------+--------------------------------+",
         ];
-        assert_batches_eq!(&expected_b, &[b]);
+        assert_batches_eq!(&expected_b, &b);
     }
 
     #[test]
@@ -649,7 +944,104 @@ mod tests {
 
         table_buffer.add_rows(rows);
 
-        let size = table_buffer._computed_size();
-        assert_eq!(size, 18150);
+        let size = table_buffer.computed_size();
+        assert_eq!(size, 18198);
+    }
+
+    #[test]
+    fn split() {
+        let mut table_buffer = TableBuffer::new(PartitionKey::from("table"), &["tag"]);
+        let schema = SchemaBuilder::with_capacity(3)
+            .tag("tag")
+            .influx_field("value", InfluxFieldType::Integer)
+            .timestamp()
+            .build()
+            .unwrap();
+
+        let rows = (0..10)
+            .map(|i| Row {
+                time: i,
+                fields: vec![
+                    Field {
+                        name: "tag".to_string(),
+                        value: FieldData::Tag("a".to_string()),
+                    },
+                    Field {
+                        name: "value".to_string(),
+                        value: FieldData::Integer(i),
+                    },
+                    Field {
+                        name: "time".to_string(),
+                        value: FieldData::Timestamp(i),
+                    },
+                ],
+            })
+            .collect();
+
+        table_buffer.add_rows(rows);
+        assert_eq!(table_buffer.mutable_table_chunk.row_count, 10);
+
+        let split = table_buffer.split(schema.as_arrow()).unwrap();
+        assert_eq!(split.file_number, 1);
+        let expected_old = vec![
+            "+-----+-------+--------------------------------+",
+            "| tag | value | time                           |",
+            "+-----+-------+--------------------------------+",
+            "| a   | 0     | 1970-01-01T00:00:00Z           |",
+            "| a   | 1     | 1970-01-01T00:00:00.000000001Z |",
+            "| a   | 2     | 1970-01-01T00:00:00.000000002Z |",
+            "| a   | 3     | 1970-01-01T00:00:00.000000003Z |",
+            "| a   | 4     | 1970-01-01T00:00:00.000000004Z |",
+            "| a   | 5     | 1970-01-01T00:00:00.000000005Z |",
+            "| a   | 6     | 1970-01-01T00:00:00.000000006Z |",
+            "| a   | 7     | 1970-01-01T00:00:00.000000007Z |",
+            "| a   | 8     | 1970-01-01T00:00:00.000000008Z |",
+            "+-----+-------+--------------------------------+",
+        ];
+        assert_batches_eq!(&expected_old, &[split.record_batch.clone()]);
+
+        let mut batches = table_buffer.record_batches(schema.as_arrow(), &[]).unwrap();
+        assert_eq!(split.record_batch, batches[0]);
+
+        let expected_new = vec![
+            "+-----+-------+--------------------------------+",
+            "| tag | value | time                           |",
+            "+-----+-------+--------------------------------+",
+            "| a   | 9     | 1970-01-01T00:00:00.000000009Z |",
+            "+-----+-------+--------------------------------+",
+        ];
+        let batches = vec![batches.pop().unwrap()];
+        assert_batches_eq!(expected_new, &batches);
+
+        table_buffer.clear_persisting_data();
+
+        let filter = &[Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(Expr::Column(Column {
+                relation: None,
+                name: "tag".to_string(),
+            })),
+            op: datafusion::logical_expr::Operator::Eq,
+            right: Box::new(Expr::Literal(datafusion::scalar::ScalarValue::Utf8(Some(
+                "a".to_string(),
+            )))),
+        })];
+        let a_rows = table_buffer
+            .mutable_table_chunk
+            .index
+            .get_rows_from_index_for_filter(filter)
+            .unwrap();
+        assert_eq!(a_rows, &[0]);
+
+        let a = table_buffer
+            .record_batches(schema.as_arrow(), filter)
+            .unwrap();
+        let expected_a = vec![
+            "+-----+-------+--------------------------------+",
+            "| tag | value | time                           |",
+            "+-----+-------+--------------------------------+",
+            "| a   | 9     | 1970-01-01T00:00:00.000000009Z |",
+            "+-----+-------+--------------------------------+",
+        ];
+        assert_batches_eq!(expected_a, &a);
     }
 }


### PR DESCRIPTION
This is a bit light on the test coverage, but I expect there is going to be some big refactoring coming to segment state and some of these other pieces that track parquet files in the system. However, I wanted to get this in so that we can keep things moving along. Big changes here:

* Create a persister module in the write_buffer
* Check the size of the buffer (all open segments) every 10s and predict its size in 5 minutes based on growth rate
* If the projected growth rate is over the configured limit, either close segments that haven't received writes in a minute, or persist the largest tables (oldest 90% of their data)
* Added functions to table buffer to split a table based on 90% older timestamp data and 10% newer timestamp data, to persist the old and keep the new in memory
* When persisting, write the information in the WAL
* When replaying from the WAL, clear out the buffer of the persisted data
* Updated the object store path for persisted parquet files in a segment to have a file number since we can now have multiple parquet files per segment