### PR TITLE
refactor: use more `dyn Trait` in write buffer

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -330,9 +330,9 @@ impl Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
-pub(crate) struct HttpApi<W, Q, T> {
+pub(crate) struct HttpApi<Q, T> {
     common_state: CommonServerState,
-    write_buffer: Arc<W>,
+    write_buffer: Arc<dyn WriteBuffer>,
     time_provider: Arc<T>,
     pub(crate) query_executor: Arc<Q>,
     max_request_bytes: usize,
@@ -340,11 +340,11 @@ pub(crate) struct HttpApi<W, Q, T> {
     legacy_write_param_unifier: SingleTenantRequestUnifier,
 }
 
-impl<W, Q, T> HttpApi<W, Q, T> {
+impl<Q, T> HttpApi<Q, T> {
     pub(crate) fn new(
         common_state: CommonServerState,
         time_provider: Arc<T>,
-        write_buffer: Arc<W>,
+        write_buffer: Arc<dyn WriteBuffer>,
         query_executor: Arc<Q>,
         max_request_bytes: usize,
         authorizer: Arc<dyn Authorizer>,
@@ -362,9 +362,8 @@ impl<W, Q, T> HttpApi<W, Q, T> {
     }
 }
 
-impl<W, Q, T> HttpApi<W, Q, T>
+impl<Q, T> HttpApi<Q, T>
 where
-    W: WriteBuffer,
     Q: QueryExecutor,
     T: TimeProvider,
     Error: From<<Q as QueryExecutor>::Error>,
@@ -1048,8 +1047,8 @@ struct LastCacheDeleteRequest {
     name: String,
 }
 
-pub(crate) async fn route_request<W: WriteBuffer, Q: QueryExecutor, T: TimeProvider>(
-    http_server: Arc<HttpApi<W, Q, T>>,
+pub(crate) async fn route_request<Q: QueryExecutor, T: TimeProvider>(
+    http_server: Arc<HttpApi<Q, T>>,
     mut req: Request<Body>,
 ) -> Result<Response<Body>, Infallible>
 where

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -23,7 +23,6 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{ready, stream::Fuse, Stream, StreamExt};
 use hyper::http::HeaderValue;
 use hyper::{header::ACCEPT, header::CONTENT_TYPE, Body, Request, Response, StatusCode};
-use influxdb3_write::WriteBuffer;
 use iox_time::TimeProvider;
 use observability_deps::tracing::info;
 use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, TIME_COLUMN_NAME};
@@ -36,9 +35,8 @@ use super::{Error, HttpApi, Result};
 
 const DEFAULT_CHUNK_SIZE: usize = 10_000;
 
-impl<W, Q, T> HttpApi<W, Q, T>
+impl<Q, T> HttpApi<Q, T>
 where
-    W: WriteBuffer,
     Q: QueryExecutor,
     T: TimeProvider,
     Error: From<<Q as QueryExecutor>::Error>,

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1580,7 +1580,7 @@ mod tests {
     use insta::assert_json_snapshot;
     use iox_time::{MockProvider, Time};
 
-    async fn setup_write_buffer() -> WriteBufferImpl<MockProvider> {
+    async fn setup_write_buffer() -> WriteBufferImpl {
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let persister = Arc::new(Persister::new(obj_store, "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -117,7 +117,7 @@ impl LastCacheProvider {
     }
 
     /// Initialize a [`LastCacheProvider`] from a [`InnerCatalog`]
-    pub(crate) fn new_from_catalog(catalog: &InnerCatalog) -> Result<Self, Error> {
+    pub fn new_from_catalog(catalog: &InnerCatalog) -> Result<Self, Error> {
         let provider = LastCacheProvider::new();
         for db_schema in catalog.databases() {
             for tbl_def in db_schema.tables() {

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -33,7 +33,7 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
 
 #[derive(Debug)]
-pub(crate) struct QueryableBuffer {
+pub struct QueryableBuffer {
     pub(crate) executor: Arc<Executor>,
     catalog: Arc<Catalog>,
     last_cache_provider: Arc<LastCacheProvider>,
@@ -43,7 +43,7 @@ pub(crate) struct QueryableBuffer {
 }
 
 impl QueryableBuffer {
-    pub(crate) fn new(
+    pub fn new(
         executor: Arc<Executor>,
         catalog: Arc<Catalog>,
         persister: Arc<Persister>,
@@ -61,7 +61,7 @@ impl QueryableBuffer {
         }
     }
 
-    pub(crate) fn get_table_chunks(
+    pub fn get_table_chunks(
         &self,
         db_schema: Arc<DatabaseSchema>,
         table_name: &str,
@@ -283,11 +283,7 @@ impl QueryableBuffer {
         receiver
     }
 
-    pub(crate) fn persisted_parquet_files(
-        &self,
-        db_name: &str,
-        table_name: &str,
-    ) -> Vec<ParquetFile> {
+    pub fn persisted_parquet_files(&self, db_name: &str, table_name: &str) -> Vec<ParquetFile> {
         self.persisted_files.get_files(db_name, table_name)
     }
 }


### PR DESCRIPTION
There is no issue for this. The purpose of these changes are to enable downstream implementations of the write buffer in InfluxDB Pro.

### Summary

* Refactor the `WriteBufferImpl` to remove its `<T>` generic for the `TimeProvider` by using an `Arc<dyn TimeProvider>`.
* Change the type definition for `Server` and `HttpApi` to use an `Arc<dyn WriteBuffer>` instead of a generic for the write buffer.
* Make `QueryableBuffer` and its `pub(crate)` methods `pub`.
* Make the `LastCacheProvider::new_from_catalog` method `pub`.