### PR TITLE
fix: fix typo 'exceeed' with 'exceeded' in master-1.x

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -59,7 +59,7 @@ func ErrDatabaseNotFound(name string) error { return fmt.Errorf("database not fo
 
 // ErrMaxSelectPointsLimitExceeded is an error when a query hits the maximum number of points.
 func ErrMaxSelectPointsLimitExceeded(n, limit int) error {
-	return fmt.Errorf("max-select-point limit exceeed: (%d/%d)", n, limit)
+	return fmt.Errorf("max-select-point limit exceeded: (%d/%d)", n, limit)
 }
 
 // ErrMaxConcurrentQueriesLimitExceeded is an error when a query cannot be run

--- a/query/monitor_test.go
+++ b/query/monitor_test.go
@@ -55,7 +55,7 @@ func TestPointLimitMonitor(t *testing.T) {
 
 	if err := query.DrainCursor(cur); err == nil {
 		t.Fatalf("expected an error")
-	} else if got, want := err.Error(), "max-select-point limit exceeed: (10/1)"; got != want {
+	} else if got, want := err.Error(), "max-select-point limit exceeded: (10/1)"; got != want {
 		t.Fatalf("unexpected error: got=%v want=%v", got, want)
 	}
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -1281,7 +1281,7 @@ func TestServer_Query_MaxSelectSeriesN(t *testing.T) {
 
 	test.addQueries([]*Query{
 		&Query{
-			name:    "exceeed max series",
+			name:    "exceeded max series",
 			command: `SELECT COUNT(value) FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"max-select-series limit exceeded: (4/3)"}]}`,
 		},


### PR DESCRIPTION
Closes #25295

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

https://github.com/influxdata/influxdb/blob/0582cf41484da8e0ea9791381f8ededb9ae86e79/query/executor.go#L61-L63

@davidby-influx @gwossum 