### PR TITLE
feat: snapshots track their own sequence number

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -86,6 +86,10 @@ impl SequenceNumber {
     pub fn next(&self) -> Self {
         Self(self.0 + 1)
     }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
 }
 
 #[derive(Debug)]

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -600,7 +600,7 @@ impl WalFileSequenceNumber {
         Self(self.0 + 1)
     }
 
-    pub fn get(&self) -> u64 {
+    pub fn as_u64(&self) -> u64 {
         self.0
     }
 }

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -256,7 +256,7 @@ impl WalObjectStore {
             None => {
                 debug!(
                     "notify sent to buffer for wal file {}",
-                    wal_contents.wal_file_number.get()
+                    wal_contents.wal_file_number.as_u64()
                 );
                 self.file_notifier.notify(wal_contents);
                 None

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -1,5 +1,5 @@
 use chrono::prelude::*;
-use influxdb3_wal::WalFileSequenceNumber;
+use influxdb3_wal::{SnapshotSequenceNumber, WalFileSequenceNumber};
 use object_store::path::Path as ObjPath;
 use std::ops::Deref;
 
@@ -104,10 +104,10 @@ impl AsRef<ObjPath> for ParquetFilePath {
 pub struct SnapshotInfoFilePath(ObjPath);
 
 impl SnapshotInfoFilePath {
-    pub fn new(host_prefix: &str, wal_file_sequence_number: WalFileSequenceNumber) -> Self {
+    pub fn new(host_prefix: &str, snapshot_sequence_number: SnapshotSequenceNumber) -> Self {
         let path = ObjPath::from(format!(
             "{host_prefix}/snapshots/{:020}.{}",
-            object_store_file_stem(wal_file_sequence_number.as_u64()),
+            object_store_file_stem(snapshot_sequence_number.as_u64()),
             SNAPSHOT_INFO_FILE_EXTENSION
         ));
         Self(path)
@@ -173,7 +173,7 @@ fn parquet_file_percent_encoded() {
 #[test]
 fn snapshot_info_file_path_new() {
     assert_eq!(
-        *SnapshotInfoFilePath::new("my_host", WalFileSequenceNumber::new(0)),
+        *SnapshotInfoFilePath::new("my_host", SnapshotSequenceNumber::new(0)),
         ObjPath::from("my_host/snapshots/18446744073709551615.info.json")
     );
 }

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -23,7 +23,7 @@ impl CatalogFilePath {
     pub fn new(host_prefix: &str, wal_file_sequence_number: WalFileSequenceNumber) -> Self {
         let path = ObjPath::from(format!(
             "{host_prefix}/catalogs/{:020}.{}",
-            object_store_file_stem(wal_file_sequence_number.get()),
+            object_store_file_stem(wal_file_sequence_number.as_u64()),
             CATALOG_FILE_EXTENSION
         ));
         Self(path)
@@ -62,7 +62,7 @@ impl ParquetFilePath {
         let path = ObjPath::from(format!(
             "{host_prefix}/dbs/{db_name}/{table_name}/{}/{}.{}",
             date.format("%Y-%m-%d/%H-%M"),
-            wal_file_sequence_number.get(),
+            wal_file_sequence_number.as_u64(),
             PARQUET_FILE_EXTENSION
         ));
         Self(path)
@@ -79,7 +79,7 @@ impl ParquetFilePath {
         let path = ObjPath::from(format!(
             "dbs/{db_name}/{table_name}/{}/{:010}.{}",
             date_time.format("%Y-%m-%d/%H-%M"),
-            wal_file_sequence_number.get(),
+            wal_file_sequence_number.as_u64(),
             PARQUET_FILE_EXTENSION
         ));
         Self(path)
@@ -107,7 +107,7 @@ impl SnapshotInfoFilePath {
     pub fn new(host_prefix: &str, wal_file_sequence_number: WalFileSequenceNumber) -> Self {
         let path = ObjPath::from(format!(
             "{host_prefix}/snapshots/{:020}.{}",
-            object_store_file_stem(wal_file_sequence_number.get()),
+            object_store_file_stem(wal_file_sequence_number.as_u64()),
             SNAPSHOT_INFO_FILE_EXTENSION
         ));
         Self(path)

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -473,8 +473,8 @@ mod tests {
         let snapshots = persister.load_snapshots(2).await.unwrap();
         assert_eq!(snapshots.len(), 2);
         // The most recent one is first
-        assert_eq!(snapshots[0].wal_file_sequence_number.get(), 2);
-        assert_eq!(snapshots[1].wal_file_sequence_number.get(), 1);
+        assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 2);
+        assert_eq!(snapshots[1].wal_file_sequence_number.as_u64(), 1);
     }
 
     #[tokio::test]
@@ -494,7 +494,7 @@ mod tests {
         let snapshots = persister.load_snapshots(2).await.unwrap();
         // We asked for the most recent 2 but there should only be 1
         assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].wal_file_sequence_number.get(), 0);
+        assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 0);
     }
 
     #[tokio::test]
@@ -517,7 +517,7 @@ mod tests {
         let snapshots = persister.load_snapshots(9500).await.unwrap();
         // We asked for the most recent 9500 so there should be 9001 of them
         assert_eq!(snapshots.len(), 9001);
-        assert_eq!(snapshots[0].wal_file_sequence_number.get(), 9000);
+        assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 9000);
     }
 
     #[tokio::test]

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -270,7 +270,7 @@ impl Persister for PersisterImpl {
     async fn persist_snapshot(&self, persisted_snapshot: &PersistedSnapshot) -> Result<()> {
         let snapshot_file_path = SnapshotInfoFilePath::new(
             self.host_identifier_prefix.as_str(),
-            persisted_snapshot.wal_file_sequence_number,
+            persisted_snapshot.snapshot_sequence_number,
         );
         let json = serde_json::to_vec_pretty(persisted_snapshot)?;
         self.object_store
@@ -362,6 +362,8 @@ impl<W: Write + Send> TrackedMemoryArrowWriter<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use influxdb3_catalog::catalog::SequenceNumber;
+    use influxdb3_wal::SnapshotSequenceNumber;
     use object_store::memory::InMemory;
     use {
         arrow::array::Int32Array, arrow::datatypes::DataType, arrow::datatypes::Field,
@@ -425,7 +427,9 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
+            catalog_sequence_number: SequenceNumber::new(0),
             databases: HashMap::new(),
             min_time: 0,
             max_time: 1,
@@ -442,7 +446,9 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
+            catalog_sequence_number: SequenceNumber::default(),
             databases: HashMap::new(),
             min_time: 0,
             max_time: 1,
@@ -450,7 +456,9 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_2 = PersistedSnapshot {
+            snapshot_sequence_number: SnapshotSequenceNumber::new(1),
             wal_file_sequence_number: WalFileSequenceNumber::new(1),
+            catalog_sequence_number: SequenceNumber::default(),
             databases: HashMap::new(),
             max_time: 1,
             min_time: 0,
@@ -458,7 +466,9 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_3 = PersistedSnapshot {
+            snapshot_sequence_number: SnapshotSequenceNumber::new(2),
             wal_file_sequence_number: WalFileSequenceNumber::new(2),
+            catalog_sequence_number: SequenceNumber::default(),
             databases: HashMap::new(),
             min_time: 0,
             max_time: 1,
@@ -472,9 +482,11 @@ mod tests {
 
         let snapshots = persister.load_snapshots(2).await.unwrap();
         assert_eq!(snapshots.len(), 2);
-        // The most recent one is first
+        // The most recent files are first
         assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 2);
+        assert_eq!(snapshots[0].snapshot_sequence_number.as_u64(), 2);
         assert_eq!(snapshots[1].wal_file_sequence_number.as_u64(), 1);
+        assert_eq!(snapshots[1].snapshot_sequence_number.as_u64(), 1);
     }
 
     #[tokio::test]
@@ -483,7 +495,9 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
+            catalog_sequence_number: SequenceNumber::default(),
             databases: HashMap::new(),
             min_time: 0,
             max_time: 1,
@@ -505,7 +519,9 @@ mod tests {
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         for id in 0..9001 {
             let info_file = PersistedSnapshot {
+                snapshot_sequence_number: SnapshotSequenceNumber::new(id),
                 wal_file_sequence_number: WalFileSequenceNumber::new(id),
+                catalog_sequence_number: SequenceNumber::new(id as u32),
                 databases: HashMap::new(),
                 min_time: 0,
                 max_time: 1,
@@ -518,6 +534,8 @@ mod tests {
         // We asked for the most recent 9500 so there should be 9001 of them
         assert_eq!(snapshots.len(), 9001);
         assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 9000);
+        assert_eq!(snapshots[0].snapshot_sequence_number.as_u64(), 9000);
+        assert_eq!(snapshots[0].catalog_sequence_number.as_u32(), 9000);
     }
 
     #[tokio::test]

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -225,7 +225,11 @@ impl QueryableBuffer {
                 wal_file_number.as_u64(),
             );
             // persist the individual files, building the snapshot as we go
-            let mut persisted_snapshot = PersistedSnapshot::new(wal_file_number);
+            let mut persisted_snapshot = PersistedSnapshot::new(
+                snapshot_details.snapshot_sequence_number,
+                wal_file_number,
+                catalog.sequence_number(),
+            );
             for persist_job in persist_jobs {
                 let path = persist_job.path.to_string();
                 let database_name = Arc::clone(&persist_job.database_name);

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -197,7 +197,10 @@ impl QueryableBuffer {
                 if !catalog.is_updated() {
                     break;
                 }
-                info!("persisting catalog for wal file {}", wal_file_number.get());
+                info!(
+                    "persisting catalog for wal file {}",
+                    wal_file_number.as_u64()
+                );
                 let inner_catalog = catalog.clone_inner();
                 let sequence_number = inner_catalog.sequence_number();
 
@@ -219,7 +222,7 @@ impl QueryableBuffer {
             info!(
                 "persisting {} chunks for wal number {}",
                 persist_jobs.len(),
-                wal_file_number.get(),
+                wal_file_number.as_u64(),
             );
             // persist the individual files, building the snapshot as we go
             let mut persisted_snapshot = PersistedSnapshot::new(wal_file_number);


### PR DESCRIPTION
Closes #25249

## Commits

### https://github.com/influxdata/influxdb/commit/a923398ddd137d1b2d233f721631703a05d07242
* Updated the `WalFileSequenceNumber::get` method to `as_u64` to make the method's intent clearer from the call site.

### https://github.com/influxdata/influxdb/commit/f418ee3b6244b9bf62c98e3f2a66721d91425b2d
* Snapshots get their own monotonically increasing sequence number independent of the WAL file sequence number. This allows GET'ing the next snapshot file from the object store using the most recent pulled snapshot, vs. having to do a LIST operation to see if there are more snapshots.
* The most recent snapshot sequence number is used to initialize the `SnapshotTracker` on startup.
* In addition, the catalog sequence number associated with a snapshot is tracked on the `SnapshotDetails`.
* Existing tests were updated to handle the struct changes and a new test was added to the write buffer test suite that verifies when an existing snapshot is loaded, the new snapshots generated henceforth use the correct sequence number.