### PR TITLE
feat: Adds functionality to clear out bad shard list 

### DIFF
--- a/tsdb/shard_internal_test.go
+++ b/tsdb/shard_internal_test.go
@@ -278,6 +278,10 @@ func NewTempShard(index string) *TempShard {
 	}
 }
 
+func CloseShard(t testing.TB, sh *TempShard) {
+	require.NoError(t, sh.Close(), "closing temporary shard")
+}
+
 // Close closes the shard and removes all underlying data.
 func (sh *TempShard) Close() error {
 	defer os.RemoveAll(sh.path)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -678,6 +678,9 @@ func (s *Store) Shard(id uint64) *Shard {
 // longer in a "bad" state. This method will return any shards that
 // were removed from the cache.
 func (s *Store) ClearBadShardList() map[uint64]error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	badShards := s.GetBadShardList()
 	clear(s.badShards.shardErrors)
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -55,7 +55,7 @@ const SeriesFileDirectory = "_series"
 // databaseState keeps track of the state of a database.
 type databaseState struct{ indexTypes map[string]int }
 
-// struct to hold the result of opening each reader in a goroutine
+// struct to hold the result of opening each readegr in a goroutine
 type shardResponse struct {
 	s   *Shard
 	err error
@@ -678,10 +678,10 @@ func (s *Store) Shard(id uint64) *Shard {
 // longer in a "bad" state. This method will return any shards that
 // were removed from the cache.
 func (s *Store) ClearBadShardList() map[uint64]error {
+	badShards := s.GetBadShardList()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	badShards := s.GetBadShardList()
 	clear(s.badShards.shardErrors)
 
 	return badShards

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -282,7 +282,7 @@ func TestStore_BadShardClear(t *testing.T) {
 			require.ErrorIs(t, err2, tsdb.ErrPreviousShardFail{})
 			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
 
-			require.Equal(t, 1, len(s.Store.GetBadShardList()))
+			require.Len(t, s.Store.GetBadShardList(), 1)
 
 			badShards := s.ClearBadShardList()
 			require.Len(t, badShards, 1)

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"go.uber.org/zap/zaptest"
-	"log"
 	"math"
 	"math/rand"
 	"os"
@@ -38,7 +37,7 @@ func TestStore_DeleteRetentionPolicy(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
@@ -114,7 +113,7 @@ func TestStore_CreateShard(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
@@ -151,7 +150,7 @@ func TestStore_StartupShardProgress(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		require.NoError(t, s.CreateShard("db0", "rp0", 1, true))
@@ -191,7 +190,7 @@ func TestStore_BadShardLoading(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		require.NoError(t, s.CreateShard("db0", "rp0", 1, true))
@@ -241,13 +240,13 @@ func TestStore_BadShard(t *testing.T) {
 	for _, idx := range indexes {
 		func() {
 			s := MustOpenStore(t, idx)
-			defer require.NoErrorf(t, s.Close(), "closing store with index type: %s", idx)
+			defer s.CloseStore(t, idx)
 
 			sh := tsdb.NewTempShard(idx)
 			shId := sh.ID()
 			err := s.OpenShard(sh.Shard, false)
 			require.NoError(t, err, "opening temp shard")
-			defer require.NoError(t, sh.Close(), "closing temporary shard")
+			defer tsdb.CloseShard(t, sh)
 
 			expErr := errors.New(errStr)
 			s.SetShardOpenErrorForTest(sh.ID(), expErr)
@@ -262,12 +261,76 @@ func TestStore_BadShard(t *testing.T) {
 	}
 }
 
+func TestStore_BadShardClear(t *testing.T) {
+	const errStr = "a shard open error"
+	indexes := tsdb.RegisteredIndexes()
+	for _, idx := range indexes {
+		func() {
+			s := MustOpenStore(t, idx)
+			defer s.CloseStore(t, idx)
+
+			sh := tsdb.NewTempShard(idx)
+			shId := sh.ID()
+			err := s.OpenShard(sh.Shard, false)
+			require.NoError(t, err, "opening temp shard")
+			defer tsdb.CloseShard(t, sh)
+
+			expErr := errors.New(errStr)
+			s.SetShardOpenErrorForTest(sh.ID(), expErr)
+			err2 := s.OpenShard(sh.Shard, false)
+			require.Error(t, err2, "no error opening bad shard")
+			require.ErrorIs(t, err2, tsdb.ErrPreviousShardFail{})
+			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
+
+			require.Equal(t, 1, len(s.Store.GetBadShardList()))
+
+			badShards := s.ClearBadShardList()
+			require.Len(t, badShards, 1)
+
+			// Check that bad shard list has been cleared
+			require.Empty(t, s.Store.GetBadShardList())
+
+			s.SetShardOpenErrorForTest(sh.ID(), expErr)
+			err2 = s.OpenShard(sh.Shard, false)
+			require.Error(t, err2, "no error opening bad shard")
+			require.ErrorIs(t, err2, tsdb.ErrPreviousShardFail{})
+			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
+
+			// Check that bad shard list now has a bad shard in it
+			require.Len(t, s.Store.GetBadShardList(), 1)
+		}()
+	}
+}
+
+func TestStore_BadShardClearNoBadShards(t *testing.T) {
+	indexes := tsdb.RegisteredIndexes()
+	for _, idx := range indexes {
+		func() {
+			s := MustOpenStore(t, idx)
+			defer s.CloseStore(t, idx)
+
+			sh := tsdb.NewTempShard(idx)
+			err := s.OpenShard(sh.Shard, false)
+			require.NoError(t, err, "opening temp shard")
+			require.NoError(t, sh.Close(), "closing temporary shard")
+
+			require.Empty(t, s.Store.GetBadShardList())
+
+			badShards := s.ClearBadShardList()
+			require.Empty(t, badShards)
+
+			// Check that bad shard list has been cleared
+			require.Empty(t, s.Store.GetBadShardList())
+		}()
+	}
+}
+
 func TestStore_CreateMixedShards(t *testing.T) {
 	t.Parallel()
 
 	test := func(index1 string, index2 string) {
 		s := MustOpenStore(t, index1)
-		defer s.Close()
+		defer s.CloseStore(t, index1)
 
 		// Create a new shard and verify that it exists.
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
@@ -323,7 +386,7 @@ func TestStore_DropMeasurementMixedShards(t *testing.T) {
 
 	test := func(index1 string, index2 string) {
 		s := MustOpenStore(t, index1)
-		defer s.Close()
+		defer s.CloseStore(t, index1)
 
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
 			t.Fatal(err)
@@ -368,7 +431,7 @@ func TestStore_DropConcurrentWriteMultipleShards(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
 			t.Fatal(err)
@@ -432,7 +495,7 @@ func TestStore_WriteMixedShards(t *testing.T) {
 
 	test := func(index1 string, index2 string) {
 		s := MustOpenStore(t, index1)
-		defer s.Close()
+		defer s.CloseStore(t, index1)
 
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
 			t.Fatal(err)
@@ -505,7 +568,7 @@ func TestStore_DeleteSeries_NonExistentDB(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		if err := s.DeleteSeries("db0", nil, nil); err != nil {
 			t.Fatal(err.Error())
@@ -523,7 +586,7 @@ func TestStore_DeleteSeries_MultipleSources(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
 			t.Fatal(err)
@@ -553,7 +616,7 @@ func TestStore_DeleteShard(t *testing.T) {
 
 	test := func(index string) error {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
@@ -642,7 +705,7 @@ func TestStore_CreateShardSnapShot(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a new shard and verify that it exists.
 		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
@@ -670,7 +733,7 @@ func TestStore_Open(t *testing.T) {
 
 	test := func(index string) {
 		s := NewStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0", "2"), 0777); err != nil {
 			t.Fatal(err)
@@ -713,7 +776,7 @@ func TestStore_Open_InvalidDatabaseFile(t *testing.T) {
 
 	test := func(index string) {
 		s := NewStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Ensure the directory exists before creating the file.
 		if err := os.MkdirAll(s.Path(), 0777); err != nil {
@@ -744,7 +807,7 @@ func TestStore_Open_InvalidRetentionPolicy(t *testing.T) {
 
 	test := func(index string) {
 		s := NewStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create an RP file instead of a directory.
 		if err := os.MkdirAll(filepath.Join(s.Path(), "db0"), 0777); err != nil {
@@ -774,7 +837,7 @@ func TestStore_Open_InvalidShard(t *testing.T) {
 
 	test := func(index string) {
 		s := NewStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create a non-numeric shard file.
 		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0"), 0777); err != nil {
@@ -804,7 +867,7 @@ func TestShards_CreateIterator(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard #0 with data.
 		s.MustCreateShardWithData("db0", "rp0", 0,
@@ -889,7 +952,7 @@ func TestStore_NewReadersBlocked(t *testing.T) {
 	test := func(index string) {
 		t.Helper()
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		shardInUse := func(shardID uint64) bool {
 			t.Helper()
@@ -962,8 +1025,8 @@ func TestStore_NewReadersBlocked(t *testing.T) {
 func TestStore_BackupRestoreShard(t *testing.T) {
 	test := func(index string) {
 		s0, s1 := MustOpenStore(t, index), MustOpenStore(t, index)
-		defer s0.Close()
-		defer s1.Close()
+		defer s0.CloseStore(t, index)
+		defer s1.CloseStore(t, index)
 
 		// Create shard with data.
 		s0.MustCreateShardWithData("db0", "rp0", 100,
@@ -1043,7 +1106,7 @@ func TestStore_Shard_SeriesN(t *testing.T) {
 
 	test := func(index string) error {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard with data.
 		s.MustCreateShardWithData("db0", "rp0", 1,
@@ -1079,7 +1142,7 @@ func TestStore_MeasurementNames_Deduplicate(t *testing.T) {
 
 	test := func(index string) {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard with data.
 		s.MustCreateShardWithData("db0", "rp0", 1,
@@ -1183,7 +1246,7 @@ func TestStore_Cardinality_Tombstoning(t *testing.T) {
 		if err := store.Open(); err != nil {
 			panic(err)
 		}
-		defer store.Close()
+		defer store.CloseStore(t, index)
 		testStoreCardinalityTombstoning(t, store)
 	}
 
@@ -1249,7 +1312,7 @@ func TestStore_Cardinality_Unique(t *testing.T) {
 		if err := store.Open(); err != nil {
 			panic(err)
 		}
-		defer store.Close()
+		defer store.CloseStore(t, index)
 		testStoreCardinalityUnique(t, store)
 	}
 
@@ -1331,7 +1394,7 @@ func TestStore_Cardinality_Duplicates(t *testing.T) {
 		if err := store.Open(); err != nil {
 			panic(err)
 		}
-		defer store.Close()
+		defer store.CloseStore(t, index)
 		testStoreCardinalityDuplicates(t, store)
 	}
 
@@ -1351,7 +1414,7 @@ func TestStore_MetaQuery_Timeout(t *testing.T) {
 		if err := store.Open(); err != nil {
 			panic(err)
 		}
-		defer store.Close()
+		defer store.CloseStore(t, index)
 		testStoreMetaQueryTimeout(t, store, index)
 	}
 
@@ -1543,7 +1606,7 @@ func TestStore_Cardinality_Compactions(t *testing.T) {
 		if err := store.Open(); err != nil {
 			panic(err)
 		}
-		defer store.Close()
+		defer store.CloseStore(t, index)
 		return testStoreCardinalityCompactions(store)
 	}
 
@@ -1568,7 +1631,7 @@ func TestStore_Cardinality_Limit_On_InMem_Index(t *testing.T) {
 	if err := store.Open(); err != nil {
 		panic(err)
 	}
-	defer store.Close()
+	defer store.CloseStore(t, "inmem")
 
 	// Generate 200,000 series to write.
 	series := genTestSeries(64, 5, 5)
@@ -1678,7 +1741,7 @@ func TestStore_Sketches(t *testing.T) {
 
 	test := func(index string) error {
 		store := MustOpenStore(t, index)
-		defer store.Close()
+		defer store.CloseStore(t, index)
 
 		// Generate point data to write to the shards.
 		series := genTestSeries(10, 2, 4) // 160 series
@@ -1917,7 +1980,7 @@ func TestStore_TagValues(t *testing.T) {
 					t.Fatalf("got:\n%#v\n\nexp:\n%#v", got, exp)
 				}
 			})
-			s.Close()
+			s.CloseStore(t, index)
 		}
 	}
 }
@@ -1927,7 +1990,7 @@ func TestStore_Measurements_Auth(t *testing.T) {
 
 	test := func(index string) error {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard #0 with data.
 		s.MustCreateShardWithData("db0", "rp0", 0,
@@ -2016,7 +2079,7 @@ func TestStore_TagKeys_Auth(t *testing.T) {
 
 	test := func(index string) error {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard #0 with data.
 		s.MustCreateShardWithData("db0", "rp0", 0,
@@ -2114,7 +2177,7 @@ func TestStore_TagValues_Auth(t *testing.T) {
 
 	test := func(index string) error {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		// Create shard #0 with data.
 		s.MustCreateShardWithData("db0", "rp0", 0,
@@ -2245,7 +2308,7 @@ func createTagValues(mname string, kvs map[string][]string) tsdb.TagValues {
 func TestStore_MeasurementNames_ConcurrentDropShard(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		shardN := 10
 		for i := 0; i < shardN; i++ {
@@ -2330,7 +2393,7 @@ func TestStore_MeasurementNames_ConcurrentDropShard(t *testing.T) {
 func TestStore_TagKeys_ConcurrentDropShard(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		shardN := 10
 		for i := 0; i < shardN; i++ {
@@ -2421,7 +2484,7 @@ func TestStore_TagKeys_ConcurrentDropShard(t *testing.T) {
 func TestStore_TagValues_ConcurrentDropShard(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		s := MustOpenStore(t, index)
-		defer s.Close()
+		defer s.CloseStore(t, index)
 
 		shardN := 10
 		for i := 0; i < shardN; i++ {
@@ -2546,7 +2609,7 @@ func BenchmarkStore_SeriesCardinality_100_Shards(b *testing.B) {
 				_, _ = store.SeriesCardinality(context.Background(), "db")
 			}
 		})
-		store.Close()
+		store.CloseStore(b, index)
 	}
 }
 
@@ -2702,9 +2765,7 @@ func BenchmarkStore_TagValues(b *testing.B) {
 				for _, bm := range benchmarks {
 					s, shardIDs := setup(bm.shards, bm.measurements, bm.tagValues, index, useRand == 1)
 					teardown := func() {
-						if err := s.Close(); err != nil {
-							b.Fatal(err)
-						}
+						s.CloseStore(b, index)
 					}
 
 					cnd := "Unfiltered"
@@ -2811,17 +2872,13 @@ func (s *Store) Reopen(tb testing.TB, newOpts ...StoreOption) error {
 }
 
 // Close closes the store and removes the underlying data.
-func (s *Store) Close() error {
+func (s *Store) CloseStore(t testing.TB, idx string) {
 	defer func(path string) {
-		err := os.RemoveAll(path)
-		if err != nil {
-			log.Fatal(err)
-		}
+		require.NoError(t, os.RemoveAll(path), "removing file failed")
 	}(s.path)
 	if s.Store != nil {
-		return s.Store.Close()
+		require.NoErrorf(t, s.Close(), "closing store with index type: %s", idx)
 	}
-	return nil
 }
 
 // MustCreateShardWithData creates a shard and writes line protocol data to it.


### PR DESCRIPTION
This PR adds test and new method to clear out the bad shards list
the method will return the values of the shards that it cleared out
along with the errors. This is the first part in the feature
for adding a load-shards command to influxd-ctl.

companion PR: https://github.com/influxdata/plutonium/pull/4193

Closes https://github.com/influxdata/feature-requests/issues/591