### PR TITLE
test: add a test to check last cache init from catalog

### DIFF
--- a/influxdb3_write/src/catalog.rs
+++ b/influxdb3_write/src/catalog.rs
@@ -383,9 +383,9 @@ pub struct LastCacheDefinition {
 }
 
 impl LastCacheDefinition {
-    /// Create a new [`LastCacheDefinition`]
+    /// Create a new [`LastCacheDefinition`] with explicit value columns
     #[cfg(test)]
-    pub(crate) fn new(
+    pub(crate) fn new_with_explicit_value_columns(
         table: impl Into<String>,
         name: impl Into<String>,
         key_columns: impl IntoIterator<Item: Into<String>>,
@@ -400,6 +400,25 @@ impl LastCacheDefinition {
             value_columns: LastCacheValueColumnsDef::Explicit {
                 columns: value_columns.into_iter().map(Into::into).collect(),
             },
+            count: count.try_into()?,
+            ttl,
+        })
+    }
+
+    /// Create a new [`LastCacheDefinition`] with explicit value columns
+    #[cfg(test)]
+    pub(crate) fn new_all_non_key_value_columns(
+        table: impl Into<String>,
+        name: impl Into<String>,
+        key_columns: impl IntoIterator<Item: Into<String>>,
+        count: usize,
+        ttl: u64,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            table: table.into(),
+            name: name.into(),
+            key_columns: key_columns.into_iter().map(Into::into).collect(),
+            value_columns: LastCacheValueColumnsDef::AllNonKeyColumns,
             count: count.try_into()?,
             ttl,
         })
@@ -740,7 +759,7 @@ mod tests {
             SeriesKey::None,
         );
         table_def.add_last_cache(
-            LastCacheDefinition::new(
+            LastCacheDefinition::new_with_explicit_value_columns(
                 "test",
                 "test_table_last_cache",
                 ["tag_2", "tag_3"],

--- a/influxdb3_write/src/last_cache/snapshots/influxdb3_write__last_cache__tests__catalog_initialization.snap
+++ b/influxdb3_write/src/last_cache/snapshots/influxdb3_write__last_cache__tests__catalog_initialization.snap
@@ -1,0 +1,49 @@
+---
+source: influxdb3_write/src/last_cache/mod.rs
+expression: caches
+---
+[
+  {
+    "table": "test_table",
+    "name": "test_cache_1",
+    "key_columns": [
+      "t1",
+      "t2"
+    ],
+    "value_columns": {
+      "type": "all_non_key_columns"
+    },
+    "count": 1,
+    "ttl": 600
+  },
+  {
+    "table": "test_table_2",
+    "name": "test_cache_2",
+    "key_columns": [
+      "t1"
+    ],
+    "value_columns": {
+      "type": "explicit",
+      "columns": [
+        "f1",
+        "time"
+      ]
+    },
+    "count": 5,
+    "ttl": 60
+  },
+  {
+    "table": "test_table_2",
+    "name": "test_cache_3",
+    "key_columns": [],
+    "value_columns": {
+      "type": "explicit",
+      "columns": [
+        "f2",
+        "time"
+      ]
+    },
+    "count": 10,
+    "ttl": 500
+  }
+]


### PR DESCRIPTION
Part of #25183

This PR adds a unit test to check the function that initializes the last cache from a Catalog. It would also be useful to verify loading on server start/stop/restart, so I did not close the issue with this PR.