### PR TITLE
feat: metacache REST APIs to create and delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "futures",
  "hex",
  "http 0.2.12",
+ "humantime",
  "hyper 0.14.31",
  "influxdb-line-protocol",
  "influxdb3_cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -4588,7 +4588,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -4605,7 +4605,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "slab",
  "thiserror 1.0.69",
  "tinyvec",
@@ -4818,7 +4818,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -4935,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",
@@ -5486,7 +5486,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6121,7 +6121,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7135,7 +7135,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest 0.12.9",
  "ring",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "hex",
  "humantime",
  "hyper 0.14.31",
+ "influxdb3_cache",
  "influxdb3_catalog",
  "influxdb3_client",
  "influxdb3_process",
@@ -2765,6 +2766,7 @@ dependencies = [
  "iox_time",
  "parking_lot",
  "schema",
+ "serde",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -2884,6 +2886,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.31",
  "influxdb-line-protocol",
+ "influxdb3_cache",
  "influxdb3_catalog",
  "influxdb3_id",
  "influxdb3_process",
@@ -3015,6 +3018,7 @@ dependencies = [
  "hex",
  "indexmap 2.6.0",
  "influxdb-line-protocol",
+ "influxdb3_cache",
  "influxdb3_catalog",
  "influxdb3_id",
  "influxdb3_telemetry",
@@ -6552,9 +6556,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -24,6 +24,7 @@ trace_exporters.workspace = true
 trogging.workspace = true
 
 # Local Crates
+influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -7,6 +7,382 @@ use test_helpers::assert_contains;
 use crate::TestServer;
 
 #[tokio::test]
+async fn api_v3_configure_meta_cache_create() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/meta_cache",
+        base = server.client_addr()
+    );
+
+    // Write some LP to the database to initialize the catalog
+    let db_name = "foo";
+    let tbl_name = "bar";
+    server
+        .write_lp_to_db(
+            db_name,
+            format!("{tbl_name},t1=a,t2=aa,t3=aaa f1=\"potato\",f2=true,f3=4i,f4=4u,f5=5 1000"),
+            influxdb3_client::Precision::Second,
+        )
+        .await
+        .expect("write to db");
+
+    #[derive(Default)]
+    struct TestCase {
+        description: &'static str,
+        db: Option<&'static str>,
+        table: Option<&'static str>,
+        cache_name: Option<&'static str>,
+        max_cardinality: Option<usize>,
+        max_age: Option<u64>,
+        columns: &'static [&'static str],
+        expected: StatusCode,
+    }
+
+    let test_cases = [
+        TestCase {
+            description: "no parameters specified",
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "missing database name",
+            table: Some("bar"),
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "invalid database name",
+            db: Some("carrot"),
+            table: Some("bar"),
+            expected: StatusCode::NOT_FOUND,
+            ..Default::default()
+        },
+        TestCase {
+            description: "invalid table name",
+            db: Some("foo"),
+            table: Some("celery"),
+            expected: StatusCode::NOT_FOUND,
+            ..Default::default()
+        },
+        TestCase {
+            description: "no columns specified",
+            db: Some("foo"),
+            table: Some("bar"),
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "invalid column specified, that does not exist",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["leek"],
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "invalid column specified, that is not tag or string",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["f2"],
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "valid request, creates cache",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1", "t2"],
+            expected: StatusCode::CREATED,
+            ..Default::default()
+        },
+        TestCase {
+            description:
+                "identical to previous request, still success, but results in no 204 content",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1", "t2"],
+            expected: StatusCode::NO_CONTENT,
+            ..Default::default()
+        },
+        TestCase {
+            description: "same as previous, but with incompatible configuratin, max cardinality",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1", "t2"],
+            max_cardinality: Some(1),
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "same as previous, but with incompatible configuratin, max age",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1", "t2"],
+            max_age: Some(1),
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+        TestCase {
+            description: "valid request, creates cache",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1"],
+            cache_name: Some("my_cache"),
+            expected: StatusCode::CREATED,
+            ..Default::default()
+        },
+        TestCase {
+            description: "same as previous, but with incompatible configuratino, column set",
+            db: Some("foo"),
+            table: Some("bar"),
+            columns: &["t1", "t2"],
+            cache_name: Some("my_cache"),
+            expected: StatusCode::BAD_REQUEST,
+            ..Default::default()
+        },
+    ];
+
+    for tc in test_cases {
+        let body = serde_json::json!({
+            "db": tc.db,
+            "table": tc.table,
+            "name": tc.cache_name,
+            "columns": tc.columns,
+            "max_cardinality": tc.max_cardinality,
+            "max_age": tc.max_age
+        });
+        let resp = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("send request to create meta cache");
+        let status = resp.status();
+        assert_eq!(
+            tc.expected,
+            status,
+            "test case failed: {description}",
+            description = tc.description
+        );
+    }
+}
+
+#[tokio::test]
+async fn api_v3_configure_meta_cache_delete() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/meta_cache",
+        base = server.client_addr()
+    );
+
+    let db_name = "foo";
+    let tbl_name = "bar";
+    let cache_name = "test_cache";
+    server
+        .write_lp_to_db(
+            db_name,
+            format!("{tbl_name},t1=a,t2=aa f1=true 1000"),
+            influxdb3_client::Precision::Second,
+        )
+        .await
+        .expect("write lp to db");
+
+    struct TestCase {
+        description: &'static str,
+        request: Request,
+        expected: StatusCode,
+    }
+
+    enum Request {
+        Create(serde_json::Value),
+        Delete(DeleteRequest),
+    }
+
+    #[derive(Default)]
+    struct DeleteRequest {
+        db: Option<&'static str>,
+        table: Option<&'static str>,
+        name: Option<&'static str>,
+    }
+
+    use Request::*;
+    let mut test_cases = [
+        TestCase {
+            description: "create a metadata cache",
+            request: Create(serde_json::json!({
+                "db": db_name,
+                "table": tbl_name,
+                "name": cache_name,
+                "columns": ["t1", "t2"],
+            })),
+            expected: StatusCode::CREATED,
+        },
+        TestCase {
+            description: "delete with no parameters fails",
+            request: Delete(DeleteRequest {
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing table, name params",
+            request: Delete(DeleteRequest {
+                db: Some(db_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing name param",
+            request: Delete(DeleteRequest {
+                db: Some(db_name),
+                table: Some(tbl_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing table param",
+            request: Delete(DeleteRequest {
+                db: Some(db_name),
+                name: Some(cache_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing db param",
+            request: Delete(DeleteRequest {
+                table: Some(tbl_name),
+                name: Some(cache_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing db, table param",
+            request: Delete(DeleteRequest {
+                name: Some(cache_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "missing db, name param",
+            request: Delete(DeleteRequest {
+                table: Some(tbl_name),
+                ..Default::default()
+            }),
+            expected: StatusCode::BAD_REQUEST,
+        },
+        TestCase {
+            description: "valid request, will delete",
+            request: Delete(DeleteRequest {
+                db: Some(db_name),
+                table: Some(tbl_name),
+                name: Some(cache_name),
+            }),
+            expected: StatusCode::OK,
+        },
+        TestCase {
+            description: "same as previous, but gets 404 as the cache was already deleted",
+            request: Delete(DeleteRequest {
+                db: Some(db_name),
+                table: Some(tbl_name),
+                name: Some(cache_name),
+            }),
+            expected: StatusCode::NOT_FOUND,
+        },
+    ];
+
+    // do a pass through the test cases deleting via JSON in the body:
+    for tc in &test_cases {
+        match &tc.request {
+            Create(body) => assert_eq!(
+                tc.expected,
+                client
+                    .post(&url)
+                    .json(&body)
+                    .send()
+                    .await
+                    .expect("create request sends")
+                    .status(),
+                "creation test case failed: {description}",
+                description = tc.description
+            ),
+            Delete(DeleteRequest { db, table, name }) => {
+                let body = serde_json::json!({
+                    "db": db,
+                    "table": table,
+                    "name": name,
+                });
+                assert_eq!(
+                    tc.expected,
+                    client
+                        .delete(&url)
+                        .json(&body)
+                        .send()
+                        .await
+                        .expect("delete request send")
+                        .status(),
+                    "deletion test case using JSON body failed: {description}",
+                    description = tc.description
+                );
+            }
+        }
+    }
+
+    // do another pass through the test cases, this time deleting via parameters in the URI:
+
+    // on this pass, need to switch the status code that does not provide any params to a 415
+    // UNSUPPORTED MEDIA TYPE error, as the handler sees no URI parameters, and attempts to parse
+    // the body as JSON, thus resulting in the 415.
+    test_cases[1].expected = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+    for tc in &test_cases {
+        match &tc.request {
+            Create(body) => assert_eq!(
+                tc.expected,
+                client
+                    .post(&url)
+                    .json(&body)
+                    .send()
+                    .await
+                    .expect("create request sends")
+                    .status(),
+                "creation test case failed: {description}",
+                description = tc.description
+            ),
+            Delete(DeleteRequest { db, table, name }) => {
+                let mut params = vec![];
+                if let Some(db) = db {
+                    params.push(("db", db));
+                }
+                if let Some(table) = table {
+                    params.push(("table", table));
+                }
+                if let Some(name) = name {
+                    params.push(("name", name));
+                }
+                assert_eq!(
+                    tc.expected,
+                    client
+                        .delete(&url)
+                        .query(&params)
+                        .send()
+                        .await
+                        .expect("delete request send")
+                        .status(),
+                    "deletion test case using URI parameters failed: {description}",
+                    description = tc.description
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn api_v3_configure_last_cache_create() {
     let server = TestServer::spawn().await;
     let client = reqwest::Client::new();

--- a/influxdb3_cache/Cargo.toml
+++ b/influxdb3_cache/Cargo.toml
@@ -22,6 +22,7 @@ async-trait.workspace = true
 datafusion.workspace = true
 indexmap.workspace = true
 parking_lot.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/influxdb3_cache/src/meta_cache/cache.rs
+++ b/influxdb3_cache/src/meta_cache/cache.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use arrow::{
     array::{ArrayRef, RecordBatch, StringViewBuilder},
     datatypes::{DataType, Field, SchemaBuilder, SchemaRef},
@@ -18,6 +18,21 @@ use influxdb3_wal::{FieldData, Row};
 use iox_time::TimeProvider;
 use schema::{InfluxColumnType, InfluxFieldType};
 use serde::Deserialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheError {
+    #[error("must pass a non-empty set of column ids")]
+    EmptyColumnSet,
+    #[error(
+        "cannot use a column of type {attempted} in a metadata cache, only \
+                    tags and string fields can be used"
+    )]
+    NonTagOrStringColumn { attempted: InfluxColumnType },
+    #[error("cannot overwrite an an existing cache: {message}")]
+    ConfigurationMismatch { message: String },
+    #[error("unexpected error: {0}")]
+    Unexpected(#[from] anyhow::Error),
+}
 
 /// A metadata cache for storing distinct values for a set of columns in a table
 #[derive(Debug)]
@@ -103,6 +118,12 @@ impl From<Duration> for MaxAge {
     }
 }
 
+impl From<u64> for MaxAge {
+    fn from(seconds: u64) -> Self {
+        Self(Duration::new(seconds, 0))
+    }
+}
+
 impl MaxAge {
     pub(crate) fn as_seconds(&self) -> u64 {
         self.0.as_secs()
@@ -122,9 +143,9 @@ impl MetaCache {
             max_age,
             column_ids,
         }: CreateMetaCacheArgs,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, CacheError> {
         if column_ids.is_empty() {
-            bail!("must pass a non-empty set of column ids");
+            return Err(CacheError::EmptyColumnSet);
         }
         let _ = table_def.index_column_ids();
         let mut builder = SchemaBuilder::new();
@@ -136,10 +157,7 @@ impl MetaCache {
                 InfluxColumnType::Tag | InfluxColumnType::Field(InfluxFieldType::String) => {
                     DataType::Utf8View
                 }
-                other => bail!(
-                    "cannot use a column of type {other} in a metadata cache, only \
-                    tags and string fields can be used"
-                ),
+                attempted => return Err(CacheError::NonTagOrStringColumn { attempted }),
             };
 
             builder.push(Arc::new(Field::new(col.name.as_ref(), data_type, false)));
@@ -264,23 +282,24 @@ impl MetaCache {
     }
 
     /// Compare the configuration of a given cache, producing a helpful error message if they differ
-    pub(crate) fn compare_config(&self, other: &Self) -> Result<(), anyhow::Error> {
+    pub(crate) fn compare_config(&self, other: &Self) -> Result<(), CacheError> {
         if self.max_cardinality != other.max_cardinality {
-            bail!(
+            let message = format!(
                 "incompatible `max_cardinality`, expected {}, got {}",
-                self.max_cardinality,
-                other.max_cardinality
+                self.max_cardinality, other.max_cardinality
             );
+            return Err(CacheError::ConfigurationMismatch { message });
         }
         if self.max_age != other.max_age {
-            bail!(
+            let message = format!(
                 "incompatible `max_age`, expected {}, got {}",
                 self.max_age.as_secs(),
                 other.max_age.as_secs()
-            )
+            );
+            return Err(CacheError::ConfigurationMismatch { message });
         }
         if self.column_ids != other.column_ids {
-            bail!(
+            let message = format!(
                 "incompatible column id selection, expected {}, got {}",
                 self.column_ids
                     .iter()
@@ -293,7 +312,8 @@ impl MetaCache {
                     .map(|id| id.to_string())
                     .collect::<Vec<_>>()
                     .join(","),
-            )
+            );
+            return Err(CacheError::ConfigurationMismatch { message });
         }
 
         Ok(())

--- a/influxdb3_cache/src/meta_cache/mod.rs
+++ b/influxdb3_cache/src/meta_cache/mod.rs
@@ -1,7 +1,7 @@
 //! The Metadata Cache holds the distinct values for a column or set of columns on a table
 
 mod cache;
-pub use cache::{CreateMetaCacheArgs, MaxAge, MaxCardinality};
+pub use cache::{CacheError, CreateMetaCacheArgs, MaxAge, MaxCardinality};
 mod provider;
 pub use provider::{MetaCacheProvider, ProviderError};
 mod table_function;

--- a/influxdb3_cache/src/meta_cache/mod.rs
+++ b/influxdb3_cache/src/meta_cache/mod.rs
@@ -1,8 +1,9 @@
 //! The Metadata Cache holds the distinct values for a column or set of columns on a table
 
 mod cache;
+pub use cache::{CreateMetaCacheArgs, MaxAge, MaxCardinality};
 mod provider;
-pub use provider::MetaCacheProvider;
+pub use provider::{MetaCacheProvider, ProviderError};
 mod table_function;
 pub use table_function::MetaCacheFunction;
 pub use table_function::META_CACHE_UDTF_NAME;

--- a/influxdb3_cache/src/meta_cache/provider.rs
+++ b/influxdb3_cache/src/meta_cache/provider.rs
@@ -14,7 +14,7 @@ use super::cache::{CreateMetaCacheArgs, MetaCache};
 
 #[derive(Debug, thiserror::Error)]
 #[error("metadata cache provider error: {0:#}")]
-pub struct Error(#[from] anyhow::Error);
+pub struct ProviderError(#[from] anyhow::Error);
 
 /// Triple nested map for storing a multiple metadata caches per table.
 ///
@@ -35,7 +35,7 @@ impl MetaCacheProvider {
     pub fn new_from_catalog(
         time_provider: Arc<dyn TimeProvider>,
         catalog: Arc<Catalog>,
-    ) -> Result<Arc<Self>, Error> {
+    ) -> Result<Arc<Self>, ProviderError> {
         let provider = Arc::new(MetaCacheProvider {
             time_provider,
             catalog: Arc::clone(&catalog),
@@ -77,7 +77,7 @@ impl MetaCacheProvider {
         time_provider: Arc<dyn TimeProvider>,
         catalog: Arc<Catalog>,
         eviction_interval: Duration,
-    ) -> Result<Arc<Self>, Error> {
+    ) -> Result<Arc<Self>, ProviderError> {
         let provider = Self::new_from_catalog(time_provider, catalog)?;
 
         background_eviction_process(Arc::clone(&provider), eviction_interval);
@@ -139,7 +139,7 @@ impl MetaCacheProvider {
             max_age,
             column_ids,
         }: CreateMetaCacheArgs,
-    ) -> Result<Option<MetaCacheDefinition>, Error> {
+    ) -> Result<Option<MetaCacheDefinition>, ProviderError> {
         let cache_name = if let Some(cache_name) = cache_name {
             cache_name
         } else {
@@ -233,19 +233,19 @@ impl MetaCacheProvider {
     /// table or its parent database empty, this will remove that branch.
     pub fn delete_cache(
         &self,
-        db_id: DbId,
-        table_id: TableId,
+        db_id: &DbId,
+        table_id: &TableId,
         cache_name: &str,
-    ) -> Result<(), Error> {
+    ) -> Result<(), ProviderError> {
         let mut lock = self.cache_map.write();
-        let db = lock.get_mut(&db_id).context("database does not exist")?;
-        let table = db.get_mut(&table_id).context("table does not exist")?;
+        let db = lock.get_mut(db_id).context("database does not exist")?;
+        let table = db.get_mut(table_id).context("table does not exist")?;
         table.remove(cache_name).context("cache does not exist")?;
         if table.is_empty() {
-            db.remove(&table_id);
+            db.remove(table_id);
         }
         if db.is_empty() {
-            lock.remove(&db_id);
+            lock.remove(db_id);
         }
         Ok(())
     }

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -30,6 +30,7 @@ trace_http.workspace = true
 tracker.workspace = true
 
 # Local Deps
+influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -57,6 +57,7 @@ flate2.workspace = true
 futures.workspace = true
 hex.workspace = true
 hyper.workspace = true
+humantime.workspace = true
 mime.workspace = true
 object_store.workspace = true
 parking_lot.workspace = true

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -234,6 +234,7 @@ mod tests {
     use crate::serve;
     use datafusion::parquet::data_type::AsBytes;
     use hyper::{body, Body, Client, Request, Response, StatusCode};
+    use influxdb3_cache::meta_cache::MetaCacheProvider;
     use influxdb3_catalog::catalog::Catalog;
     use influxdb3_id::{DbId, TableId};
     use influxdb3_telemetry::store::TelemetryStore;
@@ -778,13 +779,20 @@ mod tests {
         let catalog = Arc::new(Catalog::new(sample_host_id, instance_id));
         let write_buffer_impl = Arc::new(
             influxdb3_write::write_buffer::WriteBufferImpl::new(
-                Arc::clone(&persister),
-                Arc::clone(&catalog),
-                LastCacheProvider::new_from_catalog(catalog as _).unwrap(),
-                Arc::<MockProvider>::clone(&time_provider),
-                Arc::clone(&exec),
-                WalConfig::test_config(),
-                Some(parquet_cache),
+                influxdb3_write::write_buffer::WriteBufferImplArgs {
+                    persister: Arc::clone(&persister),
+                    catalog: Arc::clone(&catalog),
+                    last_cache: LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap(),
+                    meta_cache: MetaCacheProvider::new_from_catalog(
+                        Arc::clone(&time_provider) as _,
+                        Arc::clone(&catalog),
+                    )
+                    .unwrap(),
+                    time_provider: Arc::clone(&time_provider) as _,
+                    executor: Arc::clone(&exec),
+                    wal_config: WalConfig::test_config(),
+                    parquet_cache: Some(parquet_cache),
+                },
             )
             .await
             .unwrap(),

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -18,6 +18,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
 use datafusion_util::config::DEFAULT_SCHEMA;
 use datafusion_util::MemoryStream;
+use influxdb3_cache::meta_cache::{MetaCacheFunction, META_CACHE_UDTF_NAME};
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
 use influxdb3_telemetry::store::TelemetryStore;
 use influxdb3_write::last_cache::LastCacheFunction;
@@ -449,6 +450,13 @@ impl QueryNamespace for Database {
             Arc::new(LastCacheFunction::new(
                 self.db_schema.id,
                 self.write_buffer.last_cache_provider(),
+            )),
+        );
+        ctx.inner().register_udtf(
+            META_CACHE_UDTF_NAME,
+            Arc::new(MetaCacheFunction::new(
+                self.db_schema.id,
+                self.write_buffer.meta_cache_provider(),
             )),
         );
         ctx

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -242,6 +242,8 @@ pub enum CatalogOp {
     CreateDatabase(DatabaseDefinition),
     CreateTable(TableDefinition),
     AddFields(FieldAdditions),
+    CreateMetaCache(MetaCacheDefinition),
+    DeleteMetaCache(MetaCacheDelete),
     CreateLastCache(LastCacheDefinition),
     DeleteLastCache(LastCacheDelete),
     DeleteDatabase(DeleteDatabaseDefinition),
@@ -508,6 +510,13 @@ pub struct MetaCacheDefinition {
     pub max_cardinality: usize,
     /// The maximum age in seconds, similar to a time-to-live (TTL), for entries in the cache
     pub max_age_seconds: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MetaCacheDelete {
+    pub table_name: Arc<str>,
+    pub table_id: TableId,
+    pub cache_name: Arc<str>,
 }
 
 #[serde_as]

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -19,6 +19,7 @@ observability_deps.workspace = true
 schema.workspace = true
 
 # Local deps
+influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -84,10 +84,10 @@ pub enum Error {
     #[error("table not found {table_name:?} in db {db_name:?}")]
     TableNotFound { db_name: String, table_name: String },
 
-    #[error("tried accessing database and table that do not exist")]
+    #[error("tried accessing database that does not exist")]
     DbDoesNotExist,
 
-    #[error("tried accessing database and table that do not exist")]
+    #[error("tried accessing table that do not exist")]
     TableDoesNotExist,
 
     #[error("tried accessing column with name ({0}) that does not exist")]

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -17,6 +17,7 @@ use datafusion::common::DataFusionError;
 use datafusion::logical_expr::Expr;
 use datafusion_util::stream_from_batches;
 use hashbrown::HashMap;
+use influxdb3_cache::meta_cache::MetaCacheProvider;
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
 use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::{CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalOp, WriteBatch};
@@ -40,6 +41,7 @@ use tokio::sync::oneshot::Receiver;
 pub struct QueryableBuffer {
     pub(crate) executor: Arc<Executor>,
     catalog: Arc<Catalog>,
+    meta_cache_provider: Arc<MetaCacheProvider>,
     last_cache_provider: Arc<LastCacheProvider>,
     persister: Arc<Persister>,
     persisted_files: Arc<PersistedFiles>,
@@ -50,14 +52,27 @@ pub struct QueryableBuffer {
     persisted_snapshot_notify_tx: tokio::sync::watch::Sender<Option<PersistedSnapshot>>,
 }
 
+pub struct QueryableBufferArgs {
+    pub executor: Arc<Executor>,
+    pub catalog: Arc<Catalog>,
+    pub persister: Arc<Persister>,
+    pub last_cache_provider: Arc<LastCacheProvider>,
+    pub meta_cache_provider: Arc<MetaCacheProvider>,
+    pub persisted_files: Arc<PersistedFiles>,
+    pub parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
+}
+
 impl QueryableBuffer {
     pub fn new(
-        executor: Arc<Executor>,
-        catalog: Arc<Catalog>,
-        persister: Arc<Persister>,
-        last_cache_provider: Arc<LastCacheProvider>,
-        persisted_files: Arc<PersistedFiles>,
-        parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
+        QueryableBufferArgs {
+            executor,
+            catalog,
+            persister,
+            last_cache_provider,
+            meta_cache_provider,
+            persisted_files,
+            parquet_cache,
+        }: QueryableBufferArgs,
     ) -> Self {
         let buffer = Arc::new(RwLock::new(BufferState::new(Arc::clone(&catalog))));
         let (persisted_snapshot_notify_tx, persisted_snapshot_notify_rx) =
@@ -66,6 +81,7 @@ impl QueryableBuffer {
             executor,
             catalog,
             last_cache_provider,
+            meta_cache_provider,
             persister,
             persisted_files,
             buffer,
@@ -129,11 +145,22 @@ impl QueryableBuffer {
             .collect())
     }
 
-    /// Called when the wal has persisted a new file. Buffer the contents in memory and update the last cache so the data is queryable.
+    /// Update the caches managed by the database
+    fn write_wal_contents_to_caches(&self, write: &WalContents) {
+        self.last_cache_provider.write_wal_contents_to_cache(write);
+        self.meta_cache_provider.write_wal_contents_to_cache(write);
+    }
+
+    /// Called when the wal has persisted a new file. Buffer the contents in memory and update the
+    /// last cache so the data is queryable.
     fn buffer_contents(&self, write: WalContents) {
-        self.last_cache_provider.write_wal_contents_to_cache(&write);
+        self.write_wal_contents_to_caches(&write);
         let mut buffer = self.buffer.write();
-        buffer.buffer_ops(write.ops, &self.last_cache_provider);
+        buffer.buffer_ops(
+            write.ops,
+            &self.last_cache_provider,
+            &self.meta_cache_provider,
+        );
     }
 
     /// Called when the wal has written a new file and is attempting to snapshot. Kicks off persistence of
@@ -147,6 +174,7 @@ impl QueryableBuffer {
             ?snapshot_details,
             "Buffering contents and persisting snapshotted data"
         );
+        self.write_wal_contents_to_caches(&write);
         let persist_jobs = {
             let mut buffer = self.buffer.write();
 
@@ -191,7 +219,11 @@ impl QueryableBuffer {
 
             // we must buffer the ops after the snapshotting as this data should not be persisted
             // with this set of wal files
-            buffer.buffer_ops(write.ops, &self.last_cache_provider);
+            buffer.buffer_ops(
+                write.ops,
+                &self.last_cache_provider,
+                &self.meta_cache_provider,
+            );
 
             persisting_chunks
         };
@@ -372,7 +404,12 @@ impl BufferState {
         }
     }
 
-    pub fn buffer_ops(&mut self, ops: Vec<WalOp>, last_cache_provider: &LastCacheProvider) {
+    pub fn buffer_ops(
+        &mut self,
+        ops: Vec<WalOp>,
+        last_cache_provider: &LastCacheProvider,
+        meta_cache_provider: &MetaCacheProvider,
+    ) {
         for op in ops {
             match op {
                 WalOp::Write(write_batch) => self.add_write_batch(write_batch),
@@ -391,6 +428,25 @@ impl BufferState {
                     // eg. creating or deleting last cache itself
                     for op in catalog_batch.ops {
                         match op {
+                            CatalogOp::CreateMetaCache(definition) => {
+                                let table_def = db_schema
+                                    .table_definition_by_id(&definition.table_id)
+                                    .expect("table should exist");
+                                meta_cache_provider.create_from_definition(
+                                    db_schema.id,
+                                    table_def,
+                                    &definition,
+                                );
+                            }
+                            CatalogOp::DeleteMetaCache(cache) => {
+                                // this only fails if the db/table/cache do not exist, so we ignore
+                                // the error if it happens.
+                                let _ = meta_cache_provider.delete_cache(
+                                    &db_schema.id,
+                                    &cache.table_id,
+                                    &cache.cache_name,
+                                );
+                            }
                             CatalogOp::CreateLastCache(definition) => {
                                 let table_def = db_schema
                                     .table_definition_by_id(&definition.table_id)
@@ -402,7 +458,8 @@ impl BufferState {
                                 );
                             }
                             CatalogOp::DeleteLastCache(cache) => {
-                                // we can ignore it if this doesn't exist for any reason
+                                // this only fails if the db/table/cache do not exist, so we ignore
+                                // the error if it happens.
                                 let _ = last_cache_provider.delete_cache(
                                     db_schema.id,
                                     cache.table_id,

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -333,7 +333,8 @@ fn validate_and_qualify_v3_line(
 
         // qualify the fields:
         for (field_name, field_val) in line.field_set.iter() {
-            if let Some((col_id, col_def)) = table_def.column_def_and_id(field_name.as_str()) {
+            if let Some((col_id, col_def)) = table_def.column_id_and_definition(field_name.as_str())
+            {
                 let field_col_type = influx_column_type_from_field_value(field_val);
                 let existing_col_type = col_def.data_type;
                 if field_col_type != existing_col_type {
@@ -554,7 +555,8 @@ fn validate_and_qualify_v1_line(
         }
         for (field_name, field_val) in line.field_set.iter() {
             // This field already exists, so check the incoming type matches existing type:
-            if let Some((col_id, col_def)) = table_def.column_def_and_id(field_name.as_str()) {
+            if let Some((col_id, col_def)) = table_def.column_id_and_definition(field_name.as_str())
+            {
                 let field_col_type = influx_column_type_from_field_value(field_val);
                 let existing_col_type = col_def.data_type;
                 if field_col_type != existing_col_type {


### PR DESCRIPTION
Closes #25546 
Closes #25547

Adds two new APIs:

* `POST /api/v3/configure/meta_cache`: create a metadata cache
* `DELETE /api/v3/configure/meta_cache`: delete a metadata cache

These operations, like similar for the last cache, tie into the WAL; so corresponding catalog/WAL operations were added for both create/delete.

An integration test was added in the `influxdb3` crate for both of these APIs, and in addition, a test was added to check that the metadata cache can be queried via the `/api/v3/query_sql` API.

Also made some QoL improvements to the `WriteBufferImpl` and `QueryExecutorImpl` by using arg structs in their `new` constructors. 