### PR TITLE
chore: upgrade go toolchain to 1.21.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.21.10-latest
+    default: go1.21.12-latest
 
   workflow:
     type: string


### PR DESCRIPTION
Fixes CVE-2024-24790, reported by X-Ray.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
