### PR TITLE
fix: check num items to prune before pruning parquet cache

### DIFF
--- a/influxdb3_write/src/parquet_cache/mod.rs
+++ b/influxdb3_write/src/parquet_cache/mod.rs
@@ -338,10 +338,10 @@ impl Cache {
     /// This is a no-op if the `used` amount on the cache is not >= its `capacity`
     fn prune(&self) -> Option<usize> {
         let used = self.used.load(Ordering::SeqCst);
-        if used < self.capacity {
+        let n_to_prune = (self.map.len() as f64 * self.prune_percent).floor() as usize;
+        if used < self.capacity || n_to_prune == 0 {
             return None;
         }
-        let n_to_prune = (self.map.len() as f64 * self.prune_percent).floor() as usize;
         // use a BinaryHeap to determine the cut-off time, at which, entries that were
         // last hit before that time will be pruned:
         let mut prune_heap = BinaryHeap::with_capacity(n_to_prune);

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+for (( ; ; ))
+do
+  rm -rf /tmp/influxdb*
+  TEST_LOG=1 RUST_LOG=info RUST_LOG_SPAN_EVENTS=full RUST_BACKTRACE=1 cargo nextest run --workspace --failure-output immediate-final --no-fail-fast
+  echo "sleeping"
+  sleep 1
+done


### PR DESCRIPTION
When running the tests repeatedly the tests failed intermittently as the background runner wakes up to prune the cache and the tests are loading and removing the data. The check whether `n_to_prune` is greater than 0 before going ahead with pruning fixes the issue

Closes: https://github.com/influxdata/influxdb/issues/25446
