### PR TITLE
fix: prevent retention service from hanging

### DIFF
--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -14,38 +14,40 @@ import (
 
 // TSDBStoreMock is a mockable implementation of tsdb.Store.
 type TSDBStoreMock struct {
-	BackupShardFn             func(id uint64, since time.Time, w io.Writer) error
-	BackupSeriesFileFn        func(database string, w io.Writer) error
-	ExportShardFn             func(id uint64, ExportStart time.Time, ExportEnd time.Time, w io.Writer) error
-	CloseFn                   func() error
-	CreateShardFn             func(database, policy string, shardID uint64, enabled bool) error
-	CreateShardSnapshotFn     func(id uint64) (string, error)
-	DatabasesFn               func() []string
-	DeleteDatabaseFn          func(name string) error
-	DeleteMeasurementFn       func(ctx context.Context, database, name string) error
-	DeleteRetentionPolicyFn   func(database, name string) error
-	DeleteSeriesFn            func(ctx context.Context, database string, sources []influxql.Source, condition influxql.Expr) error
-	DeleteShardFn             func(id uint64) error
-	DiskSizeFn                func() (int64, error)
-	ExpandSourcesFn           func(sources influxql.Sources) (influxql.Sources, error)
-	ImportShardFn             func(id uint64, r io.Reader) error
-	MeasurementsCardinalityFn func(database string) (int64, error)
-	MeasurementNamesFn        func(ctx context.Context, auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error)
-	OpenFn                    func() error
-	PathFn                    func() string
-	RestoreShardFn            func(id uint64, r io.Reader) error
-	SeriesCardinalityFn       func(database string) (int64, error)
-	SetShardEnabledFn         func(shardID uint64, enabled bool) error
-	ShardFn                   func(id uint64) *tsdb.Shard
-	ShardGroupFn              func(ids []uint64) tsdb.ShardGroup
-	ShardIDsFn                func() []uint64
-	ShardNFn                  func() int
-	ShardRelativePathFn       func(id uint64) (string, error)
-	ShardsFn                  func(ids []uint64) []*tsdb.Shard
-	TagKeysFn                 func(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
-	TagValuesFn               func(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
-	WithLoggerFn              func(log *zap.Logger)
-	WriteToShardFn            func(shardID uint64, points []models.Point) error
+	BackupShardFn               func(id uint64, since time.Time, w io.Writer) error
+	BackupSeriesFileFn          func(database string, w io.Writer) error
+	ExportShardFn               func(id uint64, ExportStart time.Time, ExportEnd time.Time, w io.Writer) error
+	CloseFn                     func() error
+	CreateShardFn               func(database, policy string, shardID uint64, enabled bool) error
+	CreateShardSnapshotFn       func(id uint64) (string, error)
+	DatabasesFn                 func() []string
+	DeleteDatabaseFn            func(name string) error
+	DeleteMeasurementFn         func(ctx context.Context, database, name string) error
+	DeleteRetentionPolicyFn     func(database, name string) error
+	DeleteSeriesFn              func(ctx context.Context, database string, sources []influxql.Source, condition influxql.Expr) error
+	DeleteShardFn               func(id uint64) error
+	DiskSizeFn                  func() (int64, error)
+	ExpandSourcesFn             func(sources influxql.Sources) (influxql.Sources, error)
+	ImportShardFn               func(id uint64, r io.Reader) error
+	MeasurementsCardinalityFn   func(database string) (int64, error)
+	MeasurementNamesFn          func(ctx context.Context, auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error)
+	OpenFn                      func() error
+	PathFn                      func() string
+	RestoreShardFn              func(id uint64, r io.Reader) error
+	SeriesCardinalityFn         func(database string) (int64, error)
+	SetShardEnabledFn           func(shardID uint64, enabled bool) error
+	SetShardNewReadersBlockedFn func(shardID uint64, blocked bool) error
+	ShardFn                     func(id uint64) *tsdb.Shard
+	ShardGroupFn                func(ids []uint64) tsdb.ShardGroup
+	ShardIDsFn                  func() []uint64
+	ShardInUseFn                func(shardID uint64) (bool, error)
+	ShardNFn                    func() int
+	ShardRelativePathFn         func(id uint64) (string, error)
+	ShardsFn                    func(ids []uint64) []*tsdb.Shard
+	TagKeysFn                   func(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
+	TagValuesFn                 func(ctx context.Context, auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
+	WithLoggerFn                func(log *zap.Logger)
+	WriteToShardFn              func(shardID uint64, points []models.Point) error
 }
 
 func (s *TSDBStoreMock) BackupShard(id uint64, since time.Time, w io.Writer) error {
@@ -112,6 +114,9 @@ func (s *TSDBStoreMock) SeriesCardinality(database string) (int64, error) {
 func (s *TSDBStoreMock) SetShardEnabled(shardID uint64, enabled bool) error {
 	return s.SetShardEnabledFn(shardID, enabled)
 }
+func (s *TSDBStoreMock) SetShardNewReadersBlocked(shardID uint64, blocked bool) error {
+	return s.SetShardNewReadersBlockedFn(shardID, blocked)
+}
 func (s *TSDBStoreMock) Shard(id uint64) *tsdb.Shard {
 	return s.ShardFn(id)
 }
@@ -120,6 +125,9 @@ func (s *TSDBStoreMock) ShardGroup(ids []uint64) tsdb.ShardGroup {
 }
 func (s *TSDBStoreMock) ShardIDs() []uint64 {
 	return s.ShardIDsFn()
+}
+func (s *TSDBStoreMock) ShardInUse(shardID uint64) (bool, error) {
+	return s.ShardInUseFn(shardID)
 }
 func (s *TSDBStoreMock) ShardN() int {
 	return s.ShardNFn()

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -34,6 +34,9 @@ type Engine interface {
 	SetCompactionsEnabled(enabled bool)
 	ScheduleFullCompaction() error
 
+	SetNewReadersBlocked(blocked bool) error
+	InUse() (bool, error)
+
 	WithLogger(*zap.Logger)
 
 	LoadMetadataIndex(shardID uint64, index Index) error

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -712,7 +712,7 @@ type Compactor struct {
 
 	FileStore interface {
 		NextGeneration() int
-		TSMReader(path string) *TSMReader
+		TSMReader(path string) (*TSMReader, error)
 	}
 
 	// RateLimit is the limit for disk writes for all concurrent compactions.
@@ -943,7 +943,10 @@ func (c *Compactor) compact(fast bool, tsmFiles []string, logger *zap.Logger) ([
 		default:
 		}
 
-		tr := c.FileStore.TSMReader(file)
+		tr, err := c.FileStore.TSMReader(file)
+		if err != nil {
+			return nil, errCompactionAborted{fmt.Errorf("error creating reader for %q: %w", file, err)}
+		}
 		if tr == nil {
 			// This would be a bug if this occurred as tsmFiles passed in should only be
 			// assigned to one compaction at any one time.  A nil tr would mean the file

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -3074,11 +3074,11 @@ func (w *fakeFileStore) BlockCount(path string, idx int) int {
 	return w.blockCount
 }
 
-func (w *fakeFileStore) TSMReader(path string) *tsm1.TSMReader {
+func (w *fakeFileStore) TSMReader(path string) (*tsm1.TSMReader, error) {
 	r := MustOpenTSMReader(path)
 	w.readers = append(w.readers, r)
 	r.Ref()
-	return r
+	return r, nil
 }
 
 func (w *fakeFileStore) Close() {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -507,6 +507,24 @@ func (e *Engine) disableSnapshotCompactions() {
 	}
 }
 
+// SetNewReadersBlocked sets if new readers can access the shard. If blocked
+// is true, the number of reader blocks is incremented and new readers will
+// receive an error instead of shard access. If blocked is false, the number
+// of reader blocks is decremented. If the reader blocks drops to 0, then
+// new readers will be granted access to the shard.
+func (e *Engine) SetNewReadersBlocked(blocked bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.FileStore.SetNewReadersBlocked(blocked)
+}
+
+// InUse returns true if the shard is in-use by readers.
+func (e *Engine) InUse() (bool, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.FileStore.InUse()
+}
+
 // ScheduleFullCompaction will force the engine to fully compact all data stored.
 // This will cancel and running compactions and snapshot any data in the cache to
 // TSM files.  This is an expensive operation.

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -35,6 +35,10 @@ const (
 	BadTSMFileExtension = "bad"
 )
 
+var (
+	ErrNewReadersBlocked = errors.New("new readers blocked")
+)
+
 // TSMFile represents an on-disk TSM file.
 type TSMFile interface {
 	// Path returns the underlying file path for the TSMFile.  If the file
@@ -190,6 +194,10 @@ type FileStore struct {
 	obs tsdb.FileStoreObserver
 
 	copyFiles bool
+
+	// newReaderBlockCount keeps track of the current new reader block requests.
+	// If non-zero, no new TSMReader objects may be created.
+	newReaderBlockCount int
 }
 
 // FileStat holds information about a TSM file on disk.
@@ -391,6 +399,10 @@ func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) e
 		f.mu.RUnlock()
 		return nil
 	}
+	if f.newReadersBlocked() {
+		f.mu.RUnlock()
+		return fmt.Errorf("WalkKeys: %q: %w", f.dir, ErrNewReadersBlocked)
+	}
 
 	// Ensure files are not unmapped while we're iterating over them.
 	for _, r := range f.files {
@@ -449,6 +461,10 @@ func (f *FileStore) Apply(ctx context.Context, fn func(r TSMFile) error) error {
 	limiter := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
 	f.mu.RLock()
+	if f.newReadersBlocked() {
+		f.mu.RUnlock()
+		return fmt.Errorf("Apply: %q: %w", f.dir, ErrNewReadersBlocked)
+	}
 	errC := make(chan error, len(f.files))
 
 	for _, f := range f.files {
@@ -725,22 +741,85 @@ func (f *FileStore) Cost(key []byte, min, max int64) query.IteratorCost {
 // Reader returns a TSMReader for path if one is currently managed by the FileStore.
 // Otherwise it returns nil. If it returns a file, you must call Unref on it when
 // you are done, and never use it after that.
-func (f *FileStore) TSMReader(path string) *TSMReader {
+func (f *FileStore) TSMReader(path string) (*TSMReader, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	if f.newReadersBlocked() {
+		return nil, fmt.Errorf("TSMReader: %q (%q): %w", f.dir, path, ErrNewReadersBlocked)
+	}
 	for _, r := range f.files {
 		if r.Path() == path {
 			r.Ref()
-			return r.(*TSMReader)
+			return r.(*TSMReader), nil
 		}
 	}
+	return nil, nil
+}
+
+// SetNewReadersBlocked sets if new readers can access the files in this FileStore.
+// If blocked is true, the number of reader blocks is incremented and new readers will
+// receive an error instead of reader access. If blocked is false, the number
+// of reader blocks is decremented. If the reader blocks drops to 0, then
+// new readers will be granted access to the files.
+func (f *FileStore) SetNewReadersBlocked(block bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if block {
+		if f.newReaderBlockCount < 0 {
+			return fmt.Errorf("newReaderBlockCount for %q was %d before block operation, block failed", f.dir, f.newReaderBlockCount)
+		}
+		f.newReaderBlockCount++
+	} else {
+		if f.newReaderBlockCount <= 0 {
+			return fmt.Errorf("newReadersBlockCount for %q was %d before unblock operation, unblock failed", f.dir, f.newReaderBlockCount)
+		}
+		f.newReaderBlockCount--
+	}
 	return nil
+}
+
+// newReadersBlocked returns true if new references to TSMReader objects are not allowed.
+// Must be called with f.mu lock held (reader or writer).
+// See SetNewReadersBlocked for interface to allow and block access to TSMReader objects.
+func (f *FileStore) newReadersBlocked() bool {
+	return f.newReaderBlockCount > 0
+}
+
+// InUse returns true if any files in this FileStore are in-use.
+// InUse can only be called if a new readers have been blocked using SetNewReadersBlocked.
+// This is to avoid a race condition between calling InUse and attempting an operation
+// that requires no active readers. Calling InUse without a new readers block results
+// in an error.
+func (f *FileStore) InUse() (bool, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if !f.newReadersBlocked() {
+		return false, fmt.Errorf("InUse called without a new reader block for %q", f.dir)
+	}
+	for _, r := range f.files {
+		if r.InUse() {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // KeyCursor returns a KeyCursor for key and t across the files in the FileStore.
 func (f *FileStore) KeyCursor(ctx context.Context, key []byte, t int64, ascending bool) *KeyCursor {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	if f.newReadersBlocked() {
+		// New readers are blocked for this FileStore because there is a delete attempt in progress.
+		// Return an empty cursor to appease the callers since they generally don't handle
+		// a nil KeyCursor gracefully.
+		return &KeyCursor{
+			key:       key,
+			seeks:     nil,
+			ctx:       ctx,
+			col:       metrics.GroupFromContext(ctx),
+			ascending: ascending,
+		}
+	}
 	return newKeyCursor(ctx, f, key, t, ascending)
 }
 
@@ -1216,6 +1295,10 @@ func (f *FileStore) CreateSnapshot() (string, error) {
 	f.traceLogger.Info("Creating snapshot", zap.String("dir", f.dir))
 
 	f.mu.Lock()
+	if f.newReadersBlocked() {
+		f.mu.Unlock()
+		return "", fmt.Errorf("CreateSnapshot: %q: %w", f.dir, ErrNewReadersBlocked)
+	}
 	// create a copy of the files slice and ensure they aren't closed out from
 	// under us, nor the slice mutated.
 	files := make([]TSMFile, len(f.files))

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -2782,6 +2783,154 @@ func newTestFileStore(tb testing.TB, dir string) *tsm1.FileStore {
 	})
 
 	return fs
+}
+
+func TestFileStore_ReaderBlocking(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 3 TSM files...
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+	}
+
+	files, err := newFileDir(t, dir, data...)
+	require.NoError(t, err)
+
+	fs := newTestFileStore(t, dir)
+	require.NoError(t, fs.Open(context.Background()))
+
+	fsInUse := func() bool {
+		t.Helper()
+		require.NoError(t, fs.SetNewReadersBlocked(true))
+		defer func() {
+			t.Helper()
+			require.NoError(t, fs.SetNewReadersBlocked(false))
+		}()
+		inUse, err := fs.InUse()
+		require.NoError(t, err)
+		return inUse
+	}
+
+	checkUnblocked := func() {
+		t.Helper()
+
+		require.False(t, fsInUse())
+		_, err := fs.InUse()
+
+		var applyCount atomic.Uint32
+		err = fs.Apply(context.Background(), func(r tsm1.TSMFile) error {
+			applyCount.Add(1)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, uint32(len(files)), applyCount.Load(), "Apply should be called for all files")
+
+		snap, err := fs.CreateSnapshot()
+		require.NoError(t, err)
+		require.NotEmpty(t, snap)
+
+		buf := make([]tsm1.FloatValue, 1000)
+		c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+		// closeC exists because we want to call c.Close() if a test fails in a defer,
+		// but we also need to call c.Close() as part of the test. closeC makes sure we
+		// don't double close it.
+		closeC := func() {
+			t.Helper()
+			if c != nil {
+				c.Close() // Close does not return anything
+				c = nil
+			}
+		}
+		defer closeC()
+		require.NotNil(t, c)
+		require.True(t, fsInUse())
+
+		values, err := c.ReadFloatBlock(&buf)
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+		c.Next()
+		values, err = c.ReadFloatBlock(&buf)
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+		c.Next()
+		values, err = c.ReadFloatBlock(&buf)
+		require.NoError(t, err)
+		require.Empty(t, values)
+		closeC()
+		require.False(t, fsInUse())
+
+		r, err := fs.TSMReader(files[0])
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		require.True(t, fsInUse())
+		r.Unref()
+		require.False(t, fsInUse())
+
+		// Keys() will call WalkKeys() which will can be blocked.
+		keys := fs.Keys()
+		require.NotNil(t, keys)
+		require.Len(t, keys, 2)
+
+		require.False(t, fsInUse())
+	}
+
+	checkBlocked := func() {
+		t.Helper()
+
+		require.False(t, fsInUse())
+
+		applyCount := 0
+		err := fs.Apply(context.Background(), func(r tsm1.TSMFile) error {
+			applyCount++
+			return nil
+		})
+		require.ErrorIs(t, err, tsm1.ErrNewReadersBlocked)
+		require.Zero(t, applyCount, "Apply should not be called for any files when new readers are blocked")
+
+		snap, err := fs.CreateSnapshot()
+		require.ErrorIs(t, err, tsm1.ErrNewReadersBlocked)
+		require.Empty(t, snap)
+
+		buf := make([]tsm1.FloatValue, 1000)
+		c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+		require.NotNil(t, c)
+		defer c.Close()
+		values, err := c.ReadFloatBlock(&buf)
+		require.NoError(t, err)
+		require.Empty(t, values)
+
+		r, err := fs.TSMReader(files[0])
+		require.ErrorIs(t, err, tsm1.ErrNewReadersBlocked)
+		require.Nil(t, r)
+
+		// Keys() will call WalkKeys() which will can be blocked.
+		keys := fs.Keys()
+		require.Nil(t, keys)
+
+		require.False(t, fsInUse())
+	}
+
+	checkUnblocked()
+	require.NoError(t, fs.SetNewReadersBlocked(true))
+	checkBlocked()
+
+	// nested block
+	require.NoError(t, fs.SetNewReadersBlocked(true))
+	checkBlocked()
+
+	// still blocked
+	require.NoError(t, fs.SetNewReadersBlocked(false))
+	checkBlocked()
+
+	// unblocked
+	require.NoError(t, fs.SetNewReadersBlocked(false))
+	checkUnblocked()
+
+	// Too many unblocks, sir, too many.
+	require.Error(t, fs.SetNewReadersBlocked(false))
+	checkUnblocked()
 }
 
 type mockObserver struct {

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -2817,7 +2817,6 @@ func TestFileStore_ReaderBlocking(t *testing.T) {
 		t.Helper()
 
 		require.False(t, fsInUse())
-		_, err := fs.InUse()
 
 		var applyCount atomic.Uint32
 		err = fs.Apply(context.Background(), func(r tsm1.TSMFile) error {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -200,6 +200,24 @@ func (s *Shard) setEnabledNoLock(enabled bool) {
 	}
 }
 
+// SetNewReadersBlocked sets if new readers can access the shard. If blocked
+// is true, the number of reader blocks is incremented and new readers will
+// receive an error instead of shard access. If blocked is false, the number
+// of reader blocks is decremented. If the reader blocks drops to 0, then
+// new readers will be granted access to the shard.
+func (s *Shard) SetNewReadersBlocked(blocked bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s._engine.SetNewReadersBlocked(blocked)
+}
+
+// InUse returns true if this shard is in-use.
+func (s *Shard) InUse() (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s._engine.InUse()
+}
+
 // ScheduleFullCompaction forces a full compaction to be schedule on the shard.
 func (s *Shard) ScheduleFullCompaction() error {
 	engine, err := s.Engine()

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -17,6 +17,9 @@ import (
 	"testing"
 	"time"
 
+	assert2 "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -29,7 +32,6 @@ import (
 	_ "github.com/influxdata/influxdb/v2/tsdb/engine"
 	_ "github.com/influxdata/influxdb/v2/tsdb/index"
 	"github.com/influxdata/influxql"
-	assert2 "github.com/stretchr/testify/assert"
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
@@ -1148,6 +1150,87 @@ _reserved,region=uswest value="foo" 0
 			})
 		}
 		sh.Close()
+	}
+}
+
+func TestShard_ReadersBlocked(t *testing.T) {
+	setup := func(index string) Shards {
+		shards := NewShards(t, index, 2)
+		shards.MustOpen()
+
+		shards[0].MustWritePointsString(`cpu,host=serverA,region=uswest a=2.2,b=33.3,value=100 0`)
+
+		shards[1].MustWritePointsString(`
+			cpu,host=serverA,region=uswest a=2.2,c=12.3,value=100,z="hello" 0
+			disk q=100 0
+		`)
+
+		shards[0].Shard.ScheduleFullCompaction()
+		shards[1].Shard.ScheduleFullCompaction()
+
+		return shards
+	}
+
+	shardInUse := func(sh *tsdb.Shard) bool {
+		t.Helper()
+		require.NoError(t, sh.SetNewReadersBlocked(true))
+		defer sh.SetNewReadersBlocked(false)
+		inUse, err := sh.InUse()
+		require.NoError(t, err)
+		return inUse
+	}
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(fmt.Sprintf("%s_readers_blocked", index), func(t *testing.T) {
+			shards := setup(index)
+			defer shards.Close()
+
+			s1 := shards[0].Shard
+			m := influxql.Measurement{
+				Database:        "db0",
+				RetentionPolicy: "rp0",
+				Name:            "cpu",
+			}
+			opts := query.IteratorOptions{
+				Aux:        []influxql.VarRef{{Val: "a", Type: influxql.Float}, {Val: "b", Type: influxql.Float}},
+				StartTime:  models.MinNanoTime,
+				EndTime:    models.MaxNanoTime,
+				Ascending:  false,
+				Limit:      5,
+				Ordered:    true,
+				Authorizer: query.OpenAuthorizer,
+			}
+
+			// Block new readers. Due to internal interfaces, CreateIterator won't return an error but
+			// it should return a faux iterator.
+			require.NoError(t, s1.SetNewReadersBlocked(true))
+			require.False(t, shardInUse(s1))
+			it, err := s1.CreateIterator(context.Background(), &m, opts)
+			require.NoError(t, err) // It would be great to get an error, but alas that's major internal replumbing.
+			require.NotNil(t, it)
+			require.False(t, shardInUse(s1)) // Remember, it isn't a real iterator.
+			fit, ok := it.(query.FloatIterator)
+			require.True(t, ok)
+			p, err := fit.Next()
+			require.NoError(t, err)
+			require.Nil(t, p)
+			require.NoError(t, fit.Close())
+			require.NoError(t, s1.SetNewReadersBlocked(false))
+			require.False(t, shardInUse(s1))
+
+			// CreateIterator, make sure shard shows as in-use during iterator life.
+			require.False(t, shardInUse(s1))
+			it, err = s1.CreateIterator(context.Background(), &m, opts)
+			require.NoError(t, err)
+			fit, ok = it.(query.FloatIterator)
+			require.True(t, ok)
+			p, err = fit.Next()
+			require.NoError(t, err)
+			require.NotNil(t, p)
+			require.True(t, shardInUse(s1))
+			require.NoError(t, fit.Close())
+			require.False(t, shardInUse(s1))
+		})
 	}
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -757,6 +757,31 @@ func (s *Store) DeleteShards() error {
 	return nil
 }
 
+// SetShardNewReadersBlocked sets if new readers can access the shard. If blocked
+// is true, the number of reader blocks is incremented and new readers will
+// receive an error instead of shard access. If blocked is false, the number
+// of reader blocks is decremented. If the reader blocks drops to 0, then
+// new readers will be granted access to the shard.
+func (s *Store) SetShardNewReadersBlocked(shardID uint64, blocked bool) error {
+	sh := s.Shard(shardID)
+	if sh == nil {
+		return fmt.Errorf("SetShardNewReadersBlocked: shardID=%d, blocked=%t: %w", shardID, blocked, ErrShardNotFound)
+	}
+	return sh.SetNewReadersBlocked(blocked)
+}
+
+// ShardInUse returns true if a shard is in-use (e.g. has active readers).
+// SetShardNewReadersBlocked(id, true) should be called before checking
+// ShardInUse to prevent race conditions where a reader could gain
+// access to the shard immediately after ShardInUse is called.
+func (s *Store) ShardInUse(shardID uint64) (bool, error) {
+	sh := s.Shard(shardID)
+	if sh == nil {
+		return false, fmt.Errorf("ShardInUse: shardID=%d: %w", shardID, ErrShardNotFound)
+	}
+	return sh.InUse()
+}
+
 // DeleteShard removes a shard from disk.
 func (s *Store) DeleteShard(shardID uint64) error {
 	sh := s.Shard(shardID)


### PR DESCRIPTION
Fix issue that can cause the retention service to hang waiting on a `Shard.Close` call. When this occurs, no other shards will be deleted by the retention service. This is usually noticed as an increase in disk usage because old shards are not cleaned up.

The fix adds to new methods to `Store`, `SetShardNewReadersBlocked` and `InUse`. `InUse` can be used to poll if a shard has active readers, which the retention service uses to skip over in-use shards to prevent the service from hanging. `SetShardNewReadersBlocked` determines if new read access may be granted to a shard. This is required to prevent race conditions around the use of `InUse` and the deletion of shards.

If the retention service skips over a shard because it is in-use, the shard will be checked again the next time the retention service is run. It can be deleted on subsequent checks if it is no longer in-use. If the shards is stuck in-use, the retention service will not be able to delete the shards, which can be observed in the logs for manual intervention. Other shards can still be deleted by the retention service even if a shard is stuck with readers.

This is a port of ad68ec8 from master-1.x to main-2.x.

closes: #25076
(cherry picked from commit b4bd607eefe4af3c38a73a5883866a66daecd7db)
