### PR TITLE
test: metadata cache query using JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "influxdb3_wal",
  "influxdb3_write",
  "influxdb_iox_client",
+ "insta",
  "iox_query",
  "iox_time",
  "libc",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -86,6 +86,7 @@ arrow-flight.workspace = true
 assert_cmd.workspace = true
 futures.workspace = true
 hyper.workspace = true
+insta.workspace = true
 pretty_assertions.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1308,4 +1308,18 @@ async fn api_v3_query_sql_meta_cache() {
         ",
         resp
     );
+
+    // do the query using JSON format:
+    let resp = server
+        .api_v3_query_sql(&[
+            ("db", "foo"),
+            ("format", "json"),
+            ("q", "SELECT * FROM meta_cache('cpu')"),
+        ])
+        .await
+        .json::<Value>()
+        .await
+        .unwrap();
+
+    insta::assert_json_snapshot!(resp);
 }

--- a/influxdb3/tests/server/snapshots/server__query__api_v3_query_sql_meta_cache.snap
+++ b/influxdb3/tests/server/snapshots/server__query__api_v3_query_sql_meta_cache.snap
@@ -1,0 +1,18 @@
+---
+source: influxdb3/tests/server/query.rs
+expression: resp
+---
+[
+  {
+    "host": "c",
+    "region": "ca"
+  },
+  {
+    "host": "b",
+    "region": "eu"
+  },
+  {
+    "host": "a",
+    "region": "us"
+  }
+]


### PR DESCRIPTION
No issue for this here, but this is related to an issue for performance testing the metadata cache in Pro (https://github.com/influxdata/influxdb_pro/issues/218). This just checks that queries to the metadata cache, which uses Arrow's `Utf8View` type, can be written as JSON in API responses.
