### PR TITLE
feat: delete table

### DIFF
--- a/influxdb3/src/commands/manage/database.rs
+++ b/influxdb3/src/commands/manage/database.rs
@@ -5,31 +5,30 @@ use secrecy::ExposeSecret;
 use crate::commands::common::InfluxDb3Config;
 
 #[derive(Debug, clap::Parser)]
-enum Command {
-    Delete(Config),
-}
-
-#[derive(Debug, clap::Parser)]
 pub(crate) struct ManageDatabaseConfig {
     #[clap(subcommand)]
     command: Command,
 }
 
 #[derive(Debug, clap::Parser)]
-pub struct Config {
+enum Command {
+    Delete(DatabaseConfig),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct DatabaseConfig {
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
 }
 
-pub async fn delete_database(manage_db_config: ManageDatabaseConfig) -> Result<(), Box<dyn Error>> {
-    match manage_db_config.command {
+pub async fn delete_database(config: ManageDatabaseConfig) -> Result<(), Box<dyn Error>> {
+    match config.command {
         Command::Delete(config) => {
             let InfluxDb3Config {
                 host_url,
                 database_name,
                 auth_token,
             } = config.influxdb3_config;
-
             println!(
                 "Are you sure you want to delete {:?}? Enter 'yes' to confirm",
                 database_name

--- a/influxdb3/src/commands/manage/mod.rs
+++ b/influxdb3/src/commands/manage/mod.rs
@@ -1,0 +1,2 @@
+pub mod database;
+pub mod table;

--- a/influxdb3/src/commands/manage/table.rs
+++ b/influxdb3/src/commands/manage/table.rs
@@ -1,0 +1,60 @@
+use std::{error::Error, io};
+
+use secrecy::ExposeSecret;
+
+use crate::commands::common::InfluxDb3Config;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct ManageTableConfig {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Parser)]
+enum Command {
+    Delete(TableConfig),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct TableConfig {
+    #[clap(short = 't', long = "table")]
+    table: String,
+
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+}
+
+pub async fn delete_table(config: ManageTableConfig) -> Result<(), Box<dyn Error>> {
+    match config.command {
+        Command::Delete(config) => {
+            let InfluxDb3Config {
+                host_url,
+                database_name,
+                auth_token,
+            } = config.influxdb3_config;
+            println!(
+                "Are you sure you want to delete {:?}.{:?}? Enter 'yes' to confirm",
+                database_name, &config.table,
+            );
+            let mut confirmation = String::new();
+            let _ = io::stdin().read_line(&mut confirmation);
+            if confirmation.trim() != "yes" {
+                println!("Cannot delete table without confirmation");
+            } else {
+                let mut client = influxdb3_client::Client::new(host_url)?;
+                if let Some(t) = auth_token {
+                    client = client.with_auth_token(t.expose_secret());
+                }
+                client
+                    .api_v3_configure_table_delete(&database_name, &config.table)
+                    .await?;
+
+                println!(
+                    "Table {:?}.{:?} deleted successfully",
+                    &database_name, &config.table
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -26,8 +26,8 @@ use trogging::{
 
 mod commands {
     pub(crate) mod common;
-    pub mod database;
     pub mod last_cache;
+    pub mod manage;
     pub mod query;
     pub mod serve;
     pub mod token;
@@ -94,7 +94,10 @@ enum Command {
     LastCache(commands::last_cache::Config),
 
     /// Manage database (delete only for the moment)
-    Database(commands::database::ManageDatabaseConfig),
+    Database(commands::manage::database::ManageDatabaseConfig),
+
+    /// Manage table (delete only for the moment)
+    Table(commands::manage::table::ManageTableConfig),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -152,9 +155,15 @@ fn main() -> Result<(), std::io::Error> {
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }
-            Some(Command::Database(db_config)) => {
-                if let Err(e) = commands::database::delete_database(db_config).await {
+            Some(Command::Database(config)) => {
+                if let Err(e) = commands::manage::database::delete_database(config).await {
                     eprintln!("Database delete command failed: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::Table(config)) => {
+                if let Err(e) = commands::manage::table::delete_table(config).await {
+                    eprintln!("Table delete command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -6,7 +6,8 @@ use hashbrown::HashMap;
 use indexmap::IndexMap;
 use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
 use influxdb3_wal::{
-    CatalogBatch, CatalogOp, FieldAdditions, LastCacheDefinition, LastCacheDelete,
+    CatalogBatch, CatalogOp, DeleteTableDefinition, FieldAdditions, LastCacheDefinition,
+    LastCacheDelete,
 };
 use influxdb_line_protocol::FieldValue;
 use iox_time::Time;
@@ -18,7 +19,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use thiserror::Error;
 
-const SOFT_DB_DELETION_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
+const SOFT_DELETION_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
 
 #[derive(Debug, Error, Clone)]
 pub enum Error {
@@ -468,6 +469,8 @@ impl DatabaseSchema {
         debug!(name = ?db_schema.name, deleted = ?db_schema.deleted, full_batch = ?catalog_batch, "Updating / adding to catalog");
         let mut updated_or_new_tables = SerdeVecMap::new();
         let mut schema_deleted = false;
+        let mut table_deleted = false;
+        let mut deleted_table_defn = None;
         let mut schema_name = Arc::clone(&db_schema.name);
 
         for catalog_op in &catalog_batch.ops {
@@ -540,12 +543,16 @@ impl DatabaseSchema {
                     schema_deleted = true;
                     let deletion_time = Time::from_timestamp_nanos(params.deletion_time);
                     schema_name =
-                        DatabaseSchema::make_new_schema_name(&params.database_name, deletion_time);
+                        make_new_name_using_deleted_time(&params.database_name, deletion_time);
+                }
+                CatalogOp::DeleteTable(table_definition) => {
+                    table_deleted = true;
+                    deleted_table_defn = Some(table_definition);
                 }
             }
         }
 
-        if updated_or_new_tables.is_empty() && !schema_deleted {
+        if updated_or_new_tables.is_empty() && !schema_deleted && !table_deleted {
             Ok(None)
         } else {
             for (table_id, table_def) in &db_schema.tables {
@@ -553,6 +560,8 @@ impl DatabaseSchema {
                     updated_or_new_tables.insert(*table_id, Arc::clone(table_def));
                 }
             }
+
+            check_and_mark_table_as_deleted(deleted_table_defn, &mut updated_or_new_tables);
 
             // With the final list of updated/new tables update the current mapping
             let new_table_maps = updated_or_new_tables
@@ -592,7 +601,7 @@ impl DatabaseSchema {
     }
 
     pub fn table_schema(&self, table_name: impl Into<Arc<str>>) -> Option<Schema> {
-        self.table_schema_and_id(table_name)
+        self.table_id_and_schema(table_name)
             .map(|(_, schema)| schema.clone())
     }
 
@@ -603,7 +612,7 @@ impl DatabaseSchema {
             .cloned()
     }
 
-    pub fn table_schema_and_id(
+    pub fn table_id_and_schema(
         &self,
         table_name: impl Into<Arc<str>>,
     ) -> Option<(TableId, Schema)> {
@@ -629,7 +638,7 @@ impl DatabaseSchema {
         self.tables.get(table_id).cloned()
     }
 
-    pub fn table_definition_and_id(
+    pub fn table_id_and_definition(
         &self,
         table_name: impl Into<Arc<str>>,
     ) -> Option<(TableId, Arc<TableDefinition>)> {
@@ -665,21 +674,30 @@ impl DatabaseSchema {
     pub fn table_id_to_name(&self, table_id: &TableId) -> Option<Arc<str>> {
         self.table_map.get_by_left(table_id).map(Arc::clone)
     }
+}
 
-    pub fn soft_delete_db(&mut self, deletion_time: Time) {
-        self.deleted = true;
-        self.name = DatabaseSchema::make_new_schema_name(&self.name, deletion_time);
+fn check_and_mark_table_as_deleted(
+    deleted_table_defn: Option<&DeleteTableDefinition>,
+    updated_or_new_tables: &mut SerdeVecMap<TableId, Arc<TableDefinition>>,
+) {
+    if let Some(deleted_table_defn) = deleted_table_defn {
+        if let Some(deleted_table) = updated_or_new_tables.get_mut(&deleted_table_defn.table_id) {
+            let deletion_time = Time::from_timestamp_nanos(deleted_table_defn.deletion_time);
+            let table_name =
+                make_new_name_using_deleted_time(&deleted_table_defn.table_name, deletion_time);
+            let new_table_def = Arc::make_mut(deleted_table);
+            new_table_def.deleted = true;
+            new_table_def.table_name = table_name;
+        }
     }
+}
 
-    pub fn make_new_schema_name(name: &str, deletion_time: Time) -> Arc<str> {
-        Arc::from(format!(
-            "{}-{}",
-            name,
-            deletion_time
-                .date_time()
-                .format(SOFT_DB_DELETION_TIME_FORMAT)
-        ))
-    }
+fn make_new_name_using_deleted_time(name: &str, deletion_time: Time) -> Arc<str> {
+    Arc::from(format!(
+        "{}-{}",
+        name,
+        deletion_time.date_time().format(SOFT_DELETION_TIME_FORMAT)
+    ))
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -691,6 +709,7 @@ pub struct TableDefinition {
     pub column_map: BiHashMap<ColumnId, Arc<str>>,
     pub series_key: Option<Vec<ColumnId>>,
     pub last_caches: HashMap<Arc<str>, LastCacheDefinition>,
+    pub deleted: bool,
 }
 
 impl TableDefinition {
@@ -745,6 +764,7 @@ impl TableDefinition {
             column_map,
             series_key,
             last_caches: HashMap::new(),
+            deleted: false,
         })
     }
 
@@ -1186,7 +1206,9 @@ mod tests {
                                         "table_id": 0,
                                         "table_name": "tbl1",
                                         "cols": [],
-                                        "next_column_id": 0
+                                        "next_column_id": 0,
+                                        "deleted": false
+
                                     }
                                 ],
                                 [
@@ -1195,7 +1217,9 @@ mod tests {
                                         "table_id": 0,
                                         "table_name": "tbl1",
                                         "cols": [],
-                                        "next_column_id": 0
+                                        "next_column_id": 0,
+                                        "deleted": false
+
                                     }
                                 ]
                             ],
@@ -1247,7 +1271,9 @@ mod tests {
                                                     "nullable": true
                                                 }
                                             ]
-                                        ]
+                                        ],
+                                        "deleted": false
+
                                     }
                                 ]
                             ],
@@ -1472,5 +1498,56 @@ mod tests {
             .apply_catalog_batch(catalog_batch.as_catalog().unwrap())
             .expect_err("should fail to apply AddFields operation for non-existent table");
         assert_contains!(err.to_string(), "Table banana not in DB schema for foo");
+    }
+
+    #[test]
+    fn test_check_and_mark_table_as_deleted() {
+        let db_id = DbId::new();
+        let deleted_table_id = TableId::new();
+        let table_name = Arc::from("boo");
+        let deleted_table_defn = DeleteTableDefinition {
+            database_id: db_id,
+            database_name: Arc::from("foo"),
+            table_id: deleted_table_id,
+            table_name: Arc::clone(&table_name),
+            deletion_time: 0,
+        };
+        let mut map = IndexMap::new();
+        let table_defn = Arc::new(
+            TableDefinition::new(
+                deleted_table_id,
+                Arc::clone(&table_name),
+                vec![
+                    (ColumnId::from(0), "tag_1".into(), InfluxColumnType::Tag),
+                    (ColumnId::from(1), "tag_2".into(), InfluxColumnType::Tag),
+                    (ColumnId::from(2), "tag_3".into(), InfluxColumnType::Tag),
+                    (
+                        ColumnId::from(3),
+                        "time".into(),
+                        InfluxColumnType::Timestamp,
+                    ),
+                    (
+                        ColumnId::from(4),
+                        "field".into(),
+                        InfluxColumnType::Field(InfluxFieldType::String),
+                    ),
+                ],
+                SeriesKey::Some(vec![
+                    ColumnId::from(0),
+                    ColumnId::from(1),
+                    ColumnId::from(2),
+                ]),
+            )
+            .unwrap(),
+        );
+        map.insert(deleted_table_id, table_defn);
+        let mut updated_or_new_tables = SerdeVecMap::from(map);
+
+        check_and_mark_table_as_deleted(Some(&deleted_table_defn), &mut updated_or_new_tables);
+
+        let deleted_table = updated_or_new_tables.get(&deleted_table_id).unwrap();
+        assert_eq!(&*deleted_table.table_name, "boo-19700101T000000");
+        assert!(deleted_table.deleted);
+        assert!(deleted_table.series_key.is_some());
     }
 }

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -111,6 +111,7 @@ struct TableSnapshot {
     cols: SerdeVecMap<ColumnId, ColumnDefinitionSnapshot>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     last_caches: Vec<LastCacheSnapshot>,
+    deleted: bool,
 }
 
 /// Representation of Arrow's `DataType` for table snapshots.
@@ -255,6 +256,7 @@ impl From<&TableDefinition> for TableSnapshot {
                 })
                 .collect(),
             last_caches: def.last_caches.values().map(Into::into).collect(),
+            deleted: def.deleted,
         }
     }
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -127,7 +127,8 @@ expression: catalog
                     "nullable": true
                   }
                 ]
-              ]
+              ],
+              "deleted": false
             }
           ],
           [
@@ -246,7 +247,8 @@ expression: catalog
                     "nullable": true
                   }
                 ]
-              ]
+              ],
+              "deleted": false
             }
           ]
         ],

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -103,7 +103,8 @@ expression: catalog
                   "n": 1,
                   "ttl": 600
                 }
-              ]
+              ],
+              "deleted": false
             }
           ]
         ],

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -92,7 +92,8 @@ expression: catalog
                     "nullable": false
                   }
                 ]
