### PR TITLE
refactor: move catalog and last cache initialization out of write buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,7 @@ dependencies = [
 name = "influxdb3"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "arrow-array",
  "arrow-flight",
@@ -2406,6 +2407,7 @@ dependencies = [
  "hex",
  "humantime",
  "hyper 0.14.30",
+ "influxdb3_catalog",
  "influxdb3_client",
  "influxdb3_process",
  "influxdb3_server",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -24,6 +24,7 @@ trace_exporters.workspace = true
 trogging.workspace = true
 
 # Local Crates
+influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }
 influxdb3_server = { path = "../influxdb3_server" }

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -32,6 +32,7 @@ influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }
 
 # Crates.io dependencies
+anyhow.workspace = true
 backtrace.workspace = true
 base64.workspace = true
 clap.workspace = true

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -227,7 +227,9 @@ mod tests {
     use crate::serve;
     use datafusion::parquet::data_type::AsBytes;
     use hyper::{body, Body, Client, Request, Response, StatusCode};
+    use influxdb3_catalog::catalog::Catalog;
     use influxdb3_wal::WalConfig;
+    use influxdb3_write::last_cache::LastCacheProvider;
     use influxdb3_write::persister::Persister;
     use influxdb3_write::WriteBuffer;
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
@@ -762,6 +764,8 @@ mod tests {
         let write_buffer: Arc<dyn WriteBuffer> = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
+                Arc::new(Catalog::new()),
+                Arc::new(LastCacheProvider::new()),
                 Arc::<MockProvider>::clone(&time_provider),
                 Arc::clone(&exec),
                 WalConfig::test_config(),

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -63,6 +63,7 @@ impl Error {
 type CacheMap = RwLock<HashMap<String, HashMap<String, HashMap<String, LastCache>>>>;
 
 /// Provides all last-N-value caches for the entire database
+#[derive(Default)]
 pub struct LastCacheProvider {
     cache_map: CacheMap,
 }
@@ -110,10 +111,8 @@ pub struct CreateCacheArguments {
 
 impl LastCacheProvider {
     /// Create a new [`LastCacheProvider`]
-    pub(crate) fn new() -> Self {
-        Self {
-            cache_map: Default::default(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Initialize a [`LastCacheProvider`] from a [`InnerCatalog`]
@@ -1586,6 +1585,8 @@ mod tests {
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         WriteBufferImpl::new(
             persister,
+            Arc::new(Catalog::new()),
+            Arc::new(LastCacheProvider::new()),
             time_provider,
             crate::test_help::make_exec(),
             WalConfig::test_config(),


### PR DESCRIPTION
There is no issue for this PR. This is some refactoring required for downstream efforts to enable read replication.

### Main changes

* Moved initialization of the catalog and last cache out of the `WriteBufferImpl::new` function, and have them passed into that function as arguments. This was done so that we can initialize them independently of the write buffer, which adds a step when setting up the write buffer, but this was necessary to enable the initialization of a write buffer and read replicas that co-exist and share the catalog/last cache.
* Some error variants were added to enable the above change as well as allow for different write buffer implementations downstream.

Otherwise, there are some minor visibility changes and tweaks here and there.