### PR TITLE
refactor: remove query concurrency limit

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -517,7 +517,6 @@ pub async fn command(config: Config) -> Result<()> {
         exec: Arc::clone(&exec),
         metrics: Arc::clone(&metrics),
         datafusion_config: Arc::new(config.datafusion_config),
-        concurrent_query_limit: 10,
         query_log_size: config.query_log_size,
         telemetry_store: Arc::clone(&telemetry_store),
         sys_events_store: Arc::clone(&sys_events_store),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -830,7 +830,6 @@ mod tests {
             exec: Arc::clone(&exec),
             metrics: Arc::clone(&metrics),
             datafusion_config: Default::default(),
-            concurrent_query_limit: 10,
             query_log_size: 10,
             telemetry_store: Arc::clone(&sample_telem_store),
             sys_events_store: Arc::clone(&sys_events_store),


### PR DESCRIPTION
Part of #25627 

This removes the query concurrency limit (which was previously hard-coded to `10`) by setting the query semaphore limit in the `QueryExecutorImpl` to [`tokio::sync::Semaphore::MAX_PERMITS`](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html#associatedconstant.MAX_PERMITS).

This does not close the related issue, as the concurrency should probably have _at least_ a configurable limit.