### PR TITLE
feat: Added fluxQueryRespBytes metric to 1.x /debug/vars

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -411,30 +411,31 @@ func (h *Handler) Close() {
 
 // Statistics maintains statistics for the httpd service.
 type Statistics struct {
-	Requests                     int64
-	CQRequests                   int64
-	QueryRequests                int64
-	WriteRequests                int64
-	PingRequests                 int64
-	StatusRequests               int64
-	WriteRequestBytesReceived    int64
-	QueryRequestBytesTransmitted int64
-	PointsWrittenOK              int64
-	PointsWrittenDropped         int64
-	PointsWrittenFail            int64
-	AuthenticationFailures       int64
-	RequestDuration              int64
-	QueryRequestDuration         int64
-	WriteRequestDuration         int64
-	ActiveRequests               int64
-	ActiveWriteRequests          int64
-	ClientErrors                 int64
-	ServerErrors                 int64
-	RecoveredPanics              int64
-	PromWriteRequests            int64
-	PromReadRequests             int64
-	FluxQueryRequests            int64
-	FluxQueryRequestDuration     int64
+	Requests                         int64
+	CQRequests                       int64
+	QueryRequests                    int64
+	WriteRequests                    int64
+	PingRequests                     int64
+	StatusRequests                   int64
+	WriteRequestBytesReceived        int64
+	QueryRequestBytesTransmitted     int64
+	PointsWrittenOK                  int64
+	PointsWrittenDropped             int64
+	PointsWrittenFail                int64
+	AuthenticationFailures           int64
+	RequestDuration                  int64
+	QueryRequestDuration             int64
+	WriteRequestDuration             int64
+	ActiveRequests                   int64
+	ActiveWriteRequests              int64
+	ClientErrors                     int64
+	ServerErrors                     int64
+	RecoveredPanics                  int64
+	PromWriteRequests                int64
+	PromReadRequests                 int64
+	FluxQueryRequests                int64
+	FluxQueryRequestDuration         int64
+	FluxQueryRequestBytesTransmitted int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -443,29 +444,30 @@ func (h *Handler) Statistics(tags map[string]string) []models.Statistic {
 		Name: "httpd",
 		Tags: tags,
 		Values: map[string]interface{}{
-			statRequest:                      atomic.LoadInt64(&h.stats.Requests),
-			statQueryRequest:                 atomic.LoadInt64(&h.stats.QueryRequests),
-			statWriteRequest:                 atomic.LoadInt64(&h.stats.WriteRequests),
-			statPingRequest:                  atomic.LoadInt64(&h.stats.PingRequests),
-			statStatusRequest:                atomic.LoadInt64(&h.stats.StatusRequests),
-			statWriteRequestBytesReceived:    atomic.LoadInt64(&h.stats.WriteRequestBytesReceived),
-			statQueryRequestBytesTransmitted: atomic.LoadInt64(&h.stats.QueryRequestBytesTransmitted),
-			statPointsWrittenOK:              atomic.LoadInt64(&h.stats.PointsWrittenOK),
-			statPointsWrittenDropped:         atomic.LoadInt64(&h.stats.PointsWrittenDropped),
-			statPointsWrittenFail:            atomic.LoadInt64(&h.stats.PointsWrittenFail),
-			statAuthFail:                     atomic.LoadInt64(&h.stats.AuthenticationFailures),
-			statRequestDuration:              atomic.LoadInt64(&h.stats.RequestDuration),
-			statQueryRequestDuration:         atomic.LoadInt64(&h.stats.QueryRequestDuration),
-			statWriteRequestDuration:         atomic.LoadInt64(&h.stats.WriteRequestDuration),
-			statRequestsActive:               atomic.LoadInt64(&h.stats.ActiveRequests),
-			statWriteRequestsActive:          atomic.LoadInt64(&h.stats.ActiveWriteRequests),
-			statClientError:                  atomic.LoadInt64(&h.stats.ClientErrors),
-			statServerError:                  atomic.LoadInt64(&h.stats.ServerErrors),
-			statRecoveredPanics:              atomic.LoadInt64(&h.stats.RecoveredPanics),
-			statPromWriteRequest:             atomic.LoadInt64(&h.stats.PromWriteRequests),
-			statPromReadRequest:              atomic.LoadInt64(&h.stats.PromReadRequests),
-			statFluxQueryRequests:            atomic.LoadInt64(&h.stats.FluxQueryRequests),
-			statFluxQueryRequestDuration:     atomic.LoadInt64(&h.stats.FluxQueryRequestDuration),
+			statRequest:                          atomic.LoadInt64(&h.stats.Requests),
+			statQueryRequest:                     atomic.LoadInt64(&h.stats.QueryRequests),
+			statWriteRequest:                     atomic.LoadInt64(&h.stats.WriteRequests),
+			statPingRequest:                      atomic.LoadInt64(&h.stats.PingRequests),
+			statStatusRequest:                    atomic.LoadInt64(&h.stats.StatusRequests),
+			statWriteRequestBytesReceived:        atomic.LoadInt64(&h.stats.WriteRequestBytesReceived),
+			statQueryRequestBytesTransmitted:     atomic.LoadInt64(&h.stats.QueryRequestBytesTransmitted),
+			statPointsWrittenOK:                  atomic.LoadInt64(&h.stats.PointsWrittenOK),
+			statPointsWrittenDropped:             atomic.LoadInt64(&h.stats.PointsWrittenDropped),
+			statPointsWrittenFail:                atomic.LoadInt64(&h.stats.PointsWrittenFail),
+			statAuthFail:                         atomic.LoadInt64(&h.stats.AuthenticationFailures),
+			statRequestDuration:                  atomic.LoadInt64(&h.stats.RequestDuration),
+			statQueryRequestDuration:             atomic.LoadInt64(&h.stats.QueryRequestDuration),
+			statWriteRequestDuration:             atomic.LoadInt64(&h.stats.WriteRequestDuration),
+			statRequestsActive:                   atomic.LoadInt64(&h.stats.ActiveRequests),
+			statWriteRequestsActive:              atomic.LoadInt64(&h.stats.ActiveWriteRequests),
+			statClientError:                      atomic.LoadInt64(&h.stats.ClientErrors),
+			statServerError:                      atomic.LoadInt64(&h.stats.ServerErrors),
+			statRecoveredPanics:                  atomic.LoadInt64(&h.stats.RecoveredPanics),
+			statPromWriteRequest:                 atomic.LoadInt64(&h.stats.PromWriteRequests),
+			statPromReadRequest:                  atomic.LoadInt64(&h.stats.PromReadRequests),
+			statFluxQueryRequests:                atomic.LoadInt64(&h.stats.FluxQueryRequests),
+			statFluxQueryRequestDuration:         atomic.LoadInt64(&h.stats.FluxQueryRequestDuration),
+			statFluxQueryRequestBytesTransmitted: atomic.LoadInt64(&h.stats.FluxQueryRequestBytesTransmitted),
 		},
 	}}
 }
