### PR TITLE
fix: Ensure tags are never null

### DIFF
--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -282,7 +282,7 @@ impl MutableTableChunk {
                             let mut tag_builder = StringDictionaryBuilder::new();
                             // append nulls for all previous rows
                             for _ in 0..(row_index + self.row_count) {
-                                tag_builder.append_value("".to_string());
+                                tag_builder.append_value("");
                             }
                             e.insert(Builder::Tag(tag_builder));
                         }
@@ -390,8 +390,8 @@ impl MutableTableChunk {
                         Builder::I64(b) => b.append_null(),
                         Builder::U64(b) => b.append_null(),
                         Builder::String(b) => b.append_null(),
-                        Builder::Tag(b) => b.append_value("".to_string()),
-                        Builder::Key(b) => b.append_value("".to_string()),
+                        Builder::Tag(b) => b.append_value(""),
+                        Builder::Key(b) => b.append_value(""),
                         Builder::Time(b) => b.append_null(),
                     }
                 }
@@ -468,7 +468,7 @@ impl MutableTableChunk {
                 let mut tag_builder: StringDictionaryBuilder<Int32Type> =
                     StringDictionaryBuilder::new();
                 for _ in 0..self.row_count {
-                    tag_builder.append_value("".to_string());
+                    tag_builder.append_value("");
                 }
 
                 cols.push(Arc::new(tag_builder.finish()));

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -282,7 +282,7 @@ impl MutableTableChunk {
                             let mut tag_builder = StringDictionaryBuilder::new();
                             // append nulls for all previous rows
                             for _ in 0..(row_index + self.row_count) {
-                                tag_builder.append_null();
+                                tag_builder.append_value("".to_string());
                             }
                             e.insert(Builder::Tag(tag_builder));
                         }
@@ -390,8 +390,8 @@ impl MutableTableChunk {
                         Builder::I64(b) => b.append_null(),
                         Builder::U64(b) => b.append_null(),
                         Builder::String(b) => b.append_null(),
-                        Builder::Tag(b) => b.append_null(),
-                        Builder::Key(b) => b.append_null(),
+                        Builder::Tag(b) => b.append_value("".to_string()),
+                        Builder::Key(b) => b.append_value("".to_string()),
                         Builder::Time(b) => b.append_null(),
                     }
                 }
@@ -467,7 +467,10 @@ impl MutableTableChunk {
                 schema_builder.influx_column(col_name.as_ref(), InfluxColumnType::Tag);
                 let mut tag_builder: StringDictionaryBuilder<Int32Type> =
                     StringDictionaryBuilder::new();
-                tag_builder.append_nulls(self.row_count);
+                for _ in 0..self.row_count {
+                    tag_builder.append_value("".to_string());
+                }
+
                 cols.push(Arc::new(tag_builder.finish()));
             }
         }


### PR DESCRIPTION
This injects empty strings into tags for any rows in the buffer where the tag value is null. This is required because the tags are what make up the series key, which must have all non-null values.

There is an ongoing discussion about what the real behavior should be here, but for now this will get our users running that break without this behavior. Discussion is in #25674.

Fixes #25648