### PR TITLE
fix(config): fix max-concurrent-deletes typo in config.sample.toml

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -113,7 +113,7 @@
 
   # MaxConcurrentDeletes is the maximum number of simultaneous DELETE calls on a shard
   # The default is 1, and should be left unchanged for most users
-  # MaxConcurrentDeletes = 1
+  # max-concurrent-deletes = 1
 
   # CompactThroughput is the rate limit in bytes per second that we
   # will allow TSM compactions to write to disk. Note that short bursts are allowed


### PR DESCRIPTION
Closes #25294

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

`MaxConcurrentDeletes` should be replaced with `max-concurrent-deletes`

https://github.com/influxdata/influxdb/blob/0582cf41484da8e0ea9791381f8ededb9ae86e79/etc/config.sample.toml#L114-L117

@davidby-influx @gwossum 