### PR TITLE
chore: upgrade go 1.21.12 -> 1.22.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.21.12-latest
+    default: go1.22.7-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/influxdb
 
-go 1.21
+go 1.22
 
 require (
 	collectd.org v0.3.0


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/744
