### PR TITLE
feat(influx_inspect): Adds an additional log to rebuild TSI

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -127,6 +127,7 @@ func (cmd *Command) run(dataDir, walDir string) error {
 		}
 	}
 
+	cmd.Logger.Info("TSI rebuild completed successfully!")
 	return nil
 }
 


### PR DESCRIPTION
Output for re-building TSI now includes a completion log

example: 

```
......
renaming new segment "/Users/devan/.influxdb/data/tstestdbthree/_series/00/0000.tmp" to "/Users/devan/.influxdb/data/tstestdbthree/_series/00/0000"
renaming new segment "/Users/devan/.influxdb/data/tstestdbthree/_series/07/0000.tmp" to "/Users/devan/.influxdb/data/tstestdbthree/_series/07/0000"
removing index file /Users/devan/.influxdb/data/tstestdbthree/_series/07/index
removing index file /Users/devan/.influxdb/data/tstestdbthree/_series/00/index
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/00
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/01
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/02
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/03
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/04
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/05
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/06
compacted  /Users/devan/.influxdb/data/tstestdbthree/_series/07
2024-11-21T21:16:53.003236Z     info    TSI rebuild completed successfully!     {"log_id": "0t09Cd5W000"}
```

Closes https://github.com/influxdata/feature-requests/issues/612

