### PR TITLE
chore: porting the changes from pro

### DIFF
--- a/influxdb3_sys_events/benches/store_benchmark.rs
+++ b/influxdb3_sys_events/benches/store_benchmark.rs
@@ -12,7 +12,7 @@ use iox_time::{SystemProvider, TimeProvider};
 use observability_deps::tracing::debug;
 use rand::Rng;
 
-const MAX_WRITE_ITERATIONS: u32 = 5000;
+const MAX_WRITE_ITERATIONS: u32 = 100_000;
 
 #[allow(dead_code)]
 #[derive(Debug)]


### PR DESCRIPTION
move ringbuffer to be allocated on heap as the MAX_CAPACITY per event type has gone up to 10k

(no issue)