### PR TITLE
refactor: separate catalog schema API

### DIFF
--- a/influxdb3_catalog/src/lib.rs
+++ b/influxdb3_catalog/src/lib.rs
@@ -1,2 +1,34 @@
+use std::sync::Arc;
+
+use catalog::DatabaseSchema;
+use influxdb3_id::DbId;
+
 pub mod catalog;
 pub(crate) mod serialize;
+
+/// Provide [`DatabaseSchema`] and there derivatives where needed.
+///
+/// This trait captures the read-only behaviour of the [`catalog::Catalog`] as where it is used to
+/// serve queries and provide schema-related info of the underlying database.
+pub trait DatabaseSchemaProvider: std::fmt::Debug + Send + Sync + 'static {
+    /// Convert a database name to its corresponding [`DbId`]
+    fn db_name_to_id(&self, db_name: &str) -> Option<DbId>;
+
+    /// Convert a [`DbId`] into its corresponding database name
+    fn db_id_to_name(&self, db_id: DbId) -> Option<Arc<str>>;
+
+    /// Get the [`DatabaseSchema`] for the given name, or `None` otherwise
+    fn db_schema(&self, db_name: &str) -> Option<Arc<DatabaseSchema>>;
+
+    /// Get the [`DatabaseSchema`] for the given [`DbId`], or `None` otherwise
+    fn db_schema_by_id(&self, db_id: DbId) -> Option<Arc<DatabaseSchema>>;
+
+    /// Get the [`DatabaseSchema`] as well as the corresponding [`DbId`] for the given name
+    fn db_schema_and_id(&self, db_name: &str) -> Option<(DbId, Arc<DatabaseSchema>)>;
+
+    /// Get a list of the database names in the underlying catalog'd instance
+    fn db_names(&self) -> Vec<String>;
+
+    /// List out all [`DatabaseSchema`] in the database
+    fn list_db_schema(&self) -> Vec<Arc<DatabaseSchema>>;
+}

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -694,8 +694,8 @@ where
 
         let (db_id, db_schema) = self
             .write_buffer
-            .catalog()
-            .db_schema_and_id(db)
+            .db_schema_provider()
+            .db_schema_and_id(&db)
             .ok_or_else(|| WriteBufferError::DbDoesNotExist)?;
         let table_id = db_schema
             .table_name_to_id(table.as_str())
@@ -741,8 +741,8 @@ where
 
         let (db_id, db_schema) = self
             .write_buffer
-            .catalog()
-            .db_schema_and_id(db)
+            .db_schema_provider()
+            .db_schema_and_id(&db)
             .ok_or_else(|| WriteBufferError::DbDoesNotExist)?;
         let table_id = db_schema
             .table_name_to_id(table)

