### PR TITLE
chore: loadShards changes to more cleanly support 2.x feature

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -531,7 +531,7 @@ func (s *Store) loadShards() error {
 		return fmt.Errorf("error while finding shards to load: %w", err)
 	}
 
-	// Find total shard count for progress and channel size.
+	// Setup progress metrics.
 	if s.startupProgressMetrics != nil {
 		for _, _ = range shards {
 			s.startupProgressMetrics.AddShard()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -99,7 +100,9 @@ func (se *shardErrorMap) setShardOpenError(shardID uint64, err error) {
 	if err == nil {
 		delete(se.shardErrors, shardID)
 	} else {
-		se.shardErrors[shardID] = &ErrPreviousShardFail{error: fmt.Errorf("opening shard previously failed with: %w", err)}
+		if se.shardErrors[shardID] != err {
+			se.shardErrors[shardID] = &ErrPreviousShardFail{error: fmt.Errorf("opening shard previously failed with: %w", err)}
+		}
 	}
 }
 
@@ -328,6 +331,149 @@ func (s *Store) Open() error {
 	return nil
 }
 
+// generateTrailingPath returns the last part of a shard path or WAL path
+// based on the shardID, db, and rp.
+func (s *Store) generateTrailingPath(shardID uint64, db, rp string) string {
+	return filepath.Join(db, rp, strconv.FormatUint(shardID, 10))
+}
+
+// generatePath returns the path to a shard based on its db, rp, and shardID.
+func (s *Store) generatePath(shardID uint64, db, rp string) string {
+	return filepath.Join(s.path, s.generateTrailingPath(shardID, db, rp))
+}
+
+// generateWALPath returns the WAL path to a shard based on its db, rp, and shardID.
+func (s *Store) generateWALPath(shardID uint64, db, rp string) string {
+	return filepath.Join(s.EngineOptions.Config.WALDir, s.generateTrailingPath(shardID, db, rp))
+}
+
+// shardLoader is an independent object that can load shards from disk in a thread-safe manner.
+// It should be created with Store.newShardLoader. The result of shardLoader.Load should then
+// be registered with Store.registerShard.
+type shardLoader struct {
+	// NOTE: shardLoader should not directly reference the Store that creates it or any of its fields.
+
+	shardID    uint64
+	db         string
+	rp         string
+	sfile      *SeriesFile
+	engineOpts EngineOptions
+	enabled    bool
+	logger     *zap.Logger
+
+	// Should be loaded even if loading failed previously?
+	force bool
+
+	// Path to shard on disk
+	path string
+
+	// Path to WAL on disk
+	walPath string
+
+	// loadErr indicates if Load should fail immediately with an error.
+	loadErr error
+}
+
+// Load loads a shard from disk in a thread-safe manner. After a call to Load,
+// the result must be registered with Store.registerShard, whether or not an error
+// occurred. The returned shard is guaranteed to not be nil and have the correct shard ID,
+//
+//	although it will not be properly loaded if there was an error.
+func (l *shardLoader) Load() *shardResponse {
+	// Open engine.
+	shard := NewShard(l.shardID, l.path, l.walPath, l.sfile, l.engineOpts)
+
+	err := func() error {
+		// Stop and return error if previous open failed.
+		if l.loadErr != nil {
+			return l.loadErr
+		}
+
+		// Set options based on caller preferences.
+		shard.EnableOnOpen = l.enabled
+		shard.CompactionDisabled = l.engineOpts.CompactionDisabled
+		shard.WithLogger(l.logger)
+
+		// Open the shard.
+		if err := shard.Open(); err != nil {
+			return err
+		}
+
+		return nil
+	}()
+
+	return &shardResponse{s: shard, err: err}
+}
+
+type shardLoaderOption func(*shardLoader)
+
+// withForceLoad allows forcing shard opens even if a previous load failed with an error.
+func withForceLoad(force bool) shardLoaderOption {
+	return func(l *shardLoader) {
+		l.force = force
+	}
+}
+
+// withIndexVersion overrides the index version for a shard during loading.
+func withIndexVersion(indexVersion string) shardLoaderOption {
+	return func(l *shardLoader) {
+		l.engineOpts.IndexVersion = indexVersion
+	}
+}
+
+// newShardLoader generates a shardLoader that can be used to load a shard in a
+// thread-safe manner. The result of the shardLoader.Load() must then be
+// populated into s using Store.registerShard.
+// s.mu must be held before calling newShardLoader. newShardLoader is not thread-safe.
+// Note that any errors detected during newShardLoader will not be returned to caller until
+// Load is called. This is to simplify error handling for client code.
+func (s *Store) newShardLoader(shardID uint64, db, rp string, enabled bool, opts ...shardLoaderOption) *shardLoader {
+	l := &shardLoader{
+		shardID:    shardID,
+		db:         db,
+		rp:         rp,
+		engineOpts: s.EngineOptions,
+		enabled:    enabled,
+		logger:     s.baseLogger,
+
+		path:    s.generatePath(shardID, db, rp),
+		walPath: s.generateWALPath(shardID, db, rp),
+	}
+
+	for _, o := range opts {
+		o(l)
+	}
+
+	// Check for error from last load attempt.
+	lastErr, _ := s.badShards.shardError(shardID)
+	if lastErr != nil && !l.force {
+		l.loadErr = lastErr
+		return l
+	}
+
+	// Provide an implementation of the ShardIDSets
+	l.engineOpts.SeriesIDSets = shardSet{store: s, db: db}
+
+	// Retrieve cached series file or load it if not cached in s.
+	sfile, err := s.openSeriesFile(db)
+	if err != nil {
+		l.loadErr = fmt.Errorf("error loading series file for database %q: %w", db, err)
+		return l
+	}
+	l.sfile = sfile
+
+	// Retrieve cached index or create if not already cached in s.
+	idx, err := s.createIndexIfNotExists(db)
+	if err != nil {
+		l.loadErr = fmt.Errorf("error loading index for database %q: %w", db, err)
+		return l
+	}
+
+	l.engineOpts.InmemIndex = idx
+
+	return l
+}
+
 // loadShards loads all shards on disk. s.mu must be held before calling loadShards.
 func (s *Store) loadShards() error {
 	// Limit the number of concurrent TSM files to be opened to the number of cores.
@@ -379,191 +525,65 @@ func (s *Store) loadShards() error {
 
 	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
-	// Determine how many shards we need to open by checking the store path.
-	dbDirs, err := os.ReadDir(s.path)
+	// Get list of shards and their db / rp.
+	shards, err := s.findShards(log)
 	if err != nil {
-		return err
-	}
-
-	// For thread-safety reasons, we need to load and cache the database series files and
-	// indices serially. Once they are all created and cached, they can be retrieved in
-	// parallel later.
-	for _, db := range dbDirs {
-		rpDirs, err := s.getRetentionPolicyDirs(db, log)
-		if err != nil {
-			return err
-		} else if rpDirs == nil {
-			continue
-		}
-
-		// Load and cache series file.
-		_, err = s.openSeriesFile(db.Name())
-		if err != nil {
-			return err
-		}
-
-		// Create and cache database index.
-		_, err = s.createIndexIfNotExists(db.Name())
-		if err != nil {
-			return err
-		}
-	}
-
-	walkShardsAndProcess := func(fn func(shardID uint64, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error) error {
-		for _, db := range dbDirs {
-			rpDirs, err := s.getRetentionPolicyDirs(db, log)
-			if err != nil {
-				return err
-			} else if rpDirs == nil {
-				continue
-			}
-
-			for _, rp := range rpDirs {
-				shardDirs, err := s.getShards(rp, db, log)
-				if err != nil {
-					return err
-				} else if shardDirs == nil {
-					continue
-				}
-
-				for _, sh := range shardDirs {
-					fullPath := filepath.Join(s.path, db.Name(), rp.Name())
-
-					// Series file should not be in a retention policy but skip just in case.
-					if sh.Name() == SeriesFileDirectory {
-						log.Warn("Skipping series file in retention policy dir", zap.String("path", fullPath))
-						continue
-					}
-
-					// Shard file names are numeric shardIDs
-					shardID, err := strconv.ParseUint(sh.Name(), 10, 64)
-					if err != nil {
-						log.Info("invalid shard ID found at path", zap.String("path", fullPath))
-						continue
-					}
-
-					if s.EngineOptions.ShardFilter != nil && !s.EngineOptions.ShardFilter(db.Name(), rp.Name(), shardID) {
-						log.Info("skipping shard", zap.String("path", fullPath), logger.Shard(shardID))
-						continue
-					}
-
-					if err := fn(shardID, sh, db, rp); err != nil {
-						return err
-					}
-				}
-			}
-		}
-
-		return nil
+		return fmt.Errorf("error while finding shards to load: %w", err)
 	}
 
 	// Find total shard count for progress and channel size.
-	totalShardCount := 0
-	err = walkShardsAndProcess(func(shardID uint64, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {
-		totalShardCount++
-		if s.startupProgressMetrics != nil {
+	if s.startupProgressMetrics != nil {
+		for _, _ = range shards {
 			s.startupProgressMetrics.AddShard()
 		}
-		return nil
-	})
-	if err != nil {
-		return err
 	}
 
 	// Do the actual work of loading shards.
-	shardResC := make(chan *shardResponse, totalShardCount)
+	shardResC := make(chan *shardResponse, len(shards))
 	pendingShardCount := 0
-	err = walkShardsAndProcess(func(shardID uint64, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {
+	for _, sh := range shards {
 		pendingShardCount++
 
-		loadSingleShard := func(shardID uint64, db, rp, sh string) (rshard *Shard, rerr error) {
-			defer func() {
-				shardResC <- &shardResponse{s: rshard, err: rerr}
-				if s.startupProgressMetrics != nil {
-					s.startupProgressMetrics.CompletedShard()
-				}
-			}()
+		// Override index type in EngineOptions if no TSI index found on disk.
+		indexVersion := s.EngineOptions.IndexVersion
+		if indexVersion != InmemIndexName {
+			if _, err := os.Stat(filepath.Join(s.generatePath(sh.id, sh.db, sh.rp), "index")); errors.Is(err, fs.ErrNotExist) {
+				indexVersion = InmemIndexName
+			}
+		}
 
+		// loader must be created serially for thread-safety, then they can be used in  parallel manner.
+		loader := s.newShardLoader(sh.id, sh.db, sh.rp, false, withIndexVersion(indexVersion))
+
+		// Now perform the actual loading in parallel in separate goroutines.
+		go func() {
 			t.Take()
 			defer t.Release()
 
+			log := log.With(logger.Shard(sh.id), zap.String("path", loader.path))
 			start := time.Now()
-			path := filepath.Join(s.path, db, rp, sh)
-			walPath := filepath.Join(s.EngineOptions.Config.WALDir, db, rp, sh)
-
-			// Load cached series file.
-			sfile, err := s.openSeriesFile(db)
-			if err != nil {
-				return nil, err
+			res := loader.Load()
+			if res.err != nil {
+				log.Info("Opened shard", zap.String("index_version", res.s.IndexType()), zap.Duration("duration", time.Since(start)))
+			} else {
+				log.Error("Failed to open shard", zap.Error(res.err))
 			}
 
-			// Load cached index.
-			idx, err := s.createIndexIfNotExists(db)
-			if err != nil {
-				return nil, err
+			shardResC <- res
+			if s.startupProgressMetrics != nil {
+				s.startupProgressMetrics.CompletedShard()
 			}
-
-			// Copy options and assign shared index.
-			opt := s.EngineOptions
-			opt.InmemIndex = idx
-
-			// Provide an implementation of the ShardIDSets
-			opt.SeriesIDSets = shardSet{store: s, db: db}
-
-			// Existing shards should continue to use inmem index.
-			if _, err := os.Stat(filepath.Join(path, "index")); os.IsNotExist(err) {
-				opt.IndexVersion = InmemIndexName
-			}
-
-			// Open engine.
-			shard := NewShard(shardID, path, walPath, sfile, opt)
-
-			// Disable compactions, writes and queries until all shards are loaded
-			shard.EnableOnOpen = false
-			shard.CompactionDisabled = s.EngineOptions.CompactionDisabled
-			shard.WithLogger(s.baseLogger)
-
-			err = s.OpenShard(shard, false)
-			if err != nil {
-				log.Error("Failed to open shard", logger.Shard(shardID), zap.Error(err))
-				return nil, fmt.Errorf("failed to open shard: %d: %w", shardID, err)
-			}
-
-			log.Info("Opened shard", zap.String("index_version", shard.IndexType()), zap.String("path", path), zap.Duration("duration", time.Since(start)))
-			return shard, nil
-		}
-		go loadSingleShard(shardID, db.Name(), rp.Name(), sh.Name())
-
-		return nil
-	})
-	if err != nil {
-		// We can't abort on this error, because we need to wait for all the goroutines we just spawned.
-		log.Error("error walking shards while loading", zap.Error(err))
+		}()
 	}
 
+	// Register shards serially as the parallel goroutines finish opening them.
 	for finishedShardCount := 0; finishedShardCount < pendingShardCount; finishedShardCount++ {
 		res := <-shardResC
-		if res.s == nil || res.err != nil {
-			continue
-		}
-		s.shards[res.s.id] = res.s
-		s.epochs[res.s.id] = newEpochTracker()
-		if _, ok := s.databases[res.s.database]; !ok {
-			s.databases[res.s.database] = new(databaseState)
-		}
-		s.databases[res.s.database].addIndexType(res.s.IndexType())
+		s.registerShard(res)
 	}
 
-	// Check if any databases are running multiple index types.
-	for db, state := range s.databases {
-		if state.hasMultipleIndexTypes() {
-			var fields []zapcore.Field
-			for idx, cnt := range state.indexTypes {
-				fields = append(fields, zap.Int(fmt.Sprintf("%s_count", idx), cnt))
-			}
-			log.Warn("Mixed shard index types", append(fields, logger.Database(db))...)
-		}
-	}
+	// Check and log if any databases are running multiple index types.
+	s.warnMixedIndexTypes()
 
 	// Enable all shards
 	for _, sh := range s.shards {
@@ -576,6 +596,56 @@ func (s *Store) loadShards() error {
 	}
 
 	return nil
+}
+
+// registerShard registers a shardResponse from a shardLoader.Load operation with s.
+// registerShard should always be called with the result of shardLoader.Load, even if
+// the shard loading failed. This makes sure errors opening shards are properly tracked.
+// s.mu should be held before calling registerShard. registerShard is not thread-safe and
+// and should not be used in a paralell manner.
+func (s *Store) registerShard(res *shardResponse) {
+	if res.s == nil {
+		s.Logger.Error("registerShard called with nil")
+		return
+	}
+	if res.err != nil {
+		s.badShards.setShardOpenError(res.s.ID(), res.err)
+		return
+	}
+	s.shards[res.s.id] = res.s
+	s.epochs[res.s.id] = newEpochTracker()
+	if _, ok := s.databases[res.s.database]; !ok {
+		s.databases[res.s.database] = new(databaseState)
+	}
+	s.databases[res.s.database].addIndexType(res.s.IndexType())
+
+}
+
+// warnMixedIndexTypes checks the databases listed in dbList for mixed
+// index types and logs warnings if any are found. If no dbList is given, then
+// all databases in s are checked.
+func (s *Store) warnMixedIndexTypes(dbList ...string) {
+	var dbStates map[string]*databaseState
+	if len(dbList) == 0 {
+		dbStates = s.databases
+	} else {
+		dbStates = make(map[string]*databaseState)
+		for _, db := range dbList {
+			if state, ok := s.databases[db]; ok {
+				dbStates[db] = state
+			}
+		}
+
+	}
+	for db, state := range dbStates {
+		if state.hasMultipleIndexTypes() {
+			var fields []zapcore.Field
+			for idx, cnt := range state.indexTypes {
+				fields = append(fields, zap.Int(fmt.Sprintf("%s_count", idx), cnt))
+			}
+			s.Logger.Warn("Mixed shard index types", append(fields, logger.Database(db))...)
+		}
+	}
 }
 
 // Close closes the store and all associated shards. After calling Close accessing
@@ -818,47 +888,10 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64, en
 		return err
 	}
 
-	// Retrieve database series file.
-	sfile, err := s.openSeriesFile(database)
-	if err != nil {
-		return err
-	}
-
-	// Retrieve shared index, if needed.
-	idx, err := s.createIndexIfNotExists(database)
-	if err != nil {
-		return err
-	}
-
-	// Copy index options and pass in shared index.
-	opt := s.EngineOptions
-	opt.InmemIndex = idx
-	opt.SeriesIDSets = shardSet{store: s, db: database}
-
-	path := filepath.Join(s.path, database, retentionPolicy, strconv.FormatUint(shardID, 10))
-	shard := NewShard(shardID, path, walPath, sfile, opt)
-	shard.WithLogger(s.baseLogger)
-	shard.EnableOnOpen = enabled
-
-	if err := s.OpenShard(shard, false); err != nil {
-		return err
-	}
-
-	s.shards[shardID] = shard
-	s.epochs[shardID] = newEpochTracker()
-	if _, ok := s.databases[database]; !ok {
-		s.databases[database] = new(databaseState)
-	}
-	s.databases[database].addIndexType(shard.IndexType())
-	if state := s.databases[database]; state.hasMultipleIndexTypes() {
-		var fields []zapcore.Field
-		for idx, cnt := range state.indexTypes {
-			fields = append(fields, zap.Int(fmt.Sprintf("%s_count", idx), cnt))
-		}
-		s.Logger.Warn("Mixed shard index types", append(fields, logger.Database(database))...)
-	}
-
-	return nil
+	loader := s.newShardLoader(shardID, database, retentionPolicy, enabled)
+	res := loader.Load()
+	s.registerShard(res)
+	return res.err
 }
 
 // CreateShardSnapShot will create a hard link to the underlying shard and return a path.
@@ -2440,6 +2473,68 @@ func (s shardSet) ForEach(f func(ids *SeriesIDSet)) error {
 		f(idx.SeriesIDSet())
 	}
 	return nil
+}
+
+type shardInfo struct {
+	id uint64
+	db string
+	rp string
+}
+
+// findShards returns a list of all shards and their db / rp that are found
+// in s.path.
+func (s *Store) findShards(log *zap.Logger) ([]shardInfo, error) {
+	var shards []shardInfo
+
+	// Determine how many shards we need to open by checking the store path.
+	dbDirs, err := os.ReadDir(s.path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, db := range dbDirs {
+		rpDirs, err := s.getRetentionPolicyDirs(db, log)
+		if err != nil {
+			return nil, err
+		} else if rpDirs == nil {
+			continue
+		}
+
+		for _, rp := range rpDirs {
+			shardDirs, err := s.getShards(rp, db, log)
+			if err != nil {
+				return nil, err
+			} else if shardDirs == nil {
+				continue
+			}
+
+			for _, sh := range shardDirs {
+				fullPath := filepath.Join(s.path, db.Name(), rp.Name())
+
+				// Series file should not be in a retention policy but skip just in case.
+				if sh.Name() == SeriesFileDirectory {
+					log.Warn("Skipping series file in retention policy dir", zap.String("path", fullPath))
+					continue
+				}
+
+				// Shard file names are numeric shardIDs
+				shardID, err := strconv.ParseUint(sh.Name(), 10, 64)
+				if err != nil {
+					log.Info("invalid shard ID found at path", zap.String("path", fullPath))
+					continue
+				}
+
+				if s.EngineOptions.ShardFilter != nil && !s.EngineOptions.ShardFilter(db.Name(), rp.Name(), shardID) {
+					log.Info("skipping shard", zap.String("path", fullPath), logger.Shard(shardID))
+					continue
+				}
+
+				shards = append(shards, shardInfo{id: shardID, db: db.Name(), rp: rp.Name()})
+			}
+		}
+	}
+
+	return shards, nil
 }
 
 func (s *Store) getRetentionPolicyDirs(db os.DirEntry, log *zap.Logger) ([]os.DirEntry, error) {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -2549,7 +2549,7 @@ func (s *Store) findShards(log *zap.Logger) ([]shardInfo, error) {
 				// Shard file names are numeric shardIDs
 				shardID, err := strconv.ParseUint(sh.Name(), 10, 64)
 				if err != nil {
-					log.Info("invalid shard ID found at path", zap.String("path", fullPath))
+					log.Warn("invalid shard ID found at path", zap.String("path", fullPath))
 					continue
 				}
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -383,8 +383,7 @@ type shardLoader struct {
 // Load loads a shard from disk in a thread-safe manner. After a call to Load,
 // the result must be registered with Store.registerShard, whether or not an error
 // occurred. The returned shard is guaranteed to not be nil and have the correct shard ID,
-//
-//	although it will not be properly loaded if there was an error.
+// although it will not be properly loaded if there was an error.
 func (l *shardLoader) Load() *shardResponse {
 	// Open engine.
 	if l.shard == nil {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -445,19 +445,16 @@ func (s *Store) loadShards() error {
 		return nil
 	}
 
-	// We use `rawShardCount` as a buffer size for channel creation below.
-	// If there is no startupProgressMetrics count then this will be 0 creating a
-	// zero buffer channel.
 	rawShardCount := 0
-	if s.startupProgressMetrics != nil {
-		err := walkShardsAndProcess(func(shardID uint64, sfile *SeriesFile, idx interface{}, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {
-			rawShardCount++
+	err = walkShardsAndProcess(func(shardID uint64, sfile *SeriesFile, idx interface{}, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {
+		rawShardCount++
+		if s.startupProgressMetrics != nil {
 			s.startupProgressMetrics.AddShard()
-			return nil
-		})
-		if err != nil {
-			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	shardResC := make(chan *shardResponse, rawShardCount)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -536,8 +536,10 @@ func (s *Store) loadShards() error {
 
 		return nil
 	})
-	// We can't abort on this error, because we need to wait for all the goroutines we just spawned.
-	log.Error("error walking shards while loading", zap.Error(err))
+	if err != nil {
+		// We can't abort on this error, because we need to wait for all the goroutines we just spawned.
+		log.Error("error walking shards while loading", zap.Error(err))
+	}
 
 	for finishedShardCount := 0; finishedShardCount < pendingShardCount; finishedShardCount++ {
 		res := <-shardResC

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -364,7 +364,7 @@ type shardLoader struct {
 	enabled    bool
 	logger     *zap.Logger
 
-	// Shard we are working with. Could be created by the loader are given by client code.
+	// Shard we are working with. Could be created by the loader or given by client code.
 	shard *Shard
 
 	// Should be loaded even if loading failed previously?

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -328,6 +328,7 @@ func (s *Store) Open() error {
 	return nil
 }
 
+// loadShards loads all shards on disk. s.mu must be held before calling loadShards.
 func (s *Store) loadShards() error {
 	// Limit the number of concurrent TSM files to be opened to the number of cores.
 	s.EngineOptions.OpenLimiter = limiter.NewFixed(runtime.GOMAXPROCS(0))
@@ -456,6 +457,7 @@ func (s *Store) loadShards() error {
 		return nil
 	}
 
+	// Find total shard count for progress and channel size.
 	totalShardCount := 0
 	err = walkShardsAndProcess(func(shardID uint64, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {
 		totalShardCount++
@@ -468,6 +470,7 @@ func (s *Store) loadShards() error {
 		return err
 	}
 
+	// Do the actual work of loading shards.
 	shardResC := make(chan *shardResponse, totalShardCount)
 	pendingShardCount := 0
 	err = walkShardsAndProcess(func(shardID uint64, sh os.DirEntry, db os.DirEntry, rp os.DirEntry) error {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -919,6 +919,7 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64, en
 	loader := s.newShardLoader(shardID, database, retentionPolicy, enabled)
 	res := loader.Load()
 	s.registerShard(res)
+	s.warnMixedIndexTypes(database)
 	return res.err
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -823,20 +823,12 @@ func (s *Store) ReopenShard(shardID uint64, force bool) error {
 		return ErrShardNotFound
 	}
 
-	var loader *shardLoader
-	func() {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		loader = s.newShardLoader(shardID, "", "", true, withExistingShard(sh), withForceLoad(force))
-	}()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
+	loader := s.newShardLoader(shardID, "", "", true, withExistingShard(sh), withForceLoad(force))
 	res := loader.Load()
-
-	func() {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		s.registerShard(res)
-	}()
+	s.registerShard(res)
 
 	return res.err
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -402,11 +402,7 @@ func (l *shardLoader) Load() *shardResponse {
 		}
 
 		// Open the shard.
-		if err := l.shard.Open(); err != nil {
-			return err
-		}
-
-		return nil
+		return l.shard.Open()
 	}()
 
 	return &shardResponse{s: l.shard, err: err}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -209,7 +209,7 @@ func TestStore_BadShardLoading(t *testing.T) {
 		require.NotNil(t, sh)
 
 		s.SetShardOpenErrorForTest(sh.ID(), errors.New("a shard opening error occurred"))
-		err2 := s.OpenShard(s.Shard(sh.ID()), false)
+		err2 := s.ReopenShard(sh.ID(), false)
 		require.Error(t, err2, "no error opening bad shard")
 
 		msl := &mockStartupLogger{}
@@ -243,21 +243,26 @@ func TestStore_BadShard(t *testing.T) {
 			s := MustOpenStore(t, idx)
 			defer s.CloseStore(t, idx)
 
-			sh := tsdb.NewTempShard(idx)
-			shId := sh.ID()
-			err := s.OpenShard(sh.Shard, false)
+			var shId uint64 = 1
+			require.NoError(t, s.CreateShard("db0", "rp0", shId, true))
+			err := s.ReopenShard(shId, false)
 			require.NoError(t, err, "opening temp shard")
-			defer tsdb.CloseShard(t, sh)
 
 			expErr := errors.New(errStr)
-			s.SetShardOpenErrorForTest(sh.ID(), expErr)
-			err2 := s.OpenShard(sh.Shard, false)
+			s.SetShardOpenErrorForTest(shId, expErr)
+			err2 := s.ReopenShard(shId, false)
+			require.Error(t, err2, "no error opening bad shard")
+			require.True(t, errors.Is(err2, tsdb.ErrPreviousShardFail{}), "exp: ErrPreviousShardFail, got: %v", err2)
+			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
+
+			// make sure we didn't modify the shard open error when we tried to reopen it
+			err2 = s.ReopenShard(shId, false)
 			require.Error(t, err2, "no error opening bad shard")
 			require.True(t, errors.Is(err2, tsdb.ErrPreviousShardFail{}), "exp: ErrPreviousShardFail, got: %v", err2)
 			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
 
 			// This should succeed with the force (and because opening an open shard automatically succeeds)
-			require.NoError(t, s.OpenShard(sh.Shard, true), "forced re-opening previously failing shard")
+			require.NoError(t, s.ReopenShard(shId, true), "forced re-opening previously failing shard")
 		}()
 	}
 }
@@ -270,15 +275,13 @@ func TestStore_BadShardClear(t *testing.T) {
 			s := MustOpenStore(t, idx)
 			defer s.CloseStore(t, idx)
 
-			sh := tsdb.NewTempShard(idx)
-			shId := sh.ID()
-			err := s.OpenShard(sh.Shard, false)
-			require.NoError(t, err, "opening temp shard")
-			defer tsdb.CloseShard(t, sh)
+			var shId uint64 = 1
+			require.NoError(t, s.CreateShard("db0", "rp0", shId, true))
+			require.NoError(t, s.ReopenShard(shId, false))
 
 			expErr := errors.New(errStr)
-			s.SetShardOpenErrorForTest(sh.ID(), expErr)
-			err2 := s.OpenShard(sh.Shard, false)
+			s.SetShardOpenErrorForTest(shId, expErr)
+			err2 := s.ReopenShard(shId, false)
 			require.Error(t, err2, "no error opening bad shard")
 			require.ErrorIs(t, err2, tsdb.ErrPreviousShardFail{})
 			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
@@ -291,8 +294,8 @@ func TestStore_BadShardClear(t *testing.T) {
 			// Check that bad shard list has been cleared
 			require.Empty(t, s.Store.GetBadShardList())
 
-			s.SetShardOpenErrorForTest(sh.ID(), expErr)
-			err2 = s.OpenShard(sh.Shard, false)
+			s.SetShardOpenErrorForTest(shId, expErr)
+			err2 = s.ReopenShard(shId, false)
 			require.Error(t, err2, "no error opening bad shard")
 			require.ErrorIs(t, err2, tsdb.ErrPreviousShardFail{})
 			require.EqualError(t, err2, fmt.Errorf("not attempting to open shard %d; opening shard previously failed with: %w", shId, expErr).Error())
@@ -310,10 +313,9 @@ func TestStore_BadShardClearNoBadShards(t *testing.T) {
 			s := MustOpenStore(t, idx)
 			defer s.CloseStore(t, idx)
 
-			sh := tsdb.NewTempShard(idx)
-			err := s.OpenShard(sh.Shard, false)
-			require.NoError(t, err, "opening temp shard")
-			require.NoError(t, sh.Close(), "closing temporary shard")
+			var shID uint64 = 1
+			require.NoError(t, s.CreateShard("db0", "rp0", shID, true))
+			require.NoError(t, s.ReopenShard(shID, false))
 
 			require.Empty(t, s.Store.GetBadShardList())
 
@@ -2342,7 +2344,7 @@ func TestStore_MeasurementNames_ConcurrentDropShard(t *testing.T) {
 							return
 						}
 						time.Sleep(500 * time.Microsecond)
-						if err := s.OpenShard(sh, false); err != nil {
+						if err := s.ReopenShard(sh.ID(), false); err != nil {
 							errC <- err
 							return
 						}
@@ -2427,7 +2429,7 @@ func TestStore_TagKeys_ConcurrentDropShard(t *testing.T) {
 							return
 						}
 						time.Sleep(500 * time.Microsecond)
-						if err := s.OpenShard(sh, false); err != nil {
+						if err := s.ReopenShard(sh.ID(), false); err != nil {
 							errC <- err
 							return
 						}
@@ -2518,7 +2520,7 @@ func TestStore_TagValues_ConcurrentDropShard(t *testing.T) {
 							return
 						}
 						time.Sleep(500 * time.Microsecond)
-						if err := s.OpenShard(sh, false); err != nil {
+						if err := s.ReopenShard(sh.ID(), false); err != nil {
 							errC <- err
 							return
 						}


### PR DESCRIPTION
Changes to `loadShards` to support a 2.x feature without making it difficult to keep TSM code in sync. Also includes minor code quality improvements.