### PR TITLE
fix: prevent retention service creating orphaned shard files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/google/btree v1.0.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-jsonnet v0.17.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.0.2
 	github.com/influxdata/cron v0.0.0-20201006132531-4bb0a200dcbe
 	github.com/influxdata/flux v0.195.1
@@ -161,7 +162,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect


### PR DESCRIPTION
Under certain circumstances, the retention service can fail to delete shards from the store in a timely manner. When the shard groups are pruned based on age, this leaves orphaned shard files on the disk. The retention service will then not attempt to remove the obsolete shard files because the meta store does not know about them. This can cause excessive disk space usage for some users.

This corrects that by requiring shards files be deleted before they can be removed from the meta store.

closes: #25116
(cherry picked from commit 7bd3f89d181fdb789e87f9380961f42d7790de5c) closes https://github.com/influxdata/influxdb/issues/24545

Co-authored-by: Geoffrey Wossum <gwossum@influxdata.com>
(cherry picked from commit 0dc48b12609d840b86cca439476e106fc2692d44)