### PR TITLE
feat: add `--pid-file` option to write PID files

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -144,6 +144,8 @@ type InfluxdOpts struct {
 	TracingType       string
 	ReportingDisabled bool
 
+	PIDFile string
+
 	AssetsPath string
 	BoltPath   string
 	SqLitePath string
@@ -212,6 +214,8 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		LogLevel:          zapcore.InfoLevel,
 		FluxLogEnabled:    false,
 		ReportingDisabled: false,
+
+		PIDFile: "",
 
 		BoltPath:   filepath.Join(dir, bolt.DefaultFilename),
 		SqLitePath: filepath.Join(dir, sqlite.DefaultFilename),
@@ -324,6 +328,12 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "reporting-disabled",
 			Default: o.ReportingDisabled,
 			Desc:    "disable sending telemetry data to https://telemetry.influxdata.com every 8 hours",
+		},
+		{
+			DestP:   &o.PIDFile,
+			Flag:    "pid-file",
+			Default: o.PIDFile,
+			Desc:    "write process ID to a file",
 		},
 		{
 			DestP:   &o.SessionLength,


### PR DESCRIPTION
Add `--pid-file` option to write PID files on startup. The PID filename is specified by the argument after `--pid-file`.

Example: `influxd --pid-file /var/lib/influxd/influxd.pid`

PID files are automatically removed when the influxd process is shutdown.

Closes: #25473

