### PR TITLE
feat: allow telemetry endpoint to be passed in

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -262,6 +262,15 @@ pub struct Config {
         action
     )]
     pub disable_parquet_mem_cache: bool,
+
+    /// telemetry server endpoint
+    #[clap(
+        long = "telemetry-endpoint",
+        env = "INFLUXDB3_TELEMETRY_ENDPOINT",
+        default_value = "localhost",
+        action
+    )]
+    pub telemetry_endpoint: String,
 }
 
 /// Specified size of the Parquet cache in megabytes (MB)
@@ -450,6 +459,7 @@ pub async fn command(config: Config) -> Result<()> {
         catalog.instance_id(),
         num_cpus,
         Arc::clone(&write_buffer_impl.persisted_files()),
+        config.telemetry_endpoint,
     )
     .await;
 
@@ -502,6 +512,7 @@ async fn setup_telemetry_store(
     instance_id: Arc<str>,
     num_cpus: usize,
     persisted_files: Arc<PersistedFiles>,
+    telemetry_endpoint: String,
 ) -> Arc<TelemetryStore> {
     let os = std::env::consts::OS;
     let influxdb_pkg_version = env!("CARGO_PKG_VERSION");
@@ -520,6 +531,7 @@ async fn setup_telemetry_store(
         Arc::from(storage_type),
         num_cpus,
         persisted_files,
+        telemetry_endpoint,
     )
     .await
 }

--- a/influxdb3_telemetry/src/store.rs
+++ b/influxdb3_telemetry/src/store.rs
@@ -40,6 +40,7 @@ impl TelemetryStore {
         storage_type: Arc<str>,
         cores: usize,
         persisted_files: Arc<dyn ParquetMetrics>,
+        telemetry_endpoint: String,
     ) -> Arc<Self> {
         debug!(
             instance_id = ?instance_id,
@@ -58,6 +59,7 @@ impl TelemetryStore {
         if !cfg!(test) {
             sample_metrics(store.clone(), Duration::from_secs(SAMPLER_INTERVAL_SECS)).await;
             send_telemetry_in_background(
+                telemetry_endpoint,
                 store.clone(),
                 Duration::from_secs(MAIN_SENDER_INTERVAL_SECS),
             )
@@ -304,6 +306,7 @@ mod tests {
             Arc::from("Memory"),
             10,
             parqet_file_metrics,
+            "http://localhost/telemetry".to_owned(),
         )
         .await;
         // check snapshot


### PR DESCRIPTION
Allow the endpoint for telemetry to be passed in via the cli args, e.g

```
--telemetry-endpoint "https://somehost/test/"
```

and the actual endpoint always appends `v3` to it. So, above URL becomes "https://somehost/test/v3"
