### PR TITLE
feat(logging): Add startup logging for shard counts (#25378) (#25507)

### DIFF
--- a/cmd/influxd/run/startup_logger.go
+++ b/cmd/influxd/run/startup_logger.go
@@ -1,0 +1,32 @@
+package run
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+)
+
+type StartupProgressLogger struct {
+	shardsCompleted atomic.Uint64
+	shardsTotal     atomic.Uint64
+	logger          *zap.Logger
+}
+
+func NewStartupProgressLogger(logger *zap.Logger) *StartupProgressLogger {
+	return &StartupProgressLogger{
+		logger: logger,
+	}
+}
+
+func (s *StartupProgressLogger) AddShard() {
+	s.shardsTotal.Add(1)
+}
+
+func (s *StartupProgressLogger) CompletedShard() {
+	shardsCompleted := s.shardsCompleted.Add(1)
+	totalShards := s.shardsTotal.Load()
+
+	percentShards := float64(shardsCompleted) / float64(totalShards) * 100
+	s.logger.Info(fmt.Sprintf("Finished loading shard, current progress %.1f%% shards (%d / %d).", percentShards, shardsCompleted, totalShards))
+}

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/cmd/influxd/run"
 	"github.com/influxdata/influxdb/v2/influxql/query"
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	errors2 "github.com/influxdata/influxdb/v2/kit/platform/errors"
@@ -167,6 +168,9 @@ func (e *Engine) WithLogger(log *zap.Logger) {
 	if e.precreatorService != nil {
 		e.precreatorService.WithLogger(log)
 	}
+
+	sl := run.NewStartupProgressLogger(e.logger)
+	e.tsdbStore.WithStartupMetrics(sl)
 }
 
 // PrometheusCollectors returns all the prometheus collectors associated with


### PR DESCRIPTION
* feat(logging): Add startup logging for shard counts (#25378) This PR adds a check to see how many shards are remaining vs how many shards are opened. This change displays the percent completed too.

closes influxdata/feature-requests#476

(cherry picked from commit 3c87f52)

closes https://github.com/influxdata/influxdb/issues/25506

(cherry picked from commit 2ffb108a270b076fafee03fda1a0dd9de631e4ff)

