### PR TITLE
feat: set tcp_nodelay in hyper builder

### DIFF
--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -196,6 +196,7 @@ where
 
     let addr = AddrIncoming::from_listener(server.listener)?;
     hyper::server::Builder::new(addr, Http::new())
+        .tcp_nodelay(true)
         .serve(hybrid_make_service)
         .with_graceful_shutdown(shutdown.cancelled())
         .await?;


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25466
