### PR TITLE
fix: Change references of Edge into OSS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ exclude = [
 
 [workspace.package]
 version = "0.1.0"
-authors = ["influxdata Edge Developers"]
+authors = ["InfluxData OSS Developers"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -1,4 +1,4 @@
-//! Entrypoint for InfluxDB 3.0 Edge Server
+//! Entrypoint for InfluxDB 3.0 OSS Server
 
 use anyhow::{bail, Context};
 use clap_blocks::{
@@ -363,7 +363,7 @@ pub async fn command(config: Config) -> Result<()> {
         uuid = %PROCESS_UUID.as_ref() as &str,
         num_cpus,
         %build_malloc_conf,
-        "InfluxDB3 Edge server starting",
+        "InfluxDB3 OSS server starting",
     );
 
     let metrics = setup_metric_registry();

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -51,21 +51,21 @@ clap::Arg::new("help")
 .action(clap::ArgAction::Help)
 .global(true)
 ),
-about = "InfluxDB 3.0 Edge server and command line tools",
-long_about = r#"InfluxDB 3.0 Edge server and command line tools
+about = "InfluxDB 3.0 OSS server and command line tools",
+long_about = r#"InfluxDB 3.0 OSS server and command line tools
 
 Examples:
-    # Run the InfluxDB 3.0 Edge server
-    influxdb3 serve
+    # Run the InfluxDB 3.0 OSS server
+    influxdb3 serve --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
 
     # Display all commands
     influxdb3 --help
 
-    # Run the InfluxDB 3.0 Edge server in all-in-one mode with extra verbose logging
-    influxdb3 serve -v
+    # Run the InfluxDB 3.0 OSS server with extra verbose logging
+    influxdb3 serve -v --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
 
-    # Run InfluxDB 3.0 Edge with full debug logging specified with LOG_FILTER
-    LOG_FILTER=debug influxdb3 serve
+    # Run InfluxDB 3.0 OSS with full debug logging specified with LOG_FILTER
+    LOG_FILTER=debug influxdb3 serve --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
 "#
 )]
 struct Config {

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -155,11 +155,11 @@ impl Serialize for Catalog {
 }
 
 impl Catalog {
-    /// Limit for the number of Databases that InfluxDB Edge can have
+    /// Limit for the number of Databases that InfluxDB 3.0 OSS can have
     pub(crate) const NUM_DBS_LIMIT: usize = 5;
-    /// Limit for the number of columns per table that InfluxDB Edge can have
+    /// Limit for the number of columns per table that InfluxDB 3.0 OSS can have
     pub(crate) const NUM_COLUMNS_PER_TABLE_LIMIT: usize = 500;
-    /// Limit for the number of tables across all DBs that InfluxDB Edge can have
+    /// Limit for the number of tables across all DBs that InfluxDB 3.0 OSS can have
     pub(crate) const NUM_TABLES_LIMIT: usize = 2000;
 
     pub fn new(host_id: Arc<str>, instance_id: Arc<str>) -> Self {

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -1,4 +1,4 @@
-//! InfluxDB 3.0 Edge server implementation
+//! InfluxDB 3.0 OSS server implementation
 //!
 //! The server is responsible for handling the HTTP API
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -436,7 +436,7 @@ impl QueryNamespace for Database {
         query_params: StatementParams,
     ) -> QueryCompletedToken<StateReceived> {
         let trace_id = span_ctx.map(|ctx| ctx.trace_id);
-        let namespace_name: Arc<str> = Arc::from("influxdb3 edge");
+        let namespace_name: Arc<str> = Arc::from("influxdb3 oss");
         self.query_log.push(
             NamespaceId::new(0),
             namespace_name,


### PR DESCRIPTION
This changes the code to reference InfluxDB 3 OSS rather than Edge which had been it's original name when we first started the project. With this we now have the code reflect what we are actually calling it. On top of this the long help text has been changed to give advice about how to actually run the code now with the bare minimum set of flags needed now as `influxdb serve` is no longer a viable command on it's own.

Closes #25649