### PR TITLE
chore: remove unnecessary fmt.Sprintf calls

### DIFF
--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -2960,13 +2960,13 @@ type mockStartupLogger struct {
 
 func (m *mockStartupLogger) AddShard() {
 	m.mu.Lock()
-	m._shardTracker = append(m._shardTracker, fmt.Sprintf("shard-add"))
+	m._shardTracker = append(m._shardTracker, "shard-add")
 	m.mu.Unlock()
 }
 
 func (m *mockStartupLogger) CompletedShard() {
 	m.mu.Lock()
-	m._shardTracker = append(m._shardTracker, fmt.Sprintf("shard-complete"))
+	m._shardTracker = append(m._shardTracker, "shard-complete")
 	m.mu.Unlock()
 }
 


### PR DESCRIPTION
Remove unnecessary fmt.Sprintf calls for static code checks in main-2.x.

