### PR TITLE
feat: add option to flush WAL on shutdown

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -514,6 +514,11 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Desc:    "The max amount of time a write will wait when the WAL already has `storage-wal-max-concurrent-writes` active writes. Set to 0 to disable the timeout.",
 		},
 		{
+			DestP: &o.StorageConfig.Data.WALFlushOnShutdown,
+			Flag:  "storage-wal-flush-on-shutdown",
+			Desc:  "Flushes and clears the WAL on shutdown",
+		},
+		{
 			DestP: &o.StorageConfig.Data.ValidateKeys,
 			Flag:  "storage-validate-keys",
 			Desc:  "Validates incoming writes to ensure keys only have valid unicode characters.",

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// disks or when WAL write contention is seen.  A value of 0 fsyncs every write to the WAL.
 	WALFsyncDelay toml.Duration `toml:"wal-fsync-delay"`
 
+	// WALFlushOnShutdown determines if the WAL should be flushed when influxd is shutdown.
+	// This is useful in upgrade and downgrade scenarios to prevent WAL format compatibility issues.
+	WALFlushOnShutdown bool `toml:"wal-flush-on-shutdown"`
+
 	// Enables unicode validation on series keys on write.
 	ValidateKeys bool `toml:"validate-keys"`
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -5,37 +5,29 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/influxdb/v2/tsdb"
 )
 
 func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	c := tsdb.NewConfig()
-	if _, err := toml.Decode(`
+	_, err := toml.Decode(`
 dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
 wal-fsync-delay = "10s"
+wal-flush-on-shutdown = true
 tsm-use-madv-willneed = true
-`, &c); err != nil {
-		t.Fatal(err)
-	}
+`, &c)
+	require.NoError(t, err)
 
