### PR TITLE
feat: CLI to manage last caches

### DIFF
--- a/influxdb3/src/commands/last_cache/create.rs
+++ b/influxdb3/src/commands/last_cache/create.rs
@@ -1,0 +1,74 @@
+use std::error::Error;
+
+use secrecy::ExposeSecret;
+
+use crate::commands::common::InfluxDb3Config;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// The table name for which the cache is being created
+    #[clap(short = 't', long = "table")]
+    table: String,
+
+    /// Specify a name for the cache
+    #[clap(long = "cache-name")]
+    cache_name: Option<String>,
+
+    /// Specify which columns in the table to use as keys in the cache
+    #[clap(long = "key-columns")]
+    key_columns: Option<Vec<String>>,
+
+    /// Specify which columns in the table to store as values in the cache
+    #[clap(long = "value-columns")]
+    value_columns: Option<Vec<String>>,
+
+    /// Specify the number of entries per unique key column combination the cache will
+    /// store
+    #[clap(long = "count")]
+    count: Option<usize>,
+
+    /// Specify the time-to-live (TTL) for entries in a cache in seconds
+    #[clap(long = "ttl")]
+    ttl: Option<u64>,
+}
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let InfluxDb3Config {
+        host_url,
+        database_name,
+        auth_token,
+    } = config.influxdb3_config;
+    let mut client = influxdb3_client::Client::new(host_url)?;
+    if let Some(t) = auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+    let mut b = client.api_v3_configure_last_cache_create(database_name, config.table);
+
+    // Add optional parameters:
+    if let Some(name) = config.cache_name {
+        b = b.name(name);
+    }
+    if let Some(keys) = config.key_columns {
+        b = b.key_columns(keys);
+    }
+    if let Some(vals) = config.value_columns {
+        b = b.value_columns(vals);
+    }
+    if let Some(count) = config.count {
+        b = b.count(count);
+    }
+    if let Some(ttl) = config.ttl {
+        b = b.ttl(ttl);
+    }
+
+    // Make the request:
+    match b.send().await? {
+        Some(cache_name) => println!("new cache created: {cache_name}"),
+        None => println!("a cache already exists for the provided parameters"),
+    }
+
+    Ok(())
+}

--- a/influxdb3/src/commands/last_cache/create.rs
+++ b/influxdb3/src/commands/last_cache/create.rs
@@ -13,24 +13,23 @@ pub struct Config {
     #[clap(short = 't', long = "table")]
     table: String,
 
-    /// Specify a name for the cache
+    /// Give a name for the cache.
     #[clap(long = "cache-name")]
     cache_name: Option<String>,
 
-    /// Specify which columns in the table to use as keys in the cache
+    /// Which columns in the table to use as keys in the cache
     #[clap(long = "key-columns")]
     key_columns: Option<Vec<String>>,
 
-    /// Specify which columns in the table to store as values in the cache
+    /// Which columns in the table to store as values in the cache
     #[clap(long = "value-columns")]
     value_columns: Option<Vec<String>>,
 
-    /// Specify the number of entries per unique key column combination the cache will
-    /// store
+    /// The number of entries per unique key column combination the cache will store
     #[clap(long = "count")]
     count: Option<usize>,
 
-    /// Specify the time-to-live (TTL) for entries in a cache in seconds
+    /// The time-to-live (TTL) for entries in a cache in seconds
     #[clap(long = "ttl")]
     ttl: Option<u64>,
 }

--- a/influxdb3/src/commands/last_cache/delete.rs
+++ b/influxdb3/src/commands/last_cache/delete.rs
@@ -1,0 +1,38 @@
+use std::error::Error;
+
+use secrecy::ExposeSecret;
+
+use crate::commands::common::InfluxDb3Config;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// The table name for which the cache is being created
+    #[clap(short = 't', long = "table")]
+    table: String,
+
+    /// The cache name for which the cache is being created
+    #[clap(short = 'n', long = "cache-name")]
+    cache_name: String,
+}
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let InfluxDb3Config {
+        host_url,
+        database_name,
+        auth_token,
+    } = config.influxdb3_config;
+    let mut client = influxdb3_client::Client::new(host_url)?;
+    if let Some(t) = auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+    client
+        .api_v3_configure_last_cache_delete(database_name, config.table, config.cache_name)
+        .await?;
+
+    println!("last cache deleted successfully");
+
+    Ok(())
+}

--- a/influxdb3/src/commands/last_cache/delete.rs
+++ b/influxdb3/src/commands/last_cache/delete.rs
@@ -9,11 +9,11 @@ pub struct Config {
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
 
-    /// The table name for which the cache is being created
+    /// The table under which the cache is being deleted
     #[clap(short = 't', long = "table")]
     table: String,
 
-    /// The cache name for which the cache is being created
+    /// The name of the cache being deleted
     #[clap(short = 'n', long = "cache-name")]
     cache_name: String,
 }

