### PR TITLE
feat: create DB and Tables via REST and CLI

### DIFF
--- a/influxdb3/src/commands/manage/table.rs
+++ b/influxdb3/src/commands/manage/table.rs
@@ -1,31 +1,71 @@
-use std::{error::Error, io};
+use std::{error::Error, fmt::Display, io, str::FromStr};
 
 use secrecy::ExposeSecret;
 
 use crate::commands::common::InfluxDb3Config;
 
 #[derive(Debug, clap::Parser)]
-pub(crate) struct ManageTableConfig {
+pub(crate) struct Config {
     #[clap(subcommand)]
     command: Command,
 }
 
 #[derive(Debug, clap::Parser)]
 enum Command {
-    Delete(TableConfig),
+    Create(CreateTableConfig),
+    Delete(DeleteTableConfig),
 }
 
 #[derive(Debug, clap::Parser)]
-pub struct TableConfig {
-    #[clap(short = 't', long = "table")]
-    table: String,
+pub struct DeleteTableConfig {
+    #[clap(short = 't', long = "table", required = true)]
+    table_name: String,
 
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
 }
 
-pub async fn delete_table(config: ManageTableConfig) -> Result<(), Box<dyn Error>> {
+#[derive(Debug, clap::Parser)]
+pub struct CreateTableConfig {
+    #[clap(short = 't', long = "table", required = true)]
+    table_name: String,
+
+    #[clap(long = "tags", required = true, num_args=0..)]
+    tags: Vec<String>,
+
+    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, required = true, num_args=0..)]
+    fields: Vec<(String, DataType)>,
+
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+}
+
+pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
     match config.command {
+        Command::Create(CreateTableConfig {
+            table_name,
+            tags,
+            fields,
+            influxdb3_config:
+                InfluxDb3Config {
+                    host_url,
+                    database_name,
+                    auth_token,
+                },
+        }) => {
+            let mut client = influxdb3_client::Client::new(host_url)?;
+            if let Some(t) = auth_token {
+                client = client.with_auth_token(t.expose_secret());
+            }
+            client
+                .api_v3_configure_table_create(&database_name, &table_name, tags, fields)
+                .await?;
+
+            println!(
+                "Table {:?}.{:?} created successfully",
+                &database_name, &table_name
+            );
+        }
         Command::Delete(config) => {
             let InfluxDb3Config {
                 host_url,
@@ -34,7 +74,7 @@ pub async fn delete_table(config: ManageTableConfig) -> Result<(), Box<dyn Error
             } = config.influxdb3_config;
             println!(
                 "Are you sure you want to delete {:?}.{:?}? Enter 'yes' to confirm",
-                database_name, &config.table,
+                database_name, &config.table_name,
             );
             let mut confirmation = String::new();
             let _ = io::stdin().read_line(&mut confirmation);
@@ -46,15 +86,74 @@ pub async fn delete_table(config: ManageTableConfig) -> Result<(), Box<dyn Error
                     client = client.with_auth_token(t.expose_secret());
                 }
                 client
-                    .api_v3_configure_table_delete(&database_name, &config.table)
+                    .api_v3_configure_table_delete(&database_name, &config.table_name)
                     .await?;
 
                 println!(
                     "Table {:?}.{:?} deleted successfully",
-                    &database_name, &config.table
+                    &database_name, &config.table_name
                 );
             }
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DataType {
+    Int64,
+    Uint64,
+    Float64,
+    Utf8,
+    Bool,
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("{0} is not a valid data type, values are int64, uint64, float64, utf8, and bool")]
+pub struct ParseDataTypeError(String);
+
+impl FromStr for DataType {
+    type Err = ParseDataTypeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "int64" => Ok(Self::Int64),
+            "uint64" => Ok(Self::Uint64),
+            "float64" => Ok(Self::Float64),
+            "utf8" => Ok(Self::Utf8),
+            "bool" => Ok(Self::Bool),
+            _ => Err(ParseDataTypeError(s.into())),
+        }
+    }
+}
+
+impl Display for DataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Int64 => write!(f, "int64"),
+            Self::Uint64 => write!(f, "uint64"),
+            Self::Float64 => write!(f, "float64"),
+            Self::Utf8 => write!(f, "utf8"),
+            Self::Bool => write!(f, "bool"),
+        }
+    }
+}
+
+impl From<DataType> for String {
+    fn from(data: DataType) -> Self {
+        data.to_string()
+    }
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find(':')
+        .ok_or_else(|| format!("invalid FIELD:VALUE. No `:` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -97,10 +97,10 @@ enum Command {
     MetaCache(commands::meta_cache::Config),
 
     /// Manage database (delete only for the moment)
-    Database(commands::manage::database::ManageDatabaseConfig),
+    Database(commands::manage::database::Config),
 
     /// Manage table (delete only for the moment)
-    Table(commands::manage::table::ManageTableConfig),
+    Table(commands::manage::table::Config),
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -166,14 +166,14 @@ fn main() -> Result<(), std::io::Error> {
                 }
             }
             Some(Command::Database(config)) => {
-                if let Err(e) = commands::manage::database::delete_database(config).await {
-                    eprintln!("Database delete command failed: {e}");
+                if let Err(e) = commands::manage::database::command(config).await {
+                    eprintln!("Database command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }
             Some(Command::Table(config)) => {
-                if let Err(e) = commands::manage::table::delete_table(config).await {
-                    eprintln!("Table delete command failed: {e}");
+                if let Err(e) = commands::manage::table::command(config).await {
+                    eprintln!("Table command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -1083,60 +1083,6 @@ async fn api_v3_configure_table_create_then_write() {
 }
 
 #[test_log::test(tokio::test)]
-async fn api_v3_configure_table_create_no_tags() {
-    let server = TestServer::spawn().await;
-    let client = reqwest::Client::new();
-    let db_url = format!(
-        "{base}/api/v3/configure/database",
-        base = server.client_addr()
-    );
-    let table_url = format!("{base}/api/v3/configure/table", base = server.client_addr());
-
-    let resp = client
-        .post(&db_url)
-        .json(&json!({ "db": "foo" }))
-        .send()
-        .await
-        .expect("create database call did not succeed");
-    assert_eq!(StatusCode::OK, resp.status());
-
-    let resp = client
-        .post(&table_url)
-        .json(&json!({
-            "db": "foo" ,
-            "table": "bar",
-            "tags": [],
-            "fields": [
-                {
-                    "name": "field1",
-                    "type": "uint64"
-                },
-                {
-                    "name": "field2",
-                    "type": "int64"
-                },
-                {
-                    "name": "field3",
-                    "type": "float64"
-                },
-                {
-                    "name": "field4",
-                    "type": "utf8"
-                },
-                {
-                    "name": "field5",
-                    "type": "bool"
-                }
-            ]
-
-        }))
-        .send()
-        .await
-        .expect("create table call failed");
-    assert_eq!(StatusCode::UNPROCESSABLE_ENTITY, resp.status());
-}
-
-#[test_log::test(tokio::test)]
 async fn api_v3_configure_table_create_no_fields() {
     let server = TestServer::spawn().await;
     let client = reqwest::Client::new();

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -886,6 +886,289 @@ async fn api_v3_configure_db_delete_missing_query_param() {
 }
 
 #[test_log::test(tokio::test)]
+async fn api_v3_configure_db_create() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("delete database call succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_db_create_db_with_same_name() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("delete database call succeed");
+    assert_eq!(StatusCode::BAD_REQUEST, resp.status());
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_db_create_db_hit_limit() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+    for i in 0..5 {
+        let resp = client
+            .post(&url)
+            .json(&json!({ "db": format!("foo{i}") }))
+            .send()
+            .await
+            .expect("create database call did not succeed");
+        assert_eq!(StatusCode::OK, resp.status());
+    }
+
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo5" }))
+        .send()
+        .await
+        .expect("create database succeeded");
+    assert_eq!(StatusCode::UNPROCESSABLE_ENTITY, resp.status());
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_db_create_db_reuse_old_name() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+    let resp = client
+        .delete(format!("{url}?db=foo"))
+        .send()
+        .await
+        .expect("delete database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+    let resp = client
+        .post(&url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_table_create_then_write() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let db_url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+    let table_url = format!("{base}/api/v3/configure/table", base = server.client_addr());
+
+    let resp = client
+        .post(&db_url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+
+    let resp = client
+        .post(&table_url)
+        .json(&json!({
+            "db": "foo" ,
+            "table": "bar",
+            "tags": ["tag1", "tag2"],
+            "fields": [
+                {
+                    "name": "field1",
+                    "type": "uint64"
+                },
+                {
+                    "name": "field2",
+                    "type": "int64"
+                },
+                {
+                    "name": "field3",
+                    "type": "float64"
+                },
+                {
+                    "name": "field4",
+                    "type": "utf8"
+                },
+                {
+                    "name": "field5",
+                    "type": "bool"
+                }
+            ]
+
+        }))
+        .send()
+        .await
+        .expect("create table call failed");
+    assert_eq!(StatusCode::OK, resp.status());
+    let result = server
+        .api_v3_query_sql(&[
+            ("db", "foo"),
+            ("q", "SELECT * FROM bar"),
+            ("format", "json"),
+        ])
+        .await
+        .json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(result, json!([]));
+    server
+        .write_lp_to_db(
+            "foo",
+            "bar,tag1=1,tag2=2 field1=1u,field2=2i,field3=3,field4=\"4\",field5=true 1000",
+            influxdb3_client::Precision::Second,
+        )
+        .await
+        .expect("write to db");
+    let result = server
+        .api_v3_query_sql(&[
+            ("db", "foo"),
+            ("q", "SELECT * FROM bar"),
+            ("format", "json"),
+        ])
+        .await
+        .json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        json!([{
+            "tag1": "1",
+            "tag2": "2",
+            "field1": 1,
+            "field2": 2,
+            "field3": 3.0,
+            "field4": "4",
+            "field5": true,
+            "time": "1970-01-01T00:16:40"
+        }])
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_table_create_no_tags() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let db_url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+    let table_url = format!("{base}/api/v3/configure/table", base = server.client_addr());
+
+    let resp = client
+        .post(&db_url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+
+    let resp = client
+        .post(&table_url)
+        .json(&json!({
+            "db": "foo" ,
+            "table": "bar",
+            "tags": [],
+            "fields": [
+                {
+                    "name": "field1",
+                    "type": "uint64"
+                },
+                {
+                    "name": "field2",
+                    "type": "int64"
+                },
+                {
+                    "name": "field3",
+                    "type": "float64"
+                },
+                {
+                    "name": "field4",
+                    "type": "utf8"
+                },
+                {
+                    "name": "field5",
+                    "type": "bool"
+                }
+            ]
+
+        }))
+        .send()
+        .await
+        .expect("create table call failed");
+    assert_eq!(StatusCode::UNPROCESSABLE_ENTITY, resp.status());
+}
+
+#[test_log::test(tokio::test)]
+async fn api_v3_configure_table_create_no_fields() {
+    let server = TestServer::spawn().await;
+    let client = reqwest::Client::new();
+    let db_url = format!(
+        "{base}/api/v3/configure/database",
+        base = server.client_addr()
+    );
+    let table_url = format!("{base}/api/v3/configure/table", base = server.client_addr());
+
+    let resp = client
+        .post(&db_url)
+        .json(&json!({ "db": "foo" }))
+        .send()
+        .await
+        .expect("create database call did not succeed");
+    assert_eq!(StatusCode::OK, resp.status());
+
+    let resp = client
+        .post(&table_url)
+        .json(&json!({
+            "db": "foo" ,
+            "table": "bar",
+            "tags": ["one", "two"],
+            "fields": []
+        }))
+        .send()
+        .await
+        .expect("create table call failed");
+    assert_eq!(StatusCode::UNPROCESSABLE_ENTITY, resp.status());
+}
+
+#[test_log::test(tokio::test)]
 async fn api_v3_configure_table_delete() {
     let db_name = "foo";
     let tbl_name = "tbl";

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -586,6 +586,16 @@ impl DatabaseSchema {
             catalog_batch.database_id,
             Arc::clone(&catalog_batch.database_name),
         );
+
+        // We need to special case when we create a DB via the commandline as
+        // this will only contain one op to create a database. If we don't
+        // startup of the database will fail
+        if catalog_batch.ops.len() == 1 {
+            if let CatalogOp::CreateDatabase(_) = catalog_batch.ops[0] {
+                return Ok(db_schema);
+            }
+        }
+
         let new_db = DatabaseSchema::new_if_updated_from_batch(&db_schema, catalog_batch)?
             .expect("database must be new");
         Ok(new_db)

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -250,10 +250,6 @@ impl Error {
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
-            Self::WriteBuffer(err @ WriteBufferError::EmptyTagSet) => Response::builder()
-                .status(StatusCode::UNPROCESSABLE_ENTITY)
-                .body(Body::from(err.to_string()))
-                .unwrap(),
             Self::WriteBuffer(err @ WriteBufferError::EmptyFields) => Response::builder()
                 .status(StatusCode::UNPROCESSABLE_ENTITY)
                 .body(Body::from(err.to_string()))

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -62,7 +62,15 @@ pub trait WriteBuffer:
 /// Database manager - supports only delete operation
 #[async_trait::async_trait]
 pub trait DatabaseManager: Debug + Send + Sync + 'static {
+    async fn create_database(&self, name: String) -> Result<(), write_buffer::Error>;
     async fn soft_delete_database(&self, name: String) -> Result<(), write_buffer::Error>;
+    async fn create_table(
+        &self,
+        db: String,
+        table: String,
+        tags: Vec<String>,
+        fields: Vec<(String, String)>,
+    ) -> Result<(), write_buffer::Error>;
     async fn soft_delete_table(
         &self,
         db_name: String,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -100,9 +100,7 @@ pub enum Error {
     #[error("table not found {table_name:?} in db {db_name:?}")]
     TableNotFound { db_name: String, table_name: String },
 
-    // These two errors are exclusive to the table creation API
-    #[error("table creation failed due to no tags")]
-    EmptyTagSet,
+    // This error is exclusive to the table creation API
     #[error("table creation failed due to no fields")]
     EmptyFields,
 
@@ -712,9 +710,6 @@ impl DatabaseManager for WriteBufferImpl {
         tags: Vec<String>,
         fields: Vec<(String, String)>,
     ) -> Result<(), self::Error> {
-        if tags.is_empty() {
-            return Err(self::Error::EmptyTagSet);
-        }
         if fields.is_empty() {
             return Err(self::Error::EmptyFields);
         }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -31,6 +31,8 @@ use influxdb3_cache::parquet_cache::ParquetCacheOracle;
 use influxdb3_catalog::catalog;
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
 use influxdb3_id::{ColumnId, DbId, TableId};
+use influxdb3_wal::FieldDataType;
+use influxdb3_wal::TableDefinition;
 use influxdb3_wal::{
     object_store::WalObjectStore, DeleteDatabaseDefinition, PluginDefinition, PluginType,
     TriggerDefinition, TriggerSpecificationDefinition, WalContents,
@@ -40,6 +42,7 @@ use influxdb3_wal::{
     MetaCacheDefinition, MetaCacheDelete, Wal, WalConfig, WalFileNotifier, WalOp,
 };
 use influxdb3_wal::{CatalogOp::CreateLastCache, DeleteTableDefinition};
+use influxdb3_wal::{DatabaseDefinition, FieldDefinition};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::QueryChunk;
 use iox_time::{Time, TimeProvider};
@@ -97,8 +100,17 @@ pub enum Error {
     #[error("table not found {table_name:?} in db {db_name:?}")]
     TableNotFound { db_name: String, table_name: String },
 
+    // These two errors are exclusive to the table creation API
+    #[error("table creation failed due to no tags")]
+    EmptyTagSet,
+    #[error("table creation failed due to no fields")]
+    EmptyFields,
+
     #[error("tried accessing database that does not exist")]
     DbDoesNotExist,
+
+    #[error("tried creating database named '{0}' that already exists")]
+    DatabaseExists(String),
 
     #[error("tried accessing table that do not exist")]
     TableDoesNotExist,
@@ -644,6 +656,30 @@ impl LastCacheManager for WriteBufferImpl {
 
 #[async_trait::async_trait]
 impl DatabaseManager for WriteBufferImpl {
+    async fn create_database(&self, name: String) -> crate::Result<(), self::Error> {
+        if self.catalog.db_name_to_id(&name).is_some() {
+            return Err(self::Error::DatabaseExists(name.clone()));
+        }
+        // Create the Database
+        let db_schema = self.catalog.db_or_create(&name)?;
+        let db_id = db_schema.id;
+
+        let catalog_batch = CatalogBatch {
+            time_ns: self.time_provider.now().timestamp_nanos(),
+            database_id: db_id,
+            database_name: Arc::clone(&db_schema.name),
+            ops: vec![CatalogOp::CreateDatabase(DatabaseDefinition {
+                database_id: db_id,
+                database_name: Arc::clone(&db_schema.name),
+            })],
+        };
+        self.catalog.apply_catalog_batch(&catalog_batch)?;
+        let wal_op = WalOp::Catalog(catalog_batch);
+        self.wal.write_ops(vec![wal_op]).await?;
+        debug!(db_id = ?db_id, name = ?&db_schema.name, "successfully created database");
+        Ok(())
+    }
+
     async fn soft_delete_database(&self, name: String) -> crate::Result<(), self::Error> {
         let (db_id, db_schema) =
             self.catalog
@@ -667,6 +703,94 @@ impl DatabaseManager for WriteBufferImpl {
         let wal_op = WalOp::Catalog(catalog_batch);
         self.wal.write_ops(vec![wal_op]).await?;
         debug!(db_id = ?db_id, name = ?&db_schema.name, "successfully deleted database");
+        Ok(())
+    }
+    async fn create_table(
+        &self,
+        db: String,
+        table: String,
+        tags: Vec<String>,
+        fields: Vec<(String, String)>,
+    ) -> Result<(), self::Error> {
+        if tags.is_empty() {
+            return Err(self::Error::EmptyTagSet);
+        }
+        if fields.is_empty() {
+            return Err(self::Error::EmptyFields);
+        }
+        let (db_id, db_schema) =
+            self.catalog
+                .db_id_and_schema(&db)
+                .ok_or_else(|| self::Error::DatabaseNotFound {
+                    db_name: db.to_owned(),
+                })?;
+
+        let table_id = TableId::new();
+        let table_name = table.into();
+        let mut key = Vec::new();
+        let field_definitions = {
+            let mut field_definitions = Vec::new();
+            for tag in tags {
+                let id = ColumnId::new();
+                key.push(id);
+                field_definitions.push(FieldDefinition {
+                    name: tag.into(),
+                    id,
+                    data_type: FieldDataType::Tag,
+                });
+            }
+
+            for (name, ty) in fields {
+                field_definitions.push(FieldDefinition {
+                    name: name.into(),
+                    id: ColumnId::new(),
+                    data_type: match ty.as_str() {
+                        "uint64" => FieldDataType::UInteger,
+                        "float64" => FieldDataType::Float,
+                        "int64" => FieldDataType::Integer,
+                        "bool" => FieldDataType::Boolean,
+                        "utf8" => FieldDataType::String,
+                        _ => todo!(),
+                    },
+                });
+            }
+
+            field_definitions.push(FieldDefinition {
+                name: "time".into(),
+                id: ColumnId::new(),
+                data_type: FieldDataType::Timestamp,
+            });
+
+            field_definitions
+        };
+
+        let catalog_table_def = TableDefinition {
+            database_id: db_schema.id,
+            database_name: Arc::clone(&db_schema.name),
+            table_name: Arc::clone(&table_name),
+            table_id,
+            field_definitions,
+            key,
+        };
+
+        let catalog_batch = CatalogBatch {
+            time_ns: self.time_provider.now().timestamp_nanos(),
+            database_id: db_id,
+            database_name: Arc::clone(&db_schema.name),
+            ops: vec![CatalogOp::CreateTable(catalog_table_def)],
+        };
+        self.catalog.apply_catalog_batch(&catalog_batch)?;
+        let wal_op = WalOp::Catalog(catalog_batch);
+        self.wal.write_ops(vec![wal_op]).await?;
+
+        debug!(
+            db_name = ?db_schema.name,
+            db_id = ?db_id,
+            table_id = ?table_id,
+            name = ?table_name,
+            "successfully created table"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
This commit does a few things:

1. It brings the database command naming scheme for types inline with the rest of the CLI types
2. It brings the table command naming scheme for types inline with the rest of the CLI types
3. Adds tests to check that the num of dbs is not exceeded and that you cannot create more than one database with a given name.
4. Adds tests to check that you can create a table and put data into it and querying it
5. Adds tests for the CLI for both the database and table commands
6. It creates an endpoint to create databases given a JSON blob
7. It creates an endpoint to create tables given a JSON blob

With this users can now create a database or table without first needing to write to the database via the line protocol!

Closes #25640
Closes #25641