### PR TITLE
Fixes #25611: Remove unused v3 write API and associated function

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -429,12 +429,6 @@ where
         self.write_lp_inner(params, req, false, false).await
     }
 
-    async fn write_v3(&self, req: Request<Body>) -> Result<Response<Body>> {
-        let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
-        let params: WriteParams = serde_urlencoded::from_str(query)?;
-        self.write_lp_inner(params, req, false, true).await
-    }
-
     async fn write_lp_inner(
         &self,
         params: WriteParams,
@@ -1374,7 +1368,6 @@ pub(crate) async fn route_request<T: TimeProvider>(
 
             http_server.write_lp_inner(params, req, false, false).await
         }
-        (Method::POST, "/api/v3/write") => http_server.write_v3(req).await,
         (Method::POST, "/api/v3/write_lp") => http_server.write_lp(req).await,
         (Method::GET | Method::POST, "/api/v3/query_sql") => http_server.query_sql(req).await,
         (Method::GET | Method::POST, "/api/v3/query_influxql") => {


### PR DESCRIPTION
# Closes #25611 

## Proposed changes:
This pull request removes the unused v3 write API and its associated function, as discussed in #25611 . Since the v3 write API currently offers no significant advantage and isn't aligned with the immediate goals of the project, we are removing it ahead of the first public release to avoid committing to this API prematurely.

### Changes made
1. Removed the entry point for the v3 write API:
   ```rust
   (Method::POST, "/api/v3/write") => http_server.write_v3(req).await,
2. Deleted the write_v3 function located in influxdb/influxdb3_server/src/http.rs:
   ```rust
    async fn write_v3(&self, req: Request<Body>) -> Result<Response<Body>> { 
         let query = req.uri().query().ok_or(Error::MissingWriteParams)?; 
         let params: WriteParams = serde_urlencoded::from_str(query)?; 
         self.write_lp_inner(params, req, false, true).await 
    } 
3. Updated and/or removed associated tests to align with these changes.

✅  I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
✅  Signed [CLA](https://influxdata.com/community/cla/).