### PR TITLE
refactor: remove lower lock in last cache

### DIFF
--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -61,7 +61,7 @@ impl Error {
 }
 
 /// A three level hashmap storing Database Name -> Table Name -> Cache Name -> LastCache
-type CacheMap = RwLock<HashMap<String, HashMap<String, HashMap<String, Arc<LastCache>>>>>;
+type CacheMap = RwLock<HashMap<String, HashMap<String, HashMap<String, LastCache>>>>;
 
 /// Provides all last-N-value caches for the entire database
 pub struct LastCacheProvider {
@@ -118,12 +118,12 @@ impl LastCacheProvider {
     }
 
     /// Get a read guard on a [`LastCache`] from the provider
-    fn get_cache(
+    fn contains_cache(
         &self,
         db_name: &str,
         tbl_name: &str,
         cache_name: Option<&str>,
-    ) -> Result<Arc<LastCache>, Error> {
+    ) -> Option<(String, ArrowSchemaRef)> {
         self.cache_map
             .read()
             .get(db_name)
@@ -131,14 +131,15 @@ impl LastCacheProvider {
             .and_then(|tbl| {
                 if let Some(name) = cache_name {
                     tbl.get(name)
+                        .map(|lc| (name.to_string(), Arc::clone(&lc.schema)))
                 } else if tbl.len() == 1 {
-                    tbl.iter().map(|(_, lc)| lc).next()
+                    tbl.iter()
+                        .map(|(name, lc)| (name.to_string(), Arc::clone(&lc.schema)))
+                        .next()
                 } else {
                     None
                 }
             })
-            .ok_or(Error::CacheDoesNotExist)
-            .map(Arc::clone)
     }
 
     /// Create a new entry in the last cache for a given database and table, along with the given
@@ -282,7 +283,7 @@ impl LastCacheProvider {
             .or_default()
             .entry(tbl_name)
             .or_default()
-            .insert(cache_name.clone(), Arc::new(last_cache));
+            .insert(cache_name.clone(), last_cache);
 
         Ok(cache_name)
     }
@@ -384,11 +385,6 @@ pub(crate) struct LastCache {
     series_key: Option<HashSet<String>>,
     /// Whether or not this cache accepts newly written fields
     accept_new_fields: bool,
-    /// Contains the arrow schema and internal cache state
-    inner: RwLock<LastCacheInner>,
-}
-
-struct LastCacheInner {
     /// The Arrow Schema for the table that this cache is associated with
     schema: ArrowSchemaRef,
     /// The internal state of the cache
@@ -411,10 +407,8 @@ impl LastCache {
             key_columns: Arc::new(key_columns.into_iter().collect()),
             series_key,
             accept_new_fields,
-            inner: RwLock::new(LastCacheInner {
-                schema,
-                state: LastCacheState::Init,
-            }),
+            schema,
+            state: LastCacheState::Init,
         }
     }
 
@@ -438,12 +432,7 @@ impl LastCache {
                 "new configuration accepts new fields while the existing does not"
             }));
         }
