### PR TITLE
fix(coordinator): fix closing opened twice in points writer

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -89,7 +89,6 @@ func (w *WritePointsRequest) AddPoint(name string, value interface{}, timestamp 
 // NewPointsWriter returns a new instance of PointsWriter for a node.
 func NewPointsWriter() *PointsWriter {
 	return &PointsWriter{
-		closing:      make(chan struct{}),
 		WriteTimeout: DefaultWriteTimeout,
 		Logger:       zap.NewNop(),
 		stats:        &WriteStatistics{},


### PR DESCRIPTION
Closes #25290

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

Just remove opened `closing` in `NewPointsWriter`

@davidby-influx @gwossum 