### PR TITLE
fix: GROUP BY queries with offset that crosses a DST boundary fail. (#25082)

### DIFF
--- a/query/iterator.go
+++ b/query/iterator.go
@@ -854,6 +854,10 @@ func (opt IteratorOptions) Window(t int64) (start, end int64) {
 		end = t + dt
 	}
 
+	// As above, the offset has to happen before the time zone calculation.
+	// This is another fix for https://github.com/influxdata/influxdb/issues/20238
+	// that was missed the first time.
+	end += int64(opt.Interval.Offset)
 	// Retrieve the zone offset for the end time.
 	if opt.Location != nil {
 		_, endOffset := opt.Zone(end)
@@ -879,7 +883,6 @@ func (opt IteratorOptions) Window(t int64) (start, end int64) {
 			}
 		}
 	}
-	end += int64(opt.Interval.Offset)
 	return
 }
 


### PR DESCRIPTION
This is actually the second fix for
https://github.com/influxdata/influxdb/issues/20238 for when the time zone falls back in autumn.

closes https://github.com/influxdata/influxdb/issues/25078

(cherry picked from commit d60741b5063ce829cf32ca86f4746b16d1c4d31c)

closes https://github.com/influxdata/influxdb/issues/25079