### PR TITLE
chore: upgrade to rust 1.83.0

### DIFF
--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -467,7 +467,7 @@ pub struct WriteRequestBuilder<'c, B> {
     body: B,
 }
 
-impl<'c, B> WriteRequestBuilder<'c, B> {
+impl<B> WriteRequestBuilder<'_, B> {
     /// Set the precision
     pub fn precision(mut self, set_to: Precision) -> Self {
         self.precision = Some(set_to);

--- a/influxdb3_write/src/last_cache/mod.rs
+++ b/influxdb3_write/src/last_cache/mod.rs
@@ -1037,7 +1037,7 @@ struct ExtendedLastCacheState<'a> {
     key_column_values: Vec<&'a KeyValue>,
 }
 
-impl<'a> ExtendedLastCacheState<'a> {
+impl ExtendedLastCacheState<'_> {
     /// Produce a set of [`RecordBatch`]es from this extended state
     ///
     /// This converts any additional columns to arrow arrays which will extend the [`RecordBatch`]es

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
No issue for this. This updates the Rust toolchain to the latest 1.83.0 release
