### PR TITLE
feat: Modify optimized compaction to cover edge cases

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -84,7 +84,15 @@ const (
 
 	// MaxTSMFileSize is the maximum size of TSM files.
 	MaxTSMFileSize = uint32(2048 * 1024 * 1024) // 2GB
+
 )
+
+// SingleGenerationReason outputs a log message for our single generation compaction
+// when checked for full compaction.
+// 1048576000 is a magic number for bytes per gigabyte.
+func SingleGenerationReason() string {
+	return fmt.Sprintf("not fully compacted and not idle because single generation with many files under %d GB and many files under aggressive compaction points per block count (%d points)", int(MaxTSMFileSize/1048576000), AggressiveMaxPointsPerBlock)
+}
 
 // Config holds the configuration for the tsbd package.
 type Config struct {

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -52,6 +52,10 @@ const (
 	// block in a TSM file
 	DefaultMaxPointsPerBlock = 1000
 
+	// AggressiveMaxPointsPerBlock is used when we want to further compact blocks
+	// it is 100 times the default amount of points we use per block
+	AggressiveMaxPointsPerBlock = 100000
+
 	// DefaultMaxSeriesPerDatabase is the maximum number of series a node can hold per database.
 	// This limit only applies to the "inmem" index.
 	DefaultMaxSeriesPerDatabase = 1000000

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -84,8 +84,9 @@ const (
 
 	// MaxTSMFileSize is the maximum size of TSM files.
 	MaxTSMFileSize = uint32(2048 * 1024 * 1024) // 2GB
-
 )
+
+var SingleGenerationReasonText string = SingleGenerationReason()
 
 // SingleGenerationReason outputs a log message for our single generation compaction
 // when checked for full compaction.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -54,7 +54,7 @@ const (
 
 	// AggressiveMaxPointsPerBlock is used when we want to further compact blocks
 	// it is 100 times the default amount of points we use per block
-	AggressiveMaxPointsPerBlock = 100000
+	AggressiveMaxPointsPerBlock = DefaultMaxPointsPerBlock * 100
 
 	// DefaultMaxSeriesPerDatabase is the maximum number of series a node can hold per database.
 	// This limit only applies to the "inmem" index.
@@ -81,6 +81,9 @@ const (
 	// partition snapshot compactions that can run at one time.
 	// A value of 0 results in runtime.GOMAXPROCS(0).
 	DefaultSeriesFileMaxConcurrentSnapshotCompactions = 0
+
+	// MaxTSMFileSize is the maximum size of TSM files.
+	MaxTSMFileSize = uint32(2048 * 1024 * 1024) // 2GB
 )
 
 // Config holds the configuration for the tsbd package.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -92,7 +92,7 @@ var SingleGenerationReasonText string = SingleGenerationReason()
 // when checked for full compaction.
 // 1048576000 is a magic number for bytes per gigabyte.
 func SingleGenerationReason() string {
-	return fmt.Sprintf("not fully compacted and not idle because single generation with more then 2 files under %d GB and more then 1 file(s) under aggressive compaction points per block count (%d points)", int(MaxTSMFileSize/1048576000), AggressiveMaxPointsPerBlock)
+	return fmt.Sprintf("not fully compacted and not idle because single generation with more than 2 files under %d GB and more than 1 file(s) under aggressive compaction points per block count (%d points)", int(MaxTSMFileSize/1048576000), AggressiveMaxPointsPerBlock)
 }
 
 // Config holds the configuration for the tsbd package.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -92,7 +92,7 @@ var SingleGenerationReasonText string = SingleGenerationReason()
 // when checked for full compaction.
 // 1048576000 is a magic number for bytes per gigabyte.
 func SingleGenerationReason() string {
-	return fmt.Sprintf("not fully compacted and not idle because single generation with many files under %d GB and many files under aggressive compaction points per block count (%d points)", int(MaxTSMFileSize/1048576000), AggressiveMaxPointsPerBlock)
+	return fmt.Sprintf("not fully compacted and not idle because single generation with more then 2 files under %d GB and more then 1 file(s) under aggressive compaction points per block count (%d points)", int(MaxTSMFileSize/1048576000), AggressiveMaxPointsPerBlock)
 }
 
 // Config holds the configuration for the tsbd package.

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -470,11 +470,8 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 		for i, group := range generations {
 			var skip bool
 
-			gs := group.size()
-			bc := c.FileStore.BlockCount(group.files[0].Path, 1)
-			gl := len(generations)
 			// Skip the file if it's over the max size and contains a full block and it does not have any tombstones
-			if gl > 2 && gs >= uint64(maxTSMFileSize) && bc == tsdb.DefaultMaxPointsPerBlock && !group.hasTombstones() {
+			if len(generations) > 2 && group.size() > uint64(maxTSMFileSize) && c.FileStore.BlockCount(group.files[0].Path, 1) == tsdb.DefaultMaxPointsPerBlock && !group.hasTombstones() {
 				skip = true
 			}
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -397,7 +397,7 @@ func (c *DefaultPlanner) PlanOptimize() (compactGroup []CompactionGroup, compact
 			}
 		}
 
-		if len(currentGen) == 0 || currentGen.level() == cur.level() {
+		if len(currentGen) == 0 || currentGen.level() >= cur.level() {
 			currentGen = append(currentGen, cur)
 			continue
 		}

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -248,7 +248,7 @@ func (c *DefaultPlanner) FullyCompacted() (bool, string) {
 			}
 
 			if filesUnderMaxTsmSizeCount > 1 && aggressivePointsPerBlockCount < len(gens[0].files) {
-				return false, tsdb.SingleGenerationReason()
+				return false, tsdb.SingleGenerationReasonText
 			}
 		}
 		return true, ""

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -469,7 +469,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 			var skip bool
 
 			// Skip the file if it's over the max size and contains a full block and it does not have any tombstones
-			if len(generations) > 2 && group.size() > uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(group.files[0].Path, 1) == tsdb.DefaultMaxPointsPerBlock && !group.hasTombstones() {
+			if len(generations) > 2 && group.size() > uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(group.files[0].Path, 1) >= tsdb.DefaultMaxPointsPerBlock && !group.hasTombstones() {
 				skip = true
 			}
 
@@ -545,7 +545,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 		// Skip the file if it's over the max size and contains a full block or the generation is split
 		// over multiple files.  In the latter case, that would mean the data in the file spilled over
 		// the 2GB limit.
-		if g.size() > uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(g.files[0].Path, 1) == tsdb.DefaultMaxPointsPerBlock {
+		if g.size() > uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(g.files[0].Path, 1) >= tsdb.DefaultMaxPointsPerBlock {
 			start = i + 1
 		}
 
@@ -589,7 +589,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 			}
 
 			// Skip the file if it's over the max size and it contains a full block
-			if gen.size() >= uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(gen.files[0].Path, 1) == tsdb.DefaultMaxPointsPerBlock && !gen.hasTombstones() {
+			if gen.size() >= uint64(tsdb.MaxTSMFileSize) && c.FileStore.BlockCount(gen.files[0].Path, 1) >= tsdb.DefaultMaxPointsPerBlock && !gen.hasTombstones() {
 				startIndex++
 				continue
 			}

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -225,9 +225,6 @@ func (c *DefaultPlanner) ParseFileName(path string) (int, int, error) {
 // FullyCompacted returns true if the shard is fully compacted.
 func (c *DefaultPlanner) FullyCompacted() (bool, string) {
 	gens := c.findGenerations(false)
-	// 1048576000 is a magic number for bytes per gigabyte
-	singleGenReason := fmt.Sprintf("not fully compacted and not idle because single generation with many files under %d GB and many files under aggressive compaction points per block count (%d points)", int(tsdb.MaxTSMFileSize/1048576000), tsdb.AggressiveMaxPointsPerBlock)
-
 	if len(gens) > 1 {
 		return false, "not fully compacted and not idle because of more than one generation"
 	} else if gens.hasTombstones() {
@@ -251,7 +248,7 @@ func (c *DefaultPlanner) FullyCompacted() (bool, string) {
 			}
 
 			if filesUnderMaxTsmSizeCount > 1 && aggressivePointsPerBlockCount < len(gens[0].files) {
-				return false, singleGenReason
+				return false, tsdb.SingleGenerationReason()
 			}
 		}
 		return true, ""

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -241,7 +241,7 @@ func (c *DefaultPlanner) FullyCompacted() (bool, string) {
 			aggressivePointsPerBlockCount := 0
 			filesUnderMaxTsmSizeCount := 0
 			for _, tsmFile := range gens[0].files {
-				if c.FileStore.BlockCount(tsmFile.Path, 0) == tsdb.AggressiveMaxPointsPerBlock {
+				if c.FileStore.BlockCount(tsmFile.Path, 1) == tsdb.AggressiveMaxPointsPerBlock {
 					aggressivePointsPerBlockCount++
 				}
 				if tsmFile.Size < maxTSMFileSize {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2411,7 +2411,7 @@ func TestDefaultPlanner_PlanOptimize_SmallSingleGenerationUnderLevel4(t *testing
 		expFiles = append(expFiles, file)
 	}
 	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-	require.Equal(t, int64(0), len(tsmP), "compaction group; Plan()")
+	require.Equal(t, 0, len(tsmP), "compaction group; Plan()")
 	require.Equal(t, int64(0), pLenP, "compaction group length; Plan()")
 
 	tsm, pLen, gLen := cp.PlanOptimize()

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2645,6 +2645,12 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 
 			// Reverse test files and re-run tests
 			slices.Reverse(test.fs)
+			if len(test.bc) > 0 {
+				slices.Reverse(test.bc)
+				err := ffs.SetBlockCounts(test.bc)
+				require.NoError(t, err, "setting reverse block counts")
+			}
+
 			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
 			expectedNotFullyCompacted(cp, test.expectedFullyCompactedReasonExp, test.expectedgenerationCount)
 		})
@@ -2771,6 +2777,12 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 
 			// Reverse test files and re-run tests
 			slices.Reverse(test.fs)
+			if len(test.bc) > 0 {
+				slices.Reverse(test.bc)
+				err := ffs.SetBlockCounts(test.bc)
+				require.NoError(t, err, "setting reverse block counts")
+			}
+
 			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
 			expectedFullyCompacted(cp, test.expectedFullyCompactedReasonExp)
 		})

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2500,8 +2500,7 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	_, cgLen = cp.Plan(time.Now().Add(-1))
 	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
 
-	cgroup, cgLen, genLen := cp.PlanOptimize()
-	require.Equal(t, len(data), len(cgroup), "compaction group")
+	_, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, int64(1), cgLen, "compaction group length")
 	require.Equal(t, int64(1), genLen, "generation count")
 }

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2212,65 +2212,6 @@ func TestDefaultPlanner_PlanOptimize_NoLevel4(t *testing.T) {
 	}
 }
 
-func TestDefaultPlanner_PlanOptimize_Level4(t *testing.T) {
-	data := []tsm1.FileStat{
-		{
-			Path: "01-04.tsm1",
-			Size: 251 * 1024 * 1024,
-		},
-		{
-			Path: "02-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "03-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "04-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "05-03.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "06-04.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "07-03.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-	}
-
-	cp := tsm1.NewDefaultPlanner(
-		&fakeFileStore{
-			PathsFn: func() []tsm1.FileStat {
-				return data
-			},
-		}, tsdb.DefaultCompactFullWriteColdDuration,
-	)
-
-	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4], data[5]}
-	tsm, pLen, _ := cp.PlanOptimize()
-	if exp, got := 1, len(tsm); exp != got {
-		t.Fatalf("group length mismatch: got %v, exp %v", got, exp)
-	} else if pLen != int64(len(tsm)) {
-		t.Fatalf("tsm file plan length mismatch: got %v, exp %v", pLen, exp)
-	}
-
-	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, p := range expFiles1 {
-		if got, exp := tsm[0][i], p.Path; got != exp {
-			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
-		}
-	}
-}
-
 // This test is added to acount for many TSM files within a group being over 2 GB
 // we want to ensure that the shard will be planned.
 func TestDefaultPlanner_PlanOptimize_LargeMultiGeneration(t *testing.T) {
@@ -2881,11 +2822,11 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGen2GBLastLevel2(t *testing.T) 
 			Size: 1048 * 1024 * 1024,
 		},
 		{
-			Path: "03-02.tsm1",
+			Path: "03-03.tsm1",
 			Size: 2048 * 1024 * 1024,
 		},
 		{
-			Path: "03-03.tsm1",
+			Path: "03-04.tsm1",
 			Size: 2048 * 1024 * 1024,
 		},
 		{
@@ -2893,7 +2834,7 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGen2GBLastLevel2(t *testing.T) 
 			Size: 600 * 1024 * 1024,
 		},
 		{
-			Path: "03-05.tsm1",
+			Path: "03-06.tsm1",
 			Size: 500 * 1024 * 1024,
 		},
 	}
@@ -2925,89 +2866,6 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGen2GBLastLevel2(t *testing.T) 
 	require.Equal(t, int64(1), cgLen, "compaction group length")
 	require.Equal(t, int64(3), genLen, "generation count")
 	require.Equal(t, len(expFiles), len(tsm[0]), "tsm files in compaction group")
-}
-
-func TestDefaultPlanner_PlanOptimize_Multiple(t *testing.T) {
-	data := []tsm1.FileStat{
-		{
-			Path: "01-04.tsm1",
-			Size: 251 * 1024 * 1024,
-		},
-		{
-			Path: "02-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "03-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "04-04.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		{
-			Path: "05-03.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "06-03.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "07-04.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "08-04.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "09-04.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		{
-			Path: "10-04.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-	}
-
-	cp := tsm1.NewDefaultPlanner(
-		&fakeFileStore{
-			PathsFn: func() []tsm1.FileStat {
-				return data
-			},
-		}, tsdb.DefaultCompactFullWriteColdDuration,
-	)
-
-	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	expFiles2 := []tsm1.FileStat{data[6], data[7], data[8], data[9]}
-
-	tsm, pLen, _ := cp.PlanOptimize()
-	if exp, got := 2, len(tsm); exp != got {
-		t.Fatalf("group length mismatch: got %v, exp %v", got, exp)
-	} else if pLen != int64(len(tsm)) {
-		t.Fatalf("tsm file plan length mismatch: got %v, exp %v", pLen, exp)
-	}
-
-	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, p := range expFiles1 {
-		if got, exp := tsm[0][i], p.Path; got != exp {
-			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
-		}
-	}
-
-	if exp, got := len(expFiles2), len(tsm[1]); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, p := range expFiles2 {
-		if got, exp := tsm[1][i], p.Path; got != exp {
-			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
-		}
-	}
 }
 
 func TestDefaultPlanner_PlanOptimize_Tombstones(t *testing.T) {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2501,9 +2501,9 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
-	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-	require.Equal(t, int64(0), cgLen, "compaction group length")
-	require.Equal(t, int64(0), genLen, "generation count")
+	require.Equal(t, len(data), cgroup, "compaction group")
+	require.Equal(t, int64(4), cgLen, "compaction group length")
+	require.Equal(t, int64(1), genLen, "generation count")
 }
 
 // This test is added to account for halting state after
@@ -2621,10 +2621,9 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlock
 	_, cgLen = cp.Plan(time.Now().Add(-1))
 	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
 
-	cgroup, cgLen, genLen := cp.PlanOptimize()
-	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-	require.Equal(t, int64(0), cgLen, "compaction group length")
-	require.Equal(t, int64(0), genLen, "generation count")
+	_, cgLen, genLen := cp.PlanOptimize()
+	require.Equal(t, int64(8), cgLen, "compaction group length")
+	require.Equal(t, int64(1), genLen, "generation count")
 }
 
 // This test is added to account for a single generation that has a group size

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2411,8 +2411,8 @@ func TestDefaultPlanner_PlanOptimize_SmallSingleGenerationUnderLevel4(t *testing
 		expFiles = append(expFiles, file)
 	}
 	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-	require.Equal(t, 0, len(tsmP), "compaction group; Plan()")
-	require.Equal(t, 0, pLenP, "compaction group length; Plan()")
+	require.Equal(t, int64(0), len(tsmP), "compaction group; Plan()")
+	require.Equal(t, int64(0), pLenP, "compaction group length; Plan()")
 
 	tsm, pLen, gLen := cp.PlanOptimize()
 	require.Equal(t, 1, len(tsm), "compaction group")

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2822,11 +2822,8 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGenLessThen2GBNotMaxAggrBlocks(
 
 	cp := tsm1.NewDefaultPlanner(fs, tsdb.DefaultCompactFullWriteColdDuration)
 
-	// 1048576000 is a magic number for bytes per gigabyte
-	reasonExp := fmt.Sprintf("not fully compacted and not idle because single generation with many files under %d GB and many files under aggressive compaction points per block count (%d points)", int(tsdb.MaxTSMFileSize/1048576000), tsdb.AggressiveMaxPointsPerBlock)
-
 	compacted, reason := cp.FullyCompacted()
-	require.Equal(t, reason, reasonExp, "fullyCompacted reason")
+	require.Equal(t, reason, tsdb.SingleGenerationReasonText, "fullyCompacted reason")
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2419,8 +2419,8 @@ func TestDefaultPlanner_PlanOptimize_SmallSingleGenerationUnderLevel4(t *testing
 }
 
 // This test is added to account for a single generation that has a group size
-// under 2 GB so it should be further compacted to a single file.
-// FullyCompacted should NOT skip over opening this shard.
+// under 2 GB and all files at max default points per block of 1000.
+// This should be planned for compaction at a more aggressive points per block.
 func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	// ~650 MB total group size
 	data := []tsm1.FileStat{
@@ -2486,8 +2486,8 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration_Halt(t *testing.T) 
 }
 
 // This test is added to account for a single generation that has a group size
-// under 2 GB so it should be further compacted to a single file.
-// FullyCompacted should NOT skip over opening this shard.
+// under 2 GB and a mix of aggressive max blocks and default max blocks
+// it should be further compacted.
 func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlocks(t *testing.T) {
 	// > 2 GB total group size
 	// 50% of files are at aggressive max block size
@@ -2554,6 +2554,7 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlock
 
 // This test is added to account for a single generation that has a group size
 // over 2 GB with 1 file under 2 GB all at max points per block with aggressive compaction.
+// It should not compact any further.
 func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationMaxAggressiveBlocks(t *testing.T) {
 	// > 2 GB total group size
 	// 100% of files are at aggressive max block size
@@ -2594,7 +2595,9 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationMaxAggressiveBlocks(
 }
 
 // This test is added to account for a single generation that has a group size
-// over 2 GB with 1 file under 2 GB all at max points per block with aggressive compaction.
+// over 2 GB at max points per block with aggressive compaction, and, 1 file
+// under 2 GB at default max points per block.
+// It should not compact any further.
 func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationNoMaxAggrBlocks(t *testing.T) {
 	// > 2 GB total group size
 	// 100% of files are at aggressive max block size
@@ -2681,7 +2684,8 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGenLessThen2GBMaxAggrBlocks(t *
 }
 
 // This test is added to account for a single generation that has a group size
-// over 2 GB and multiple files under 2 GB all at max points per block for aggressive compaction.
+// over 2 GB and multiple files under 2 GB with multiple files under aggressive
+// max points per block. This should further compact.
 func TestDefaultPlanner_FullyCompacted_ManySingleGenLessThen2GBNotMaxAggrBlocks(t *testing.T) {
 	// > 2 GB total group size
 	// 100% of files are at aggressive max block size

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -3256,7 +3256,7 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 
 	err := ffs.SetBlockCounts([]int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock})
 	require.NoError(t, err, "SetBlockCounts")
-  
+
 	cp := tsm1.NewDefaultPlanner(ffs, time.Nanosecond)
 
 	plan, pLen := cp.Plan(time.Now().Add(-time.Second))
@@ -3441,7 +3441,7 @@ func TestDefaultPlanner_Plan_NotFullOverMaxsize(t *testing.T) {
 		bcs = append(bcs, 100)
 	}
 
-	err := fs.SetBlockCounts(bcs)
+	err := ffs.SetBlockCounts(bcs)
 	require.NoError(t, err, "SetBlockCounts")
 
 	cp := tsm1.NewDefaultPlanner(

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2501,8 +2501,8 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
-	require.Equal(t, len(data), cgroup, "compaction group")
-	require.Equal(t, int64(4), cgLen, "compaction group length")
+	require.Equal(t, len(data), len(cgroup), "compaction group")
+	require.Equal(t, int64(1), cgLen, "compaction group length")
 	require.Equal(t, int64(1), genLen, "generation count")
 }
 
@@ -2622,7 +2622,7 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlock
 	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
 
 	_, cgLen, genLen := cp.PlanOptimize()
-	require.Equal(t, int64(8), cgLen, "compaction group length")
+	require.Equal(t, int64(1), cgLen, "compaction group length")
 	require.Equal(t, int64(1), genLen, "generation count")
 }
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2282,7 +2282,7 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 
 	furtherCompactedTests := []PlanOptimizeTests{
 		// Large multi generation group with files at and under 2GB
-		PlanOptimizeTests{
+		{
 			[]tsm1.FileStat{
 				{
 					Path: "01-05.tsm1",
@@ -2330,7 +2330,7 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			3,
 		},
 		// ~650mb group size
-		PlanOptimizeTests{
+		{
 			[]tsm1.FileStat{
 				{
 					Path: "01-05.tsm1",
@@ -2354,7 +2354,7 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			1,
 		},
 		// ~650 MB total group size with generations under 4
-		PlanOptimizeTests{
+		{
 			[]tsm1.FileStat{
 				{
 					Path: "01-02.tsm1",

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2487,7 +2487,7 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	cp := tsm1.NewDefaultPlanner(fs, tsdb.DefaultCompactFullWriteColdDuration)
 
 	compacted, reason := cp.FullyCompacted()
-	require.Equal(t, reason, tsdb.SingleGenerationReason(), "fullyCompacted reason")
+	require.Equal(t, reason, tsdb.SingleGenerationReasonText, "fullyCompacted reason")
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
@@ -2607,7 +2607,7 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlock
 
 	cp := tsm1.NewDefaultPlanner(fs, tsdb.DefaultCompactFullWriteColdDuration)
 	compacted, reason := cp.FullyCompacted()
-	require.Equal(t, reason, tsdb.SingleGenerationReason(), "fullyCompacted reason")
+	require.Equal(t, reason, tsdb.SingleGenerationReasonText, "fullyCompacted reason")
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2272,15 +2272,15 @@ func TestDefaultPlanner_PlanOptimize_LargeMultiGeneration(t *testing.T) {
 	}
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
 	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-	require.Equal(t, 0, len(tsmP), "compaction group; Plan()")
-	require.Equal(t, int64(0), pLenP, "compaction group length; Plan()")
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	tsm, pLen, _ := cp.PlanOptimize()
 	require.Equal(t, 1, len(tsm), "compaction group")
@@ -2325,15 +2325,15 @@ func TestDefaultPlanner_PlanOptimize_SmallSingleGeneration(t *testing.T) {
 	}
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
 	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-	require.Equal(t, 0, len(tsmP), "compaction group; Plan()")
-	require.Equal(t, int64(0), pLenP, "compaction group length; Plan()")
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	tsm, pLen, gLen := cp.PlanOptimize()
 	require.Equal(t, 1, len(tsm), "compaction group")
@@ -2375,15 +2375,15 @@ func TestDefaultPlanner_PlanOptimize_SmallSingleGenerationUnderLevel4(t *testing
 	}
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
 	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-	require.Equal(t, 0, len(tsmP), "compaction group; Plan()")
-	require.Equal(t, int64(0), pLenP, "compaction group length; Plan()")
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	tsm, pLen, gLen := cp.PlanOptimize()
 	require.Equal(t, 1, len(tsm), "compaction group")
@@ -2432,14 +2432,15 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration(t *testing.T) {
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	_, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, int64(1), cgLen, "compaction group length")
@@ -2472,19 +2473,20 @@ func TestDefaultPlanner_FullyCompacted_SmallSingleGeneration_Halt(t *testing.T) 
 	require.True(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-	require.Equal(t, int64(0), cgLen, "compaction group length")
-	require.Equal(t, int64(0), genLen, "generation count")
+	require.Zero(t, cgLen, "compaction group length")
+	require.Zero(t, genLen, "generation count")
 }
 
 // This test is added to account for a single generation that has a group size
@@ -2552,14 +2554,15 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationUnderAggressiveBlock
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	_, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, int64(1), cgLen, "compaction group length")
@@ -2603,14 +2606,15 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationMaxAggressiveBlocks(
 	require.True(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
@@ -2656,14 +2660,15 @@ func TestDefaultPlanner_FullyCompacted_LargeSingleGenerationNoMaxAggrBlocks(t *t
 	require.True(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
@@ -2712,19 +2717,20 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGenLessThen2GBMaxAggrBlocks(t *
 	require.True(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	cgroup, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-	require.Equal(t, int64(0), cgLen, "compaction group length")
-	require.Equal(t, int64(0), genLen, "generation count")
+	require.Zero(t, cgLen, "compaction group length")
+	require.Zero(t, genLen, "generation count")
 }
 
 // This test is added to account for a single generation that has a group size
@@ -2768,14 +2774,15 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGenLessThen2GBNotMaxAggrBlocks(
 	require.False(t, compacted, "is fully compacted")
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	_, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, int64(1), cgLen, "compaction group length")
@@ -2853,14 +2860,15 @@ func TestDefaultPlanner_FullyCompacted_ManySingleGen2GBLastLevel2(t *testing.T) 
 	}
 
 	_, cgLen := cp.PlanLevel(1)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(1)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
 	_, cgLen = cp.PlanLevel(2)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(2)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
 	_, cgLen = cp.PlanLevel(3)
-	require.Equal(t, int64(0), cgLen, "compaction group length; PlanLevel(3)")
+	require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 
-	_, cgLen = cp.Plan(time.Now().Add(-1))
-	require.Equal(t, int64(0), cgLen, "compaction group length; Plan()")
+	tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
+	require.Zero(t, len(tsmP), "compaction group; Plan()")
+	require.Zero(t, pLenP, "compaction group length; Plan()")
 
 	tsm, cgLen, genLen := cp.PlanOptimize()
 	require.Equal(t, int64(1), cgLen, "compaction group length")

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2174,7 +2174,7 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 						for _, f := range level4Groups[0] {
 							e.logger.Info("TSM optimized compaction on single generation running, increasing total points per block to 100_000.", zap.String("path", f))
 						}
-						e.Compactor.Size = tsdb.DefaultMaxPointsPerBlock * 100
+						e.Compactor.Size = tsdb.AggressiveMaxPointsPerBlock
 					} else {
 						e.Compactor.Size = tsdb.DefaultMaxPointsPerBlock
 					}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2130,8 +2130,9 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, len4)
 
 			// If no full compactions are need, see if an optimize is needed
+			var genLen int64
 			if len(level4Groups) == 0 {
-				level4Groups, len4 = e.CompactionPlan.PlanOptimize()
+				level4Groups, len4, genLen = e.CompactionPlan.PlanOptimize()
 				atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, len4)
 			}
 
@@ -2166,6 +2167,17 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 						level3Groups = level3Groups[1:]
 					}
 				case 4:
+					// This is a heuristic. 100_000 points per block is suitable for when we have a
+					// single generation with multiple files at max block size under 2 GB.
+					if genLen == 1 {
+						// Log TSM files that will have an increased points per block count.
+						for _, f := range level4Groups[0] {
+							e.logger.Info("TSM optimized compaction on single generation running, increasing total points per block to 100_000.", zap.String("path", f))
+						}
+						e.Compactor.Size = tsdb.DefaultMaxPointsPerBlock * 100
+					} else {
+						e.Compactor.Size = tsdb.DefaultMaxPointsPerBlock
+					}
 					if e.compactFull(level4Groups[0], wg) {
 						level4Groups = level4Groups[1:]
 					}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2889,7 +2889,7 @@ type mockPlanner struct{}
 
 func (m *mockPlanner) Plan(lastWrite time.Time) ([]tsm1.CompactionGroup, int64) { return nil, 0 }
 func (m *mockPlanner) PlanLevel(level int) ([]tsm1.CompactionGroup, int64)      { return nil, 0 }
-func (m *mockPlanner) PlanOptimize() ([]tsm1.CompactionGroup, int64)            { return nil, 0 }
+func (m *mockPlanner) PlanOptimize() ([]tsm1.CompactionGroup, int64, int64)     { return nil, 0, 0 }
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)                    {}
 func (m *mockPlanner) FullyCompacted() (bool, string)                           { return false, "not compacted" }
 func (m *mockPlanner) ForceFull()                                               {}


### PR DESCRIPTION
This PR changes the algorithm for compaction to account for the following
cases that were not previously accounted for:

- Many generations with a groupsize over 2 GB
- Single generation with many files and a groupsize under 2 GB

Where groupsize is the total size of the TSM files in said shard directory.