### PR TITLE
feat: Update catalog to use sequence number in path

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -79,9 +79,9 @@ pub const TIME_COLUMN_NAME: &str = "time";
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
-pub struct SequenceNumber(u32);
+pub struct CatalogSequenceNumber(u32);
 
-impl SequenceNumber {
+impl CatalogSequenceNumber {
     pub fn new(id: u32) -> Self {
         Self(id)
     }
@@ -202,7 +202,7 @@ impl Catalog {
         self.inner.read().databases.values().cloned().collect()
     }
 
-    pub fn sequence_number(&self) -> SequenceNumber {
+    pub fn sequence_number(&self) -> CatalogSequenceNumber {
         self.inner.read().sequence
     }
 
@@ -280,7 +280,7 @@ impl Catalog {
     /// After the catalog has been persisted, mark it as not updated, if the sequence number
     /// matches. If it doesn't then the catalog was updated while persistence was running and
     /// will need to be persisted on the next snapshot.
-    pub fn set_updated_false_if_sequence_matches(&self, sequence_number: SequenceNumber) {
+    pub fn set_updated_false_if_sequence_matches(&self, sequence_number: CatalogSequenceNumber) {
         let mut inner = self.inner.write();
         if inner.sequence == sequence_number {
             inner.updated = false;
@@ -297,7 +297,7 @@ impl Catalog {
 pub struct InnerCatalog {
     /// The catalog is a map of databases with their table schemas
     databases: SerdeVecMap<DbId, Arc<DatabaseSchema>>,
-    sequence: SequenceNumber,
+    sequence: CatalogSequenceNumber,
     /// The host_id is the prefix that is passed in when starting up (`host_identifier_prefix`)
     host_id: Arc<str>,
     /// The instance_id uniquely identifies the instance that generated the catalog
@@ -366,7 +366,7 @@ impl InnerCatalog {
     pub(crate) fn new(host_id: Arc<str>, instance_id: Arc<str>) -> Self {
         Self {
             databases: SerdeVecMap::new(),
-            sequence: SequenceNumber::new(0),
+            sequence: CatalogSequenceNumber::new(0),
             host_id,
             instance_id,
             updated: false,
@@ -374,7 +374,7 @@ impl InnerCatalog {
         }
     }
 
-    pub fn sequence_number(&self) -> SequenceNumber {
+    pub fn sequence_number(&self) -> CatalogSequenceNumber {
         self.sequence
     }
 

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -17,7 +17,7 @@ use datafusion::catalog::Session;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::Expr;
 use influxdb3_catalog::catalog::Catalog;
-use influxdb3_catalog::catalog::{self, SequenceNumber};
+use influxdb3_catalog::catalog::CatalogSequenceNumber;
 use influxdb3_id::ParquetFileId;
 use influxdb3_id::TableId;
 use influxdb3_id::{ColumnId, DbId};
@@ -151,15 +151,6 @@ pub struct BufferedWriteRequest {
     pub index_count: usize,
 }
 
-/// A persisted Catalog that contains the database, table, and column schemas.
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PersistedCatalog {
-    /// The wal file number that triggered the snapshot to persisst this catalog
-    pub wal_file_sequence_number: WalFileSequenceNumber,
-    /// The catalog that was persisted.
-    pub catalog: catalog::InnerCatalog,
-}
-
 /// The collection of Parquet files that were persisted in a snapshot
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PersistedSnapshot {
@@ -178,7 +169,7 @@ pub struct PersistedSnapshot {
     /// The wal file sequence number that triggered this snapshot
     pub wal_file_sequence_number: WalFileSequenceNumber,
     /// The catalog sequence number associated with this snapshot
-    pub catalog_sequence_number: SequenceNumber,
+    pub catalog_sequence_number: CatalogSequenceNumber,
     /// The size of the snapshot parquet files in bytes.
     pub parquet_size_bytes: u64,
     /// The number of rows across all parquet files in the snapshot.
@@ -197,7 +188,7 @@ impl PersistedSnapshot {
         host_id: String,
         snapshot_sequence_number: SnapshotSequenceNumber,
         wal_file_sequence_number: WalFileSequenceNumber,
-        catalog_sequence_number: SequenceNumber,
+        catalog_sequence_number: CatalogSequenceNumber,
     ) -> Self {
         Self {
             host_id,
@@ -326,10 +317,10 @@ pub(crate) fn guess_precision(timestamp: i64) -> Precision {
 
 #[cfg(test)]
 mod test_helpers {
-    use crate::catalog::Catalog;
     use crate::write_buffer::validator::WriteValidator;
     use crate::Precision;
     use data_types::NamespaceName;
+    use influxdb3_catalog::catalog::Catalog;
     use influxdb3_wal::{Gen1Duration, WriteBatch};
     use iox_time::Time;
     use std::sync::Arc;

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -1,4 +1,5 @@
 use chrono::prelude::*;
+use influxdb3_catalog::catalog::CatalogSequenceNumber;
 use influxdb3_wal::{SnapshotSequenceNumber, WalFileSequenceNumber};
 use object_store::path::Path as ObjPath;
 use std::ops::Deref;
@@ -20,11 +21,11 @@ fn object_store_file_stem(n: u64) -> u64 {
 pub struct CatalogFilePath(ObjPath);
 
 impl CatalogFilePath {
-    pub fn new(host_prefix: &str, wal_file_sequence_number: WalFileSequenceNumber) -> Self {
+    pub fn new(host_prefix: &str, catalog_sequence_number: CatalogSequenceNumber) -> Self {
+        let num = u64::MAX - catalog_sequence_number.as_u32() as u64;
         let path = ObjPath::from(format!(
             "{host_prefix}/catalogs/{:020}.{}",
-            object_store_file_stem(wal_file_sequence_number.as_u64()),
-            CATALOG_FILE_EXTENSION
+            num, CATALOG_FILE_EXTENSION
         ));
         Self(path)
     }
@@ -123,7 +124,7 @@ impl AsRef<ObjPath> for SnapshotInfoFilePath {
 #[test]
 fn catalog_file_path_new() {
     assert_eq!(
-        *CatalogFilePath::new("my_host", WalFileSequenceNumber::new(0)),
+        *CatalogFilePath::new("my_host", CatalogSequenceNumber::new(0)),
         ObjPath::from("my_host/catalogs/18446744073709551615.json")
     );
 }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -541,7 +541,7 @@ mod tests {
     use bytes::Bytes;
     use datafusion_util::config::register_iox_object_store;
     use futures_util::StreamExt;
-    use influxdb3_catalog::catalog::SequenceNumber;
+    use influxdb3_catalog::catalog::CatalogSequenceNumber;
     use influxdb3_id::{DbId, ParquetFileId};
     use influxdb3_test_helpers::object_store::RequestCountedObjectStore;
     use influxdb3_wal::{Gen1Duration, SnapshotSequenceNumber, WalFileSequenceNumber};
@@ -1137,7 +1137,7 @@ mod tests {
             "test_host".to_string(),
             prev_snapshot_seq,
             WalFileSequenceNumber::new(0),
-            SequenceNumber::new(0),
+            CatalogSequenceNumber::new(0),
         );
         let snapshot_json = serde_json::to_vec(&prev_snapshot).unwrap();
         // set ParquetFileId to be 0 so that we can make sure when it's loaded from the
@@ -1231,7 +1231,7 @@ mod tests {
         // If we manage to make it so that scenario only increments the catalog sequence once, then
         // this assertion may fail:
         assert_eq!(
-            SequenceNumber::new(2),
+            CatalogSequenceNumber::new(2),
             persisted_snapshot.catalog_sequence_number
         );
     }
@@ -1247,7 +1247,7 @@ mod tests {
             "test_host".to_string(),
             prev_snapshot_seq,
             WalFileSequenceNumber::new(0),
-            SequenceNumber::new(0),
+            CatalogSequenceNumber::new(0),
         );
 
         assert_eq!(prev_snapshot.next_file_id.as_u64(), 0);

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -159,7 +159,7 @@ fn update_persisted_files_with_snapshot(
 #[cfg(test)]
 mod tests {
 
-    use influxdb3_catalog::catalog::SequenceNumber;
+    use influxdb3_catalog::catalog::CatalogSequenceNumber;
     use influxdb3_wal::{SnapshotSequenceNumber, WalFileSequenceNumber};
     use observability_deps::tracing::info;
     use pretty_assertions::assert_eq;
@@ -257,7 +257,7 @@ mod tests {
     ) -> PersistedSnapshot {
         let snap1 = SnapshotSequenceNumber::new(snapshot_id);
         let wal1 = WalFileSequenceNumber::new(wal_id);
-        let cat1 = SequenceNumber::new(catalog_id);
+        let cat1 = CatalogSequenceNumber::new(catalog_id);
         let mut new_snapshot =
             PersistedSnapshot::new("sample-host-id".to_owned(), snap1, wal1, cat1);
         parquet_files.into_iter().for_each(|file| {

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -215,7 +215,7 @@ impl QueryableBuffer {
                 let sequence_number = inner_catalog.sequence_number();
 
                 match persister
-                    .persist_catalog(wal_file_number, &Catalog::from_inner(inner_catalog))
+                    .persist_catalog(&Catalog::from_inner(inner_catalog))
                     .await
                 {
                     Ok(_) => {

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -806,13 +806,13 @@ fn apply_precision_to_timestamp(precision: Precision, ts: i64) -> i64 {
 mod tests {
     use std::sync::Arc;
 
-    use crate::{catalog::Catalog, write_buffer::Error, Precision};
+    use super::WriteValidator;
+    use crate::{write_buffer::Error, Precision};
     use data_types::NamespaceName;
+    use influxdb3_catalog::catalog::Catalog;
     use influxdb3_id::TableId;
     use influxdb3_wal::Gen1Duration;
     use iox_time::Time;
-
-    use super::WriteValidator;
 
     #[test]
     fn write_validator_v1() -> Result<(), Error> {


### PR DESCRIPTION
Updates the catalog to use its own sequence number in the path. This will enable downstream Pro systems that pick up PersistedSnapshots to get the specific catalog that a snapshot is associated with since its sequence number is included.

Also updated the type to be CatalogSequenceNumber to make it more clear & readable when being used.