### PR TITLE
feat(circleci): add inclusivity checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,16 @@ jobs:
       - run:
           name: Yamllint
           command: yamllint --config-file .circleci/yamllint.yml --strict .
+  inclusivity:
+    docker:
+      - image: cimg/go:1.23
+    steps:
+      - checkout
+      - run:
+          name: Build and run inclusivity checker
+          command: |
+            go install github.com/get-woke/woke@v0.19.0
+            woke --exit-1-on-failure .
   cargo-audit:
     docker:
       - image: quay.io/influxdb/rust:ci
@@ -471,6 +481,8 @@ workflows:
       - fmt:
           <<: *any_filter
       - lint:
+          <<: *any_filter
+      - inclusivity:
           <<: *any_filter
       - cargo-audit:
           <<: *any_filter

--- a/.circleci/scripts/package-validation/validate
+++ b/.circleci/scripts/package-validation/validate
@@ -8,7 +8,7 @@ usage() {
 usage: validate [type] [path]
 
 Program:
-    This application performs sanity checks on the provided InfluxDB
+    This application performs quick checks on the provided InfluxDB
     package. InfluxDB should *not* be installed on the system before
     running this application. This validates new installations and
     performs specific checks relevant only to InfluxDB.

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     fn catalog_serialization() {
-        let host_id = Arc::from("dummy-host-id");
+        let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let cloned_instance_id = Arc::clone(&instance_id);
         let catalog = Catalog::new(host_id, cloned_instance_id);
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[test]
     fn serialize_series_keys() {
-        let host_id = Arc::from("dummy-host-id");
+        let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let catalog = Catalog::new(host_id, instance_id);
         let mut database = DatabaseSchema {
@@ -1136,7 +1136,7 @@ mod tests {
 
     #[test]
     fn serialize_last_cache() {
-        let host_id = Arc::from("dummy-host-id");
+        let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let catalog = Catalog::new(host_id, instance_id);
         let mut database = DatabaseSchema {
@@ -1193,8 +1193,8 @@ mod tests {
 
     #[test]
     fn catalog_instance_and_host_ids() {
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let cloned_host_id = Arc::clone(&host_id);
         let cloned_instance_id = Arc::clone(&instance_id);
         let catalog = Catalog::new(cloned_host_id, cloned_instance_id);

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -154,7 +154,7 @@ expression: catalog
     }
   ],
   "sequence": 0,
-  "host_id": "dummy-host-id",
+  "host_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -79,7 +79,7 @@ expression: catalog
     }
   ],
   "sequence": 0,
-  "host_id": "dummy-host-id",
+  "host_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -68,7 +68,7 @@ expression: catalog
     }
   ],
   "sequence": 0,
-  "host_id": "dummy-host-id",
+  "host_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -772,9 +772,9 @@ mod tests {
             DedicatedExecutor::new_testing(),
         ));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
-        let dummy_host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
-        let catalog = Arc::new(Catalog::new(dummy_host_id, instance_id));
+        let sample_host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
+        let catalog = Arc::new(Catalog::new(sample_host_id, instance_id));
         let write_buffer_impl = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
@@ -791,14 +791,14 @@ mod tests {
 
         let parquet_metrics_provider: Arc<PersistedFiles> =
             Arc::clone(&write_buffer_impl.persisted_files());
-        let dummy_telem_store =
+        let sample_telem_store =
             TelemetryStore::new_without_background_runners(parquet_metrics_provider);
         let write_buffer: Arc<dyn WriteBuffer> = write_buffer_impl;
         let common_state = crate::CommonServerState::new(
             Arc::clone(&metrics),
             None,
             trace_header_parser,
-            Arc::clone(&dummy_telem_store),
+            Arc::clone(&sample_telem_store),
         )
         .unwrap();
         let query_executor = crate::query_executor::QueryExecutorImpl::new(
@@ -809,7 +809,7 @@ mod tests {
             Arc::new(HashMap::new()),
             10,
             10,
-            Arc::clone(&dummy_telem_store),
+            Arc::clone(&sample_telem_store),
         );
 
         // bind to port 0 will assign a random available port:

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -651,7 +651,7 @@ mod tests {
             test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider) as _);
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let executor = make_exec(Arc::clone(&object_store));
-        let host_id = Arc::from("dummy-host-id");
+        let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
         let write_buffer_impl = Arc::new(
@@ -674,7 +674,7 @@ mod tests {
         );
 
         let persisted_files: Arc<PersistedFiles> = Arc::clone(&write_buffer_impl.persisted_files());
-        let dummy_telem_store = TelemetryStore::new_without_background_runners(persisted_files);
+        let sample_telem_store = TelemetryStore::new_without_background_runners(persisted_files);
         let write_buffer: Arc<dyn WriteBuffer> = write_buffer_impl;
         let metrics = Arc::new(Registry::new());
         let df_config = Arc::new(Default::default());
@@ -686,7 +686,7 @@ mod tests {
             df_config,
             10,
             10,
-            dummy_telem_store,
+            sample_telem_store,
         );
 
         (write_buffer, query_executor, time_provider)

--- a/influxdb3_telemetry/src/sender.rs
+++ b/influxdb3_telemetry/src/sender.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut mock_server = Server::new_async().await;
         let mut sender = TelemetrySender::new(client, mock_server.url());
         let mock = mock_server.mock("POST", "/api/v3").create_async().await;
-        let telem_payload = create_dummy_payload();
+        let telem_payload = create_sample_payload();
 
         let result = sender.try_sending(&telem_payload).await;
 
@@ -141,12 +141,12 @@ mod tests {
         assert_eq!("https://foo.com/foo", new_url.as_str());
     }
 
-    fn create_dummy_payload() -> TelemetryPayload {
+    fn create_sample_payload() -> TelemetryPayload {
         TelemetryPayload {
-            os: Arc::from("dummy-str"),
-            version: Arc::from("dummy-str"),
-            storage_type: Arc::from("dummy-str"),
-            instance_id: Arc::from("dummy-str"),
+            os: Arc::from("sample-str"),
+            version: Arc::from("sample-str"),
+            storage_type: Arc::from("sample-str"),
+            instance_id: Arc::from("sample-str"),
             cores: 10,
             product_type: "OSS",
             cpu_utilization_percent_min: 100.0,

--- a/influxdb3_telemetry/src/store.rs
+++ b/influxdb3_telemetry/src/store.rs
@@ -67,7 +67,7 @@ impl TelemetryStore {
     }
 
     pub fn new_without_background_runners(persisted_files: Arc<dyn ParquetMetrics>) -> Arc<Self> {
-        let instance_id = Arc::from("dummy-instance-id");
+        let instance_id = Arc::from("sample-instance-id");
         let os = Arc::from("Linux");
         let influx_version = Arc::from("influxdb3-0.1.0");
         let storage_type = Arc::from("Memory");
@@ -285,9 +285,9 @@ mod tests {
     use super::*;
 
     #[derive(Debug)]
-    struct DummyParquetMetrics;
+    struct SampleParquetMetrics;
 
-    impl ParquetMetrics for DummyParquetMetrics {
+    impl ParquetMetrics for SampleParquetMetrics {
         fn get_metrics(&self) -> (u64, f64, u64) {
             (200, 500.25, 100)
         }
@@ -296,7 +296,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_telemetry_store_cpu_mem() {
         // create store
-        let parqet_file_metrics = Arc::new(DummyParquetMetrics);
+        let parqet_file_metrics = Arc::new(SampleParquetMetrics);
         let store: Arc<TelemetryStore> = TelemetryStore::new(
             Arc::from("some-instance-id"),
             Arc::from("Linux"),
@@ -315,7 +315,7 @@ mod tests {
         let expected_mem_in_mb = 117;
         store.add_cpu_and_memory(89.0, mem_used_bytes);
         let snapshot = store.snapshot();
-        info!(snapshot = ?snapshot, "dummy snapshot 1");
+        info!(snapshot = ?snapshot, "sample snapshot 1");
         assert_eq!(89.0, snapshot.cpu_utilization_percent_min);
         assert_eq!(89.0, snapshot.cpu_utilization_percent_max);
         assert_eq!(89.0, snapshot.cpu_utilization_percent_avg);
@@ -326,7 +326,7 @@ mod tests {
         // add cpu/mem snapshot 2
         store.add_cpu_and_memory(100.0, 134567890);
         let snapshot = store.snapshot();
-        info!(snapshot = ?snapshot, "dummy snapshot 2");
+        info!(snapshot = ?snapshot, "sample snapshot 2");
         assert_eq!(89.0, snapshot.cpu_utilization_percent_min);
         assert_eq!(100.0, snapshot.cpu_utilization_percent_max);
         assert_eq!(94.5, snapshot.cpu_utilization_percent_avg);
@@ -400,7 +400,7 @@ mod tests {
         store.reset_metrics();
         // check snapshot 3
         let snapshot = store.snapshot();
-        info!(snapshot = ?snapshot, "dummy snapshot 3");
+        info!(snapshot = ?snapshot, "sample snapshot 3");
         assert_eq!(0.0, snapshot.cpu_utilization_percent_min);
         assert_eq!(0.0, snapshot.cpu_utilization_percent_max);
         assert_eq!(0.0, snapshot.cpu_utilization_percent_avg);

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1621,8 +1621,8 @@ mod tests {
         let (obj_store, parquet_cache) =
             test_cached_obj_store_and_oracle(obj_store, Arc::clone(&time_provider));
         let persister = Arc::new(Persister::new(obj_store, "test_host"));
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
         WriteBufferImpl::new(
             persister,
@@ -3205,8 +3205,8 @@ mod tests {
         database.tables.insert(table_def.table_id, table_def);
         // Create the catalog and clone its InnerCatalog (which is what the LastCacheProvider is
         // initialized from):
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let mut catalog = Catalog::new(host_id, instance_id);
         let db_id = database.id;
         catalog.insert_database(database);

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -430,8 +430,8 @@ mod tests {
 
     #[tokio::test]
     async fn persist_catalog() {
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
@@ -446,8 +446,8 @@ mod tests {
 
     #[tokio::test]
     async fn persist_and_load_newest_catalog() {
-        let host_id: Arc<str> = Arc::from("dummy-host-id");
-        let instance_id: Arc<str> = Arc::from("dummy-instance-id");
+        let host_id: Arc<str> = Arc::from("sample-host-id");
+        let instance_id: Arc<str> = Arc::from("sample-instance-id");
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -571,8 +571,8 @@ mod tests {
 
     #[test]
     fn parse_lp_into_buffer() {
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
         let db_name = NamespaceName::new("foo").unwrap();
         let lp = "cpu,region=west user=23.2 100\nfoo f1=1i";

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -259,7 +259,7 @@ mod tests {
         let wal1 = WalFileSequenceNumber::new(wal_id);
         let cat1 = SequenceNumber::new(catalog_id);
         let mut new_snapshot =
-            PersistedSnapshot::new("dummy-host-id".to_owned(), snap1, wal1, cat1);
+            PersistedSnapshot::new("sample-host-id".to_owned(), snap1, wal1, cat1);
         parquet_files.into_iter().for_each(|file| {
             // TODO: Check why `add_parquet_file` method does not check if file is
             //       already present. This is checked when trying to add a new PersistedSnapshot

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -826,8 +826,8 @@ mod tests {
 
     #[test]
     fn write_validator_v1() -> Result<(), Error> {
-        let host_id = Arc::from("dummy-host-id");
-        let instance_id = Arc::from("dummy-instance-id");
+        let host_id = Arc::from("sample-host-id");
+        let instance_id = Arc::from("sample-instance-id");
         let namespace = NamespaceName::new("test").unwrap();
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
         let result = WriteValidator::initialize(namespace.clone(), catalog, 0)?


### PR DESCRIPTION
Add inclusivity checks to the build and fail if using non-inclusive language. The codebase is already quite clean with just a handful of fixes needed.

The output when encountering non-inclusive language is clear and actionable. Eg:
```
influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap:71:14-19: `dummy` may be insensitive, use `placeholder`, `sample` instead (error)
  "host_id": "dummy-host-id",
```

Other tools exist, but the `woke` tool is easy to use, supports overrides and is used by a lot of companies and projects (2.5M downloads). Sadly, the underlying tool's name may elicit negative responses from some, but this PR is not about any of that. It is about creating and maintaining an inclusive environment when developing InfluxDB.

References:
- https://docs.getwoke.tech