### PR TITLE
fix: change failed query with missing db to 404

### DIFF
--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1,5 +1,6 @@
 use crate::TestServer;
 use futures::StreamExt;
+use hyper::StatusCode;
 use influxdb3_client::Precision;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
@@ -53,6 +54,18 @@ async fn api_v3_query_sql() {
         println!("{resp}");
         assert_eq!(t.expected, resp, "query failed: {q}", q = t.query);
     }
+}
+
+#[tokio::test]
+async fn api_v3_query_sql_not_found() {
+    let server = TestServer::spawn().await;
+    let params = vec![
+        ("q", "SELECT * FROM foo"),
+        ("format", "pretty"),
+        ("db", "foo"),
+    ];
+    let resp = server.api_v3_query_sql(&params).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -677,6 +690,18 @@ async fn api_v3_query_json_format() {
         println!("{resp}");
         assert_eq!(t.expected, resp, "query failed: {q}", q = t.query);
     }
+}
+
+#[tokio::test]
+async fn api_v1_query_sql_not_found() {
+    let server = TestServer::spawn().await;
+    let params = vec![
+        ("q", "SELECT * FROM foo"),
+        ("format", "pretty"),
+        ("db", "foo"),
+    ];
+    let resp = server.api_v1_query(&params, None).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -369,6 +369,18 @@ impl Error {
                     .body(body)
                     .unwrap()
             }
+            Self::Query(query_executor::Error::DatabaseNotFound { .. }) => {
+                let err: ErrorMessage<()> = ErrorMessage {
+                    error: self.to_string(),
+                    data: None,
+                };
+                let serialized = serde_json::to_string(&err).unwrap();
+                let body = Body::from(serialized);
+                Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(body)
+                    .unwrap()
+            }
             Self::SerdeJson(_) => Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))


### PR DESCRIPTION
This changes the status code of a failed query that uses a db that does not exist. We now instead return a 404 rather than the default 500 code

Closes #25653
