### PR TITLE
feat: allow `influx -import` to import from stdin

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -101,7 +101,7 @@ func main() {
   -pps
 			How many points per second the import will allow.  By default it is zero and will not throttle importing.
   -path
-			Path to file to import
+			Path to file to import ('-' for stdin)
   -compressed
 			Set to true if the import file is compressed
 

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -87,11 +87,16 @@ func (i *Importer) Import() error {
 	}()
 
 	// Open the file
-	f, err := os.Open(i.config.Path)
-	if err != nil {
-		return err
+	var f *os.File
+	if i.config.Path == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		if f, err = os.Open(i.config.Path); err != nil {
+			return err
+		}
+		defer f.Close()
 	}
-	defer f.Close()
 
 	var r io.Reader
 


### PR DESCRIPTION
Allow `influx -import` to import from stdin by specifying `-` as the path. Example: `influx -import -path -`


