### PR TITLE
feat: add partial param v1

### DIFF
--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1003,10 +1003,12 @@ async fn api_v1_query_chunked() {
                           "values": [
                             [1, "a", 0.9],
                             [2, "a", 0.89],
-                          ]
+                          ],
+                          "partial": true
                         }
                       ],
-                      "statement_id": 0
+                      "statement_id": 0,
+                      "partial": true
                     }
                   ]
                 }),
@@ -1044,10 +1046,12 @@ async fn api_v1_query_chunked() {
                             [1, "a", 0.9],
                             [2, "a", 0.89],
                             [3, "a", 0.85]
-                          ]
+                          ],
+                          "partial": true
                         }
                       ],
-                      "statement_id": 0
+                      "statement_id": 0,
+                      "partial": true
                     }
                   ]
                 }),
@@ -1086,10 +1090,12 @@ async fn api_v1_query_chunked() {
                           "values": [
                             [1, "a", 0.9],
                             [2, "a", 0.89],
-                          ]
+                          ],
+                          "partial": true
                         }
                       ],
-                      "statement_id": 0
+                      "statement_id": 0,
+                      "partial": true
                     }
                   ]
                 }),
@@ -1102,10 +1108,12 @@ async fn api_v1_query_chunked() {
                           "columns": ["time","host","usage"],
                           "values": [
                             [3, "a", 0.85]
-                          ]
+                          ],
+                          "partial": true
                         }
                       ],
-                      "statement_id": 0
+                      "statement_id": 0,
+                      "partial": true
                     }
                   ]
                 }),
@@ -1119,10 +1127,12 @@ async fn api_v1_query_chunked() {
                           "values": [
                             [4, "a", 0.5],
                             [5, "a", 0.6],
-                          ]
+                          ],
+                          "partial": true
                         }
                       ],
-                      "statement_id": 0
+                      "statement_id": 0,
+                      "partial": true
                     }
                   ]
                 }),


### PR DESCRIPTION
Closes #25014

This pull request includes the following changes:

- Adds the "Transfer-Encoding: chunked" header if the response is chunked.
- Adds support for the partial parameter in the JSON response.

Check-list:

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
