### PR TITLE
docs: `PROFILING.md`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,12 @@ codegen-units = 16
 lto = false
 incremental = true
 
+# This profile extends the `quick-release` profile with debuginfo turned on in order to
+# produce more human friendly symbols for profiling tools
+[profile.quick-bench]
+inherits = "quick-release"
+debug = 1
+
 # Per insta docs: https://insta.rs/docs/quickstart/#optional-faster-runs
 [profile.dev.package.insta]
 opt-level = 3

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,0 +1,44 @@
+# Profiling `influxdb3`
+
+This document explains several profiling strategies.
+
+## Preparation
+
+### Choosing a profile
+
+In order to profile the `influxdb3` binary, you will need to build and run it using the
+appropriate profile. Available profiles are configured in [Cargo.toml] and are listed here:
+
+- `release`: this is the profile used for release builds, and will produce a fully-optimized
+production quality release binary. The compile time for this profile can be quite long, so for
+rapid iteration, this profile is not recommended.
+- `quick-release`: this is a modified version of `release` intended to produce a close-to-production
+binary, but with a faster build time. So, it is more suitable to rapid iterations and testing out
+changes.
+- `bench`: this is the same as `release`, but will compile the binary with `debuginfo` turned on
+for more readable symbols in generated profiles.
+- `quick-bench`: a modified version of `quick-release` that compiles the binary with `debuginfo`
+turned on.
+- `dev`: this profile produces an unoptimized binary with `debuginfo` turned on.
+
+Generally, if you are getting started, we recommend you use either the `quick-release` or
+`quick-bench` profiles to get up and running faster, then once you want to get as much performance
+as you can out of the binary, use `release` or `bench`.
+
+### Building and running the binary
+
+Once you have chosen a profile, you can build the `influxdb3` binary using cargo:
+
+```
+cargo build -p influxdb3 --profile <profile>
+```
+
+This will build the binary and place it in the `target` folder in your working directory, e.g.,
+`target/<profile>/influxdb3`.
+
+You can then prfile the `influxdb3` server, or whichever command, using the fully-qualified path
+and the profiling tools of your choice. For example,
+
+```
+<path_to_working_directory>/target/<profile>/influxdb3 serve
+```


### PR DESCRIPTION
Part of #25067

Changes in this PR:
* Addition of a `PROFILING.md` file, which briefly outlines how to build the `influxdb3` binary in preparation for profiling
* Addition of a `quick-bench` profile, which extends the already existing `quick-release` profile with `debuginfo` turned on