### PR TITLE
chore: upgrade ui assets package to 2.7.10

### DIFF
--- a/scripts/fetch-ui-assets.sh
+++ b/scripts/fetch-ui-assets.sh
@@ -18,7 +18,7 @@ declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
 declare -r STATIC_DIR="$ROOT_DIR/static"
 
-UI_RELEASE="OSS-v2.7.9"
+UI_RELEASE="OSS-v2.7.10"
 
 # Download the SHA256 checksum attached to the release. To verify the integrity
 # of the download, this checksum will be used to check the download tar file


### PR DESCRIPTION
Upgrade UI assets package to OSS 2.7.10.

Closes: #25504
(cherry picked from commit 9d9e92c67d868c5a3906eef1d15c664f845e4b9d)

