### PR TITLE
fix: default url for telemetry should include protocol

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -267,7 +267,7 @@ pub struct Config {
     #[clap(
         long = "telemetry-endpoint",
         env = "INFLUXDB3_TELEMETRY_ENDPOINT",
-        default_value = "localhost",
+        default_value = "http://127.0.0.1:9999",
         action
     )]
     pub telemetry_endpoint: String,

--- a/influxdb3_telemetry/src/sender.rs
+++ b/influxdb3_telemetry/src/sender.rs
@@ -132,6 +132,19 @@ mod tests {
         mock.assert_async().await;
     }
 
+    #[test_log::test(test)]
+    #[should_panic]
+    fn test_sender_creation_with_invalid_url_panics() {
+        let client = reqwest::Client::new();
+        let _ = TelemetrySender::new(client, "localhost");
+    }
+
+    #[test_log::test(test)]
+    fn test_sender_creation_with_valid_url_succeeds() {
+        let client = reqwest::Client::new();
+        let _ = TelemetrySender::new(client, "http://localhost");
+    }
+
     #[test]
     fn test_url_join() {
         let url = Url::parse("https://foo.com/boo/1.html").unwrap();


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25502
