### PR TITLE
fix(tsi1/partition/test): fix data races in test code (#57) (#25338)

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -116,8 +116,7 @@ func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 // Only for tests!
 func (p *Partition) SetMaxLogFileSize(new int64) (old int64) {
 	p.mu.Lock()
-	old = p.maxLogFileSize
-	p.maxLogFileSize = new
+	old, p.maxLogFileSize = p.maxLogFileSize, new
 	p.mu.Unlock()
 	return old
 }
@@ -357,7 +356,7 @@ func (p *Partition) CurrentCompactionN() int {
 }
 
 // Wait will block until all compactions are finished.
-// must only be called while they are disabled.
+// Must only be called while they are disabled.
 func (p *Partition) Wait() {
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
@@ -387,15 +386,14 @@ func (p *Partition) Close() error {
 	}
 
 	// Close log files.
-	var err error
+	var err []error
 	for _, f := range p.fileSet.files {
-		if localErr := f.Close(); localErr != nil {
-			err = localErr
-		}
+		localErr := f.Close()
+		err = append(err, localErr)
 	}
 	p.fileSet.files = nil
 
-	return err
+	return errors.Join(err...)
 }
 
 // closing returns true if the partition is currently closing. It does not require


### PR DESCRIPTION
* fix(tsi1/partition/test): fix data races in test code (#57)

* fix(tsi1/partition/test): fix data races in test code

This PR is like influxdata/influxdb#24613 but solves it with a setter method for MaxLogFileSize which allows unexporting that value and MaxLogFileAge. There are actually two places locks were needed in test code. The behavior of production code is unchanged.

(cherry picked from commit f0235c4daf4b97769db932f7346c1d3aecf57f8f)

* feat: modify error handling to be more idiomatic

closes https://github.com/influxdata/influxdb/issues/24042

* fix: errors.Join() filters nil errors

closes https://github.com/influxdata/influxdb/issues/25341 ---------

Co-authored-by: Phil Bracikowski <13472206+philjb@users.noreply.github.com>
(cherry picked from commit 5c9e45f03340d6bb3bb48a2341c5e7da73860a89)

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
