### PR TITLE
feat: change CI to use cargo-nextest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,8 +188,8 @@ jobs:
       - checkout
       - rust_components
       - run:
-          name: cargo test --workspace
-          command: cargo test --workspace
+          name: cargo nextest run --workspace
+          command: cargo nextest run --workspace
 
   # Build a dev binary.
   #

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,10 @@
 [advisories]
 yanked = "deny"
 ignore = [
-    "RUSTSEC-2024-0363"
+    "RUSTSEC-2024-0363",
+    # dependent on arrow-* upgrading dependencies on lexical-core
+    # see https://github.com/apache/arrow-rs/pull/6401
+    "RUSTSEC-2023-0086",
 ]
 git-fetch-with-cli = true
 


### PR DESCRIPTION
This changes our CI to use cargo-nextest which is faster and does not
have issues around global statics. Since it runs each test in it's
own process we don't have to worry about tests stepping on each other's
toes in this regard. It also updates the CI to ignore the current
cargo deny failure as we can't do anything until the arrow crates are
upgraded.