### PR TITLE
feat: add insta crate yaml feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"
 hyper = "0.14"
-insta = { version = "1.39", features = ["json", "redactions"] }
+insta = { version = "1.39", features = ["json", "redactions", "yaml"] }
 indexmap = { version = "2.2.6" }
 libc = { version = "0.2" }
 mime = "0.3.17"


### PR DESCRIPTION
No issue for this, but this adds the `"yaml"` feature to our [`insta`](https://insta.rs/) dependency, which provides a much better user-experience when doing snapshot tests, via the `insta::assert_yaml_snapshot()` macro. YAML is easier to read than JSON, and it also can serialize integers as keys, which is useful for our various ID types.
