### PR TITLE
fix: prevent an infinite loop in measurementFieldSetChangeMgr (#25155)

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2276,10 +2276,12 @@ func (fscm *measurementFieldSetChangeMgr) appendToChangesFile(first writeRequest
 	// requests
 	for {
 		select {
-		case wr := <-fscm.writeRequests:
-			changes = append(changes, wr.changes)
-			errorChannels = append(errorChannels, wr.errorReturn)
-			continue
+		case wr, ok := <-fscm.writeRequests:
+			if ok {
+				changes = append(changes, wr.changes)
+				errorChannels = append(errorChannels, wr.errorReturn)
+				continue
+			}
 		default:
 		}
 		break


### PR DESCRIPTION
The measurementFieldSetChangeMgr has a possibly infinite loop if the writeRequests channel is closed while in the inner loop to consolidate write requests. We need to check for ok on channel receive and exit the loop when ok is false.

closes https://github.com/influxdata/influxdb/issues/25151

(cherry picked from commit 176fca2138a856ed54243a17d06e0926d200d382)

closes https://github.com/influxdata/influxdb/issues/25153