### PR TITLE
fix: restore windows build to working state

### DIFF
--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -7,7 +7,7 @@ use once_cell::sync::Lazy;
 /// The process name on the local OS running `influxdb3`
 pub const INFLUXDB3_PROCESS_NAME: &str = "influxdb3";
 
-#[cfg(feature = "jemalloc_replacing_malloc")]
+#[cfg(all(feature = "jemalloc_replacing_malloc", not(target_env = "msvc")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
Closes #25132

This restores windows build to work again as a cfg guard was missing to bypass jemalloc on window.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
