### PR TITLE
feat: add option to flush WAL on shutdown

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -514,6 +514,11 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Desc:    "The max amount of time a write will wait when the WAL already has `storage-wal-max-concurrent-writes` active writes. Set to 0 to disable the timeout.",
 		},
 		{
+			DestP: &o.StorageConfig.Data.WALFlushOnShutdown,
+			Flag:  "storage-wal-flush-on-shutdown",
+			Desc:  "Flushes and clears the WAL on shutdown",
+		},
+		{
 			DestP: &o.StorageConfig.Data.ValidateKeys,
 			Flag:  "storage-validate-keys",
 			Desc:  "Validates incoming writes to ensure keys only have valid unicode characters.",

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// disks or when WAL write contention is seen.  A value of 0 fsyncs every write to the WAL.
 	WALFsyncDelay toml.Duration `toml:"wal-fsync-delay"`
 
+	// WALFlushOnShutdown determines if the WAL should be flushed when influxd is shutdown.
+	// This is useful in upgrade and downgrade scenarios to prevent WAL format compatibility issues.
+	WALFlushOnShutdown bool `toml:"wal-flush-on-shutdown"`
+
 	// Enables unicode validation on series keys on write.
 	ValidateKeys bool `toml:"validate-keys"`
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -5,37 +5,29 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/influxdb/v2/tsdb"
 )
 
 func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	c := tsdb.NewConfig()
-	if _, err := toml.Decode(`
+	_, err := toml.Decode(`
 dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
 wal-fsync-delay = "10s"
+wal-flush-on-shutdown = true
 tsm-use-madv-willneed = true
-`, &c); err != nil {
-		t.Fatal(err)
-	}
+`, &c)
+	require.NoError(t, err)
 
-	if err := c.Validate(); err != nil {
-		t.Errorf("unexpected validate error: %s", err)
-	}
-
-	if got, exp := c.Dir, "/var/lib/influxdb/data"; got != exp {
-		t.Errorf("unexpected dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.WALDir, "/var/lib/influxdb/wal"; got != exp {
-		t.Errorf("unexpected wal-dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
-		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.TSMWillNeed, true; got != exp {
-		t.Errorf("unexpected tsm-madv-willneed:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
+	require.NoError(t, c.Validate())
+	require.Equal(t, "/var/lib/influxdb/data", c.Dir)
+	require.Equal(t, "/var/lib/influxdb/wal", c.WALDir)
+	require.Equal(t, time.Duration(10*time.Second), time.Duration(c.WALFsyncDelay))
+	require.True(t, c.WALFlushOnShutdown)
+	require.True(t, c.TSMWillNeed)
 }
 
 func TestConfig_Validate_Error(t *testing.T) {

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -29,7 +29,7 @@ var (
 // Engine represents a swappable storage engine for the shard.
 type Engine interface {
 	Open(ctx context.Context) error
-	Close() error
+	Close(flush bool) error
 	SetEnabled(enabled bool)
 	SetCompactionsEnabled(enabled bool)
 	ScheduleFullCompaction() error
@@ -41,6 +41,7 @@ type Engine interface {
 
 	LoadMetadataIndex(shardID uint64, index Index) error
 
+	FlushWAL() error
 	CreateSnapshot(skipCacheOk bool) (string, error)
 	Backup(w io.Writer, basePath string, since time.Time) error
 	Export(w io.Writer, basePath string, start time.Time, end time.Time) error

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -41,7 +41,6 @@ type Engine interface {
 
 	LoadMetadataIndex(shardID uint64, index Index) error
 
-	FlushWAL() error
 	CreateSnapshot(skipCacheOk bool) (string, error)
 	Backup(w io.Writer, basePath string, since time.Time) error
 	Export(w io.Writer, basePath string, start time.Time, end time.Time) error

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -782,7 +782,7 @@ func (e *Engine) Close(flush bool) error {
 	var flushErr error
 	if e.WALEnabled && flush {
 		// Even if the snapshot fails, we still have to proceed and close the engine.
-		flushErr = e.FlushWAL()
+		flushErr = e.flushWAL()
 	}
 
 	e.SetCompactionsEnabled(false)
@@ -1913,8 +1913,8 @@ func (e *Engine) doWriteSnapshot(flush bool) (err error) {
 	return e.writeSnapshotAndCommit(log, closedFiles, snapshot)
 }
 
-// FlushWAL flushes the WAL and empties the WAL directory.
-func (e *Engine) FlushWAL() error {
+// flushWAL flushes the WAL and empties the WAL directory.
+func (e *Engine) flushWAL() error {
 	return e.writeSnapshotWithRetries(true)
 }
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1825,7 +1825,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	t.Cleanup(func() { idx.Close() })
 
 	e := tsm1.NewEngine(1, idx, dir, walPath, sfile.SeriesFile, opt).(*tsm1.Engine)
-	t.Cleanup(func() { e.Close() })
+	t.Cleanup(func() { e.Close(false) })
 
 	// mock the planner so compactions don't run during the test
 	e.CompactionPlan = &mockPlanner{}
@@ -2644,7 +2644,7 @@ func (e *Engine) close(cleanup bool) error {
 			os.RemoveAll(e.root)
 		}
 	}()
-	return e.Engine.Close()
+	return e.Engine.Close(false)
 }
 
 // Reopen closes and reopens the engine.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -512,7 +512,11 @@ func (s *Store) Close() error {
 
 	// Close all the shards in parallel.
 	if err := s.walkShards(s.shardsSlice(), func(sh *Shard) error {
-		return sh.Close()
+		if s.EngineOptions.Config.WALFlushOnShutdown {
+			return sh.FlushAndClose()
+		} else {
+			return sh.Close()
+		}
 	}); err != nil {
 		return err
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -2627,6 +2627,8 @@ func WithWALFlushOnShutdown(flush bool) StoreOption {
 func NewStore(tb testing.TB, index string, opts ...StoreOption) *Store {
 	tb.Helper()
 
+	// The WAL directory must not be rooted under the data path. Otherwise reopening
+	// the store will generate series indices for the WAL directories.
 	rootPath := tb.TempDir()
 	path := filepath.Join(rootPath, "data")
 	walPath := filepath.Join(rootPath, "wal")


### PR DESCRIPTION
Add `--storage-wal-flush-on-shutdown` to flush WAL on database shutdown. On successful shutdown, all WAL data will be committed to TSM files and the WAL directories will not contain any .wal files.

Closes: #25422