--- a/influxdb3/src/commands/last_cache/mod.rs
+++ b/influxdb3/src/commands/last_cache/mod.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+
+pub mod create;
+pub mod delete;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Create a new last-n-value cache
+    Create(create::Config),
+    /// Delete an existing last-n-value cache
+    Delete(delete::Config),
+}
+
+pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    match config.command {
+        Command::Create(config) => create::command(config).await,
+        Command::Delete(config) => delete::command(config).await,
+    }
+}

--- a/influxdb3/src/commands/token.rs
+++ b/influxdb3/src/commands/token.rs
@@ -15,12 +15,13 @@ pub struct Config {
 
 #[derive(Debug, clap::Parser)]
 pub enum SubCommand {
-    Token,
+    /// Create a new auth token
+    Create,
 }
 
 pub fn command(config: Config) -> Result<(), Box<dyn Error>> {
     match config.cmd {
-        SubCommand::Token => {
+        SubCommand::Create => {
             let token = {
                 let mut token = String::from("apiv3_");
                 let mut key = [0u8; 64];

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -27,6 +27,7 @@ use trogging::{
 mod commands {
     pub(crate) mod common;
     pub mod create;
+    pub mod last_cache;
     pub mod query;
     pub mod serve;
     pub mod write;
@@ -87,6 +88,9 @@ enum Command {
 
     /// Create new resources
     Create(commands::create::Config),
+
+    /// Manage last-n-value caches
+    LastCache(commands::last_cache::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -135,6 +139,12 @@ fn main() -> Result<(), std::io::Error> {
             Some(Command::Create(config)) => {
                 if let Err(e) = commands::create::command(config) {
                     eprintln!("Create command failed: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::LastCache(config)) => {
+                if let Err(e) = commands::last_cache::command(config).await {
+                    eprintln!("Last Cache command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -26,10 +26,10 @@ use trogging::{
 
 mod commands {
     pub(crate) mod common;
-    pub mod create;
     pub mod last_cache;
     pub mod query;
     pub mod serve;
+    pub mod token;
     pub mod write;
 }
 
@@ -86,8 +86,8 @@ enum Command {
     /// Perform a set of writes to a running InfluxDB 3.0 server
     Write(commands::write::Config),
 
-    /// Create new resources
-    Create(commands::create::Config),
+    /// Manage tokens for your InfluxDB 3.0 server
+    Token(commands::token::Config),
 
     /// Manage last-n-value caches
     LastCache(commands::last_cache::Config),
@@ -136,9 +136,9 @@ fn main() -> Result<(), std::io::Error> {
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }
-            Some(Command::Create(config)) => {
-                if let Err(e) = commands::create::command(config) {
-                    eprintln!("Create command failed: {e}");
+            Some(Command::Token(config)) => {
+                if let Err(e) = commands::token::command(config) {
+                    eprintln!("Token command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }


### PR DESCRIPTION
Closes #25100

This PR adds a new command to the `influxdb3` CLI, which includes two sub-commands to create and delete last caches, respectively.

Here are each of their `--help` outputs:

### Creation

```
Create a new last-n-value cache

Usage: influxdb3 last-cache create [OPTIONS] --dbname <DATABASE_NAME> --table <TABLE>

Options:
  -h, --host <HOST_URL>                The host URL of the running InfluxDB 3.0 server [env: INFLUXDB3_HOST_URL=] [default: http://127.0.0.1:8181]
  -d, --dbname <DATABASE_NAME>         The database name to run the query against [env: INFLUXDB3_DATABASE_NAME=]
      --token <AUTH_TOKEN>             The token for authentication with the InfluxDB 3.0 server [env: INFLUXDB3_AUTH_TOKEN=]
  -t, --table <TABLE>                  The table name for which the cache is being created
      --cache-name <CACHE_NAME>        Give a name for the cache
      --help                           Print help information
      --key-columns <KEY_COLUMNS>      Which columns in the table to use as keys in the cache
      --value-columns <VALUE_COLUMNS>  Which columns in the table to store as values in the cache
      --count <COUNT>                  The number of entries per unique key column combination the cache will store
      --ttl <TTL>                      The time-to-live (TTL) for entries in a cache in seconds
```

### Deletion

```
Delete an existing last-n-value cache

Usage: influxdb3 last-cache delete [OPTIONS] --dbname <DATABASE_NAME> --table <TABLE> --cache-name <CACHE_NAME>

Options:
  -h, --host <HOST_URL>          The host URL of the running InfluxDB 3.0 server [env: INFLUXDB3_HOST_URL=] [default: http://127.0.0.1:8181]
  -d, --dbname <DATABASE_NAME>   The database name to run the query against [env: INFLUXDB3_DATABASE_NAME=]
      --token <AUTH_TOKEN>       The token for authentication with the InfluxDB 3.0 server [env: INFLUXDB3_AUTH_TOKEN=]
  -t, --table <TABLE>            The table under which the cache is being deleted
  -n, --cache-name <CACHE_NAME>  The name of the cache being deleted
      --help                     Print help information
```

## Other Changes

In addition to the above, this PR flips the order of the existing `influxdb3 create token` command to follow the same `influxdb3 <resource> <action>` paradigm as above, i.e., `influxdb3 token create`.