### PR TITLE
chore: Upgrade to rustc 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,7 +2416,6 @@ dependencies = [
  "num_cpus",
  "object_store",
  "observability_deps",
- "once_cell",
  "panic_logging",
  "parking_lot",
  "parquet_file",
@@ -2489,7 +2488,6 @@ version = "0.1.0"
 dependencies = [
  "iox_time",
  "metric",
- "once_cell",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ mime = "0.3.17"
 mockito = { version = "1.4.0", default-features = false }
 num_cpus = "1.16.0"
 object_store = "0.10.1"
-once_cell = { version = "1.18", features = ["parking_lot"] }
 parking_lot = "0.12.1"
 parquet = { version = "52.1.0", features = ["object_store"] }
 pbjson = "0.6.0"
@@ -139,20 +138,21 @@ tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63d
 trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63ddc10e3cf1c28b05e6c1cef03b71da7f8a", default-features = true, features = ["clap"] }
 
 [workspace.lints.rust]
-rust_2018_idioms = "deny"
-unreachable_pub = "deny"
-missing_debug_implementations = "deny"
 missing_copy_implementations = "deny"
+missing_debug_implementations = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+unreachable_pub = "deny"
 
 [workspace.lints.clippy]
-dbg_macro = "deny"
-todo = "deny"
 clone_on_ref_ptr = "deny"
+dbg_macro = "deny"
 future_not_send = "deny"
+todo = "deny"
 
 [workspace.lints.rustdoc]
-broken_intra_doc_links = "deny"
 bare_urls = "deny"
+broken_intra_doc_links = "deny"
 
 # This profile optimizes for runtime performance and small binary size at the expense of longer
 # build times. It's most suitable for final release builds.

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -38,7 +38,6 @@ hashbrown.workspace = true
 hex.workspace = true
 libc.workspace = true
 num_cpus.workspace = true
-once_cell.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
 secrecy.workspace = true

--- a/influxdb3_process/Cargo.toml
+++ b/influxdb3_process/Cargo.toml
@@ -14,7 +14,6 @@ metric.workspace = true
 tokio_metrics_bridge.workspace = true
 
 # Crates.io dependencies
-once_cell.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use iox_time::{SystemProvider, Time, TimeProvider};
 use metric::U64Gauge;
-use once_cell::sync::Lazy;
 
 /// The process name on the local OS running `influxdb3`
 pub const INFLUXDB3_PROCESS_NAME: &str = "influxdb3";
@@ -32,8 +31,8 @@ pub fn build_malloc_conf() -> String {
 }
 
 /// Package version.
-pub static INFLUXDB3_VERSION: Lazy<&'static str> =
-    Lazy::new(|| option_env!("CARGO_PKG_VERSION").unwrap_or("UNKNOWN"));
+pub static INFLUXDB3_VERSION: LazyLock<&'static str> =
+    LazyLock::new(|| option_env!("CARGO_PKG_VERSION").unwrap_or("UNKNOWN"));
 
 /// Build-time GIT revision hash.
 pub static INFLUXDB3_GIT_HASH: &str = env!(
@@ -48,7 +47,7 @@ pub static INFLUXDB3_GIT_HASH_SHORT: &str = env!(
 );
 
 /// Version string that is combined from [`INFLUXDB3_VERSION`] and [`INFLUXDB3_GIT_HASH`].
-pub static VERSION_STRING: Lazy<&'static str> = Lazy::new(|| {
+pub static VERSION_STRING: LazyLock<&'static str> = LazyLock::new(|| {
     let s = format!(
         "{}, revision {}",
         &INFLUXDB3_VERSION[..],
@@ -59,14 +58,14 @@ pub static VERSION_STRING: Lazy<&'static str> = Lazy::new(|| {
 });
 
 /// A UUID that is unique for the process lifetime.
-pub static PROCESS_UUID: Lazy<&'static str> = Lazy::new(|| {
+pub static PROCESS_UUID: LazyLock<&'static str> = LazyLock::new(|| {
     let s = uuid::Uuid::new_v4().to_string();
     let s: Box<str> = Box::from(s);
     Box::leak(s)
 });
 
 /// Process start time.
-pub static PROCESS_START_TIME: Lazy<Time> = Lazy::new(|| SystemProvider::new().now());
+pub static PROCESS_START_TIME: LazyLock<Time> = LazyLock::new(|| SystemProvider::new().now());
 
 pub fn setup_metric_registry() -> Arc<metric::Registry> {
     let registry = Arc::new(metric::Registry::default());
@@ -101,7 +100,7 @@ pub fn setup_metric_registry() -> Arc<metric::Registry> {
 
 /// String version of [`usize::MAX`].
 #[allow(dead_code)]
-pub static USIZE_MAX: Lazy<&'static str> = Lazy::new(|| {
+pub static USIZE_MAX: LazyLock<&'static str> = LazyLock::new(|| {
     let s = usize::MAX.to_string();
     let s: Box<str> = Box::from(s);
     Box::leak(s)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
This commit updates us to rustc 1.80. There are two significant changes here:

1. LazyLock and LazyCell have been stabilized meaning we can replace our usage of Lazy from the once_cell crate with the std lib versions
2. Lints were added to handle unknown cfg directives. `tokio_unstable` is affected by this and while we do have the flags in our .cargo/config.toml Cargo still output a lint for it so we supress that warning now in our Cargo.toml for the workspace

Besides that it was a painless upgrade and now we're on the latest and greatest.