### PR TITLE
refactor: method on catalog did not need mut self

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -253,7 +253,7 @@ impl Catalog {
         self.inner.read().db_exists(db_id)
     }
 
-    pub fn insert_database(&mut self, db: DatabaseSchema) {
+    pub fn insert_database(&self, db: DatabaseSchema) {
         let mut inner = self.inner.write();
         inner.db_map.insert(db.id, Arc::clone(&db.name));
         inner.databases.insert(db.id, Arc::new(db));

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -3198,7 +3198,7 @@ mod tests {
         // initialized from):
         let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let mut catalog = Catalog::new(host_id, instance_id);
+        let catalog = Catalog::new(host_id, instance_id);
         let db_id = database.id;
         catalog.insert_database(database);
         let catalog = Arc::new(catalog);


### PR DESCRIPTION
No issue, this changes the function signature for the `Catalog::insert_database` method to take `&self` instead of `&mut self`, the latter being unnecessary since the type allows interior mutability.
