### PR TITLE
feat: track parquet cache metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "influxdb3_write",
  "insta",
  "iox_time",
+ "metric",
  "object_store",
  "observability_deps",
  "parking_lot",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -393,6 +393,7 @@ pub async fn command(config: Config) -> Result<()> {
         let (object_store, parquet_cache) = create_cached_obj_store_and_oracle(
             object_store,
             Arc::clone(&time_provider) as _,
+            Arc::clone(&metrics),
             config.parquet_mem_cache_size.as_num_bytes(),
             config.parquet_mem_cache_prune_percentage.into(),
             config.parquet_mem_cache_prune_interval.into(),

--- a/influxdb3_cache/Cargo.toml
+++ b/influxdb3_cache/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 # Core Crates
 iox_time.workspace = true
+metric.workspace = true
 observability_deps.workspace = true
 schema.workspace = true
 

--- a/influxdb3_cache/src/parquet_cache/metrics.rs
+++ b/influxdb3_cache/src/parquet_cache/metrics.rs
@@ -7,7 +7,7 @@ pub(super) struct AccessMetrics {
     cache_misses_while_fetching: U64Counter,
 }
 
-const CACHE_ACCESS_NAME: &str = "parquet_cache_access";
+pub(super) const CACHE_ACCESS_NAME: &str = "influxdb3_parquet_cache_access";
 
 impl AccessMetrics {
     pub(super) fn new(metric_registry: &Registry) -> Self {
@@ -44,8 +44,8 @@ pub(super) struct SizeMetrics {
     cache_size_n_files: U64Gauge,
 }
 
-const CACHE_SIZE_MB_NAME: &str = "parquet_cache_size_bytes";
-const CACHE_SIZE_N_FILES_NAME: &str = "parquet_cache_size_number_of_files";
+pub(super) const CACHE_SIZE_MB_NAME: &str = "influxdb3_parquet_cache_size_bytes";
+pub(super) const CACHE_SIZE_N_FILES_NAME: &str = "influxdb3_parquet_cache_size_number_of_files";
 
 impl SizeMetrics {
     pub(super) fn new(metric_registry: &Registry) -> Self {

--- a/influxdb3_cache/src/parquet_cache/metrics.rs
+++ b/influxdb3_cache/src/parquet_cache/metrics.rs
@@ -1,0 +1,79 @@
+use metric::{Registry, U64Counter, U64Gauge};
+
+#[derive(Debug)]
+pub(super) struct AccessMetrics {
+    cache_hits: U64Counter,
+    cache_misses: U64Counter,
+    cache_misses_while_fetching: U64Counter,
+}
+
+const CACHE_ACCESS_NAME: &str = "parquet_cache_access";
+
+impl AccessMetrics {
+    pub(super) fn new(metric_registry: &Registry) -> Self {
+        let m_access = metric_registry.register_metric::<U64Counter>(
+            CACHE_ACCESS_NAME,
+            "track accesses to the in-memory parquet cache",
+        );
+        let cache_hits = m_access.recorder(&[("status", "cached")]);
+        let cache_misses = m_access.recorder(&[("status", "miss")]);
+        let cache_misses_while_fetching = m_access.recorder(&[("status", "miss_while_fetching")]);
+        Self {
+            cache_hits,
+            cache_misses,
+            cache_misses_while_fetching,
+        }
+    }
+
+    pub(super) fn record_cache_hit(&self) {
+        self.cache_hits.inc(1);
+    }
+
+    pub(super) fn record_cache_miss(&self) {
+        self.cache_misses.inc(1);
+    }
+
+    pub(super) fn record_cache_miss_while_fetching(&self) {
+        self.cache_misses_while_fetching.inc(1);
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SizeMetrics {
+    cache_size_bytes: U64Gauge,
+    cache_size_n_files: U64Gauge,
+}
+
+const CACHE_SIZE_MB_NAME: &str = "parquet_cache_size_bytes";
+const CACHE_SIZE_N_FILES_NAME: &str = "parquet_cache_size_number_of_files";
+
+impl SizeMetrics {
+    pub(super) fn new(metric_registry: &Registry) -> Self {
+        let cache_size_bytes = metric_registry
+            .register_metric::<U64Gauge>(
+                CACHE_SIZE_MB_NAME,
+                "track size of in-memory parquet cache",
+            )
+            .recorder(&[]);
+        let cache_size_n_files = metric_registry
+            .register_metric::<U64Gauge>(
+                CACHE_SIZE_N_FILES_NAME,
+                "track number of files in the in-memory parquet cache",
+            )
+            .recorder(&[]);
+        Self {
+            cache_size_bytes,
+            cache_size_n_files,
+        }
+    }
+
+    pub(super) fn record_file_addition(&self, size_bytes: u64) {
+        self.cache_size_bytes.inc(size_bytes);
+        self.cache_size_n_files.inc(1);
+    }
+
+    pub(super) fn record_file_deletions(&self, total_size_bytes: u64, n_files: u64) {
+        self.cache_size_bytes.dec(total_size_bytes);
+        self.cache_size_n_files.dec(n_files);
+    }
+}

--- a/influxdb3_cache/src/parquet_cache/metrics.rs
+++ b/influxdb3_cache/src/parquet_cache/metrics.rs
@@ -44,14 +44,14 @@ pub(super) struct SizeMetrics {
     cache_size_n_files: U64Gauge,
 }
 
-pub(super) const CACHE_SIZE_MB_NAME: &str = "influxdb3_parquet_cache_size_bytes";
+pub(super) const CACHE_SIZE_BYTES_NAME: &str = "influxdb3_parquet_cache_size_bytes";
 pub(super) const CACHE_SIZE_N_FILES_NAME: &str = "influxdb3_parquet_cache_size_number_of_files";
 
 impl SizeMetrics {
     pub(super) fn new(metric_registry: &Registry) -> Self {
         let cache_size_bytes = metric_registry
             .register_metric::<U64Gauge>(
-                CACHE_SIZE_MB_NAME,
+                CACHE_SIZE_BYTES_NAME,
                 "track size of in-memory parquet cache",
             )
             .recorder(&[]);
@@ -67,9 +67,9 @@ impl SizeMetrics {
         }
     }
 
-    pub(super) fn record_file_addition(&self, size_bytes: u64) {
+    pub(super) fn record_file_additions(&self, size_bytes: u64, n_files: u64) {
         self.cache_size_bytes.inc(size_bytes);
-        self.cache_size_n_files.inc(1);
+        self.cache_size_n_files.inc(n_files);
     }
 
     pub(super) fn record_file_deletions(&self, total_size_bytes: u64, n_files: u64) {

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -768,8 +768,11 @@ mod tests {
         let metrics = Arc::new(metric::Registry::new());
         let object_store: Arc<DynObjectStore> = Arc::new(object_store::memory::InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(start_time)));
-        let (object_store, parquet_cache) =
-            test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider) as _);
+        let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(
+            object_store,
+            Arc::clone(&time_provider) as _,
+            Default::default(),
+        );
         let parquet_store =
             ParquetStorage::new(Arc::clone(&object_store), StorageId::from("influxdb3"));
         let exec = Arc::new(Executor::new_with_config_and_executor(

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -672,8 +672,11 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
-        let (object_store, parquet_cache) =
-            test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider) as _);
+        let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(
+            object_store,
+            Arc::clone(&time_provider) as _,
+            Default::default(),
+        );
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let exec = make_exec(Arc::clone(&object_store));
         let host_id = Arc::from("sample-host-id");

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -750,8 +750,11 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let time_provider: Arc<dyn TimeProvider> =
             Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
-        let (object_store, parquet_cache) =
-            test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider));
+        let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(
+            object_store,
+            Arc::clone(&time_provider),
+            Default::default(),
+        );
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
         let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog) as _).unwrap();
@@ -2183,8 +2186,11 @@ mod tests {
     ) -> (WriteBufferImpl, IOxSessionContext, Arc<dyn TimeProvider>) {
         let time_provider: Arc<dyn TimeProvider> = Arc::new(MockProvider::new(start));
         let (object_store, parquet_cache) = if use_cache {
-            let (object_store, parquet_cache) =
-                test_cached_obj_store_and_oracle(object_store, Arc::clone(&time_provider));
+            let (object_store, parquet_cache) = test_cached_obj_store_and_oracle(
+                object_store,
+                Arc::clone(&time_provider),
+                Default::default(),
+            );
             (object_store, Some(parquet_cache))
         } else {
             (object_store, None)


### PR DESCRIPTION
Closes #25427

Adds metrics to track the following in the in-memory parquet cache:

* cache size in bytes (also included a fix in the calculation of that)
* cache size in n files
* cache hits
* cache misses
* cache misses while the oracle is fetching a file

A test was added to check this functionality