--- a/influxdb3_server/src/system_tables/parquet_files.rs
+++ b/influxdb3_server/src/system_tables/parquet_files.rs
@@ -94,7 +94,7 @@ impl IoxSystemTable for ParquetFilesTable {
         let parquet_files: Vec<ParquetFile> = self.buffer.parquet_files(
             self.db_id,
             self.buffer
-                .catalog()
+                .db_schema_provider()
                 .db_schema_by_id(self.db_id)
                 .expect("db exists")
                 .table_name_to_id(table_name.as_str())

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -23,7 +23,7 @@ use datafusion::{
 };
 use hashbrown::{HashMap, HashSet};
 use indexmap::{IndexMap, IndexSet};
-use influxdb3_catalog::catalog::Catalog;
+use influxdb3_catalog::DatabaseSchemaProvider;
 use influxdb3_id::DbId;
 use influxdb3_id::TableId;
 use influxdb3_wal::{
@@ -66,7 +66,7 @@ type CacheMap = RwLock<HashMap<DbId, HashMap<TableId, HashMap<String, LastCache>
 
 /// Provides all last-N-value caches for the entire database
 pub struct LastCacheProvider {
-    catalog: Arc<Catalog>,
+    db_schema_provider: Arc<dyn DatabaseSchemaProvider>,
     cache_map: CacheMap,
 }
 
@@ -116,19 +116,15 @@ pub struct CreateCacheArguments {
 }
 
 impl LastCacheProvider {
-    /// Create a new [`LastCacheProvider`]
-    pub fn new(catalog: Arc<Catalog>) -> Self {
-        Self {
-            catalog,
+    /// Initialize a [`LastCacheProvider`] from a [`DatabaseSchemaProvider`]
+    pub fn new_from_db_schema_provider(
+        db_schema_provider: Arc<dyn DatabaseSchemaProvider>,
+    ) -> Result<Self, Error> {
+        let provider = LastCacheProvider {
+            db_schema_provider: Arc::clone(&db_schema_provider),
             cache_map: Default::default(),
-        }
-    }
-
-    /// Initialize a [`LastCacheProvider`] from a [`Catalog`]
-    pub fn new_from_catalog(catalog: Arc<Catalog>) -> Result<Self, Error> {
-        let provider = LastCacheProvider::new(Arc::clone(&catalog));
-        let inner_catalog = catalog.inner().read();
-        for db_schema in inner_catalog.databases() {
+        };
+        for db_schema in db_schema_provider.list_db_schema() {
             for table_def in db_schema.tables() {
                 for (cache_name, cache_def) in table_def.last_caches() {
                     assert!(
@@ -197,7 +193,7 @@ impl LastCacheProvider {
                     .iter()
                     .flat_map(|(table_id, table_map)| {
                         let table_name = self
-                            .catalog
+                            .db_schema_provider
                             .db_schema_by_id(db)
                             .expect("db exists")
                             .table_id_to_name(*table_id)
@@ -1624,7 +1620,7 @@ mod tests {
         WriteBufferImpl::new(
             persister,
             Arc::clone(&catalog),
-            Arc::new(LastCacheProvider::new(catalog)),
+            Arc::new(LastCacheProvider::new_from_db_schema_provider(catalog as _).unwrap()),
             time_provider,
             crate::test_help::make_exec(),
             WalConfig::test_config(),
@@ -3209,7 +3205,7 @@ mod tests {
         catalog.insert_database(database);
         let catalog = Arc::new(catalog);
         // This is the function we are testing, which initializes the LastCacheProvider from the catalog:
-        let provider = LastCacheProvider::new_from_catalog(Arc::clone(&catalog))
+        let provider = LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _)
             .expect("create last cache provider from catalog");
         // There should be a total of 3 caches:
         assert_eq!(3, provider.size());

--- a/influxdb3_write/src/last_cache/table_function.rs
+++ b/influxdb3_write/src/last_cache/table_function.rs
@@ -99,7 +99,7 @@ impl TableFunctionImpl for LastCacheFunction {
         };
         let table_id = self
             .provider
-            .catalog
+            .db_schema_provider
             .db_schema_by_id(self.db_id)
             .expect("db exists")
             .table_name_to_id(table_name.as_str())

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -17,6 +17,7 @@ use datafusion::catalog::Session;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::Expr;
 use influxdb3_catalog::catalog::{self, SequenceNumber};
+use influxdb3_catalog::DatabaseSchemaProvider;
 use influxdb3_id::DbId;
 use influxdb3_id::ParquetFileId;
 use influxdb3_id::TableId;
@@ -74,8 +75,8 @@ pub trait Bufferer: Debug + Send + Sync + 'static {
         precision: Precision,
     ) -> write_buffer::Result<BufferedWriteRequest>;
 
-    /// Returns the catalog
-    fn catalog(&self) -> Arc<catalog::Catalog>;
+    /// Returns the database schema provider
+    fn db_schema_provider(&self) -> Arc<dyn DatabaseSchemaProvider>;
 
     /// Returns the parquet files for a given database and table
     fn parquet_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile>;

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -22,7 +22,7 @@ use datafusion::catalog::Session;
 use datafusion::common::DataFusionError;
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::Expr;
-use influxdb3_catalog::catalog::Catalog;
+use influxdb3_catalog::{catalog::Catalog, DatabaseSchemaProvider};
 use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::object_store::WalObjectStore;
 use influxdb3_wal::CatalogOp::CreateLastCache;
@@ -407,7 +407,7 @@ impl Bufferer for WriteBufferImpl {
             .await
     }
 
-    fn catalog(&self) -> Arc<Catalog> {
+    fn db_schema_provider(&self) -> Arc<dyn DatabaseSchemaProvider> {
         self.catalog()
     }
 
@@ -587,7 +587,8 @@ mod tests {
             test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,
@@ -661,7 +662,8 @@ mod tests {
 
         // now load a new buffer from object storage
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,
@@ -719,7 +721,8 @@ mod tests {
 
         // load a new write buffer to ensure its durable
         let catalog = Arc::new(wbuf.persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
@@ -757,7 +760,8 @@ mod tests {
 
         // and do another replay and verification
         let catalog = Arc::new(wbuf.persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
@@ -814,7 +818,8 @@ mod tests {
 
         // do another reload and verify it's gone
         let catalog = Arc::new(wbuf.persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
@@ -970,7 +975,8 @@ mod tests {
                 .await
                 .unwrap(),
         );
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&write_buffer.persister),
             catalog,
@@ -1978,7 +1984,8 @@ mod tests {
         };
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
-        let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap();
+        let last_cache =
+            LastCacheProvider::new_from_db_schema_provider(Arc::clone(&catalog) as _).unwrap();
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -14,7 +14,10 @@ use datafusion::common::DataFusionError;
 use datafusion::logical_expr::Expr;
 use datafusion_util::stream_from_batches;
 use hashbrown::HashMap;
-use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
+use influxdb3_catalog::{
+    catalog::{Catalog, DatabaseSchema},
+    DatabaseSchemaProvider,
+};
 use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::{CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalOp, WriteBatch};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};


### PR DESCRIPTION
Separate out methods of the Catalog API that are used on the query side into a new trait `DatabaseSchemaProvider`. The new trait includes methods from the Catalog that get the underlying `DatabaseSchema` or interact with names/IDs.

This will allow for a separate implementation of the Catalog for pro that only needs to hold a replicated/combined view in-memory of one or more catalogs without the need to do persistence that a write buffer's catalog needs to do.

While in there I also switched the `QueryExecutorImpl::new` method to take an args struct to avoid the clippy lint.