### PR TITLE
chore: remove unnecessary rustsec for the tonic cve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,14 +2223,16 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hashlink"
@@ -2560,7 +2562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -2595,7 +2597,7 @@ dependencies = [
  "datafusion_util",
  "dotenvy",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "hex",
  "humantime",
  "hyper 0.14.30",
@@ -2645,7 +2647,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "bimap",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "influxdb-line-protocol",
  "influxdb3_id",
@@ -2827,7 +2829,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "object_store",
  "parking_lot",
  "tokio",
@@ -2843,7 +2845,7 @@ dependencies = [
  "crc32fast",
  "data_types",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "influxdb-line-protocol",
  "influxdb3_id",
@@ -2879,7 +2881,7 @@ dependencies = [
  "datafusion_util",
  "futures",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "hex",
  "indexmap 2.6.0",
  "influxdb-line-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2237,9 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ dotenvy = "0.15.7"
 flate2 = "1.0.27"
 futures = "0.3.28"
 futures-util = "0.3.30"
-hashbrown = { version = "0.14.5", features = ["serde"] }
+hashbrown = { version = "0.15.1", features = ["serde"], default-features = false }
 hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ dotenvy = "0.15.7"
 flate2 = "1.0.27"
 futures = "0.3.28"
 futures-util = "0.3.30"
-hashbrown = { version = "0.15.1", features = ["serde"], default-features = false }
+hashbrown = { version = "0.15.1", features = ["serde"] }
 hex = "0.4.3"
 http = "0.2.9"
 humantime = "2.1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -8,9 +8,6 @@ ignore = [
     # dependent on arrow-* upgrading dependencies on lexical-core
     # see https://github.com/apache/arrow-rs/pull/6401
     "RUSTSEC-2023-0086",
-    # Tonic + hyper upgrade is large - unblocking pipeline for now.
-    # https://rustsec.org/advisories/RUSTSEC-2024-0376
-    "RUSTSEC-2024-0376",
 ]
 git-fetch-with-cli = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
     "CC0-1.0",
     "ISC",
     "MIT",
+    "Zlib",
 ]
 
 exceptions = [

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -1028,7 +1028,7 @@ mod tests {
         table_buffer.buffer_chunk(0, rows);
 
         let size = table_buffer.computed_size();
-        assert_eq!(size, 18095);
+        assert_eq!(size, 18119);
     }
 
     #[test]


### PR DESCRIPTION
`cargo deny` was showing that no crate matched the advisory criteria for this [RUSTSEC advisory](https://rustsec.org/advisories/RUSTSEC-2024-0376.html), so this PR removes the ignore entry.

In addition, the `hashbrown` crate was causing a new audit failure, and updating it required that the `Zlib` license be added to our list of allowed licenses.

No issue for this, but it is blocking another PR at the moment (https://github.com/influxdata/influxdb/pull/25515).