-        if !self
-            .inner
-            .read()
-            .schema
-            .contains(&other.inner.read().schema)
-        {
+        if !self.schema.contains(&other.schema) {
             return Err(Error::cache_already_exists(
                 "the schema from specified value columns do not align",
             ));
@@ -464,10 +453,9 @@ impl LastCache {
     ///
     /// This will panic if the internal cache state's keys are out-of-order with respect to the
     /// order of the `key_columns` on this [`LastCache`]
-    pub(crate) fn push(&self, row: &Row) {
-        let mut inner = self.inner.write();
-        let schema = Arc::clone(&inner.schema);
-        let mut target = &mut inner.state;
+    pub(crate) fn push(&mut self, row: &Row) {
+        let schema = Arc::clone(&self.schema);
+        let mut target = &mut self.state;
         let mut key_iter = self.key_columns.iter().peekable();
         while let (Some(key), peek) = (key_iter.next(), key_iter.peek()) {
             if target.is_init() {
@@ -526,7 +514,7 @@ impl LastCache {
         };
 
         let mut sb = ArrowSchemaBuilder::new();
-        for f in inner.schema.fields().iter() {
+        for f in self.schema.fields().iter() {
             sb.push(Arc::clone(f));
         }
         for (name, data_type) in new_columns {
@@ -534,7 +522,7 @@ impl LastCache {
             sb.try_merge(&field).expect("buffer should have validated incoming writes to prevent against data type conflicts");
         }
         let new_schema = Arc::new(sb.finish());
-        inner.schema = new_schema;
+        self.schema = new_schema;
     }
 
     /// Produce a set of [`RecordBatch`]es from the cache, using the given set of [`Predicate`]s
@@ -547,10 +535,8 @@ impl LastCache {
             .map(|key| predicates.iter().find(|p| p.key == *key))
             .collect();
 
-        let inner = self.inner.read();
-
         let mut caches = vec![ExtendedLastCacheState {
-            state: &inner.state,
+            state: &self.state,
             additional_columns: vec![],
         }];
 
@@ -587,7 +573,7 @@ impl LastCache {
 
         caches
             .into_iter()
-            .map(|c| c.to_record_batch(&inner.schema))
+            .map(|c| c.to_record_batch(&self.schema))
             .collect()
     }
 
@@ -635,8 +621,8 @@ impl LastCache {
     }
 
     /// Remove expired values from the internal cache state
-    fn remove_expired(&self) {
-        self.inner.write().state.remove_expired();
+    fn remove_expired(&mut self) {
+        self.state.remove_expired();
     }
 }
 

--- a/influxdb3_write/src/last_cache/table_function.rs
+++ b/influxdb3_write/src/last_cache/table_function.rs
@@ -11,16 +11,24 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use super::{LastCache, LastCacheProvider};
+use super::LastCacheProvider;
+
+struct LastCacheFunctionProvider {
+    db_name: String,
+    table_name: String,
+    cache_name: String,
+    schema: SchemaRef,
+    provider: Arc<LastCacheProvider>,
+}
 
 #[async_trait]
-impl TableProvider for LastCache {
+impl TableProvider for LastCacheFunctionProvider {
     fn as_any(&self) -> &dyn Any {
-        &self.inner as &dyn Any
+        self as &dyn Any
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.inner.read().schema)
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> TableType {
@@ -41,8 +49,19 @@ impl TableProvider for LastCache {
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let predicates = self.convert_filter_exprs(filters);
-        let batches = self.to_record_batches(&predicates)?;
+        let read = self.provider.cache_map.read();
+        let batches = if let Some(cache) = read
+            .get(&self.db_name)
+            .and_then(|db| db.get(&self.table_name))
+            .and_then(|tbl| tbl.get(&self.cache_name))
+        {
+            let predicates = cache.convert_filter_exprs(filters);
+            cache.to_record_batches(&predicates)?
+        } else {
+            // If there is no cache, it means that it was removed, in which case, we just return
+            // an empty set of record batches.
+            vec![]
+        };
         let mut exec = MemoryExec::try_new(&[batches], self.schema(), projection.cloned())?;
 
         let show_sizes = ctx.config_options().explain.show_sizes;
@@ -82,12 +101,19 @@ impl TableFunctionImpl for LastCacheFunction {
 
         // Note: the compiler seems to get upset when using a functional approach, due to the
         // dyn Trait, so I've resorted to using a match:
-        match self
-            .provider
-            .get_cache(&self.db_name, table_name, cache_name.map(|x| x.as_str()))
-        {
-            Ok(last_cache) => Ok(last_cache),
-            Err(_) => plan_err!("unable to retrieve last cache using provided arguments"),
+        match self.provider.contains_cache(
+            &self.db_name,
+            table_name,
+            cache_name.map(|x| x.as_str()),
+        ) {
+            Some((cache_name, schema)) => Ok(Arc::new(LastCacheFunctionProvider {
+                db_name: self.db_name.clone(),
+                table_name: table_name.clone(),
+                cache_name,
+                schema,
+                provider: Arc::clone(&self.provider),
+            })),
+            None => plan_err!("could not find cache for the given arguments"),
         }
     }
 }


### PR DESCRIPTION
Part of #25095

This contains a single commit, and changes the `LastCache` design to eliminate the lower lock that was introduced in #25143.

I will leave a review with comments/concerns in-line.