### PR TITLE
fix(tsi1): fix data race between appendEntry and FlushAndSync tsi1.(*LogFile)

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1086,8 +1086,8 @@ func (f *LogFile) seriesSketches() (sketch, tSketch estimator.Sketch, err error)
 }
 
 func (f *LogFile) Writes(entries []LogEntry) error {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
 	for i := range entries {
 		entry := &entries[i]

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1085,9 +1085,10 @@ func (f *LogFile) seriesSketches() (sketch, tSketch estimator.Sketch, err error)
 	return sketch, tSketch, nil
 }
 
-func (f *LogFile) ExecEntries(entries []LogEntry) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+func (f *LogFile) Writes(entries []LogEntry) error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for i := range entries {
 		entry := &entries[i]
 		if err := f.appendEntry(entry); err != nil {
@@ -1095,14 +1096,6 @@ func (f *LogFile) ExecEntries(entries []LogEntry) error {
 		}
 		f.execEntry(entry)
 	}
-	return nil
-}
-
-func (f *LogFile) Writes(entries []LogEntry) error {
-	if err := f.ExecEntries(entries); err != nil {
-		return err
-	}
-
 	// Flush buffer and sync to disk.
 	return f.FlushAndSync()
 }


### PR DESCRIPTION
Closes #25181

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/master-1.x/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

From version 1.6.6 to 1.8.10, there are two relevant changes in `tsdb/index/tsi1/log_file.go`:

- 331569bc11d9c4212812d33305d07fdb393e4150: `f.mu.RLock()` has been used instead of `f.mu.Lock()` in [`Writes(entries []LogEntry)`](https://github.com/influxdata/influxdb/commit/331569bc11d9c4212812d33305d07fdb393e4150#diff-a32d3c62b7f891108e6cf9d79c6aea67ea7cafe3c88d0e10feb3add4b0deb64bR1076), causing an internal map to be modified for concurrent use
- 4ef4fe9aef0a75f1058e493bd7c26434f40f8b0a: Fixed the problem of the previous commit 331569bc11d9c4212812d33305d07fdb393e4150, but do not solve the write competition problem between [`ExecEntries`](https://github.com/influxdata/influxdb/commit/4ef4fe9aef0a75f1058e493bd7c26434f40f8b0a#diff-a32d3c62b7f891108e6cf9d79c6aea67ea7cafe3c88d0e10feb3add4b0deb64bR1076) and [`f.FlushAndSync`](https://github.com/influxdata/influxdb/commit/4ef4fe9aef0a75f1058e493bd7c26434f40f8b0a#diff-a32d3c62b7f891108e6cf9d79c6aea67ea7cafe3c88d0e10feb3add4b0deb64bR1089)

So this pull request first reverts 4ef4fe9aef0a75f1058e493bd7c26434f40f8b0a, and then changes `f.mu.RLock()` to `f.mu.Lock()`.

Then this issue did not recur.

@davidby-influx 