### PR TITLE
feat: add instance id and host id to catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,8 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
 ]
@@ -3901,6 +3903,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -6197,6 +6244,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"
 hyper = "0.14"
-insta = { version = "1.39", features = ["json"] }
+insta = { version = "1.39", features = ["json", "redactions"] }
 indexmap = { version = "2.2.6" }
 libc = { version = "0.2" }
 mime = "0.3.17"

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -1,6 +1,5 @@
 ---
 source: influxdb3_catalog/src/catalog.rs
-assertion_line: 710
 expression: catalog
 ---
 {
@@ -151,5 +150,7 @@ expression: catalog
       }
     }
   },
-  "sequence": 0
+  "sequence": 0,
+  "host_id": "dummy-host-id",
+  "instance_id": "instance-id"
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -1,6 +1,5 @@
 ---
 source: influxdb3_catalog/src/catalog.rs
-assertion_line: 903
 expression: catalog
 ---
 {
@@ -76,5 +75,7 @@ expression: catalog
       }
     }
   },
-  "sequence": 0
+  "sequence": 0,
+  "host_id": "dummy-host-id",
+  "instance_id": "instance-id"
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -1,6 +1,5 @@
 ---
 source: influxdb3_catalog/src/catalog.rs
-assertion_line: 856
 expression: catalog
 ---
 {
@@ -66,5 +65,7 @@ expression: catalog
       }
     }
   },
-  "sequence": 0
+  "sequence": 0,
+  "host_id": "dummy-host-id",
+  "instance_id": "instance-id"
 }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -760,11 +760,13 @@ mod tests {
         ));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(start_time)));
+        let dummy_host_id = Arc::from("dummy-host-id");
+        let instance_id = Arc::from("dummy-instance-id");
 
         let write_buffer: Arc<dyn WriteBuffer> = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
-                Arc::new(Catalog::new()),
+                Arc::new(Catalog::new(dummy_host_id, instance_id)),
                 Arc::new(LastCacheProvider::new()),
                 Arc::<MockProvider>::clone(&time_provider),
                 Arc::clone(&exec),

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -633,10 +633,12 @@ mod tests {
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let executor = make_exec(object_store);
+        let host_id = Arc::from("dummy-host-id");
+        let instance_id = Arc::from("instance-id");
         let write_buffer: Arc<dyn WriteBuffer> = Arc::new(
             WriteBufferImpl::new(
                 Arc::clone(&persister),
-                Arc::new(Catalog::new()),
+                Arc::new(Catalog::new(host_id, instance_id)),
                 Arc::new(LastCacheProvider::new()),
                 Arc::<MockProvider>::clone(&time_provider),
                 Arc::clone(&executor),

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1583,9 +1583,11 @@ mod tests {
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let persister = Arc::new(Persister::new(obj_store, "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let host_id = Arc::from("dummy-host-id");
+        let instance_id = Arc::from("dummy-instance-id");
         WriteBufferImpl::new(
             persister,
-            Arc::new(Catalog::new()),
+            Arc::new(Catalog::new(host_id, instance_id)),
             Arc::new(LastCacheProvider::new()),
             time_provider,
             crate::test_help::make_exec(),
@@ -3131,7 +3133,9 @@ mod tests {
             .insert(Arc::clone(&table_def.name), table_def);
         // Create the catalog and clone its InnerCatalog (which is what the LastCacheProvider is
         // initialized from):
-        let mut catalog = Catalog::new();
+        let host_id = Arc::from("dummy-host-id");
+        let instance_id = Arc::from("dummy-instance-id");
+        let mut catalog = Catalog::new(host_id, instance_id);
         catalog.insert_database(database);
         let inner = catalog.clone_inner();
         // This is the function we are testing, which initializes the LastCacheProvider from the catalog:

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -1,6 +1,5 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
-assertion_line: 774
 expression: catalog_json
 ---
 {
@@ -58,5 +57,7 @@ expression: catalog_json
       }
     }
   },
+  "host_id": "dummy-host-id",
+  "instance_id": "[uuid]",
   "sequence": 3
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -52,5 +52,7 @@ expression: catalog_json
       }
     }
   },
+  "host_id": "dummy-host-id",
+  "instance_id": "[uuid]",
   "sequence": 2
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -45,5 +45,7 @@ expression: catalog_json
       }
     }
   },
+  "host_id": "dummy-host-id",
+  "instance_id": "[uuid]",
   "sequence": 4
 }

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -781,8 +781,10 @@ mod tests {
 
     #[test]
     fn write_validator_v1() -> Result<(), Error> {
+        let host_id = Arc::from("dummy-host-id");
+        let instance_id = Arc::from("dummy-instance-id");
         let namespace = NamespaceName::new("test").unwrap();
-        let catalog = Arc::new(Catalog::new());
+        let catalog = Arc::new(Catalog::new(host_id, instance_id));
         let result = WriteValidator::initialize(namespace.clone(), catalog, 0)?
             .v1_parse_lines_and_update_schema("cpu,tag1=foo val1=\"bar\" 1234", false)?
             .convert_lines_to_buffer(


### PR DESCRIPTION
- uses Arc<str> to represent create once and read everywhere type of string
- updated snapshots for insta asserts, uses redaction to hardcode randomly generated UUID strings
- added methods to catalog to expose instace and host ids

Closes: https://github.com/influxdata/influxdb/issues/25315