### PR TITLE
feat: Add u32 ID for Tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "object_store",
  "observability_deps",
  "parking_lot",
+ "pretty_assertions",
  "schema",
  "serde",
  "serde_json",

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -1,7 +1,7 @@
 //! Implementation of the Catalog that sits entirely in memory.
 
 use crate::catalog::Error::TableNotFound;
-use influxdb3_id::DbId;
+use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::{
     CatalogBatch, CatalogOp, FieldAdditions, LastCacheDefinition, LastCacheDelete,
 };
@@ -484,6 +484,7 @@ impl DatabaseSchema {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TableDefinition {
+    pub table_id: TableId,
     pub name: Arc<str>,
     pub schema: Schema,
     pub last_caches: BTreeMap<String, LastCacheDefinition>,
@@ -519,6 +520,7 @@ impl TableDefinition {
         let schema = schema_builder.build().unwrap();
 
         Ok(Self {
+            table_id: TableId::new(),
             name,
             schema,
             last_caches: BTreeMap::new(),
@@ -843,10 +845,12 @@ mod tests {
                         "name": "db1",
                         "tables": {
                             "tbl1": {
+                                "table_id": 0,
                                 "name": "tbl1",
                                 "cols": {}
                             },
                             "tbl1": {
+                                "table_id": 0,
                                 "name": "tbl1",
                                 "cols": {}
                             }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -9,6 +9,7 @@ expression: catalog
       "name": "test_db",
       "tables": {
         "test_table_1": {
+          "table_id": 0,
           "name": "test_table_1",
           "cols": {
             "bool_field": {
@@ -79,6 +80,7 @@ expression: catalog
           }
         },
         "test_table_2": {
+          "table_id": 1,
           "name": "test_table_2",
           "cols": {
             "bool_field": {

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -9,6 +9,7 @@ expression: catalog
       "name": "test_db",
       "tables": {
         "test_table_1": {
+          "table_id": 0,
           "name": "test",
           "cols": {
             "field": {

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -9,6 +9,7 @@ expression: catalog
       "name": "test_db",
       "tables": {
         "test_table_1": {
+          "table_id": 0,
           "name": "test_table_1",
           "key": [
             "tag_1",

--- a/influxdb3_id/src/lib.rs
+++ b/influxdb3_id/src/lib.rs
@@ -13,7 +13,7 @@ impl DbId {
         Self(NEXT_DB_ID.fetch_add(1, Ordering::SeqCst))
     }
 
-    pub fn next_id() -> DbId {
+    pub fn next_id() -> Self {
         Self(NEXT_DB_ID.load(Ordering::SeqCst))
     }
 
@@ -33,6 +33,41 @@ impl Default for DbId {
 }
 
 impl From<u32> for DbId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash)]
+pub struct TableId(u32);
+
+static NEXT_TABLE_ID: AtomicU32 = AtomicU32::new(0);
+
+impl TableId {
+    pub fn new() -> Self {
+        Self(NEXT_TABLE_ID.fetch_add(1, Ordering::SeqCst))
+    }
+
+    pub fn next_id() -> Self {
+        Self(NEXT_TABLE_ID.load(Ordering::SeqCst))
+    }
+
+    pub fn set_next_id(&self) {
+        NEXT_TABLE_ID.store(self.0, Ordering::SeqCst)
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for TableId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<u32> for TableId {
     fn from(value: u32) -> Self {
         Self(value)
     }

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -30,5 +30,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
+[dev-dependencies]
+pretty_assertions.workspace = true
+
 [lints]
 workspace = true

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -613,7 +613,7 @@ mod tests {
         Field, FieldData, Gen1Duration, Row, SnapshotSequenceNumber, TableChunk, TableChunks,
     };
     use async_trait::async_trait;
-    use influxdb3_id::DbId;
+    use influxdb3_id::{DbId, TableId};
     use object_store::memory::InMemory;
     use std::any::Any;
     use tokio::sync::oneshot::Receiver;
@@ -644,7 +644,7 @@ mod tests {
             database_id: DbId::from(0),
             database_name: Arc::clone(&db_name),
             table_chunks: HashMap::from([(
-                Arc::clone(&table_name),
+                (Arc::clone(&table_name), TableId::from(0)),
                 TableChunks {
                     min_time: 1,
                     max_time: 3,
@@ -692,7 +692,7 @@ mod tests {
             database_id: DbId::from(0),
             database_name: Arc::clone(&db_name),
             table_chunks: HashMap::from([(
-                Arc::clone(&table_name),
+                (Arc::clone(&table_name), TableId::from(1)),
                 TableChunks {
                     min_time: 12,
                     max_time: 12,
@@ -731,42 +731,56 @@ mod tests {
             ops: vec![WalOp::Write(WriteBatch {
                 database_id: DbId::from(0),
                 database_name: "db1".into(),
-                table_chunks: HashMap::from([(
-                    "table1".into(),
-                    TableChunks {
-                        min_time: 1,
-                        max_time: 12,
-                        chunk_time_to_chunk: HashMap::from([(
-                            0,
-                            TableChunk {
-                                rows: vec![
-                                    Row {
-                                        time: 1,
-                                        fields: vec![
-                                            Field {
-                                                name: "f1".into(),
-                                                value: FieldData::Integer(1),
-                                            },
-                                            Field {
-                                                name: "time".into(),
-                                                value: FieldData::Timestamp(1),
-                                            },
-                                        ],
-                                    },
-                                    Row {
-                                        time: 3,
-                                        fields: vec![
-                                            Field {
-                                                name: "f1".into(),
-                                                value: FieldData::Integer(2),
-                                            },
-                                            Field {
-                                                name: "time".into(),
-                                                value: FieldData::Timestamp(3),
-                                            },
-                                        ],
-                                    },
-                                    Row {
+                table_chunks: HashMap::from([
+                    (
+                        ("table1".into(), TableId::from(0)),
+                        TableChunks {
+                            min_time: 1,
+                            max_time: 3,
+                            chunk_time_to_chunk: HashMap::from([(
+                                0,
+                                TableChunk {
+                                    rows: vec![
+                                        Row {
+                                            time: 1,
+                                            fields: vec![
+                                                Field {
+                                                    name: "f1".into(),
+                                                    value: FieldData::Integer(1),
+                                                },
+                                                Field {
+                                                    name: "time".into(),
+                                                    value: FieldData::Timestamp(1),
+                                                },
+                                            ],
+                                        },
+                                        Row {
+                                            time: 3,
+                                            fields: vec![
+                                                Field {
+                                                    name: "f1".into(),
+                                                    value: FieldData::Integer(2),
+                                                },
+                                                Field {
+                                                    name: "time".into(),
+                                                    value: FieldData::Timestamp(3),
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            )]),
+                        },
+                    ),
+                    (
+                        ("table1".into(), TableId::from(1)),
+                        TableChunks {
+                            min_time: 12,
+                            max_time: 12,
+                            chunk_time_to_chunk: HashMap::from([(
+                                0,
+                                TableChunk {
+                                    rows: vec![Row {
                                         time: 12,
                                         fields: vec![
                                             Field {
@@ -778,12 +792,12 @@ mod tests {
                                                 value: FieldData::Timestamp(62_000000000),
                                             },
                                         ],
-                                    },
-                                ],
-                            },
-                        )]),
-                    },
-                )]),
+                                    }],
+                                },
+                            )]),
+                        },
+                    ),
+                ]),
                 min_time_ns: 1,
                 max_time_ns: 62_000000000,
             })],
@@ -802,7 +816,7 @@ mod tests {
                 database_id: DbId::from(0),
                 database_name: "db1".into(),
                 table_chunks: HashMap::from([(
-                    "table1".into(),
+                    ("table1".into(), TableId::from(1)),
                     TableChunks {
                         min_time: 12,
                         max_time: 12,
@@ -862,7 +876,7 @@ mod tests {
 
         {
             let notified_writes = replay_notifier.notified_writes.lock();
-            assert_eq!(
+            pretty_assertions::assert_eq!(
                 *notified_writes,
                 vec![file_1_contents.clone(), file_2_contents.clone()]
             );
@@ -874,7 +888,7 @@ mod tests {
             database_id: DbId::from(0),
             database_name: Arc::clone(&db_name),
             table_chunks: HashMap::from([(
-                Arc::clone(&table_name),
+                (Arc::clone(&table_name), TableId::from(0)),
                 TableChunks {
                     min_time: 26,
                     max_time: 26,
@@ -934,7 +948,7 @@ mod tests {
                 database_id: DbId::from(0),
                 database_name: "db1".into(),
                 table_chunks: HashMap::from([(
-                    "table1".into(),
+                    ("table1".into(), TableId::from(0)),
                     TableChunks {
                         min_time: 26,
                         max_time: 26,

--- a/influxdb3_wal/src/serialize.rs
+++ b/influxdb3_wal/src/serialize.rs
@@ -92,7 +92,7 @@ mod tests {
         Field, FieldData, Row, TableChunk, TableChunks, WalFileSequenceNumber, WalOp, WriteBatch,
     };
     use hashbrown::HashMap;
-    use influxdb3_id::DbId;
+    use influxdb3_id::{DbId, TableId};
     use std::sync::Arc;
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
         };
         let table_name: Arc<str> = "table2".into();
         let mut table_chunks = HashMap::new();
-        table_chunks.insert(table_name, chunks);
+        table_chunks.insert((table_name, TableId::from(0)), chunks);
 
         let contents = WalContents {
             min_timestamp_ns: 0,

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -431,7 +431,7 @@ impl LastCacheProvider {
                         if db_cache.is_empty() {
                             continue;
                         }
-                        for (tbl_name, tbl_chunks) in &batch.table_chunks {
+                        for ((tbl_name, _table_id), tbl_chunks) in &batch.table_chunks {
                             if let Some(tbl_cache) = db_cache.get_mut(tbl_name.as_ref()) {
                                 for (_, last_cache) in tbl_cache.iter_mut() {
                                     for chunk in tbl_chunks.chunk_time_to_chunk.values() {

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -18,6 +18,7 @@ use datafusion::error::DataFusionError;
 use datafusion::prelude::Expr;
 use influxdb3_catalog::catalog::{self, SequenceNumber};
 use influxdb3_id::DbId;
+use influxdb3_id::TableId;
 use influxdb3_wal::{LastCacheDefinition, SnapshotSequenceNumber, WalFileSequenceNumber};
 use iox_query::QueryChunk;
 use iox_time::Time;
@@ -168,6 +169,8 @@ pub struct PersistedSnapshot {
     pub next_file_id: ParquetFileId,
     /// The next db id to be used with databases when the snapshot is loaded
     pub next_db_id: DbId,
+    /// The next table id to be used with databases when the snapshot is loaded
+    pub next_table_id: TableId,
     /// The snapshot sequence number associated with this snapshot
     pub snapshot_sequence_number: SnapshotSequenceNumber,
     /// The wal file sequence number that triggered this snapshot
@@ -198,6 +201,7 @@ impl PersistedSnapshot {
             host_id,
             next_file_id: ParquetFileId::current(),
             next_db_id: DbId::next_id(),
+            next_table_id: TableId::next_id(),
             snapshot_sequence_number,
             wal_file_sequence_number,
             catalog_sequence_number,

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -57,11 +57,12 @@ impl ParquetFilePath {
         db_name: &str,
         db_id: u32,
         table_name: &str,
+        table_id: u32,
         date: DateTime<Utc>,
         wal_file_sequence_number: WalFileSequenceNumber,
     ) -> Self {
         let path = ObjPath::from(format!(
-            "{host_prefix}/dbs/{db_name}-{db_id}/{table_name}/{}/{}.{}",
+            "{host_prefix}/dbs/{db_name}-{db_id}/{table_name}-{table_id}/{}/{}.{}",
             date.format("%Y-%m-%d/%H-%M"),
             wal_file_sequence_number.as_u64(),
             PARQUET_FILE_EXTENSION
@@ -73,13 +74,14 @@ impl ParquetFilePath {
         db_name: &str,
         db_id: u32,
         table_name: &str,
+        table_id: u32,
         chunk_time: i64,
         wal_file_sequence_number: WalFileSequenceNumber,
     ) -> Self {
         // Convert the chunk time into a date time string for YYYY-MM-DDTHH-MM
         let date_time = DateTime::<Utc>::from_timestamp_nanos(chunk_time);
         let path = ObjPath::from(format!(
-            "dbs/{db_name}-{db_id}/{table_name}/{}/{:010}.{}",
+            "dbs/{db_name}-{db_id}/{table_name}-{table_id}/{}/{:010}.{}",
             date_time.format("%Y-%m-%d/%H-%M"),
             wal_file_sequence_number.as_u64(),
             PARQUET_FILE_EXTENSION
@@ -150,10 +152,11 @@ fn parquet_file_path_new() {
             "my_db",
             0,
             "my_table",
+            0,
             Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
             WalFileSequenceNumber::new(0),
         ),
-        ObjPath::from("my_host/dbs/my_db-0/my_table/2038-01-19/03-14/0.parquet")
+        ObjPath::from("my_host/dbs/my_db-0/my_table-0/2038-01-19/03-14/0.parquet")
     );
 }
 
@@ -161,16 +164,17 @@ fn parquet_file_path_new() {
 fn parquet_file_percent_encoded() {
     assert_eq!(
         ParquetFilePath::new(
-            "my_host",
+            "..",
             "..",
             0,
             "..",
+            0,
             Utc.with_ymd_and_hms(2038, 1, 19, 3, 14, 7).unwrap(),
             WalFileSequenceNumber::new(0),
         )
         .as_ref()
         .as_ref(),
-        "my_host/dbs/..-0/%2E%2E/2038-01-19/03-14/0.parquet"
+        "%2E%2E/dbs/..-0/..-0/2038-01-19/03-14/0.parquet"
     );
 }
 

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -416,7 +416,7 @@ mod tests {
     use super::*;
     use crate::ParquetFileId;
     use influxdb3_catalog::catalog::SequenceNumber;
-    use influxdb3_id::DbId;
+    use influxdb3_id::{DbId, TableId};
     use influxdb3_wal::SnapshotSequenceNumber;
     use object_store::memory::InMemory;
     use observability_deps::tracing::info;
@@ -490,6 +490,7 @@ mod tests {
             host_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(0),
+            next_table_id: TableId::from(0),
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::new(0),
@@ -512,6 +513,7 @@ mod tests {
             host_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(0),
+            next_table_id: TableId::from(0),
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::default(),
@@ -525,6 +527,7 @@ mod tests {
             host_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(1),
             next_db_id: DbId::from(0),
+            next_table_id: TableId::from(0),
             snapshot_sequence_number: SnapshotSequenceNumber::new(1),
             wal_file_sequence_number: WalFileSequenceNumber::new(1),
             catalog_sequence_number: SequenceNumber::default(),
@@ -538,6 +541,7 @@ mod tests {
             host_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(2),
             next_db_id: DbId::from(0),
+            next_table_id: TableId::from(0),
             snapshot_sequence_number: SnapshotSequenceNumber::new(2),
             wal_file_sequence_number: WalFileSequenceNumber::new(2),
             catalog_sequence_number: SequenceNumber::default(),
@@ -572,6 +576,7 @@ mod tests {
             host_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(0),
+            next_table_id: TableId::from(0),
             snapshot_sequence_number: SnapshotSequenceNumber::new(0),
             wal_file_sequence_number: WalFileSequenceNumber::new(0),
             catalog_sequence_number: SequenceNumber::default(),
@@ -599,6 +604,7 @@ mod tests {
                 host_id: "test_host".to_string(),
                 next_file_id: ParquetFileId::from(id),
                 next_db_id: DbId::from(0),
+                next_table_id: TableId::from(0),
                 snapshot_sequence_number: SnapshotSequenceNumber::new(id),
                 wal_file_sequence_number: WalFileSequenceNumber::new(id),
                 catalog_sequence_number: SequenceNumber::new(id as u32),
@@ -717,6 +723,7 @@ mod tests {
             "db_one",
             0,
             "table_one",
+            0,
             Utc::now(),
             WalFileSequenceNumber::new(1),
         );

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -53,7 +53,8 @@ expression: catalog_json
               "vals": null
             }
           ],
-          "name": "table"
+          "name": "table",
+          "table_id": 1
         }
       }
     }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -48,7 +48,8 @@ expression: catalog_json
               "vals": null
             }
           ],
-          "name": "table"
+          "name": "table",
+          "table_id": 1
         }
       }
     }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -41,7 +41,8 @@ expression: catalog_json
               }
             }
           },
-          "name": "table"
+          "name": "table",
+          "table_id": 1
         }
       }
     }


### PR DESCRIPTION
This commit adds a u32 identifier for tables. This is mostly the same as
previous work done for the DbId and updates tests accordingly. The
important bit here is that I uncovered a double table creation bug
whereby we would create a new table, then insert the same new table as
part of the CatalogOp::AddFields, causing an off by one error for the id.
This commit removes the offending extra insert so that only one is done
to add the definition to the catalog.

Since we also needed to add the TableId to WriteBatch, we needed to do
custom serialization and deserialization logic as the tuple won't automatically
turn into a string for the serialization.
Closes #25375