### PR TITLE
fix(backup): fix DBRetentionAndShardFromPath parsing error between different OS

### DIFF
--- a/cmd/influxd/backup_util/backup_util.go
+++ b/cmd/influxd/backup_util/backup_util.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
-	"strings"
 	"sync/atomic"
 
 	internal "github.com/influxdata/influxdb/cmd/influxd/backup_util/internal"
@@ -219,10 +219,12 @@ func (w *CountingWriter) BytesWritten() int64 {
 	return atomic.LoadInt64(&w.Total)
 }
 
-// retentionAndShardFromPath will take the shard relative path and split it into the
-// retention policy name and shard ID. The first part of the path should be the database name.
+var separatorRegexp = regexp.MustCompile(`[/\\]`)
+
+// DBRetentionAndShardFromPath will take the shard relative path and split it into the
+// database name, retention policy name and shard ID. The first part of the path should be the database name.
 func DBRetentionAndShardFromPath(path string) (db, retention, shard string, err error) {
-	a := strings.Split(path, string(filepath.Separator))
+	a := separatorRegexp.Split(path, -1)
 	if len(a) != 3 {
 		return "", "", "", fmt.Errorf("expected database, retention policy, and shard id in path: %s", path)
 	}


### PR DESCRIPTION
Closes #25361

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).

Use ``separatorRegexp = regexp.MustCompile(`[/\\]`)`` to `Split` instead of `strings.Split(path, string(filepath.Separator))`

@davidby-influx @gwossum 