### PR TITLE
fix: Store.validateArgs wrongfully overwriting start, end unix time (#25146) (#25165)

### DIFF
--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -100,10 +100,10 @@ func (s *Store) validateArgs(database, rp string, start, end int64) (string, str
 		return "", "", 0, 0, errors.New("invalid retention policy")
 	}
 
-	if start <= 0 {
+	if start <= models.MinNanoTime {
 		start = models.MinNanoTime
 	}
-	if end <= 0 {
+	if end >= models.MaxNanoTime {
 		end = models.MaxNanoTime
 	}
 	return database, rp, start, end, nil


### PR DESCRIPTION
When querying data before 1970-01-01 (UNIX time 0) validateArgs would set start to -in64 max and end to int64 max.

closes https://github.com/influxdata/influxdb/issues/24669

Co-authored-by: Paul Hegenberg <paul.hegenberg@gmail.com>

closes https://github.com/influxdata/influxdb/issues/25149

(cherry picked from commit c4bfaa895417c174cef76f5308eebb6aaddbfa36)

closes https://github.com/influxdata/influxdb/issues/25150