### PR TITLE
feat: Add non-unique u16 Id to ColumnDefinition

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -1,8 +1,9 @@
 //! Implementation of the Catalog that sits entirely in memory.
 
 use crate::catalog::Error::TableNotFound;
+use arrow::datatypes::SchemaRef;
 use bimap::BiHashMap;
-use influxdb3_id::{DbId, TableId};
+use influxdb3_id::{ColumnId, DbId, TableId};
 use influxdb3_wal::{
     CatalogBatch, CatalogOp, FieldAdditions, LastCacheDefinition, LastCacheDelete,
 };
@@ -656,7 +657,9 @@ impl DatabaseSchema {
     }
 
     pub fn get_table_schema(&self, table_id: TableId) -> Option<&Schema> {
-        self.tables.get(&table_id).map(|table| &table.schema)
+        self.tables
+            .get(&table_id)
+            .map(|table| table.influx_schema())
     }
 
     pub fn get_table(&self, table_id: TableId) -> Option<&TableDefinition> {
@@ -687,7 +690,7 @@ impl DatabaseSchema {
 pub struct TableDefinition {
     pub table_id: TableId,
     pub table_name: Arc<str>,
-    pub schema: Schema,
+    pub schema: TableSchema,
     pub last_caches: BTreeMap<String, LastCacheDefinition>,
 }
 
@@ -719,7 +722,7 @@ impl TableDefinition {
         for (name, column_type) in ordered_columns {
             schema_builder.influx_column(name, *column_type);
         }
-        let schema = schema_builder.build().unwrap();
+        let schema = TableSchema::new(schema_builder.build().unwrap());
 
         Ok(Self {
             table_id,
@@ -753,6 +756,7 @@ impl TableDefinition {
         // validate the series key is the same
         let existing_key = self
             .schema
+            .schema()
             .series_key()
             .map(|k| k.iter().map(|v| v.to_string()).collect());
 
@@ -767,7 +771,11 @@ impl TableDefinition {
             Vec::with_capacity(table_definition.field_definitions.len());
 
         for field_def in &table_definition.field_definitions {
-            if let Some(existing_type) = self.schema.field_type_by_name(field_def.name.as_ref()) {
+            if let Some(existing_type) = self
+                .schema
+                .schema()
+                .field_type_by_name(field_def.name.as_ref())
+            {
                 if existing_type != field_def.data_type.into() {
                     return Err(Error::FieldTypeMismatch {
                         table_name: self.table_name.to_string(),
@@ -853,7 +861,7 @@ impl TableDefinition {
 
     /// Check if the column exists in the [`TableDefinition`]s schema
     pub fn column_exists(&self, column: &str) -> bool {
-        self.schema.find_index_of(column).is_some()
+        self.influx_schema().find_index_of(column).is_some()
     }
 
     /// Add the columns to this [`TableDefinition`]
@@ -863,7 +871,7 @@ impl TableDefinition {
         // Use BTree to insert existing and new columns, and use that to generate the
         // resulting schema, to ensure column order is consistent:
         let mut cols = BTreeMap::new();
-        for (col_type, field) in self.schema.iter() {
+        for (col_type, field) in self.influx_schema().iter() {
             cols.insert(field.name(), col_type);
         }
         for (name, column_type) in columns.iter() {
@@ -874,6 +882,7 @@ impl TableDefinition {
         if cols.len() > Catalog::NUM_COLUMNS_PER_TABLE_LIMIT {
             return Err(Error::TooManyColumns);
         }
+
         let mut schema_builder = SchemaBuilder::with_capacity(columns.len());
         // TODO: may need to capture some schema-level metadata, currently, this causes trouble in
         // tests, so I am omitting this for now:
@@ -883,13 +892,19 @@ impl TableDefinition {
         }
         let schema = schema_builder.build().unwrap();
 
-        self.schema = schema;
+        // Now that we have all the columns we know will be added and haven't
+        // triggered the limit add the ColumnId <-> Name mapping to the schema
+        for (name, _) in columns.iter() {
+            self.schema.add_column(name);
+        }
+
+        self.schema.schema = schema;
 
         Ok(())
     }
 
     pub fn index_columns(&self) -> Vec<&str> {
-        self.schema
+        self.influx_schema()
             .iter()
             .filter_map(|(col_type, field)| match col_type {
                 InfluxColumnType::Tag => Some(field.name().as_str()),
@@ -898,20 +913,24 @@ impl TableDefinition {
             .collect()
     }
 
-    pub fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &TableSchema {
         &self.schema
     }
 
+    pub fn influx_schema(&self) -> &Schema {
+        &self.schema.schema
+    }
+
     pub fn num_columns(&self) -> usize {
-        self.schema.len()
+        self.influx_schema().len()
     }
 
     pub fn field_type_by_name(&self, name: &str) -> Option<InfluxColumnType> {
-        self.schema.field_type_by_name(name)
+        self.influx_schema().field_type_by_name(name)
     }
 
     pub fn is_v3(&self) -> bool {
-        self.schema.series_key().is_some()
+        self.influx_schema().series_key().is_some()
     }
 
     /// Add a new last cache to this table definition
@@ -927,6 +946,98 @@ impl TableDefinition {
 
     pub fn last_caches(&self) -> impl Iterator<Item = (&String, &LastCacheDefinition)> {
         self.last_caches.iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TableSchema {
+    schema: Schema,
+    column_map: BiHashMap<ColumnId, Arc<str>>,
+    next_column_id: ColumnId,
+}
+
+impl TableSchema {
+    /// Creates a new `TableSchema` from scratch and assigns an id based off the
+    /// index. Any changes to the schema after this point will use the
+    /// next_column_id. For example if we have a column foo and drop it and then
+    /// add a new column foo, then it will use a new id, not reuse the old one.
+    fn new(schema: Schema) -> Self {
+        let column_map: BiHashMap<ColumnId, Arc<str>> = schema
+            .as_arrow()
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(idx, field)| (ColumnId::from(idx as u16), field.name().as_str().into()))
+            .collect();
+        Self {
+            schema,
+            next_column_id: ColumnId::from(column_map.len() as u16),
+            column_map,
+        }
+    }
+
+    pub(crate) fn new_with_mapping(
+        schema: Schema,
+        column_map: BiHashMap<ColumnId, Arc<str>>,
+        next_column_id: ColumnId,
+    ) -> Self {
+        Self {
+            schema,
+            column_map,
+            next_column_id,
+        }
+    }
+
+    pub fn as_arrow(&self) -> SchemaRef {
+        self.schema.as_arrow()
+    }
+
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    pub(crate) fn column_map(&self) -> &BiHashMap<ColumnId, Arc<str>> {
+        &self.column_map
+    }
+
+    pub(crate) fn next_column_id(&self) -> ColumnId {
+        self.next_column_id
+    }
+
+    fn add_column(&mut self, column_name: &str) {
+        let id = self.next_column_id;
+        self.next_column_id = id.next_id();
+        self.column_map.insert(id, column_name.into());
+    }
+
+    pub fn series_key(&self) -> Option<Vec<&str>> {
+        self.schema.series_key()
+    }
+
+    pub fn iter(&self) -> schema::SchemaIter<'_> {
+        self.schema.iter()
+    }
+
+    pub fn name_to_id(&self, name: Arc<str>) -> Option<ColumnId> {
+        self.column_map.get_by_right(&name).copied()
+    }
+
+    pub fn id_to_name(&self, id: ColumnId) -> Option<Arc<str>> {
+        self.column_map.get_by_left(&id).cloned()
+    }
+
+    pub fn name_to_id_unchecked(&self, name: Arc<str>) -> ColumnId {
+        *self
+            .column_map
+            .get_by_right(&name)
+            .expect("Column exists in mapping")
+    }
+
+    pub fn id_to_name_unchecked(&self, id: ColumnId) -> Arc<str> {
+        self.column_map
+            .get_by_left(&id)
+            .expect("Column exists in mapping")
+            .clone()
     }
 }
 
@@ -1053,12 +1164,16 @@ mod tests {
                             {
                                 "table_id": 0,
                                 "table_name": "tbl1",
-                                "cols": {}
+                                "cols": {},
+                                "column_map": [],
+                                "next_column_id": 0
                             },
                             {
                                 "table_id": 0,
                                 "table_name": "tbl1",
-                                "cols": {}
+                                "cols": {},
+                                "column_map": [],
+                                "next_column_id": 0
                             }
                         ]
                     }
@@ -1091,7 +1206,14 @@ mod tests {
                                         "influx_type": "field",
                                         "nullable": true
                                     }
-                                }
+                                },
+                                "column_map": [
+                                    {
+                                        "column_id": 0,
+                                        "name": "col1"
+                                    }
+                                ],
+                                "next_column_id": 1
                             }
                         ]
                     }
@@ -1103,7 +1225,7 @@ mod tests {
     }
 
     #[test]
-    fn add_columns_updates_schema() {
+    fn add_columns_updates_schema_and_column_map() {
         let mut database = DatabaseSchema {
             id: DbId::from(0),
             name: "test".into(),
@@ -1124,15 +1246,21 @@ mod tests {
         );
 
         let table = database.tables.get_mut(&TableId::from(0)).unwrap();
+        assert_eq!(table.schema.column_map().len(), 1);
+        assert_eq!(table.schema.id_to_name_unchecked(0.into()), "test".into());
+
         table
             .add_columns(vec![("test2".to_string(), InfluxColumnType::Tag)])
             .unwrap();
-        let schema = table.schema();
+        let schema = table.influx_schema();
         assert_eq!(
             schema.field(0).0,
             InfluxColumnType::Field(InfluxFieldType::String)
         );
         assert_eq!(schema.field(1).0, InfluxColumnType::Tag);
+
+        assert_eq!(table.schema.column_map().len(), 2);
+        assert_eq!(table.schema.name_to_id_unchecked("test2".into()), 1.into());
     }
 
     #[test]

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -1080,11 +1080,13 @@ mod tests {
                                 "table_name": "tbl1",
                                 "cols": {
                                     "col1": {
+                                        "column_id": 0,
                                         "type": "i64",
                                         "influx_type": "field",
                                         "nullable": true
                                     },
                                     "col1": {
+                                        "column_id": 0,
                                         "type": "u64",
                                         "influx_type": "field",
                                         "nullable": true

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -13,26 +13,31 @@ expression: catalog
           "table_name": "test_table_1",
           "cols": {
             "bool_field": {
+              "column_id": 0,
               "type": "bool",
               "influx_type": "field",
               "nullable": true
             },
             "f64_field": {
+              "column_id": 1,
               "type": "f64",
               "influx_type": "field",
               "nullable": true
             },
             "i64_field": {
+              "column_id": 2,
               "type": "i64",
               "influx_type": "field",
               "nullable": true
             },
             "string_field": {
+              "column_id": 3,
               "type": "str",
               "influx_type": "field",
               "nullable": true
             },
             "tag_1": {
+              "column_id": 4,
               "type": {
                 "dict": [
                   "i32",
@@ -43,6 +48,7 @@ expression: catalog
               "nullable": true
             },
             "tag_2": {
+              "column_id": 5,
               "type": {
                 "dict": [
                   "i32",
@@ -53,6 +59,7 @@ expression: catalog
               "nullable": true
             },
             "tag_3": {
+              "column_id": 6,
               "type": {
                 "dict": [
                   "i32",
@@ -63,6 +70,7 @@ expression: catalog
               "nullable": true
             },
             "time": {
+              "column_id": 7,
               "type": {
                 "time": [
                   "ns",
@@ -73,6 +81,7 @@ expression: catalog
               "nullable": false
             },
             "u64_field": {
+              "column_id": 8,
               "type": "u64",
               "influx_type": "field",
               "nullable": true
@@ -84,26 +93,31 @@ expression: catalog
           "table_name": "test_table_2",
           "cols": {
             "bool_field": {
+              "column_id": 0,
               "type": "bool",
               "influx_type": "field",
               "nullable": true
             },
             "f64_field": {
+              "column_id": 1,
               "type": "f64",
               "influx_type": "field",
               "nullable": true
             },
             "i64_field": {
+              "column_id": 2,
               "type": "i64",
               "influx_type": "field",
               "nullable": true
             },
             "string_field": {
+              "column_id": 3,
               "type": "str",
               "influx_type": "field",
               "nullable": true
             },
             "tag_1": {
+              "column_id": 4,
               "type": {
                 "dict": [
                   "i32",
@@ -114,6 +128,7 @@ expression: catalog
               "nullable": true
             },
             "tag_2": {
+              "column_id": 5,
               "type": {
                 "dict": [
                   "i32",
@@ -124,6 +139,7 @@ expression: catalog
               "nullable": true
             },
             "tag_3": {
+              "column_id": 6,
               "type": {
                 "dict": [
                   "i32",
@@ -134,6 +150,7 @@ expression: catalog
               "nullable": true
             },
             "time": {
+              "column_id": 7,
               "type": {
                 "time": [
                   "ns",
@@ -144,6 +161,7 @@ expression: catalog
               "nullable": false
             },
             "u64_field": {
+              "column_id": 8,
               "type": "u64",
               "influx_type": "field",
               "nullable": true

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -86,7 +86,46 @@ expression: catalog
               "influx_type": "field",
               "nullable": true
             }
-          }
+          },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "bool_field"
+            },
+            {
+              "column_id": 1,
+              "name": "f64_field"
+            },
+            {
+              "column_id": 2,
+              "name": "i64_field"
+            },
+            {
+              "column_id": 3,
+              "name": "string_field"
+            },
+            {
+              "column_id": 4,
+              "name": "tag_1"
+            },
+            {
+              "column_id": 5,
+              "name": "tag_2"
+            },
+            {
+              "column_id": 6,
+              "name": "tag_3"
+            },
+            {
+              "column_id": 7,
+              "name": "time"
+            },
+            {
+              "column_id": 8,
+              "name": "u64_field"
+            }
+          ],
+          "next_column_id": 9
         },
         {
           "table_id": 2,
@@ -166,7 +205,46 @@ expression: catalog
               "influx_type": "field",
               "nullable": true
             }
-          }
+          },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "bool_field"
+            },
+            {
+              "column_id": 1,
+              "name": "f64_field"
+            },
+            {
+              "column_id": 2,
+              "name": "i64_field"
+            },
+            {
+              "column_id": 3,
+              "name": "string_field"
+            },
+            {
+              "column_id": 4,
+              "name": "tag_1"
+            },
+            {
+              "column_id": 5,
+              "name": "tag_2"
+            },
+            {
+              "column_id": 6,
+              "name": "tag_3"
+            },
+            {
+              "column_id": 7,
+              "name": "time"
+            },
+            {
+              "column_id": 8,
+              "name": "u64_field"
+            }
+          ],
+          "next_column_id": 9
         }
       ]
     }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -13,11 +13,13 @@ expression: catalog
           "table_name": "test",
           "cols": {
             "field": {
+              "column_id": 0,
               "type": "str",
               "influx_type": "field",
               "nullable": true
             },
             "tag_1": {
+              "column_id": 1,
               "type": {
                 "dict": [
                   "i32",
@@ -28,6 +30,7 @@ expression: catalog
               "nullable": true
             },
             "tag_2": {
+              "column_id": 2,
               "type": {
                 "dict": [
                   "i32",
@@ -38,6 +41,7 @@ expression: catalog
               "nullable": true
             },
             "tag_3": {
+              "column_id": 3,
               "type": {
                 "dict": [
                   "i32",
@@ -48,6 +52,7 @@ expression: catalog
               "nullable": true
             },
             "time": {
+              "column_id": 4,
               "type": {
                 "time": [
                   "ns",

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -78,7 +78,30 @@ expression: catalog
               "n": 1,
               "ttl": 600
             }
-          ]
+          ],
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "field"
+            },
+            {
+              "column_id": 1,
+              "name": "tag_1"
+            },
+            {
+              "column_id": 2,
+              "name": "tag_2"
+            },
+            {
+              "column_id": 3,
+              "name": "tag_3"
+            },
+            {
+              "column_id": 4,
+              "name": "time"
+            }
+          ],
+          "next_column_id": 5
         }
       ]
     }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -67,7 +67,30 @@ expression: catalog
               "influx_type": "time",
               "nullable": false
             }
-          }
+          },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "field"
+            },
+            {
+              "column_id": 1,
+              "name": "tag_1"
+            },
+            {
+              "column_id": 2,
+              "name": "tag_2"
+            },
+            {
+              "column_id": 3,
+              "name": "tag_3"
+            },
+            {
+              "column_id": 4,
+              "name": "time"
+            }
+          ],
+          "next_column_id": 5
         }
       ]
     }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -18,11 +18,13 @@ expression: catalog
           ],
           "cols": {
             "field": {
+              "column_id": 0,
               "type": "str",
               "influx_type": "field",
               "nullable": true
             },
             "tag_1": {
+              "column_id": 1,
               "type": {
                 "dict": [
                   "i32",
@@ -33,6 +35,7 @@ expression: catalog
               "nullable": false
             },
             "tag_2": {
+              "column_id": 2,
               "type": {
                 "dict": [
                   "i32",
@@ -43,6 +46,7 @@ expression: catalog
               "nullable": false
             },
             "tag_3": {
+              "column_id": 3,
               "type": {
                 "dict": [
                   "i32",
@@ -53,6 +57,7 @@ expression: catalog
               "nullable": false
             },
             "time": {
+              "column_id": 4,
               "type": {
                 "time": [
                   "ns",

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -143,7 +143,7 @@ impl LastCacheProvider {
                                     )
                                     .expect("table exists"),
                                 table_name: table_def.table_name.to_string(),
-                                schema: table_def.schema.clone(),
+                                schema: table_def.influx_schema().clone(),
                                 cache_name: Some(cache_name.to_owned()),
                                 count: Some(cache_def.count.into()),
                                 ttl: Some(Duration::from_secs(cache_def.ttl)),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -339,7 +339,7 @@ impl WriteBufferImpl {
         for parquet_file in parquet_files {
             let parquet_chunk = parquet_chunk_from_file(
                 &parquet_file,
-                &table_schema,
+                table_schema.schema(),
                 self.persister.object_store_url().clone(),
                 self.persister.object_store(),
                 chunk_order,
@@ -490,7 +490,7 @@ impl LastCacheManager for WriteBufferImpl {
                 .table_id_to_name(db_id, table_id)
                 .expect("table exists")
                 .to_string(),
-            schema,
+            schema: schema.schema().clone(),
             cache_name,
             count,
             ttl,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -109,13 +109,13 @@ impl QueryableBuffer {
                 let row_count = batches.iter().map(|b| b.num_rows()).sum::<usize>();
                 let chunk_stats = create_chunk_statistics(
                     Some(row_count),
-                    &schema,
+                    &schema.schema(),
                     Some(ts_min_max),
                     &NoColumnRanges,
                 );
                 Arc::new(BufferChunk {
                     batches,
-                    schema: schema.clone(),
+                    schema: schema.schema().clone(),
                     stats: Arc::new(chunk_stats),
                     partition_id: TransitionPartitionId::new(
                         data_types::TableId::new(0),
@@ -420,7 +420,7 @@ impl BufferState {
             let table_buffer = database_buffer.entry(table_id).or_insert_with(|| {
                 let table_schema = db_schema.get_table(table_id).expect("table should exist");
                 let sort_key = table_schema
-                    .schema
+                    .influx_schema()
                     .primary_key()
                     .iter()
                     .map(|c| c.to_string())

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -11,16 +11,19 @@ expression: catalog_json
         {
           "cols": {
             "f1": {
+              "column_id": 0,
               "influx_type": "field",
               "nullable": true,
               "type": "bool"
             },
             "f2": {
+              "column_id": 1,
               "influx_type": "field",
               "nullable": true,
               "type": "i64"
             },
             "t1": {
+              "column_id": 2,
               "influx_type": "tag",
               "nullable": true,
               "type": {
@@ -31,6 +34,7 @@ expression: catalog_json
               }
             },
             "time": {
+              "column_id": 3,
               "influx_type": "time",
               "nullable": false,
               "type": {

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -17,13 +17,13 @@ expression: catalog_json
               "type": "bool"
             },
             "f2": {
-              "column_id": 1,
+              "column_id": 3,
               "influx_type": "field",
               "nullable": true,
               "type": "i64"
             },
             "t1": {
-              "column_id": 2,
+              "column_id": 1,
               "influx_type": "tag",
               "nullable": true,
               "type": {
@@ -34,7 +34,7 @@ expression: catalog_json
               }
             },
             "time": {
-              "column_id": 3,
+              "column_id": 2,
               "influx_type": "time",
               "nullable": false,
               "type": {
@@ -45,6 +45,24 @@ expression: catalog_json
               }
             }
           },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "f1"
+            },
+            {
+              "column_id": 1,
+              "name": "t1"
+            },
+            {
+              "column_id": 2,
+              "name": "time"
+            },
+            {
+              "column_id": 3,
+              "name": "f2"
+            }
+          ],
           "last_caches": [
             {
               "keys": [
@@ -58,6 +76,7 @@ expression: catalog_json
               "vals": null
             }
           ],
+          "next_column_id": 4,
           "table_id": 0,
           "table_name": "table"
         }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -39,6 +39,20 @@ expression: catalog_json
               }
             }
           },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "f1"
+            },
+            {
+              "column_id": 1,
+              "name": "t1"
+            },
+            {
+              "column_id": 2,
+              "name": "time"
+            }
+          ],
           "last_caches": [
             {
               "keys": [
@@ -52,6 +66,7 @@ expression: catalog_json
               "vals": null
             }
           ],
+          "next_column_id": 3,
           "table_id": 0,
           "table_name": "table"
         }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -11,11 +11,13 @@ expression: catalog_json
         {
           "cols": {
             "f1": {
+              "column_id": 0,
               "influx_type": "field",
               "nullable": true,
               "type": "bool"
             },
             "t1": {
+              "column_id": 1,
               "influx_type": "tag",
               "nullable": true,
               "type": {
@@ -26,6 +28,7 @@ expression: catalog_json
               }
             },
             "time": {
+              "column_id": 2,
               "influx_type": "time",
               "nullable": false,
               "type": {

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -17,13 +17,13 @@ expression: catalog_json
               "type": "bool"
             },
             "f2": {
-              "column_id": 1,
+              "column_id": 3,
               "influx_type": "field",
               "nullable": true,
               "type": "i64"
             },
             "t1": {
-              "column_id": 2,
+              "column_id": 1,
               "influx_type": "tag",
               "nullable": true,
               "type": {
@@ -34,7 +34,7 @@ expression: catalog_json
               }
             },
             "time": {
-              "column_id": 3,
+              "column_id": 2,
               "influx_type": "time",
               "nullable": false,
               "type": {
@@ -45,6 +45,25 @@ expression: catalog_json
               }
             }
           },
+          "column_map": [
+            {
+              "column_id": 0,
+              "name": "f1"
+            },
+            {
+              "column_id": 1,
+              "name": "t1"
+            },
+            {
+              "column_id": 2,
+              "name": "time"
+            },
+            {
+              "column_id": 3,
+              "name": "f2"
+            }
+          ],
+          "next_column_id": 4,
           "table_id": 0,
           "table_name": "table"
         }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -11,16 +11,19 @@ expression: catalog_json
         {
           "cols": {
             "f1": {
+              "column_id": 0,
               "influx_type": "field",
               "nullable": true,
               "type": "bool"
             },
             "f2": {
+              "column_id": 1,
               "influx_type": "field",
               "nullable": true,
               "type": "i64"
             },
             "t1": {
+              "column_id": 2,
               "influx_type": "tag",
               "nullable": true,
               "type": {
@@ -31,6 +34,7 @@ expression: catalog_json
               }
             },
             "time": {
+              "column_id": 3,
               "influx_type": "time",
               "nullable": false,
               "type": {


### PR DESCRIPTION
This commit adds the column_id field to ColumnDefinition so that the output for a Catalog will contain the id of that column. This is non unique, whereas TableIds and DbIds will be unique. The column_id corresponds to it's index in the schema.

Closes #25386