### PR TITLE
feat: Significantly decrease startup times for WAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitcode"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1bce7608560cd4bf0296a4262d0dbf13e6bcec5ff2105724c8ab88cc7fc784"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a539389a13af092cd345a2b47ae7dec12deb306d660b2223d25cd3419b253ebe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +998,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -2458,6 +2488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glam"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3376,7 @@ name = "influxdb3_wal"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bitcode",
  "byteorder",
  "bytes",
  "crc32fast",
@@ -3355,7 +3392,6 @@ dependencies = [
  "parking_lot",
  "schema",
  "serde",
- "serde_json",
  "serde_with",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ inherits = "release"
 codegen-units = 16
 lto = false
 incremental = true
+debug = 1
 
 # This profile extends the `quick-release` profile with debuginfo turned on in order to
 # produce more human friendly symbols for profiling tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ async-trait = "0.1"
 backtrace = "0.3"
 base64 = "0.22.0"
 bimap = "0.6.3"
+bitcode = { version = "0.6.3", features = ["serde"] }
 byteorder = "1.3.4"
 bytes = "1.9"
 chrono = "0.4"
@@ -182,7 +183,6 @@ inherits = "release"
 codegen-units = 16
 lto = false
 incremental = true
-debug = 1
 
 # This profile extends the `quick-release` profile with debuginfo turned on in order to
 # produce more human friendly symbols for profiling tools

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -40,6 +40,7 @@ use std::{collections::HashMap, path::Path, str::FromStr};
 use std::{num::NonZeroUsize, sync::Arc};
 use thiserror::Error;
 use tokio::net::TcpListener;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use trace_exporters::TracingConfig;
 use trace_http::ctx::TraceHeaderParser;
@@ -359,6 +360,7 @@ fn ensure_directory_exists(p: &Path) {
 }
 
 pub async fn command(config: Config) -> Result<()> {
+    let startup_timer = Instant::now();
     let num_cpus = num_cpus::get();
     let build_malloc_conf = build_malloc_conf();
     info!(
@@ -542,7 +544,7 @@ pub async fn command(config: Config) -> Result<()> {
     } else {
         builder.build()
     };
-    serve(server, frontend_shutdown).await?;
+    serve(server, frontend_shutdown, startup_timer).await?;
 
     Ok(())
 }

--- a/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
+++ b/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
@@ -1,6 +1,7 @@
 ---
 source: influxdb3_cache/src/last_cache/mod.rs
 expression: caches
+snapshot_kind: text
 ---
 [
   {
@@ -11,9 +12,7 @@ expression: caches
       0,
       1
     ],
-    "value_columns": {
-      "type": "all_non_key_columns"
-    },
+    "value_columns": "all_non_key_columns",
     "count": 1,
     "ttl": 600
   },
@@ -25,11 +24,12 @@ expression: caches
       6
     ],
     "value_columns": {
-      "type": "explicit",
-      "columns": [
-        8,
-        7
-      ]
+      "explicit": {
+        "columns": [
+          8,
+          7
+        ]
+      }
     },
     "count": 5,
     "ttl": 60
@@ -40,11 +40,12 @@ expression: caches
     "name": "test_cache_3",
     "key_columns": [],
     "value_columns": {
-      "type": "explicit",
-      "columns": [
-        9,
-        7
-      ]
+      "explicit": {
+        "columns": [
+          9,
+          7
+        ]
+      }
     },
     "count": 10,
     "ttl": 500

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -845,7 +845,7 @@ pub struct LastCacheCreatedResponse {
 /// A last cache will either store values for an explicit set of columns, or will accept all
 /// non-key columns
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum LastCacheValueColumnsDef {
     /// Explicit list of column names
     Explicit { columns: Vec<u32> },
@@ -1220,8 +1220,9 @@ mod tests {
                     "name": "cache_name",
                     "key_columns": [0, 1],
                     "value_columns": {
-                        "type": "explicit",
-                        "columns": [2, 3]
+                        "explicit": {
+                            "columns": [2, 3]
+                        }
                     },
                     "ttl": 120,
                     "count": 5

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -773,6 +773,7 @@ mod tests {
     }
 
     async fn setup_server(start_time: i64) -> (String, CancellationToken, Arc<dyn WriteBuffer>) {
+        let server_start_time = tokio::time::Instant::now();
         let trace_header_parser = trace_http::ctx::TraceHeaderParser::new();
         let metrics = Arc::new(metric::Registry::new());
         let object_store: Arc<DynObjectStore> = Arc::new(object_store::memory::InMemory::new());
@@ -865,7 +866,7 @@ mod tests {
         let frontend_shutdown = CancellationToken::new();
         let shutdown = frontend_shutdown.clone();
 
-        tokio::spawn(async move { serve(server, frontend_shutdown).await });
+        tokio::spawn(async move { serve(server, frontend_shutdown, server_start_time).await });
 
         (format!("http://{addr}"), shutdown, write_buffer)
     }

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -18,6 +18,7 @@ influxdb3_id = { path = "../influxdb3_id" }
 
 # crates.io dependencies
 async-trait.workspace = true
+bitcode.workspace = true
 bytes.workspace = true
 byteorder.workspace = true
 crc32fast.workspace  = true
@@ -27,7 +28,6 @@ indexmap.workspace = true
 object_store.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -40,6 +40,9 @@ pub enum Error {
     #[error("deserialize error: {0}")]
     Serialize(#[from] crate::serialize::Error),
 
+    #[error("join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+
     #[error("object store error: {0}")]
     ObjectStoreError(#[from] ::object_store::Error),
 
@@ -426,7 +429,7 @@ impl LastCacheDefinition {
 /// A last cache will either store values for an explicit set of columns, or will accept all
 /// non-key columns
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum LastCacheValueColumnsDef {
     /// Explicit list of column names
     Explicit { columns: Vec<ColumnId> },

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -513,11 +513,10 @@ impl BufferState {
                 let sort_key = table_def
                     .series_key
                     .iter()
-                    .map(|c| table_def.column_id_to_name_unchecked(c).to_string())
-                    .collect::<Vec<_>>();
+                    .map(|c| Arc::clone(&table_def.column_id_to_name_unchecked(c)));
                 let index_columns = table_def.index_column_ids();
 
-                TableBuffer::new(index_columns, SortKey::from(sort_key))
+                TableBuffer::new(index_columns, SortKey::from_columns(sort_key))
             });
             for (chunk_time, chunk) in table_chunks.chunk_time_to_chunk {
                 table_buffer.buffer_chunk(chunk_time, chunk.rows);


### PR DESCRIPTION
feat: add startup time to logging output 

This change adds a startup time counter to the output when starting up
a server. The main purpose of this is to verify whether the impact of
changes actually speeds up the loading of the server.

feat: Significantly decrease startup times for WAL 

This commit does a few important things to speedup startup times:
1. We avoid changing an Arc<str> to a String with the series key as the
   From<String> impl will call with_column which will then turn it into
   an Arc<str> again. Instead we can just call `with_column` directly
   and pass in the iterator without also collecting into a Vec<String>
2. We switch to using bitcode as the serialization format for the WAL.
   This significantly reduces startup time as this format is faster to
   use instead of JSON, which was eating up massive amounts of time.
   Part of this change involves not using the tag feature of serde as
   it's currently not supported by bincode
3. We also parallelize reading and deserializing the WAL files before
   we then apply them in order. This reduces time waiting on IO and we
   eagerly evaluate each spawned task in order as much as possible.

This gives us about a 189% speedup over what we were doing before.

Closes https://github.com/influxdata/influxdb/issues/25534