### PR TITLE
feat(processing_engine): Runtime and Write-back improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,8 +3267,10 @@ dependencies = [
 name = "influxdb3_py_api"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "influxdb3_catalog",
  "influxdb3_wal",
+ "parking_lot",
  "pyo3",
  "schema",
 ]
@@ -3471,6 +3473,7 @@ dependencies = [
  "parquet",
  "parquet_file",
  "pretty_assertions",
+ "pyo3",
  "schema",
  "serde",
  "serde_json",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -475,20 +475,18 @@ pub async fn command(config: Config) -> Result<()> {
     )
     .map_err(Error::InitializeMetaCache)?;
 
-    let write_buffer_impl = Arc::new(
-        WriteBufferImpl::new(WriteBufferImplArgs {
-            persister: Arc::clone(&persister),
-            catalog: Arc::clone(&catalog),
-            last_cache,
-            meta_cache,
-            time_provider: Arc::<SystemProvider>::clone(&time_provider),
-            executor: Arc::clone(&exec),
-            wal_config,
-            parquet_cache,
-        })
-        .await
-        .map_err(|e| Error::WriteBufferInit(e.into()))?,
-    );
+    let write_buffer_impl = WriteBufferImpl::new(WriteBufferImplArgs {
+        persister: Arc::clone(&persister),
+        catalog: Arc::clone(&catalog),
+        last_cache,
+        meta_cache,
+        time_provider: Arc::<SystemProvider>::clone(&time_provider),
+        executor: Arc::clone(&exec),
+        wal_config,
+        parquet_cache,
+    })
+    .await
+    .map_err(|e| Error::WriteBufferInit(e.into()))?;
 
     let telemetry_store = setup_telemetry_store(
         &config.object_store_config,

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -9,7 +9,7 @@ use influxdb3_id::DbId;
 use influxdb3_id::SerdeVecMap;
 use influxdb3_id::TableId;
 use influxdb3_wal::{
-    LastCacheDefinition, LastCacheValueColumnsDef, PluginDefinition, TriggerDefinition,
+    LastCacheDefinition, LastCacheValueColumnsDef, PluginDefinition, PluginType, TriggerDefinition,
 };
 use schema::InfluxColumnType;
 use schema::InfluxFieldType;
@@ -163,7 +163,7 @@ struct ProcessingEnginePluginSnapshot {
     pub plugin_name: String,
     pub code: String,
     pub function_name: String,
-    pub plugin_type: String,
+    pub plugin_type: PluginType,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -411,7 +411,7 @@ impl From<&PluginDefinition> for ProcessingEnginePluginSnapshot {
             plugin_name: plugin.plugin_name.to_string(),
             code: plugin.code.to_string(),
             function_name: plugin.function_name.to_string(),
-            plugin_type: serde_json::to_string(&plugin.plugin_type).unwrap(),
+            plugin_type: plugin.plugin_type,
         }
     }
 }
@@ -419,10 +419,10 @@ impl From<&PluginDefinition> for ProcessingEnginePluginSnapshot {
 impl From<ProcessingEnginePluginSnapshot> for PluginDefinition {
     fn from(plugin: ProcessingEnginePluginSnapshot) -> Self {
         Self {
-            plugin_name: plugin.plugin_type.to_string(),
+            plugin_name: plugin.plugin_name.to_string(),
             code: plugin.code.to_string(),
             function_name: plugin.function_name.to_string(),
-            plugin_type: serde_json::from_str(&plugin.plugin_type).expect("serialized plugin type"),
+            plugin_type: plugin.plugin_type,
         }
     }
 }

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -11,7 +11,9 @@ system-py = ["pyo3"]
 [dependencies]
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_catalog = {path = "../influxdb3_catalog"}
-schema = { workspace = true }
+async-trait.workspace = true
+schema.workspace = true
+parking_lot.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -984,9 +984,16 @@ where
         self.write_buffer
             .insert_trigger(
                 db.as_str(),
-                trigger_name,
+                trigger_name.clone(),
                 plugin_name,
                 trigger_specification,
+            )
+            .await?;
+        self.write_buffer
+            .run_trigger(
+                Arc::clone(&self.write_buffer),
+                db.as_str(),
+                trigger_name.as_str(),
             )
             .await?;
         Ok(Response::builder()

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -801,26 +801,24 @@ mod tests {
         let sample_host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let catalog = Arc::new(Catalog::new(sample_host_id, instance_id));
-        let write_buffer_impl = Arc::new(
-            influxdb3_write::write_buffer::WriteBufferImpl::new(
-                influxdb3_write::write_buffer::WriteBufferImplArgs {
-                    persister: Arc::clone(&persister),
-                    catalog: Arc::clone(&catalog),
-                    last_cache: LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap(),
-                    meta_cache: MetaCacheProvider::new_from_catalog(
-                        Arc::clone(&time_provider) as _,
-                        Arc::clone(&catalog),
-                    )
-                    .unwrap(),
-                    time_provider: Arc::clone(&time_provider) as _,
-                    executor: Arc::clone(&exec),
-                    wal_config: WalConfig::test_config(),
-                    parquet_cache: Some(parquet_cache),
-                },
-            )
-            .await
-            .unwrap(),
-        );
+        let write_buffer_impl = influxdb3_write::write_buffer::WriteBufferImpl::new(
+            influxdb3_write::write_buffer::WriteBufferImplArgs {
+                persister: Arc::clone(&persister),
+                catalog: Arc::clone(&catalog),
+                last_cache: LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap(),
+                meta_cache: MetaCacheProvider::new_from_catalog(
+                    Arc::clone(&time_provider) as _,
+                    Arc::clone(&catalog),
+                )
+                .unwrap(),
+                time_provider: Arc::clone(&time_provider) as _,
+                executor: Arc::clone(&exec),
+                wal_config: WalConfig::test_config(),
+                parquet_cache: Some(parquet_cache),
+            },
+        )
+        .await
+        .unwrap();
 
         let sys_events_store = Arc::new(SysEventStore::new(Arc::<MockProvider>::clone(
             &time_provider,

--- a/influxdb3_server/src/query_executor.rs
+++ b/influxdb3_server/src/query_executor.rs
@@ -682,29 +682,27 @@ mod tests {
         let host_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let catalog = Arc::new(Catalog::new(host_id, instance_id));
-        let write_buffer_impl = Arc::new(
-            WriteBufferImpl::new(WriteBufferImplArgs {
-                persister,
-                catalog: Arc::clone(&catalog),
-                last_cache: LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap(),
-                meta_cache: MetaCacheProvider::new_from_catalog(
-                    Arc::<MockProvider>::clone(&time_provider),
-                    Arc::clone(&catalog),
-                )
-                .unwrap(),
-                time_provider: Arc::<MockProvider>::clone(&time_provider),
-                executor: Arc::clone(&exec),
-                wal_config: WalConfig {
-                    gen1_duration: Gen1Duration::new_1m(),
-                    max_write_buffer_size: 100,
-                    flush_interval: Duration::from_millis(10),
-                    snapshot_size: 1,
-                },
-                parquet_cache: Some(parquet_cache),
-            })
-            .await
+        let write_buffer_impl = WriteBufferImpl::new(WriteBufferImplArgs {
+            persister,
+            catalog: Arc::clone(&catalog),
+            last_cache: LastCacheProvider::new_from_catalog(Arc::clone(&catalog)).unwrap(),
+            meta_cache: MetaCacheProvider::new_from_catalog(
+                Arc::<MockProvider>::clone(&time_provider),
+                Arc::clone(&catalog),
+            )
             .unwrap(),
-        );
+            time_provider: Arc::<MockProvider>::clone(&time_provider),
+            executor: Arc::clone(&exec),
+            wal_config: WalConfig {
+                gen1_duration: Gen1Duration::new_1m(),
+                max_write_buffer_size: 100,
+                flush_interval: Duration::from_millis(10),
+                snapshot_size: 1,
+            },
+            parquet_cache: Some(parquet_cache),
+        })
+        .await
+        .unwrap();
 
         let persisted_files: Arc<PersistedFiles> = Arc::clone(&write_buffer_impl.persisted_files());
         let telemetry_store = TelemetryStore::new_without_background_runners(persisted_files);

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -554,7 +554,7 @@ pub struct TriggerDefinition {
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum TriggerSpecificationDefinition {
     SingleTableWalWrite { table_name: String },
     AllTablesWalWrite,

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-"system-py" = ["influxdb3_py_api/system-py"]
+"system-py" = ["influxdb3_py_api/system-py", "pyo3"]
 
 [dependencies]
 # Core Crates
@@ -59,6 +59,12 @@ thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
 uuid.workspace = true
+
+[dependencies.pyo3]
+version = "0.23.3"
+# this is necessary to automatically initialize the Python interpreter
+features = ["auto-initialize"]
+optional = true
 
 [dev-dependencies]
 # Core Crates

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -24,8 +24,8 @@ use influxdb3_id::ParquetFileId;
 use influxdb3_id::SerdeVecMap;
 use influxdb3_id::TableId;
 use influxdb3_id::{ColumnId, DbId};
+use influxdb3_wal::MetaCacheDefinition;
 use influxdb3_wal::{LastCacheDefinition, SnapshotSequenceNumber, WalFileSequenceNumber};
-use influxdb3_wal::{MetaCacheDefinition, PluginType, TriggerSpecificationDefinition};
 use iox_query::QueryChunk;
 use iox_time::Time;
 use serde::{Deserialize, Serialize};
@@ -33,6 +33,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
+use write_buffer::plugins::ProcessingEngineManager;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -168,30 +169,6 @@ pub trait LastCacheManager: Debug + Send + Sync + 'static {
         db_id: DbId,
         tbl_id: TableId,
         cache_name: &str,
-    ) -> Result<(), write_buffer::Error>;
-}
-
-/// `[ProcessingEngineManager]` is used to interact with the processing engine,
-/// in particular plugins and triggers.
-///
-#[async_trait::async_trait]
-pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
-    /// Inserts a plugin
-    async fn insert_plugin(
-        &self,
-        db: &str,
-        plugin_name: String,
-        code: String,
-        function_name: String,
-        plugin_type: PluginType,
-    ) -> Result<(), write_buffer::Error>;
-
-    async fn insert_trigger(
-        &self,
-        db_name: &str,
-        trigger_name: String,
-        plugin_name: String,
-        trigger_specification: TriggerSpecificationDefinition,
     ) -> Result<(), write_buffer::Error>;
 }
 

--- a/influxdb3_write/src/write_buffer/plugins.rs
+++ b/influxdb3_write/src/write_buffer/plugins.rs
@@ -1,0 +1,190 @@
+use crate::write_buffer::PluginEvent;
+use crate::{write_buffer, WriteBuffer};
+use influxdb3_wal::{PluginType, TriggerDefinition, TriggerSpecificationDefinition};
+use observability_deps::tracing::warn;
+use std::fmt::Debug;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::broadcast::error::RecvError;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("couldn't find db")]
+    MissingDb,
+
+    #[cfg(feature = "system-py")]
+    #[error(transparent)]
+    PyError(#[from] pyo3::PyErr),
+
+    #[error(transparent)]
+    WriteBufferError(#[from] write_buffer::Error),
+}
+
+/// `[ProcessingEngineManager]` is used to interact with the processing engine,
+/// in particular plugins and triggers.
+///
+#[async_trait::async_trait]
+pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
+    /// Inserts a plugin
+    async fn insert_plugin(
+        &self,
+        db: &str,
+        plugin_name: String,
+        code: String,
+        function_name: String,
+        plugin_type: PluginType,
+    ) -> crate::Result<(), write_buffer::Error>;
+
+    async fn insert_trigger(
+        &self,
+        db_name: &str,
+        trigger_name: String,
+        plugin_name: String,
+        trigger_specification: TriggerSpecificationDefinition,
+    ) -> crate::Result<(), write_buffer::Error>;
+
+    /// Starts running the trigger, which will run in the background.
+    async fn run_trigger(
+        &self,
+        write_buffer: Arc<dyn WriteBuffer>,
+        db_name: &str,
+        trigger_name: &str,
+    ) -> crate::Result<(), write_buffer::Error>;
+}
+
+#[cfg(feature = "system-py")]
+pub(crate) fn run_plugin(
+    db_name: String,
+    trigger_definition: TriggerDefinition,
+    mut context: PluginContext,
+) {
+    let trigger_plugin = TriggerPlugin {
+        trigger_definition,
+        db_name,
+    };
+    tokio::task::spawn(async move {
+        trigger_plugin
+            .run_plugin(&mut context)
+            .await
+            .expect("trigger plugin failed");
+    });
+}
+
+pub(crate) struct PluginContext {
+    // tokio channel for inputs
+    pub(crate) trigger_rx: tokio::sync::broadcast::Receiver<PluginEvent>,
+    // handler to write data back to the DB.
+    pub(crate) write_buffer: Arc<dyn WriteBuffer>,
+}
+
+#[async_trait::async_trait]
+trait RunnablePlugin {
+    async fn process_event(
+        &self,
+        event: PluginEvent,
+        write_buffer: Arc<dyn WriteBuffer>,
+    ) -> Result<(), Error>;
+    async fn run_plugin(&self, context: &mut PluginContext) -> Result<(), Error> {
+        loop {
+            match context.trigger_rx.recv().await {
+                Err(RecvError::Closed) => {
+                    break;
+                }
+                Err(RecvError::Lagged(_)) => {
+                    warn!("plugin lagged");
+                }
+                Ok(event) => {
+                    self.process_event(event, context.write_buffer.clone())
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+#[derive(Debug)]
+struct TriggerPlugin {
+    trigger_definition: TriggerDefinition,
+    db_name: String,
+}
+
+#[cfg(feature = "system-py")]
+mod python_plugin {
+    use super::*;
+    use crate::Precision;
+    use data_types::NamespaceName;
+    use influxdb3_py_api::system_py::PyWriteBatch;
+    use influxdb3_wal::WalOp;
+    use iox_time::Time;
+    use std::time::SystemTime;
+
+    #[async_trait::async_trait]
+    impl RunnablePlugin for TriggerPlugin {
+        async fn process_event(
+            &self,
+            event: PluginEvent,
+            write_buffer: Arc<dyn WriteBuffer>,
+        ) -> Result<(), Error> {
+            let Some(schema) = write_buffer.catalog().db_schema(self.db_name.as_str()) else {
+                return Err(Error::MissingDb);
+            };
+
+            let mut output_lines = Vec::new();
+
+            match event {
+                PluginEvent::WriteWalContents(wal_contents) => {
+                    for wal_op in &wal_contents.ops {
+                        match wal_op {
+                            WalOp::Write(write_batch) => {
+                                let py_write_batch = PyWriteBatch {
+                                    // TODO: don't clone the write batch
+                                    write_batch: write_batch.clone(),
+                                    schema: Arc::clone(&schema),
+                                };
+                                match &self.trigger_definition.trigger {
+                                    TriggerSpecificationDefinition::SingleTableWalWrite {
+                                        table_name,
+                                    } => {
+                                        output_lines.extend(py_write_batch.call_against_table(
+                                            table_name,
+                                            &self.trigger_definition.plugin.code,
+                                            &self.trigger_definition.plugin.function_name,
+                                        )?);
+                                    }
+                                    TriggerSpecificationDefinition::AllTablesWalWrite => {
+                                        for table in schema.table_map.right_values() {
+                                            output_lines.extend(
+                                                py_write_batch.call_against_table(
+                                                    table.as_ref(),
+                                                    &self.trigger_definition.plugin.code,
+                                                    &self.trigger_definition.plugin.function_name,
+                                                )?,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            WalOp::Catalog(_) => {}
+                        }
+                    }
+                }
+            }
+            if !output_lines.is_empty() {
+                let ingest_time = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap();
+                write_buffer
+                    .write_lp(
+                        NamespaceName::new(self.db_name.to_string()).unwrap(),
+                        output_lines.join("\n").as_str(),
+                        Time::from_timestamp_nanos(ingest_time.as_nanos() as i64),
+                        false,
+                        Precision::Nanosecond,
+                    )
+                    .await?;
+            }
+
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This makes two major changes, running plugins in their own tasks and enabling writing back line protocol to the WriteBuffer.

### Running Plugins as Separate Tasks
Each plugin now runs in its own task, started either when created through the API or when the system is started. It is connected to the rest of the system through two mechanisms: 
* A broadcast channel whose sender is owned by the `QueryableBuffer` and whose receiver it polls from.
* An Arc<dyn WriteBuffer> to enable write-backs. This also gives access to the catalog and much of the rest of the db as we continue to build out the API.
Right now the only message being sent is `Arc<WalContents>`, but I expect the PluginEvent enum to be expanded both for other triggering events and control messages, e.g. Shutdown, Status, etc.


### Write-Back Line Protocol
The running pythons have a reference to the WriteBuffer, and this PR also adds a simple receiver for python to write line protocols to with the `insert_line_protocol` call. Everything is buffered per PluginEvent, and data is copied several times, so there is a lot of room for improvement. 

Example REST calls

Creating a Plugin:

```
curl -X POST 'http://127.0.0.1:8181/api/v3/configure/processing_engine_plugin' \ 
-H 'Content-Type: application/json' \
-d '{
    "db": "load_test",
    "plugin_name": "counter_output",
    "plugin_type": "wal_rows",                 
    "function_name": "count_points",
    "code": "import time\nfrom collections import defaultdict\nfrom influxdb_client_3.write_client.client.write.point import Point\n\ndef count_points(iterator, output):\n    start_time = time.time()\n    table_counts = defaultdict(int)\n    \n    while True:\n        point = iterator.next_point()\n        if point is None:\n            break\n            \n        measurement = point._name\n        table_counts[measurement] += 1\n    \n    for table_name, count in table_counts.items():\n        stats_point = Point(\"table_counts\")\n        stats_point.tag(\"table_name\", table_name)\n        stats_point.field(\"row_count\", count)\n        output.insert_line_protocol(str(stats_point))\n    \n    end_time = time.time()\n    duration = end_time - start_time\n    \n    print(f\"Processing completed in {duration:.2f} seconds\")"
}'
```
Creating a Trigger:
```
 curl -X POST 'http://127.0.0.1:8181/api/v3/configure/processing_engine_trigger' \
-H 'Content-Type: application/json' \
-d '{
    "db": "load_test",
    "plugin_name": "counter_output",
    "trigger_name": "counter_output_trigger",
    "trigger_specification": {
         "single_table_wal_write": {"table_name": "measurement_data"}
    }
}'
```
