### PR TITLE
chore: unblock CI for tonic/hyper audit failures

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,9 @@ ignore = [
     # dependent on arrow-* upgrading dependencies on lexical-core
     # see https://github.com/apache/arrow-rs/pull/6401
     "RUSTSEC-2023-0086",
+    # Tonic + hyper upgrade is large - unblocking pipeline for now.
+    # https://rustsec.org/advisories/RUSTSEC-2024-0376
+    "RUSTSEC-2024-0376",
 ]
 git-fetch-with-cli = true
 


### PR DESCRIPTION
We will need to wait on the RUSTSEC advisory to be resolved upstream, i.e., by having tonic and hyper upgraded in core, before we can lift this advisory ignore and use the latest versions of those crates.