### PR TITLE
feat: use host identifier prefix in object store paths

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -199,7 +199,8 @@ pub struct Config {
     )]
     pub buffer_mem_limit_mb: usize,
 
-    /// The host idendifier used as a prefix in all object store file paths.
+    /// The host idendifier used as a prefix in all object store file paths. This should be unique
+    /// for any hosts that share the same object store configuration, i.e., the same bucket.
     #[clap(long = "host-id", env = "INFLUXDB3_HOST_IDENTIFIER_PREFIX", action)]
     pub host_identifier_prefix: String,
 }

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -198,6 +198,10 @@ pub struct Config {
         action
     )]
     pub buffer_mem_limit_mb: usize,
+
+    /// The host idendifier used as a prefix in all object store file paths.
+    #[clap(long = "host-id", env = "INFLUXDB3_HOST_IDENTIFIER_PREFIX", action)]
+    pub host_identifier_prefix: String,
 }
 
 /// If `p` does not exist, try to create it as a directory.
@@ -289,7 +293,10 @@ pub async fn command(config: Config) -> Result<()> {
 
     let common_state =
         CommonServerState::new(Arc::clone(&metrics), trace_exporter, trace_header_parser)?;
-    let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+    let persister = Arc::new(PersisterImpl::new(
+        Arc::clone(&object_store),
+        config.host_identifier_prefix,
+    ));
     let wal_config = WalConfig {
         level_0_duration: config.level_0_duration.as_duration(),
         max_write_buffer_size: config.wal_max_write_buffer_size,

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -93,6 +93,7 @@ impl TestServer {
             .args(["--http-bind", &bind_addr.to_string()])
             .args(["--object-store", "memory"])
             .args(["--wal-flush-interval", "10ms"])
+            .args(["--host-id", "test-server"])
             .args(config.as_args());
 
         // If TEST_LOG env var is not defined, discard stdout/stderr
@@ -145,6 +146,7 @@ impl TestServer {
     }
 
     async fn wait_until_ready(&self) {
+        let mut count = 0;
         while self
             .http_client
             .get(format!("{base}/health", base = self.client_addr()))
@@ -152,6 +154,11 @@ impl TestServer {
             .await
             .is_err()
         {
+            if count > 500 {
+                panic!("server failed to start");
+            } else {
+                count += 1;
+            }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -768,7 +768,7 @@ mod tests {
             },
             DedicatedExecutor::new_testing(),
         ));
-        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(start_time)));
 
         let write_buffer = Arc::new(

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1554,7 +1554,7 @@ mod tests {
 
     async fn setup_write_buffer() -> WriteBufferImpl<MockProvider> {
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let persister = Arc::new(PersisterImpl::new(obj_store));
+        let persister = Arc::new(PersisterImpl::new(obj_store, "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         WriteBufferImpl::new(
             persister,

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -60,13 +60,18 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct PersisterImpl {
     object_store: Arc<dyn ObjectStore>,
+    host_identifier_prefix: String,
     pub(crate) mem_pool: Arc<dyn MemoryPool>,
 }
 
 impl PersisterImpl {
-    pub fn new(object_store: Arc<dyn ObjectStore>) -> Self {
+    pub fn new(
+        object_store: Arc<dyn ObjectStore>,
+        host_identifier_prefix: impl Into<String>,
+    ) -> Self {
         Self {
             object_store,
+            host_identifier_prefix: host_identifier_prefix.into(),
             mem_pool: Arc::new(UnboundedMemoryPool::default()),
         }
     }
@@ -76,6 +81,10 @@ impl PersisterImpl {
         batches: SendableRecordBatchStream,
     ) -> Result<ParquetBytes> {
         serialize_to_parquet(Arc::clone(&self.mem_pool), batches).await
+    }
+
+    pub fn host_identifier_prefix(&self) -> &str {
+        &self.host_identifier_prefix
     }
 }
 
@@ -115,7 +124,9 @@ impl Persister for PersisterImpl {
     type Error = Error;
 
     async fn load_catalog(&self) -> Result<Option<PersistedCatalog>> {
-        let mut list = self.object_store.list(Some(&CatalogFilePath::dir()));
+        let mut list = self
+            .object_store
+            .list(Some(&CatalogFilePath::dir(&self.host_identifier_prefix)));
         let mut catalog_path: Option<ObjPath> = None;
         while let Some(item) = list.next().await {
             let item = item?;
@@ -181,10 +192,14 @@ impl Persister for PersisterImpl {
             };
 
             let mut snapshot_list = if let Some(offset) = offset {
-                self.object_store
-                    .list_with_offset(Some(&SnapshotInfoFilePath::dir()), &offset)
+                self.object_store.list_with_offset(
+                    Some(&SnapshotInfoFilePath::dir(&self.host_identifier_prefix)),
+                    &offset,
+                )
             } else {
-                self.object_store.list(Some(&SnapshotInfoFilePath::dir()))
+                self.object_store.list(Some(&SnapshotInfoFilePath::dir(
+                    &self.host_identifier_prefix,
+                )))
             };
 
             // Why not collect into a Result<Vec<ObjectMeta>, object_store::Error>>
@@ -232,7 +247,10 @@ impl Persister for PersisterImpl {
         wal_file_sequence_number: WalFileSequenceNumber,
         catalog: Catalog,
     ) -> Result<()> {
-        let catalog_path = CatalogFilePath::new(wal_file_sequence_number);
+        let catalog_path = CatalogFilePath::new(
+            self.host_identifier_prefix.as_str(),
+            wal_file_sequence_number,
+        );
         let json = serde_json::to_vec_pretty(&catalog)?;
         self.object_store
             .put(catalog_path.as_ref(), json.into())
@@ -241,8 +259,10 @@ impl Persister for PersisterImpl {
     }
 
     async fn persist_snapshot(&self, persisted_snapshot: &PersistedSnapshot) -> Result<()> {
-        let snapshot_file_path =
-            SnapshotInfoFilePath::new(persisted_snapshot.wal_file_sequence_number);
+        let snapshot_file_path = SnapshotInfoFilePath::new(
+            self.host_identifier_prefix.as_str(),
+            persisted_snapshot.wal_file_sequence_number,
+        );
         let json = serde_json::to_vec_pretty(persisted_snapshot)?;
         self.object_store
             .put(snapshot_file_path.as_ref(), json.into())
@@ -345,7 +365,7 @@ mod tests {
     async fn persist_catalog() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let catalog = Catalog::new();
         let _ = catalog.db_or_create("my_db");
 
@@ -359,7 +379,7 @@ mod tests {
     async fn persist_and_load_newest_catalog() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let catalog = Catalog::new();
         let _ = catalog.db_or_create("my_db");
 
@@ -394,7 +414,7 @@ mod tests {
     async fn persist_snapshot_info_file() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             databases: HashMap::new(),
@@ -411,7 +431,7 @@ mod tests {
     async fn persist_and_load_snapshot_info_files() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             databases: HashMap::new(),
@@ -452,7 +472,7 @@ mod tests {
     async fn persist_and_load_snapshot_info_files_with_fewer_than_requested() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             databases: HashMap::new(),
@@ -473,7 +493,7 @@ mod tests {
     async fn persist_and_load_over_9000_snapshot_info_files() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         for id in 0..9001 {
             let info_file = PersistedSnapshot {
                 wal_file_sequence_number: WalFileSequenceNumber::new(id),
@@ -494,7 +514,7 @@ mod tests {
     #[tokio::test]
     async fn load_snapshot_works_with_no_exising_snapshots() {
         let store = InMemory::new();
-        let persister = PersisterImpl::new(Arc::new(store));
+        let persister = PersisterImpl::new(Arc::new(store), "test_host");
 
         let snapshots = persister.load_snapshots(100).await.unwrap();
         assert!(snapshots.is_empty());
@@ -504,7 +524,7 @@ mod tests {
     async fn get_parquet_bytes() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
@@ -531,7 +551,7 @@ mod tests {
     async fn persist_and_load_parquet_bytes() {
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
-        let persister = PersisterImpl::new(Arc::new(local_disk));
+        let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
 
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let stream_builder = RecordBatchReceiverStreamBuilder::new(schema.clone(), 5);
@@ -546,6 +566,7 @@ mod tests {
         stream_builder.tx().send(Ok(batch2)).await.unwrap();
 
         let path = ParquetFilePath::new(
+            "test_host",
             "db_one",
             "table_one",
             Utc::now(),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -140,6 +140,7 @@ impl<T: TimeProvider> WriteBufferImpl<T> {
         // teh background flush task.
         let wal = WalObjectStore::new(
             persister.object_store(),
+            persister.host_identifier_prefix(),
             Arc::clone(&queryable_buffer) as Arc<dyn WalFileNotifier>,
             wal_config,
         )
@@ -590,7 +591,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn writes_data_to_wal_and_is_queryable() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let level_0_duration = Level0Duration::new_5m();
         let write_buffer = WriteBufferImpl::new(
@@ -704,7 +705,11 @@ mod tests {
             .unwrap();
         // Check that the catalog was persisted, without advancing time:
         let object_store = wbuf.persister.object_store();
-        let catalog_json = fetch_catalog_as_json(Arc::clone(&object_store)).await;
+        let catalog_json = fetch_catalog_as_json(
+            Arc::clone(&object_store),
+            wbuf.persister.host_identifier_prefix(),
+        )
+        .await;
         insta::assert_json_snapshot!("catalog-immediately-after-last-cache-create", catalog_json);
         // Do another write that will update the state of the catalog, specifically, the table
         // that the last cache was created for, and add a new field to the table/cache `f2`:
@@ -731,7 +736,11 @@ mod tests {
         .unwrap();
         // Check the catalog again, to make sure it still has the last cache with the correct
         // configuration:
-        let catalog_json = fetch_catalog_as_json(Arc::clone(&object_store)).await;
+        let catalog_json = fetch_catalog_as_json(
+            Arc::clone(&object_store),
+            wbuf.persister.host_identifier_prefix(),
+        )
+        .await;
         // NOTE: the asserted snapshot is correct in-so-far as the catalog contains the last cache
         // configuration; however, it is not correct w.r.t. the fields. The second write adds a new
         // field `f2` to the last cache (which you can see in the query below), but the persisted
@@ -760,7 +769,11 @@ mod tests {
             .await
             .unwrap();
         // Catalog should be persisted, and no longer have the last cache, without advancing time:
-        let catalog_json = fetch_catalog_as_json(Arc::clone(&object_store)).await;
+        let catalog_json = fetch_catalog_as_json(
+            Arc::clone(&object_store),
+            wbuf.persister.host_identifier_prefix(),
+        )
+        .await;
         insta::assert_json_snapshot!("catalog-immediately-after-last-cache-delete", catalog_json);
         // Do another write so there is data to be persisted in the buffer:
         wbuf.write_lp(
@@ -786,15 +799,22 @@ mod tests {
             }
         }
         // Check the catalog again, to ensure the last cache is still gone:
-        let catalog_json = fetch_catalog_as_json(Arc::clone(&object_store)).await;
+        let catalog_json = fetch_catalog_as_json(
+            Arc::clone(&object_store),
+            wbuf.persister.host_identifier_prefix(),
+        )
+        .await;
         insta::assert_json_snapshot!(
             "catalog-after-allowing-time-to-persist-segments-after-delete",
             catalog_json
         );
     }
 
-    async fn fetch_catalog_as_json(object_store: Arc<dyn ObjectStore>) -> serde_json::Value {
-        let mut list = object_store.list(Some(&CatalogFilePath::dir()));
+    async fn fetch_catalog_as_json(
+        object_store: Arc<dyn ObjectStore>,
+        host_identifier_prefix: &str,
+    ) -> serde_json::Value {
+        let mut list = object_store.list(Some(&CatalogFilePath::dir(host_identifier_prefix)));
         let Some(item) = list.next().await else {
             panic!("there should have been a catalog file persisted");
         };
@@ -811,7 +831,7 @@ mod tests {
 
     async fn setup(start: Time) -> (WriteBufferImpl<MockProvider>, IOxSessionContext) {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store)));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(start));
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&persister),


### PR DESCRIPTION
Closes #25216

This enforces the use of a host identifier prefix in all object store paths, i.e., for parquet files, catalog files, snapshot files, and WAL files.

Both the `PersisterImpl` and `WalObjectStore` hold the host identifier prefix and use it when constructing paths to get/put files in the object store.

The `influxdb3` binary requires a new argument `--host-id` to be passed to the `serve` command that is used to specify the prefix:
```
$ influxdb3 serve --help
Run the InfluxDB 3.0 server

Usage: influxdb3 serve [OPTIONS] --host-id <HOST_IDENTIFIER_PREFIX>

Options:
      [...]
      
      --host-id <HOST_IDENTIFIER_PREFIX>
          The host idendifier used as a prefix in all object store file paths
          
          [env: INFLUXDB3_HOST_IDENTIFIER_PREFIX=]
```