### PR TITLE
fix: add additional logging on loading fields.idxl files (#25309) (#25319)

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2499,7 +2499,15 @@ func (fscm *measurementFieldSetChangeMgr) loadAllFieldChanges(log *zap.Logger) (
 			return nil
 		}
 	})()
+	changesetCount := 0
+	totalChanges := 0
 	for fcs, err = fscm.loadFieldChangeSet(fd); err == nil; fcs, err = fscm.loadFieldChangeSet(fd) {
+		totalChanges += len(fcs)
+		changesetCount++
+		log.Debug("loading field change set",
+			zap.Int("set", changesetCount),
+			zap.Int("changes", len(fcs)),
+			zap.Int("total_changes", totalChanges))
 		changes = append(changes, fcs)
 	}
 	if errors.Is(err, io.EOF) {
@@ -2543,7 +2551,7 @@ func (fscm *measurementFieldSetChangeMgr) loadFieldChangeSet(r io.Reader) (Field
 }
 
 func (fs *MeasurementFieldSet) ApplyChanges() error {
-	log, end := logger.NewOperation(context.TODO(), fs.changeMgr.logger, "loading changes", "field indices")
+	log, end := logger.NewOperation(context.TODO(), fs.changeMgr.logger, "loading changes", "field indices", zap.String("path", fs.changeMgr.changeFilePath))
 	defer end()
 	changes, err := fs.changeMgr.loadAllFieldChanges(log)
 	if err != nil {


### PR DESCRIPTION
Log the path of the file being loaded, and when level=debug log progress for each set of field changes

closes https://github.com/influxdata/influxdb/issues/25289

(cherry picked from commit 5d8d1120e1ba060b0842d533953519fc5cd1aeed)

closes https://github.com/influxdata/influxdb/issues/25311

(cherry picked from commit 96c97a76f4d4c7bfb96a4a90cbf7fb36bbbcd083)

closes https://github.com/influxdata/influxdb/issues/25313