-              ]
+              ],
+              "deleted": false
             }
           ]
         ],

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -245,6 +245,7 @@ pub enum CatalogOp {
     CreateLastCache(LastCacheDefinition),
     DeleteLastCache(LastCacheDelete),
     DeleteDatabase(DeleteDatabaseDefinition),
+    DeleteTable(DeleteTableDefinition),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -257,6 +258,15 @@ pub struct DatabaseDefinition {
 pub struct DeleteDatabaseDefinition {
     pub database_id: DbId,
     pub database_name: Arc<str>,
+    pub deletion_time: i64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeleteTableDefinition {
+    pub database_id: DbId,
+    pub database_name: Arc<str>,
+    pub table_id: TableId,
+    pub table_name: Arc<str>,
     pub deletion_time: i64,
 }
 

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -498,6 +498,14 @@ impl LastCacheProvider {
         lock.remove(db_id);
     }
 
+    /// Delete all caches for table from the provider
+    pub fn delete_caches_for_table(&self, db_id: &DbId, table_id: &TableId) {
+        let mut write_guard = self.cache_map.write();
+        if let Some(tables) = write_guard.get_mut(db_id) {
+            tables.remove(table_id);
+        }
+    }
+
     /// Write the contents from a wal file into the cache by iterating over its database and table batches
     /// to find entries that belong in the cache.
     ///
@@ -1806,7 +1814,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema("foo").unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id("cpu").unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition("cpu").unwrap();
         let col_id = table_def.column_name_to_id("host").unwrap();
 
         // Create the last cache:
@@ -1915,7 +1923,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema("foo").unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id("cpu").unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition("cpu").unwrap();
         let host_col_id = table_def.column_name_to_id("host").unwrap();
         let region_col_id = table_def.column_name_to_id("region").unwrap();
 
@@ -2152,7 +2160,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema("foo").unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id("cpu").unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition("cpu").unwrap();
         let host_col_id = table_def.column_name_to_id("host").unwrap();
         let region_col_id = table_def.column_name_to_id("region").unwrap();
 
@@ -2334,7 +2342,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema("foo").unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id("cpu").unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition("cpu").unwrap();
         let host_col_id = table_def.column_name_to_id("host").unwrap();
         let region_col_id = table_def.column_name_to_id("region").unwrap();
 
@@ -2480,7 +2488,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema("cassini_mission").unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id("temp").unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition("temp").unwrap();
         let component_id_col_id = table_def.column_name_to_id("component_id").unwrap();
         let active_col_id = table_def.column_name_to_id("active").unwrap();
         let type_col_id = table_def.column_name_to_id("type").unwrap();
@@ -2614,7 +2622,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema(db_name).unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id(tbl_name).unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition(tbl_name).unwrap();
         let state_col_id = table_def.column_name_to_id("state").unwrap();
         let county_col_id = table_def.column_name_to_id("county").unwrap();
         let farm_col_id = table_def.column_name_to_id("farm").unwrap();
@@ -2752,7 +2760,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema(db_name).unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id(tbl_name).unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition(tbl_name).unwrap();
         let state_col_id = table_def.column_name_to_id("state").unwrap();
         let county_col_id = table_def.column_name_to_id("county").unwrap();
         let farm_col_id = table_def.column_name_to_id("farm").unwrap();
@@ -2960,7 +2968,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema(db_name).unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id(tbl_name).unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition(tbl_name).unwrap();
         let game_id_col_id = table_def.column_name_to_id("game_id").unwrap();
 
         // Create the last cache using default tags as keys
@@ -3061,7 +3069,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema(db_name).unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id(tbl_name).unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition(tbl_name).unwrap();
         let t1_col_id = table_def.column_name_to_id("t1").unwrap();
 
         // Create the last cache using the single `t1` tag column as key
@@ -3198,7 +3206,7 @@ mod tests {
         .unwrap();
 
         let (db_id, db_schema) = wbuf.catalog().db_id_and_schema(db_name).unwrap();
-        let (tbl_id, table_def) = db_schema.table_definition_and_id(tbl_name).unwrap();
+        let (tbl_id, table_def) = db_schema.table_id_and_definition(tbl_name).unwrap();
         let t1_col_id = table_def.column_name_to_id("t1").unwrap();
         let t2_col_id = table_def.column_name_to_id("t2").unwrap();
         let f1_col_id = table_def.column_name_to_id("f1").unwrap();

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -51,7 +51,12 @@ pub trait WriteBuffer: Bufferer + ChunkContainer + LastCacheManager + DatabaseMa
 /// Database manager - supports only delete operation
 #[async_trait::async_trait]
 pub trait DatabaseManager: Debug + Send + Sync + 'static {
-    async fn delete_database(&self, name: String) -> Result<(), write_buffer::Error>;
+    async fn soft_delete_database(&self, name: String) -> Result<(), write_buffer::Error>;
+    async fn soft_delete_table(
+        &self,
+        db_name: String,
+        table_name: String,
+    ) -> Result<(), write_buffer::Error>;
 }
 
 /// The buffer is for buffering data in memory and in the wal before it is persisted as parquet files in storage.

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -27,12 +27,12 @@ use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::logical_expr::Expr;
 use influxdb3_catalog::catalog::Catalog;
 use influxdb3_id::{ColumnId, DbId, TableId};
-use influxdb3_wal::CatalogOp::CreateLastCache;
 use influxdb3_wal::{object_store::WalObjectStore, DeleteDatabaseDefinition};
 use influxdb3_wal::{
     CatalogBatch, CatalogOp, LastCacheDefinition, LastCacheDelete, Wal, WalConfig, WalFileNotifier,
     WalOp,
 };
+use influxdb3_wal::{CatalogOp::CreateLastCache, DeleteTableDefinition};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
@@ -76,8 +76,11 @@ pub enum Error {
     #[error("error in last cache: {0}")]
     LastCacheError(#[from] last_cache::Error),
 
-    #[error("database not found {0}")]
-    DatabaseNotFound(String),
+    #[error("database not found {db_name:?}")]
+    DatabaseNotFound { db_name: String },
+
+    #[error("table not found {table_name:?} in db {db_name:?}")]
+    TableNotFound { db_name: String, table_name: String },
 
     #[error("tried accessing database and table that do not exist")]
     DbDoesNotExist,
@@ -313,7 +316,7 @@ impl WriteBufferImpl {
         })?;
 
         let (table_id, table_schema) =
-            db_schema.table_schema_and_id(table_name).ok_or_else(|| {
+            db_schema.table_id_and_schema(table_name).ok_or_else(|| {
                 DataFusionError::Execution(format!(
                     "table {} not found in db {}",
                     table_name, database_name
@@ -537,11 +540,13 @@ impl LastCacheManager for WriteBufferImpl {
 
 #[async_trait::async_trait]
 impl DatabaseManager for WriteBufferImpl {
-    async fn delete_database(&self, name: String) -> crate::Result<(), self::Error> {
-        let (db_id, db_schema) = self
-            .catalog
-            .db_id_and_schema(&name)
-            .ok_or_else(|| self::Error::DatabaseNotFound(name))?;
+    async fn soft_delete_database(&self, name: String) -> crate::Result<(), self::Error> {
+        let (db_id, db_schema) =
+            self.catalog
+                .db_id_and_schema(&name)
+                .ok_or_else(|| self::Error::DatabaseNotFound {
+                    db_name: name.to_owned(),
+                })?;
 
         let deletion_time = self.time_provider.now();
         let catalog_batch = CatalogBatch {
@@ -558,6 +563,49 @@ impl DatabaseManager for WriteBufferImpl {
         let wal_op = WalOp::Catalog(catalog_batch);
         self.wal.write_ops(vec![wal_op]).await?;
         debug!(db_id = ?db_id, name = ?&db_schema.name, "successfully deleted database");
+        Ok(())
+    }
+
+    async fn soft_delete_table(
+        &self,
+        db_name: String,
+        table_name: String,
+    ) -> crate::Result<(), self::Error> {
+        let (db_id, db_schema) = self.catalog.db_id_and_schema(&db_name).ok_or_else(|| {
+            self::Error::DatabaseNotFound {
+                db_name: db_name.to_owned(),
+            }
+        })?;
+
+        let (table_id, table_defn) = db_schema
+            .table_id_and_definition(table_name.as_str())
+            .ok_or_else(|| self::Error::TableNotFound {
+                db_name: db_name.to_owned(),
+                table_name: table_name.to_owned(),
+            })?;
+        let deletion_time = self.time_provider.now();
+        let catalog_batch = CatalogBatch {
+            time_ns: deletion_time.timestamp_nanos(),
+            database_id: db_id,
+            database_name: Arc::clone(&db_schema.name),
+            ops: vec![CatalogOp::DeleteTable(DeleteTableDefinition {
+                database_id: db_id,
+                database_name: Arc::clone(&db_schema.name),
+                deletion_time: deletion_time.timestamp_nanos(),
+                table_id,
+                table_name: Arc::clone(&table_defn.table_name),
+            })],
+        };
+        self.catalog.apply_catalog_batch(&catalog_batch)?;
+        let wal_op = WalOp::Catalog(catalog_batch);
+        self.wal.write_ops(vec![wal_op]).await?;
+        debug!(
+            db_id = ?db_id,
+            db_name = ?&db_schema.name,
+            table_id = ?table_id,
+            table_name = ?table_defn.table_name,
+            "successfully deleted table"
+        );
         Ok(())
     }
 }
@@ -1937,7 +1985,37 @@ mod tests {
             .await
             .unwrap();
 
-        let result = write_buffer.delete_database("foo".to_string()).await;
+        let result = write_buffer.soft_delete_database("foo".to_string()).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_table() {
+        let start_time = Time::from_rfc3339("2024-11-14T11:00:00+00:00").unwrap();
+        let test_store = Arc::new(InMemory::new());
+        let wal_config = WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(10),
+            snapshot_size: 1,
+        };
+        let (write_buffer, _) =
+            setup_cache_optional(start_time, test_store, wal_config, false).await;
+        let _ = write_buffer
+            .write_lp(
+                NamespaceName::new("foo").unwrap(),
+                "cpu,warehouse=us-east,room=01a,device=10001 reading=37\n",
+                start_time,
+                false,
+                Precision::Nanosecond,
+            )
+            .await
+            .unwrap();
+
+        let result = write_buffer
+            .soft_delete_table("foo".to_string(), "cpu".to_string())
+            .await;
 
         assert!(result.is_ok());
     }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -66,6 +66,7 @@ expression: catalog_json
                   }
                 ]
               ],
+              "deleted": false,
               "last_caches": [
                 {
                   "keys": [

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -56,6 +56,7 @@ expression: catalog_json
                   }
                 ]
               ],
+              "deleted": false,
               "last_caches": [
                 {
                   "keys": [

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -66,6 +66,7 @@ expression: catalog_json
                   }
                 ]
               ],
+              "deleted": false,
               "table_id": 0,
               "table_name": "table"
             }


### PR DESCRIPTION
This commit allows deleting (soft) a table. For an user, following command will allow soft deleting a table (bar) in db (foo)

```
influxdb3 table delete --dbname foo --table bar --host $host
```

- Added `soft_delete_table` to `DatabaseManager` trait, which already hosts `soft_delete_database` method. The code roughly follows the same flow as db delete. Although like db schema, it does clone on write because the reference is behind an Arc, `Arc::make_mut` is used in this change.
- Moved db delete related cli parser under "manage" module that has both db and table delete functionality
- Some minor tidyups (removing unused methods, renaming method so that the order in name matches actual return type eg. `table_id_and_schema`, should return (id, schema) and not (schema, id))

closes: https://github.com/influxdata/influxdb/issues/25561