### PR TITLE
feat: add `--pid-file` option to write PID files

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -144,6 +144,9 @@ type InfluxdOpts struct {
 	TracingType       string
 	ReportingDisabled bool
 
+	PIDFile          string
+	OverwritePIDFile bool
+
 	AssetsPath string
 	BoltPath   string
 	SqLitePath string
@@ -212,6 +215,9 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		LogLevel:          zapcore.InfoLevel,
 		FluxLogEnabled:    false,
 		ReportingDisabled: false,
+
+		PIDFile:          "",
+		OverwritePIDFile: false,
 
 		BoltPath:   filepath.Join(dir, bolt.DefaultFilename),
 		SqLitePath: filepath.Join(dir, sqlite.DefaultFilename),
@@ -324,6 +330,18 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "reporting-disabled",
 			Default: o.ReportingDisabled,
 			Desc:    "disable sending telemetry data to https://telemetry.influxdata.com every 8 hours",
+		},
+		{
+			DestP:   &o.PIDFile,
+			Flag:    "pid-file",
+			Default: o.PIDFile,
+			Desc:    "write process ID to a file",
+		},
+		{
+			DestP:   &o.OverwritePIDFile,
+			Flag:    "overwrite-pid-file",
+			Default: o.OverwritePIDFile,
+			Desc:    "overwrite PID file if it already exists instead of exiting",
 		},
 		{
 			DestP:   &o.SessionLength,

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -55,6 +55,8 @@ type TestLauncher struct {
 	Bucket *influxdb.Bucket
 	Auth   *influxdb.Authorization
 
+	Logger *zap.Logger
+
 	httpClient *httpc.Client
 	apiClient  *api.APIClient
 
@@ -146,7 +148,10 @@ func (tl *TestLauncher) Run(tb zaptest.TestingT, ctx context.Context, setters ..
 	}
 
 	// Set up top-level logger to write into the test-case.
-	tl.Launcher.log = zaptest.NewLogger(tb, zaptest.Level(opts.LogLevel)).With(zap.String("test_name", tb.Name()))
+	if tl.Logger == nil {
+		tl.Logger = zaptest.NewLogger(tb, zaptest.Level(opts.LogLevel)).With(zap.String("test_name", tb.Name()))
+	}
+	tl.Launcher.log = tl.Logger
 	return tl.Launcher.run(ctx, opts)
 }
 

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -3,8 +3,14 @@ package launcher_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"io/fs"
 	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -14,6 +20,10 @@ import (
 	"github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/tenant"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // Default context.
@@ -163,4 +173,130 @@ func TestLauncher_PingHeaders(t *testing.T) {
 
 	assert.Equal(t, []string{"OSS"}, resp.Header.Values("X-Influxdb-Build"))
 	assert.Equal(t, []string{"dev"}, resp.Header.Values("X-Influxdb-Version"))
+}
+
+func TestLauncher_PIDFile(t *testing.T) {
+	pidDir := t.TempDir()
+	pidFilename := filepath.Join(pidDir, "influxd.pid")
+
+	l := launcher.RunAndSetupNewLauncherOrFail(ctx, t, func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFilename
+	})
+	defer func() {
+		l.ShutdownOrFail(t, ctx)
+		require.NoFileExists(t, pidFilename)
+	}()
+
+	require.FileExists(t, pidFilename)
+	pidBytes, err := os.ReadFile(pidFilename)
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(os.Getpid()), string(pidBytes))
+}
+
+func TestLauncher_PIDFile_Locked(t *testing.T) {
+	pidDir := t.TempDir()
+	pidFilename := filepath.Join(pidDir, "influxd.pid")
+	lockContents := []byte("foobar") // something wouldn't appear in normal lock file
+
+	// Write PID file to lock out the launcher.
+	require.NoError(t, os.WriteFile(pidFilename, lockContents, 0666))
+	require.FileExists(t, pidFilename)
+	origSt, err := os.Stat(pidFilename)
+	require.NoError(t, err)
+
+	// Make sure we get an error about the PID file from the launcher
+	l := launcher.NewTestLauncher()
+	err = l.Run(t, ctx, func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFilename
+	})
+	defer func() {
+		l.ShutdownOrFail(t, ctx)
+
+		require.FileExists(t, pidFilename)
+		contents, err := os.ReadFile(pidFilename)
+		require.NoError(t, err)
+		require.Equal(t, lockContents, contents)
+		curSt, err := os.Stat(pidFilename)
+		require.NoError(t, err)
+
+		// CircleCI test runners for darwin don't have `noatime` / `relatime`, so
+		// the atime will differ, which is inside the system specific data.
+		if runtime.GOOS != "darwin" {
+			require.Equal(t, origSt, curSt)
+		}
+	}()
+
+	require.ErrorIs(t, err, launcher.ErrPIDFileExists)
+	require.ErrorContains(t, err, fmt.Sprintf("error writing PIDFile %q: PID file exists (possible unclean shutdown or another instance already running)", pidFilename))
+}
+
+func TestLauncher_PIDFile_Overwrite(t *testing.T) {
+	pidDir := t.TempDir()
+	pidFilename := filepath.Join(pidDir, "influxd.pid")
+	lockContents := []byte("foobar") // something wouldn't appear in normal lock file
+
+	// Write PID file to lock out the launcher (or not in this case).
+	require.NoError(t, os.WriteFile(pidFilename, lockContents, 0666))
+	require.FileExists(t, pidFilename)
+
+	// Make sure we get an error about the PID file from the launcher.
+	l := launcher.NewTestLauncher()
+	loggerCore, ol := observer.New(zap.WarnLevel)
+	l.Logger = zap.New(loggerCore)
+	err := l.Run(t, ctx, func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFilename
+		o.OverwritePIDFile = true
+	})
+	defer func() {
+		l.ShutdownOrFail(t, ctx)
+
+		require.NoFileExists(t, pidFilename)
+	}()
+	require.NoError(t, err)
+
+	expLogs := []observer.LoggedEntry{
+		{
+			Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "PID file already exists, attempting to overwrite"},
+			Context: []zapcore.Field{zap.String("pidFile", pidFilename)},
+		},
+	}
+	require.Equal(t, expLogs, ol.AllUntimed())
+	require.FileExists(t, pidFilename)
+	pidBytes, err := os.ReadFile(pidFilename)
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(os.Getpid()), string(pidBytes))
+}
+
+func TestLauncher_PIDFile_OverwriteFail(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test will fail when run as root")
+	}
+
+	pidDir := t.TempDir()
+	pidFilename := filepath.Join(pidDir, "influxd.pid")
+	lockContents := []byte("foobar") // something wouldn't appear in normal lock file
+
+	// Write PID file to lock out the launcher.
+	require.NoError(t, os.WriteFile(pidFilename, lockContents, 0666))
+	require.FileExists(t, pidFilename)
+	require.NoError(t, os.Chmod(pidFilename, 0000))
+
+	// Make sure we get an error about the PID file from the launcher
+	l := launcher.NewTestLauncher()
+	err := l.Run(t, ctx, func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFilename
+		o.OverwritePIDFile = true
+	})
+	defer func() {
+		l.ShutdownOrFail(t, ctx)
+
+		require.NoError(t, os.Chmod(pidFilename, 0644))
+		require.FileExists(t, pidFilename)
+		pidBytes, err := os.ReadFile(pidFilename)
+		require.NoError(t, err)
+		require.Equal(t, lockContents, pidBytes)
+	}()
+
+	require.ErrorContains(t, err, fmt.Sprintf("error writing PIDFile %[1]q: overwrite file: open %[1]s:", pidFilename))
+	require.ErrorIs(t, err, fs.ErrPermission)
 }


### PR DESCRIPTION
Add `--pid-file` option to write PID files on startup. The PID filename is specified by the argument after `--pid-file`. If the PID file already exists, influxd will exit unless the `--overwrite-pid-file` flag is also used.
    
Example: `influxd --pid-file /var/lib/influxd/influxd.pid`
    
PID files are automatically removed when the influxd process is shutdown.
    
Closes: #25498 

(cherry picked from commit c35321b470b319738b8e7bfaf04f693597d4691a)
(cherry picked from commit 48f760065bdb7c8272909d6509589650be1be8a6)