### PR TITLE
feat: Add json lines support to query output

### DIFF
--- a/influxdb3/src/commands/query.rs
+++ b/influxdb3/src/commands/query.rs
@@ -68,6 +68,7 @@ pub struct Config {
 enum Format {
     Pretty,
     Json,
+    JsonLines,
     Csv,
     Parquet,
 }
@@ -83,6 +84,7 @@ impl From<Format> for influxdb3_client::Format {
         match this {
             Format::Pretty => Self::Pretty,
             Format::Json => Self::Json,
+            Format::JsonLines => Self::JsonLines,
             Format::Csv => Self::Csv,
             Format::Parquet => Self::Parquet,
         }

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -815,6 +815,8 @@ impl Display for QueryKind {
 #[serde(rename_all = "snake_case")]
 pub enum Format {
     Json,
+    #[serde(rename = "jsonl")]
+    JsonLines,
     Csv,
     Parquet,
     Pretty,


### PR DESCRIPTION
This commit adds support for JSON Lines which also lets us stream the body back to the consumer, rather than needing to buffer the entirety of the query in memory before sending it back to the user.

Closes #24654