-	if err := c.Validate(); err != nil {
-		t.Errorf("unexpected validate error: %s", err)
-	}
-
-	if got, exp := c.Dir, "/var/lib/influxdb/data"; got != exp {
-		t.Errorf("unexpected dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.WALDir, "/var/lib/influxdb/wal"; got != exp {
-		t.Errorf("unexpected wal-dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
-		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
-	if got, exp := c.TSMWillNeed, true; got != exp {
-		t.Errorf("unexpected tsm-madv-willneed:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
-	}
+	require.NoError(t, c.Validate())
+	require.Equal(t, "/var/lib/influxdb/data", c.Dir)
+	require.Equal(t, "/var/lib/influxdb/wal", c.WALDir)
+	require.Equal(t, time.Duration(10*time.Second), time.Duration(c.WALFsyncDelay))
+	require.True(t, c.WALFlushOnShutdown)
+	require.True(t, c.TSMWillNeed)
 }
 
 func TestConfig_Validate_Error(t *testing.T) {

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -29,7 +29,7 @@ var (
 // Engine represents a swappable storage engine for the shard.
 type Engine interface {
 	Open(ctx context.Context) error
-	Close() error
+	Close(flush bool) error
 	SetEnabled(enabled bool)
 	SetCompactionsEnabled(enabled bool)
 	ScheduleFullCompaction() error

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -774,7 +774,17 @@ func (e *Engine) Open(ctx context.Context) error {
 }
 
 // Close closes the engine. Subsequent calls to Close are a nop.
-func (e *Engine) Close() error {
+// If flush is true, then the WAL is flushed and cleared before the
+// engine is closed.
+func (e *Engine) Close(flush bool) error {
+	// Flushing the WAL involves writing a snapshot, which has to be done before
+	// compactions are disabled.
+	var flushErr error
+	if e.WALEnabled && flush {
+		// Even if the snapshot fails, we still have to proceed and close the engine.
+		flushErr = e.flushWAL()
+	}
+
 	e.SetCompactionsEnabled(false)
 
 	// Lock now and close everything else down.
@@ -782,17 +792,13 @@ func (e *Engine) Close() error {
 	defer e.mu.Unlock()
 	e.done = nil // Ensures that the channel will not be closed again.
 
-	var err error = nil
-	err = e.fieldset.Close()
-	if err2 := e.FileStore.Close(); err2 != nil && err == nil {
-		err = err2
-	}
+	setCloseErr := e.fieldset.Close()
+	storeCloseErr := e.FileStore.Close()
+	var walCloseErr error
 	if e.WALEnabled {
-		if err2 := e.WAL.Close(); err2 != nil && err == nil {
-			err = err2
-		}
+		walCloseErr = e.WAL.Close()
 	}
-	return err
+	return errors.Join(flushErr, setCloseErr, storeCloseErr, walCloseErr)
 }
 
 // WithLogger sets the logger for the engine.
@@ -1835,7 +1841,11 @@ func (e *Engine) CreateSeriesIfNotExists(key, name []byte, tags models.Tags) err
 func (e *Engine) WriteTo(w io.Writer) (n int64, err error) { panic("not implemented") }
 
 // WriteSnapshot will snapshot the cache and write a new TSM file with its contents, releasing the snapshot when done.
-func (e *Engine) WriteSnapshot() (err error) {
+func (e *Engine) WriteSnapshot() error {
+	return e.doWriteSnapshot(false)
+}
+
+func (e *Engine) doWriteSnapshot(flush bool) (err error) {
 	// Lock and grab the cache snapshot along with all the closed WAL
 	// filenames associated with the snapshot
 
@@ -1858,8 +1868,14 @@ func (e *Engine) WriteSnapshot() (err error) {
 		defer e.mu.Unlock()
 
 		if e.WALEnabled {
-			if err = e.WAL.CloseSegment(); err != nil {
-				return
+			if !flush {
+				if err = e.WAL.CloseSegment(); err != nil {
+					return
+				}
+			} else {
+				if err = e.WAL.CloseAllSegments(); err != nil {
+					return
+				}
 			}
 
 			segments, err = e.WAL.ClosedSegments()
@@ -1897,17 +1913,30 @@ func (e *Engine) WriteSnapshot() (err error) {
 	return e.writeSnapshotAndCommit(log, closedFiles, snapshot)
 }
 
+// flushWAL flushes the WAL and empties the WAL directory.
+func (e *Engine) flushWAL() error {
+	return e.writeSnapshotWithRetries(true)
+}
+
+// writeSnapshotWithRetries calls WriteSnapshot and will retry with a backoff if WriteSnapshot
+// fails with ErrSnapshotInProgress. If flush is true then no new WAL segments are opened so
+// that the WAL has no segment files on success.
+func (e *Engine) writeSnapshotWithRetries(flush bool) error {
+	err := e.doWriteSnapshot(flush)
+	for i := 0; i < 3 && err == ErrSnapshotInProgress; i += 1 {
+		backoff := time.Duration(math.Pow(32, float64(i))) * time.Millisecond
+		time.Sleep(backoff)
+		err = e.doWriteSnapshot(flush)
+	}
+	return err
+}
+
 // CreateSnapshot will create a temp directory that holds
 // temporary hardlinks to the underlying shard files.
 // skipCacheOk controls whether it is permissible to fail writing out
 // in-memory cache data when a previous snapshot is in progress.
 func (e *Engine) CreateSnapshot(skipCacheOk bool) (string, error) {
-	err := e.WriteSnapshot()
-	for i := 0; i < 3 && err == ErrSnapshotInProgress; i += 1 {
-		backoff := time.Duration(math.Pow(32, float64(i))) * time.Millisecond
-		time.Sleep(backoff)
-		err = e.WriteSnapshot()
-	}
+	err := e.writeSnapshotWithRetries(false)
 	if err == ErrSnapshotInProgress && skipCacheOk {
 		e.logger.Warn("Snapshotter busy: proceeding without cache contents")
 	} else if err != nil {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1825,7 +1825,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	t.Cleanup(func() { idx.Close() })
 
 	e := tsm1.NewEngine(1, idx, dir, walPath, sfile.SeriesFile, opt).(*tsm1.Engine)
-	t.Cleanup(func() { e.Close() })
+	t.Cleanup(func() { e.Close(false) })
 
 	// mock the planner so compactions don't run during the test
 	e.CompactionPlan = &mockPlanner{}
@@ -2644,7 +2644,7 @@ func (e *Engine) close(cleanup bool) error {
 			os.RemoveAll(e.root)
 		}
 	}()
-	return e.Engine.Close()
+	return e.Engine.Close(false)
 }
 
 // Reopen closes and reopens the engine.

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -559,6 +559,14 @@ func (l *WAL) CloseSegment() error {
 	return nil
 }
 
+// CloseAllSegments closes the current segment regardless of whether it contains data
+// and does not open a new one.
+func (l *WAL) CloseAllSegments() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.closeCurrentSegmentFile()
+}
+
 // Delete deletes the given keys, returning the segment ID for the operation.
 func (l *WAL) Delete(ctx context.Context, keys [][]byte) (int, error) {
 	if len(keys) == 0 {
@@ -634,15 +642,24 @@ func segmentFileNames(dir string) ([]string, error) {
 	return names, nil
 }
 
-// newSegmentFile will close the current segment file and open a new one, updating bookkeeping info on the log.
-func (l *WAL) newSegmentFile() error {
-	l.currentSegmentID++
+// closeCurrentSegmentFile will close the current segment file. l.mu must be held before calling this method.
+func (l *WAL) closeCurrentSegmentFile() error {
 	if l.currentSegmentWriter != nil {
 		l.sync()
 
 		if err := l.currentSegmentWriter.close(); err != nil {
 			return err
 		}
+		l.currentSegmentWriter = nil
+	}
+	return nil
+}
+
+// newSegmentFile will close the current segment file and open a new one, updating bookkeeping info on the log.
+func (l *WAL) newSegmentFile() error {
+	l.currentSegmentID++
+	if err := l.closeCurrentSegmentFile(); err != nil {
+		return err
 	}
 
 	fileName := filepath.Join(l.path, fmt.Sprintf("%s%05d.%s", WALFilePrefix, l.currentSegmentID, WALFileExtension))

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -512,7 +512,11 @@ func (s *Store) Close() error {
 
 	// Close all the shards in parallel.
 	if err := s.walkShards(s.shardsSlice(), func(sh *Shard) error {
-		return sh.Close()
+		if s.EngineOptions.Config.WALFlushOnShutdown {
+			return sh.FlushAndClose()
+		} else {
+			return sh.Close()
+		}
 	}); err != nil {
 		return err
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"math/rand"
 	"os"
@@ -488,6 +489,7 @@ func TestStore_Open_InvalidDatabaseFile(t *testing.T) {
 		defer s.Close()
 
 		// Create a file instead of a directory for a database.
+		require.NoError(t, os.MkdirAll(s.Path(), 0777))
 		f, err := os.Create(filepath.Join(s.Path(), "db0"))
 		if err != nil {
 			t.Fatal(err)
@@ -653,6 +655,139 @@ func TestShards_CreateIterator(t *testing.T) {
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) { test(t, index) })
+	}
+}
+
+func requireFloatIteratorPoints(t *testing.T, fitr query.FloatIterator, expPts []*query.FloatPoint) {
+	for idx, expPt := range expPts {
+		pt, err := fitr.Next()
+		require.NoError(t, err, "Got error on index=%d", idx)
+		require.Equal(t, expPt, pt, "Mismatch on index=%d", idx)
+	}
+	pt, err := fitr.Next()
+	require.NoError(t, err)
+	require.Nil(t, pt)
+}
+
+func walFiles(t *testing.T, s *Store) []string {
+	// Make sure the WAL directory is really there so we don't get false empties because
+	// the path calcuation is wrong or a cleanup routine blew away the whole WAL directory.
+	require.DirExists(t, s.walPath)
+	var dirs, files []string
+	err := filepath.Walk(s.walPath, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			dirs = append(dirs, path)
+		} else {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, dirs, "expected shard WAL directories, none found")
+	return files
+}
+
+func TestStore_FlushWALOnClose(t *testing.T) {
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run("TestStore_FlushWALOnClose_"+index, func(t *testing.T) {
+			s := MustOpenStore(t, index, WithWALFlushOnShutdown(true))
+			defer s.Close()
+
+			// Create shard #0 with data.
+			s.MustCreateShardWithData("db0", "rp0", 0,
+				`cpu,host=serverA value=1  0`,
+				`cpu,host=serverA value=2 10`,
+				`cpu,host=serverB value=3 20`,
+			)
+
+			// Create shard #1 with data.
+			s.MustCreateShardWithData("db0", "rp0", 1,
+				`cpu,host=serverA value=1 30`,
+				`mem,host=serverA value=2 40`, // skip: wrong source
+				`cpu,host=serverC value=3 60`,
+			)
+			expPts := []*query.FloatPoint{
+				&query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(0, 0).UnixNano(), Value: 1},
+				&query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(10, 0).UnixNano(), Value: 2},
+				&query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(30, 0).UnixNano(), Value: 1},
+				&query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverB"), Time: time.Unix(20, 0).UnixNano(), Value: 3},
+				&query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverC"), Time: time.Unix(60, 0).UnixNano(), Value: 3},
+			}
+
+			require.NotEmpty(t, walFiles(t, s))
+
+			checkPoints := func(exp []*query.FloatPoint) {
+				// Retrieve shard group.
+				shards := s.ShardGroup([]uint64{0, 1})
+				// Create iterator.
+				m := &influxql.Measurement{Name: "cpu"}
+				itr, err := shards.CreateIterator(context.Background(), m, query.IteratorOptions{
+					Expr:       influxql.MustParseExpr(`value`),
+					Dimensions: []string{"host"},
+					Ascending:  true,
+					StartTime:  influxql.MinTime,
+					EndTime:    influxql.MaxTime,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, itr)
+				defer itr.Close()
+				fitr, ok := itr.(query.FloatIterator)
+				require.True(t, ok)
+				requireFloatIteratorPoints(t, fitr, exp)
+			}
+			checkPoints(expPts)
+
+			require.NoError(t, s.Close())
+			s.Store = nil
+			require.Empty(t, walFiles(t, s))
+
+			require.NoError(t, s.Reopen(t))
+			checkPoints(expPts)
+			require.Empty(t, walFiles(t, s)) // we haven't written any points, no WAL yet.
+			s.MustWriteToShardString(1, `cpu,host=serverC value=5 90`)
+			expPts = append(expPts, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverC"), Time: time.Unix(90, 0).UnixNano(), Value: 5})
+			checkPoints(expPts)
+			require.NotEmpty(t, walFiles(t, s)) // we create a WAL file with the write
+
+			// One shard has a WAL, one does not
+			require.NoError(t, s.Close())
+			s.Store = nil
+			require.Empty(t, walFiles(t, s))
+
+			// Open again
+			require.NoError(t, s.Reopen(t))
+			checkPoints(expPts)
+			require.Empty(t, walFiles(t, s))
+
+			// Close with no writes, no WAL files
+			require.NoError(t, s.Close())
+			s.Store = nil
+			require.Empty(t, walFiles(t, s))
+
+			// Open again, but this time don't flush WAL on shutdown
+			require.NoError(t, s.Reopen(t, WithWALFlushOnShutdown(false)))
+			checkPoints(expPts)
+			require.Empty(t, walFiles(t, s))
+
+			// Write new point, creating WAL on one shard
+			s.MustWriteToShardString(1, `cpu,host=serverC value=6 100`)
+			expPts = append(expPts, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverC"), Time: time.Unix(100, 0).UnixNano(), Value: 6})
+			checkPoints(expPts)
+			require.NotEmpty(t, walFiles(t, s)) // we create a WAL file with the write
+
+			// Close and check that the shard is not flushed
+			require.NoError(t, s.Close())
+			s.Store = nil
+			require.NotEmpty(t, walFiles(t, s))
+
+			// Let's make sure we /really/ didn't flush the WAL by deleting the WAL and then making sure that last point we wrote has gone missing.
+			require.NoError(t, os.RemoveAll(s.walPath))
+			require.NoError(t, s.Reopen(t))
+			expPts = expPts[:len(expPts)-1]
+			checkPoints(expPts)
+			require.Empty(t, walFiles(t, s)) // also sanity checks that WAL directories have been recreated
+		})
 	}
 }
 
@@ -2473,30 +2608,57 @@ func BenchmarkStore_TagValues(b *testing.B) {
 // Store is a test wrapper for tsdb.Store.
 type Store struct {
 	*tsdb.Store
-	index string
+	path    string
+	index   string
+	walPath string
+	opts    []StoreOption
+}
+
+type StoreOption func(s *Store) error
+
+func WithWALFlushOnShutdown(flush bool) StoreOption {
+	return func(s *Store) error {
+		s.EngineOptions.Config.WALFlushOnShutdown = flush
+		return nil
+	}
 }
 
 // NewStore returns a new instance of Store with a temporary path.
-func NewStore(tb testing.TB, index string) *Store {
+func NewStore(tb testing.TB, index string, opts ...StoreOption) *Store {
 	tb.Helper()
 
-	path := tb.TempDir()
+	// The WAL directory must not be rooted under the data path. Otherwise reopening
+	// the store will generate series indices for the WAL directories.
+	rootPath := tb.TempDir()
+	path := filepath.Join(rootPath, "data")
+	walPath := filepath.Join(rootPath, "wal")
 
-	s := &Store{Store: tsdb.NewStore(path), index: index}
+	s := &Store{
+		Store:   tsdb.NewStore(path),
+		path:    path,
+		index:   index,
+		walPath: walPath,
+		opts:    opts,
+	}
 	s.EngineOptions.IndexVersion = index
-	s.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
+	s.EngineOptions.Config.WALDir = walPath
 	s.EngineOptions.Config.TraceLoggingEnabled = true
 	s.WithLogger(zaptest.NewLogger(tb))
+
+	for _, o := range s.opts {
+		err := o(s)
+		require.NoError(tb, err)
+	}
 
 	return s
 }
 
 // MustOpenStore returns a new, open Store using the specified index,
 // at a temporary path.
-func MustOpenStore(tb testing.TB, index string) *Store {
+func MustOpenStore(tb testing.TB, index string, opts ...StoreOption) *Store {
 	tb.Helper()
 
-	s := NewStore(tb, index)
+	s := NewStore(tb, index, opts...)
 
 	if err := s.Open(context.Background()); err != nil {
 		panic(err)
@@ -2505,25 +2667,38 @@ func MustOpenStore(tb testing.TB, index string) *Store {
 }
 
 // Reopen closes and reopens the store as a new store.
-func (s *Store) Reopen(tb testing.TB) error {
+func (s *Store) Reopen(tb testing.TB, newOpts ...StoreOption) error {
 	tb.Helper()
 
-	if err := s.Store.Close(); err != nil {
-		return err
+	if s.Store != nil {
+		if err := s.Store.Close(); err != nil {
+			return err
+		}
 	}
 
-	s.Store = tsdb.NewStore(s.Path())
+	s.Store = tsdb.NewStore(s.path)
 	s.EngineOptions.IndexVersion = s.index
-	s.EngineOptions.Config.WALDir = filepath.Join(s.Path(), "wal")
+	s.EngineOptions.Config.WALDir = s.walPath
 	s.EngineOptions.Config.TraceLoggingEnabled = true
 	s.WithLogger(zaptest.NewLogger(tb))
+	if len(newOpts) > 0 {
+		s.opts = newOpts
+	}
+
+	for _, o := range s.opts {
+		err := o(s)
+		require.NoError(tb, err)
+	}
 
 	return s.Store.Open(context.Background())
 }
 
 // Close closes the store and removes the underlying data.
 func (s *Store) Close() error {
-	return s.Store.Close()
+	if s.Store != nil {
+		return s.Store.Close()
+	}
+	return nil
 }
 
 // MustCreateShardWithData creates a shard and writes line protocol data to it.


### PR DESCRIPTION
Add `--storage-wal-flush-on-shutdown` to flush WAL on database shutdown. On successful shutdown, all WAL data will be committed to TSM files and the WAL directories will not contain any .wal files.

Clean cherry-pick of #25444 from main-2.x.

Closes: #25450
(cherry picked from commit 96bade409e73709bd01f9cadf1d745767887bfeb)
