### PR TITLE
fix: add host id to parquet file paths

### DIFF
--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -53,7 +53,7 @@ pub struct ParquetFilePath(ObjPath);
 
 impl ParquetFilePath {
     /// Generate a parquet file path using the given arguments. This will convert the provided
-    /// `chunk_time` into a date time string with format `'YYYY-MM-DDTHH-MM'`
+    /// `chunk_time` into a date time string with format `'YYYY-MM-DD/HH-MM'`
     pub fn new(
         host_prefix: &str,
         db_name: &str,

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -726,7 +726,7 @@ mod tests {
             0,
             "table_one",
             0,
-            Utc::now(),
+            Utc::now().timestamp_nanos_opt().unwrap(),
             WalFileSequenceNumber::new(1),
         );
         let (bytes_written, meta) = persister

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -167,7 +167,8 @@ impl QueryableBuffer {
                             table_id: *table_id,
                             table_name: Arc::clone(&table_name),
                             chunk_time: chunk.chunk_time,
-                            path: ParquetFilePath::new_with_chunk_time(
+                            path: ParquetFilePath::new(
+                                self.persister.host_identifier_prefix(),
                                 db_name.as_ref(),
                                 database_id.as_u32(),
                                 table_name.as_ref(),


### PR DESCRIPTION
Cleans up a legacy method for producing parquet file paths that was no longer used in release code (was only being used in tests) and makes the method that produces the parquet file path using a WAL sequence number and i64 timestamp the defaul `new` constructor for the `ParquetFilePath` type.

Tests that checked this function were modified accordingly.

Closes #25387
