### PR TITLE
refactor: remove `Persister` trait in favour of concrete implementation

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,8 +22,8 @@ allow = [
 exceptions = [
     # We should probably NOT bundle CA certs but use the OS ones.
     { name = "webpki-roots", allow = ["MPL-2.0"] },
-    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
-    { allow = ["OpenSSL"], crate = "ring" },
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+    { allow = ["OpenSSL"], name = "ring" },
 ]
 
 [[licenses.clarify]]

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -15,7 +15,7 @@ use influxdb3_server::{
     CommonServerState,
 };
 use influxdb3_wal::{Level0Duration, WalConfig};
-use influxdb3_write::persister::PersisterImpl;
+use influxdb3_write::persister::Persister;
 use influxdb3_write::write_buffer::WriteBufferImpl;
 use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
 use iox_time::SystemProvider;
@@ -293,7 +293,7 @@ pub async fn command(config: Config) -> Result<()> {
 
     let common_state =
         CommonServerState::new(Arc::clone(&metrics), trace_exporter, trace_header_parser)?;
-    let persister = Arc::new(PersisterImpl::new(
+    let persister = Arc::new(Persister::new(
         Arc::clone(&object_store),
         config.host_identifier_prefix,
     ));

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -582,7 +582,7 @@ mod tests {
     use datafusion::{assert_batches_sorted_eq, error::DataFusionError};
     use futures::TryStreamExt;
     use influxdb3_wal::{Level0Duration, WalConfig};
-    use influxdb3_write::{persister::PersisterImpl, write_buffer::WriteBufferImpl, Bufferer};
+    use influxdb3_write::{persister::Persister, write_buffer::WriteBufferImpl, Bufferer};
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
     use iox_time::{MockProvider, Time};
     use metric::Registry;
@@ -621,7 +621,7 @@ mod tests {
         // Set up QueryExecutor
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
-        let persister = Arc::new(PersisterImpl::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let executor = make_exec(object_store);
         let write_buffer = Arc::new(

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1568,7 +1568,7 @@ mod tests {
 
     use crate::{
         last_cache::{KeyValue, LastCacheProvider, Predicate, DEFAULT_CACHE_TTL},
-        persister::PersisterImpl,
+        persister::Persister,
         write_buffer::WriteBufferImpl,
         Bufferer, LastCacheManager, Precision,
     };
@@ -1582,7 +1582,7 @@ mod tests {
 
     async fn setup_write_buffer() -> WriteBufferImpl<MockProvider> {
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let persister = Arc::new(PersisterImpl::new(obj_store, "test_host"));
+        let persister = Arc::new(Persister::new(obj_store, "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         WriteBufferImpl::new(
             persister,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -11,23 +11,17 @@ pub mod paths;
 pub mod persister;
 pub mod write_buffer;
 
-use crate::paths::ParquetFilePath;
 use async_trait::async_trait;
-use bytes::Bytes;
 use data_types::{NamespaceName, TimestampMinMax};
-use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionState;
-use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::Expr;
 use influxdb3_catalog::catalog::{self, SequenceNumber};
 use influxdb3_wal::{LastCacheDefinition, SnapshotSequenceNumber, WalFileSequenceNumber};
 use iox_query::QueryChunk;
 use iox_time::Time;
 use last_cache::LastCacheProvider;
-use parquet::format::FileMetaData;
 use serde::{Deserialize, Serialize};
-use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
@@ -130,58 +124,6 @@ pub trait LastCacheManager: Debug + Send + Sync + 'static {
         tbl_name: &str,
         cache_name: &str,
     ) -> Result<(), write_buffer::Error>;
-}
-
-pub const DEFAULT_OBJECT_STORE_URL: &str = "iox://influxdb3/";
-
-#[async_trait]
-pub trait Persister: Debug + Send + Sync + 'static {
-    /// Loads the most recently persisted catalog from object storage.
-    async fn load_catalog(&self) -> persister::Result<Option<PersistedCatalog>>;
-
-    /// Loads the most recently persisted N snapshot parquet file lists from object storage.
-    async fn load_snapshots(
-        &self,
-        most_recent_n: usize,
-    ) -> persister::Result<Vec<PersistedSnapshot>>;
-
-    // Loads a Parquet file from ObjectStore
-    async fn load_parquet_file(&self, path: ParquetFilePath) -> persister::Result<Bytes>;
-
-    /// Persists the catalog with the given `WalFileSequenceNumber`. If this is the highest ID, it will
-    /// be the catalog that is returned the next time `load_catalog` is called.
-    async fn persist_catalog(
-        &self,
-        wal_file_sequence_number: WalFileSequenceNumber,
-        catalog: catalog::Catalog,
-    ) -> persister::Result<()>;
-
-    /// Persists the snapshot file
-    async fn persist_snapshot(
-        &self,
-        persisted_snapshot: &PersistedSnapshot,
-    ) -> persister::Result<()>;
-
-    // Writes a SendableRecorgBatchStream to the Parquet format and persists it
-    // to Object Store at the given path. Returns the number of bytes written and the file metadata.
-    async fn persist_parquet_file(
-        &self,
-        path: ParquetFilePath,
-        record_batch: SendableRecordBatchStream,
-    ) -> persister::Result<(u64, FileMetaData)>;
-
-    /// Returns the configured `ObjectStore` that data is loaded from and persisted to.
-    fn object_store(&self) -> Arc<dyn object_store::ObjectStore>;
-
-    // This is used by the query engine to know where to read parquet files from. This assumes
-    // that there is a `ParquetStorage` with an id of `influxdb3` and that this url has been
-    // registered with the query execution context. Kind of ugly here, but not sure where else
-    // to keep this.
-    fn object_store_url(&self) -> ObjectStoreUrl {
-        ObjectStoreUrl::parse(DEFAULT_OBJECT_STORE_URL).unwrap()
-    }
-
-    fn as_any(&self) -> &dyn Any;
 }
 
 /// A single write request can have many lines in it. A writer can request to accept all lines that are valid, while


### PR DESCRIPTION
Closes #25259

In addition, `deny.toml` had some incorrect field names in `[license.exceptions]`, those were fixed from `crate` to `name`.