### PR TITLE
fix: strip double quotes from measurement names in v2/delete

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1017,7 +1017,7 @@ func (h *Handler) serveDeleteV2(w http.ResponseWriter, r *http.Request, user met
 			case influxql.EQ:
 				tag, ok := e.LHS.(*influxql.VarRef)
 				if ok && tag.Val == measurement {
-					srcs = append(srcs, &influxql.Measurement{Name: e.RHS.String()})
+					srcs = append(srcs, &influxql.Measurement{Name: strings.Trim(e.RHS.String(), `"`)})
 					return true, nil
 				}
 			// Not permitted in V2 API DELETE predicates


### PR DESCRIPTION
When searching for a measurement in the v2/delete API, remove any quotes put on the measurement name (e.g. to alllow special characters) before string comparisons.

closes https://github.com/influxdata/influxdb/issues/25406