@@ -2161,6 +2163,8 @@ func (h *Handler) serveFluxQuery(w http.ResponseWriter, r *http.Request, user me
 			if n == 0 {
 				// If the encoder did not write anything, we can write an error header.
 				h.httpError(w, err.Error(), http.StatusInternalServerError)
+			} else {
+				atomic.AddInt64(&h.stats.FluxQueryRequestBytesTransmitted, int64(n))
 			}
 		}
 	}

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -20,30 +20,31 @@ import (
 
 // statistics gathered by the httpd package.
 const (
-	statRequest                      = "req"                    // Number of HTTP requests served.
-	statQueryRequest                 = "queryReq"               // Number of query requests served.
-	statWriteRequest                 = "writeReq"               // Number of write requests serverd.
-	statPingRequest                  = "pingReq"                // Number of ping requests served.
-	statStatusRequest                = "statusReq"              // Number of status requests served.
-	statWriteRequestBytesReceived    = "writeReqBytes"          // Sum of all bytes in write requests.
-	statQueryRequestBytesTransmitted = "queryRespBytes"         // Sum of all bytes returned in query reponses.
-	statPointsWrittenOK              = "pointsWrittenOK"        // Number of points written OK.
-	statValuesWrittenOK              = "valuesWrittenOK"        // Number of values (fields) written OK.
-	statPointsWrittenDropped         = "pointsWrittenDropped"   // Number of points dropped by the storage engine.
-	statPointsWrittenFail            = "pointsWrittenFail"      // Number of points that failed to be written.
-	statAuthFail                     = "authFail"               // Number of authentication failures.
-	statRequestDuration              = "reqDurationNs"          // Number of (wall-time) nanoseconds spent inside requests.
-	statQueryRequestDuration         = "queryReqDurationNs"     // Number of (wall-time) nanoseconds spent inside query requests.
-	statWriteRequestDuration         = "writeReqDurationNs"     // Number of (wall-time) nanoseconds spent inside write requests.
-	statRequestsActive               = "reqActive"              // Number of currently active requests.
-	statWriteRequestsActive          = "writeReqActive"         // Number of currently active write requests.
-	statClientError                  = "clientError"            // Number of HTTP responses due to client error.
-	statServerError                  = "serverError"            // Number of HTTP responses due to server error.
-	statRecoveredPanics              = "recoveredPanics"        // Number of panics recovered by HTTP handler.
-	statPromWriteRequest             = "promWriteReq"           // Number of write requests to the prometheus endpoint.
-	statPromReadRequest              = "promReadReq"            // Number of read requests to the prometheus endpoint.
-	statFluxQueryRequests            = "fluxQueryReq"           // Number of flux query requests served.
-	statFluxQueryRequestDuration     = "fluxQueryReqDurationNs" // Number of (wall-time) nanoseconds spent executing Flux query requests.
+	statRequest                          = "req"                    // Number of HTTP requests served.
+	statQueryRequest                     = "queryReq"               // Number of query requests served.
+	statWriteRequest                     = "writeReq"               // Number of write requests serverd.
+	statPingRequest                      = "pingReq"                // Number of ping requests served.
+	statStatusRequest                    = "statusReq"              // Number of status requests served.
+	statWriteRequestBytesReceived        = "writeReqBytes"          // Sum of all bytes in write requests.
+	statQueryRequestBytesTransmitted     = "queryRespBytes"         // Sum of all bytes returned in query reponses.
+	statPointsWrittenOK                  = "pointsWrittenOK"        // Number of points written OK.
+	statValuesWrittenOK                  = "valuesWrittenOK"        // Number of values (fields) written OK.
+	statPointsWrittenDropped             = "pointsWrittenDropped"   // Number of points dropped by the storage engine.
+	statPointsWrittenFail                = "pointsWrittenFail"      // Number of points that failed to be written.
+	statAuthFail                         = "authFail"               // Number of authentication failures.
+	statRequestDuration                  = "reqDurationNs"          // Number of (wall-time) nanoseconds spent inside requests.
+	statQueryRequestDuration             = "queryReqDurationNs"     // Number of (wall-time) nanoseconds spent inside query requests.
+	statWriteRequestDuration             = "writeReqDurationNs"     // Number of (wall-time) nanoseconds spent inside write requests.
+	statRequestsActive                   = "reqActive"              // Number of currently active requests.
+	statWriteRequestsActive              = "writeReqActive"         // Number of currently active write requests.
+	statClientError                      = "clientError"            // Number of HTTP responses due to client error.
+	statServerError                      = "serverError"            // Number of HTTP responses due to server error.
+	statRecoveredPanics                  = "recoveredPanics"        // Number of panics recovered by HTTP handler.
+	statPromWriteRequest                 = "promWriteReq"           // Number of write requests to the prometheus endpoint.
+	statPromReadRequest                  = "promReadReq"            // Number of read requests to the prometheus endpoint.
+	statFluxQueryRequests                = "fluxQueryReq"           // Number of flux query requests served.
+	statFluxQueryRequestDuration         = "fluxQueryReqDurationNs" // Number of (wall-time) nanoseconds spent executing Flux query requests.
+	statFluxQueryRequestBytesTransmitted = "fluxQueryRespBytes"     // Sum of all bytes returned in Flux query reponses.
 
 )
 


### PR DESCRIPTION
Closes #25671 

This PR adds an additional statistic "fluxQueryRespBytes" to the output of /debug/vars, in turn making it available to Telegraf and other monitoring tools.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).