### PR TITLE
test: fix MeasurementNamesFn missing retentionPolicy parameter caused by #22388

### DIFF
--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -536,7 +536,7 @@ func NewQueryExecutor() *QueryExecutor {
 		return nil
 	}
 
-	e.TSDBStore.MeasurementNamesFn = func(auth query.FineAuthorizer, database string, cond influxql.Expr) ([][]byte, error) {
+	e.TSDBStore.MeasurementNamesFn = func(auth query.FineAuthorizer, database string, retentionPolicy string, cond influxql.Expr) ([][]byte, error) {
 		return nil, nil
 	}
 

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -31,7 +31,7 @@ type TSDBStoreMock struct {
 	ImportShardFn               func(id uint64, r io.Reader) error
 	MeasurementSeriesCountsFn   func(database string) (measuments int, series int)
 	MeasurementsCardinalityFn   func(database string) (int64, error)
-	MeasurementNamesFn          func(auth query.FineAuthorizer, database string, cond influxql.Expr) ([][]byte, error)
+	MeasurementNamesFn          func(auth query.FineAuthorizer, database string, retentionPolicy string, cond influxql.Expr) ([][]byte, error)
 	OpenFn                      func() error
 	PathFn                      func() string
 	RestoreShardFn              func(id uint64, r io.Reader) error
@@ -96,7 +96,7 @@ func (s *TSDBStoreMock) ImportShard(id uint64, r io.Reader) error {
 	return s.ImportShardFn(id, r)
 }
 func (s *TSDBStoreMock) MeasurementNames(ctx context.Context, auth query.FineAuthorizer, database string, retentionPolicy string, cond influxql.Expr) ([][]byte, error) {
-	return s.MeasurementNamesFn(auth, database, cond)
+	return s.MeasurementNamesFn(auth, database, retentionPolicy, cond)
 }
 func (s *TSDBStoreMock) MeasurementSeriesCounts(database string) (measuments int, series int) {
 	return s.MeasurementSeriesCountsFn(database)


### PR DESCRIPTION
Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

Fix `MeasurementNamesFn` missing `retentionPolicy` parameter caused by #22388.

@davidby-influx @gwossum 