### PR TITLE
fix: un-pub QueryableBuffer and fix compile errors

### DIFF
--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -621,9 +621,9 @@ mod tests {
 
     async fn setup() -> (Arc<TestWriteBuffer>, QueryExecutorImpl, Arc<MockProvider>) {
         // Set up QueryExecutor
-        let object_store =
+        let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
-        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store) as _));
+        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let executor = make_exec(object_store);
         let level_0_duration = Level0Duration::new_5m();

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of an in-memory buffer for writes that persists data into a wal if it is configured.
 
 pub mod persisted_files;
-pub mod queryable_buffer;
+mod queryable_buffer;
 mod table_buffer;
 pub(crate) mod validator;
 

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -33,7 +33,7 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
 
 #[derive(Debug)]
-pub struct QueryableBuffer {
+pub(crate) struct QueryableBuffer {
     pub(crate) executor: Arc<Executor>,
     catalog: Arc<Catalog>,
     last_cache_provider: Arc<LastCacheProvider>,
@@ -283,7 +283,11 @@ impl QueryableBuffer {
         receiver
     }
 
-    pub fn persisted_parquet_files(&self, db_name: &str, table_name: &str) -> Vec<ParquetFile> {
+    pub(crate) fn persisted_parquet_files(
+        &self,
+        db_name: &str,
+        table_name: &str,
+    ) -> Vec<ParquetFile> {
         self.persisted_files.get_files(db_name, table_name)
     }
 }


### PR DESCRIPTION
Follows #25225

This fixes some compiler errors that slipped through in the above PR, and also un-`pub`'s the `QueryableBuffer`, returning it to only be `pub(crate)`, which was missed in the above PR.