### PR TITLE
feat: CLI to create and delete metadata caches

### DIFF
--- a/influxdb3/src/commands/meta_cache/create.rs
+++ b/influxdb3/src/commands/meta_cache/create.rs
@@ -1,0 +1,86 @@
+use std::{error::Error, num::NonZeroUsize};
+
+use secrecy::ExposeSecret;
+
+use crate::commands::common::{InfluxDb3Config, SeparatedList};
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    #[clap(flatten)]
+    meta_cache_config: MetaCacheConfig,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct MetaCacheConfig {
+    /// The table name for which the cache is being created
+    #[clap(short = 't', long = "table")]
+    table: String,
+
+    /// Give the name of the cache.
+    ///
+    /// This will be automatically generated if not provided
+    #[clap(long = "cache-name")]
+    cache_name: Option<String>,
+
+    /// Which columns in the table to cache distinct values for, as a comma-separated list of the
+    /// column names.
+    ///
+    /// The cache is a hieararchical structure, with a level for each column specified; the order
+    /// specified here will determine the order of the levels from top-to-bottom of the cache
+    /// hierarchy.
+    #[clap(long = "columns")]
+    columns: SeparatedList<String>,
+
+    /// The maximum number of distinct value combinations to hold in the cache
+    #[clap(long = "max-cardinality")]
+    max_cardinality: Option<NonZeroUsize>,
+
+    /// The maximum age of an entry in the cache entered as a human-readable duration, e.g., "30d", "24h"
+    #[clap(long = "max-age")]
+    max_age: Option<humantime::Duration>,
+}
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let InfluxDb3Config {
+        host_url,
+        database_name,
+        auth_token,
+    } = config.influxdb3_config;
+    let MetaCacheConfig {
+        table,
+        cache_name,
+        columns,
+        max_cardinality,
+        max_age,
+    } = config.meta_cache_config;
+
+    let mut client = influxdb3_client::Client::new(host_url)?;
+    if let Some(t) = auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+    let mut b = client.api_v3_configure_meta_cache_create(database_name, table, columns);
+
+    // Add the optional stuff:
+    if let Some(name) = cache_name {
+        b = b.name(name);
+    }
+    if let Some(max_cardinality) = max_cardinality {
+        b = b.max_cardinality(max_cardinality);
+    }
+    if let Some(max_age) = max_age {
+        b = b.max_age(max_age.into());
+    }
+
+    match b.send().await? {
+        Some(def) => println!(
+            "new cache created: {}",
+            serde_json::to_string_pretty(&def).expect("serialize meta cache definition as JSON")
+        ),
+        None => println!("a cache already exists for the provided parameters"),
+    }
+
+    Ok(())
+}

--- a/influxdb3/src/commands/meta_cache/delete.rs
+++ b/influxdb3/src/commands/meta_cache/delete.rs
@@ -1,0 +1,38 @@
+use std::error::Error;
+
+use secrecy::ExposeSecret;
+
+use crate::commands::common::InfluxDb3Config;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// The table under which the cache is being deleted
+    #[clap(short = 't', long = "table")]
+    table: String,
+
+    /// The name of the cache being deleted
+    #[clap(short = 'n', long = "cache-name")]
+    cache_name: String,
+}
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let InfluxDb3Config {
+        host_url,
+        database_name,
+        auth_token,
+    } = config.influxdb3_config;
+    let mut client = influxdb3_client::Client::new(host_url)?;
+    if let Some(t) = auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+    client
+        .api_v3_configure_meta_cache_delete(database_name, config.table, config.cache_name)
+        .await?;
+
+    println!("meta cache deleted successfully");
+
+    Ok(())
+}

--- a/influxdb3/src/commands/meta_cache/mod.rs
+++ b/influxdb3/src/commands/meta_cache/mod.rs
@@ -1,0 +1,26 @@
+use std::error::Error;
+
+pub mod create;
+pub mod delete;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Create a new metadata cache
+    Create(create::Config),
+
+    /// Delete a metadata cache
+    Delete(delete::Config),
+}
+
+pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    match config.command {
+        Command::Create(config) => create::command(config).await,
+        Command::Delete(config) => delete::command(config).await,
+    }
+}

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -28,6 +28,7 @@ mod commands {
     pub(crate) mod common;
     pub mod last_cache;
     pub mod manage;
+    pub mod meta_cache;
     pub mod query;
     pub mod serve;
     pub mod token;
@@ -93,6 +94,9 @@ enum Command {
     /// Manage last-n-value caches
     LastCache(commands::last_cache::Config),
 
+    /// Manage metadata caches
+    MetaCache(commands::meta_cache::Config),
+
     /// Manage database (delete only for the moment)
     Database(commands::manage::database::ManageDatabaseConfig),
 
@@ -152,6 +156,12 @@ fn main() -> Result<(), std::io::Error> {
             Some(Command::LastCache(config)) => {
                 if let Err(e) = commands::last_cache::command(config).await {
                     eprintln!("Last Cache command failed: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::MetaCache(config)) => {
+                if let Err(e) = commands::meta_cache::command(config).await {
+                    eprintln!("Metadata Cache command faild: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }


### PR DESCRIPTION
This follows #25593.

This adds two new CLI commands to the `influxdb3` binary:
* `influxdb3 meta-cache create`
* `influxdb3 meta-cache delete`

To create and delete metadata caches, respectively.

A basic integration test was added to check that this works E2E.

The `influxdb3_client` was updated with methods to create and delete metadata caches, and which is what the CLI commands use under the hood.

Closes #25548