### PR TITLE
refactor: improvements to the catlog API

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -692,18 +692,15 @@ where
             ttl,
         } = self.read_body_json(req).await?;
 
-        let db_id = self
+        let (db_id, db_schema) = self
             .write_buffer
             .catalog()
-            .db_name_to_id(db.as_str().into())
+            .db_schema_and_id(db)
             .ok_or_else(|| WriteBufferError::DbDoesNotExist)?;
-        let table_id = self
-            .write_buffer
-            .catalog()
-            .db_schema(&db_id)
-            .expect("db should exist")
-            .table_name_to_id(table.as_str().into())
+        let table_id = db_schema
+            .table_name_to_id(table.as_str())
             .ok_or_else(|| WriteBufferError::TableDoesNotExist)?;
+
         match self
             .write_buffer
             .create_last_cache(
@@ -742,17 +739,13 @@ where
             self.read_body_json(req).await?
         };
 
-        let db_id = self
+        let (db_id, db_schema) = self
             .write_buffer
             .catalog()
-            .db_name_to_id(db.into())
+            .db_schema_and_id(db)
             .ok_or_else(|| WriteBufferError::DbDoesNotExist)?;
-        let table_id = self
-            .write_buffer
-            .catalog()
-            .db_schema(&db_id)
-            .expect("db should exist")
-            .table_name_to_id(table.into())
+        let table_id = db_schema
+            .table_name_to_id(table)
             .ok_or_else(|| WriteBufferError::TableDoesNotExist)?;
         self.write_buffer
             .delete_last_cache(db_id, table_id, &name)

--- a/influxdb3_server/src/system_tables/parquet_files.rs
+++ b/influxdb3_server/src/system_tables/parquet_files.rs
@@ -95,9 +95,9 @@ impl IoxSystemTable for ParquetFilesTable {
             self.db_id,
             self.buffer
                 .catalog()
-                .db_schema(&self.db_id)
+                .db_schema_by_id(self.db_id)
                 .expect("db exists")
-                .table_name_to_id(table_name.as_str().into())
+                .table_name_to_id(table_name.as_str())
                 .expect("table exists"),
         );
 

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -196,17 +196,14 @@ impl LastCacheProvider {
                 table
                     .iter()
                     .flat_map(|(table_id, table_map)| {
-                        table_map.iter().map(|(lc_name, lc)| {
-                            lc.to_definition(
-                                *table_id,
-                                self.catalog
-                                    .db_schema(&db)
-                                    .expect("db exists")
-                                    .table_id_to_name(*table_id)
-                                    .expect("table exists")
-                                    .to_string(),
-                                lc_name,
-                            )
+                        let table_name = self
+                            .catalog
+                            .db_schema_by_id(db)
+                            .expect("db exists")
+                            .table_id_to_name(*table_id)
+                            .expect("table exists");
+                        table_map.iter().map(move |(lc_name, lc)| {
+                            lc.to_definition(*table_id, table_name.as_ref(), lc_name)
                         })
                     })
                     .collect()

--- a/influxdb3_write/src/last_cache/table_function.rs
+++ b/influxdb3_write/src/last_cache/table_function.rs
@@ -100,9 +100,9 @@ impl TableFunctionImpl for LastCacheFunction {
         let table_id = self
             .provider
             .catalog
-            .db_schema(&self.db_id)
+            .db_schema_by_id(self.db_id)
             .expect("db exists")
-            .table_name_to_id(table_name.as_str().into())
+            .table_name_to_id(table_name.as_str())
             .expect("table exists");
 
         match self.provider.get_cache_name_and_schema(


### PR DESCRIPTION
This extends the Catalog and underlying DatabaseSchema API to make accessing database and table schema, as well as their IDs moreconvenient.

For example, instead of having to call `db_name_to_id`, then use that ID to call `db_schema`, this just reverts `db_schema` to be called with the name, and handles the ID conversion internally.

A `db_schema_by_id` method was added where we are accessing via the ID.

This would reduce the number of read locks acquired from two down to one.

The `db_name_to_id` and `db_id_to_name` methods are still available in the API in case they are needed, but these changes make them less needed throughout our codebase.

Otherwise, I changed the arg to be `impl Into<Arc<str>>` instead of `Arc<str>`, which allows us to pass in `&str`s without having to call `.into()`.

Similar treatment was given to the `DatabaseSchema` type re: accessing tables.

Closes #25462