### PR TITLE
feat: move Table Id/Name mapping into DB Schema

### DIFF
--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -156,6 +156,5 @@ expression: catalog
   "sequence": 0,
   "host_id": "dummy-host-id",
   "instance_id": "instance-id",
-  "db_map": [],
-  "table_map": []
+  "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -81,6 +81,5 @@ expression: catalog
   "sequence": 0,
   "host_id": "dummy-host-id",
   "instance_id": "instance-id",
-  "db_map": [],
-  "table_map": []
+  "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -70,6 +70,5 @@ expression: catalog
   "sequence": 0,
   "host_id": "dummy-host-id",
   "instance_id": "instance-id",
-  "db_map": [],
-  "table_map": []
+  "db_map": []
 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -700,7 +700,9 @@ where
         let table_id = self
             .write_buffer
             .catalog()
-            .table_name_to_id(db_id, table.as_str().into())
+            .db_schema(&db_id)
+            .expect("db should exist")
+            .table_name_to_id(table.as_str().into())
             .ok_or_else(|| WriteBufferError::TableDoesNotExist)?;
         match self
             .write_buffer
@@ -748,7 +750,9 @@ where
         let table_id = self
             .write_buffer
             .catalog()
-            .table_name_to_id(db_id, table.into())
+            .db_schema(&db_id)
+            .expect("db should exist")
+            .table_name_to_id(table.into())
             .ok_or_else(|| WriteBufferError::TableDoesNotExist)?;
         self.write_buffer
             .delete_last_cache(db_id, table_id, &name)

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -377,10 +377,7 @@ impl Database {
 
     async fn query_table(&self, table_name: &str) -> Option<Arc<QueryTable>> {
         let table_name = table_name.into();
-        let table_id = self
-            .write_buffer
-            .catalog()
-            .table_name_to_id(self.db_schema.id, Arc::clone(&table_name))?;
+        let table_id = self.db_schema.table_name_to_id(Arc::clone(&table_name))?;
         self.db_schema.get_table_schema(table_id).map(|schema| {
             Arc::new(QueryTable {
                 db_schema: Arc::clone(&self.db_schema),
@@ -515,10 +512,7 @@ impl SchemaProvider for Database {
     }
 
     fn table_exist(&self, name: &str) -> bool {
-        self.write_buffer
-            .catalog()
-            .table_name_to_id(self.db_schema.id, name.into())
-            .is_some()
+        self.db_schema.table_name_to_id(name.into()).is_some()
     }
 }
 

--- a/influxdb3_server/src/system_tables/parquet_files.rs
+++ b/influxdb3_server/src/system_tables/parquet_files.rs
@@ -95,7 +95,9 @@ impl IoxSystemTable for ParquetFilesTable {
             self.db_id,
             self.buffer
                 .catalog()
-                .table_name_to_id(self.db_id, table_name.as_str().into())
+                .db_schema(&self.db_id)
+                .expect("db exists")
+                .table_name_to_id(table_name.as_str().into())
                 .expect("table exists"),
         );
 

--- a/influxdb3_write/src/last_cache/table_function.rs
+++ b/influxdb3_write/src/last_cache/table_function.rs
@@ -100,7 +100,9 @@ impl TableFunctionImpl for LastCacheFunction {
         let table_id = self
             .provider
             .catalog
-            .table_name_to_id(self.db_id, table_name.as_str().into())
+            .db_schema(&self.db_id)
+            .expect("db exists")
+            .table_name_to_id(table_name.as_str().into())
             .expect("table exists");
 
         match self.provider.get_cache_name_and_schema(

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -68,12 +68,5 @@ expression: catalog_json
   ],
   "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 3,
-  "table_map": [
-    {
-      "db_id": 0,
-      "name": "table",
-      "table_id": 0
-    }
-  ]
+  "sequence": 3
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -63,12 +63,5 @@ expression: catalog_json
   ],
   "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 2,
-  "table_map": [
-    {
-      "db_id": 0,
-      "name": "table",
-      "table_id": 0
-    }
-  ]
+  "sequence": 2
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -55,12 +55,5 @@ expression: catalog_json
   ],
   "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 4,
-  "table_map": [
-    {
-      "db_id": 0,
-      "name": "table",
-      "table_id": 0
-    }
-  ]
+  "sequence": 4
 }


### PR DESCRIPTION
This is some follow up work to #25421 where we move the table mapping into the DatabaseSchema struct itself. This code as a result has been simplified compared to the original version and has the following changes:

- By using the DatabaseSchema over the catalog in as many places as possible, we reduce the number of locks that we need to take on the Catalog. In many places we already had access to the schema and so this simplified things as we now would not need to look up tables with both the database id and the name/id of the table
- Code centered on making sure the ids was updated so that it only needed to occur when applying catalog ops
- We still need to add the id to name mapping in the validate lines fns for both v1 and v2, but it's now in the same spot as when we insert the table into the db schema making it more obvious what's going on

Overall, the code should be simpler to reason about and moving the map into the DatabaseSchema was the right thing to do. The tests have also been updated accordingly to handle these changes.

Closes #25429