### PR TITLE
chore(circleci): update to use language-checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,8 @@ jobs:
       - run:
           name: Build and run inclusivity checker
           command: |
-            go install github.com/get-woke/woke@v0.19.0
-            woke --exit-1-on-failure .
+            go install github.com/jdstrand/language-checker@latest
+            language-checker --exit-1-on-failure .
   cargo-audit:
     docker:
       - image: quay.io/influxdb/rust:ci


### PR DESCRIPTION
In thinking about PR #25437 more, I couldn't help but feel like the choice of tool (ie, it's name) could perhaps be a distraction for some contributors. Since the [tool itself](https://github.com/get-woke/woke) is popular, easy to use, etc I decided to [fork the project](https://github.com/jdstrand/language-checker) and update influxdb to use the fork instead to reduce any impediments to contribution.