### PR TITLE
Refactor: use rand.New(rand.NewSource) instead of deprecated rand.Seed

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -137,7 +137,7 @@ func writePoints(clnt client.Client) {
 		log.Fatal(err)
 	}
 
-    rand.Seed(time.Now().UnixNano())
+    rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < sampleSize; i++ {
 		regions := []string{"us-west1", "us-west2", "us-west3", "us-east1"}
 		tags := map[string]string{

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -85,7 +85,7 @@ func ExampleClient_Write() {
 		pts        = make([]client.Point, sampleSize)
 	)
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 	for i := 0; i < sampleSize; i++ {
 		pts[i] = client.Point{
 			Measurement: "shapes",

--- a/client/v2/example_test.go
+++ b/client/v2/example_test.go
@@ -190,7 +190,7 @@ func ExampleClient_write1000() {
 	}
 	defer c.Close()
 
-	rand.Seed(42)
+	rand.New(rand.NewSource(42))
 
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  "systemstats",

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	m := NewMain()
 	if err := m.Run(os.Args[1:]...); err != nil {

--- a/internal/testutil/strings.go
+++ b/internal/testutil/strings.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MakeSentence returns a string made up of n words.
-// MakeSentence uses rand.Int31n and therefore calling rand.Seed will produce
+// MakeSentence uses rand.Int31n and therefore calling rand.New(rand.NewSource) will produce
 // deterministic results.
 func MakeSentence(n int) string {
 	s := make([]string, n)

--- a/models/tagkeysset_test.go
+++ b/models/tagkeysset_test.go
@@ -230,7 +230,7 @@ func BenchmarkTagKeysSet_UnionBytes(b *testing.B) {
 		bytes.Split([]byte("tag04,tag05"), commaB),
 	}
 
-	rand.Seed(20040409)
+	rand.New(rand.NewSource(20040409))
 
 	tests := []int{
 		10,

--- a/pkg/encoding/simple8b/encoding_test.go
+++ b/pkg/encoding/simple8b/encoding_test.go
@@ -76,7 +76,7 @@ func combine(fns ...func() []uint64) func() []uint64 {
 // TestEncodeAll ensures 100% test coverage of simple8b.EncodeAll and
 // verifies all output by comparing the original input with the output of simple8b.DecodeAll
 func TestEncodeAll(t *testing.T) {
-	rand.Seed(0)
+	rand.New(rand.NewSource(0))
 
 	tests := []struct {
 		name string

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 func Test_Data_DropDatabase(t *testing.T) {

--- a/storage/reads/keymerger_test.go
+++ b/storage/reads/keymerger_test.go
@@ -146,7 +146,7 @@ func BenchmarkKeyMerger_MergeKeys(b *testing.B) {
 		bytes.Split([]byte("tag04,tag05"), commaB),
 	}
 
-	rand.Seed(20040409)
+	rand.New(rand.NewSource(20040409))
 
 	tests := []int{
 		10,
@@ -180,7 +180,7 @@ func BenchmarkKeyMerger_MergeTagKeys(b *testing.B) {
 		models.ParseTags([]byte("foo,tag04=v0,tag05=v0")),
 	}
 
-	rand.Seed(20040409)
+	rand.New(rand.NewSource(20040409))
 
 	tests := []int{
 		10,

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	if seed == 0 {
 		seed = time.Now().UnixNano()
 	}
-	rand.Seed(seed)
+	rand.New(rand.NewSource(seed))
 
 	var r int
 	for _, indexType = range tsdb.RegisteredIndexes() {

--- a/tsdb/engine/tsm1/array_encoding_test.go
+++ b/tsdb/engine/tsm1/array_encoding_test.go
@@ -130,7 +130,7 @@ func BenchmarkDecodeIntegerArrayBlock(b *testing.B) {
 	}
 	for _, bm := range cases {
 		b.Run(fmt.Sprintf("%s_%d", bm.enc, bm.n), func(b *testing.B) {
-			rand.Seed(int64(bm.n * 1e3))
+			rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 			valueCount := bm.n
 			times := getTimes(valueCount, 60, time.Second)

--- a/tsdb/engine/tsm1/batch_boolean_test.go
+++ b/tsdb/engine/tsm1/batch_boolean_test.go
@@ -180,7 +180,7 @@ func Test_BooleanArrayDecodeAll_Multi_Compressed(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%0.2f", tc.n, tc.p), func(t *testing.T) {
-			rand.Seed(int64(tc.n * tc.n))
+			rand.New(rand.NewSource(int64(tc.n * tc.n)))
 
 			enc := tsm1.NewBooleanEncoder(tc.n)
 			values := make([]bool, tc.n)

--- a/tsdb/engine/tsm1/batch_integer_test.go
+++ b/tsdb/engine/tsm1/batch_integer_test.go
@@ -1102,7 +1102,7 @@ func BenchmarkIntegerArrayDecodeAllUncompressed(b *testing.B) {
 	}
 
 	for _, size := range benchmarks {
-		rand.Seed(int64(size * 1e3))
+		rand.New(rand.NewSource(int64(size * 1e3)))
 
 		enc := NewIntegerEncoder(size)
 		for i := 0; i < size; i++ {
@@ -1130,7 +1130,7 @@ func BenchmarkIntegerArrayDecodeAllPackedSimple(b *testing.B) {
 		1000,
 	}
 	for _, size := range benchmarks {
-		rand.Seed(int64(size * 1e3))
+		rand.New(rand.NewSource(int64(size * 1e3)))
 
 		enc := NewIntegerEncoder(size)
 		for i := 0; i < size; i++ {
@@ -1163,7 +1163,7 @@ func BenchmarkIntegerArrayDecodeAllRLE(b *testing.B) {
 		{1000, 0},
 	}
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		enc := NewIntegerEncoder(bm.n)
 		acc := int64(0)

--- a/tsdb/engine/tsm1/batch_string_test.go
+++ b/tsdb/engine/tsm1/batch_string_test.go
@@ -374,7 +374,7 @@ func BenchmarkStringArrayDecodeAll(b *testing.B) {
 		{1000, 10},
 	}
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		s := NewStringEncoder(bm.n)
 		for c := 0; c < bm.n; c++ {

--- a/tsdb/engine/tsm1/batch_timestamp_test.go
+++ b/tsdb/engine/tsm1/batch_timestamp_test.go
@@ -1090,7 +1090,7 @@ func BenchmarkTimeArrayDecodeAllUncompressed(b *testing.B) {
 	}
 
 	for _, size := range benchmarks {
-		rand.Seed(int64(size * 1e3))
+		rand.New(rand.NewSource(int64(size * 1e3)))
 
 		enc := NewTimeEncoder(size)
 		for i := 0; i < size; i++ {
@@ -1118,7 +1118,7 @@ func BenchmarkTimeArrayDecodeAllPackedSimple(b *testing.B) {
 		1000,
 	}
 	for _, size := range benchmarks {
-		rand.Seed(int64(size * 1e3))
+		rand.New(rand.NewSource(int64(size * 1e3)))
 
 		enc := NewTimeEncoder(size)
 		for i := 0; i < size; i++ {

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -1573,7 +1573,7 @@ func BenchmarkDecodeIntegerBlock(b *testing.B) {
 	}
 	for _, bm := range cases {
 		b.Run(fmt.Sprintf("%s_%d", bm.enc, bm.n), func(b *testing.B) {
-			rand.Seed(int64(bm.n * 1e3))
+			rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 			valueCount := bm.n
 			times := getTimes(valueCount, 60, time.Second)

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -627,7 +627,7 @@ func BenchmarkIntegerBatch_DecodeAllUncompressed(b *testing.B) {
 	}
 
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		enc := NewIntegerEncoder(bm.n)
 		for i := 0; i < bm.n; i++ {
@@ -663,7 +663,7 @@ func BenchmarkIntegerBatch_DecodeAllPackedSimple(b *testing.B) {
 		{1000},
 	}
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		enc := NewIntegerEncoder(bm.n)
 		for i := 0; i < bm.n; i++ {

--- a/tsdb/engine/tsm1/string_test.go
+++ b/tsdb/engine/tsm1/string_test.go
@@ -191,7 +191,7 @@ func BenchmarkStringDecoder_DecodeAll(b *testing.B) {
 		{1000, 10},
 	}
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		s := NewStringEncoder(bm.n)
 		for c := 0; c < bm.n; c++ {

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -625,7 +625,7 @@ func BenchmarkTimeBatch_DecodeAllUncompressed(b *testing.B) {
 	}
 
 	for _, size := range benchmarks {
-		rand.Seed(int64(size * 1e3))
+		rand.New(rand.NewSource(int64(size * 1e3)))
 
 		enc := NewTimeEncoder(size)
 		for i := 0; i < size; i++ {
@@ -661,7 +661,7 @@ func BenchmarkTimeBatch_DecodeAllPackedSimple(b *testing.B) {
 		{1000},
 	}
 	for _, bm := range benchmarks {
-		rand.Seed(int64(bm.n * 1e3))
+		rand.New(rand.NewSource(int64(bm.n * 1e3)))
 
 		enc := NewTimeEncoder(bm.n)
 		for i := 0; i < bm.n; i++ {

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -125,7 +125,7 @@ func TestLogFile_SeriesStoredInOrder(t *testing.T) {
 
 	// Generate and add test data
 	tvm := make(map[string]struct{})
-	rand.Seed(time.Now().Unix())
+	rand.New(rand.NewSource(time.Now().Unix()))
 	for i := 0; i < 100; i++ {
 		tv := fmt.Sprintf("server-%d", rand.Intn(50)) // Encourage adding duplicate series.
 		tvm[tv] = struct{}{}


### PR DESCRIPTION
Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.