### PR TITLE
feat: make query executor as trait object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -4583,7 +4583,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -4600,7 +4600,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "slab",
  "thiserror 1.0.69",
  "tinyvec",
@@ -4813,7 +4813,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -4930,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",
@@ -5481,7 +5481,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6116,7 +6116,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6552,9 +6552,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7130,7 +7130,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest 0.12.9",
  "ring",
- "rustls 0.23.16",
+ "rustls 0.23.18",
  "serde",
  "serde_json",
  "sha2",

--- a/influxdb3_server/src/grpc.rs
+++ b/influxdb3_server/src/grpc.rs
@@ -4,11 +4,13 @@ use arrow_flight::flight_service_server::{
     FlightService as Flight, FlightServiceServer as FlightServer,
 };
 use authz::Authorizer;
-use iox_query::QueryDatabase;
 
-pub(crate) fn make_flight_server<Q: QueryDatabase>(
-    server: Arc<Q>,
+use crate::{query_executor, QueryExecutor};
+
+pub(crate) fn make_flight_server(
+    server: Arc<dyn QueryExecutor<Error = query_executor::Error>>,
     authz: Option<Arc<dyn Authorizer>>,
 ) -> FlightServer<impl Flight> {
-    service_grpc_flight::make_server(server, authz)
+    let query_db = server.upcast();
+    service_grpc_flight::make_server(query_db, authz)
 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -365,22 +365,22 @@ impl Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
-pub(crate) struct HttpApi<Q, T> {
+pub(crate) struct HttpApi<T> {
     common_state: CommonServerState,
     write_buffer: Arc<dyn WriteBuffer>,
     time_provider: Arc<T>,
-    pub(crate) query_executor: Arc<Q>,
+    pub(crate) query_executor: Arc<dyn QueryExecutor<Error = query_executor::Error>>,
     max_request_bytes: usize,
     authorizer: Arc<dyn Authorizer>,
     legacy_write_param_unifier: SingleTenantRequestUnifier,
 }
 
-impl<Q, T> HttpApi<Q, T> {
+impl<T> HttpApi<T> {
     pub(crate) fn new(
         common_state: CommonServerState,
         time_provider: Arc<T>,
         write_buffer: Arc<dyn WriteBuffer>,
-        query_executor: Arc<Q>,
+        query_executor: Arc<dyn QueryExecutor<Error = query_executor::Error>>,
         max_request_bytes: usize,
         authorizer: Arc<dyn Authorizer>,
     ) -> Self {
@@ -397,11 +397,9 @@ impl<Q, T> HttpApi<Q, T> {
     }
 }
 
-impl<Q, T> HttpApi<Q, T>
+impl<T> HttpApi<T>
 where
-    Q: QueryExecutor,
     T: TimeProvider,
-    Error: From<<Q as QueryExecutor>::Error>,
 {
     async fn write_lp(&self, req: Request<Body>) -> Result<Response<Body>> {
         let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
@@ -1166,13 +1164,10 @@ struct DeleteTableRequest {
     table: String,
 }
 
-pub(crate) async fn route_request<Q: QueryExecutor, T: TimeProvider>(
-    http_server: Arc<HttpApi<Q, T>>,
+pub(crate) async fn route_request<T: TimeProvider>(
+    http_server: Arc<HttpApi<T>>,
     mut req: Request<Body>,
-) -> Result<Response<Body>, Infallible>
-where
-    Error: From<<Q as QueryExecutor>::Error>,
-{
+) -> Result<Response<Body>, Infallible> {
     if let Err(e) = http_server.authorize_request(&mut req).await {
         match e {
             AuthorizationError::Unauthorized => {

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -29,17 +29,13 @@ use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, TIME_COLUMN_NAME};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::QueryExecutor;
-
 use super::{Error, HttpApi, Result};
 
 const DEFAULT_CHUNK_SIZE: usize = 10_000;
 
-impl<Q, T> HttpApi<Q, T>
+impl<T> HttpApi<T>
 where
-    Q: QueryExecutor,
     T: TimeProvider,
-    Error: From<<Q as QueryExecutor>::Error>,
 {
     /// Implements the v1 query API for InfluxDB
     ///


### PR DESCRIPTION
- This commit moves `QueryExecutorImpl` behind a `dyn` (trait object) as we have other impls in core for `QueryExecutor` and this will keep both pro and OSS traits in sync

The other commit fixes the errors picked up by audit job, below is the summary

- address https://rustsec.org/advisories/RUSTSEC-2024-0399.html by running `cargo update --precise 0.23.18 --package rustls@0.23.14`
- address yanked version of `url` crate (2.5.3) by running `cargo update -p url`


(No issue)

