### PR TITLE
refactor: remove conversion step in validator

### DIFF
--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -343,13 +343,14 @@ mod test_helpers {
         let db_name = NamespaceName::new(db_name).unwrap();
         let result = WriteValidator::initialize(db_name.clone(), catalog, 0)
             .unwrap()
-            .v1_parse_lines_and_update_schema(lp, false)
-            .unwrap()
-            .convert_lines_to_buffer(
+            .v1_parse_lines_and_update_schema(
+                lp,
+                false,
                 Time::from_timestamp_nanos(0),
-                Gen1Duration::new_5m(),
                 Precision::Nanosecond,
-            );
+            )
+            .unwrap()
+            .convert_lines_to_buffer(Gen1Duration::new_5m());
 
         result.valid_data
     }


### PR DESCRIPTION
The write validator now builds the row data destined for the WAL directly, vs. creating an intermediate type to hold row data.

This also extends the test in the write validator to test the new vs. existing table code paths.

Closes #25512