### PR TITLE
fix: plan queries on DF threadpool to not block IO in REST API

### DIFF
--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod builder;
 mod grpc;
 mod http;
 pub mod query_executor;
+mod query_planner;
 mod service;
 mod system_tables;
 
@@ -152,11 +153,21 @@ pub trait QueryExecutor: QueryDatabase + Debug + Send + Sync + 'static {
     fn upcast(&self) -> Arc<(dyn QueryDatabase + 'static)>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum QueryKind {
     Sql,
     InfluxQl,
 }
+
+impl QueryKind {
+    pub(crate) fn query_type(&self) -> &'static str {
+        match self {
+            Self::Sql => "sql",
+            Self::InfluxQl => "influxql",
+        }
+    }
+}
+
 impl<T> Server<T> {
     pub fn authorizer(&self) -> Arc<dyn Authorizer> {
         Arc::clone(&self.authorizer)

--- a/influxdb3_server/src/query_planner.rs
+++ b/influxdb3_server/src/query_planner.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use datafusion::{error::DataFusionError, physical_plan::ExecutionPlan};
+use iox_query::{exec::IOxSessionContext, frontend::sql::SqlQueryPlanner};
+use iox_query_influxql::frontend::planner::InfluxQLQueryPlanner;
+use iox_query_params::StatementParams;
+
+type Result<T, E = DataFusionError> = std::result::Result<T, E>;
+
+/// A query planner for creating physical query plans for SQL/InfluxQL queries made through the REST
+/// API using a separate threadpool.
+///
+/// This is based on the similar implementation for the planner in the flight service [here][ref].
+///
+/// [ref]: https://github.com/influxdata/influxdb3_core/blob/6fcbb004232738d55655f32f4ad2385523d10696/service_grpc_flight/src/planner.rs#L24-L33
+pub(crate) struct Planner {
+    ctx: IOxSessionContext,
+}
+
+impl Planner {
+    /// Create a new `Planner`
+    pub(crate) fn new(ctx: &IOxSessionContext) -> Self {
+        Self {
+            ctx: ctx.child_ctx("rest_api_query_planner"),
+        }
+    }
+
+    /// Plan a SQL query and return a DataFusion physical plan
+    pub(crate) async fn sql(
+        &self,
+        query: impl AsRef<str> + Send,
+        params: StatementParams,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let planner = SqlQueryPlanner::new();
+        let query = query.as_ref();
+        let ctx = self.ctx.child_ctx("rest_api_query_planner_sql");
+
+        planner.query(query, params, &ctx).await
+    }
+
+    /// Plan an InfluxQL query and return a DataFusion physical plan
+    pub(crate) async fn influxql(
+        &self,
+        query: impl AsRef<str> + Send,
+        params: impl Into<StatementParams> + Send,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let query = query.as_ref();
+        let ctx = self.ctx.child_ctx("rest_api_query_planner_influxql");
+
+        InfluxQLQueryPlanner::query(query, params, &ctx).await
+    }
+}


### PR DESCRIPTION
Related to #25562

This follows changes that were made in `influxdb_iox` to improve the handling of concurrent queries (see https://github.com/influxdata/influxdb_iox/pull/11029). Those can be seen in action in `influxdb3_core` in the flight service here: https://github.com/influxdata/influxdb3_core/blob/6fcbb004232738d55655f32f4ad2385523d10696/service_grpc_flight/src/lib.rs#L664-L679

Though we use that flight service for servicing gRPC requests, our code for handling queries made via the REST API was still performing query planning on the IO thread pool.

Query planning is CPU intensive, so can throttle the amount of requests that can be handled concurrently. This offloads the planning to the DataFusion thread pool in the REST API.

A `Planner` type was added as a central point for handling the two types of queries that we receive: `SQL` and `InfluxQL`.

## Note

I don't have a great way to test this in this PR, but the need for this change seemed obvious enough from the above linked IOx PR. If the perf team still sees poor results after this then we can revisit, and perhaps come up with some benchmarks.