### PR TITLE
fix(tsi1): fix data race between appendEntry and FlushAndSync tsi1.(*LogFile) (#25182)

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1085,9 +1085,10 @@ func (f *LogFile) seriesSketches() (sketch, tSketch estimator.Sketch, err error)
 	return sketch, tSketch, nil
 }
 
-func (f *LogFile) ExecEntries(entries []LogEntry) error {
+func (f *LogFile) Writes(entries []LogEntry) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
 	for i := range entries {
 		entry := &entries[i]
 		if err := f.appendEntry(entry); err != nil {
@@ -1095,14 +1096,6 @@ func (f *LogFile) ExecEntries(entries []LogEntry) error {
 		}
 		f.execEntry(entry)
 	}
-	return nil
-}
-
-func (f *LogFile) Writes(entries []LogEntry) error {
-	if err := f.ExecEntries(entries); err != nil {
-		return err
-	}
-
 	// Flush buffer and sync to disk.
 	return f.FlushAndSync()
 }


### PR DESCRIPTION
Extend lock lifespan to encompass the
flushAndSync() call to avoid a race

closes https://github.com/influxdata/influxdb/issues/25181

(cherry picked from commit 7333da95920a4723829ddff631df14c71cd71430)

closes https://github.com/influxdata/influxdb/issues/25186