### PR TITLE
fix: Field not in queryable buffer

### DIFF
--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1332,15 +1332,16 @@ async fn api_v3_query_sql_meta_cache() {
 }
 
 /// Test that if we write in a row of LP that is missing a tag value, we're still able to query.
-#[tokio::test]
-async fn api_v3_query_null_tag_values() {
+/// Also tests that if the buffer is missing a field, we're still able to query.
+#[test_log::test(tokio::test)]
+async fn api_v3_query_null_tag_values_null_fields() {
     let server = TestServer::spawn().await;
 
     server
         .write_lp_to_db(
             "foo",
-            "cpu,host=a,region=us-east usage=0.9 1
-            cpu,host=b usage=0.80 4",
+            "cpu,host=a,region=us-east usage=0.9,system=0.1 1
+            cpu,host=b usage=0.80,system=0.1 4",
             Precision::Second,
         )
         .await
@@ -1373,6 +1374,40 @@ async fn api_v3_query_null_tag_values() {
             | a    | us-east | 1970-01-01T00:00:01 | 0.9   |\n\
             | b    |         | 1970-01-01T00:00:04 | 0.8   |\n\
             +------+---------+---------------------+-------+",
+        resp
+    );
+
+    server
+        .write_lp_to_db(
+            "foo",
+            "cpu,host=a,region=us-east usage=0.9 10000000",
+            Precision::Second,
+        )
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(&url)
+        .query(&[
+            ("db", "foo"),
+            ("q", "SELECT * FROM cpu ORDER BY time"),
+            ("format", "pretty"),
+        ])
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        "+------+---------+--------+---------------------+-------+\n\
+         | host | region  | system | time                | usage |\n\
+         +------+---------+--------+---------------------+-------+\n\
+         | a    | us-east | 0.1    | 1970-01-01T00:00:01 | 0.9   |\n\
+         | b    |         | 0.1    | 1970-01-01T00:00:04 | 0.8   |\n\
+         | a    | us-east |        | 1970-04-26T17:46:40 | 0.9   |\n\
+         +------+---------+--------+---------------------+-------+",
         resp
     );
 }


### PR DESCRIPTION
Fixes an error that would get thrown when doing a query against a table that has a field defined in its schema, but doesn't have it in the queryable buffer because that field hasn't been written to.