### PR TITLE
refactor: parquet cache with less locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,12 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clru"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,13 +2812,13 @@ dependencies = [
 name = "influxdb3_write"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "arrow_util",
  "async-trait",
  "byteorder",
  "bytes",
  "chrono",
- "clru",
  "crc32fast",
  "crossbeam-channel",
  "data_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,6 +2821,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "crossbeam-channel",
+ "dashmap",
  "data_types",
  "datafusion",
  "datafusion_util",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -267,6 +267,7 @@ pub async fn command(config: Config) -> Result<()> {
         object_store,
         Arc::clone(&time_provider) as _,
         cache_capacity,
+        0.1,
     );
 
     let trace_exporter = config.tracing_config.build()?;

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -261,13 +261,14 @@ pub async fn command(config: Config) -> Result<()> {
         make_object_store(&config.object_store_config).map_err(Error::ObjectStoreParsing)?;
     let time_provider = Arc::new(SystemProvider::new());
 
-    // TODO(trevor): make this configurable/optional:
+    // TODO(trevor): make the cache capacity and prune percent configurable/optional:
     let cache_capacity = 1024 * 1024 * 1024;
+    let prune_percent = 0.1;
     let (object_store, parquet_cache) = create_cached_obj_store_and_oracle(
         object_store,
         Arc::clone(&time_provider) as _,
         cache_capacity,
-        0.1,
+        prune_percent,
     );
 
     let trace_exporter = config.tracing_config.build()?;

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -745,7 +745,9 @@ mod tests {
         let common_state =
             crate::CommonServerState::new(Arc::clone(&metrics), None, trace_header_parser).unwrap();
         let object_store: Arc<DynObjectStore> = Arc::new(object_store::memory::InMemory::new());
-        let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(object_store);
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(start_time)));
+        let (object_store, parquet_cache) =
+            test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider) as _);
         let parquet_store =
             ParquetStorage::new(Arc::clone(&object_store), StorageId::from("influxdb3"));
         let exec = Arc::new(Executor::new_with_config_and_executor(
@@ -761,7 +763,6 @@ mod tests {
             DedicatedExecutor::new_testing(),
         ));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
-        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(start_time)));
         let dummy_host_id = Arc::from("dummy-host-id");
         let instance_id = Arc::from("dummy-instance-id");
 

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -630,9 +630,10 @@ mod tests {
         // Set up QueryExecutor
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
-        let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(object_store);
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let (object_store, parquet_cache) =
+            test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider) as _);
+        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let executor = make_exec(Arc::clone(&object_store));
         let host_id = Arc::from("dummy-host-id");
         let instance_id = Arc::from("instance-id");

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -24,12 +24,12 @@ influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 
 # crates.io dependencies
+anyhow.workspace = true
 arrow.workspace = true
 async-trait.workspace = true
 byteorder.workspace  = true
 bytes.workspace = true
 chrono.workspace  = true
-clru.workspace = true
 crc32fast.workspace  = true
 crossbeam-channel.workspace  = true
 datafusion.workspace = true

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -32,6 +32,7 @@ bytes.workspace = true
 chrono.workspace  = true
 crc32fast.workspace  = true
 crossbeam-channel.workspace  = true
+dashmap.workspace = true
 datafusion.workspace = true
 futures.workspace = true
 futures-util.workspace = true

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1579,13 +1579,15 @@ mod tests {
     use influxdb3_id::DbId;
     use influxdb3_wal::{LastCacheDefinition, WalConfig};
     use insta::assert_json_snapshot;
-    use iox_time::{MockProvider, Time};
+    use iox_time::{MockProvider, Time, TimeProvider};
 
     async fn setup_write_buffer() -> WriteBufferImpl {
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (obj_store, parquet_cache) = test_cached_obj_store_and_oracle(obj_store);
+        let time_provider: Arc<dyn TimeProvider> =
+            Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let (obj_store, parquet_cache) =
+            test_cached_obj_store_and_oracle(obj_store, Arc::clone(&time_provider));
         let persister = Arc::new(Persister::new(obj_store, "test_host"));
-        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let host_id = Arc::from("dummy-host-id");
         let instance_id = Arc::from("dummy-instance-id");
         WriteBufferImpl::new(

--- a/influxdb3_write/src/parquet_cache/mod.rs
+++ b/influxdb3_write/src/parquet_cache/mod.rs
@@ -125,14 +125,17 @@ struct CacheValue {
 impl CacheValue {
     /// Get the size of the cache value's memory footprint in bytes
     fn size(&self) -> usize {
-        let Self { data, meta } = self;
-        let ObjectMeta {
-            location,
-            last_modified: _,
-            size: _,
-            e_tag,
-            version,
-        } = meta;
+        let Self {
+            data,
+            meta:
+                ObjectMeta {
+                    location,
+                    last_modified: _,
+                    size: _,
+                    e_tag,
+                    version,
+                },
+        } = self;
 
         data.len()
             + location.as_ref().len()


### PR DESCRIPTION
Closes #25382 
Closes #25383 

This refactors the parquet cache to use less locking by switching from using the `clru` crate to a hand-rolled cache implementation. The new cache still acts as an LRU, but it uses atomics to track hit-time per entry, and handles pruning in a separate process that is decoupled from insertion/gets to the cache.

The `Cache` type uses a [`DashMap`](https://docs.rs/dashmap/latest/dashmap/struct.DashMap.html) internally to store cache entries. This should help reduce lock contention, and also has the added benefit of not requiring mutability to insert  into _or_ get from the map.

The cache maps an `object_store::Path` to a `CacheEntry`. On a hit, an entry will have its `hit_time` (an `AtomicI64`) incremented. During a prune operation, entries that have the oldest hit times will be removed from the cache. See the `Cache::prune` method for details.

The cache is setup with a memory _capacity_ and a _prune percent_. The cache tracks memory used when entries are added, based on their _size_, and when a prune is invoked in the background, if the cache has exceeded its capacity, it will prune `prune_percent * cache.len()` entries from the cache.

Two tests were added:
* `cache_evicts_lru_when_full` to check LRU behaviour of the cache
* `cache_hit_while_fetching` to check that a cache entry hit while a request is in flight to fetch that entry will not result in extra calls to the underlying object store