### PR TITLE
feat: configurable last cache eviction

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -444,7 +444,7 @@ pub async fn command(config: Config) -> Result<()> {
         WriteBufferImpl::new(
             Arc::clone(&persister),
             Arc::clone(&catalog),
-            Arc::new(last_cache),
+            last_cache,
             Arc::<SystemProvider>::clone(&time_provider),
             Arc::clone(&exec),
             wal_config,

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -272,10 +272,8 @@ pub struct Config {
     )]
     pub telemetry_endpoint: String,
 
-    /// The interval on which to evict expired entries from the Last-N-Value cache.
-    ///
-    /// Note, this can be fairly conservative, since the cache may hold expired entries, but will
-    /// not produce them when queried.
+    /// The interval on which to evict expired entries from the Last-N-Value cache, expressed as a
+    /// human-readable time, e.g., "20s", "1m", "1h".
     #[clap(
         long = "last-cache-eviction-interval",
         env = "INFLUXDB3_LAST_CACHE_EVICTION_INTERVAL",

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -780,7 +780,7 @@ mod tests {
             influxdb3_write::write_buffer::WriteBufferImpl::new(
                 Arc::clone(&persister),
                 Arc::clone(&catalog),
-                Arc::new(LastCacheProvider::new_from_catalog(catalog as _).unwrap()),
+                LastCacheProvider::new_from_catalog(catalog as _).unwrap(),
                 Arc::<MockProvider>::clone(&time_provider),
                 Arc::clone(&exec),
                 WalConfig::test_config(),

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -674,7 +674,7 @@ mod tests {
             WriteBufferImpl::new(
                 Arc::clone(&persister),
                 Arc::clone(&catalog),
-                Arc::new(LastCacheProvider::new_from_catalog(catalog as _).unwrap()),
+                LastCacheProvider::new_from_catalog(catalog as _).unwrap(),
                 Arc::<MockProvider>::clone(&time_provider),
                 Arc::clone(&exec),
                 WalConfig {

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -591,7 +591,7 @@ mod tests {
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&time_provider),
             crate::test_help::make_exec(),
             WalConfig::test_config(),
@@ -665,7 +665,7 @@ mod tests {
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&time_provider),
             crate::test_help::make_exec(),
             WalConfig {
@@ -723,7 +723,7 @@ mod tests {
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&wbuf.time_provider),
             Arc::clone(&wbuf.buffer.executor),
             WalConfig {
@@ -761,7 +761,7 @@ mod tests {
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&wbuf.time_provider),
             Arc::clone(&wbuf.buffer.executor),
             WalConfig {
@@ -818,7 +818,7 @@ mod tests {
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&wbuf.persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&wbuf.time_provider),
             Arc::clone(&wbuf.buffer.executor),
             WalConfig {
@@ -974,7 +974,7 @@ mod tests {
         let write_buffer = WriteBufferImpl::new(
             Arc::clone(&write_buffer.persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&write_buffer.time_provider),
             Arc::clone(&write_buffer.buffer.executor),
             WalConfig {
@@ -1982,7 +1982,7 @@ mod tests {
         let wbuf = WriteBufferImpl::new(
             Arc::clone(&persister),
             catalog,
-            Arc::new(last_cache),
+            last_cache,
             Arc::clone(&time_provider),
             crate::test_help::make_exec(),
             wal_config,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -125,9 +125,8 @@ impl QueryableBuffer {
 
     /// Called when the wal has persisted a new file. Buffer the contents in memory and update the last cache so the data is queryable.
     fn buffer_contents(&self, write: WalContents) {
-        let mut buffer = self.buffer.write();
-        self.last_cache_provider.evict_expired_cache_entries();
         self.last_cache_provider.write_wal_contents_to_cache(&write);
+        let mut buffer = self.buffer.write();
         buffer.buffer_ops(write.ops, &self.last_cache_provider);
     }
 


### PR DESCRIPTION
Closes #25519

This alters the eviction behaviour of the last-n-value cache:
* The cache, when queried, will not produce entries that are expired. This actually wasn't done before, which would have been a bug, but this also allows us to more leniently run cache eviction.
* The process that runs eviction on the `LastCacheProvider` is now run in the background, by default, every `1m`, but the interval can be configured by the user on server start with the `--last-cache-eviction-interval` argument.
* Cache eviction is no longer run on every buffered write, which should reduce lock contention