### PR TITLE
fix: fix compilation on alpine linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef
 	github.com/kevinburke/go-bindata v3.22.0+incompatible
 	github.com/mattn/go-isatty v0.0.19
-	github.com/mattn/go-sqlite3 v1.14.18
+	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/mileusna/useragent v0.0.0-20190129205925-3e331f0949a5
 	github.com/mna/pigeon v1.0.1-0.20180808201053-bb0192cfc2ae

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.18 h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI=
-github.com/mattn/go-sqlite3 v1.14.18/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-tty v0.0.4 h1:NVikla9X8MN0SQAqCYzpGyXv0jY7MNl3HOWD2dkle7E=
 github.com/mattn/go-tty v0.0.4/go.mod h1:u5GGXBtZU6RQoKV8gY5W6UhMudbR5vXnUe7j3pxse28=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/scripts/ci/test-downgrade.sh
+++ b/scripts/ci/test-downgrade.sh
@@ -29,7 +29,7 @@ function download_older_binary () {
 
     local -r archive="influxd-${target_version}.tar.gz"
     curl -sL -o "${dl_dir}/${archive}" "$dl_url"
-    echo "${dl_sha}  ${dl_dir}/${archive}" | sha256sum --check --
+    echo "${dl_sha}  ${dl_dir}/${archive}" | sha256sum -c --
     tar xzf "${dl_dir}/${archive}" -C "$dl_dir" --strip-components=1
     rm "${dl_dir}/${archive}"
     mv "${dl_dir}/influxd" "${dl_dir}/influxd-${target_version}"

--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -31,10 +31,10 @@ curl -L https://github.com/influxdata/ui/releases/download/$UI_RELEASE/build.tar
 # Verify the checksums match; exit if they don't.
 case "$(uname -s)" in
     FreeBSD | Darwin)
-        echo "$(cat sha256.txt)" | shasum --algorithm 256 --check \
+        echo "$(cat sha256.txt)" | shasum --algorithm 256 -c \
             || { echo "Checksums did not match for downloaded UI assets!"; exit 1; } ;;
     Linux)
-        echo "$(cat sha256.txt)" | sha256sum --check -- \
+        echo "$(cat sha256.txt)" | sha256sum -c -- \
             || { echo "Checksums did not match for downloaded UI assets!"; exit 1; } ;;
     *)
         echo "The '$(uname -s)' operating system is not supported as a build host for the UI" >&2


### PR DESCRIPTION
sha256sum in busybox doesn't support --check.

go-sqlite3 fails to build: https://github.com/mattn/go-sqlite3/issues/1164

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
