### PR TITLE
feat(edge): Add 'flux enabled' to 'show diagnostics'

### DIFF
--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -108,6 +108,7 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"max-row-limit":        c.MaxRowLimit,
 		"max-connection-limit": c.MaxConnectionLimit,
 		"access-log-path":      c.AccessLogPath,
+		"flux-enabled":         c.FluxEnabled,
 	}), nil
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/feature-requests/issues/421

Adds a "flux-enabled" boolean column to our diagnostics output when calling SHOW DIAGNOSTICS;

With flux disabled in influxdb.conf
```
name: config-httpd
access-log-path bind-address enabled flux-enabled https-enabled max-connection-limit max-row-limit
--------------- ------------ ------- ------------ ------------- -------------------- -------------
                :8086        true    false        false         0                    0
```

With flux enabled in influxdb.conf
```
name: config-httpd
access-log-path bind-address enabled flux-enabled https-enabled max-connection-limit max-row-limit
--------------- ------------ ------- ------------ ------------- -------------------- -------------
                :8086        true    true         false         0                    0
```

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
