### PR TITLE
fix: throw error when adding fields to non-existent table in WAL

### DIFF
--- a/influxdb3_wal/src/create.rs
+++ b/influxdb3_wal/src/create.rs
@@ -1,0 +1,135 @@
+//! A set of helper methods for creating WAL operations in tests.
+
+use std::sync::Arc;
+
+use influxdb3_id::{ColumnId, DbId};
+
+use crate::*;
+
+pub fn wal_contents(
+    (min_timestamp_ns, max_timestamp_ns, wal_file_number): (i64, i64, u64),
+    ops: impl IntoIterator<Item = WalOp>,
+) -> WalContents {
+    WalContents {
+        min_timestamp_ns,
+        max_timestamp_ns,
+        wal_file_number: WalFileSequenceNumber::new(wal_file_number),
+        ops: ops.into_iter().collect(),
+        snapshot: None,
+    }
+}
+
+pub fn catalog_batch_op(
+    db_id: DbId,
+    db_name: impl Into<Arc<str>>,
+    time_ns: i64,
+    ops: impl IntoIterator<Item = CatalogOp>,
+) -> WalOp {
+    WalOp::Catalog(CatalogBatch {
+        database_id: db_id,
+        database_name: db_name.into(),
+        time_ns,
+        ops: ops.into_iter().collect(),
+    })
+}
+
+pub fn add_fields_op(
+    database_id: DbId,
+    db_name: impl Into<Arc<str>>,
+    table_id: TableId,
+    table_name: impl Into<Arc<str>>,
+    fields: impl IntoIterator<Item = FieldDefinition>,
+) -> CatalogOp {
+    CatalogOp::AddFields(FieldAdditions {
+        database_name: db_name.into(),
+        database_id,
+        table_name: table_name.into(),
+        table_id,
+        field_definitions: fields.into_iter().collect(),
+    })
+}
+
+pub fn create_table_op(
+    db_id: DbId,
+    db_name: impl Into<Arc<str>>,
+    table_id: TableId,
+    table_name: impl Into<Arc<str>>,
+    fields: impl IntoIterator<Item = FieldDefinition>,
+) -> CatalogOp {
+    CatalogOp::CreateTable(TableDefinition {
+        database_id: db_id,
+        database_name: db_name.into(),
+        table_name: table_name.into(),
+        table_id,
+        field_definitions: fields.into_iter().collect(),
+        key: None,
+    })
+}
+
+pub fn field_def(
+    id: ColumnId,
+    name: impl Into<Arc<str>>,
+    data_type: FieldDataType,
+) -> FieldDefinition {
+    FieldDefinition {
+        name: name.into(),
+        data_type,
+        id,
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CreateLastCacheOpBuilder {
+    table_id: TableId,
+    table_name: Arc<str>,
+    name: Arc<str>,
+    key_columns: Vec<ColumnId>,
+    value_columns: Option<LastCacheValueColumnsDef>,
+    count: Option<LastCacheSize>,
+    ttl: Option<u64>,
+}
+
+impl CreateLastCacheOpBuilder {
+    pub fn build(self) -> CatalogOp {
+        CatalogOp::CreateLastCache(LastCacheDefinition {
+            table_id: self.table_id,
+            table: self.table_name,
+            name: self.name,
+            key_columns: self.key_columns,
+            value_columns: self
+                .value_columns
+                .unwrap_or(LastCacheValueColumnsDef::AllNonKeyColumns),
+            count: self.count.unwrap_or_else(|| LastCacheSize::new(1).unwrap()),
+            ttl: self.ttl.unwrap_or(3600),
+        })
+    }
+}
+
+pub fn create_last_cache_op_builder(
+    table_id: TableId,
+    table_name: impl Into<Arc<str>>,
+    cache_name: impl Into<Arc<str>>,
+    key_columns: impl IntoIterator<Item = ColumnId>,
+) -> CreateLastCacheOpBuilder {
+    CreateLastCacheOpBuilder {
+        table_id,
+        table_name: table_name.into(),
+        name: cache_name.into(),
+        key_columns: key_columns.into_iter().collect(),
+        value_columns: None,
+        count: None,
+        ttl: None,
+    }
+}
+
+pub fn delete_last_cache_op(
+    table_id: TableId,
+    table_name: impl Into<Arc<str>>,
+    cache_name: impl Into<Arc<str>>,
+) -> CatalogOp {
+    CatalogOp::DeleteLastCache(LastCacheDelete {
+        table_name: table_name.into(),
+        table_id,
+        name: cache_name.into(),
+    })
+}

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -3,6 +3,7 @@
 //! writes durable until they can be written in larger batches as Parquet files and other snapshot and
 //! index files in object storage.
 
+pub mod create;
 pub mod object_store;
 pub mod serialize;
 mod snapshot_tracker;


### PR DESCRIPTION
Closes #25524

In addition to throwing an error when an `AddFields` operation is applied for a table that does not exist, this PR adds some helper methods to the `influxdb3_wal` crate for creating WAL operations that were previously added in pro.

A test was added to check for the failure condition.