### PR TITLE
refactor: Tidy up telemetry tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2000,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -2789,7 +2801,8 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "futures-util",
- "influxdb3_write",
+ "mockall",
+ "mockito",
  "num",
  "observability_deps",
  "parking_lot",
@@ -2867,6 +2880,7 @@ dependencies = [
  "influxdb-line-protocol",
  "influxdb3_catalog",
  "influxdb3_id",
+ "influxdb3_telemetry",
  "influxdb3_test_helpers",
  "influxdb3_wal",
  "insta",
@@ -3476,6 +3490,32 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ indexmap = { version = "2.2.6" }
 libc = { version = "0.2" }
 mime = "0.3.17"
 mockito = { version = "1.4.0", default-features = false }
+mockall = { version = "0.13.0" }
 num_cpus = "1.16.0"
 object_store = "0.10.2"
 parking_lot = "0.12.1"

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -236,10 +236,12 @@ mod tests {
     use influxdb3_id::{DbId, TableId};
     use influxdb3_telemetry::store::TelemetryStore;
     use influxdb3_wal::WalConfig;
-    use influxdb3_write::last_cache::LastCacheProvider;
     use influxdb3_write::parquet_cache::test_cached_obj_store_and_oracle;
     use influxdb3_write::persister::Persister;
     use influxdb3_write::WriteBuffer;
+    use influxdb3_write::{
+        last_cache::LastCacheProvider, write_buffer::persisted_files::PersistedFiles,
+    };
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
@@ -787,9 +789,10 @@ mod tests {
             .unwrap(),
         );
 
-        let dummy_telem_store = TelemetryStore::new_without_background_runners(Arc::clone(
-            &write_buffer_impl.persisted_files(),
-        ));
+        let parquet_metrics_provider: Arc<PersistedFiles> =
+            Arc::clone(&write_buffer_impl.persisted_files());
+        let dummy_telem_store =
+            TelemetryStore::new_without_background_runners(parquet_metrics_provider);
         let write_buffer: Arc<dyn WriteBuffer> = write_buffer_impl;
         let common_state = crate::CommonServerState::new(
             Arc::clone(&metrics),

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -610,8 +610,11 @@ mod tests {
     use influxdb3_telemetry::store::TelemetryStore;
     use influxdb3_wal::{Gen1Duration, WalConfig};
     use influxdb3_write::{
-        last_cache::LastCacheProvider, parquet_cache::test_cached_obj_store_and_oracle,
-        persister::Persister, write_buffer::WriteBufferImpl, WriteBuffer,
+        last_cache::LastCacheProvider,
+        parquet_cache::test_cached_obj_store_and_oracle,
+        persister::Persister,
+        write_buffer::{persisted_files::PersistedFiles, WriteBufferImpl},
+        WriteBuffer,
     };
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
     use iox_time::{MockProvider, Time};
@@ -657,7 +660,7 @@ mod tests {
         let host_id = Arc::from("dummy-host-id");
         let instance_id = Arc::from("instance-id");
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
-        let write_buffer = Arc::new(
+        let write_buffer_impl = Arc::new(
             WriteBufferImpl::new(
                 Arc::clone(&persister),
                 Arc::clone(&catalog),
@@ -676,10 +679,9 @@ mod tests {
             .unwrap(),
         );
 
-        let dummy_telem_store = TelemetryStore::new_without_background_runners(Arc::clone(
-            &write_buffer.persisted_files(),
-        ));
-        let write_buffer: Arc<dyn WriteBuffer> = write_buffer;
+        let persisted_files: Arc<PersistedFiles> = Arc::clone(&write_buffer_impl.persisted_files());
+        let dummy_telem_store = TelemetryStore::new_without_background_runners(persisted_files);
+        let write_buffer: Arc<dyn WriteBuffer> = write_buffer_impl;
         let metrics = Arc::new(Registry::new());
         let df_config = Arc::new(Default::default());
         let query_executor = QueryExecutorImpl::new(

--- a/influxdb3_telemetry/Cargo.toml
+++ b/influxdb3_telemetry/Cargo.toml
@@ -18,10 +18,9 @@ sysinfo.workspace = true
 num.workspace = true
 thiserror.workspace = true
 
-# Local Deps
-influxdb3_write = { path = "../influxdb3_write" }
-
 [dev-dependencies]
 test-log.workspace = true
 proptest.workspace = true
+mockito.workspace = true
+mockall.workspace = true
 

--- a/influxdb3_telemetry/src/lib.rs
+++ b/influxdb3_telemetry/src/lib.rs
@@ -20,3 +20,7 @@ pub enum TelemetryError {
 }
 
 pub type Result<T, E = TelemetryError> = std::result::Result<T, E>;
+
+pub trait ParquetMetrics: Send + Sync + std::fmt::Debug + 'static {
+    fn get_metrics(&self) -> (u64, f64, u64);
+}

--- a/influxdb3_telemetry/src/sender.rs
+++ b/influxdb3_telemetry/src/sender.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use observability_deps::tracing::debug;
+use reqwest::{IntoUrl, Url};
 use serde::Serialize;
 
 use crate::store::TelemetryStore;
@@ -8,19 +9,27 @@ use crate::{Result, TelemetryError};
 
 pub(crate) struct TelemetrySender {
     client: reqwest::Client,
-    req_path: String,
+    full_url: Url,
 }
 
 impl TelemetrySender {
-    pub fn new(client: reqwest::Client, req_path: String) -> Self {
-        Self { client, req_path }
+    pub fn new(client: reqwest::Client, base_url: impl IntoUrl) -> Self {
+        let base_url = base_url
+            .into_url()
+            .expect("Cannot parse telemetry sender url");
+        Self {
+            client,
+            full_url: base_url
+                .join("/api/v3")
+                .expect("Cannot set the telemetry request path"),
+        }
     }
 
-    pub async fn try_sending(&self, telemetry: &TelemetryPayload) -> Result<()> {
+    pub async fn try_sending(&mut self, telemetry: &TelemetryPayload) -> Result<()> {
         debug!(telemetry = ?telemetry, "trying to send data to telemetry server");
         let json = serde_json::to_vec(&telemetry).map_err(TelemetryError::CannotSerializeJson)?;
         self.client
-            .post(self.req_path.as_str())
+            .post(self.full_url.as_str())
             .body(json)
             .send()
             .await
@@ -77,24 +86,90 @@ pub(crate) async fn send_telemetry_in_background(
     duration_secs: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let telem_sender = TelemetrySender::new(
+        let mut telem_sender = TelemetrySender::new(
             reqwest::Client::new(),
-            "https://telemetry.influxdata.foo.com".to_owned(),
+            "https://telemetry.influxdata.foo.com",
         );
         let mut interval = tokio::time::interval(duration_secs);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             interval.tick().await;
-            let telemetry = store.snapshot();
-            if let Err(e) = telem_sender.try_sending(&telemetry).await {
-                // TODO: change to error! - until endpoint is decided keep
-                //       this as debug log
-                debug!(error = ?e, "Cannot send telemetry");
-            }
-            // if we tried sending and failed, we currently still reset the
-            // metrics, it is ok to miss few samples
-            store.reset_metrics();
+            send_telemetry(&store, &mut telem_sender).await;
         }
     })
+}
+
+async fn send_telemetry(store: &Arc<TelemetryStore>, telem_sender: &mut TelemetrySender) {
+    let telemetry = store.snapshot();
+    if let Err(e) = telem_sender.try_sending(&telemetry).await {
+        // Not able to send telemetry is not a crucial error
+        // leave it as debug
+        debug!(error = ?e, "Cannot send telemetry");
+    }
+    // if we tried sending and failed, we currently still reset the
+    // metrics, it is ok to miss few samples
+    store.reset_metrics();
+}
+
+#[cfg(test)]
+mod tests {
+    use mockito::Server;
+    use reqwest::Url;
+    use std::sync::Arc;
+
+    use crate::sender::{TelemetryPayload, TelemetrySender};
+
+    #[test_log::test(tokio::test)]
+    async fn test_sending_telemetry() {
+        let client = reqwest::Client::new();
+        let mut mock_server = Server::new_async().await;
+        let mut sender = TelemetrySender::new(client, mock_server.url());
+        let mock = mock_server.mock("POST", "/api/v3").create_async().await;
+        let telem_payload = create_dummy_payload();
+
+        let result = sender.try_sending(&telem_payload).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[test]
+    fn test_url_join() {
+        let url = Url::parse("https://foo.com/").unwrap();
+        let new_url = url.join("/foo").unwrap();
+        assert_eq!("https://foo.com/foo", new_url.as_str());
+    }
+
+    fn create_dummy_payload() -> TelemetryPayload {
+        TelemetryPayload {
+            os: Arc::from("dummy-str"),
+            version: Arc::from("dummy-str"),
+            storage_type: Arc::from("dummy-str"),
+            instance_id: Arc::from("dummy-str"),
+            cores: 10,
+            product_type: "OSS",
+            cpu_utilization_percent_min: 100.0,
+            cpu_utilization_percent_max: 100.0,
+            cpu_utilization_percent_avg: 100.0,
+            memory_used_mb_min: 250,
+            memory_used_mb_max: 250,
+            memory_used_mb_avg: 250,
+            write_requests_min: 100,
+            write_requests_max: 100,
+            write_requests_avg: 100,
+            write_lines_min: 200_000,
+            write_lines_max: 200_000,
+            write_lines_avg: 200_000,
+            write_mb_min: 15,
+            write_mb_max: 15,
+            write_mb_avg: 15,
+            query_requests_min: 15,
+            query_requests_max: 15,
+            query_requests_avg: 15,
+            parquet_file_count: 100,
+            parquet_file_size_mb: 100.0,
+            parquet_row_count: 100,
+        }
+    }
 }

--- a/influxdb3_telemetry/src/stats.rs
+++ b/influxdb3_telemetry/src/stats.rs
@@ -102,8 +102,7 @@ impl<T: Default + Num + Copy + NumCast + PartialOrd> Stats<T> {
 /// It calculates min/max/avg by using already calculated min/max/avg for
 /// possibly a higher resolution.
 ///
-/// For eg.
-///
+/// # Example
 /// Let's say we're looking at the stats for number of lines written.
 /// And we have 1st sample's minimum was 20 and the 3rd sample's
 /// minimum was 10. This means in the 1st sample for a whole minute

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -23,6 +23,7 @@ influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }
 influxdb3_wal = { path = "../influxdb3_wal" }
+influxdb3_telemetry = { path = "../influxdb3_telemetry" }
 
 # crates.io dependencies
 anyhow.workspace = true

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -6,6 +6,7 @@ use crate::{ParquetFile, PersistedSnapshot};
 use hashbrown::HashMap;
 use influxdb3_id::DbId;
 use influxdb3_id::TableId;
+use influxdb3_telemetry::ParquetMetrics;
 use parking_lot::RwLock;
 
 type DatabaseToTables = HashMap<DbId, TableToFiles>;
@@ -55,9 +56,11 @@ impl PersistedFiles {
 
         files
     }
+}
 
+impl ParquetMetrics for PersistedFiles {
     /// Get parquet file metrics, file count, row count and size in MB
-    pub fn get_metrics(&self) -> (u64, f64, u64) {
+    fn get_metrics(&self) -> (u64, f64, u64) {
         let inner = self.inner.read();
         (
             inner.parquet_files_count,


### PR DESCRIPTION
- Introduced traits, `ParquetMetrics` and `SystemInfoProvider` to enable writing easier tests
- Uses mockito for code that depends on reqwest::Client and also uses  mockall to generally mock any traits like `SystemInfoProvider`
- Minor updates to docs
