### PR TITLE
feat: Add u64 id field to ParquetFiles

### DIFF
--- a/influxdb3_write/src/cache.rs
+++ b/influxdb3_write/src/cache.rs
@@ -1,6 +1,8 @@
 use crate::persister::serialize_to_parquet;
 use crate::persister::Error;
 use crate::ParquetFile;
+use crate::NEXT_FILE_ID;
+
 use bytes::Bytes;
 use datafusion::execution::memory_pool::MemoryPool;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -9,6 +11,7 @@ use object_store::path::Path as ObjPath;
 use object_store::ObjectStore;
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::task;
@@ -84,6 +87,7 @@ impl ParquetCache {
                         files.insert(
                             path.clone(),
                             ParquetFile {
+                                id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
                                 chunk_time: min_time,
                                 path: path.clone(),
                                 size_bytes,
@@ -97,6 +101,7 @@ impl ParquetCache {
                         HashMap::from([(
                             path.clone(),
                             ParquetFile {
+                                id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
                                 chunk_time: min_time,
                                 path: path.clone(),
                                 size_bytes,
@@ -113,6 +118,7 @@ impl ParquetCache {
                     HashMap::from([(
                         path.clone(),
                         ParquetFile {
+                            id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
                             chunk_time: min_time,
                             path: path.clone(),
                             size_bytes,

--- a/influxdb3_write/src/cache.rs
+++ b/influxdb3_write/src/cache.rs
@@ -1,7 +1,7 @@
 use crate::persister::serialize_to_parquet;
 use crate::persister::Error;
 use crate::ParquetFile;
-use crate::NEXT_FILE_ID;
+use crate::ParquetFileId;
 
 use bytes::Bytes;
 use datafusion::execution::memory_pool::MemoryPool;
@@ -11,7 +11,6 @@ use object_store::path::Path as ObjPath;
 use object_store::ObjectStore;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::task;
@@ -87,7 +86,7 @@ impl ParquetCache {
                         files.insert(
                             path.clone(),
                             ParquetFile {
-                                id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
+                                id: ParquetFileId::new(),
                                 chunk_time: min_time,
                                 path: path.clone(),
                                 size_bytes,
@@ -101,7 +100,7 @@ impl ParquetCache {
                         HashMap::from([(
                             path.clone(),
                             ParquetFile {
-                                id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
+                                id: ParquetFileId::new(),
                                 chunk_time: min_time,
                                 path: path.clone(),
                                 size_bytes,
@@ -118,7 +117,7 @@ impl ParquetCache {
                     HashMap::from([(
                         path.clone(),
                         ParquetFile {
-                            id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
+                            id: ParquetFileId::new(),
                             chunk_time: min_time,
                             path: path.clone(),
                             size_bytes,

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -427,6 +427,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            last_file_id: 0,
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::new(0),
@@ -446,6 +447,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            last_file_id: 0,
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::default(),
@@ -456,6 +458,7 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_2 = PersistedSnapshot {
+            last_file_id: 1,
             snapshot_sequence_number: SnapshotSequenceNumber::new(1),
             wal_file_sequence_number: WalFileSequenceNumber::new(1),
             catalog_sequence_number: SequenceNumber::default(),
@@ -466,6 +469,7 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_3 = PersistedSnapshot {
+            last_file_id: 2,
             snapshot_sequence_number: SnapshotSequenceNumber::new(2),
             wal_file_sequence_number: WalFileSequenceNumber::new(2),
             catalog_sequence_number: SequenceNumber::default(),
@@ -483,8 +487,10 @@ mod tests {
         let snapshots = persister.load_snapshots(2).await.unwrap();
         assert_eq!(snapshots.len(), 2);
         // The most recent files are first
+        assert_eq!(snapshots[0].last_file_id, 2);
         assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 2);
         assert_eq!(snapshots[0].snapshot_sequence_number.as_u64(), 2);
+        assert_eq!(snapshots[1].last_file_id, 1);
         assert_eq!(snapshots[1].wal_file_sequence_number.as_u64(), 1);
         assert_eq!(snapshots[1].snapshot_sequence_number.as_u64(), 1);
     }
@@ -495,6 +501,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
+            last_file_id: 0,
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::default(),
@@ -519,6 +526,7 @@ mod tests {
         let persister = PersisterImpl::new(Arc::new(local_disk), "test_host");
         for id in 0..9001 {
             let info_file = PersistedSnapshot {
+                last_file_id: id,
                 snapshot_sequence_number: SnapshotSequenceNumber::new(id),
                 wal_file_sequence_number: WalFileSequenceNumber::new(id),
                 catalog_sequence_number: SequenceNumber::new(id as u32),
@@ -533,6 +541,7 @@ mod tests {
         let snapshots = persister.load_snapshots(9500).await.unwrap();
         // We asked for the most recent 9500 so there should be 9001 of them
         assert_eq!(snapshots.len(), 9001);
+        assert_eq!(snapshots[0].last_file_id, 9000);
         assert_eq!(snapshots[0].wal_file_sequence_number.as_u64(), 9000);
         assert_eq!(snapshots[0].snapshot_sequence_number.as_u64(), 9000);
         assert_eq!(snapshots[0].catalog_sequence_number.as_u32(), 9000);

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -144,7 +144,7 @@ impl<T: TimeProvider> WriteBufferImpl<T> {
         NEXT_FILE_ID.store(
             persisted_snapshots
                 .first()
-                .map(|s| s.last_file_id)
+                .map(|s| s.next_file_id.as_u64())
                 .unwrap_or(0),
             Ordering::SeqCst,
         );

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -14,7 +14,7 @@ use crate::write_buffer::queryable_buffer::QueryableBuffer;
 use crate::write_buffer::validator::WriteValidator;
 use crate::{
     BufferedWriteRequest, Bufferer, ChunkContainer, LastCacheManager, ParquetFile, Persister,
-    Precision, WriteBuffer, WriteLineError,
+    Precision, WriteBuffer, WriteLineError, NEXT_FILE_ID,
 };
 use async_trait::async_trait;
 use data_types::{ChunkId, ChunkOrder, ColumnType, NamespaceName, NamespaceNameError};
@@ -38,6 +38,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use observability_deps::tracing::{debug, error};
 use parquet_file::storage::ParquetExecInput;
 use schema::Schema;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -139,6 +140,14 @@ impl<T: TimeProvider> WriteBufferImpl<T> {
         let last_snapshot_sequence_number = persisted_snapshots
             .first()
             .map(|s| s.snapshot_sequence_number);
+        // Set the next file id to use when persisting ParquetFiles
+        NEXT_FILE_ID.store(
+            persisted_snapshots
+                .first()
+                .map(|s| s.last_file_id)
+                .unwrap_or(0),
+            Ordering::SeqCst,
+        );
         let persisted_files = Arc::new(PersistedFiles::new_from_persisted_snapshots(
             persisted_snapshots,
         ));
@@ -1171,6 +1180,8 @@ mod tests {
             Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
 
         // create a snapshot file that will be loaded on initialization of the write buffer:
+        // Set NEXT_FILE_ID to a non zero number for the snapshot
+        NEXT_FILE_ID.store(500, Ordering::SeqCst);
         let prev_snapshot_seq = SnapshotSequenceNumber::new(42);
         let prev_snapshot = PersistedSnapshot::new(
             prev_snapshot_seq,
@@ -1178,6 +1189,9 @@ mod tests {
             SequenceNumber::new(0),
         );
         let snapshot_json = serde_json::to_vec(&prev_snapshot).unwrap();
+        // set NEXT_FILE_ID to be 0 so that we can make sure when it's loaded from the
+        // snapshot that it becomes the expected number
+        NEXT_FILE_ID.store(0, Ordering::SeqCst);
 
         // put the snapshot file in object store:
         object_store
@@ -1200,6 +1214,9 @@ mod tests {
             },
         )
         .await;
+
+        // Assert that loading the snapshots sets NEXT_FILE_ID to the correct id number
+        assert_eq!(NEXT_FILE_ID.load(Ordering::SeqCst), 500);
 
         // there should be one snapshot already, i.e., the one we created above:
         verify_snapshot_count(1, &wbuf.persister).await;

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -4,7 +4,7 @@ use crate::paths::ParquetFilePath;
 use crate::persister::PersisterImpl;
 use crate::write_buffer::persisted_files::PersistedFiles;
 use crate::write_buffer::table_buffer::TableBuffer;
-use crate::{ParquetFile, PersistedSnapshot, Persister, NEXT_FILE_ID};
+use crate::{ParquetFile, ParquetFileId, PersistedSnapshot, Persister};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use data_types::{
@@ -27,7 +27,6 @@ use parquet::format::FileMetaData;
 use schema::sort::SortKey;
 use schema::Schema;
 use std::any::Any;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -246,7 +245,7 @@ impl QueryableBuffer {
                     database_name,
                     table_name,
                     ParquetFile {
-                        id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
+                        id: ParquetFileId::new(),
                         path,
                         size_bytes,
                         row_count: meta.num_rows as u64,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -4,7 +4,7 @@ use crate::paths::ParquetFilePath;
 use crate::persister::PersisterImpl;
 use crate::write_buffer::persisted_files::PersistedFiles;
 use crate::write_buffer::table_buffer::TableBuffer;
-use crate::{ParquetFile, PersistedSnapshot, Persister};
+use crate::{ParquetFile, PersistedSnapshot, Persister, NEXT_FILE_ID};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use data_types::{
@@ -27,6 +27,7 @@ use parquet::format::FileMetaData;
 use schema::sort::SortKey;
 use schema::Schema;
 use std::any::Any;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -245,6 +246,7 @@ impl QueryableBuffer {
                     database_name,
                     table_name,
                     ParquetFile {
+                        id: NEXT_FILE_ID.fetch_add(1, Ordering::SeqCst),
                         path,
                         size_bytes,
                         row_count: meta.num_rows as u64,


### PR DESCRIPTION
This commit does a few things:
1. It adds a u64 id field to ParquetFile
2. It gets this from an AtomicU64 so they can always use the most up to date one across threads
3. The last available file id is persisted as part of our snapshot process
4. The snapshot when loaded will set the AtomicU64 to the proper value

With this current work on the FileIndex in our Pro version will be able to utilize these ids while doing compaction and we can refer to them with a unique u64.

Closes #25250 